### PR TITLE
KAFKA-14834: [11/N] Update table joins to identify out-of-order records with `isLatest`

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -620,11 +620,17 @@ public class InternalStreamsBuilder implements InternalNameProvider {
     }
 
     private void enableVersionedSemantics() {
-        versionedSemanticsNodes.forEach(node -> ((VersionedSemanticsGraphNode) node).enableVersionedSemantics(isVersionedUpstream(node)));
+        versionedSemanticsNodes.forEach(node -> {
+            for (final GraphNode parentNode : node.parentNodes()) {
+                if (isVersionedOrVersionedUpstream(parentNode)) {
+                    ((VersionedSemanticsGraphNode) node).enableVersionedSemantics(true, parentNode.nodeName());
+                }
+            }
+        });
         tableSuppressNodesNodes.forEach(node -> {
             if (isVersionedUpstream(node)) {
                 throw new TopologyException("suppress() is only supported for non-versioned KTables " +
-                        "(note that version semantics might be inherited from upstream)");
+                    "(note that version semantics might be inherited from upstream)");
             }
         });
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -48,7 +48,7 @@ import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionRes
 import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionReceiveProcessorSupplier;
 import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionWrapper;
 import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionWrapperSerde;
-import org.apache.kafka.streams.kstream.internals.graph.ForeignJoinSubscriptionNode;
+import org.apache.kafka.streams.kstream.internals.graph.ForeignTableJoinNode;
 import org.apache.kafka.streams.kstream.internals.graph.ForeignJoinSubscriptionSendNode;
 import org.apache.kafka.streams.kstream.internals.graph.KTableKTableJoinNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorGraphNode;
@@ -1218,7 +1218,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             );
         builder.addGraphNode(subscriptionReceiveNode, subscriptionJoinNode);
 
-        final StatefulProcessorNode<KO, Change<VO>> foreignTableJoinNode = new ForeignJoinSubscriptionNode<>(
+        final StatefulProcessorNode<KO, Change<VO>> foreignTableJoinNode = new ForeignTableJoinNode<>(
             new ProcessorParameters<>(
                 new ForeignTableJoinProcessorSupplier<>(subscriptionStore, combinedKeySchema),
                 renamed.suffixWithOrElseGet("-foreign-join-subscription", builder, SUBSCRIPTION_PROCESSOR)

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -48,6 +48,8 @@ import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionRes
 import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionReceiveProcessorSupplier;
 import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionWrapper;
 import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionWrapperSerde;
+import org.apache.kafka.streams.kstream.internals.graph.ForeignJoinSubscriptionNode;
+import org.apache.kafka.streams.kstream.internals.graph.ForeignJoinSubscriptionSendNode;
 import org.apache.kafka.streams.kstream.internals.graph.KTableKTableJoinNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorGraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
@@ -804,6 +806,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         kTableKTableJoinNode.setOutputVersioned(isOutputVersioned);
 
         builder.addGraphNode(this.graphNode, kTableKTableJoinNode);
+        builder.addGraphNode(((KTableImpl<?, ?, ?>) other).graphNode, kTableKTableJoinNode);
 
         // we can inherit parent key serde if user do not provide specific overrides
         return new KTableImpl<K, Change<VR>, VR>(
@@ -1098,7 +1101,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         //not be done needlessly.
         ((KTableImpl<?, ?, ?>) foreignKeyTable).enableSendingOldValues(true);
 
-        //Old values must be sent such that the ForeignJoinSubscriptionSendProcessorSupplier can propagate deletions to the correct node.
+        //Old values must be sent such that the SubscriptionSendProcessorSupplier can propagate deletions to the correct node.
         //This occurs whenever the extracted foreignKey changes values.
         enableSendingOldValues(true);
 
@@ -1138,8 +1141,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             keySerde
         );
 
-        final KTableValueGetterSupplier<K, V> primaryKeyValueGetter = valueGetterSupplier();
-        final StatefulProcessorNode<K, Change<V>> subscriptionSendNode = new StatefulProcessorNode<>(
+        final ProcessorGraphNode<K, Change<V>> subscriptionSendNode = new ForeignJoinSubscriptionSendNode<>(
             new ProcessorParameters<>(
                 new SubscriptionSendProcessorSupplier<>(
                     foreignKeyExtractor,
@@ -1147,13 +1149,10 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
                     valueHashSerdePseudoTopic,
                     foreignKeySerde,
                     valueSerde == null ? null : valueSerde.serializer(),
-                    leftJoin,
-                    primaryKeyValueGetter
+                    leftJoin
                 ),
                 renamed.suffixWithOrElseGet("-subscription-registration-processor", builder, SUBSCRIPTION_REGISTRATION)
-            ),
-            Collections.emptySet(),
-            Collections.singleton(primaryKeyValueGetter)
+            )
         );
         builder.addGraphNode(graphNode, subscriptionSendNode);
 
@@ -1219,13 +1218,13 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             );
         builder.addGraphNode(subscriptionReceiveNode, subscriptionJoinNode);
 
-        final StatefulProcessorNode<KO, Change<VO>> foreignTableJoinNode = new StatefulProcessorNode<>(
+        final StatefulProcessorNode<KO, Change<VO>> foreignTableJoinNode = new ForeignJoinSubscriptionNode<>(
             new ProcessorParameters<>(
-                new ForeignTableJoinProcessorSupplier<>(subscriptionStore, combinedKeySchema, foreignKeyValueGetter),
+                new ForeignTableJoinProcessorSupplier<>(subscriptionStore, combinedKeySchema),
                 renamed.suffixWithOrElseGet("-foreign-join-subscription", builder, SUBSCRIPTION_PROCESSOR)
             ),
             Collections.singleton(subscriptionStore),
-            Collections.singleton(foreignKeyValueGetter)
+            Collections.emptySet()
         );
         builder.addGraphNode(((KTableImpl<KO, VO, ?>) foreignKeyTable).graphNode, foreignTableJoinNode);
 
@@ -1259,6 +1258,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         resultSourceNodes.add(foreignResponseSource.nodeName());
         builder.internalTopologyBuilder.copartitionSources(resultSourceNodes);
 
+        final KTableValueGetterSupplier<K, V> primaryKeyValueGetter = valueGetterSupplier();
         final StatefulProcessorNode<K, SubscriptionResponseWrapper<VO>> responseJoinNode = new StatefulProcessorNode<>(
             new ProcessorParameters<>(
                 new ResponseJoinProcessorSupplier<>(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableAbstractJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableAbstractJoin.java
@@ -18,17 +18,16 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.kstream.ValueJoiner;
 
-abstract class KTableKTableAbstractJoin<K, V1, V2, VOut> implements
+public abstract class KTableKTableAbstractJoin<K, V1, V2, VOut> implements
     KTableProcessorSupplier<K, V1, K, VOut> {
 
     private final KTableImpl<K, ?, V1> table1;
     private final KTableImpl<K, ?, V2> table2;
     final KTableValueGetterSupplier<K, V1> valueGetterSupplier1;
     final KTableValueGetterSupplier<K, V2> valueGetterSupplier2;
-    final KTableValueGetter<K, V1> valueGetter1;
-    final KTableValueGetter<K, V2> valueGetter2;
     final ValueJoiner<? super V1, ? super V2, ? extends VOut> joiner;
 
+    boolean useVersionedSemantics = false;
     boolean sendOldValues = false;
 
     KTableKTableAbstractJoin(final KTableImpl<K, ?, V1> table1,
@@ -38,8 +37,6 @@ abstract class KTableKTableAbstractJoin<K, V1, V2, VOut> implements
         this.table2 = table2;
         this.valueGetterSupplier1 = table1.valueGetterSupplier();
         this.valueGetterSupplier2 = table2.valueGetterSupplier();
-        this.valueGetter1 = valueGetterSupplier1.get();
-        this.valueGetter2 = valueGetterSupplier2.get();
         this.joiner = joiner;
     }
 
@@ -50,5 +47,18 @@ abstract class KTableKTableAbstractJoin<K, V1, V2, VOut> implements
         table2.enableSendingOldValues(true);
         sendOldValues = true;
         return true;
+    }
+
+    public void setUseVersionedSemantics(final boolean useVersionedSemantics) {
+        this.useVersionedSemantics = useVersionedSemantics;
+    }
+
+    // VisibleForTesting
+    public boolean isUseVersionedSemantics() {
+        return useVersionedSemantics;
+    }
+
+    public String joinThisParentNodeName() {
+        return table1.graphNode.nodeName();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoin.java
@@ -42,7 +42,7 @@ class KTableKTableInnerJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
 
     @Override
     public Processor<K, Change<V1>, K, Change<VOut>> get() {
-        return new KTableKTableJoinProcessor(valueGetter1, valueGetter2);
+        return new KTableKTableJoinProcessor(valueGetterSupplier2.get());
     }
 
     @Override
@@ -64,14 +64,11 @@ class KTableKTableInnerJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
 
     private class KTableKTableJoinProcessor extends ContextualProcessor<K, Change<V1>, K, Change<VOut>> {
 
-        private final KTableValueGetter<K, V1> thisValueGetter;
-        private final KTableValueGetter<K, V2> otherValueGetter;
+        private final KTableValueGetter<K, V2> valueGetter;
         private Sensor droppedRecordsSensor;
 
-        KTableKTableJoinProcessor(final KTableValueGetter<K, V1> thisValueGetter,
-                                  final KTableValueGetter<K, V2> otherValueGetter) {
-            this.thisValueGetter = thisValueGetter;
-            this.otherValueGetter = otherValueGetter;
+        KTableKTableJoinProcessor(final KTableValueGetter<K, V2> valueGetter) {
+            this.valueGetter = valueGetter;
         }
 
         @Override
@@ -82,8 +79,7 @@ class KTableKTableInnerJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
                 context.taskId().toString(),
                 (StreamsMetricsImpl) context.metrics()
             );
-            thisValueGetter.init(context);
-            otherValueGetter.init(context);
+            valueGetter.init(context);
         }
 
         @Override
@@ -107,20 +103,17 @@ class KTableKTableInnerJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
             }
 
             // drop out-of-order records from versioned tables (cf. KIP-914)
-            if (thisValueGetter.isVersioned()) {
-                final ValueAndTimestamp<V1> valueAndTimestampLeft = thisValueGetter.get(record.key());
-                if (valueAndTimestampLeft != null && valueAndTimestampLeft.timestamp() > record.timestamp()) {
-                    LOG.info("Skipping out-of-order record from versioned table while performing table-table join.");
-                    droppedRecordsSensor.record();
-                    return;
-                }
+            if (useVersionedSemantics && !record.value().isLatest) {
+                LOG.info("Skipping out-of-order record from versioned table while performing table-table join.");
+                droppedRecordsSensor.record();
+                return;
             }
 
             VOut newValue = null;
             final long resultTimestamp;
             VOut oldValue = null;
 
-            final ValueAndTimestamp<V2> valueAndTimestampRight = otherValueGetter.get(record.key());
+            final ValueAndTimestamp<V2> valueAndTimestampRight = valueGetter.get(record.key());
             final V2 valueRight = getValueOrNull(valueAndTimestampRight);
             if (valueRight == null) {
                 return;
@@ -141,8 +134,7 @@ class KTableKTableInnerJoin<K, V1, V2, VOut> extends KTableKTableAbstractJoin<K,
 
         @Override
         public void close() {
-            thisValueGetter.close();
-            otherValueGetter.close();
+            valueGetter.close();
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionJoinProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionJoinProcessorSupplier.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 /**
  * Receives {@code SubscriptionWrapper<K>} events and processes them according to their Instruction.
  * Depending on the results, {@code SubscriptionResponseWrapper}s are created, which will be propagated to
- * the {@code SubscriptionResolverJoinProcessorSupplier} instance.
+ * the {@code ResponseJoinProcessorSupplier} instance.
  *
  * @param <K> Type of primary keys
  * @param <KO> Type of foreign key

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionReceiveProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionReceiveProcessorSupplier.java
@@ -103,7 +103,7 @@ public class SubscriptionReceiveProcessorSupplier<K, KO>
                 final ValueAndTimestamp<SubscriptionWrapper<K>> newValue = ValueAndTimestamp.make(record.value(), record.timestamp());
                 final ValueAndTimestamp<SubscriptionWrapper<K>> oldValue = store.get(subscriptionKey);
 
-                //This store is used by the prefix scanner in ForeignJoinSubscriptionProcessorSupplier
+                //This store is used by the prefix scanner in ForeignTableJoinProcessorSupplier
                 if (record.value().getInstruction().equals(SubscriptionWrapper.Instruction.DELETE_KEY_AND_PROPAGATE) ||
                     record.value().getInstruction().equals(SubscriptionWrapper.Instruction.DELETE_KEY_NO_PROPAGATE)) {
                     store.delete(subscriptionKey);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/BaseJoinProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/BaseJoinProcessorNode.java
@@ -51,11 +51,13 @@ abstract class BaseJoinProcessorNode<K, V1, V2, VR> extends GraphNode {
         this.otherJoinSideNodeName = otherJoinSideNodeName;
     }
 
-    ProcessorParameters<K, V1, ?, ?> thisProcessorParameters() {
+    // VisibleForTesting
+    public ProcessorParameters<K, V1, ?, ?> thisProcessorParameters() {
         return joinThisProcessorParameters;
     }
 
-    ProcessorParameters<K, V2, ?, ?> otherProcessorParameters() {
+    // VisibleForTesting
+    public ProcessorParameters<K, V2, ?, ?> otherProcessorParameters() {
         return joinOtherProcessorParameters;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ForeignJoinSubscriptionNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ForeignJoinSubscriptionNode.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals.graph;
+
+import java.util.Set;
+import org.apache.kafka.streams.kstream.internals.KTableValueGetterSupplier;
+import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.ForeignTableJoinProcessorSupplier;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.state.StoreBuilder;
+
+public class ForeignJoinSubscriptionNode<K, V> extends StatefulProcessorNode<K, V> implements VersionedSemanticsGraphNode {
+
+    public ForeignJoinSubscriptionNode(final ProcessorParameters<K, V, ?, ?> processorParameters,
+                                       final Set<StoreBuilder<?>> preRegisteredStores,
+                                       final Set<KTableValueGetterSupplier<?, ?>> valueGetterSuppliers) {
+        super(processorParameters, preRegisteredStores, valueGetterSuppliers);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void enableVersionedSemantics(final boolean useVersionedSemantics, final String parentNodeName) {
+        final ProcessorSupplier<?, ?, ?, ?> processorSupplier = processorParameters().processorSupplier();
+        if (!(processorSupplier instanceof ForeignTableJoinProcessorSupplier)) {
+            throw new IllegalStateException("Unexpected processor type for foreign-key table-table join subscription processor: " + processorSupplier.getClass().getName());
+        }
+
+        final ForeignTableJoinProcessorSupplier<?, ?, ?> subscriptionProcessor
+            = (ForeignTableJoinProcessorSupplier<?, ?, ?>) processorSupplier;
+        subscriptionProcessor.setUseVersionedSemantics(useVersionedSemantics);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ForeignJoinSubscriptionSendNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ForeignJoinSubscriptionSendNode.java
@@ -14,28 +14,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.kafka.streams.kstream.internals.graph;
 
-import org.apache.kafka.streams.kstream.internals.KTableRepartitionMap;
+import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionSendProcessorSupplier;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 
-public class TableRepartitionMapNode<K, V> extends ProcessorGraphNode<K, V> implements VersionedSemanticsGraphNode {
+public class ForeignJoinSubscriptionSendNode<K, V> extends ProcessorGraphNode<K, V> implements VersionedSemanticsGraphNode {
 
-    public TableRepartitionMapNode(final String nodeName,
-                                   final ProcessorParameters<K, V, ?, ?> processorParameters) {
-        super(nodeName, processorParameters);
+    public ForeignJoinSubscriptionSendNode(final ProcessorParameters<K, V, ?, ?> processorParameters) {
+        super(processorParameters);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public void enableVersionedSemantics(final boolean useVersionedSemantics, final String parentNodeName) {
-        final ProcessorSupplier<K, V, ?, ?> processorSupplier = processorParameters().processorSupplier();
-        if (!(processorSupplier instanceof KTableRepartitionMap)) {
-            throw new IllegalStateException("Unexpected processor type for table repartition map: " + processorSupplier.getClass().getName());
+        final ProcessorSupplier<?, ?, ?, ?> processorSupplier = processorParameters().processorSupplier();
+        if (!(processorSupplier instanceof SubscriptionSendProcessorSupplier)) {
+            throw new IllegalStateException("Unexpected processor type for foreign-key table-table join subscription send processor: " + processorSupplier.getClass().getName());
         }
 
-        final KTableRepartitionMap<K, V, ?, ?> tableRepartitionMap = (KTableRepartitionMap<K, V, ?, ?>) processorSupplier;
-        tableRepartitionMap.setUseVersionedSemantics(useVersionedSemantics);
+        final SubscriptionSendProcessorSupplier<?, ?, ?> subscriptionSendProcessor
+            = (SubscriptionSendProcessorSupplier<?, ?, ?>) processorSupplier;
+        subscriptionSendProcessor.setUseVersionedSemantics(useVersionedSemantics);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ForeignTableJoinNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ForeignTableJoinNode.java
@@ -22,11 +22,11 @@ import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.ForeignTableJoi
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.state.StoreBuilder;
 
-public class ForeignJoinSubscriptionNode<K, V> extends StatefulProcessorNode<K, V> implements VersionedSemanticsGraphNode {
+public class ForeignTableJoinNode<K, V> extends StatefulProcessorNode<K, V> implements VersionedSemanticsGraphNode {
 
-    public ForeignJoinSubscriptionNode(final ProcessorParameters<K, V, ?, ?> processorParameters,
-                                       final Set<StoreBuilder<?>> preRegisteredStores,
-                                       final Set<KTableValueGetterSupplier<?, ?>> valueGetterSuppliers) {
+    public ForeignTableJoinNode(final ProcessorParameters<K, V, ?, ?> processorParameters,
+                                final Set<StoreBuilder<?>> preRegisteredStores,
+                                final Set<KTableValueGetterSupplier<?, ?>> valueGetterSuppliers) {
         super(processorParameters, preRegisteredStores, valueGetterSuppliers);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableFilterNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableFilterNode.java
@@ -31,7 +31,7 @@ public class TableFilterNode<K, V> extends TableProcessorNode<K, V> implements V
 
     @SuppressWarnings("unchecked")
     @Override
-    public void enableVersionedSemantics(final boolean useVersionedSemantics) {
+    public void enableVersionedSemantics(final boolean useVersionedSemantics, final String parentNodeName) {
         final ProcessorSupplier<K, V, ?, ?> processorSupplier = processorParameters().processorSupplier();
         if (!(processorSupplier instanceof KTableFilter)) {
             throw new IllegalStateException("Unexpected processor type for table filter: " + processorSupplier.getClass().getName());

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/VersionedSemanticsGraphNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/VersionedSemanticsGraphNode.java
@@ -28,6 +28,6 @@ public interface VersionedSemanticsGraphNode {
     /**
      * @param useVersionedSemantics whether versioned semantics should be enabled
      */
-    void enableVersionedSemantics(final boolean useVersionedSemantics);
+    void enableVersionedSemantics(boolean useVersionedSemantics, String parentNodeName);
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.integration;
 
+import java.util.Collections;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
@@ -202,6 +203,9 @@ public abstract class AbstractJoinIntegrationTest {
                     final List<TestRecord<Long, String>> output = outputTopic.readRecordsToList();
                     assertThat(output, equalTo(updatedExpected));
                     expectedFinalResult = updatedExpected.get(expected.size() - 1);
+                } else {
+                    final List<TestRecord<Long, String>> output = outputTopic.readRecordsToList();
+                    assertThat(output, equalTo(Collections.emptyList()));
                 }
             }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
@@ -87,7 +87,37 @@ public abstract class AbstractJoinIntegrationTest {
 
     StreamsBuilder builder;
 
-    private final List<Input<String>> input = Arrays.asList(
+    protected final List<Input<String>> input = Arrays.asList(
+        new Input<>(INPUT_TOPIC_LEFT, null, 1),
+        new Input<>(INPUT_TOPIC_RIGHT, null, 2),
+        new Input<>(INPUT_TOPIC_LEFT, "A", 3),
+        new Input<>(INPUT_TOPIC_RIGHT, "a", 4),
+        new Input<>(INPUT_TOPIC_LEFT, "B", 5),
+        new Input<>(INPUT_TOPIC_RIGHT, "b", 6),
+        new Input<>(INPUT_TOPIC_LEFT, null, 7),
+        new Input<>(INPUT_TOPIC_RIGHT, null, 8),
+        new Input<>(INPUT_TOPIC_LEFT, "C", 9),
+        new Input<>(INPUT_TOPIC_RIGHT, "c", 10),
+        new Input<>(INPUT_TOPIC_RIGHT, null, 11),
+        new Input<>(INPUT_TOPIC_LEFT, null, 12),
+        new Input<>(INPUT_TOPIC_RIGHT, null, 13),
+        new Input<>(INPUT_TOPIC_RIGHT, "d", 7), // out-of-order data with null as latest
+        new Input<>(INPUT_TOPIC_LEFT, "D", 6),
+        new Input<>(INPUT_TOPIC_LEFT, null, 2),
+        new Input<>(INPUT_TOPIC_RIGHT, null, 3),
+        new Input<>(INPUT_TOPIC_RIGHT, "e", 14),
+        new Input<>(INPUT_TOPIC_LEFT, "E", 15),
+        new Input<>(INPUT_TOPIC_LEFT, null, 10), // out-of-order data with non-null as latest
+        new Input<>(INPUT_TOPIC_RIGHT, null, 9),
+        new Input<>(INPUT_TOPIC_LEFT, "F", 4),
+        new Input<>(INPUT_TOPIC_RIGHT, "f", 3)
+    );
+
+    // used for stream-stream join tests where out-of-order data does not meaningfully affect
+    // the result, and the main `input` list results in too many result records/test noise.
+    // also used for table-table multi-join tests, since out-of-order data with table-table
+    // joins is already tested in non-multi-join settings.
+    protected final List<Input<String>> inputWithoutOutOfOrderData = Arrays.asList(
         new Input<>(INPUT_TOPIC_LEFT, null, 1),
         new Input<>(INPUT_TOPIC_RIGHT, null, 2),
         new Input<>(INPUT_TOPIC_LEFT, "A", 3),
@@ -102,13 +132,10 @@ public abstract class AbstractJoinIntegrationTest {
         new Input<>(INPUT_TOPIC_LEFT, null, 12),
         new Input<>(INPUT_TOPIC_RIGHT, null, 13),
         new Input<>(INPUT_TOPIC_RIGHT, "d", 14),
-        new Input<>(INPUT_TOPIC_LEFT, "D", 15),
-        new Input<>(INPUT_TOPIC_LEFT, "E", 4), // out-of-order data
-        new Input<>(INPUT_TOPIC_RIGHT, "e", 3),
-        new Input<>(INPUT_TOPIC_RIGHT, "f", 7),
-        new Input<>(INPUT_TOPIC_LEFT, "F", 8)
+        new Input<>(INPUT_TOPIC_LEFT, "D", 15)
     );
 
+    // used for stream-stream self joins where only one input topic is needed
     private final List<Input<String>> leftInput = Arrays.asList(
         new Input<>(INPUT_TOPIC_LEFT, null, 1),
         new Input<>(INPUT_TOPIC_LEFT, "A", 2),
@@ -144,11 +171,11 @@ public abstract class AbstractJoinIntegrationTest {
         STREAMS_CONFIG.put(StreamsConfig.STATE_DIR_CONFIG, testFolder.getRoot().getPath());
     }
 
-    void runTestWithDriver(final List<List<TestRecord<Long, String>>> expectedResult) {
-        runTestWithDriver(expectedResult, null);
+    void runTestWithDriver(final List<Input<String>> input, final List<List<TestRecord<Long, String>>> expectedResult) {
+        runTestWithDriver(input, expectedResult, null);
     }
 
-    void runTestWithDriver(final List<List<TestRecord<Long, String>>> expectedResult, final String storeName) {
+    void runTestWithDriver(final List<Input<String>> input, final List<List<TestRecord<Long, String>>> expectedResult, final String storeName) {
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(STREAMS_CONFIG), STREAMS_CONFIG)) {
             final TestInputTopic<Long, String> right = driver.createInputTopic(INPUT_TOPIC_RIGHT, new LongSerializer(), new StringSerializer());
             final TestInputTopic<Long, String> left = driver.createInputTopic(INPUT_TOPIC_LEFT, new LongSerializer(), new StringSerializer());
@@ -184,7 +211,7 @@ public abstract class AbstractJoinIntegrationTest {
         }
     }
 
-    void runTestWithDriver(final TestRecord<Long, String> expectedFinalResult, final String storeName) throws InterruptedException {
+    void runTestWithDriver(final List<Input<String>> input, final TestRecord<Long, String> expectedFinalResult, final String storeName) throws InterruptedException {
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(STREAMS_CONFIG), STREAMS_CONFIG)) {
             final TestInputTopic<Long, String> right = driver.createInputTopic(INPUT_TOPIC_RIGHT, new LongSerializer(), new StringSerializer());
             final TestInputTopic<Long, String> left = driver.createInputTopic(INPUT_TOPIC_LEFT, new LongSerializer(), new StringSerializer());
@@ -258,7 +285,7 @@ public abstract class AbstractJoinIntegrationTest {
         }
     }
 
-    private static final class Input<V> {
+    protected static final class Input<V> {
         String topic;
         KeyValue<Long, V> record;
         long timestamp;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamStreamJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamStreamJoinIntegrationTest.java
@@ -137,31 +137,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-a", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-b", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-c", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-a", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-b", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-d", null, 14L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-e", null, 3L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-e", null, 5L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-e", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-e", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-f", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-f", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-e", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-a", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-b", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-d", null, 14L))
+                new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L))
         );
 
         leftStream.join(
@@ -170,7 +146,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
             JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
         ).to(OUTPUT_TOPIC);
 
-        runTestWithDriver(expectedResult);
+        runTestWithDriver(inputWithoutOutOfOrderData, expectedResult);
     }
 
     @Test
@@ -206,31 +182,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-a", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-b", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-c", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-a", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-b", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-d", null, 14L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-e", null, 3L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-e", null, 5L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-e", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-e", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-f", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-f", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-e", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-a", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-b", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-d", null, 14L))
+                new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L))
         );
 
         leftStream.map(MockMapper.noOpKeyValueMapper())
@@ -241,7 +193,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
             ).to(OUTPUT_TOPIC);
 
-        runTestWithDriver(expectedResult);
+        runTestWithDriver(inputWithoutOutOfOrderData, expectedResult);
     }
 
     @Test
@@ -277,31 +229,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-a", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-b", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-c", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-a", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-b", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-d", null, 14L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-e", null, 3L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-e", null, 5L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-e", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-e", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-f", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-f", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-e", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-a", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-b", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-d", null, 14L))
+                new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L))
         );
 
         leftStream.leftJoin(
@@ -310,7 +238,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
             JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
         ).to(OUTPUT_TOPIC);
 
-        runTestWithDriver(expectedResult);
+        runTestWithDriver(inputWithoutOutOfOrderData, expectedResult);
     }
 
     @Test
@@ -346,31 +274,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-a", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-b", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-c", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-a", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-b", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-d", null, 14L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-e", null, 3L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-e", null, 5L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-e", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-e", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-f", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-f", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-e", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-a", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-b", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-d", null, 14L))
+                new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L))
         );
 
         leftStream.map(MockMapper.noOpKeyValueMapper())
@@ -381,7 +285,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
             ).to(OUTPUT_TOPIC);
 
-        runTestWithDriver(expectedResult);
+        runTestWithDriver(inputWithoutOutOfOrderData, expectedResult);
     }
 
     @Test
@@ -417,31 +321,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-a", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-b", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-c", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-a", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-b", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-d", null, 14L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-e", null, 3L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-e", null, 5L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-e", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-e", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-f", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-f", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-e", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-a", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-b", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-d", null, 14L))
+                new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L))
         );
 
         leftStream.outerJoin(
@@ -450,7 +330,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
             JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
         ).to(OUTPUT_TOPIC);
 
-        runTestWithDriver(expectedResult);
+        runTestWithDriver(inputWithoutOutOfOrderData, expectedResult);
     }
 
     @Test
@@ -486,31 +366,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-a", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-b", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-c", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-a", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-b", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-d", null, 14L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-e", null, 3L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-e", null, 5L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-e", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-e", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-f", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-f", null, 15L)),
-            Arrays.asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-e", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-a", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-b", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-d", null, 14L))
+                new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L))
         );
 
         leftStream.map(MockMapper.noOpKeyValueMapper())
@@ -521,7 +377,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
             ).to(OUTPUT_TOPIC);
 
-        runTestWithDriver(expectedResult);
+        runTestWithDriver(inputWithoutOutOfOrderData, expectedResult);
     }
 
     @Test
@@ -548,7 +404,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 new TestRecord<>(ANY_UNIQUE_KEY, "C-a-b", null, 9L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "C-b-a", null, 9L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "C-b-b", null, 9L)),
-            Arrays.<TestRecord<Long, String>>asList(
+            Arrays.asList(
                 new TestRecord<>(ANY_UNIQUE_KEY, "A-c-a", null, 10L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "A-c-b", null, 10L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "B-c-a", null, 10L),
@@ -567,7 +423,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
             null,
             null,
             null,
-            Arrays.<TestRecord<Long, String>>asList(
+            Arrays.asList(
                 new TestRecord<>(ANY_UNIQUE_KEY, "A-d-a", null, 14L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "A-d-b", null, 14L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "A-d-c", null, 14L),
@@ -589,7 +445,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 new TestRecord<>(ANY_UNIQUE_KEY, "A-d-d", null, 14L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "B-d-d", null, 14L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "C-d-d", null, 14L)),
-            Arrays.<TestRecord<Long, String>>asList(
+            Arrays.asList(
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-a-a", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-a-b", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-a-c", null, 15L),
@@ -605,163 +461,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-d-a", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-d-b", null, 15L),
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-d-c", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null, 15L)),
-            Arrays.<TestRecord<Long, String>>asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-a-a", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-a-b", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-a-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-a-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-b-a", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-b-b", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-b-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-b-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-c-a", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-c-b", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-c-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-c-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-d-a", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-d-b", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-d-c", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-d-d", null, 14L)),
-            Arrays.<TestRecord<Long, String>>asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-e-a", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-e-b", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-e-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-e-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-e-a", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-e-b", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-e-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-e-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-e-a", null, 5L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-e-b", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-e-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-e-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-e-a", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-e-b", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-e-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-e-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-e-a", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-e-b", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-e-c", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-e-d", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-e-e", null, 3L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-a-e", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-a-e", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null, 4L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-a-e", null, 5L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-e-e", null, 5L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-b-e", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-b-e", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-b-e", null, 6L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-a-e", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-b-e", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-e-e", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-c-e", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-c-e", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-c-e", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-c-e", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-d-e", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-d-e", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-d-e", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-d-e", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-a-e", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-b-e", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-c-e", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-d-e", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-e-e", null, 15L)),
-            Arrays.<TestRecord<Long, String>>asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-f-e", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-f-a", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-f-b", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-f-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-f-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-f-e", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-f-a", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-f-b", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-f-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-f-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-f-e", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-f-a", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-f-b", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-f-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-f-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-f-e", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-f-a", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-f-b", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-f-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-f-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-f-e", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-f-a", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-f-b", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-f-c", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-f-d", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-e-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-a-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-a-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-e-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-a-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-e-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-b-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-b-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-b-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-f-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-f-f", null, 7L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-a-f", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-b-f", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-e-f", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-f-f", null, 9L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-c-f", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-c-f", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-c-f", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-c-f", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "A-d-f", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "B-d-f", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "C-d-f", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "E-d-f", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-a-f", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-b-f", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-c-f", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-d-f", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-e-f", null, 15L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "D-f-f", null, 15L)),
-            Arrays.<TestRecord<Long, String>>asList(
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-e-e", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-e-a", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-e-b", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-e-f", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-e-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-e-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-a-e", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-a-a", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-a-b", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-a-f", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-a-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-a-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-b-e", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-b-a", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-b-b", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-b-f", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-b-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-b-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-f-e", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-f-a", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-f-b", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-f-f", null, 8L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-f-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-f-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-c-e", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-c-a", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-c-b", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-c-f", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-c-c", null, 10L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-c-d", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-d-e", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-d-a", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-d-b", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-d-f", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-d-c", null, 14L),
-                new TestRecord<>(ANY_UNIQUE_KEY, "F-d-d", null, 14L))
+                new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null, 15L))
         );
 
         leftStream.join(
@@ -774,6 +474,6 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
             JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
         ).to(OUTPUT_TOPIC);
 
-        runTestWithDriver(expectedResult);
+        runTestWithDriver(inputWithoutOutOfOrderData, expectedResult);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamTableJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamTableJoinIntegrationTest.java
@@ -87,14 +87,18 @@ public class StreamTableJoinIntegrationTest extends AbstractJoinIntegrationTest 
             null,
             null,
             null,
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  15L)),
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d", null,  4L)),
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  6L)),
             null,
             null,
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null,  8L))
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+            null,
+            null,
+            null,
+            null
         );
 
-        runTestWithDriver(expectedResult);
+        runTestWithDriver(input, expectedResult);
     }
 
     @Test
@@ -120,14 +124,18 @@ public class StreamTableJoinIntegrationTest extends AbstractJoinIntegrationTest 
             null,
             null,
             null,
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L)),
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d", null,  4L)),
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 6L)),
             null,
             null,
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null,  8L))
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-null", null,  4L)),
+            null
         );
 
-        runTestWithDriver(expectedResult);
+        runTestWithDriver(input, expectedResult);
     }
 
     @Test
@@ -154,14 +162,18 @@ public class StreamTableJoinIntegrationTest extends AbstractJoinIntegrationTest 
             null,
             null,
             null,
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  15L)),
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-a", null,  4L)),
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-b", null,  6L)),
             null,
             null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-a", null,  4L)),
             null
         );
 
-        runTestWithDriver(expectedResult);
+        runTestWithDriver(input, expectedResult);
     }
 
     @Test
@@ -188,13 +200,17 @@ public class StreamTableJoinIntegrationTest extends AbstractJoinIntegrationTest 
             null,
             null,
             null,
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L)),
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-a", null,  4L)),
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-b", null, 6L)),
             null,
             null,
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-null", null,  8L))
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-a", null,  4L)),
+            null
         );
 
-        runTestWithDriver(expectedResult);
+        runTestWithDriver(input, expectedResult);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TableTableJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TableTableJoinIntegrationTest.java
@@ -63,11 +63,10 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
         builder = new StreamsBuilder();
     }
 
-    private final TestRecord<Long, String> expectedFinalJoinResultUnversioned = new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null, 8L);
-    private final TestRecord<Long, String> expectedFinalJoinResultVersioned = new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L);
-    private final TestRecord<Long, String> expectedFinalJoinResultLeftVersionedOnly = new TestRecord<>(ANY_UNIQUE_KEY, "D-f", null, 15L);
-    private final TestRecord<Long, String> expectedFinalJoinResultRightVersionedOnly = new TestRecord<>(ANY_UNIQUE_KEY, "F-d", null, 14L);
-    private final TestRecord<Long, String> expectedFinalMultiJoinResult = new TestRecord<>(ANY_UNIQUE_KEY, "F-f-f", null,  8L);
+    private final TestRecord<Long, String> expectedFinalJoinResultUnversioned = new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null, 4L);
+    private final TestRecord<Long, String> expectedFinalJoinResultLeftVersionedOnly = new TestRecord<>(ANY_UNIQUE_KEY, "E-f", null, 15L);
+    private final TestRecord<Long, String> expectedFinalJoinResultRightVersionedOnly = new TestRecord<>(ANY_UNIQUE_KEY, "F-e", null, 14L);
+    private final TestRecord<Long, String> expectedFinalMultiJoinResult = new TestRecord<>(ANY_UNIQUE_KEY, "F-f-f", null,  4L);
     private final String storeName = appID + "-store";
 
     private final Materialized<Long, String, KeyValueStore<Bytes, byte[]>> materialized = Materialized.<Long, String, KeyValueStore<Bytes, byte[]>>as(storeName)
@@ -85,7 +84,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
         leftTable.join(rightTable, valueJoiner, materialized).toStream().to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalJoinResultUnversioned, storeName);
+            runTestWithDriver(input, expectedFinalJoinResultUnversioned, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -102,14 +101,18 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 null,
                 null,
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d", null,  14L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  4L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-f", null,  7L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null,  8L))
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  7L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  7L)),
+                null,
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  14L)),
+                null,
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null,  4L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(input, expectedResult, storeName);
         }
     }
 
@@ -122,7 +125,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
         leftTable.leftJoin(rightTable, valueJoiner, materialized).toStream().to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalJoinResultUnversioned, storeName);
+            runTestWithDriver(input, expectedFinalJoinResultUnversioned, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -139,14 +142,18 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  12L)),
                 null,
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d", null,  14L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  4L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-f", null,  7L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null,  8L))
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  7L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  7L)),
+                null,
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  14L)),
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-null", null,  4L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null,  4L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(input, expectedResult, storeName);
         }
     }
 
@@ -159,7 +166,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
         leftTable.outerJoin(rightTable, valueJoiner, materialized).toStream().to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalJoinResultUnversioned, storeName);
+            runTestWithDriver(input, expectedFinalJoinResultUnversioned, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -175,15 +182,19 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "C-null", null,  11L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  12L)),
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-d", null, 14L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d", null,  14L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  4L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-f", null,  7L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null,  8L))
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-d", null, 7L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  7L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-d", null, 7L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  3L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-e", null, 14L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-e", null, 14L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  9L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-null", null,  4L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f", null,  4L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(input, expectedResult, storeName);
         }
     }
 
@@ -215,14 +226,19 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
             null,
             null,
             null,
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  15L)),
+            null,
+            null,
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
             null,
             null,
             null,
             null
         );
 
-        runTestWithDriver(expectedResult, storeName);
+        runTestWithDriver(input, expectedResult, storeName);
     }
 
     @Test
@@ -253,14 +269,18 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
             Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  12L)),
             null,
             null,
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  15L)),
+            null,
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
             null,
             null,
             null,
             null
         );
 
-        runTestWithDriver(expectedResult, storeName);
+        runTestWithDriver(input, expectedResult, storeName);
     }
 
     @Test
@@ -290,15 +310,19 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
             Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "C-null", null,  11L)),
             Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  12L)),
             null,
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-d", null, 14L)),
-            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  15L)),
+            null,
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-e", null, 14L)),
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
             null,
             null,
             null,
             null
         );
 
-        runTestWithDriver(expectedResult, storeName);
+        runTestWithDriver(input, expectedResult, storeName);
     }
 
     @Test
@@ -312,7 +336,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
         leftTable.join(rightTable, valueJoiner, materialized).toStream().to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalJoinResultLeftVersionedOnly, storeName);
+            runTestWithDriver(input, expectedFinalJoinResultLeftVersionedOnly, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -329,14 +353,18 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 null,
                 null,
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  15L)),
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-e", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-f", null,  15L)),
-                null
+                null,
+                null,
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  15L)),
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-f", null,  15L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(input, expectedResult, storeName);
         }
     }
 
@@ -351,7 +379,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
         leftTable.leftJoin(rightTable, valueJoiner, materialized).toStream().to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalJoinResultLeftVersionedOnly, storeName);
+            runTestWithDriver(input, expectedFinalJoinResultLeftVersionedOnly, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -368,14 +396,18 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  12L)),
                 null,
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  15L)),
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-e", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-f", null,  15L)),
-                null
+                null,
+                null,
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-null", null,  15L)),
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-f", null,  15L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(input, expectedResult, storeName);
         }
     }
 
@@ -390,31 +422,35 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
         leftTable.outerJoin(rightTable, valueJoiner, materialized).toStream().to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalJoinResultLeftVersionedOnly, storeName);
+            runTestWithDriver(input, expectedFinalJoinResultLeftVersionedOnly, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "A-null", null,  3L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "A-a", null,  4L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-a", null,  5L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-b", null,  6L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "A-null", null, 3L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "A-a", null, 4L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-a", null, 5L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-b", null, 6L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-b", null, 7L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  8L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "C-null", null,  9L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "C-c", null,  10L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "C-null", null,  11L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  12L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null, 8L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "C-null", null, 9L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "C-c", null, 10L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "C-null", null, 11L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null, 12L)),
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-d", null, 14L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  15L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-d", null, 7L)),
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-e", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-f", null,  15L)),
-                null
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null, 3L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-e", null, 14L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null, 15L)),
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-null", null, 15L)),
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-f", null, 15L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(input, expectedResult, storeName);
         }
     }
 
@@ -429,7 +465,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
         leftTable.join(rightTable, valueJoiner, materialized).toStream().to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalJoinResultRightVersionedOnly, storeName);
+            runTestWithDriver(input, expectedFinalJoinResultRightVersionedOnly, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -446,14 +482,18 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 null,
                 null,
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d", null,  14L)),
                 null,
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-d", null,  14L))
+                null,
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  14L)),
+                null,
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-e", null,  14L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(input, expectedResult, storeName);
         }
     }
 
@@ -468,7 +508,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
         leftTable.leftJoin(rightTable, valueJoiner, materialized).toStream().to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalJoinResultRightVersionedOnly, storeName);
+            runTestWithDriver(input, expectedFinalJoinResultRightVersionedOnly, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -485,14 +525,18 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  12L)),
                 null,
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d", null,  14L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-null", null,  6L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  2L)),
                 null,
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-d", null,  14L))
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  14L)),
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-e", null,  14L)),
+                null
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(input, expectedResult, storeName);
         }
     }
 
@@ -507,7 +551,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
         leftTable.outerJoin(rightTable, valueJoiner, materialized).toStream().to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalJoinResultRightVersionedOnly, storeName);
+            runTestWithDriver(input, expectedFinalJoinResultRightVersionedOnly, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -523,15 +567,19 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "C-null", null,  11L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  12L)),
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-d", null, 14L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d", null,  14L)),
                 null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-null", null,  6L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  2L)),
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-d", null,  14L))
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-e", null,  14L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-e", null,  14L)),
+                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-e", null,  14L)),
+                null
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(input, expectedResult, storeName);
         }
     }
 
@@ -547,7 +595,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                  .to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalMultiJoinResult, storeName);
+            runTestWithDriver(input, expectedFinalMultiJoinResult, storeName);
         } else {
             // TODO K6443: the duplicate below for all the multi-joins are due to
             //             KAFKA-6443, should be updated once it is fixed.
@@ -573,18 +621,10 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 null,
                 null,
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d-d", null,  14L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f-f", null,  8L))
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(inputWithoutOutOfOrderData, expectedResult, storeName);
         }
     }
 
@@ -600,7 +640,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                  .to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalMultiJoinResult, storeName);
+            runTestWithDriver(input, expectedFinalMultiJoinResult, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -623,18 +663,10 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 null,
                 null,
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d-d", null,  14L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f-f", null,  8L))
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(inputWithoutOutOfOrderData, expectedResult, storeName);
         }
     }
 
@@ -650,7 +682,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                  .to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalMultiJoinResult, storeName);
+            runTestWithDriver(input, expectedFinalMultiJoinResult, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -678,18 +710,10 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 Arrays.asList(
                     // incorrect result `null-d` is caused by self-join of `rightTable`
                     new TestRecord<>(ANY_UNIQUE_KEY, "null-d", null, 14L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d-d", null,  14L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f-f", null,  8L))
+                    new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(inputWithoutOutOfOrderData, expectedResult, storeName);
         }
     }
 
@@ -705,7 +729,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                  .to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalMultiJoinResult, storeName);
+            runTestWithDriver(input, expectedFinalMultiJoinResult, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -728,18 +752,10 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 null,
                 null,
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d-d", null,  14L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f-f", null,  8L))
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(inputWithoutOutOfOrderData, expectedResult, storeName);
         }
     }
 
@@ -755,7 +771,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                  .to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalMultiJoinResult, storeName);
+            runTestWithDriver(input, expectedFinalMultiJoinResult, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -782,18 +798,10 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  12L)),
                 null,
                 null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d-d", null,  14L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f-f", null,  8L))
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(inputWithoutOutOfOrderData, expectedResult, storeName);
         }
     }
 
@@ -809,7 +817,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                  .to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalMultiJoinResult, storeName);
+            runTestWithDriver(input, expectedFinalMultiJoinResult, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -838,18 +846,10 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 null,
                 Arrays.asList(
                     new TestRecord<>(ANY_UNIQUE_KEY, "null-d", null, 14L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d-d", null,  14L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f-f", null,  8L))
+                    new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(inputWithoutOutOfOrderData, expectedResult, storeName);
         }
     }
 
@@ -865,7 +865,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                  .to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalMultiJoinResult, storeName);
+            runTestWithDriver(input, expectedFinalMultiJoinResult, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -890,18 +890,10 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 Arrays.asList(
                     new TestRecord<>(ANY_UNIQUE_KEY, "null-d-d", null, 14L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "null-d-d", null, 14L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d-d", null,  14L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f-f", null,  8L))
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(inputWithoutOutOfOrderData, expectedResult, storeName);
         }
     }
 
@@ -917,7 +909,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                  .to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalMultiJoinResult, storeName);
+            runTestWithDriver(input, expectedFinalMultiJoinResult, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -946,18 +938,10 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 Arrays.asList(
                     new TestRecord<>(ANY_UNIQUE_KEY, "null-d-d", null, 14L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "null-d-d", null, 14L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d-d", null,  14L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f-f", null,  8L))
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
             );
 
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(inputWithoutOutOfOrderData, expectedResult, storeName);
         }
     }
 
@@ -973,7 +957,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                  .to(OUTPUT_TOPIC);
 
         if (cacheEnabled) {
-            runTestWithDriver(expectedFinalMultiJoinResult, storeName);
+            runTestWithDriver(input, expectedFinalMultiJoinResult, storeName);
         } else {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
@@ -1004,17 +988,9 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 Arrays.asList(
                     new TestRecord<>(ANY_UNIQUE_KEY, "null-d-d", null,  14L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "null-d-d", null,  14L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-d-d", null,  14L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-e-e", null,  4L)),
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "E-f-f", null,  7L)),
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-f-f", null,  8L))
+                    new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
             );
-            runTestWithDriver(expectedResult, storeName);
+            runTestWithDriver(inputWithoutOutOfOrderData, expectedResult, storeName);
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TableTableJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TableTableJoinIntegrationTest.java
@@ -705,11 +705,9 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                     new TestRecord<>(ANY_UNIQUE_KEY, null, null,  11L)),
                 null,
                 null,
-                null,
-                Arrays.asList(
-                    // incorrect result `null-d` is caused by self-join of `rightTable`
-                    new TestRecord<>(ANY_UNIQUE_KEY, "null-d", null, 14L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
+                // incorrect result `null-d` is caused by self-join of `rightTable`
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-d", null, 14L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
             );
 
             runTestWithDriver(inputWithoutOutOfOrderData, expectedResult, storeName);
@@ -775,9 +773,8 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
                 null,
-                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "A-null-null", null,  3L)),
                 Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "A-null-null", null,  3L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "A-a-a", null,  4L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "A-a-a", null,  4L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-a-a", null,  5L)),
@@ -786,9 +783,8 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                     new TestRecord<>(ANY_UNIQUE_KEY, "B-b-b", null,  6L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  7L)),
                 null,
-                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "C-null-null", null,  9L)),
                 Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "C-null-null", null,  9L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "C-c-c", null,  10L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "C-c-c", null,  10L)),
                 Arrays.asList(
@@ -821,9 +817,8 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
                 null,
-                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "A-null-null", null,  3L)),
                 Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "A-null-null", null,  3L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "A-a-a", null,  4L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "A-a-a", null,  4L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-a-a", null,  5L)),
@@ -832,9 +827,8 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                     new TestRecord<>(ANY_UNIQUE_KEY, "B-b-b", null,  6L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-b", null, 7L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  8L)),
-                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "C-null-null", null,  9L)),
                 Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "C-null-null", null,  9L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "C-c-c", null,  10L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "C-c-c", null,  10L)),
                 Arrays.asList(
@@ -842,10 +836,8 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                     new TestRecord<>(ANY_UNIQUE_KEY, "C-null-null", null,  11L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  12L)),
                 null,
-                null,
-                Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "null-d", null, 14L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-d", null, 14L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
             );
 
             runTestWithDriver(inputWithoutOutOfOrderData, expectedResult, storeName);
@@ -913,9 +905,8 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
                 null,
-                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "A-null-null", null,  3L)),
                 Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "A-null-null", null,  3L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "A-a-a", null,  4L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "A-a-a", null,  4L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-a-a", null,  5L)),
@@ -924,9 +915,8 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                     new TestRecord<>(ANY_UNIQUE_KEY, "B-b-b", null,  6L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "null-b-b", null, 7L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  8L)),
-                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "C-null-null", null,  9L)),
                 Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "C-null-null", null,  9L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "C-c-c", null,  10L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "C-c-c", null,  10L)),
                 Arrays.asList(
@@ -961,9 +951,8 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
             final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
                 null,
                 null,
-                null,
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "A-null-null", null,  3L)),
                 Arrays.asList(
-                    new TestRecord<>(ANY_UNIQUE_KEY, "A-null-null", null,  3L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "A-a-a", null,  4L),
                     new TestRecord<>(ANY_UNIQUE_KEY, "A-a-a", null,  4L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-a-a", null,  5L)),
@@ -983,11 +972,10 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                     new TestRecord<>(ANY_UNIQUE_KEY, "C-null-null", null,  11L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  12L)),
                 null,
-                null,
                 Arrays.asList(
                     new TestRecord<>(ANY_UNIQUE_KEY, "null-d-d", null,  14L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "null-d-d", null,  14L),
-                    new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
+                    new TestRecord<>(ANY_UNIQUE_KEY, "null-d-d", null,  14L)),
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null,  15L))
             );
             runTestWithDriver(inputWithoutOutOfOrderData, expectedResult, storeName);
         }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TableTableJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TableTableJoinIntegrationTest.java
@@ -230,7 +230,6 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
             null,
             null,
             null,
-            null,
             Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
             null,
             null,
@@ -489,8 +488,8 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
                 Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, null, null,  14L)),
                 null,
-                null,
-                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-e", null,  14L))
+                Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-e", null,  14L)),
+                null
             );
 
             runTestWithDriver(input, expectedResult, storeName);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
@@ -35,7 +35,7 @@ import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.ForeignTableJoinProcessorSupplier;
 import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionSendProcessorSupplier;
-import org.apache.kafka.streams.kstream.internals.graph.ForeignJoinSubscriptionNode;
+import org.apache.kafka.streams.kstream.internals.graph.ForeignTableJoinNode;
 import org.apache.kafka.streams.kstream.internals.graph.ForeignJoinSubscriptionSendNode;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.KTableKTableJoinNode;
@@ -1110,9 +1110,9 @@ public class InternalStreamsBuilderTest {
         assertNotNull(joinThis);
         verifyVersionedSemantics((ForeignJoinSubscriptionSendNode<?, ?>) joinThis, true);
 
-        final GraphNode joinOther = getNodeByType(builder.root, ForeignJoinSubscriptionNode.class, new HashSet<>());
+        final GraphNode joinOther = getNodeByType(builder.root, ForeignTableJoinNode.class, new HashSet<>());
         assertNotNull(joinOther);
-        verifyVersionedSemantics((ForeignJoinSubscriptionNode<?, ?>) joinOther, true);
+        verifyVersionedSemantics((ForeignTableJoinNode<?, ?>) joinOther, true);
     }
 
     @Test
@@ -1134,9 +1134,9 @@ public class InternalStreamsBuilderTest {
         assertNotNull(joinThis);
         verifyVersionedSemantics((ForeignJoinSubscriptionSendNode<?, ?>) joinThis, true);
 
-        final GraphNode joinOther = getNodeByType(builder.root, ForeignJoinSubscriptionNode.class, new HashSet<>());
+        final GraphNode joinOther = getNodeByType(builder.root, ForeignTableJoinNode.class, new HashSet<>());
         assertNotNull(joinOther);
-        verifyVersionedSemantics((ForeignJoinSubscriptionNode<?, ?>) joinOther, false);
+        verifyVersionedSemantics((ForeignTableJoinNode<?, ?>) joinOther, false);
     }
 
     @Test
@@ -1158,9 +1158,9 @@ public class InternalStreamsBuilderTest {
         assertNotNull(joinThis);
         verifyVersionedSemantics((ForeignJoinSubscriptionSendNode<?, ?>) joinThis, false);
 
-        final GraphNode joinOther = getNodeByType(builder.root, ForeignJoinSubscriptionNode.class, new HashSet<>());
+        final GraphNode joinOther = getNodeByType(builder.root, ForeignTableJoinNode.class, new HashSet<>());
         assertNotNull(joinOther);
-        verifyVersionedSemantics((ForeignJoinSubscriptionNode<?, ?>) joinOther, true);
+        verifyVersionedSemantics((ForeignTableJoinNode<?, ?>) joinOther, true);
     }
 
     @Test
@@ -1179,9 +1179,9 @@ public class InternalStreamsBuilderTest {
         assertNotNull(joinThis);
         verifyVersionedSemantics((ForeignJoinSubscriptionSendNode<?, ?>) joinThis, true);
 
-        final GraphNode joinOther = getNodeByType(builder.root, ForeignJoinSubscriptionNode.class, new HashSet<>());
+        final GraphNode joinOther = getNodeByType(builder.root, ForeignTableJoinNode.class, new HashSet<>());
         assertNotNull(joinOther);
-        verifyVersionedSemantics((ForeignJoinSubscriptionNode<?, ?>) joinOther, true);
+        verifyVersionedSemantics((ForeignTableJoinNode<?, ?>) joinOther, true);
     }
 
     private void verifyVersionedSemantics(final TableFilterNode<?, ?> filterNode, final boolean expectedValue) {
@@ -1217,7 +1217,7 @@ public class InternalStreamsBuilderTest {
         assertEquals(expectedValue, joinThis.isUseVersionedSemantics());
     }
 
-    private void verifyVersionedSemantics(final ForeignJoinSubscriptionNode<?, ?> joinOtherNode, final boolean expectedValue) {
+    private void verifyVersionedSemantics(final ForeignTableJoinNode<?, ?> joinOtherNode, final boolean expectedValue) {
         final ProcessorSupplier<?, ?, ?, ?> otherProcessorSupplier = joinOtherNode.processorParameters().processorSupplier();
         assertTrue(otherProcessorSupplier instanceof ForeignTableJoinProcessorSupplier);
         final ForeignTableJoinProcessorSupplier<?, ?, ?> joinThis = (ForeignTableJoinProcessorSupplier<?, ?, ?>) otherProcessorSupplier;

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
@@ -33,7 +33,12 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.ForeignTableJoinProcessorSupplier;
+import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionSendProcessorSupplier;
+import org.apache.kafka.streams.kstream.internals.graph.ForeignJoinSubscriptionNode;
+import org.apache.kafka.streams.kstream.internals.graph.ForeignJoinSubscriptionSendNode;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.KTableKTableJoinNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamStreamJoinNode;
 import org.apache.kafka.streams.kstream.internals.graph.TableFilterNode;
 import org.apache.kafka.streams.kstream.internals.graph.TableRepartitionMapNode;
@@ -1009,6 +1014,176 @@ public class InternalStreamsBuilderTest {
         verifyVersionedSemantics((TableRepartitionMapNode<?, ?>) repartitionMap, true);
     }
 
+    @Test
+    public void shouldSetUseVersionedSemanticsOnTableJoin() {
+        // Given:
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> versionedMaterialize =
+            new MaterializedInternal<>(Materialized.as(Stores.persistentVersionedKeyValueStore("versioned", Duration.ofMinutes(5))), builder, storePrefix);
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> versionedMaterialize2 =
+            new MaterializedInternal<>(Materialized.as(Stores.persistentVersionedKeyValueStore("versioned2", Duration.ofMinutes(5))), builder, storePrefix);
+        final KTable<String, String> table1 = builder.table("t1", consumed, versionedMaterialize);
+        final KTable<String, String> table2 = builder.table("t2", consumed, versionedMaterialize2);
+        table1.join(table2, (v1, v2) -> v1 + v2);
+
+        // When:
+        builder.buildAndOptimizeTopology();
+
+        // Then:
+        final GraphNode join = getNodeByType(builder.root, KTableKTableJoinNode.class, new HashSet<>());
+        assertNotNull(join);
+        verifyVersionedSemantics((KTableKTableJoinNode<?, ?, ?, ?>) join, true, true);
+    }
+
+    @Test
+    public void shouldSetUseVersionedSemanticsOnTableJoinLeftOnly() {
+        // Given:
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> versionedMaterialize =
+            new MaterializedInternal<>(Materialized.as(Stores.persistentVersionedKeyValueStore("versioned", Duration.ofMinutes(5))), builder, storePrefix);
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> unversionedMaterialize =
+            new MaterializedInternal<>(Materialized.as("unversioned"), builder, storePrefix);
+        final KTable<String, String> table1 = builder.table("t1", consumed, versionedMaterialize);
+        final KTable<String, String> table2 = builder.table("t2", consumed, unversionedMaterialize);
+        table1.join(table2, (v1, v2) -> v1 + v2);
+
+        // When:
+        builder.buildAndOptimizeTopology();
+
+        // Then:
+        final GraphNode join = getNodeByType(builder.root, KTableKTableJoinNode.class, new HashSet<>());
+        assertNotNull(join);
+        verifyVersionedSemantics((KTableKTableJoinNode<?, ?, ?, ?>) join, true, false);
+    }
+
+    @Test
+    public void shouldSetUseVersionedSemanticsOnTableJoinRightOnly() {
+        // Given:
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> versionedMaterialize =
+            new MaterializedInternal<>(Materialized.as(Stores.persistentVersionedKeyValueStore("versioned", Duration.ofMinutes(5))), builder, storePrefix);
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> unversionedMaterialize =
+            new MaterializedInternal<>(Materialized.as("unversioned"), builder, storePrefix);
+        final KTable<String, String> table1 = builder.table("t1", consumed, unversionedMaterialize);
+        final KTable<String, String> table2 = builder.table("t2", consumed, versionedMaterialize);
+        table1.join(table2, (v1, v2) -> v1 + v2);
+
+        // When:
+        builder.buildAndOptimizeTopology();
+
+        // Then:
+        final GraphNode join = getNodeByType(builder.root, KTableKTableJoinNode.class, new HashSet<>());
+        assertNotNull(join);
+        verifyVersionedSemantics((KTableKTableJoinNode<?, ?, ?, ?>) join, false, true);
+    }
+
+    @Test
+    public void shouldSetUseVersionedSemanticsOnTableSelfJoin() {
+        // Given:
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> versionedMaterialize =
+            new MaterializedInternal<>(Materialized.as(Stores.persistentVersionedKeyValueStore("versioned", Duration.ofMinutes(5))), builder, storePrefix);
+        final KTable<String, String> table1 = builder.table("t1", consumed, versionedMaterialize);
+        table1.join(table1, (v1, v2) -> v1 + v2);
+
+        // When:
+        builder.buildAndOptimizeTopology();
+
+        // Then:
+        final GraphNode join = getNodeByType(builder.root, KTableKTableJoinNode.class, new HashSet<>());
+        assertNotNull(join);
+        verifyVersionedSemantics((KTableKTableJoinNode<?, ?, ?, ?>) join, true, true);
+    }
+
+    @Test
+    public void shouldSetUseVersionedSemanticsOnTableForeignJoin() {
+        // Given:
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> versionedMaterialize =
+            new MaterializedInternal<>(Materialized.as(Stores.persistentVersionedKeyValueStore("versioned", Duration.ofMinutes(5))), builder, storePrefix);
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> versionedMaterialize2 =
+            new MaterializedInternal<>(Materialized.as(Stores.persistentVersionedKeyValueStore("versioned2", Duration.ofMinutes(5))), builder, storePrefix);
+        final KTable<String, String> table1 = builder.table("t1", consumed, versionedMaterialize);
+        final KTable<String, String> table2 = builder.table("t2", consumed, versionedMaterialize2);
+        table1.join(table2, v -> v, (v1, v2) -> v1 + v2);
+
+        // When:
+        builder.buildAndOptimizeTopology();
+
+        // Then:
+        final GraphNode joinThis = getNodeByType(builder.root, ForeignJoinSubscriptionSendNode.class, new HashSet<>());
+        assertNotNull(joinThis);
+        verifyVersionedSemantics((ForeignJoinSubscriptionSendNode<?, ?>) joinThis, true);
+
+        final GraphNode joinOther = getNodeByType(builder.root, ForeignJoinSubscriptionNode.class, new HashSet<>());
+        assertNotNull(joinOther);
+        verifyVersionedSemantics((ForeignJoinSubscriptionNode<?, ?>) joinOther, true);
+    }
+
+    @Test
+    public void shouldSetUseVersionedSemanticsOnTableForeignJoinLeftOnly() {
+        // Given:
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> versionedMaterialize =
+            new MaterializedInternal<>(Materialized.as(Stores.persistentVersionedKeyValueStore("versioned", Duration.ofMinutes(5))), builder, storePrefix);
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> unversionedMaterialize =
+            new MaterializedInternal<>(Materialized.as("unversioned"), builder, storePrefix);
+        final KTable<String, String> table1 = builder.table("t1", consumed, versionedMaterialize);
+        final KTable<String, String> table2 = builder.table("t2", consumed, unversionedMaterialize);
+        table1.join(table2, v -> v, (v1, v2) -> v1 + v2);
+
+        // When:
+        builder.buildAndOptimizeTopology();
+
+        // Then:
+        final GraphNode joinThis = getNodeByType(builder.root, ForeignJoinSubscriptionSendNode.class, new HashSet<>());
+        assertNotNull(joinThis);
+        verifyVersionedSemantics((ForeignJoinSubscriptionSendNode<?, ?>) joinThis, true);
+
+        final GraphNode joinOther = getNodeByType(builder.root, ForeignJoinSubscriptionNode.class, new HashSet<>());
+        assertNotNull(joinOther);
+        verifyVersionedSemantics((ForeignJoinSubscriptionNode<?, ?>) joinOther, false);
+    }
+
+    @Test
+    public void shouldSetUseVersionedSemanticsOnTableForeignJoinRightOnly() {
+        // Given:
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> versionedMaterialize =
+            new MaterializedInternal<>(Materialized.as(Stores.persistentVersionedKeyValueStore("versioned", Duration.ofMinutes(5))), builder, storePrefix);
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> unversionedMaterialize =
+            new MaterializedInternal<>(Materialized.as("unversioned"), builder, storePrefix);
+        final KTable<String, String> table1 = builder.table("t1", consumed, unversionedMaterialize);
+        final KTable<String, String> table2 = builder.table("t2", consumed, versionedMaterialize);
+        table1.join(table2, v -> v, (v1, v2) -> v1 + v2);
+
+        // When:
+        builder.buildAndOptimizeTopology();
+
+        // Then:
+        final GraphNode joinThis = getNodeByType(builder.root, ForeignJoinSubscriptionSendNode.class, new HashSet<>());
+        assertNotNull(joinThis);
+        verifyVersionedSemantics((ForeignJoinSubscriptionSendNode<?, ?>) joinThis, false);
+
+        final GraphNode joinOther = getNodeByType(builder.root, ForeignJoinSubscriptionNode.class, new HashSet<>());
+        assertNotNull(joinOther);
+        verifyVersionedSemantics((ForeignJoinSubscriptionNode<?, ?>) joinOther, true);
+    }
+
+    @Test
+    public void shouldSetUseVersionedSemanticsOnTableForeignSelfJoin() {
+        // Given:
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> versionedMaterialize =
+            new MaterializedInternal<>(Materialized.as(Stores.persistentVersionedKeyValueStore("versioned", Duration.ofMinutes(5))), builder, storePrefix);
+        final KTable<String, String> table1 = builder.table("t1", consumed, versionedMaterialize);
+        table1.join(table1, v -> v, (v1, v2) -> v1 + v2);
+
+        // When:
+        builder.buildAndOptimizeTopology();
+
+        // Then:
+        final GraphNode joinThis = getNodeByType(builder.root, ForeignJoinSubscriptionSendNode.class, new HashSet<>());
+        assertNotNull(joinThis);
+        verifyVersionedSemantics((ForeignJoinSubscriptionSendNode<?, ?>) joinThis, true);
+
+        final GraphNode joinOther = getNodeByType(builder.root, ForeignJoinSubscriptionNode.class, new HashSet<>());
+        assertNotNull(joinOther);
+        verifyVersionedSemantics((ForeignJoinSubscriptionNode<?, ?>) joinOther, true);
+    }
+
     private void verifyVersionedSemantics(final TableFilterNode<?, ?> filterNode, final boolean expectedValue) {
         final ProcessorSupplier<?, ?, ?, ?> processorSupplier = filterNode.processorParameters().processorSupplier();
         assertTrue(processorSupplier instanceof KTableFilter);
@@ -1021,6 +1196,32 @@ public class InternalStreamsBuilderTest {
         assertTrue(processorSupplier instanceof KTableRepartitionMap);
         final KTableRepartitionMap<?, ?, ?, ?> repartitionMap = (KTableRepartitionMap<?, ?, ?, ?>) processorSupplier;
         assertEquals(expectedValue, repartitionMap.isUseVersionedSemantics());
+    }
+
+    private void verifyVersionedSemantics(final KTableKTableJoinNode<?, ?, ?, ?> joinNode, final boolean expectedValueLeft, final boolean expectedValueRight) {
+        final ProcessorSupplier<?, ?, ?, ?> thisProcessorSupplier = joinNode.thisProcessorParameters().processorSupplier();
+        assertTrue(thisProcessorSupplier instanceof KTableKTableAbstractJoin);
+        final KTableKTableAbstractJoin<?, ?, ?, ?> thisJoin = (KTableKTableAbstractJoin<?, ?, ?, ?>) thisProcessorSupplier;
+        assertEquals(expectedValueLeft, thisJoin.isUseVersionedSemantics());
+
+        final ProcessorSupplier<?, ?, ?, ?> otherProcessorSupplier = joinNode.otherProcessorParameters().processorSupplier();
+        assertTrue(otherProcessorSupplier instanceof KTableKTableAbstractJoin);
+        final KTableKTableAbstractJoin<?, ?, ?, ?> otherJoin = (KTableKTableAbstractJoin<?, ?, ?, ?>) otherProcessorSupplier;
+        assertEquals(expectedValueRight, otherJoin.isUseVersionedSemantics());
+    }
+
+    private void verifyVersionedSemantics(final ForeignJoinSubscriptionSendNode<?, ?> joinThisNode, final boolean expectedValue) {
+        final ProcessorSupplier<?, ?, ?, ?> thisProcessorSupplier = joinThisNode.processorParameters().processorSupplier();
+        assertTrue(thisProcessorSupplier instanceof SubscriptionSendProcessorSupplier);
+        final SubscriptionSendProcessorSupplier<?, ?, ?> joinThis = (SubscriptionSendProcessorSupplier<?, ?, ?>) thisProcessorSupplier;
+        assertEquals(expectedValue, joinThis.isUseVersionedSemantics());
+    }
+
+    private void verifyVersionedSemantics(final ForeignJoinSubscriptionNode<?, ?> joinOtherNode, final boolean expectedValue) {
+        final ProcessorSupplier<?, ?, ?, ?> otherProcessorSupplier = joinOtherNode.processorParameters().processorSupplier();
+        assertTrue(otherProcessorSupplier instanceof ForeignTableJoinProcessorSupplier);
+        final ForeignTableJoinProcessorSupplier<?, ?, ?> joinThis = (ForeignTableJoinProcessorSupplier<?, ?, ?>) otherProcessorSupplier;
+        assertEquals(expectedValue, joinThis.isUseVersionedSemantics());
     }
 
     private GraphNode getNodeByType(

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -3149,7 +3149,7 @@ public class KStreamImplTest {
                 "    Processor: KTABLE-FK-JOIN-OUTPUT-0000000018 (stores: [])\n" +
                 "      --> KTABLE-TOSTREAM-0000000020\n" +
                 "      <-- KTABLE-FK-JOIN-SUBSCRIPTION-RESPONSE-RESOLVER-PROCESSOR-0000000017\n" +
-                "    Processor: KTABLE-FK-JOIN-SUBSCRIPTION-REGISTRATION-0000000007 (stores: [KSTREAM-TOTABLE-STATE-STORE-0000000002])\n" +
+                "    Processor: KTABLE-FK-JOIN-SUBSCRIPTION-REGISTRATION-0000000007 (stores: [])\n" +
                 "      --> KTABLE-SINK-0000000008\n" +
                 "      <-- KSTREAM-TOTABLE-0000000001\n" +
                 "    Processor: KTABLE-TOSTREAM-0000000020 (stores: [])\n" +
@@ -3174,7 +3174,7 @@ public class KStreamImplTest {
                 "    Processor: KTABLE-FK-JOIN-SUBSCRIPTION-PROCESSOR-0000000012 (stores: [KSTREAM-TOTABLE-STATE-STORE-0000000005])\n" +
                 "      --> KTABLE-SINK-0000000015\n" +
                 "      <-- KTABLE-FK-JOIN-SUBSCRIPTION-PROCESSOR-0000000011\n" +
-                "    Processor: KTABLE-FK-JOIN-SUBSCRIPTION-PROCESSOR-0000000013 (stores: [KSTREAM-TOTABLE-STATE-STORE-0000000005, KTABLE-FK-JOIN-SUBSCRIPTION-STATE-STORE-0000000010])\n" +
+                "    Processor: KTABLE-FK-JOIN-SUBSCRIPTION-PROCESSOR-0000000013 (stores: [KTABLE-FK-JOIN-SUBSCRIPTION-STATE-STORE-0000000010])\n" +
                 "      --> KTABLE-SINK-0000000015\n" +
                 "      <-- KSTREAM-TOTABLE-0000000004\n" +
                 "    Sink: KTABLE-SINK-0000000015 (topic: KTABLE-FK-JOIN-SUBSCRIPTION-RESPONSE-0000000014-topic)\n" +
@@ -3254,10 +3254,10 @@ public class KStreamImplTest {
                 "    Processor: KSTREAM-TOTABLE-0000000004 (stores: [KSTREAM-TOTABLE-STATE-STORE-0000000005])\n" +
                 "      --> KTABLE-JOINOTHER-0000000008\n" +
                 "      <-- KSTREAM-SOURCE-0000000003\n" +
-                "    Processor: KTABLE-JOINOTHER-0000000008 (stores: [KSTREAM-TOTABLE-STATE-STORE-0000000005, KSTREAM-TOTABLE-STATE-STORE-0000000002])\n" +
+                "    Processor: KTABLE-JOINOTHER-0000000008 (stores: [KSTREAM-TOTABLE-STATE-STORE-0000000002])\n" +
                 "      --> KTABLE-MERGE-0000000006\n" +
                 "      <-- KSTREAM-TOTABLE-0000000004\n" +
-                "    Processor: KTABLE-JOINTHIS-0000000007 (stores: [KSTREAM-TOTABLE-STATE-STORE-0000000005, KSTREAM-TOTABLE-STATE-STORE-0000000002])\n" +
+                "    Processor: KTABLE-JOINTHIS-0000000007 (stores: [KSTREAM-TOTABLE-STATE-STORE-0000000005])\n" +
                 "      --> KTABLE-MERGE-0000000006\n" +
                 "      <-- KSTREAM-TOTABLE-0000000001\n" +
                 "    Processor: KTABLE-MERGE-0000000006 (stores: [])\n" +


### PR DESCRIPTION
There's a bug in the table-table join handling of out-of-order records in versioned tables (see https://github.com/apache/kafka/pull/13510 and https://github.com/apache/kafka/pull/13522 for context) where if the latest value for a particular key is a tombstone, then out-of-order records are not properly identified because versioned stores do not return timestamps for tombstones (so there is no timestamp to compare against, when deciding whether a record is out-of-order or not). This results in out-of-order records improperly being identified as not out-of-order, when the latest value for the key is a tombstone.

This PR fixes the bug by using the `isLatest` value from the `Change` object (see https://github.com/apache/kafka/pull/13564) instead of calling `get(key)` on the state store to fetch timestamps to compare against. As part of this fix, this PR also updates table-table joins to determine whether upstream tables are versioned by using the GraphNode mechanism, instead of checking the table's value getter. This also enables us to remove the additional state store access granted to join processors in https://github.com/apache/kafka/pull/13510 and https://github.com/apache/kafka/pull/13522, resulting in a cleaner topology.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
