### PR TITLE
MINOR: remove unused variable from QuorumMetaLogListener#handleCommit method

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -892,7 +892,6 @@ public final class QuorumController implements Controller {
             appendRaftEvent("handleCommit[baseOffset=" + reader.baseOffset() + "]", () -> {
                 try {
                     maybeCompleteAuthorizerInitialLoad();
-                    long processedRecordsSize = 0;
                     boolean isActive = isActiveController();
                     while (reader.hasNext()) {
                         Batch<ApiMessageAndVersion> batch = reader.next();


### PR DESCRIPTION
The removed `processedRecordsSize `variable  was added and used as part of the changes in https://github.com/apache/kafka/pull/10812 and its usage was removed in https://github.com/apache/kafka/pull/12747. The removal was part of fixing https://issues.apache.org/jira/browse/KAFKA-14300 and it seems to me that the variable was just left over from that PR and we can safely remove it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
