### PR TITLE
KAFKA-14859: SCRAM ZK to KRaft migration without dual write

### DIFF
--- a/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
+++ b/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
@@ -24,6 +24,7 @@ import kafka.server.{ConfigEntityName, ConfigType, DynamicBrokerConfig, ZkAdminM
 import kafka.utils.{Logging, PasswordEncoder}
 import kafka.zk.TopicZNode.TopicIdReplicaAssignment
 import kafka.zookeeper._
+import org.apache.kafka.clients.admin.ScramMechanism
 import org.apache.kafka.common.acl.AccessControlEntry
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors.ControllerMovedException
@@ -32,6 +33,7 @@ import org.apache.kafka.common.metadata._
 import org.apache.kafka.common.quota.ClientQuotaEntity
 import org.apache.kafka.common.resource.ResourcePattern
 import org.apache.kafka.common.{TopicPartition, Uuid}
+import org.apache.kafka.common.security.scram.internals.ScramCredentialUtils
 import org.apache.kafka.metadata.{LeaderRecoveryState, PartitionRegistration}
 import org.apache.kafka.metadata.migration.{MigrationClient, MigrationClientAuthException, MigrationClientException, ZkMigrationLeadershipState}
 import org.apache.kafka.server.common.{ApiMessageAndVersion, ProducerIdsBlock}
@@ -211,6 +213,21 @@ class ZkMigrationClient(
       adminZkClient.fetchAllEntityConfigs(entityType).foreach { case (name, props) =>
         val entity = new EntityData().setEntityType(entityType).setEntityName(name)
         val batch = new util.ArrayList[ApiMessageAndVersion]()
+        ScramMechanism.values().filter(_ != ScramMechanism.UNKNOWN).foreach { mechanism =>
+          val propertyValue = props.getProperty(mechanism.mechanismName)
+          if (propertyValue != null) {
+            println(s"Found ${propertyValue} for Key:${mechanism.mechanismName}")
+            val scramCredentials =  ScramCredentialUtils.credentialFromString(propertyValue)
+            batch.add(new ApiMessageAndVersion(new UserScramCredentialRecord()
+              .setName(name)
+              .setMechanism(mechanism.`type`)
+              .setSalt(scramCredentials.salt)
+              .setStoredKey(scramCredentials.storedKey)
+              .setServerKey(scramCredentials.serverKey)
+              .setIterations(scramCredentials.iterations), 0.toShort))
+            props.remove(mechanism.mechanismName)
+          }
+        }
         ZkAdminManager.clientQuotaPropsToDoubleMap(props.asScala).foreach { case (key: String, value: Double) =>
           batch.add(new ApiMessageAndVersion(new ClientQuotaRecord()
             .setEntity(List(entity).asJava)

--- a/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
+++ b/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
@@ -216,7 +216,6 @@ class ZkMigrationClient(
         ScramMechanism.values().filter(_ != ScramMechanism.UNKNOWN).foreach { mechanism =>
           val propertyValue = props.getProperty(mechanism.mechanismName)
           if (propertyValue != null) {
-            println(s"Found ${propertyValue} for Key:${mechanism.mechanismName}")
             val scramCredentials =  ScramCredentialUtils.credentialFromString(propertyValue)
             batch.add(new ApiMessageAndVersion(new UserScramCredentialRecord()
               .setName(name)

--- a/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
@@ -32,11 +32,14 @@ import org.apache.kafka.common.errors.ControllerMovedException
 import org.apache.kafka.common.metadata.{AccessControlEntryRecord, ConfigRecord, MetadataRecordType, ProducerIdsRecord}
 import org.apache.kafka.common.quota.ClientQuotaEntity
 import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourcePatternFilter, ResourceType}
+import org.apache.kafka.common.security.scram.internals.ScramCredentialUtils
+import org.apache.kafka.common.security.scram.ScramCredential
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.utils.{SecurityUtils, Time}
 import org.apache.kafka.metadata.{LeaderRecoveryState, PartitionRegistration}
 import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
 import org.apache.kafka.server.common.ApiMessageAndVersion
+import org.apache.kafka.server.util.MockRandom
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue, fail}
 import org.junit.jupiter.api.{BeforeEach, Test, TestInfo}
 
@@ -279,6 +282,34 @@ class ZkMigrationClientTest extends QuorumTestHarness {
       ConfigType.User, "user2/clients/clientA")
 
     assertEquals(2, migrationState.migrationZkVersion())
+  }
+
+  @Test
+  def testScram(): Unit = {
+    val random = new MockRandom()
+    def randomBuffer(random: MockRandom, length: Int): Array[Byte] = {
+        val buf = new Array[Byte](length)
+        random.nextBytes(buf)
+        buf
+    }
+    val scramCredential = new ScramCredential(
+        randomBuffer(random, 1024),
+        randomBuffer(random, 1024),
+        randomBuffer(random, 1024),
+        4096)
+
+    val props = new Properties()
+    props.put("SCRAM-SHA-256", ScramCredentialUtils.credentialToString(scramCredential))
+    adminZkClient.changeConfigs(ConfigType.User, "alice", props)
+
+    val brokers = new java.util.ArrayList[Integer]()
+    val batches = new java.util.ArrayList[java.util.List[ApiMessageAndVersion]]()
+
+    migrationClient.readAllMetadata(batch => batches.add(batch), brokerId => brokers.add(brokerId))
+    assertEquals(0, brokers.size())
+    assertEquals(1, batches.size())
+    assertEquals(1, batches.get(0).size)
+    // assertEquals(50, migrationState.migrationZkVersion())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
@@ -309,7 +309,6 @@ class ZkMigrationClientTest extends QuorumTestHarness {
     assertEquals(0, brokers.size())
     assertEquals(1, batches.size())
     assertEquals(1, batches.get(0).size)
-    // assertEquals(50, migrationState.migrationZkVersion())
   }
 
   @Test


### PR DESCRIPTION
Handle migrating SCRAM records in ZK when migrating from ZK to KRaft.

This does not allow the user to change SCRAM records while migration is happening.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
