### PR TITLE
KAFKA-14586: Adding redirection for StreamsResetter

### DIFF
--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.tools;
+
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+@Deprecated
+public class StreamsResetter {
+
+    public static void main(String[] args) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        System.out.println("WARNING: The 'kafka.tools' package is deprecated and will change to 'org.apache.kafka.tools' in the next major release.");
+        Class<?> toolClass = Class.forName("org.apache.kafka.tools.StreamsResetter");
+        Method main = toolClass.getDeclaredMethod("main", String[].class);
+        main.invoke(null, (Object) args);
+    }
+}


### PR DESCRIPTION
Adding Redirection for StreamsResetter. The erstwhile StreamsResetter resided in core/src/main/scala/kafka/tools package and that's where I added this class.
I tried to run the main method but it fails with 

```
Exception in thread "main" java.lang.ClassNotFoundException: org.apache.kafka.tools.StreamsResetter
	at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at kafka.tools.StreamsResetter.main(StreamsResetter.java:28)
``` 

but I created another class and invoked the class in this PR using the same way and it seemed to invoke this. 

cc @mjsax , @fvaleri , @mimaison 