### PR TITLE
KAFKA-14926: Remove metrics on Log Cleaner shutdown

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -478,7 +478,9 @@ object LogCleaner {
   private val MaxCleanTimeMetricName = "max-clean-time-secs"
   private val MaxCompactionDelayMetricsName = "max-compaction-delay-secs"
   private val DeadThreadCountMetricName = "DeadThreadCount"
-  private[log] val MetricNames = Set(MaxBufferUtilizationPercentMetricName,
+  // package private for testing
+  private[log] val MetricNames = Set(
+    MaxBufferUtilizationPercentMetricName,
     CleanerRecopyPercentMetricName,
     MaxCleanTimeMetricName,
     MaxCompactionDelayMetricsName,

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -167,8 +167,20 @@ class LogCleaner(initialConfig: CleanerConfig,
    */
   def shutdown(): Unit = {
     info("Shutting down the log cleaner.")
-    cleaners.foreach(_.shutdown())
-    cleaners.clear()
+    try {
+      cleaners.foreach(_.shutdown())
+      cleaners.clear()
+    } finally {
+      remoteMetrics()
+    }
+  }
+
+  def remoteMetrics(): Unit = {
+    metricsGroup.removeMetric("max-buffer-utilization-percent")
+    metricsGroup.removeMetric("cleaner-recopy-percent")
+    metricsGroup.removeMetric("max-clean-time-secs")
+    metricsGroup.removeMetric("max-compaction-delay-secs")
+    metricsGroup.removeMetric("DeadThreadCount")
   }
 
   override def reconfigurableConfigs: Set[String] = {

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -22,6 +22,7 @@ import java.nio._
 import java.util.Date
 import java.util.concurrent.TimeUnit
 import kafka.common._
+import kafka.log.LogCleaner.{CleanerRecopyPercentMetricName, DeadThreadCountMetricName, MaxBufferUtilizationPercentMetricName, MaxCleanTimeMetricName, MaxCompactionDelayMetricsName}
 import kafka.server.{BrokerReconfigurable, KafkaConfig}
 import kafka.utils._
 import org.apache.kafka.common.{KafkaException, TopicPartition}
@@ -124,37 +125,26 @@ class LogCleaner(initialConfig: CleanerConfig,
   private def maxOverCleanerThreads(f: CleanerThread => Double): Int =
     cleaners.foldLeft(0.0d)((max: Double, thread: CleanerThread) => math.max(max, f(thread))).toInt
 
-  private val maxBufferUtilizationPercentMetricName =  "max-buffer-utilization-percent"
-  private val cleanerRecopyPercentMetricName =  "cleaner-recopy-percent"
-  private val maxCleanTimeMetricName =  "max-clean-time-secs"
-  private val maxCompactionDelayMetricsName = "max-compaction-delay-secs"
-  private val deadThreadCountMetricName = "DeadThreadCount"
-  private val metricNames = Set.apply(maxBufferUtilizationPercentMetricName,
-                                      cleanerRecopyPercentMetricName,
-                                      maxCleanTimeMetricName,
-                                      maxCompactionDelayMetricsName,
-                                      deadThreadCountMetricName)
-
   /* a metric to track the maximum utilization of any thread's buffer in the last cleaning */
-  metricsGroup.newGauge(maxBufferUtilizationPercentMetricName,
+  metricsGroup.newGauge(MaxBufferUtilizationPercentMetricName,
     () => maxOverCleanerThreads(_.lastStats.bufferUtilization) * 100)
 
   /* a metric to track the recopy rate of each thread's last cleaning */
-  metricsGroup.newGauge(cleanerRecopyPercentMetricName, () => {
+  metricsGroup.newGauge(CleanerRecopyPercentMetricName, () => {
     val stats = cleaners.map(_.lastStats)
     val recopyRate = stats.iterator.map(_.bytesWritten).sum.toDouble / math.max(stats.iterator.map(_.bytesRead).sum, 1)
     (100 * recopyRate).toInt
   })
 
   /* a metric to track the maximum cleaning time for the last cleaning from each thread */
-  metricsGroup.newGauge(maxCleanTimeMetricName, () => maxOverCleanerThreads(_.lastStats.elapsedSecs))
+  metricsGroup.newGauge(MaxCleanTimeMetricName, () => maxOverCleanerThreads(_.lastStats.elapsedSecs))
 
   // a metric to track delay between the time when a log is required to be compacted
   // as determined by max compaction lag and the time of last cleaner run.
-  metricsGroup.newGauge(maxCompactionDelayMetricsName,
+  metricsGroup.newGauge(MaxCompactionDelayMetricsName,
     () => maxOverCleanerThreads(_.lastPreCleanStats.maxCompactionDelayMs.toDouble) / 1000)
 
-  metricsGroup.newGauge(deadThreadCountMetricName, () => deadThreadCount)
+  metricsGroup.newGauge(DeadThreadCountMetricName, () => deadThreadCount)
 
   private[log] def deadThreadCount: Int = cleaners.count(_.isThreadFailed)
 
@@ -184,7 +174,7 @@ class LogCleaner(initialConfig: CleanerConfig,
   }
 
   def removeMetrics(): Unit = {
-    metricNames.foreach(metricsGroup.removeMetric);
+    LogCleaner.MetricNames.foreach(metricsGroup.removeMetric)
   }
 
   override def reconfigurableConfigs: Set[String] = {
@@ -205,14 +195,14 @@ class LogCleaner(initialConfig: CleanerConfig,
 
   /**
     * Reconfigure log clean config. The will:
-    * 1. update desiredRatePerSec in Throttler with logCleanerIoMaxBytesPerSecond, if necessary 
+    * 1. update desiredRatePerSec in Throttler with logCleanerIoMaxBytesPerSecond, if necessary
     * 2. stop current log cleaners and create new ones.
     * That ensures that if any of the cleaners had failed, new cleaners are created to match the new config.
     */
   override def reconfigure(oldConfig: KafkaConfig, newConfig: KafkaConfig): Unit = {
     config = LogCleaner.cleanerConfig(newConfig)
 
-    val maxIoBytesPerSecond = config.maxIoBytesPerSecond;
+    val maxIoBytesPerSecond = config.maxIoBytesPerSecond
     if (maxIoBytesPerSecond != oldConfig.logCleanerIoMaxBytesPerSecond) {
       info(s"Updating logCleanerIoMaxBytesPerSecond: $maxIoBytesPerSecond")
       throttler.updateDesiredRatePerSec(maxIoBytesPerSecond)
@@ -482,6 +472,17 @@ object LogCleaner {
       config.logCleanerEnable)
 
   }
+
+  private val MaxBufferUtilizationPercentMetricName = "max-buffer-utilization-percent"
+  private val CleanerRecopyPercentMetricName = "cleaner-recopy-percent"
+  private val MaxCleanTimeMetricName = "max-clean-time-secs"
+  private val MaxCompactionDelayMetricsName = "max-compaction-delay-secs"
+  private val DeadThreadCountMetricName = "DeadThreadCount"
+  private[log] val MetricNames = Set(MaxBufferUtilizationPercentMetricName,
+    CleanerRecopyPercentMetricName,
+    MaxCleanTimeMetricName,
+    MaxCompactionDelayMetricsName,
+    DeadThreadCountMetricName)
 }
 
 /**

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -79,13 +79,9 @@ class LogCleanerTest {
       logCleaner.shutdown()
 
       val mockMetricsGroup = mockMetricsGroupCtor.constructed.get(0)
-      val numMetricsRegistered = 5
+      val numMetricsRegistered = LogCleaner.MetricNames.size
       verify(mockMetricsGroup, times(numMetricsRegistered)).newGauge(anyString(), any())
-
-      // verify that all metrics are added to the list of metric name
-      assertEquals(numMetricsRegistered, LogCleaner.MetricNames.size,
-        "All metrics are not part of MetricNames collections")
-
+      
       // verify that each metric is removed
       LogCleaner.MetricNames.foreach(verify(mockMetricsGroup).removeMetric(_))
 

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -81,7 +81,13 @@ class LogCleanerTest {
       val mockMetricsGroup = mockMetricsGroupCtor.constructed.get(0)
       val numMetricsRegistered = 5
       verify(mockMetricsGroup, times(numMetricsRegistered)).newGauge(anyString(), any())
-      verify(mockMetricsGroup, times(numMetricsRegistered)).removeMetric(anyString())
+
+      // verify that all metrics are added to the list of metric name
+      assertEquals(LogCleaner.MetricNames.size, numMetricsRegistered,
+        "All metrics are not part of MetricNames collections")
+
+      // verify that each metric is removed
+      LogCleaner.MetricNames.foreach(verify(mockMetricsGroup).removeMetric(_))
 
       // assert that we have verified all invocations on
       verifyNoMoreInteractions(mockMetricsGroup)

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -83,7 +83,7 @@ class LogCleanerTest {
       verify(mockMetricsGroup, times(numMetricsRegistered)).newGauge(anyString(), any())
 
       // verify that all metrics are added to the list of metric name
-      assertEquals(LogCleaner.MetricNames.size, numMetricsRegistered,
+      assertEquals(numMetricsRegistered, LogCleaner.MetricNames.size,
         "All metrics are not part of MetricNames collections")
 
       // verify that each metric is removed
@@ -92,9 +92,7 @@ class LogCleanerTest {
       // assert that we have verified all invocations on
       verifyNoMoreInteractions(mockMetricsGroup)
     } finally {
-      if (mockMetricsGroupCtor != null) {
-        mockMetricsGroupCtor.close()
-      }
+      mockMetricsGroupCtor.close()
     }
   }
 


### PR DESCRIPTION
# Motivation
When Log cleaning is shutdown, it doesn't remove metrics that were registered to `KafkaYammerMetrics.defaultRegistry()` which has one instance per server. Log cleaner's lifecycle is associated with lifecycle of `LogManager` and hence, there is no possibility where log cleaner will be shutdown but the broker won't. Broker shutdown will close the `jmxReporter` and hence, there is no current metric leak here.
The motivation for this code change is to "do the right thing" from a code hygiene perspective.

# Test
Added a unit test that fails before the change and passes after the change.