### PR TITLE
MINOR: only set sslEngine#setUseClientMode to false once when ssl mode is server

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -200,7 +200,6 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
                 case NONE:
                     break;
             }
-            sslEngine.setUseClientMode(false);
         } else {
             sslEngine.setUseClientMode(true);
             SSLParameters sslParams = sslEngine.getSSLParameters();


### PR DESCRIPTION
The sslEngine.setUseClientMode(false) was duplicated when ssl mode is server during SSLEngine creation in DefaultSslEngineFactory.java. The patch attempts to remove the duplicated call which was already done in  https://github.com/apache/kafka/blob/f67feb07639e238fccf2a94bf00b9b1d56d47724/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java#L192

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
