### PR TITLE
MINOR: Fix Javadoc for configureAdminResources  in Connect's RestServer

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -334,7 +334,7 @@ public abstract class RestServer {
      * <p>
      * <em>N.B.: Classes do <b>not</b> need to register the resources provided in {@link #adminResources()} with
      * the {@link ResourceConfig} parameter in this method; they are automatically registered by the parent class.</em>
-     * @param adminResourceConfig the {@link ResourceConfig} that the server's regular listeners are registered with; never null
+     * @param adminResourceConfig the {@link ResourceConfig} that the server's admin listeners are registered with; never null
      */
     protected void configureAdminResources(ResourceConfig adminResourceConfig) {
         // No-op by default


### PR DESCRIPTION
- The param Javadoc was likely copied from `configureRegularResources`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
