### PR TITLE
KAFKA-14933: Document Kafka Connect's log level REST APIs added in KIP-495

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/LoggingResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/LoggingResource.java
@@ -128,7 +128,7 @@ public class LoggingResource implements ConnectResource {
      */
     @PUT
     @Path("/{logger}")
-    @Operation(summary = "Set the level for the specified logger")
+    @Operation(summary = "Set the log level for the specified logger")
     public Response setLevel(final @PathParam("logger") String namedLogger,
                              final Map<String, String> levelMap) {
         String desiredLevelStr = levelMap.get("level");

--- a/docs/connect.html
+++ b/docs/connect.html
@@ -328,7 +328,25 @@ listeners=http://localhost:8080,https://localhost:8443</pre>
         <li><code>GET /</code>- return basic information about the Kafka Connect cluster such as the version of the Connect worker that serves the REST request (including git commit ID of the source code) and the Kafka cluster ID that is connected to.
     </ul>
 
-    <p>For the complete specification of the REST API, see the <a href="/{{version}}/generated/connect_rest.yaml">OpenAPI documentation</a></p>
+    <p>The <code>admin.listeners</code> configuration can be used to configure admin REST APIs on Kafka Connect's REST API server. Similar to the <code>listeners</code> configuration, this field should contain a list of listeners in the following format: <code>protocol://host:port,protocol2://host2:port2</code>. Currently supported protocols are <code>http</code> and <code>https</code>.
+        For example:</p>
+
+    <pre class="brush: text;">
+admin.listeners=http://localhost:8080,https://localhost:8443</pre>
+
+    <p>By default, if <code>admin.listeners</code> is not configured, the admin REST APIs will be available on the regular listeners.</p>
+
+    <p>The following are the currently supported admin REST API endpoints:</p>
+
+    <ul>
+        <li><code>GET /admin/loggers</code> - list the current loggers that have their levels explicitly set and their log levels</li>
+        <li><code>GET /admin/loggers/{name}</code> - get the log level for the specified logger</li>
+        <li><code>PUT /admin/loggers/{name}</code> - set the log level for the specified logger</li>
+    </ul>
+
+    <p>See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-495%3A+Dynamically+Adjust+Log+Levels+in+Connect">KIP-495</a> for more details about the admin logger REST APIs.</p>
+
+    <p>For the complete specification of the Kafka Connect REST API, see the <a href="/{{version}}/generated/connect_rest.yaml">OpenAPI documentation</a></p>
 
     <h4><a id="connect_errorreporting" href="#connect_errorreporting">Error Reporting in Connect</a></h4>
 


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/KAFKA-14933
- [KIP-495](https://cwiki.apache.org/confluence/display/KAFKA/KIP-495%3A+Dynamically+Adjust+Log+Levels+in+Connect) added 3 REST APIs to allow dynamically adjusting (and checking) log levels on Kafka Connect workers.
- This was added a long time ago (released in AK 2.4.0) but was never publicly documented
- This patch documents these REST APIs in https://kafka.apache.org/documentation/#connect_rest

<img width="2560" alt="Screenshot 2023-04-25 at 2 06 24 PM" src="https://user-images.githubusercontent.com/23502577/234222545-a017ce4c-5bc5-41df-a9f2-c9b459763915.png">


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
