### PR TITLE
KAFKA-14462; [10/N] Add TargetAssignmentBuilder

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
@@ -38,8 +38,8 @@ import java.util.stream.Collectors;
  */
 public class ConsumerGroupMember {
     /**
-     * A builder allowing to create a new member or update an
-     * existing one.
+     * A builder that facilitates the creation of a new member or the update of
+     * an existing one.
      *
      * Please refer to the javadoc of {{@link ConsumerGroupMember}} for the
      * definition of the fields.
@@ -521,7 +521,7 @@ public class ConsumerGroupMember {
     }
 
     /**
-     * @return The set of partitions awaiting assigning to the member.
+     * @return The set of partitions awaiting assignment to the member.
      */
     public Map<Uuid, Set<Integer>> partitionsPendingAssignment() {
         return partitionsPendingAssignment;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilder.java
@@ -63,18 +63,18 @@ public class TargetAssignmentBuilder {
         private final List<Record> records;
 
         /**
-         * The new target assignment for all members.
+         * The new target assignment for the group.
          */
-        private final Map<String, Assignment> assignments;
+        private final Map<String, Assignment> targetAssignment;
 
         TargetAssignmentResult(
             List<org.apache.kafka.coordinator.group.Record> records,
-            Map<String, Assignment> assignments
+            Map<String, Assignment> targetAssignment
         ) {
             Objects.requireNonNull(records);
-            Objects.requireNonNull(assignments);
+            Objects.requireNonNull(targetAssignment);
             this.records = records;
-            this.assignments = assignments;
+            this.targetAssignment = targetAssignment;
         }
 
         /**
@@ -85,10 +85,10 @@ public class TargetAssignmentBuilder {
         }
 
         /**
-         * @return The assignments.
+         * @return The target assignment.
          */
-        public Map<String, Assignment> assignments() {
-            return assignments;
+        public Map<String, Assignment> targetAssignment() {
+            return targetAssignment;
         }
     }
 
@@ -120,7 +120,7 @@ public class TargetAssignmentBuilder {
     /**
      * The existing target assignment.
      */
-    private Map<String, Assignment> assignments = Collections.emptyMap();
+    private Map<String, Assignment> targetAssignment = Collections.emptyMap();
 
     /**
      * The members which have been updated or deleted. Deleted members
@@ -172,15 +172,15 @@ public class TargetAssignmentBuilder {
     }
 
     /**
-     * Adds the existing target assignments.
+     * Adds the existing target assignment.
      *
-     * @param assignments   The existing target assignments.
+     * @param targetAssignment   The existing target assignment.
      * @return This object.
      */
-    public TargetAssignmentBuilder withTargetAssignments(
-        Map<String, Assignment> assignments
+    public TargetAssignmentBuilder withTargetAssignment(
+        Map<String, Assignment> targetAssignment
     ) {
-        this.assignments = assignments;
+        this.targetAssignment = targetAssignment;
         return this;
     }
 
@@ -218,7 +218,7 @@ public class TargetAssignmentBuilder {
      *
      * @return A TargetAssignmentResult which contains the records to update
      *         the existing target assignment.
-     * @throws PartitionAssignorException if the assignment can not be computed.
+     * @throws PartitionAssignorException if the target assignment cannot be computed.
      */
     public TargetAssignmentResult build() throws PartitionAssignorException {
         Map<String, AssignmentMemberSpec> memberSpecs = new HashMap<>();
@@ -226,7 +226,7 @@ public class TargetAssignmentBuilder {
         // Prepare the member spec for all members.
         members.forEach((memberId, member) -> memberSpecs.put(memberId, createAssignmentMemberSpec(
             member,
-            assignments.getOrDefault(memberId, Assignment.EMPTY),
+            targetAssignment.getOrDefault(memberId, Assignment.EMPTY),
             subscriptionMetadata
         )));
 
@@ -237,7 +237,7 @@ public class TargetAssignmentBuilder {
             } else {
                 memberSpecs.put(memberId, createAssignmentMemberSpec(
                     updatedMemberOrNull,
-                    assignments.getOrDefault(memberId, Assignment.EMPTY),
+                    targetAssignment.getOrDefault(memberId, Assignment.EMPTY),
                     subscriptionMetadata
                 ));
             }
@@ -255,13 +255,13 @@ public class TargetAssignmentBuilder {
             Collections.unmodifiableMap(topics)
         ));
 
-        // Compute delta from previous to new assignment and create the
+        // Compute delta from previous to new target assignment and create the
         // relevant records.
         List<Record> records = new ArrayList<>();
         Map<String, Assignment> newTargetAssignment = new HashMap<>();
 
         memberSpecs.keySet().forEach(memberId -> {
-            Assignment oldMemberAssignment = assignments.get(memberId);
+            Assignment oldMemberAssignment = targetAssignment.get(memberId);
             Assignment newMemberAssignment = newMemberAssignment(newGroupAssignment, memberId);
 
             newTargetAssignment.put(memberId, newMemberAssignment);
@@ -286,7 +286,7 @@ public class TargetAssignmentBuilder {
             }
         });
 
-        // Bump the assignment epoch.
+        // Bump the target assignment epoch.
         records.add(newTargetAssignmentEpochRecord(groupId, groupEpoch));
 
         return new TargetAssignmentResult(records, newTargetAssignment);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilder.java
@@ -49,7 +49,7 @@ import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignme
  *
  * When a member is deleted, it is assumed that its target assignment record
  * is deleted as part of the member deletion process. In other words, this class
- * does not yield a tombstone for remove members.
+ * does not yield a tombstone for removed members.
  */
 public class TargetAssignmentBuilder {
     /**
@@ -85,7 +85,7 @@ public class TargetAssignmentBuilder {
         }
 
         /**
-         * @return The assignment.
+         * @return The assignments.
          */
         public Map<String, Assignment> assignments() {
             return assignments;
@@ -103,7 +103,7 @@ public class TargetAssignmentBuilder {
     private final int groupEpoch;
 
     /**
-     * The partition assignor to compute the assignment.
+     * The partition assignor used to compute the assignment.
      */
     private final PartitionAssignor assignor;
 
@@ -126,7 +126,7 @@ public class TargetAssignmentBuilder {
      * The members which have been updated or deleted. Deleted members
      * are signaled by a null value.
      */
-    private Map<String, ConsumerGroupMember> updatedMembers = new HashMap<>();
+    private final Map<String, ConsumerGroupMember> updatedMembers = new HashMap<>();
 
     /**
      * Constructs the object.
@@ -148,7 +148,7 @@ public class TargetAssignmentBuilder {
     /**
      * Adds all the current members.
      *
-     * @param members   The current members in the consumer groups.
+     * @param members   The current members in the consumer group.
      * @return This object.
      */
     public TargetAssignmentBuilder withMembers(
@@ -172,9 +172,9 @@ public class TargetAssignmentBuilder {
     }
 
     /**
-     * Adds the current target assignments.
+     * Adds the existing target assignments.
      *
-     * @param assignments   The current assignments.
+     * @param assignments   The existing target assignments.
      * @return This object.
      */
     public TargetAssignmentBuilder withTargetAssignments(
@@ -207,7 +207,7 @@ public class TargetAssignmentBuilder {
      * @param memberId The member id.
      * @return This object.
      */
-    public TargetAssignmentBuilder withRemoveMembers(
+    public TargetAssignmentBuilder withRemoveMember(
         String memberId
     ) {
         return withUpdatedMember(memberId, null);
@@ -217,7 +217,7 @@ public class TargetAssignmentBuilder {
      * Builds the new target assignment.
      *
      * @return A TargetAssignmentResult which contains the records to update
-     *         the current target assignment.
+     *         the existing target assignment.
      * @throws PartitionAssignorException if the assignment can not be computed.
      */
     public TargetAssignmentResult build() throws PartitionAssignorException {
@@ -267,7 +267,7 @@ public class TargetAssignmentBuilder {
             newTargetAssignment.put(memberId, newMemberAssignment);
 
             if (oldMemberAssignment == null) {
-                // If the member had no assignment, we always create a record for him.
+                // If the member had no assignment, we always create a record for it.
                 records.add(newTargetAssignmentRecord(
                     groupId,
                     memberId,

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
@@ -501,6 +501,8 @@ public class TargetAssignmentBuilderTest {
 
         TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
 
+        assertEquals(4, result.records().size());
+
         assertUnorderedList(Arrays.asList(
             newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
                 mkTopicAssignment(fooTopicId, 1, 2),
@@ -514,12 +516,12 @@ public class TargetAssignmentBuilderTest {
                 mkTopicAssignment(fooTopicId, 5, 6),
                 mkTopicAssignment(barTopicId, 5, 6)
             ))
-        ), result.records().subList(0, result.records().size() - 1));
+        ), result.records().subList(0, 3));
 
         assertEquals(newTargetAssignmentEpochRecord(
             "my-group",
             20
-        ), result.records().get(result.records().size() - 1));
+        ), result.records().get(3));
 
         Map<String, Assignment> expectedAssignment = new HashMap<>();
         expectedAssignment.put("member-1", new Assignment(mkAssignment(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
@@ -209,7 +209,7 @@ public class TargetAssignmentBuilderTest {
                 if (updatedMemberOrNull != null) {
                     builder.withUpdatedMember(memberId, updatedMemberOrNull);
                 } else {
-                    builder.withRemoveMembers(memberId);
+                    builder.withRemoveMember(memberId);
                 }
             });
 
@@ -229,15 +229,15 @@ public class TargetAssignmentBuilderTest {
         );
 
         TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
-        assertEquals(newTargetAssignmentEpochRecord(
+        assertEquals(Collections.singletonList(newTargetAssignmentEpochRecord(
             "my-group",
             20
-        ), result.records().get(result.records().size() - 1));
+        )), result.records());
         assertEquals(Collections.emptyMap(), result.assignments());
     }
 
     @Test
-    public void testAssignmentIsNotChanged() {
+    public void testAssignmentHasNotChanged() {
         Uuid fooTopicId = Uuid.randomUuid();
         Uuid barTopicId = Uuid.randomUuid();
 
@@ -324,6 +324,8 @@ public class TargetAssignmentBuilderTest {
 
         TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
 
+        assertEquals(3, result.records().size());
+
         assertUnorderedList(Arrays.asList(
             newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
                 mkTopicAssignment(fooTopicId, 4, 5, 6),
@@ -338,7 +340,7 @@ public class TargetAssignmentBuilderTest {
         assertEquals(newTargetAssignmentEpochRecord(
             "my-group",
             20
-        ), result.records().get(result.records().size() - 1));
+        ), result.records().get(2));
 
         Map<String, Assignment> expectedAssignment = new HashMap<>();
         expectedAssignment.put("member-2", new Assignment(mkAssignment(
@@ -395,6 +397,8 @@ public class TargetAssignmentBuilderTest {
 
         TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
 
+        assertEquals(4, result.records().size());
+
         assertUnorderedList(Arrays.asList(
             newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
                 mkTopicAssignment(fooTopicId, 1, 2),
@@ -408,12 +412,12 @@ public class TargetAssignmentBuilderTest {
                 mkTopicAssignment(fooTopicId, 5, 6),
                 mkTopicAssignment(barTopicId, 5, 6)
             ))
-        ), result.records().subList(0, result.records().size() - 1));
+        ), result.records().subList(0, 3));
 
         assertEquals(newTargetAssignmentEpochRecord(
             "my-group",
             20
-        ), result.records().get(result.records().size() - 1));
+        ), result.records().get(3));
 
         Map<String, Assignment> expectedAssignment = new HashMap<>();
         expectedAssignment.put("member-1", new Assignment(mkAssignment(
@@ -565,7 +569,9 @@ public class TargetAssignmentBuilderTest {
 
         TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
 
-        // Member 1 has not record because its assignment did not change.
+        assertEquals(3, result.records().size());
+
+        // Member 1 has no record because its assignment did not change.
         assertUnorderedList(Arrays.asList(
             newTargetAssignmentRecord("my-group", "member-2", mkAssignment(
                 mkTopicAssignment(fooTopicId, 3, 4, 5),
@@ -575,12 +581,12 @@ public class TargetAssignmentBuilderTest {
                 mkTopicAssignment(fooTopicId, 6),
                 mkTopicAssignment(barTopicId, 6)
             ))
-        ), result.records().subList(0, result.records().size() - 1));
+        ), result.records().subList(0, 2));
 
         assertEquals(newTargetAssignmentEpochRecord(
             "my-group",
             20
-        ), result.records().get(result.records().size() - 1));
+        ), result.records().get(2));
 
         Map<String, Assignment> expectedAssignment = new HashMap<>();
         expectedAssignment.put("member-1", new Assignment(mkAssignment(
@@ -641,6 +647,8 @@ public class TargetAssignmentBuilderTest {
 
         TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
 
+        assertEquals(3, result.records().size());
+
         assertUnorderedList(Arrays.asList(
             newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
                 mkTopicAssignment(fooTopicId, 1, 2, 3),
@@ -650,12 +658,12 @@ public class TargetAssignmentBuilderTest {
                 mkTopicAssignment(fooTopicId, 4, 5, 6),
                 mkTopicAssignment(barTopicId, 4, 5, 6)
             ))
-        ), result.records().subList(0, result.records().size() - 1));
+        ), result.records().subList(0, 2));
 
         assertEquals(newTargetAssignmentEpochRecord(
             "my-group",
             20
-        ), result.records().get(result.records().size() - 1));
+        ), result.records().get(2));
 
         Map<String, Assignment> expectedAssignment = new HashMap<>();
         expectedAssignment.put("member-1", new Assignment(mkAssignment(
@@ -674,6 +682,7 @@ public class TargetAssignmentBuilderTest {
         List<T> expected,
         List<T> actual
     ) {
+        assertEquals(expected.size(), actual.size());
         assertEquals(new HashSet<>(expected), new HashSet<>(actual));
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
@@ -1,0 +1,679 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.consumer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.group.assignor.AssignmentMemberSpec;
+import org.apache.kafka.coordinator.group.assignor.AssignmentSpec;
+import org.apache.kafka.coordinator.group.assignor.AssignmentTopicMetadata;
+import org.apache.kafka.coordinator.group.assignor.GroupAssignment;
+import org.apache.kafka.coordinator.group.assignor.PartitionAssignor;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkAssignment;
+import static org.apache.kafka.coordinator.group.consumer.AssignmentTestUtil.mkTopicAssignment;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentEpochRecord;
+import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentRecord;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TargetAssignmentBuilderTest {
+
+    public static class TargetAssignmentBuilderTestContext {
+        private final String groupId;
+        private final int groupEpoch;
+        private final PartitionAssignor assignor = mock(PartitionAssignor.class);
+        private final Map<String, ConsumerGroupMember> members = new HashMap<>();
+        private final Map<String, TopicMetadata> subscriptionMetadata = new HashMap<>();
+        private final Map<String, ConsumerGroupMember> updatedMembers = new HashMap<>();
+        private final Map<String, Assignment> targetAssignments = new HashMap<>();
+        private final Map<String, org.apache.kafka.coordinator.group.assignor.MemberAssignment> assignments = new HashMap<>();
+
+        public TargetAssignmentBuilderTestContext(
+            String groupId,
+            int groupEpoch
+        ) {
+            this.groupId = groupId;
+            this.groupEpoch = groupEpoch;
+        }
+
+        public TargetAssignmentBuilderTestContext addGroupMember(
+            String memberId,
+            List<String> subscriptions,
+            Map<Uuid, Set<Integer>> targetPartitions
+        ) {
+            members.put(memberId, new ConsumerGroupMember.Builder(memberId)
+                .setSubscribedTopicNames(subscriptions)
+                .setRebalanceTimeoutMs(5000)
+                .build());
+
+            targetAssignments.put(memberId, new Assignment(
+                (byte) 0,
+                targetPartitions,
+                VersionedMetadata.EMPTY
+            ));
+
+            return this;
+        }
+
+        public TargetAssignmentBuilderTestContext addTopicMetadata(
+            Uuid topicId,
+            String topicName,
+            int numPartitions
+        ) {
+            subscriptionMetadata.put(topicName, new TopicMetadata(
+                topicId,
+                topicName,
+                numPartitions
+            ));
+            return this;
+        }
+
+        public TargetAssignmentBuilderTestContext updateMemberSubscription(
+            String memberId,
+            List<String> subscriptions
+        ) {
+            return updateMemberSubscription(
+                memberId,
+                subscriptions,
+                Optional.empty(),
+                Optional.empty()
+            );
+        }
+
+        public TargetAssignmentBuilderTestContext updateMemberSubscription(
+            String memberId,
+            List<String> subscriptions,
+            Optional<String> instanceId,
+            Optional<String> rackId
+        ) {
+            ConsumerGroupMember existingMember = members.get(memberId);
+            ConsumerGroupMember.Builder builder;
+            if (existingMember != null) {
+                builder = new ConsumerGroupMember.Builder(existingMember);
+            } else {
+                builder = new ConsumerGroupMember.Builder(memberId);
+            }
+            updatedMembers.put(memberId, builder
+                .setSubscribedTopicNames(subscriptions)
+                .maybeUpdateInstanceId(instanceId)
+                .maybeUpdateRackId(rackId)
+                .build());
+            return this;
+        }
+
+        public TargetAssignmentBuilderTestContext removeMemberSubscription(
+            String memberId
+        ) {
+            this.updatedMembers.put(memberId, null);
+            return this;
+        }
+
+        public TargetAssignmentBuilderTestContext prepareMemberAssignment(
+            String memberId,
+            Map<Uuid, Set<Integer>> assignment
+        ) {
+            assignments.put(memberId, new org.apache.kafka.coordinator.group.assignor.MemberAssignment(assignment));
+            return this;
+        }
+
+        private AssignmentMemberSpec assignmentMemberSpec(
+            ConsumerGroupMember member,
+            Assignment targetAssignment
+        ) {
+            Set<Uuid> subscribedTopics = new HashSet<>();
+            member.subscribedTopicNames().forEach(topicName -> {
+                TopicMetadata topicMetadata = subscriptionMetadata.get(topicName);
+                if (topicMetadata != null) {
+                    subscribedTopics.add(topicMetadata.id());
+                }
+            });
+
+            return new AssignmentMemberSpec(
+                Optional.ofNullable(member.instanceId()),
+                Optional.ofNullable(member.rackId()),
+                subscribedTopics,
+                targetAssignment.partitions()
+            );
+        }
+
+        public TargetAssignmentBuilder.TargetAssignmentResult build() {
+            // Prepare expected member specs.
+            Map<String, AssignmentMemberSpec> memberSpecs = new HashMap<>();
+            members.forEach((memberId, member) -> {
+                memberSpecs.put(memberId, assignmentMemberSpec(
+                    member,
+                    targetAssignments.getOrDefault(memberId, Assignment.EMPTY)
+                ));
+            });
+
+            updatedMembers.forEach((memberId, updatedMemberOrNull) -> {
+                if (updatedMemberOrNull == null) {
+                    memberSpecs.remove(memberId);
+                } else {
+                    memberSpecs.put(memberId, assignmentMemberSpec(
+                        updatedMemberOrNull,
+                        targetAssignments.getOrDefault(memberId, Assignment.EMPTY)
+                    ));
+                }
+            });
+
+            Map<Uuid, AssignmentTopicMetadata> topicMetadata = new HashMap<>();
+            subscriptionMetadata.forEach((topicName, metadata) -> {
+                topicMetadata.put(metadata.id(), new AssignmentTopicMetadata(metadata.numPartitions()));
+            });
+
+            AssignmentSpec assignmentSpec = new AssignmentSpec(
+                memberSpecs,
+                topicMetadata
+            );
+
+            // We use `any` here to always return an assignment but use `verify` later on
+            // to ensure that the input was correct.
+            when(assignor.assign(any())).thenReturn(new GroupAssignment(assignments));
+
+            // Create and populate the assignment builder.
+            TargetAssignmentBuilder builder = new TargetAssignmentBuilder(groupId, groupEpoch, assignor)
+                .withMembers(members)
+                .withSubscriptionMetadata(subscriptionMetadata)
+                .withTargetAssignments(targetAssignments);
+
+            updatedMembers.forEach((memberId, updatedMemberOrNull) -> {
+                if (updatedMemberOrNull != null) {
+                    builder.withUpdatedMember(memberId, updatedMemberOrNull);
+                } else {
+                    builder.withRemoveMembers(memberId);
+                }
+            });
+
+            TargetAssignmentBuilder.TargetAssignmentResult result = builder.build();
+
+            verify(assignor, times(1)).assign(assignmentSpec);
+
+            return result;
+        }
+    }
+
+    @Test
+    public void testEmpty() {
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+        assertEquals(newTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(result.records().size() - 1));
+        assertEquals(Collections.emptyMap(), result.assignments());
+    }
+
+    @Test
+    public void testAssignmentIsNotChanged() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        context.addTopicMetadata(fooTopicId, "foo", 6);
+        context.addTopicMetadata(barTopicId, "bar", 6);
+
+        context.addGroupMember("member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        ));
+
+        context.addGroupMember("member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-1", mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertEquals(Collections.singletonList(newTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        )), result.records());
+
+        Map<String, Assignment> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        )));
+        expectedAssignment.put("member-2", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        )));
+
+        assertEquals(expectedAssignment, result.assignments());
+    }
+
+    @Test
+    public void testAssignmentSwapped() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        context.addTopicMetadata(fooTopicId, "foo", 6);
+        context.addTopicMetadata(barTopicId, "bar", 6);
+
+        context.addGroupMember("member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        ));
+
+        context.addGroupMember("member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        ));
+
+        context.prepareMemberAssignment("member-1", mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertUnorderedList(Arrays.asList(
+            newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                mkTopicAssignment(fooTopicId, 4, 5, 6),
+                mkTopicAssignment(barTopicId, 4, 5, 6)
+            )),
+            newTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                mkTopicAssignment(fooTopicId, 1, 2, 3),
+                mkTopicAssignment(barTopicId, 1, 2, 3)
+            ))
+        ), result.records().subList(0, 2));
+
+        assertEquals(newTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(result.records().size() - 1));
+
+        Map<String, Assignment> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-2", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        )));
+        expectedAssignment.put("member-1", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        )));
+
+        assertEquals(expectedAssignment, result.assignments());
+    }
+
+    @Test
+    public void testNewMember() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        context.addTopicMetadata(fooTopicId, "foo", 6);
+        context.addTopicMetadata(barTopicId, "bar", 6);
+
+        context.addGroupMember("member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        ));
+
+        context.addGroupMember("member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        ));
+
+        context.updateMemberSubscription("member-3", Arrays.asList("foo", "bar", "zar"));
+
+        context.prepareMemberAssignment("member-1", mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        ));
+
+        context.prepareMemberAssignment("member-3", mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertUnorderedList(Arrays.asList(
+            newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                mkTopicAssignment(fooTopicId, 1, 2),
+                mkTopicAssignment(barTopicId, 1, 2)
+            )),
+            newTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                mkTopicAssignment(fooTopicId, 3, 4),
+                mkTopicAssignment(barTopicId, 3, 4)
+            )),
+            newTargetAssignmentRecord("my-group", "member-3", mkAssignment(
+                mkTopicAssignment(fooTopicId, 5, 6),
+                mkTopicAssignment(barTopicId, 5, 6)
+            ))
+        ), result.records().subList(0, result.records().size() - 1));
+
+        assertEquals(newTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(result.records().size() - 1));
+
+        Map<String, Assignment> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        )));
+        expectedAssignment.put("member-2", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        )));
+        expectedAssignment.put("member-3", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        )));
+
+        assertEquals(expectedAssignment, result.assignments());
+    }
+
+    @Test
+    public void testUpdateMember() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        context.addTopicMetadata(fooTopicId, "foo", 6);
+        context.addTopicMetadata(barTopicId, "bar", 6);
+
+        context.addGroupMember("member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        context.addGroupMember("member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 3, 4)
+        ));
+
+        context.addGroupMember("member-3", Arrays.asList("bar", "zar"), mkAssignment(
+            mkTopicAssignment(barTopicId, 5, 6)
+        ));
+
+        context.updateMemberSubscription(
+            "member-3",
+            Arrays.asList("foo", "bar", "zar"),
+            Optional.of("instance-id-3"),
+            Optional.of("rack-0")
+        );
+
+        context.prepareMemberAssignment("member-1", mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        ));
+
+        context.prepareMemberAssignment("member-3", mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertUnorderedList(Arrays.asList(
+            newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                mkTopicAssignment(fooTopicId, 1, 2),
+                mkTopicAssignment(barTopicId, 1, 2)
+            )),
+            newTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                mkTopicAssignment(fooTopicId, 3, 4),
+                mkTopicAssignment(barTopicId, 3, 4)
+            )),
+            newTargetAssignmentRecord("my-group", "member-3", mkAssignment(
+                mkTopicAssignment(fooTopicId, 5, 6),
+                mkTopicAssignment(barTopicId, 5, 6)
+            ))
+        ), result.records().subList(0, result.records().size() - 1));
+
+        assertEquals(newTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(result.records().size() - 1));
+
+        Map<String, Assignment> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        )));
+        expectedAssignment.put("member-2", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        )));
+        expectedAssignment.put("member-3", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        )));
+
+        assertEquals(expectedAssignment, result.assignments());
+    }
+
+    @Test
+    public void testPartialAssignmentUpdate() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        context.addTopicMetadata(fooTopicId, "foo", 6);
+        context.addTopicMetadata(barTopicId, "bar", 6);
+
+        context.addGroupMember("member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        context.addGroupMember("member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        ));
+
+        context.addGroupMember("member-3", Arrays.asList("bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        ));
+
+        context.prepareMemberAssignment("member-1", mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4, 5),
+            mkTopicAssignment(barTopicId, 3, 4, 5)
+        ));
+
+        context.prepareMemberAssignment("member-3", mkAssignment(
+            mkTopicAssignment(fooTopicId, 6),
+            mkTopicAssignment(barTopicId, 6)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        // Member 1 has not record because its assignment did not change.
+        assertUnorderedList(Arrays.asList(
+            newTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                mkTopicAssignment(fooTopicId, 3, 4, 5),
+                mkTopicAssignment(barTopicId, 3, 4, 5)
+            )),
+            newTargetAssignmentRecord("my-group", "member-3", mkAssignment(
+                mkTopicAssignment(fooTopicId, 6),
+                mkTopicAssignment(barTopicId, 6)
+            ))
+        ), result.records().subList(0, result.records().size() - 1));
+
+        assertEquals(newTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(result.records().size() - 1));
+
+        Map<String, Assignment> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        )));
+        expectedAssignment.put("member-2", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4, 5),
+            mkTopicAssignment(barTopicId, 3, 4, 5)
+        )));
+        expectedAssignment.put("member-3", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 6),
+            mkTopicAssignment(barTopicId, 6)
+        )));
+
+        assertEquals(expectedAssignment, result.assignments());
+    }
+
+    @Test
+    public void testDeleteMember() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
+            "my-group",
+            20
+        );
+
+        context.addTopicMetadata(fooTopicId, "foo", 6);
+        context.addTopicMetadata(barTopicId, "bar", 6);
+
+        context.addGroupMember("member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2),
+            mkTopicAssignment(barTopicId, 1, 2)
+        ));
+
+        context.addGroupMember("member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 3, 4),
+            mkTopicAssignment(barTopicId, 3, 4)
+        ));
+
+        context.addGroupMember("member-3", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+            mkTopicAssignment(fooTopicId, 5, 6),
+            mkTopicAssignment(barTopicId, 5, 6)
+        ));
+
+        context.removeMemberSubscription("member-3");
+
+        context.prepareMemberAssignment("member-1", mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        ));
+
+        context.prepareMemberAssignment("member-2", mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        ));
+
+        TargetAssignmentBuilder.TargetAssignmentResult result = context.build();
+
+        assertUnorderedList(Arrays.asList(
+            newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                mkTopicAssignment(fooTopicId, 1, 2, 3),
+                mkTopicAssignment(barTopicId, 1, 2, 3)
+            )),
+            newTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                mkTopicAssignment(fooTopicId, 4, 5, 6),
+                mkTopicAssignment(barTopicId, 4, 5, 6)
+            ))
+        ), result.records().subList(0, result.records().size() - 1));
+
+        assertEquals(newTargetAssignmentEpochRecord(
+            "my-group",
+            20
+        ), result.records().get(result.records().size() - 1));
+
+        Map<String, Assignment> expectedAssignment = new HashMap<>();
+        expectedAssignment.put("member-1", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3),
+            mkTopicAssignment(barTopicId, 1, 2, 3)
+        )));
+        expectedAssignment.put("member-2", new Assignment(mkAssignment(
+            mkTopicAssignment(fooTopicId, 4, 5, 6),
+            mkTopicAssignment(barTopicId, 4, 5, 6)
+        )));
+
+        assertEquals(expectedAssignment, result.assignments());
+    }
+
+    public static <T> void assertUnorderedList(
+        List<T> expected,
+        List<T> actual
+    ) {
+        assertEquals(new HashSet<>(expected), new HashSet<>(actual));
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
@@ -55,8 +55,8 @@ public class TargetAssignmentBuilderTest {
         private final Map<String, ConsumerGroupMember> members = new HashMap<>();
         private final Map<String, TopicMetadata> subscriptionMetadata = new HashMap<>();
         private final Map<String, ConsumerGroupMember> updatedMembers = new HashMap<>();
-        private final Map<String, Assignment> targetAssignments = new HashMap<>();
-        private final Map<String, MemberAssignment> assignments = new HashMap<>();
+        private final Map<String, Assignment> targetAssignment = new HashMap<>();
+        private final Map<String, MemberAssignment> memberAssignments = new HashMap<>();
 
         public TargetAssignmentBuilderTestContext(
             String groupId,
@@ -73,10 +73,9 @@ public class TargetAssignmentBuilderTest {
         ) {
             members.put(memberId, new ConsumerGroupMember.Builder(memberId)
                 .setSubscribedTopicNames(subscriptions)
-                .setRebalanceTimeoutMs(5000)
                 .build());
 
-            targetAssignments.put(memberId, new Assignment(
+            targetAssignment.put(memberId, new Assignment(
                 (byte) 0,
                 targetPartitions,
                 VersionedMetadata.EMPTY
@@ -138,7 +137,7 @@ public class TargetAssignmentBuilderTest {
             String memberId,
             Map<Uuid, Set<Integer>> assignment
         ) {
-            assignments.put(memberId, new MemberAssignment(assignment));
+            memberAssignments.put(memberId, new MemberAssignment(assignment));
         }
 
         public TargetAssignmentBuilder.TargetAssignmentResult build() {
@@ -149,7 +148,7 @@ public class TargetAssignmentBuilderTest {
             members.forEach((memberId, member) -> {
                 memberSpecs.put(memberId, createAssignmentMemberSpec(
                     member,
-                    targetAssignments.getOrDefault(memberId, Assignment.EMPTY),
+                    targetAssignment.getOrDefault(memberId, Assignment.EMPTY),
                     subscriptionMetadata
                 ));
             });
@@ -162,7 +161,7 @@ public class TargetAssignmentBuilderTest {
                 } else {
                     memberSpecs.put(memberId, createAssignmentMemberSpec(
                         updatedMemberOrNull,
-                        targetAssignments.getOrDefault(memberId, Assignment.EMPTY),
+                        targetAssignment.getOrDefault(memberId, Assignment.EMPTY),
                         subscriptionMetadata
                     ));
                 }
@@ -182,13 +181,13 @@ public class TargetAssignmentBuilderTest {
 
             // We use `any` here to always return an assignment but use `verify` later on
             // to ensure that the input was correct.
-            when(assignor.assign(any())).thenReturn(new GroupAssignment(assignments));
+            when(assignor.assign(any())).thenReturn(new GroupAssignment(memberAssignments));
 
             // Create and populate the assignment builder.
             TargetAssignmentBuilder builder = new TargetAssignmentBuilder(groupId, groupEpoch, assignor)
                 .withMembers(members)
                 .withSubscriptionMetadata(subscriptionMetadata)
-                .withTargetAssignments(targetAssignments);
+                .withTargetAssignment(targetAssignment);
 
             // Add the updated members or delete the deleted members.
             updatedMembers.forEach((memberId, updatedMemberOrNull) -> {
@@ -259,7 +258,7 @@ public class TargetAssignmentBuilderTest {
             "my-group",
             20
         )), result.records());
-        assertEquals(Collections.emptyMap(), result.assignments());
+        assertEquals(Collections.emptyMap(), result.targetAssignment());
     }
 
     @Test
@@ -309,7 +308,7 @@ public class TargetAssignmentBuilderTest {
             mkTopicAssignment(barTopicId, 4, 5, 6)
         )));
 
-        assertEquals(expectedAssignment, result.assignments());
+        assertEquals(expectedAssignment, result.targetAssignment());
     }
 
     @Test
@@ -372,7 +371,7 @@ public class TargetAssignmentBuilderTest {
             mkTopicAssignment(barTopicId, 4, 5, 6)
         )));
 
-        assertEquals(expectedAssignment, result.assignments());
+        assertEquals(expectedAssignment, result.targetAssignment());
     }
 
     @Test
@@ -450,7 +449,7 @@ public class TargetAssignmentBuilderTest {
             mkTopicAssignment(barTopicId, 5, 6)
         )));
 
-        assertEquals(expectedAssignment, result.assignments());
+        assertEquals(expectedAssignment, result.targetAssignment());
     }
 
     @Test
@@ -537,7 +536,7 @@ public class TargetAssignmentBuilderTest {
             mkTopicAssignment(barTopicId, 5, 6)
         )));
 
-        assertEquals(expectedAssignment, result.assignments());
+        assertEquals(expectedAssignment, result.targetAssignment());
     }
 
     @Test
@@ -615,7 +614,7 @@ public class TargetAssignmentBuilderTest {
             mkTopicAssignment(barTopicId, 6)
         )));
 
-        assertEquals(expectedAssignment, result.assignments());
+        assertEquals(expectedAssignment, result.targetAssignment());
     }
 
     @Test
@@ -685,7 +684,7 @@ public class TargetAssignmentBuilderTest {
             mkTopicAssignment(barTopicId, 4, 5, 6)
         )));
 
-        assertEquals(expectedAssignment, result.assignments());
+        assertEquals(expectedAssignment, result.targetAssignment());
     }
 
     public static <T> void assertUnorderedList(


### PR DESCRIPTION
This patch adds TargetAssignmentBuilder.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
