### PR TITLE
KAFKA-14936: Add Grace Period to Stream Table Join

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Joined.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Joined.java
@@ -18,6 +18,8 @@ package org.apache.kafka.streams.kstream;
 
 import org.apache.kafka.common.serialization.Serde;
 
+import java.time.Duration;
+
 /**
  * The {@code Joined} class represents optional params that can be passed to
  * {@link KStream#join(KTable, ValueJoiner, Joined) KStream#join(KTable,...)} and
@@ -29,19 +31,22 @@ public class Joined<K, V, VO> implements NamedOperation<Joined<K, V, VO>> {
     protected final Serde<V> valueSerde;
     protected final Serde<VO> otherValueSerde;
     protected final String name;
+    protected final Duration gracePeriod;
 
     private Joined(final Serde<K> keySerde,
                    final Serde<V> valueSerde,
                    final Serde<VO> otherValueSerde,
-                   final String name) {
+                   final String name,
+                   final Duration gracePeriod) {
         this.keySerde = keySerde;
         this.valueSerde = valueSerde;
         this.otherValueSerde = otherValueSerde;
         this.name = name;
+        this.gracePeriod = gracePeriod;
     }
 
     protected Joined(final Joined<K, V, VO> joined) {
-        this(joined.keySerde, joined.valueSerde, joined.otherValueSerde, joined.name);
+        this(joined.keySerde, joined.valueSerde, joined.otherValueSerde, joined.name, joined.gracePeriod);
     }
 
     /**
@@ -59,7 +64,7 @@ public class Joined<K, V, VO> implements NamedOperation<Joined<K, V, VO>> {
     public static <K, V, VO> Joined<K, V, VO> with(final Serde<K> keySerde,
                                                    final Serde<V> valueSerde,
                                                    final Serde<VO> otherValueSerde) {
-        return new Joined<>(keySerde, valueSerde, otherValueSerde, null);
+        return new Joined<>(keySerde, valueSerde, otherValueSerde, null, null);
     }
 
     /**
@@ -84,7 +89,34 @@ public class Joined<K, V, VO> implements NamedOperation<Joined<K, V, VO>> {
                                                    final Serde<V> valueSerde,
                                                    final Serde<VO> otherValueSerde,
                                                    final String name) {
-        return new Joined<>(keySerde, valueSerde, otherValueSerde, name);
+        return new Joined<>(keySerde, valueSerde, otherValueSerde, name, null);
+    }
+
+    /**
+     * Create an instance of {@code Joined} with key, value, and otherValue {@link Serde} instances.
+     * {@code null} values are accepted and will be replaced by the default serdes as defined in
+     * config.
+     *
+     * @param keySerde the key serde to use. If {@code null} the default key serde from config will be
+     * used
+     * @param valueSerde the value serde to use. If {@code null} the default value serde from config
+     * will be used
+     * @param otherValueSerde the otherValue serde to use. If {@code null} the default value serde
+     * from config will be used
+     * @param name the name used as the base for naming components of the join including any
+     * repartition topics
+     * @param gracePeriod stream buffer time
+     * @param <K> key type
+     * @param <V> value type
+     * @param <VO> other value type
+     * @return new {@code Joined} instance with the provided serdes
+     */
+    public static <K, V, VO> Joined<K, V, VO> with(final Serde<K> keySerde,
+                                                   final Serde<V> valueSerde,
+                                                   final Serde<VO> otherValueSerde,
+                                                   final String name,
+                                                   final Duration gracePeriod) {
+        return new Joined<>(keySerde, valueSerde, otherValueSerde, name, gracePeriod);
     }
 
     /**
@@ -98,7 +130,7 @@ public class Joined<K, V, VO> implements NamedOperation<Joined<K, V, VO>> {
      * @return new {@code Joined} instance configured with the keySerde
      */
     public static <K, V, VO> Joined<K, V, VO> keySerde(final Serde<K> keySerde) {
-        return new Joined<>(keySerde, null, null, null);
+        return new Joined<>(keySerde, null, null, null, null);
     }
 
     /**
@@ -112,7 +144,7 @@ public class Joined<K, V, VO> implements NamedOperation<Joined<K, V, VO>> {
      * @return new {@code Joined} instance configured with the valueSerde
      */
     public static <K, V, VO> Joined<K, V, VO> valueSerde(final Serde<V> valueSerde) {
-        return new Joined<>(null, valueSerde, null, null);
+        return new Joined<>(null, valueSerde, null, null, null);
     }
 
     /**
@@ -126,7 +158,7 @@ public class Joined<K, V, VO> implements NamedOperation<Joined<K, V, VO>> {
      * @return new {@code Joined} instance configured with the otherValueSerde
      */
     public static <K, V, VO> Joined<K, V, VO> otherValueSerde(final Serde<VO> otherValueSerde) {
-        return new Joined<>(null, null, otherValueSerde, null);
+        return new Joined<>(null, null, otherValueSerde, null, null);
     }
 
     /**
@@ -142,7 +174,23 @@ public class Joined<K, V, VO> implements NamedOperation<Joined<K, V, VO>> {
      *
      */
     public static <K, V, VO> Joined<K, V, VO> as(final String name) {
-        return new Joined<>(null, null, null, name);
+        return new Joined<>(null, null, null, name, null);
+    }
+
+    /**
+     * Create an instance of {@code Joined} with base name for all components of the join, this may
+     * include any repartition topics created to complete the join.
+     *
+     * @param name the name used as the base for naming components of the join including any
+     * repartition topics
+     * @param <K> key type
+     * @param <V> value type
+     * @param <VO> other value type
+     * @return new {@code Joined} instance configured with the name
+     *
+     */
+    public static <K, V, VO> Joined<K, V, VO> as(final Duration name) {
+        return new Joined<>(null, null, null, null, name);
     }
 
 
@@ -154,7 +202,7 @@ public class Joined<K, V, VO> implements NamedOperation<Joined<K, V, VO>> {
      * @return new {@code Joined} instance configured with the {@code name}
      */
     public Joined<K, V, VO> withKeySerde(final Serde<K> keySerde) {
-        return new Joined<>(keySerde, valueSerde, otherValueSerde, name);
+        return new Joined<>(keySerde, valueSerde, otherValueSerde, name, gracePeriod);
     }
 
     /**
@@ -165,7 +213,7 @@ public class Joined<K, V, VO> implements NamedOperation<Joined<K, V, VO>> {
      * @return new {@code Joined} instance configured with the {@code valueSerde}
      */
     public Joined<K, V, VO> withValueSerde(final Serde<V> valueSerde) {
-        return new Joined<>(keySerde, valueSerde, otherValueSerde, name);
+        return new Joined<>(keySerde, valueSerde, otherValueSerde, name, gracePeriod);
     }
 
     /**
@@ -176,7 +224,7 @@ public class Joined<K, V, VO> implements NamedOperation<Joined<K, V, VO>> {
      * @return new {@code Joined} instance configured with the {@code valueSerde}
      */
     public Joined<K, V, VO> withOtherValueSerde(final Serde<VO> otherValueSerde) {
-        return new Joined<>(keySerde, valueSerde, otherValueSerde, name);
+        return new Joined<>(keySerde, valueSerde, otherValueSerde, name, gracePeriod);
     }
 
     /**
@@ -189,7 +237,17 @@ public class Joined<K, V, VO> implements NamedOperation<Joined<K, V, VO>> {
      */
     @Override
     public Joined<K, V, VO> withName(final String name) {
-        return new Joined<>(keySerde, valueSerde, otherValueSerde, name);
+        return new Joined<>(keySerde, valueSerde, otherValueSerde, name, gracePeriod);
+    }
+
+    /**
+     * Set the grace period on the stream side of the join. Records will enter a buffer before being processed. Late records in the grace period will be processed in timestamp order, records out of the grace period will be dropped.
+     *
+     * @param gracePeriod the duration of the grace period. If zero, no buffer will be used.
+     * @return new {@code Joined} instance configured with the gracePeriod
+     */
+    public Joined<K, V, VO> withGracePeriod(final Duration gracePeriod) {
+        return new Joined<>(keySerde, valueSerde, otherValueSerde, name, gracePeriod);
     }
 
     public Serde<K> keySerde() {
@@ -202,5 +260,9 @@ public class Joined<K, V, VO> implements NamedOperation<Joined<K, V, VO>> {
 
     public Serde<VO> otherValueSerde() {
         return otherValueSerde;
+    }
+
+    public Duration gracePeriod() {
+        return gracePeriod;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -1302,11 +1302,11 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
         final Set<String> allSourceNodes = ensureCopartitionWith(Collections.singleton((AbstractStream<K, VO>) table));
 
-        final RocksDBTimeOrderedKeyValueSegmentedBytesStore store = new RocksDbTimeOrderedKeyValueBytesStoreSupplier(name,  0,false).get();
+        final RocksDBTimeOrderedKeyValueSegmentedBytesStore store = new RocksDbTimeOrderedKeyValueBytesStoreSupplier(name,  1,false).get();
 
         final TimeOrderedKeyValueBuffer<K, V> supressBuffer = new RocksDBTimeOrderedKeyValueBuffer<>(store, joined.gracePeriod(), name);
         final String bufferName = name + "-buffer";
-        final ProcessorSupplier<K, V, K, V> processorSupplier1 = (ProcessorSupplier<K, V, K, V>) new KStreamJoinSupressBufferProcessSupplier<>(supressBuffer, joined.gracePeriod());
+        final ProcessorSupplier<K, V, K, V> processorSupplier1 = new KStreamJoinSupressBufferProcessSupplier<>(supressBuffer, joined.gracePeriod());
         final ProcessorParameters<K, V, ?, ?> processorParameters1 = new ProcessorParameters<>(processorSupplier1, bufferName);
 
         final StreamTableJoinBufferNode<K, V> streamTableJoinBufferNode = new StreamTableJoinBufferNode<>(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamJoinBufferProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamJoinBufferProcessor.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.Record;
@@ -26,9 +27,7 @@ import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer;
-
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 
@@ -55,6 +54,7 @@ public class KStreamJoinBufferProcessor<K, V> extends ContextualProcessor<K, V, 
     final StreamsMetricsImpl metrics = (StreamsMetricsImpl) context.metrics();
     droppedRecordsSensor = droppedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
     buffer.setSerdesIfNull(new SerdeGetter(context));
+    buffer.init((org.apache.kafka.streams.processor.StateStoreContext) context(), (StateStore) null);
   }
   /**
    * Process the record. Note that record metadata is undefined in cases such as a forward call from a punctuator.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamJoinBufferProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamJoinBufferProcessor.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.streams.processor.api.ContextualProcessor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
+
+public class KStreamJoinBufferProcessor<K, V> extends ContextualProcessor<K, Change<V>, K, Change<V>> {
+
+  private final TimeOrderedKeyValueBuffer<K, V> buffer;
+  private Sensor droppedRecordsSensor;
+  protected long observedStreamTime = ConsumerRecord.NO_TIMESTAMP;
+  private InternalProcessorContext<K, Change<V>> internalProcessorContext;
+  private final Duration gracePeriod;
+
+
+  public KStreamJoinBufferProcessor(final TimeOrderedKeyValueBuffer<K, V> buffer,
+                                    final Duration gracePeriod) {
+    this.buffer = buffer;
+    this.gracePeriod = gracePeriod;
+    internalProcessorContext = (InternalProcessorContext<K, Change<V>>) context();
+  }
+
+  @Override
+  public void init(final ProcessorContext<K, Change<V>> context) {
+    super.init(context);
+    final StreamsMetricsImpl metrics = (StreamsMetricsImpl) context.metrics();
+    droppedRecordsSensor = droppedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
+  }
+  /**
+   * Process the record. Note that record metadata is undefined in cases such as a forward call from a punctuator.
+   *
+   * @param record the record to process
+   */
+  @Override
+  public void process(Record<K, Change<V>> record) {
+    updateObservedStreamTime(record.timestamp());
+    final long deadline = observedStreamTime + gracePeriod.toMillis();
+    if(buffer.minTimestamp() <= deadline) {
+      droppedRecordsSensor.record();
+    } else {
+      buffer.put(observedStreamTime, record, internalProcessorContext.recordContext());
+      buffer.evictWhile(() -> buffer.minTimestamp() <= deadline, this::emit);
+    }
+  }
+
+  protected void updateObservedStreamTime(final long timestamp) {
+    observedStreamTime = Math.max(observedStreamTime, timestamp);
+  }
+
+  private void emit(final TimeOrderedKeyValueBuffer.Eviction<K, V> toEmit) {
+    final ProcessorRecordContext prevRecordContext = internalProcessorContext.recordContext();
+    internalProcessorContext.setRecordContext(toEmit.recordContext());
+    try {
+      context().forward(toEmit.record()
+          .withTimestamp(toEmit.recordContext().timestamp())
+          .withHeaders(toEmit.recordContext().headers()));
+    } finally {
+      internalProcessorContext.setRecordContext(prevRecordContext);
+    }
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamJoinBufferProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamJoinBufferProcessor.java
@@ -63,6 +63,9 @@ public class KStreamJoinBufferProcessor<K, V> extends ContextualProcessor<K, V, 
    */
   @Override
   public void process(Record<K, V> record) {
+    if(record.key() == null) {
+      return;
+    }
     updateObservedStreamTime(record.timestamp());
     final long deadline = observedStreamTime - gracePeriod.toMillis();
     if(record.timestamp() < deadline) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamJoinBufferProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamJoinBufferProcessor.java
@@ -26,12 +26,17 @@ import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.RocksDBConfigSetter;
 import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.Duration;
 
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 
 public class KStreamJoinBufferProcessor<K, V> extends ContextualProcessor<K, V, K, V> {
+  final Logger LOG = LoggerFactory.getLogger(KStreamKTableJoin.class);
 
   private final TimeOrderedKeyValueBuffer<K, V> buffer;
   private Sensor droppedRecordsSensor;
@@ -64,6 +69,11 @@ public class KStreamJoinBufferProcessor<K, V> extends ContextualProcessor<K, V, 
   @Override
   public void process(Record<K, V> record) {
     if(record.key() == null) {
+      LOG.warn(
+          "Skipping record due to null join key or value. "
+              + "topic=[{}] partition=[{}] offset=[{}]",
+          internalProcessorContext.recordContext().topic(), internalProcessorContext.recordContext().partition(), internalProcessorContext.recordContext().offset());
+
       return;
     }
     updateObservedStreamTime(record.timestamp());

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamJoinSupressBufferProcessSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamJoinSupressBufferProcessSupplier.java
@@ -22,7 +22,7 @@ import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer;
 
 import java.time.Duration;
 
-public class KStreamJoinSupressBufferProcessSupplier<K, V> implements KTableProcessorSupplier<K, V, K, V> {
+public class KStreamJoinSupressBufferProcessSupplier<K, V> implements ProcessorSupplier<K, V, K, V> {
   private final TimeOrderedKeyValueBuffer<K, V> buffer;
   private final Duration gracePeriod;
 
@@ -34,38 +34,14 @@ public class KStreamJoinSupressBufferProcessSupplier<K, V> implements KTableProc
   /**
    * Return a newly constructed {@link Processor} instance.
    * The supplier should always generate a new instance each time {@link  ProcessorSupplier#get()} gets called.
-   * <p>
+   * <p>x
    * Creating a single {@link Processor} object and returning the same object reference in {@link ProcessorSupplier#get()}
    * is a violation of the supplier pattern and leads to runtime exceptions.
    *
    * @return a new {@link Processor} instance
    */
   @Override
-  public Processor<K, Change<V>, K, Change<V>> get() {
+  public Processor<K, V, K, V> get() {
     return new KStreamJoinBufferProcessor<>(buffer, gracePeriod);
-  }
-
-  @Override
-  public KTableValueGetterSupplier<K, V> view() {
-    return null;
-  }
-
-  /**
-   * Potentially enables sending old values.
-   * <p>
-   * If {@code forceMaterialization} is {@code true}, the method will force the materialization of upstream nodes to
-   * enable sending old values.
-   * <p>
-   * If {@code forceMaterialization} is {@code false}, the method will only enable the sending of old values <i>if</i>
-   * an upstream node is already materialized.
-   *
-   * @param forceMaterialization indicates if an upstream node should be forced to materialize to enable sending old
-   *                             values.
-   * @return {@code true} if sending old values is enabled, i.e. either because {@code forceMaterialization} was
-   * {@code true} or some upstream node is materialized.
-   */
-  @Override
-  public boolean enableSendingOldValues(boolean forceMaterialization) {
-    return false;
   }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamJoinSupressBufferProcessSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamJoinSupressBufferProcessSupplier.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer;
+
+import java.time.Duration;
+
+public class KStreamJoinSupressBufferProcessSupplier<K, V> implements ProcessorSupplier<K, V, K, V> {
+  private final TimeOrderedKeyValueBuffer buffer;
+  private final Duration gracePeriod;
+  public KStreamJoinSupressBufferProcessSupplier(final TimeOrderedKeyValueBuffer<K, V> buffer, final Duration gracePeriod) {
+    this.buffer = buffer;
+    this.gracePeriod = gracePeriod;
+  }
+
+  /**
+   * Return a newly constructed {@link Processor} instance.
+   * The supplier should always generate a new instance each time {@link  ProcessorSupplier#get()} gets called.
+   * <p>
+   * Creating a single {@link Processor} object and returning the same object reference in {@link ProcessorSupplier#get()}
+   * is a violation of the supplier pattern and leads to runtime exceptions.
+   *
+   * @return a new {@link Processor} instance
+   */
+  @Override
+  public Processor<K, V, K, V> get() {
+    return new KStreamJoinBufferProcessor<>(buffer, gracePeriod);
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -175,6 +175,18 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         return queryableStoreName;
     }
 
+//    public void joinedWithGrace(final Duration gracePeriod){
+//        graphNode;
+//        //check if materilized
+//        //if not version store then error
+//        //or force materlization
+//        //overwirte materlized internal with version store
+//        //overwrite of versioned
+//        processorSupplier;
+//        //
+//        queryableStoreName;
+//    }
+
     private KTable<K, V> doFilter(final Predicate<? super K, ? super V> predicate,
                                   final Named named,
                                   final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materializedInternal,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamTableJoinBufferNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamTableJoinBufferNode.java
@@ -25,7 +25,7 @@ public class StreamTableJoinBufferNode<K, V> extends GraphNode {
 
   private final String[] storeNames;
   private final ProcessorParameters<K, V, ?, ?> processorParameters;
-  public <V, K> StreamTableJoinBufferNode(final String nodeName,
+  public StreamTableJoinBufferNode(final String nodeName,
                                           final ProcessorParameters<K, V, ?, ?> processorParameters,
                                           final String[] storeNames) {
     super(nodeName);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamTableJoinBufferNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamTableJoinBufferNode.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals.graph;
+
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+
+import java.util.Arrays;
+
+public class StreamTableJoinBufferNode<K, V> extends GraphNode {
+
+  private final String[] storeNames;
+  private final ProcessorParameters<K, V, ?, ?> processorParameters;
+  public <V, K> StreamTableJoinBufferNode(final String nodeName,
+                                          final ProcessorParameters<K, V, ?, ?> processorParameters,
+                                          final String[] storeNames) {
+    super(nodeName);
+
+    // in the case of Stream-Table join the state stores associated with the KTable
+    this.storeNames = storeNames;
+    this.processorParameters = processorParameters;
+  }
+
+  @Override
+  public String toString() {
+    return "StreamTableJoinNode{" +
+        "storeNames=" + Arrays.toString(storeNames) +
+        ", processorParameters=" + processorParameters +
+        "} " + super.toString();
+  }
+
+
+  @Override
+  public void writeToTopology(InternalTopologyBuilder topologyBuilder) {
+    final String processorName = processorParameters.processorName();
+    final ProcessorSupplier<K, V, ?, ?> processorSupplier = processorParameters.processorSupplier();
+
+    topologyBuilder.addProcessor(processorName, processorSupplier, parentNodeNames());
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractSegments.java
@@ -46,6 +46,7 @@ abstract class AbstractSegments<S extends Segment> implements Segments<S> {
 
     AbstractSegments(final String name, final long retentionPeriod, final long segmentInterval) {
         this.name = name;
+        //segmentInterval != 0
         this.segmentInterval = segmentInterval;
         this.retentionPeriod = retentionPeriod;
         // Create a date formatter. Formatted timestamps are used as segment name suffixes

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
@@ -132,6 +132,9 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V>  extends WrappedStateStore<R
                 0).get());
     final Change<byte[]> serialChange = valueSerde.serializeParts(topic, record.value());
     final BufferValue buffered = new BufferValue(serialChange.oldValue, serialChange.oldValue, serialChange.newValue, recordContext);
+    if(wrapped().observedStreamTime - gracePeriod.toMillis() > record.timestamp()) {
+      return;
+    }
     wrapped().put(serializedKey, buffered.serialize(0).array());
     bufferSize += computeRecordSize(serializedKey, buffered);
     numRec++;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
@@ -82,7 +82,7 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V>  extends WrappedStateStore<R
           topic,
           new Change<>(bufferValue.newValue(), bufferValue.oldValue())
       );
-      while (keyValue != null && predicate.get() && wrapped().observedStreamTime - gracePeriod.toMillis() > minTimestamp()) {
+      while (keyValue != null && predicate.get() && wrapped().observedStreamTime - gracePeriod.toMillis() >= minTimestamp()) {
 
         if (bufferValue.context().timestamp() != minTimestamp) {
           throw new IllegalStateException(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
@@ -28,7 +28,7 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V>  extends WrappedStateStore<R
   private FullChangeSerde<V> valueSerde;
   private String topic;
 
-  RocksDBTimeOrderedKeyValueBuffer(final RocksDBTimeOrderedKeyValueSegmentedBytesStore store,
+  public RocksDBTimeOrderedKeyValueBuffer(final RocksDBTimeOrderedKeyValueSegmentedBytesStore store,
                                    final Duration gracePeriod,
                                    final String topic) {
     super(store);
@@ -38,9 +38,9 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V>  extends WrappedStateStore<R
     bufferSize = 0;
     this.topic = topic;
   }
-
+  @SuppressWarnings("unchecked")
   @Override
-  public void setSerdesIfNull(SerdeGetter getter) {
+  public void setSerdesIfNull(final SerdeGetter getter) {
     keySerde = keySerde == null ? (Serde<K>) getter.keySerde() : keySerde;
     valueSerde = valueSerde == null ? FullChangeSerde.wrap((Serde<V>) getter.valueSerde()) : valueSerde;
   }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
@@ -1,0 +1,133 @@
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.internals.Change;
+import org.apache.kafka.streams.kstream.internals.FullChangeSerde;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
+import org.apache.kafka.streams.processor.internals.SerdeGetter;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+public class RocksDBTimeOrderedKeyValueBuffer<K, V>  extends WrappedStateStore<RocksDBTimeOrderedKeyValueSegmentedBytesStore, Object, Object> implements TimeOrderedKeyValueBuffer<K, V>{
+
+  private final Duration gracePeriod;
+  private long bufferSize;
+  private long minTimestamp;
+  private int numRec;
+  private Serde<K> keySerde;
+  private FullChangeSerde<V> valueSerde;
+  private String topic;
+
+  RocksDBTimeOrderedKeyValueBuffer(final RocksDBTimeOrderedKeyValueSegmentedBytesStore store,
+                                   final Duration gracePeriod,
+                                   final String topic) {
+    super(store);
+    this.gracePeriod = gracePeriod;
+    minTimestamp = 0;
+    numRec = 0;
+    bufferSize = 0;
+    this.topic = topic;
+  }
+
+  @Override
+  public void setSerdesIfNull(SerdeGetter getter) {
+    keySerde = keySerde == null ? (Serde<K>) getter.keySerde() : keySerde;
+    valueSerde = valueSerde == null ? FullChangeSerde.wrap((Serde<V>) getter.valueSerde()) : valueSerde;
+  }
+
+  @Override
+  public void evictWhile(Supplier<Boolean> predicate, Consumer<Eviction<K, V>> callback) {
+    KeyValue<Bytes, byte[]> keyValue = null;
+
+    if (predicate.get()) {
+      final KeyValueIterator<Bytes, byte[]> iterator = wrapped()
+          .backwardFetchAll(wrapped().observedStreamTime, wrapped().observedStreamTime - gracePeriod.toMillis());
+      if (iterator.hasNext()) {
+        keyValue = iterator.next();
+      }
+      while (keyValue != null && predicate.get() && wrapped().observedStreamTime - gracePeriod.toMillis() > minTimestamp()) {
+        final K key = keySerde.deserializer().deserialize(topic, keyValue.key.get());
+        final BufferValue bufferValue = BufferValue.deserialize(ByteBuffer.wrap(keyValue.value));
+        final Change<V> value = valueSerde.deserializeParts(
+            topic,
+            new Change<>(bufferValue.newValue(), bufferValue.oldValue())
+        );
+        if (bufferValue.context().timestamp() != minTimestamp) {
+          throw new IllegalStateException(
+              "minTimestamp [" + minTimestamp + "] did not match the actual min timestamp [" +
+                  bufferValue.context().timestamp() + "]"
+          );
+        }
+        callback.accept(new Eviction<>(key, value, bufferValue.context()));
+        iterator.remove();
+        numRec--;
+        bufferSize =- computeRecordSize(keyValue.key, bufferValue);
+        if (iterator.hasNext()) {
+          keyValue = iterator.next();
+          if (keyValue == null) {
+            minTimestamp = Long.MAX_VALUE;
+          } else {
+            final BufferValue nextBufferValue = BufferValue.deserialize(ByteBuffer.wrap(keyValue.value));
+            minTimestamp = nextBufferValue.context().timestamp();
+          }
+        } else {
+          keyValue = null;
+          minTimestamp = Long.MAX_VALUE;
+        }
+      }
+    }
+  }
+
+
+  @Override
+  public Maybe<ValueAndTimestamp<V>> priorValueForBuffered(K key) {
+    return null;
+  }
+
+  @Override
+  public void put(long time, Record<K, Change<V>> record, ProcessorRecordContext recordContext) {
+    requireNonNull(record.value(), "value cannot be null");
+    requireNonNull(recordContext, "recordContext cannot be null");
+    final Bytes serializedKey = Bytes.wrap(keySerde.serializer().serialize(topic, record.key()));
+    final Change<byte[]> serialChange = valueSerde.serializeParts(topic, record.value());
+    final BufferValue buffered = new BufferValue(serialChange.oldValue, serialChange.oldValue, serialChange.newValue, recordContext);
+    wrapped().put(serializedKey, buffered.serialize(0).array());
+    bufferSize += computeRecordSize(serializedKey, buffered);
+    numRec++;
+  }
+
+  @Override
+  public int numRecords() {
+    return numRec;
+  }
+
+  @Override
+  public long bufferSize() {
+    return bufferSize;
+  }
+
+  @Override
+  public long minTimestamp() {
+    return minTimestamp;
+  }
+
+  private static long computeRecordSize(final Bytes key, final BufferValue value) {
+    long size = 0L;
+    size += 8; // buffer time
+    size += key.get().length;
+    if (value != null) {
+      size += value.residentMemorySizeEstimate();
+    }
+    return size;
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
@@ -98,7 +98,9 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V>  extends WrappedStateStore<R
   public void put(long time, Record<K, Change<V>> record, ProcessorRecordContext recordContext) {
     requireNonNull(record.value(), "value cannot be null");
     requireNonNull(recordContext, "recordContext cannot be null");
-    final Bytes serializedKey = Bytes.wrap(keySerde.serializer().serialize(topic, record.key()));
+    final Bytes serializedKey = WindowKeySchema.toStoreKeyBinary(Bytes.wrap(keySerde.serializer().serialize(topic, record.key())),
+        record.timestamp(),
+        (int) recordContext.offset());
     final Change<byte[]> serialChange = valueSerde.serializeParts(topic, record.value());
     final BufferValue buffered = new BufferValue(serialChange.oldValue, serialChange.oldValue, serialChange.newValue, recordContext);
     wrapped().put(serializedKey, buffered.serialize(0).array());

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueSegmentedBytesStore.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.processor.internals.ChangelogRecordDeserializationHelper;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.internals.PrefixedWindowKeySchemas.KeyFirstWindowKeySchema;
+import org.apache.kafka.streams.state.internals.PrefixedWindowKeySchemas.TimeFirstWindowKeySchema;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.WriteBatch;
+
+/**
+ * A RocksDB backed time-ordered segmented bytes store for window key schema.
+ */
+public class RocksDBTimeOrderedKeyValueSegmentedBytesStore extends AbstractRocksDBTimeOrderedSegmentedBytesStore {
+
+  RocksDBTimeOrderedKeyValueSegmentedBytesStore(final String name,
+                                              final String metricsScope,
+                                              final long retention,
+                                              final long segmentInterval,
+                                              final boolean withIndex) {
+    super(name, metricsScope, retention, segmentInterval, new TimeFirstWindowKeySchema(),
+        Optional.ofNullable(withIndex ? new KeyFirstWindowKeySchema() : null));
+  }
+
+  @Override
+  protected KeyValue<Bytes, byte[]> getIndexKeyValue(Bytes baseKey, byte[] baseValue) {
+    return null;
+  }
+
+  @Override
+  Map<KeyValueSegment, WriteBatch> getWriteBatches(Collection<ConsumerRecord<byte[], byte[]>> records) {
+    return null;
+  }
+
+  @Override
+  protected IndexToBaseStoreIterator getIndexToBaseStoreIterator(SegmentIterator<KeyValueSegment> segmentIterator) {
+    return null;
+  }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbTimeOrderedKeyValueBytesStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbTimeOrderedKeyValueBytesStoreSupplier.java
@@ -38,7 +38,7 @@ public class RocksDbTimeOrderedKeyValueBytesStoreSupplier {
             name,
             metricsScope(),
             retentionPeriod,
-            0,
+            1,
             withIndex
         );
   }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbTimeOrderedKeyValueBytesStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbTimeOrderedKeyValueBytesStoreSupplier.java
@@ -38,7 +38,7 @@ public class RocksDbTimeOrderedKeyValueBytesStoreSupplier {
             name,
             metricsScope(),
             retentionPeriod,
-            1,
+            Math.max(retentionPeriod / 2, 60_000L),
             withIndex
         );
   }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbTimeOrderedKeyValueBytesStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbTimeOrderedKeyValueBytesStoreSupplier.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+public class RocksDbTimeOrderedKeyValueBytesStoreSupplier {
+  private final String name;
+  private final long retentionPeriod;
+  private final boolean withIndex;
+
+  public RocksDbTimeOrderedKeyValueBytesStoreSupplier(final String name,
+                                                      final long retentionPeriod,
+                                                      final boolean withIndex) {
+    this.name = name + "-buffer";
+    this.retentionPeriod = retentionPeriod;
+    this.withIndex = withIndex;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public RocksDBTimeOrderedKeyValueSegmentedBytesStore get() {
+    return new RocksDBTimeOrderedKeyValueSegmentedBytesStore(
+            name,
+            metricsScope(),
+            retentionPeriod,
+            0,
+            withIndex
+        );
+  }
+
+  public String metricsScope() {
+    return "rocksdb-session";
+  }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamTableJoinWithGraceIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamTableJoinWithGraceIntegrationTest.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.test.TestRecord;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests all available joins of Kafka Streams DSL.
+ */
+@Category({IntegrationTest.class})
+@RunWith(value = Parameterized.class)
+public class StreamTableJoinWithGraceIntegrationTest extends AbstractJoinIntegrationTest {
+
+    private static final String STORE_NAME = "table-store";
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(600);
+    private KStream<Long, String> leftStream;
+    private KTable<Long, String> rightTable;
+    private Joined<Long, String, String> joined;
+
+    public StreamTableJoinWithGraceIntegrationTest(final boolean cacheEnabled) {
+        super(cacheEnabled);
+    }
+
+    @Before
+    public void prepareTopology() throws InterruptedException {
+        super.prepareEnvironment();
+        appID = "stream-table-join-integration-test";
+        builder = new StreamsBuilder();
+        joined = Joined.with(Serdes.Long(), Serdes.String(), Serdes.String(), "Grace", Duration.ZERO);
+    }
+
+    @Test
+    public void testInner() {
+        STREAMS_CONFIG.put(StreamsConfig.APPLICATION_ID_CONFIG, appID + "-inner");
+
+        leftStream = builder.stream(INPUT_TOPIC_LEFT);
+        rightTable = builder.table(INPUT_TOPIC_RIGHT);
+        leftStream.join(rightTable, valueJoiner).to(OUTPUT_TOPIC);
+
+        final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
+            null,
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-a", null, 5L)),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null,  6L)),
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+            null,
+            null,
+            null,
+            null
+        );
+
+        runTestWithDriver(input, expectedResult);
+    }
+
+    @Test
+    public void testLeft() {
+        STREAMS_CONFIG.put(StreamsConfig.APPLICATION_ID_CONFIG, appID + "-left");
+
+        leftStream = builder.stream(INPUT_TOPIC_LEFT);
+        rightTable = builder.table(INPUT_TOPIC_RIGHT);
+        leftStream.leftJoin(rightTable, valueJoiner).to(OUTPUT_TOPIC);
+
+        final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "A-null", null, 3L)),
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-a", null, 5L)),
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "C-null", null, 9L)),
+            null,
+            null,
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 6L)),
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-null", null,  4L)),
+            null
+        );
+
+        runTestWithDriver(input, expectedResult);
+    }
+
+    @Test
+    public void testInnerWithVersionedStore() {
+        STREAMS_CONFIG.put(StreamsConfig.APPLICATION_ID_CONFIG, appID + "-inner");
+
+        leftStream = builder.stream(INPUT_TOPIC_LEFT);
+        rightTable = builder.table(INPUT_TOPIC_RIGHT, Materialized.as(
+            Stores.persistentVersionedKeyValueStore(STORE_NAME, Duration.ofMinutes(5))));
+        leftStream.join(rightTable, valueJoiner).to(OUTPUT_TOPIC);
+
+        final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
+            null,
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-a", null, 5L)),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-b", null,  6L)),
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-a", null,  4L)),
+            null
+        );
+
+        runTestWithDriver(input, expectedResult);
+    }
+
+    @Test
+    public void testLeftWithVersionedStore() {
+        STREAMS_CONFIG.put(StreamsConfig.APPLICATION_ID_CONFIG, appID + "-left");
+
+        leftStream = builder.stream(INPUT_TOPIC_LEFT);
+        rightTable = builder.table(INPUT_TOPIC_RIGHT, Materialized.as(
+            Stores.persistentVersionedKeyValueStore(STORE_NAME, Duration.ofMinutes(5))));
+        leftStream.leftJoin(rightTable, valueJoiner).to(OUTPUT_TOPIC);
+
+        final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "A-null", null, 3L)),
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "B-a", null, 5L)),
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "C-null", null, 9L)),
+            null,
+            null,
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "D-b", null, 6L)),
+            null,
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "E-e", null,  15L)),
+            null,
+            null,
+            Collections.singletonList(new TestRecord<>(ANY_UNIQUE_KEY, "F-a", null,  4L)),
+            null
+        );
+
+        runTestWithDriver(input, expectedResult);
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinWithGraceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinWithGraceTest.java
@@ -1,0 +1,362 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.LogCaptureAppender;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.KeyValueTimestamp;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.TopologyWrapper;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.test.MockApiProcessor;
+import org.apache.kafka.test.MockApiProcessorSupplier;
+import org.apache.kafka.test.MockValueJoiner;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Random;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class KStreamKTableJoinWithGraceTest {
+    private final static KeyValueTimestamp<?, ?>[] EMPTY = new KeyValueTimestamp[0];
+
+    private final String streamTopic = "streamTopic";
+    private final String tableTopic = "tableTopic";
+    private TestInputTopic<Integer, String> inputStreamTopic;
+    private TestInputTopic<Integer, String> inputTableTopic;
+    private final int[] expectedKeys = {0, 1, 2, 3};
+
+    private MockApiProcessor<Integer, String, Void, Void> processor;
+    private TopologyTestDriver driver;
+    private StreamsBuilder builder;
+    private final MockApiProcessorSupplier<Integer, String, Void, Void> supplier = new MockApiProcessorSupplier<>();
+
+    @Before
+    public void setUp() {
+        builder = new StreamsBuilder();
+        final KStream<Integer, String> stream;
+        final KTable<Integer, String> table;
+
+        final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
+        stream = builder.stream(streamTopic, consumed);
+        table = builder.table(tableTopic, consumed);
+        stream.join(table,
+            MockValueJoiner.TOSTRING_JOINER,
+            Joined.with(Serdes.Integer(), Serdes.String(), Serdes.String(), "Grace", Duration.ZERO)
+        ).process(supplier);
+        final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
+        driver = new TopologyTestDriver(builder.build(), props);
+        inputStreamTopic = driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+        inputTableTopic = driver.createInputTopic(tableTopic, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+
+        processor = supplier.theCapturedProcessor();
+    }
+
+    @After
+    public void cleanup() {
+        driver.close();
+    }
+
+    private void pushToStream(final int messageCount, final String valuePrefix) {
+        for (int i = 0; i < messageCount; i++) {
+            inputStreamTopic.pipeInput(expectedKeys[i], valuePrefix + expectedKeys[i], i);
+        }
+    }
+
+    private void pushToTable(final int messageCount, final String valuePrefix) {
+        final Random r = new Random(System.currentTimeMillis());
+        for (int i = 0; i < messageCount; i++) {
+            inputTableTopic.pipeInput(
+                expectedKeys[i],
+                valuePrefix + expectedKeys[i],
+                r.nextInt(Integer.MAX_VALUE));
+        }
+    }
+
+    private void pushNullValueToTable() {
+        for (int i = 0; i < 2; i++) {
+            inputTableTopic.pipeInput(expectedKeys[i], null);
+        }
+    }
+
+    @Test
+    public void shouldName() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final Properties props = new Properties();
+        props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
+        final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
+        final KTable<String, String> tableB = builder.table("topic2", Materialized.as(Stores.persistentVersionedKeyValueStore("grace", Duration.ofSeconds(2))));
+        final KStream<String, String> rekeyedStream = streamA.map((k, v) -> new KeyValue<>(v, k));
+        rekeyedStream.join(tableB, (value1, value2) -> value1 + value2).to("out-one");
+        final Topology topology = builder.build(props);
+        assertEquals(expectedTopologyWithGeneratedRepartitionTopicNames, topology.describe().toString());
+    }
+
+    @Test
+    public void shouldReuseRepartitionTopicWithGeneratedName() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final Properties props = new Properties();
+        props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
+        final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
+        final KTable<String, String> tableB = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()));
+        final KTable<String, String> tableC = builder.table("topic3", Consumed.with(Serdes.String(), Serdes.String()));
+        final KStream<String, String> rekeyedStream = streamA.map((k, v) -> new KeyValue<>(v, k));
+        rekeyedStream.join(tableB, (value1, value2) -> value1 + value2).to("out-one");
+        rekeyedStream.join(tableC, (value1, value2) -> value1 + value2).to("out-two");
+        final Topology topology = builder.build(props);
+        assertEquals(expectedTopologyWithGeneratedRepartitionTopicNames, topology.describe().toString());
+    }
+
+    @Test
+    public void shouldCreateRepartitionTopicsWithUserProvidedName() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final Properties props = new Properties();
+        props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION);
+        final KStream<String, String> streamA = builder.stream("topic", Consumed.with(Serdes.String(), Serdes.String()));
+        final KTable<String, String> tableB = builder.table("topic2", Consumed.with(Serdes.String(), Serdes.String()));
+        final KTable<String, String> tableC = builder.table("topic3", Consumed.with(Serdes.String(), Serdes.String()));
+        final KStream<String, String> rekeyedStream = streamA.map((k, v) -> new KeyValue<>(v, k));
+
+        rekeyedStream.join(tableB, (value1, value2) -> value1 + value2, Joined.with(Serdes.String(), Serdes.String(), Serdes.String(), "first-join")).to("out-one");
+        rekeyedStream.join(tableC, (value1, value2) -> value1 + value2, Joined.with(Serdes.String(), Serdes.String(), Serdes.String(), "second-join")).to("out-two");
+        final Topology topology = builder.build(props);
+        System.out.println(topology.describe().toString());
+        assertEquals(expectedTopologyWithUserProvidedRepartitionTopicNames, topology.describe().toString());
+    }
+
+    @Test
+    public void shouldRequireCopartitionedStreams() {
+        final Collection<Set<String>> copartitionGroups =
+            TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
+
+        assertEquals(1, copartitionGroups.size());
+        assertEquals(new HashSet<>(Arrays.asList(streamTopic, tableTopic)), copartitionGroups.iterator().next());
+    }
+
+    @Test
+    public void shouldNotJoinWithEmptyTableOnStreamUpdates() {
+        // push two items to the primary stream. the table is empty
+        pushToStream(2, "X");
+        processor.checkAndClearProcessResult(EMPTY);
+    }
+
+    @Test
+    public void shouldNotJoinOnTableUpdates() {
+        // push two items to the primary stream. the table is empty
+        pushToStream(2, "X");
+        processor.checkAndClearProcessResult(EMPTY);
+
+        // push two items to the table. this should not produce any item.
+        pushToTable(2, "Y");
+        processor.checkAndClearProcessResult(EMPTY);
+
+        // push all four items to the primary stream. this should produce two items.
+        pushToStream(4, "X");
+        processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "X0+Y0", 0),
+                new KeyValueTimestamp<>(1, "X1+Y1", 1));
+
+        // push all items to the table. this should not produce any item
+        pushToTable(4, "YY");
+        processor.checkAndClearProcessResult(EMPTY);
+
+        // push all four items to the primary stream. this should produce four items.
+        pushToStream(4, "X");
+        processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "X0+YY0", 0),
+                new KeyValueTimestamp<>(1, "X1+YY1", 1),
+                new KeyValueTimestamp<>(2, "X2+YY2", 2),
+                new KeyValueTimestamp<>(3, "X3+YY3", 3));
+
+        // push all items to the table. this should not produce any item
+        pushToTable(4, "YYY");
+        processor.checkAndClearProcessResult(EMPTY);
+    }
+
+    @Test
+    public void shouldJoinOnlyIfMatchFoundOnStreamUpdates() {
+        // push two items to the table. this should not produce any item.
+        pushToTable(2, "Y");
+        processor.checkAndClearProcessResult(EMPTY);
+
+        // push all four items to the primary stream. this should produce two items.
+        pushToStream(4, "X");
+        processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "X0+Y0", 0),
+                new KeyValueTimestamp<>(1, "X1+Y1", 1));
+    }
+
+    @Test
+    public void shouldClearTableEntryOnNullValueUpdates() {
+        // push all four items to the table. this should not produce any item.
+        pushToTable(4, "Y");
+        processor.checkAndClearProcessResult(EMPTY);
+
+        // push all four items to the primary stream. this should produce four items.
+        pushToStream(4, "X");
+        processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "X0+Y0", 0),
+                new KeyValueTimestamp<>(1, "X1+Y1", 1),
+                new KeyValueTimestamp<>(2, "X2+Y2", 2),
+                new KeyValueTimestamp<>(3, "X3+Y3", 3));
+
+        // push two items with null to the table as deletes. this should not produce any item.
+        pushNullValueToTable();
+        processor.checkAndClearProcessResult(EMPTY);
+
+        // push all four items to the primary stream. this should produce two items.
+        pushToStream(4, "XX");
+        processor.checkAndClearProcessResult(new KeyValueTimestamp<>(2, "XX2+Y2", 2),
+                new KeyValueTimestamp<>(3, "XX3+Y3", 3));
+    }
+
+    @Test
+    public void shouldLogAndMeterWhenSkippingNullLeftKey() {
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoin.class)) {
+            final TestInputTopic<Integer, String> inputTopic =
+                driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());
+            inputTopic.pipeInput(null, "A");
+
+            assertThat(
+                appender.getMessages(),
+                hasItem("Skipping record due to null join key or value. topic=[streamTopic] partition=[0] "
+                    + "offset=[0]"));
+        }
+    }
+
+    @Test
+    public void shouldLogAndMeterWhenSkippingNullLeftValue() {
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoin.class)) {
+            final TestInputTopic<Integer, String> inputTopic =
+                driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());
+            inputTopic.pipeInput(1, null);
+
+            assertThat(
+                appender.getMessages(),
+                hasItem("Skipping record due to null join key or value. topic=[streamTopic] partition=[0] "
+                    + "offset=[0]")
+            );
+        }
+    }
+
+
+    private final String expectedTopologyWithGeneratedRepartitionTopicNames =
+        "Topologies:\n"
+        + "   Sub-topology: 0\n"
+        + "    Source: KSTREAM-SOURCE-0000000000 (topics: [topic])\n"
+        + "      --> KSTREAM-MAP-0000000007\n"
+        + "    Processor: KSTREAM-MAP-0000000007 (stores: [])\n"
+        + "      --> KSTREAM-FILTER-0000000009\n"
+        + "      <-- KSTREAM-SOURCE-0000000000\n"
+        + "    Processor: KSTREAM-FILTER-0000000009 (stores: [])\n"
+        + "      --> KSTREAM-SINK-0000000008\n"
+        + "      <-- KSTREAM-MAP-0000000007\n"
+        + "    Sink: KSTREAM-SINK-0000000008 (topic: KSTREAM-MAP-0000000007-repartition)\n"
+        + "      <-- KSTREAM-FILTER-0000000009\n"
+        + "\n"
+        + "  Sub-topology: 1\n"
+        + "    Source: KSTREAM-SOURCE-0000000010 (topics: [KSTREAM-MAP-0000000007-repartition])\n"
+        + "      --> KSTREAM-JOIN-0000000011, KSTREAM-JOIN-0000000016\n"
+        + "    Processor: KSTREAM-JOIN-0000000011 (stores: [topic2-STATE-STORE-0000000001])\n"
+        + "      --> KSTREAM-SINK-0000000012\n"
+        + "      <-- KSTREAM-SOURCE-0000000010\n"
+        + "    Processor: KSTREAM-JOIN-0000000016 (stores: [topic3-STATE-STORE-0000000004])\n"
+        + "      --> KSTREAM-SINK-0000000017\n"
+        + "      <-- KSTREAM-SOURCE-0000000010\n"
+        + "    Source: KSTREAM-SOURCE-0000000002 (topics: [topic2])\n"
+        + "      --> KTABLE-SOURCE-0000000003\n"
+        + "    Source: KSTREAM-SOURCE-0000000005 (topics: [topic3])\n"
+        + "      --> KTABLE-SOURCE-0000000006\n"
+        + "    Sink: KSTREAM-SINK-0000000012 (topic: out-one)\n"
+        + "      <-- KSTREAM-JOIN-0000000011\n"
+        + "    Sink: KSTREAM-SINK-0000000017 (topic: out-two)\n"
+        + "      <-- KSTREAM-JOIN-0000000016\n"
+        + "    Processor: KTABLE-SOURCE-0000000003 (stores: [topic2-STATE-STORE-0000000001])\n"
+        + "      --> none\n"
+        + "      <-- KSTREAM-SOURCE-0000000002\n"
+        + "    Processor: KTABLE-SOURCE-0000000006 (stores: [topic3-STATE-STORE-0000000004])\n"
+        + "      --> none\n"
+        + "      <-- KSTREAM-SOURCE-0000000005\n\n";
+
+
+    private final String expectedTopologyWithUserProvidedRepartitionTopicNames =
+            "Topologies:\n"
+                    + "   Sub-topology: 0\n"
+                    + "    Source: KSTREAM-SOURCE-0000000000 (topics: [topic])\n"
+                    + "      --> KSTREAM-MAP-0000000007\n"
+                    + "    Processor: KSTREAM-MAP-0000000007 (stores: [])\n"
+                    + "      --> first-join-repartition-filter, second-join-repartition-filter\n"
+                    + "      <-- KSTREAM-SOURCE-0000000000\n"
+                    + "    Processor: first-join-repartition-filter (stores: [])\n"
+                    + "      --> first-join-repartition-sink\n"
+                    + "      <-- KSTREAM-MAP-0000000007\n"
+                    + "    Processor: second-join-repartition-filter (stores: [])\n"
+                    + "      --> second-join-repartition-sink\n"
+                    + "      <-- KSTREAM-MAP-0000000007\n"
+                    + "    Sink: first-join-repartition-sink (topic: first-join-repartition)\n"
+                    + "      <-- first-join-repartition-filter\n"
+                    + "    Sink: second-join-repartition-sink (topic: second-join-repartition)\n"
+                    + "      <-- second-join-repartition-filter\n"
+                    + "\n"
+                    + "  Sub-topology: 1\n"
+                    + "    Source: first-join-repartition-source (topics: [first-join-repartition])\n"
+                    + "      --> first-join\n"
+                    + "    Source: KSTREAM-SOURCE-0000000002 (topics: [topic2])\n"
+                    + "      --> KTABLE-SOURCE-0000000003\n"
+                    + "    Processor: first-join (stores: [topic2-STATE-STORE-0000000001])\n"
+                    + "      --> KSTREAM-SINK-0000000012\n"
+                    + "      <-- first-join-repartition-source\n"
+                    + "    Sink: KSTREAM-SINK-0000000012 (topic: out-one)\n"
+                    + "      <-- first-join\n"
+                    + "    Processor: KTABLE-SOURCE-0000000003 (stores: [topic2-STATE-STORE-0000000001])\n"
+                    + "      --> none\n"
+                    + "      <-- KSTREAM-SOURCE-0000000002\n"
+                    + "\n"
+                    + "  Sub-topology: 2\n"
+                    + "    Source: second-join-repartition-source (topics: [second-join-repartition])\n"
+                    + "      --> second-join\n"
+                    + "    Source: KSTREAM-SOURCE-0000000005 (topics: [topic3])\n"
+                    + "      --> KTABLE-SOURCE-0000000006\n"
+                    + "    Processor: second-join (stores: [topic3-STATE-STORE-0000000004])\n"
+                    + "      --> KSTREAM-SINK-0000000017\n"
+                    + "      <-- second-join-repartition-source\n"
+                    + "    Sink: KSTREAM-SINK-0000000017 (topic: out-two)\n"
+                    + "      <-- second-join\n"
+                    + "    Processor: KTABLE-SOURCE-0000000006 (stores: [topic3-STATE-STORE-0000000004])\n"
+                    + "      --> none\n"
+                    + "      <-- KSTREAM-SOURCE-0000000005\n\n";
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBufferTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBufferTest.java
@@ -1,0 +1,104 @@
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.internals.Change;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
+import org.apache.kafka.streams.processor.internals.SerdeGetter;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.test.MockInternalNewProcessorContext;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public class RocksDBTimeOrderedKeyValueBufferTest {
+  public RocksDBTimeOrderedKeyValueBuffer<String, String> buffer;
+  public Duration grace;
+  @Mock
+  public SerdeGetter serdeGetter;
+  public InternalProcessorContext<String, String> context;
+  public StreamsMetricsImpl streamsMetrics;
+  @Mock
+  public Sensor sensor;
+
+  @Before
+  public void setUp() {
+    grace = Duration.ZERO;
+    final RocksDBTimeOrderedKeyValueSegmentedBytesStore store = new RocksDbTimeOrderedKeyValueBytesStoreSupplier("testing",  1,false).get();
+    buffer = new RocksDBTimeOrderedKeyValueBuffer<>(store, grace, "testing");
+    when(serdeGetter.keySerde()).thenReturn(new Serdes.StringSerde());
+    when(serdeGetter.valueSerde()).thenReturn(new Serdes.StringSerde());
+    buffer.setSerdesIfNull(serdeGetter);
+    final Metrics metrics = new Metrics();
+    streamsMetrics = new StreamsMetricsImpl(metrics, "test-client", StreamsConfig.METRICS_LATEST, new MockTime());
+    context = new MockInternalNewProcessorContext<String, String>(StreamsTestUtils.getStreamsConfig(), new TaskId(0,0), TestUtils.tempDirectory());
+    store.init((StateStoreContext) context, store);
+    buffer.init((StateStoreContext) context, store);
+  }
+
+  private void pipeRecord(final String key, final String value, final long time) {
+    Record<String, Change<String>> record = new Record<>(key, new Change<>(value, value), time);
+    context.setRecordContext(new ProcessorRecordContext(time, 30, 0, "testing", new RecordHeaders()));
+    buffer.put(time, record, context.recordContext());
+  }
+
+  @Test
+  public void shouldAddAndEvictRecord() {
+    AtomicInteger count = new AtomicInteger(0);
+    pipeRecord("1", "0", 0L);
+    buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
+    assertThat(count.get(), equalTo(1));
+  }
+
+  @Test
+  public void shouldAddAndEvictRecordTwice() {
+    AtomicInteger count = new AtomicInteger(0);
+    pipeRecord("1", "0", 0L);
+    buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
+    assertThat(count.get(), equalTo(1));
+    pipeRecord("2", "0", 1L);
+    buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
+    assertThat(count.get(), equalTo(2));
+  }
+
+  @Test
+  public void shouldAddRecrodsTwiceAndEvictRecordsOnce() {
+    AtomicInteger count = new AtomicInteger(0);
+    pipeRecord("1", "0", 0L);
+    buffer.evictWhile(() -> buffer.numRecords() > 1, r -> count.getAndIncrement());
+    assertThat(count.get(), equalTo(0));
+    pipeRecord("2", "0", 1L);
+    buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
+    assertThat(count.get(), equalTo(2));
+  }
+
+  @Test
+  public void shouldDropLateRecords() {
+    AtomicInteger count = new AtomicInteger(0);
+    pipeRecord("1", "0", 1L);
+    buffer.evictWhile(() -> buffer.numRecords() > 1, r -> count.getAndIncrement());
+    assertThat(count.get(), equalTo(0));
+    pipeRecord("2", "0", 0L);
+    buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
+    assertThat(count.get(), equalTo(1));
+  }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBufferTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBufferTest.java
@@ -50,7 +50,7 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
     buffer.setSerdesIfNull(serdeGetter);
     final Metrics metrics = new Metrics();
     streamsMetrics = new StreamsMetricsImpl(metrics, "test-client", StreamsConfig.METRICS_LATEST, new MockTime());
-    context = new MockInternalNewProcessorContext<String, String>(StreamsTestUtils.getStreamsConfig(), new TaskId(0,0), TestUtils.tempDirectory());
+    context = new MockInternalNewProcessorContext<>(StreamsTestUtils.getStreamsConfig(), new TaskId(0,0), TestUtils.tempDirectory());
     store.init((StateStoreContext) context, store);
     buffer.init((StateStoreContext) context, store);
   }


### PR DESCRIPTION
Add grace period to the stream table join.

Add an upstream processor that acts as a buffer to establish the grace period before sending the stream records down to the join operator to preform the join. This is a separate operator for now to make it easier to slot in the versioned table optimization and then be able to use the grace period for all types of joins. This can easily change it that is not what we want.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
