### PR TITLE
KAFKA-14938: Fixing flaky test testConnectorBoundary

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
@@ -412,10 +412,10 @@ public class ExactlyOnceSourceIntegrationTest {
         Map<String, Object> consumerProps = new HashMap<>();
         consumerProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
         // consume all records from the source topic or fail, to ensure that they were correctly produced
-        ConsumerRecords<byte[], byte[]> sourceRecords = connect.kafka().consumeAll(
+        ConsumerRecords<byte[], byte[]> sourceRecords = connect.kafka().consume(
+                MINIMUM_MESSAGES,
                 CONSUME_RECORDS_TIMEOUT_MS,
                 Collections.singletonMap(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed"),
-                null,
                 topic
         );
         assertTrue("Not enough records produced by source connector. Expected at least: " + MINIMUM_MESSAGES + " + but got " + sourceRecords.count(),

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
@@ -394,9 +394,12 @@ public class ExactlyOnceSourceIntegrationTest {
         props.put(MESSAGES_PER_POLL_CONFIG, MESSAGES_PER_POLL);
         props.put(MAX_MESSAGES_PER_SECOND_CONFIG, MESSAGES_PER_SECOND);
 
-        // expect all records to be consumed and committed by the connector
-        connectorHandle.expectedRecords(MINIMUM_MESSAGES);
-        connectorHandle.expectedCommits(MINIMUM_MESSAGES);
+        // the connector aborts some transactions, which causes records that it has emitted (and for which
+        // SourceTask::commitRecord has been invoked) to be invisible to consumers; we expect the task to
+        // emit at most 233 records in total before 100 records have been emitted as part of one or more
+        // committed transactions
+        connectorHandle.expectedRecords(233);
+        connectorHandle.expectedCommits(233);
 
         // start a source connector
         connect.configureConnector(CONNECTOR_NAME, props);
@@ -412,11 +415,11 @@ public class ExactlyOnceSourceIntegrationTest {
         Map<String, Object> consumerProps = new HashMap<>();
         consumerProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
         // consume all records from the source topic or fail, to ensure that they were correctly produced
-        ConsumerRecords<byte[], byte[]> sourceRecords = connect.kafka().consume(
-                MINIMUM_MESSAGES,
-                CONSUME_RECORDS_TIMEOUT_MS,
-                Collections.singletonMap(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed"),
-                topic
+        ConsumerRecords<byte[], byte[]> sourceRecords = connect.kafka().consumeAll(
+            CONSUME_RECORDS_TIMEOUT_MS,
+            Collections.singletonMap(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed"),
+            null,
+            topic
         );
         assertTrue("Not enough records produced by source connector. Expected at least: " + MINIMUM_MESSAGES + " + but got " + sourceRecords.count(),
                 sourceRecords.count() >= MINIMUM_MESSAGES);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
@@ -267,13 +267,17 @@ public class MonitorableSourceConnector extends SampleSourceConnector {
             if (context.transactionContext() == null || seqno != nextTransactionBoundary) {
                 return;
             }
+            long transactionSize = nextTransactionBoundary - priorTransactionBoundary;
+
             // If the transaction boundary ends on an even-numbered offset, abort it
             // Otherwise, commit
             boolean abort = nextTransactionBoundary % 2 == 0;
             calculateNextBoundary();
             if (abort) {
+                log.info("Aborting transaction of {} records", transactionSize);
                 context.transactionContext().abortTransaction(record);
             } else {
+                log.info("Committing transaction of {} records", transactionSize);
                 context.transactionContext().commitTransaction(record);
             }
         }


### PR DESCRIPTION
Fixing `org.apache.kafka.connect.integration.ExactlyOnceSourceIntegrationTest#testConnectorBoundary` test by using `consume()` in place of `consumeAll()` since we can specify the minimum records to consume in `consume()` which is sufficient to assert the test.


Ran the test successfully ~100 times
```
BUILD SUCCESSFUL in 11s
75 actionable tasks: 1 executed, 74 up-to-date
Completed run: 110
```

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
