### PR TITLE
MINOR: fix KRaftClusterTest and KRaft integration test failure

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1181,10 +1181,6 @@ public final class QuorumController implements Controller {
                 new CompleteActivationEvent(),
                 EnumSet.of(DOES_NOT_UPDATE_QUEUE_TIME, RUNS_IN_PREMIGRATION)
             );
-            activationEvent.future.exceptionally(t -> {
-                fatalFaultHandler.handleFault("exception while activating controller", t);
-                return null;
-            });
             queue.prepend(activationEvent);
         } catch (Throwable e) {
             fatalFaultHandler.handleFault("exception while claiming leadership", e);


### PR DESCRIPTION
Saw a bunch of tests in `RaftClusterSnapshotTest`, `KRaftClusterTest`, `QuorumControllerTest` failed in recent builds: [#_1801](https://ci-builds.apache.org/job/Kafka/job/kafka/job/trunk/1801), [#_1800](https://ci-builds.apache.org/job/Kafka/job/kafka/job/trunk/1800) after this PR merged: https://github.com/apache/kafka/pull/13407. 

Did some investigation, found they all failed because of this kind of error: (ex: [here](https://ci-builds.apache.org/job/Kafka/job/kafka/job/trunk/1800/testReport/junit/kafka.server/KRaftClusterTest/Build___JDK_8_and_Scala_2_12___testIncrementalAlterConfigs__/), [here](https://ci-builds.apache.org/job/Kafka/job/kafka/job/trunk/1801/testReport/junit/kafka.server/KRaftClusterTest/Build___JDK_11_and_Scala_2_13___testUnregisterBroker__/))
```
org.apache.kafka.server.fault.FaultHandlerException: fatalFaultHandler: exception while activating controller: xxxxx
```

Mostly, the reason of exception thrown is `No controller appears to be active`. And it's because when the active controller tried to write and commit the activation messages, the leadership changed to other nodes, which is quite normal. We should not treat it as fatal error with this case. 

And there are also cases like this ([here](https://ci-builds.apache.org/job/Kafka/job/kafka/job/trunk/1801/testReport/junit/org.apache.kafka.controller/QuorumControllerTest/Build___JDK_8_and_Scala_2_13___testUpgradeMigrationStateFrom34__/))
```
org.apache.kafka.server.fault.FaultHandlerException: fatalFaultHandler: exception while activating controller: java.util.concurrent.RejectedExecutionException
```
It's because while activating the controller, it's shutting down. Again, this should not be a fatal error, instead, we can just fail this commit as before.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
