### PR TITLE
MINOR: Add reason to exceptions in QuorumController

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/queue/KafkaEventQueue.java
+++ b/server-common/src/main/java/org/apache/kafka/queue/KafkaEventQueue.java
@@ -245,7 +245,7 @@ public final class KafkaEventQueue implements EventQueue {
                             continue;
                         } else if (interrupted) {
                             remove(eventContext);
-                            toDeliver = new InterruptedException();
+                            toDeliver = new InterruptedException("The event handler thread is interrupted");
                             toRun = eventContext;
                             continue;
                         } else if (shuttingDown) {
@@ -264,7 +264,7 @@ public final class KafkaEventQueue implements EventQueue {
                         }
                     } else {
                         if (interrupted) {
-                            toDeliver = new InterruptedException();
+                            toDeliver = new InterruptedException("The event handler thread is interrupted");
                         } else {
                             toDeliver = null;
                         }
@@ -303,7 +303,7 @@ public final class KafkaEventQueue implements EventQueue {
                     return new RejectedExecutionException("The event queue is shutting down");
                 }
                 if (interrupted) {
-                    return new InterruptedException();
+                    return new InterruptedException("The event handler thread is interrupted");
                 }
                 OptionalLong existingDeadlineNs = OptionalLong.empty();
                 if (eventContext.tag != null) {

--- a/server-common/src/main/java/org/apache/kafka/queue/KafkaEventQueue.java
+++ b/server-common/src/main/java/org/apache/kafka/queue/KafkaEventQueue.java
@@ -250,7 +250,7 @@ public final class KafkaEventQueue implements EventQueue {
                             continue;
                         } else if (shuttingDown) {
                             remove(eventContext);
-                            toDeliver = new RejectedExecutionException();
+                            toDeliver = new RejectedExecutionException("The event queue is shutting down");
                             toRun = eventContext;
                             continue;
                         }
@@ -300,7 +300,7 @@ public final class KafkaEventQueue implements EventQueue {
             lock.lock();
             try {
                 if (shuttingDown) {
-                    return new RejectedExecutionException();
+                    return new RejectedExecutionException("The event queue is shutting down");
                 }
                 if (interrupted) {
                     return new InterruptedException();


### PR DESCRIPTION
Saw this error message in log:
```
ERROR [QuorumController id=1] writeNoOpRecord: unable to start processing because of RejectedExecutionException. Reason: null (org.apache.kafka.controller.QuorumController)
```

The `null` reason is not helpful with only `RejectedExecutionException`. Adding the reason to it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
