### PR TITLE
MINOR: Fix incorrect description of SessionLifetimeMs

### DIFF
--- a/clients/src/main/resources/common/message/SaslAuthenticateResponse.json
+++ b/clients/src/main/resources/common/message/SaslAuthenticateResponse.json
@@ -29,6 +29,6 @@
     { "name": "AuthBytes", "type": "bytes", "versions": "0+",
       "about": "The SASL authentication bytes from the server, as defined by the SASL mechanism." },
     { "name": "SessionLifetimeMs", "type": "int64", "versions": "1+", "default": "0", "ignorable": true,
-      "about": "The duration in milliseconds that a successful session response is valid for." }
+      "about": "Number of milliseconds after which only re-authentication over the existing connection to create a new session can occur." }
   ]
 }

--- a/clients/src/main/resources/common/message/SaslAuthenticateResponse.json
+++ b/clients/src/main/resources/common/message/SaslAuthenticateResponse.json
@@ -29,6 +29,6 @@
     { "name": "AuthBytes", "type": "bytes", "versions": "0+",
       "about": "The SASL authentication bytes from the server, as defined by the SASL mechanism." },
     { "name": "SessionLifetimeMs", "type": "int64", "versions": "1+", "default": "0", "ignorable": true,
-      "about": "The SASL authentication bytes from the server, as defined by the SASL mechanism." }
+      "about": "The duration in milliseconds that a successful session response is valid for." }
   ]
 }


### PR DESCRIPTION
The current description seems like an artifact of copy-pasting from the adjacent AuthBytes field. I'm happy to improve the proposed message if there's feedback.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
