### PR TITLE
MINOR: remove spurious call to fatalFaultHandler

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1181,10 +1181,6 @@ public final class QuorumController implements Controller {
                 new CompleteActivationEvent(),
                 EnumSet.of(DOES_NOT_UPDATE_QUEUE_TIME, RUNS_IN_PREMIGRATION)
             );
-            activationEvent.future.exceptionally(t -> {
-                fatalFaultHandler.handleFault("exception while activating controller", t);
-                return null;
-            });
             queue.prepend(activationEvent);
         } catch (Throwable e) {
             fatalFaultHandler.handleFault("exception while claiming leadership", e);
@@ -1275,12 +1271,21 @@ public final class QuorumController implements Controller {
         }
         return records;
     }
+
     class CompleteActivationEvent implements ControllerWriteOperation<Void> {
         @Override
         public ControllerResult<Void> generateRecordsAndResult() {
-            List<ApiMessageAndVersion> records = generateActivationRecords(log, logReplayTracker.empty(),
-                zkMigrationEnabled, bootstrapMetadata, featureControl);
-            return ControllerResult.atomicOf(records, null);
+            try {
+                List<ApiMessageAndVersion> records = generateActivationRecords(log,
+                    logReplayTracker.empty(),
+                    zkMigrationEnabled,
+                    bootstrapMetadata,
+                    featureControl);
+                return ControllerResult.atomicOf(records, null);
+            } catch (Throwable t) {
+                throw fatalFaultHandler.handleFault("exception while completing controller " +
+                    "activation", t);
+            }
         }
 
         @Override

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -1359,7 +1359,7 @@ public class QuorumControllerTest {
         assertEquals(
             "The bootstrap metadata.version 3.3-IV0 does not support ZK migrations. Cannot continue with ZK migrations enabled.",
             assertThrows(FaultHandlerException.class, () ->
-                checkBootstrapZkMigrationRecord(MetadataVersion.IBP_3_3_IV0, true)).getCause().getCause().getMessage()
+                checkBootstrapZkMigrationRecord(MetadataVersion.IBP_3_3_IV0, true)).getCause().getMessage()
         );
     }
 


### PR DESCRIPTION
Remove a spurious call to fatalFaultHandler accidentally introduced by KAFKA-14805.  We should only invoke the fatal fault handller if we are unable to generate the activation records. If we are unable to write the activation records, a controller failover should be sufficient to remedy the situation.

Co-authored-by: Luke Chen <showuon@gmail.com>