### PR TITLE
KAFKA-14946: fix NPE when merging the deltatable

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/timeline/SnapshottableHashTable.java
+++ b/server-common/src/main/java/org/apache/kafka/timeline/SnapshottableHashTable.java
@@ -113,7 +113,7 @@ class SnapshottableHashTable<T extends SnapshottableHashTable.ElementWithStartEp
             HashTier<T> other = (HashTier<T>) source;
             // As an optimization, the deltaTable might not exist for a new key
             // as there is no previous value
-            if (deltaTable != null && other.deltaTable != null) {
+            if (other.deltaTable != null) {
                 List<T> list = new ArrayList<>();
                 Object[] otherElements = other.deltaTable.baseElements();
                 for (int slot = 0; slot < otherElements.length; slot++) {
@@ -122,6 +122,9 @@ class SnapshottableHashTable<T extends SnapshottableHashTable.ElementWithStartEp
                         // When merging in a later hash tier, we want to keep only the elements
                         // that were present at our epoch.
                         if (element.startEpoch() <= epoch) {
+                            if (deltaTable == null) {
+                                deltaTable = new BaseHashTable<>(1);
+                            }
                             deltaTable.baseAddOrReplace(element);
                         }
                     }

--- a/server-common/src/main/java/org/apache/kafka/timeline/SnapshottableHashTable.java
+++ b/server-common/src/main/java/org/apache/kafka/timeline/SnapshottableHashTable.java
@@ -113,7 +113,7 @@ class SnapshottableHashTable<T extends SnapshottableHashTable.ElementWithStartEp
             HashTier<T> other = (HashTier<T>) source;
             // As an optimization, the deltaTable might not exist for a new key
             // as there is no previous value
-            if (other.deltaTable != null) {
+            if (deltaTable != null && other.deltaTable != null) {
                 List<T> list = new ArrayList<>();
                 Object[] otherElements = other.deltaTable.baseElements();
                 for (int slot = 0; slot < otherElements.length; slot++) {

--- a/server-common/src/test/java/org/apache/kafka/timeline/SnapshottableHashTableTest.java
+++ b/server-common/src/test/java/org/apache/kafka/timeline/SnapshottableHashTableTest.java
@@ -116,7 +116,7 @@ public class SnapshottableHashTableTest {
         assertTrue(set.isEmpty());
         set.add("foo");
         registry.getOrCreateSnapshot(300);
-        // "bar" is not existed in snapshot of epoch 100 now due to revert
+        // After reverting to epoch 100, "bar" is not existed anymore
         set.remove("bar");
         // No deltatable merging is needed because nothing change in snapshot epoch 300
         registry.revertToSnapshot(100);
@@ -124,15 +124,24 @@ public class SnapshottableHashTableTest {
 
         set.add("qux");
         registry.getOrCreateSnapshot(400);
+        assertEquals(1, set.size());
         set.add("fred");
+        set.add("thud");
         registry.getOrCreateSnapshot(500);
+        assertEquals(3, set.size());
 
-        // remove the value in epoch 100, it'll create an entry in deltatable in the snapshot of epoch 500 for the deleted value in epoch 100
+        // remove the value in epoch 101(after epoch 100), it'll create an entry in deltatable in the snapshot of epoch 500 for the deleted value in epoch 101
         set.remove("qux");
+        assertEquals(2, set.size());
         // When reverting to snapshot of epoch 400, we'll merge the deltatable in epoch 500 with the one in epoch 400.
         // The deltatable in epoch 500 has an entry created above, but the deltatable in epoch 400 is null.
         // It should not throw exception while reverting (deltatable merge)
         registry.revertToSnapshot(400);
+        // After reverting, the deltatable in epoch 500 should merge to the current epoch
+        assertEquals(1, set.size());
+
+        // When reverting to epoch 100, the deltatable in epoch 400 won't be merged because the entry change is epoch 101(after epoch 100)
+        registry.revertToSnapshot(100);
         assertTrue(set.isEmpty());
     }
 


### PR DESCRIPTION
Fix NPE while merging the deltatable. Because it's possible that hashTier is not null but deltatable is null (ex: removing data), we should have null check while merging for `deltatable` like other places did. Also added tests that will fail without this change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
