### PR TITLE
KAFKA-14963; Use equals method with Uuid

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ControllerMetricsManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ControllerMetricsManager.java
@@ -202,10 +202,10 @@ final class ControllerMetricsManager {
             throw new IllegalArgumentException(String.format("Broker with id %s is not registered", brokerId));
         }
 
-        if (fencingChange == BrokerRegistrationFencingChange.FENCE) {
+        if (fencingChange.equals(BrokerRegistrationFencingChange.FENCE)) {
             fencedBrokers.add(brokerId);
             updateBrokerStateMetrics();
-        } else if (fencingChange == BrokerRegistrationFencingChange.UNFENCE) {
+        } else if (fencingChange.equals(BrokerRegistrationFencingChange.UNFENCE)) {
             fencedBrokers.remove(brokerId);
             updateBrokerStateMetrics();
         } else {
@@ -269,7 +269,7 @@ final class ControllerMetricsManager {
 
     private void replay(RemoveTopicRecord record) {
         Uuid topicId = record.topicId();
-        Predicate<TopicIdPartition> matchesTopic = tp -> tp.topicId() == topicId;
+        Predicate<TopicIdPartition> matchesTopic = tp -> tp.topicId().equals(topicId);
 
         topicCount--;
         topicPartitions.keySet().removeIf(matchesTopic);

--- a/metadata/src/test/java/org/apache/kafka/controller/ControllerMetricsManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ControllerMetricsManagerTest.java
@@ -186,11 +186,16 @@ final class ControllerMetricsManagerTest {
         ControllerMetrics metrics = new MockControllerMetrics();
         ControllerMetricsManager manager = new ControllerMetricsManager(metrics);
 
-        Uuid id = Uuid.randomUuid();
-        manager.replay(topicRecord("test", id));
-        manager.replay(partitionRecord(id, 0, 0, Arrays.asList(0, 1, 2)));
-        manager.replay(partitionRecord(id, 1, 0, Arrays.asList(0, 1, 2)));
-        manager.replay(removeTopicRecord(id));
+        Uuid createTopicId = Uuid.randomUuid();
+        Uuid createPartitionTopicId = new Uuid(
+            createTopicId.getMostSignificantBits(),
+            createTopicId.getLeastSignificantBits()
+        );
+        Uuid removeTopicId = new Uuid(createTopicId.getMostSignificantBits(), createTopicId.getLeastSignificantBits());
+        manager.replay(topicRecord("test", createTopicId));
+        manager.replay(partitionRecord(createPartitionTopicId, 0, 0, Arrays.asList(0, 1, 2)));
+        manager.replay(partitionRecord(createPartitionTopicId, 1, 0, Arrays.asList(0, 1, 2)));
+        manager.replay(removeTopicRecord(removeTopicId));
         assertEquals(0, metrics.globalPartitionCount());
     }
 


### PR DESCRIPTION
Uuid is an object so they need to be compared with the equals method and not the == operator.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
