### PR TITLE
KAFKA-14967: fix NPE in MockAdminClient CreateTopicsResult

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -391,11 +391,21 @@ public class MockAdminClient extends AdminClient {
             topicIds.put(topicName, topicId);
             topicNames.put(topicId, topicName);
             allTopics.put(topicName, new TopicMetadata(topicId, false, partitions, logDirs, newTopic.configs()));
-            future.complete(null);
+            future.complete(new CreateTopicsResult.TopicMetadataAndConfig(topicId, numberOfPartitions, replicationFactor, config(newTopic)));
             createTopicResult.put(topicName, future);
         }
 
         return new CreateTopicsResult(createTopicResult);
+    }
+
+    private static Config config(NewTopic newTopic) {
+        Collection<ConfigEntry> configEntries = new ArrayList<>();
+        if (newTopic.configs() != null) {
+            for (Map.Entry<String, String> entry : newTopic.configs().entrySet()) {
+                configEntries.add(new ConfigEntry(entry.getKey(), entry.getValue()));
+            }
+        }
+        return new Config(configEntries);
     }
 
     @Override


### PR DESCRIPTION
instead of passing `null` to the future, pass a populated `TopicAndMetadataConfig`

`MockAdminClient` has no tests that I'm aware of.

The contribution is my original work and that I license the work to the project under the project's open source license.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
