### PR TITLE
MINOR: Capture build scans on ge.apache.org to benefit from deep build insights

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,6 @@ plugins {
   id "io.swagger.core.v3.swagger-gradle-plugin" version "2.2.8"
 
   id "com.github.spotbugs" version '5.0.13' apply false
-  id 'org.gradle.test-retry' version '1.5.2' apply false
   id 'org.scoverage' version '7.0.1' apply false
   id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
   id 'com.diffplug.spotless' version '6.14.0' apply false // 6.14.1 and newer require Java 11 at compile time, so we can't upgrade until AK 4.0
@@ -227,7 +226,6 @@ subprojects {
   apply plugin: 'java-library'
   apply plugin: 'checkstyle'
   apply plugin: "com.github.spotbugs"
-  apply plugin: 'org.gradle.test-retry'
 
   // We use the shadow plugin for the jmh-benchmarks module and the `-all` jar can get pretty large, so
   // don't publish it

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 plugins {
-    id 'com.gradle.enterprise' version '3.13.2'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
+    id 'com.gradle.enterprise' version '3.13.3'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.11'
 }
 
 def isGithubActions = System.getenv('GITHUB_ACTIONS') != null

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 plugins {
-    id 'com.gradle.enterprise' version '3.13.1'
+    id 'com.gradle.enterprise' version '3.13.2'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
 }
 
@@ -30,6 +30,8 @@ gradleEnterprise {
         publishAlways()
         publishIfAuthenticated()
         obfuscation {
+            // This obfuscates the IP addresses of the build machine in the build scan.
+            // Alternatively, the build scan will provide the hostname for troubleshooting host-specific issues.
             ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+plugins {
+    id 'com.gradle.enterprise' version '3.13.1'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
+}
+
+def isGithubActions = System.getenv('GITHUB_ACTIONS') != null
+def isJenkins = System.getenv('JENKINS_URL') != null
+def isCI = isGithubActions || isJenkins
+
+gradleEnterprise {
+    server = "https://ge.apache.org"
+    buildScan {
+        capture { taskInputFiles = true }
+        uploadInBackground = !isCI
+        publishAlways()
+        publishIfAuthenticated()
+        obfuscation {
+            ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
+        }
+    }
+}
+
+buildCache {
+    local {
+        enabled = !isCI
+    }
+
+    remote(gradleEnterprise.buildCache) {
+        enabled = false
+    }
+}
+
 include 'clients',
     'connect:api',
     'connect:basic-auth-extension',

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 plugins {
-    id 'com.gradle.enterprise' version '3.13.3'
+    id 'com.gradle.enterprise' version '3.13.4'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.11'
 }
 


### PR DESCRIPTION
This PR publishes a build scan for every CI build on Jenkins and GitHub Actions and for every local build from an authenticated Apache committer. The build will not fail if publishing fails.

The build scans of the Apache Kafka project are published to the Gradle Enterprise instance at [ge.apache.org](https://ge.apache.org/), hosted by the Apache Software Foundation and run in partnership between the ASF and Gradle. This Gradle Enterprise instance has all features and extensions enabled and is freely available for use by the Apache Kafka project and all other Apache projects.

This pull request enhances the functionality of publishing build scans to the publicly available [scans.gradle.com](https://scans.gradle.com/) by instead publishing build scans to [ge.apache.org](https://ge.apache.org/). On this Gradle Enterprise instance, Apache Kafka will have access not only to all of the published build scans but other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

If interested in exploring a fully populated Gradle Enterprise instance, please explore the builds already connected to [ge.apache.org](https://ge.apache.org/), the [Spring project’s instance](https://ge.spring.io/scans?search.relativeStartTime=P28D&search.timeZoneId=Europe/Zurich), or any number of other [OSS projects](https://gradle.com/enterprise-customers/oss-projects/) for which we sponsor instances of Gradle Enterprise.

Please let me know if there are any questions about the value of Gradle Enterprise or the changes in this pull request and I’d be happy to address them.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
