### PR TITLE
MINOR: Add "versions" tag to recently added ReplicaState field on Fetch Request

### DIFF
--- a/clients/src/main/resources/common/message/FetchRequest.json
+++ b/clients/src/main/resources/common/message/FetchRequest.json
@@ -61,7 +61,7 @@
       "about": "The clusterId if known. This is used to validate metadata fetches prior to broker registration." },
     { "name": "ReplicaId", "type": "int32", "versions": "0-14", "default": "-1", "entityType": "brokerId",
       "about": "The broker ID of the follower, of -1 if this request is from a consumer." },
-    { "name": "ReplicaState", "type": "ReplicaState", "taggedVersions":"15+", "tag": 1, "fields": [
+    { "name": "ReplicaState", "type": "ReplicaState", "versions": "15+", "taggedVersions":"15+", "tag": 1, "fields": [
       { "name": "ReplicaId", "type": "int32", "versions": "15+", "default": "-1", "entityType": "brokerId",
         "about": "The replica ID of the follower, or -1 if this request is from a consumer." },
       { "name": "ReplicaEpoch", "type": "int64", "versions": "15+", "default": "-1",

--- a/clients/src/main/resources/common/message/FetchRequest.json
+++ b/clients/src/main/resources/common/message/FetchRequest.json
@@ -61,7 +61,7 @@
       "about": "The clusterId if known. This is used to validate metadata fetches prior to broker registration." },
     { "name": "ReplicaId", "type": "int32", "versions": "0-14", "default": "-1", "entityType": "brokerId",
       "about": "The broker ID of the follower, of -1 if this request is from a consumer." },
-    { "name": "ReplicaState", "type": "ReplicaState", "versions": "15+", "taggedVersions":"15+", "tag": 1, "fields": [
+    { "name": "ReplicaState", "type": "ReplicaState", "versions": "15+", "taggedVersions": "15+", "tag": 1, "fields": [
       { "name": "ReplicaId", "type": "int32", "versions": "15+", "default": "-1", "entityType": "brokerId",
         "about": "The replica ID of the follower, or -1 if this request is from a consumer." },
       { "name": "ReplicaEpoch", "type": "int64", "versions": "15+", "default": "-1",


### PR DESCRIPTION
While running a parser for the new version of kafka commons in order to generate some assets for a kafka protocol library in other language. I've noticed that the recently added `ReplicaState` attribute on Fetch request is the only one that does not have a `versions` tag.

Since my parser was relying on the existence of this tag for every field, it failed. I wonder if it is the expected state or if it is indeed a mistake.

Anyway I've update my parser in order to use `taggedVersions` as a fallback when `versions` is not present. It works for me now.

If this is the proper state of the file, please let me know!
