### PR TITLE
MINOR: improved exception/warn logging for stream-stream join store settings

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -242,13 +242,21 @@ class KStreamImplJoin {
 
     private void assertWindowSettings(final WindowBytesStoreSupplier supplier, final JoinWindows joinWindows) {
         if (!supplier.retainDuplicates()) {
-            throw new StreamsException("The StoreSupplier must set retainDuplicates=true, found retainDuplicates=false");
+            throw new StreamsException(String.format(
+              "The StoreSupplier for join store %s must set retainDuplicates = true, found retainDuplicates = false",
+              supplier.name()));
         }
-        final boolean allMatch = supplier.retentionPeriod() == (joinWindows.size() + joinWindows.gracePeriodMs()) &&
-            supplier.windowSize() == joinWindows.size();
-        if (!allMatch) {
-            throw new StreamsException(String.format("Window settings mismatch. WindowBytesStoreSupplier settings %s must match JoinWindows settings %s" +
-                                                         " for the window size and retention period", supplier, joinWindows));
+        if (supplier.retentionPeriod() != joinWindows.size() + joinWindows.gracePeriodMs()) {
+            throw new StreamsException(String.format(
+              "The StoreSupplier for join store %s must set retentionPeriod = windowSize + gracePeriod,"
+                + " found retentionPeriod = %d, joinWindows.size = %d, joinWindows.gracePeriod = %d",
+              supplier.name(), supplier.retentionPeriod(), joinWindows.size(), joinWindows.gracePeriodMs()));
+        }
+        if (supplier.windowSize() != joinWindows.size()) {
+            throw new StreamsException(String.format(
+              "The StoreSupplier for join store %s must set supplier.windowSize = joinWindows.windowSize,"
+                + " found supplier.windowSize = %d, joinWindows.size = %d",
+              supplier.name(), supplier.windowSize(), joinWindows.size()));
         }
     }
 


### PR DESCRIPTION
Trying to configure the underlying state stores in a join is pretty awkward, and getting all the parameters right can be particularly frustrating. 

At a minimum, we should break up the verification into each individual check so that it's clear which step has failed. It would also help to actually include in the error message how to fix the store parameters to match what is expected, since this is not necessarily obvious -- for example,  that retention period has to be **exactly** the sum of windowSize + gracePeriod, or that the store's windowSize is actually twice the value passed in to `JoinWindows#of` (or  the newer `JoinWindows#ofTimeDifferenceXXX` APIs that replaced it)

