### PR TITLE
MINOR: remove kraft readme link

### DIFF
--- a/config/kraft/broker.properties
+++ b/config/kraft/broker.properties
@@ -15,7 +15,7 @@
 
 #
 # This configuration file is intended for use in KRaft mode, where
-# Apache ZooKeeper is not present.  See config/kraft/README.md for details.
+# Apache ZooKeeper is not present.
 #
 
 ############################# Server Basics #############################

--- a/config/kraft/controller.properties
+++ b/config/kraft/controller.properties
@@ -15,7 +15,7 @@
 
 #
 # This configuration file is intended for use in KRaft mode, where
-# Apache ZooKeeper is not present.  See config/kraft/README.md for details.
+# Apache ZooKeeper is not present.
 #
 
 ############################# Server Basics #############################

--- a/config/kraft/server.properties
+++ b/config/kraft/server.properties
@@ -15,7 +15,7 @@
 
 #
 # This configuration file is intended for use in KRaft mode, where
-# Apache ZooKeeper is not present.  See config/kraft/README.md for details.
+# Apache ZooKeeper is not present.
 #
 
 ############################# Server Basics #############################

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -415,7 +415,7 @@
         and <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181308218">KIP-751</a> for more details.</li>
     <li>ZooKeeper has been upgraded to version 3.6.3.</li>
     <li>A preview of KRaft mode is available, though upgrading to it from the 2.8 Early Access release is not possible. See
-        the <code>config/kraft/README.md</code> file for details.</li>
+        the <a href="#kraft">KRaft section</a> for details.</li>
     <li>The release tarball no longer includes test, sources, javadoc and test sources jars. These are still published to the Maven Central repository. </li>
     <li>A number of implementation dependency jars are <a href="https://github.com/apache/kafka/pull/10203">now available in the runtime classpath
         instead of compile and runtime classpaths</a>. Compilation errors after the upgrade can be fixed by adding the missing dependency jar(s) explicitly

--- a/raft/README.md
+++ b/raft/README.md
@@ -3,7 +3,7 @@ KRaft (Kafka Raft)
 KRaft (Kafka Raft) is a protocol based on the [Raft Consensus Protocol](https://www.usenix.org/system/files/conference/atc14/atc14-paper-ongaro.pdf)
 tailored for Apache Kafka.
 
-This is used by Apache Kafka in the [KRaft (Kafka Raft Metadata) mode](https://github.com/apache/kafka/blob/trunk/config/kraft/README.md). We
+This is used by Apache Kafka in the KRaft (Kafka Raft Metadata) mode. We
 also have a standalone test server which can be used for performance testing. We describe the details to set this up below.
 
 ### Run Single Quorum ###


### PR DESCRIPTION
The `config/kraft/README.md` is already removed. We should also remove the link.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
