### PR TITLE
HOTFIX: fix the VersionedKeyValueToBytesStoreAdapter#isOpen API

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/VersionedKeyValueToBytesStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/VersionedKeyValueToBytesStoreAdapter.java
@@ -115,7 +115,7 @@ public class VersionedKeyValueToBytesStoreAdapter implements VersionedBytesStore
 
     @Override
     public boolean isOpen() {
-        return inner.persistent();
+        return inner.isOpen();
     }
 
     @Override


### PR DESCRIPTION
The VersionedKeyValueToBytesStoreAdapter#isOpen API accidentally returns the value of `inner.persistent()` when it should be returning `inner.isOpen()`