### PR TITLE
MINOR:code optimization in QuorumController

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -378,6 +378,7 @@ public final class QuorumController implements Controller {
         public void accept(ConfigResource configResource) {
             switch (configResource.type()) {
                 case BROKER_LOGGER:
+                    // BROKER_LOGGER are always allowed.
                     break;
                 case BROKER:
                     // Cluster configs are always allowed.
@@ -430,15 +431,6 @@ public final class QuorumController implements Controller {
             return new NotControllerException("The controller is in pre-migration mode.");
         } else {
             return new NotControllerException("No controller appears to be active.");
-        }
-    }
-
-    public static int exceptionToApparentController(NotControllerException e) {
-        if (e.getMessage().startsWith(ACTIVE_CONTROLLER_EXCEPTION_TEXT_PREFIX)) {
-            return Integer.parseInt(e.getMessage().substring(
-                ACTIVE_CONTROLLER_EXCEPTION_TEXT_PREFIX.length()));
-        } else {
-            return -1;
         }
     }
 
@@ -1587,11 +1579,6 @@ public final class QuorumController implements Controller {
     private final FaultHandler fatalFaultHandler;
 
     /**
-     * The slf4j log context, used to create new loggers.
-     */
-    private final LogContext logContext;
-
-    /**
      * The slf4j logger.
      */
     private final Logger log;
@@ -1823,7 +1810,6 @@ public final class QuorumController implements Controller {
         boolean zkMigrationEnabled
     ) {
         this.fatalFaultHandler = fatalFaultHandler;
-        this.logContext = logContext;
         this.log = logContext.logger(QuorumController.class);
         this.nodeId = nodeId;
         this.clusterId = clusterId;

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -350,6 +350,7 @@ public class QuorumControllerTest {
         }
     }
 
+    @Test
     public void testBalancePartitionLeaders() throws Throwable {
         List<Integer> allBrokers = Arrays.asList(1, 2, 3);
         List<Integer> brokersToKeepUnfenced = Arrays.asList(1, 2);


### PR DESCRIPTION
1. add hint in switch item "BROKER_LOGGER" in ConfigResourceExistenceChecker, otherwise, it will be classified as default break and deleted directly. I don’t know if adding hint is better than deleting directly.
2. delete some unused variables and methods.
3. add the "@Test" mark to a method in unit test that is forgotten.