### PR TITLE
KAFKA-14959: remove delayed queue and exempt sensors during ClientQuota and ClientRequestQuota managers shutdown

### DIFF
--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -572,6 +572,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
   }
 
   def shutdown(): Unit = {
+    metrics.removeSensor(delayQueueSensor.name())
     initiateShutdown()
     throttledChannelReaper.awaitShutdown()
   }

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -572,9 +572,12 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
   }
 
   def shutdown(): Unit = {
-    metrics.removeSensor(delayQueueSensor.name())
-    initiateShutdown()
-    throttledChannelReaper.awaitShutdown()
+    try {
+      initiateShutdown()
+      throttledChannelReaper.awaitShutdown()
+    } finally {
+      metrics.removeSensor(delayQueueSensor.name())
+    }
   }
 
   class DefaultQuotaCallback extends ClientQuotaCallback {

--- a/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
@@ -33,7 +33,7 @@ object ClientRequestQuotaManager {
   // create once.
   val DefaultInactiveExemptSensorExpirationTimeSeconds = Long.MaxValue
 
-  val ExemptSensorName = "exempt-" + QuotaType.Request
+  private[server] val ExemptSensorName = "exempt-" + QuotaType.Request
 }
 
 class ClientRequestQuotaManager(private val config: ClientQuotaManagerConfig,
@@ -93,7 +93,10 @@ class ClientRequestQuotaManager(private val config: ClientQuotaManagerConfig,
     nanos * ClientRequestQuotaManager.NanosToPercentagePerSecond
 
   override def shutdown(): Unit = {
-    metrics.removeSensor(exemptSensor.name())
-    super.shutdown()
+    try {
+      super.shutdown()
+    } finally {
+      metrics.removeSensor(exemptSensor.name())
+    }
   }
 }

--- a/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
@@ -28,13 +28,12 @@ import org.apache.kafka.server.quota.ClientQuotaCallback
 import scala.jdk.CollectionConverters._
 
 object ClientRequestQuotaManager {
-  val QuotaRequestPercentDefault = Int.MaxValue.toDouble
   val NanosToPercentagePerSecond = 100.0 / TimeUnit.SECONDS.toNanos(1)
   // Since exemptSensor is for all clients and has a constant name, we do not expire exemptSensor and only
   // create once.
   val DefaultInactiveExemptSensorExpirationTimeSeconds = Long.MaxValue
 
-  private val ExemptSensorName = "exempt-" + QuotaType.Request
+  val ExemptSensorName = "exempt-" + QuotaType.Request
 }
 
 class ClientRequestQuotaManager(private val config: ClientQuotaManagerConfig,
@@ -92,4 +91,9 @@ class ClientRequestQuotaManager(private val config: ClientQuotaManagerConfig,
 
   private def nanosToPercentage(nanos: Long): Double =
     nanos * ClientRequestQuotaManager.NanosToPercentagePerSecond
+
+  override def shutdown(): Unit = {
+    metrics.removeSensor(exemptSensor.name())
+    super.shutdown()
+  }
 }

--- a/core/src/test/scala/unit/kafka/server/BaseClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseClientQuotaManagerTest.scala
@@ -19,7 +19,6 @@ package kafka.server
 import java.net.InetAddress
 import java.util
 import java.util.Collections
-
 import kafka.network.RequestChannel
 import kafka.network.RequestChannel.Session
 import org.apache.kafka.common.TopicPartition

--- a/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
@@ -419,14 +419,22 @@ class ClientQuotaManagerTest extends BaseClientQuotaManagerTest {
   }
 
   @Test
-  def testDelayedQueueSensorShouldShouldExistAfterInstantiationAndBeRemovedAfterShutdown(): Unit = {
+  def testDelayedQueueSensorShouldExistAfterInstantiationAndBeRemovedAfterShutdown(): Unit = {
     val sensorName = Produce.toString + "-delayQueue"
     val clientQuotaManager = new ClientQuotaManager(config, metrics, Produce, time, "")
-    var delayedQueueSensor = metrics.getSensor(sensorName)
-    assertNotNull(delayedQueueSensor, "delayed queue sensor should exist")
-    clientQuotaManager.shutdown()
-    delayedQueueSensor = metrics.getSensor(sensorName)
-    assertNull(delayedQueueSensor, "delayed queue sensor should not exist after shutdown")
+    var clientQuotaManagerHasBeenShutdown = false;
+    try {
+      var delayedQueueSensor = metrics.getSensor(sensorName)
+      assertNotNull(delayedQueueSensor, "delayed queue sensor should exist")
+      clientQuotaManager.shutdown()
+      clientQuotaManagerHasBeenShutdown = true
+      delayedQueueSensor = metrics.getSensor(sensorName)
+      assertNull(delayedQueueSensor, "delayed queue sensor should not exist after shutdown")
+    } finally {
+      if (!clientQuotaManagerHasBeenShutdown) {
+        clientQuotaManager.shutdown();
+      }
+    }
   }
 
   private case class UserClient(user: String, clientId: String, configUser: Option[String] = None, configClientId: Option[String] = None) {

--- a/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
@@ -418,6 +418,17 @@ class ClientQuotaManagerTest extends BaseClientQuotaManagerTest {
     }
   }
 
+  @Test
+  def testDelayedQueueSensorShouldShouldExistAfterInstantiationAndBeRemovedAfterShutdown(): Unit = {
+    val sensorName = Produce.toString + "-delayQueue"
+    val clientQuotaManager = new ClientQuotaManager(config, metrics, Produce, time, "")
+    var delayedQueueSensor = metrics.getSensor(sensorName)
+    assertNotNull(delayedQueueSensor, "delayed queue sensor should exist")
+    clientQuotaManager.shutdown()
+    delayedQueueSensor = metrics.getSensor(sensorName)
+    assertNull(delayedQueueSensor, "delayed queue sensor should not exist after shutdown")
+  }
+
   private case class UserClient(user: String, clientId: String, configUser: Option[String] = None, configClientId: Option[String] = None) {
     // The class under test expects only sanitized client configs. We pass both the default value (which should not be
     // sanitized to ensure it remains unique) and non-default values, so we need to take care in generating the sanitized

--- a/core/src/test/scala/unit/kafka/server/ClientRequestQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientRequestQuotaManagerTest.scala
@@ -85,5 +85,21 @@ class ClientRequestQuotaManagerTest extends BaseClientQuotaManagerTest {
       clientRequestQuotaManager.shutdown()
     }
   }
+
+  @Test
+  def testExemptAndDelayedQueueSensorsShouldExistAfterInstantiationAndBeRemovedAfterShutdown(): Unit = {
+    val sensorName = Request.toString + "-delayQueue"
+    val clientRequestQuotaManager = new ClientRequestQuotaManager(config, metrics, time, "", None)
+    var requestDelayedQueueSensor = metrics.getSensor(sensorName)
+    assertNotNull(requestDelayedQueueSensor, "request delayed queue sensor should exist")
+    var exemptSensor = metrics.getSensor(ClientRequestQuotaManager.ExemptSensorName)
+    assertNotNull(exemptSensor, "exempt sensor should exist")
+    clientRequestQuotaManager.shutdown()
+    requestDelayedQueueSensor = metrics.getSensor(sensorName)
+    exemptSensor = metrics.getSensor(ClientRequestQuotaManager.ExemptSensorName)
+    assertNull(exemptSensor, "exempt sensor should not exist after shutdown")
+    assertNull(requestDelayedQueueSensor, "request delayed queue sensor should not exist after shutdown")
+  }
+
 }
 

--- a/core/src/test/scala/unit/kafka/server/ClientRequestQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientRequestQuotaManagerTest.scala
@@ -88,17 +88,25 @@ class ClientRequestQuotaManagerTest extends BaseClientQuotaManagerTest {
 
   @Test
   def testExemptAndDelayedQueueSensorsShouldExistAfterInstantiationAndBeRemovedAfterShutdown(): Unit = {
+    var clientRequestQuotaManagerHasBeenShutdown = false;
     val sensorName = Request.toString + "-delayQueue"
     val clientRequestQuotaManager = new ClientRequestQuotaManager(config, metrics, time, "", None)
-    var requestDelayedQueueSensor = metrics.getSensor(sensorName)
-    assertNotNull(requestDelayedQueueSensor, "request delayed queue sensor should exist")
-    var exemptSensor = metrics.getSensor(ClientRequestQuotaManager.ExemptSensorName)
-    assertNotNull(exemptSensor, "exempt sensor should exist")
-    clientRequestQuotaManager.shutdown()
-    requestDelayedQueueSensor = metrics.getSensor(sensorName)
-    exemptSensor = metrics.getSensor(ClientRequestQuotaManager.ExemptSensorName)
-    assertNull(exemptSensor, "exempt sensor should not exist after shutdown")
-    assertNull(requestDelayedQueueSensor, "request delayed queue sensor should not exist after shutdown")
+    try {
+      var requestDelayedQueueSensor = metrics.getSensor(sensorName)
+      assertNotNull(requestDelayedQueueSensor, "request delayed queue sensor should exist")
+      var exemptSensor = metrics.getSensor(ClientRequestQuotaManager.ExemptSensorName)
+      assertNotNull(exemptSensor, "exempt sensor should exist")
+      clientRequestQuotaManager.shutdown()
+      clientRequestQuotaManagerHasBeenShutdown = true
+      requestDelayedQueueSensor = metrics.getSensor(sensorName)
+      exemptSensor = metrics.getSensor(ClientRequestQuotaManager.ExemptSensorName)
+      assertNull(exemptSensor, "exempt sensor should not exist after shutdown")
+      assertNull(requestDelayedQueueSensor, "request delayed queue sensor should not exist after shutdown")
+    } finally {
+      if (!clientRequestQuotaManagerHasBeenShutdown) {
+        clientRequestQuotaManager.shutdown()
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Follows up on https://github.com/apache/kafka/pull/13623#discussion_r1182592921

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
