### PR TITLE
KAFKA-14985: attempt to fix ConnectionQuotasTest.testListenerConnectionRateLimitWhenActualRateAboveLimit() test  by bumping episilon to 8 from 7

### DIFF
--- a/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
@@ -407,7 +407,7 @@ class ConnectionQuotasTest {
     val futures = listeners.values.map { listener =>
       executor.submit((() =>
         // epsilon is set to account for the worst-case where the measurement is taken just before or after the quota window
-        acceptConnectionsAndVerifyRate(connectionQuotas, listener, connectionsPerListener, connCreateIntervalMs, listenerRateLimit, 7)): Runnable)
+        acceptConnectionsAndVerifyRate(connectionQuotas, listener, connectionsPerListener, connCreateIntervalMs, listenerRateLimit, 8)): Runnable)
     }
     futures.foreach(_.get(30, TimeUnit.SECONDS))
 


### PR DESCRIPTION
The test was observed to be failing with
```
ConnectionQuotasTest > testListenerConnectionRateLimitWhenActualRateAboveLimit() FAILED
    java.util.concurrent.ExecutionException: org.opentest4j.AssertionFailedError: Expected rate (30 +- 7), but got 37.47891810856393 (600 connections / 16.009 sec) ==> expected: <30.0> but was: <37.47891810856393>
        at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
        at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:205)
        at kafka.network.ConnectionQuotasTest.$anonfun$testListenerConnectionRateLimitWhenActualRateAboveLimit$3(ConnectionQuotasTest.scala:412)
        at scala.collection.immutable.List.foreach(List.scala:333)
        at kafka.network.ConnectionQuotasTest.testListenerConnectionRateLimitWhenActualRateAboveLimit(ConnectionQuotasTest.scala:412)        Caused by:
        org.opentest4j.AssertionFailedError: Expected rate (30 +- 7), but got 37.47891810856393 (600 connections / 16.009 sec) ==> expected: <30.0> but was: <37.47891810856393>
            at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
            at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
            at app//org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
            at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:86)
            at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1021)
            at app//kafka.network.ConnectionQuotasTest.acceptConnectionsAndVerifyRate(ConnectionQuotasTest.scala:904)
```
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
