### PR TITLE
KAFKA-14500; [3/N] add GroupMetadataKey/Value record helpers

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -323,6 +323,8 @@
               files="(ConsumerGroupMember).java"/>
     <suppress checks="ParameterNumber"
               files="(ConsumerGroupMember).java"/>
+    <suppress checks="ClassDataAbstractionCouplingCheck"
+              files="(RecordHelpersTest).java"/>
 
     <!-- storage -->
     <suppress checks="CyclomaticComplexity"

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
@@ -372,7 +372,7 @@ public class RecordHelpers {
         GenericGroup group,
         MetadataVersion metadataVersion
     ) {
-        List<GroupMetadataValue.MemberMetadata> members = new ArrayList<>();
+        List<GroupMetadataValue.MemberMetadata> members = new ArrayList<>(group.allMembers().size());
         group.allMembers().forEach(member -> {
             byte[] subscription = group.protocolName().map(member::metadata).orElse(null);
             if (subscription == null) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
@@ -37,16 +37,11 @@ import org.apache.kafka.coordinator.group.generic.GenericGroup;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MetadataVersion;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static org.apache.kafka.server.common.MetadataVersion.IBP_0_10_1_IV0;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_2_1_IV0;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_2_3_IV0;
 
 /**
  * This class contains helper methods to create records stored in
@@ -379,17 +374,6 @@ public class RecordHelpers {
         Map<String, byte[]> memberAssignments,
         MetadataVersion metadataVersion
     ) {
-        short version;
-        if (metadataVersion.isLessThan(IBP_0_10_1_IV0)) {
-            version = (short) 0;
-        } else if (metadataVersion.isLessThan(IBP_2_1_IV0)) {
-            version = (short) 1;
-        } else if (metadataVersion.isLessThan(IBP_2_3_IV0)) {
-            version = (short) 2;
-        } else {
-            version = (short) 3;
-        }
-
         List<GroupMetadataValue.MemberMetadata> members = new ArrayList<>();
         group.allMembers().forEach(member -> {
             byte[] subscription = group.protocolName().map(member::metadata).orElse(null);
@@ -430,7 +414,7 @@ public class RecordHelpers {
                     .setLeader(group.leaderOrNull())
                     .setCurrentStateTimestamp(group.currentStateTimestampOrDefault())
                     .setMembers(members),
-                version
+                metadataVersion.groupMetadataValueVersion()
             )
         );
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
@@ -365,13 +365,11 @@ public class RecordHelpers {
      * Creates a GroupMetadata record.
      *
      * @param group              The generic group.
-     * @param memberAssignments  The assignment by member id.
      * @param metadataVersion    The metadata version.
      * @return The record.
      */
     public static Record newGroupMetadataRecord(
         GenericGroup group,
-        Map<String, byte[]> memberAssignments,
         MetadataVersion metadataVersion
     ) {
         List<GroupMetadataValue.MemberMetadata> members = new ArrayList<>();
@@ -381,7 +379,7 @@ public class RecordHelpers {
                 throw new IllegalStateException("Attempted to write non-empty group metadata with no defined protocol.");
             }
 
-            byte[] assignment = memberAssignments.get(member.memberId());
+            byte[] assignment = member.assignment();
             if (assignment == null) {
                 throw new IllegalStateException("Attempted to write member " + member.memberId() +
                     " of group + " + group.groupId() + " with no assignment.");

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
@@ -31,13 +31,22 @@ import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmen
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataValue;
+import org.apache.kafka.coordinator.group.generated.GroupMetadataKey;
+import org.apache.kafka.coordinator.group.generated.GroupMetadataValue;
+import org.apache.kafka.coordinator.group.generic.GenericGroup;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.MetadataVersion;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.apache.kafka.server.common.MetadataVersion.IBP_0_10_1_IV0;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_2_1_IV0;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_2_3_IV0;
 
 /**
  * This class contains helper methods to create records stored in
@@ -339,7 +348,7 @@ public class RecordHelpers {
      * Creates a ConsumerGroupCurrentMemberAssignment tombstone.
      *
      * @param groupId   The consumer group id.
-     * @param memberId    The consumer group member id.
+     * @param memberId  The consumer group member id.
      * @return The record.
      */
     public static Record newCurrentAssignmentTombstoneRecord(
@@ -352,6 +361,94 @@ public class RecordHelpers {
                     .setGroupId(groupId)
                     .setMemberId(memberId),
                 (short) 8
+            ),
+            null // Tombstone
+        );
+    }
+
+    /**
+     * Creates a GroupMetadata record.
+     *
+     * @param group              The generic group.
+     * @param memberAssignments  The assignment by member id.
+     * @param metadataVersion    The metadata version.
+     * @return The record.
+     */
+    public static Record newGroupMetadataRecord(
+        GenericGroup group,
+        Map<String, byte[]> memberAssignments,
+        MetadataVersion metadataVersion
+    ) {
+        short version;
+        if (metadataVersion.isLessThan(IBP_0_10_1_IV0)) {
+            version = (short) 0;
+        } else if (metadataVersion.isLessThan(IBP_2_1_IV0)) {
+            version = (short) 1;
+        } else if (metadataVersion.isLessThan(IBP_2_3_IV0)) {
+            version = (short) 2;
+        } else {
+            version = (short) 3;
+        }
+
+        List<GroupMetadataValue.MemberMetadata> members = new ArrayList<>();
+        group.allMembers().forEach(member -> {
+            byte[] subscription = group.protocolName().map(member::metadata).orElse(null);
+            if (subscription == null) {
+                throw new IllegalStateException("Attempted to write non-empty group metadata with no defined protocol.");
+            }
+
+            byte[] assignment = memberAssignments.get(member.memberId());
+            if (assignment == null) {
+                throw new IllegalStateException("Attempted to write member " + member.memberId() +
+                    " of group + " + group.groupId() + " with no assignment.");
+            }
+
+            members.add(
+                new GroupMetadataValue.MemberMetadata()
+                    .setMemberId(member.memberId())
+                    .setClientId(member.clientId())
+                    .setClientHost(member.clientHost())
+                    .setRebalanceTimeout(member.rebalanceTimeoutMs())
+                    .setSessionTimeout(member.sessionTimeoutMs())
+                    .setGroupInstanceId(member.groupInstanceId().orElse(null))
+                    .setSubscription(subscription)
+                    .setAssignment(assignment)
+            );
+        });
+
+        return new Record(
+            new ApiMessageAndVersion(
+                new GroupMetadataKey()
+                    .setGroup(group.groupId()),
+                (short) 2
+            ),
+            new ApiMessageAndVersion(
+                new GroupMetadataValue()
+                    .setProtocol(group.protocolName().orElse(null))
+                    .setProtocolType(group.protocolType().orElse(""))
+                    .setGeneration(group.generationId())
+                    .setLeader(group.leaderOrNull())
+                    .setCurrentStateTimestamp(group.currentStateTimestampOrDefault())
+                    .setMembers(members),
+                version
+            )
+        );
+    }
+
+    /**
+     * Creates a GroupMetadata tombstone.
+     *
+     * @param groupId  The group id.
+     * @return The record.
+     */
+    public static Record newGroupMetadataTombstoneRecord(
+        String groupId
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new GroupMetadataKey()
+                    .setGroup(groupId),
+                (short) 2
             ),
             null // Tombstone
         );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
@@ -54,7 +54,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
@@ -467,9 +467,7 @@ public class RecordHelpersTest {
             time
         );
 
-        Map<String, byte[]> memberAssignments = new HashMap<>();
         expectedMembers.forEach(member -> {
-            memberAssignments.put(member.memberId(), member.assignment());
             group.add(new GenericGroupMember(
                 member.memberId(),
                 Optional.of(member.groupInstanceId()),
@@ -489,7 +487,6 @@ public class RecordHelpersTest {
         group.initNextGeneration();
         Record groupMetadataRecord = RecordHelpers.newGroupMetadataRecord(
             group,
-            memberAssignments,
             metadataVersion
         );
 
@@ -533,9 +530,7 @@ public class RecordHelpersTest {
             time
         );
 
-        Map<String, byte[]> memberAssignments = new HashMap<>();
         expectedMembers.forEach(member -> {
-            memberAssignments.put(member.memberId(), member.assignment());
             group.add(new GenericGroupMember(
                 member.memberId(),
                 Optional.of(member.groupInstanceId()),
@@ -555,7 +550,6 @@ public class RecordHelpersTest {
         assertThrows(IllegalStateException.class, () ->
             RecordHelpers.newGroupMetadataRecord(
                 group,
-                memberAssignments,
                 MetadataVersion.IBP_3_5_IV2
             ));
     }
@@ -574,7 +568,7 @@ public class RecordHelpersTest {
                 .setSessionTimeout(1500)
                 .setGroupInstanceId("group-instance-1")
                 .setSubscription(new byte[]{0, 1})
-                .setAssignment(new byte[]{1, 2})
+                .setAssignment(null)
         );
 
         GenericGroup group = new GenericGroup(
@@ -604,7 +598,6 @@ public class RecordHelpersTest {
         assertThrows(IllegalStateException.class, () ->
             RecordHelpers.newGroupMetadataRecord(
                 group,
-                new HashMap<>(),
                 MetadataVersion.IBP_3_5_IV2
             ));
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
@@ -457,7 +457,7 @@ public class RecordHelpersTest {
                     .setGeneration(1)
                     .setCurrentStateTimestamp(time.milliseconds())
                     .setMembers(expectedMembers),
-            expectedGroupMetadataValueVersion));
+                expectedGroupMetadataValueVersion));
 
         GenericGroup group = new GenericGroup(
             new LogContext(),

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
@@ -403,6 +403,15 @@ public class RecordHelpersTest {
         ));
     }
 
+    private static Stream<Arguments> metadataToExpectedGroupMetadataValue() {
+        return Stream.of(
+            Arguments.arguments(MetadataVersion.IBP_0_10_0_IV0, (short) 0),
+            Arguments.arguments(MetadataVersion.IBP_1_1_IV0, (short) 1),
+            Arguments.arguments(MetadataVersion.IBP_2_2_IV0, (short) 2),
+            Arguments.arguments(MetadataVersion.IBP_3_5_IV0, (short) 3)
+        );
+    }
+
     @ParameterizedTest
     @MethodSource("metadataToExpectedGroupMetadataValue")
     public void testNewGroupMetadataRecord(
@@ -598,14 +607,5 @@ public class RecordHelpersTest {
                 new HashMap<>(),
                 MetadataVersion.IBP_3_5_IV2
             ));
-    }
-
-    private static Stream<Arguments> metadataToExpectedGroupMetadataValue() {
-        return Stream.of(
-            Arguments.arguments(MetadataVersion.IBP_0_10_0_IV0, (short) 0),
-            Arguments.arguments(MetadataVersion.IBP_1_1_IV0, (short) 1),
-            Arguments.arguments(MetadataVersion.IBP_2_2_IV0, (short) 2),
-            Arguments.arguments(MetadataVersion.IBP_3_5_IV0, (short) 3)
-        );
     }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -365,6 +365,20 @@ public enum MetadataVersion {
         }
     }
 
+    public short groupMetadataValueVersion() {
+        if (this.isLessThan(IBP_0_10_1_IV0)) {
+            return 0;
+        } else if (this.isLessThan(IBP_2_1_IV0)) {
+            return 1;
+        } else if (this.isLessThan(IBP_2_3_IV0)) {
+            return 2;
+        } else {
+            // Serialize with the highest supported non-flexible version
+            // until a tagged field is introduced or the version is bumped.
+            return 3;
+        }
+    }
+
     private static final Map<String, MetadataVersion> IBP_VERSIONS;
     static {
         {

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -315,7 +315,7 @@ class MetadataVersionTest {
 
     @ParameterizedTest
     @EnumSource(value = MetadataVersion.class)
-    public void testGroupMetadataValueVersion (MetadataVersion metadataVersion) {
+    public void testGroupMetadataValueVersion(MetadataVersion metadataVersion) {
         final short expectedVersion;
         if (metadataVersion.isAtLeast(MetadataVersion.IBP_2_3_IV0)) {
             expectedVersion = 3;

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -312,4 +312,20 @@ class MetadataVersionTest {
         }
         assertEquals(expectedVersion, metadataVersion.registerBrokerRecordVersion());
     }
+
+    @ParameterizedTest
+    @EnumSource(value = MetadataVersion.class)
+    public void testGroupMetadataValueVersion (MetadataVersion metadataVersion) {
+        final short expectedVersion;
+        if (metadataVersion.isAtLeast(MetadataVersion.IBP_2_3_IV0)) {
+            expectedVersion = 3;
+        } else if (metadataVersion.isAtLeast(IBP_2_1_IV0)) {
+            expectedVersion = 2;
+        } else if (metadataVersion.isAtLeast(IBP_0_10_1_IV0)) {
+            expectedVersion = 1;
+        } else {
+            expectedVersion = 0;
+        }
+        assertEquals(expectedVersion, metadataVersion.groupMetadataValueVersion());
+    }
 }


### PR DESCRIPTION
This PR enables the new group metadata manager to generate GroupMetadataKey/Value records.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
