### PR TITLE
KAFKA-14991:Added a validation to check if the record timestamp is in the future compared to the broker's timestamp

### DIFF
--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -1839,16 +1839,18 @@ class LogCleanerTest {
     val log = makeLog(config = logConfig)
     val cleaner = makeCleaner(10)
 
+    //use slightly older timestamp to avoid validation issues with future timestamps
+    val beforeFortyEightHours = time.milliseconds() - 48 * 60 * 60 * 1000L
     // Append a message with a large timestamp.
     log.appendAsLeader(TestUtils.singletonRecords(value = "0".getBytes,
                                           key = "0".getBytes,
-                                          timestamp = time.milliseconds() + logConfig.deleteRetentionMs + 10000), leaderEpoch = 0)
+                                          timestamp = beforeFortyEightHours + logConfig.deleteRetentionMs + 10000), leaderEpoch = 0)
     log.roll()
     cleaner.clean(LogToClean(new TopicPartition("test", 0), log, 0, log.activeSegment.baseOffset))
     // Append a tombstone with a small timestamp and roll out a new log segment.
     log.appendAsLeader(TestUtils.singletonRecords(value = null,
                                           key = "0".getBytes,
-                                          timestamp = time.milliseconds() - logConfig.deleteRetentionMs - 10000), leaderEpoch = 0)
+                                          timestamp = beforeFortyEightHours - logConfig.deleteRetentionMs - 10000), leaderEpoch = 0)
     log.roll()
 
     cleaner.clean(LogToClean(new TopicPartition("test", 0), log, 1, log.activeSegment.baseOffset))

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -57,7 +57,7 @@ class DumpLogSegmentsTest {
   val snapshotPath = s"$logDir/00000000000000000000-0000000000.checkpoint"
   val indexFilePath = s"$logDir/$segmentName.index"
   val timeIndexFilePath = s"$logDir/$segmentName.timeindex"
-  val time = new MockTime(0, 0)
+  val time = new MockTime()
 
   val batches = new ArrayBuffer[BatchInfo]
   var log: UnifiedLog = _

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogValidator.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogValidator.java
@@ -593,21 +593,20 @@ public class LogValidator {
                                                               TimestampType timestampType,
                                                               long timestampDiffMaxMs) {
         if (timestampType == TimestampType.CREATE_TIME
-                && record.timestamp() != RecordBatch.NO_TIMESTAMP){
+                && record.timestamp() != RecordBatch.NO_TIMESTAMP) {
             final long timestampDiff = record.timestamp() - now;
-            if(timestampDiff > TIME_DRIFT_TOLERANCE){
+            if (timestampDiff > TIME_DRIFT_TOLERANCE) {
                 return Optional.of(new ApiRecordError(Errors.INVALID_TIMESTAMP, new RecordError(batchIndex,
                         "Timestamp " + record.timestamp() + " of message with offset " + record.offset()
                                 + " is ahead of the server's time (" + now + ").")));
             }
-            if(Math.abs(timestampDiff) > timestampDiffMaxMs){
+            if (Math.abs(timestampDiff) > timestampDiffMaxMs) {
                 return Optional.of(new ApiRecordError(Errors.INVALID_TIMESTAMP, new RecordError(batchIndex,
                         "Timestamp " + record.timestamp() + " of message with offset " + record.offset()
                                 + " is out of range. The timestamp should be within [" + (now - timestampDiffMaxMs)
                                 + ", " + (now + timestampDiffMaxMs) + "]")));
             }
-        }
-        else if (batch.timestampType() == TimestampType.LOG_APPEND_TIME)
+        } else if (batch.timestampType() == TimestampType.LOG_APPEND_TIME)
             return Optional.of(new ApiRecordError(Errors.INVALID_TIMESTAMP, new RecordError(batchIndex,
                 "Invalid timestamp type in message " + record + ". Producer should not set timestamp "
                 + "type to LogAppendTime.")));

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogValidator.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogValidator.java
@@ -598,7 +598,7 @@ public class LogValidator {
             if(timestampDiff > TIME_DRIFT_TOLERANCE){
                 return Optional.of(new ApiRecordError(Errors.INVALID_TIMESTAMP, new RecordError(batchIndex,
                         "Timestamp " + record.timestamp() + " of message with offset " + record.offset()
-                                + " is ahead of the server's time. " + now)));
+                                + " is ahead of the server's time (" + now + ").")));
             }
             if(Math.abs(timestampDiff) > timestampDiffMaxMs){
                 return Optional.of(new ApiRecordError(Errors.INVALID_TIMESTAMP, new RecordError(batchIndex,


### PR DESCRIPTION
### What changed
Added a validation to check if the record timestamp is in the future compared to the broker's timestamp and throw an exception to reject the record.

The current validation for  checking the record's timestamp based on the configuered ```timestampDiffMaxMs``` remain unchanged. This new validation will take care of scenarios where producers are sending future timestamp for a record.
Specific changes are:
- Updated validation logic in LogValidator
- Added Unit test coverage for the change
- Update Unit tests that failed because of the new validation logic

### Why?
https://issues.apache.org/jira/browse/KAFKA-14991
Improves the accuracy of the log validation logic and avoids unexpected gotchas for customers


### Testing
- Added relevant unit tests
- Reproduced the issue by setting nonseconds instead of miliseconds in the producer logic and verified that validation is working as expected. Example API response

```
"responses":[{"name":"myTopic1","partitionResponses":[{"index":0,"errorCode":32,"baseOffset":-1,"logAppendTimeMs":-1,"logStartOffset":0,"recordErrors":[
{"batchIndex":0,"batchIndexErrorMessage":"Timestamp 1755933141855875 of message with offset 0 is ahead of the server's time. 1683838582815"},
{"batchIndex":1,"batchIndexErrorMessage":"Timestamp 1755933754530625 of message with offset 1 is ahead of the server's time. 1683838582815"},
....
],"errorMessage":"One or more records have been rejected due to invalid timestamp"}]}]
``` 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
