### PR TITLE
KAFKA-14782: Implementation Details Different from Documentation (del…

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -2100,6 +2100,21 @@ public class KafkaProducerTest {
         }
     }
 
+    @Test
+    public void throwIfExplicitlySetInvalidDeliveryTimeoutMs() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 5000);
+        props.put(ProducerConfig.LINGER_MS_CONFIG, 2000);
+        props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 2000);
+        props.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 2000);
+        assertThrows(KafkaException.class,
+                () -> new KafkaProducer<>(props, new StringSerializer(), new StringSerializer()),
+                ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG + " should be equal to or larger than "
+                        + ProducerConfig.LINGER_MS_CONFIG + " + "
+                        + ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG + " + "
+                        + ProducerConfig.RETRY_BACKOFF_MS_CONFIG);
+    }
+
     private <T> FutureRecordMetadata expectAppend(
         KafkaProducerTestContext<T> ctx,
         ProducerRecord<T, T> record,


### PR DESCRIPTION
An upper bound on the time to report success or failure after a call to send() returns. This limits the total time that a record will be delayed prior to sending, the time to await acknowledgement from the broker (if expected), **and the time allowed for retriable send failures**.

If user explicitly sets delivery.timeout.ms less than sum of linger.ms, retry.backoff.ms and request.timeout.ms we throwing a ConfigException which handles in KafkaProducer constructor. 

It's described [here](https://cwiki.apache.org/confluence/display/KAFKA/KIP-91+Provide+Intuitive+User+Timeouts+in+The+Producer#KIP91ProvideIntuitiveUserTimeoutsinTheProducer-Validation) in validation section.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
