### PR TITLE
MINOR: Fix .asf.yaml github_whitelist

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -36,7 +36,7 @@ jenkins:
     - fvaleri
     - andymg3
 
-# This list allows you to triage pull requests. It can have a maximum of 20 people.
+# This list allows you to triage pull requests. It can have a maximum of 10 people.
 # https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features#Git.asf.yamlfeatures-AssigningexternalcollaboratorswiththetriageroleonGitHub
 github:
   collaborators:
@@ -50,13 +50,3 @@ github:
     - clolov
     - fvaleri
     - andymg3
-    - RivenSun2
-    - kirktrue
-    - mdedetrich
-    - akhileshchg
-    - ahuang98
-    - artemlivshits
-    - tinaselenge
-    - lihaosky
-    - niket-goel
-    - hudeqi

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -21,6 +21,8 @@ notifications:
   pullrequests: jira@kafka.apache.org
   jira_options: link label
 
+# This list allows you to trigger builds on pull requests. It can have a maximum of 10 people.
+# https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features#Git.asf.yamlfeatures-JenkinsPRwhitelisting
 jenkins:
   github_whitelist:
     - vcrfxia
@@ -33,17 +35,9 @@ jenkins:
     - clolov
     - fvaleri
     - andymg3
-    - RivenSun2
-    - kirktrue
-    - mdedetrich
-    - akhileshchg
-    - ahuang98
-    - artemlivshits
-    - tinaselenge
-    - lihaosky
-    - niket-goel
-    - hudeqi
 
+# This list allows you to triage pull requests. It can have a maximum of 20 people.
+# https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features#Git.asf.yamlfeatures-AssigningexternalcollaboratorswiththetriageroleonGitHub
 github:
   collaborators:
     - vcrfxia


### PR DESCRIPTION
After merging https://github.com/apache/kafka/pull/13713, I got a notification that the github_whitelist is capped at 10.
