### PR TITLE
KAFKA-14980: Fix MirrorSourceConnector source consumer configuration

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -158,7 +158,7 @@ public abstract class MirrorConnectorConfig extends AbstractConfig {
 
     static Map<String, Object> sourceConsumerConfig(Map<String, ?> props) {
         Map<String, Object> result = new HashMap<>();
-        result.putAll(Utils.entriesWithPrefix(props, SOURCE_PREFIX));
+        result.putAll(Utils.entriesWithPrefix(props, SOURCE_CLUSTER_PREFIX));
         result.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         result.putAll(Utils.entriesWithPrefix(props, CONSUMER_CLIENT_PREFIX));
         result.putAll(Utils.entriesWithPrefix(props, SOURCE_PREFIX + CONSUMER_CLIENT_PREFIX));

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
@@ -43,7 +43,8 @@ public class MirrorConnectorConfigTest {
     @Test
     public void testSourceConsumerConfig() {
         Map<String, String> connectorProps = makeProps(
-                MirrorConnectorConfig.CONSUMER_CLIENT_PREFIX + "max.poll.interval.ms", "120000"
+                MirrorConnectorConfig.CONSUMER_CLIENT_PREFIX + "max.poll.interval.ms", "120000",
+                MirrorConnectorConfig.SOURCE_CLUSTER_PREFIX + "bootstrap.servers", "localhost:2345"
         );
         MirrorConnectorConfig config = new TestMirrorConnectorConfig(connectorProps);
         Map<String, Object> connectorConsumerProps = config.sourceConsumerConfig("test");
@@ -52,11 +53,13 @@ public class MirrorConnectorConfigTest {
         expectedConsumerProps.put("auto.offset.reset", "earliest");
         expectedConsumerProps.put("max.poll.interval.ms", "120000");
         expectedConsumerProps.put("client.id", "source1->target2|ConnectorName|test");
+        expectedConsumerProps.put("bootstrap.servers", "localhost:2345");
         assertEquals(expectedConsumerProps, connectorConsumerProps);
 
         // checking auto.offset.reset override works
         connectorProps = makeProps(
-                MirrorConnectorConfig.CONSUMER_CLIENT_PREFIX + "auto.offset.reset", "latest"
+                MirrorConnectorConfig.CONSUMER_CLIENT_PREFIX + "auto.offset.reset", "latest",
+                MirrorConnectorConfig.SOURCE_CLUSTER_PREFIX + "bootstrap.servers", "localhost:2345"
         );
         config = new TestMirrorConnectorConfig(connectorProps);
         connectorConsumerProps = config.sourceConsumerConfig("test");


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-14980)

Fixes a typo introduced in https://github.com/apache/kafka/pull/12366 that breaks how the consumer for the source cluster is configured.

As a fix for a regression and a blocker issue, this change should be backported to 3.5 before the 3.5.0 release is put out.