### PR TITLE
KAFKA-13109: SourceTask#poll not enforcing retries in case of RetriableException

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
@@ -465,13 +465,8 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
     }
 
     protected List<SourceRecord> poll() throws InterruptedException {
-        try {
-            return task.poll();
-        } catch (RetriableException | org.apache.kafka.common.errors.RetriableException e) {
-            log.warn("{} failed to poll records from SourceTask. Will retry operation.", this, e);
-            // Do nothing. Let the framework poll whenever it's ready.
-            return null;
-        }
+        retryWithToleranceOperator.reset();
+        return retryWithToleranceOperator.execute(task::poll, Stage.TASK_POLL, this.getClass());
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ProcessingContext.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ProcessingContext.java
@@ -54,7 +54,7 @@ class ProcessingContext implements AutoCloseable {
     /**
      * Reset the internal fields before executing operations on a new record.
      */
-    private void reset() {
+    void reset() {
         attempt = 0;
         position = null;
         klass = null;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -260,6 +260,10 @@ public class RetryWithToleranceOperator implements AutoCloseable {
         return errorToleranceType;
     }
 
+    public synchronized void reset() {
+        this.context.reset();
+    }
+
     /**
      * Do an exponential backoff bounded by {@link #RETRIES_DELAY_MIN_MS} and {@link #errorMaxDelayInMillis}
      * which can be exited prematurely if {@link #triggerStop()} is called or if the thread is interrupted.

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
@@ -30,9 +30,11 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.integration.MonitorableSourceConnector;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.errors.ErrorHandlingMetrics;
+import org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator;
 import org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperatorTest;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
@@ -81,11 +83,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptySet;
+import static org.apache.kafka.common.utils.Time.SYSTEM;
 import static org.apache.kafka.connect.integration.MonitorableSourceConnector.TOPIC_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
@@ -100,6 +104,7 @@ import static org.apache.kafka.connect.runtime.TopicCreationConfig.INCLUDE_REGEX
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.PARTITIONS_CONFIG;
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.REPLICATION_FACTOR_CONFIG;
 import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_CREATION_ENABLE_CONFIG;
+import static org.apache.kafka.connect.runtime.errors.ToleranceType.ALL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -107,7 +112,9 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -288,6 +295,10 @@ public class ExactlyOnceWorkerSourceTaskTest {
     }
 
     private void createWorkerTask(TargetState initialState, Converter keyConverter, Converter valueConverter, HeaderConverter headerConverter) {
+        createWorkerTask(initialState, keyConverter, valueConverter, headerConverter, RetryWithToleranceOperatorTest.NOOP_OPERATOR);
+    }
+
+    private void createWorkerTask(TargetState initialState, Converter keyConverter, Converter valueConverter, HeaderConverter headerConverter, RetryWithToleranceOperator retryWithToleranceOperator) {
         workerTask = new ExactlyOnceWorkerSourceTask(taskId, sourceTask, statusListener, initialState, keyConverter, valueConverter, headerConverter,
                 transformationChain, producer, admin, TopicCreationGroup.configuredGroups(sourceConfig), offsetReader, offsetWriter, offsetStore,
                 config, clusterConfigState, metrics, errorHandlingMetrics, plugins.delegatingLoader(), time, RetryWithToleranceOperatorTest.NOOP_OPERATOR, statusBackingStore,
@@ -481,6 +492,37 @@ public class ExactlyOnceWorkerSourceTaskTest {
         verifyStartup();
         verifyShutdown(true, false);
         assertPollMetrics(0);
+    }
+
+    @Test
+    public void testRetriableExceptionInPoll() throws Exception {
+
+        final ErrorHandlingMetrics errorHandlingMetrics = mock(ErrorHandlingMetrics.class);
+        final RetryWithToleranceOperator retryWithToleranceOperator = new RetryWithToleranceOperator(30, 15, ALL, SYSTEM, errorHandlingMetrics);
+        createWorkerTask(TargetState.STARTED, keyConverter, valueConverter, headerConverter, retryWithToleranceOperator);
+        final CountDownLatch pollLatch = new CountDownLatch(3);
+
+        final RetriableException retriableException = new RetriableException("Error");
+        final AtomicInteger numPollInvocations = new AtomicInteger(0);
+        when(sourceTask.poll()).thenAnswer(invocation -> {
+            pollLatch.countDown();
+            numPollInvocations.incrementAndGet();
+            throw retriableException;
+        });
+
+        startTaskThread();
+        ConcurrencyUtils.awaitLatch(pollLatch, "task was not polled in time");
+
+        awaitShutdown();
+        assertEquals(pollCount(), numPollInvocations.get());
+        verifyPreflight();
+        verifyStartup();
+        verifyCleanShutdown();
+        verify(sourceTask, atLeast(numPollInvocations.get())).poll();
+        // recordRetry and recordFailure shouldn't exceed the number of poll invocations
+        verify(errorHandlingMetrics, atMost(numPollInvocations.get())).recordRetry();
+        verify(errorHandlingMetrics, atMost(numPollInvocations.get())).recordFailure();
+        verify(errorHandlingMetrics).recordSkipped();
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -379,7 +379,8 @@ public class WorkerSourceTaskTest {
         assertPollMetrics(0);
 
         verifyCleanStartup();
-        verify(statusListener).onFailure(taskId, exception);
+        // RuntimeException bubbles up as ConnectException due to retryWithTolerance
+        verify(statusListener).onFailure(eq(taskId), any(ConnectException.class));
         verify(sourceTask).stop();
         assertShouldSkipCommit();
         verifyOffsetFlush(true);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
@@ -187,6 +187,18 @@ public class RetryWithToleranceOperatorTest {
         assertThrows(ConnectException.class, () -> testHandleExceptionInStage(Stage.KAFKA_PRODUCE, new Exception()));
     }
 
+    @Test
+    public void testResetShouldResetState() {
+        RetryWithToleranceOperator retryWithToleranceOperator = setupExecutor();
+        Operation<?> exceptionThrower = () -> {
+            throw new org.apache.kafka.connect.errors.RetriableException("Test");
+        };
+        retryWithToleranceOperator.execute(exceptionThrower, Stage.TASK_POLL, RetryWithToleranceOperator.class);
+        assertTrue(retryWithToleranceOperator.failed());
+        retryWithToleranceOperator.reset();
+        assertFalse(retryWithToleranceOperator.failed());
+    }
+
     private void testHandleExceptionInStage(Stage type, Exception ex) {
         RetryWithToleranceOperator retryWithToleranceOperator = setupExecutor();
         Operation<?> exceptionThrower = () -> {


### PR DESCRIPTION
AbstractWorkerSourceTask is not enforcing the errors.retry.timeout and errors.retry.delay.max.ms parameters in case of a RetriableException during task.poll(). [KIP-298 ](https://cwiki.apache.org/confluence/display/KAFKA/KIP-298%3A+Error+Handling+in+Connect) explicitly mentions that `poll() in SourceTask will retry in case of RetriableException. 
The current behaviour is that in case of RetriableException, null is returned immediately.
This PR aims to add that support.

Note that I think SinkTask#put doesn't honour which can be taken up in a follow up PR?