### PR TITLE
KAFKA-15007: Always update the MetadataPropagator with correct MV.

### DIFF
--- a/core/src/main/scala/kafka/migration/MigrationPropagator.scala
+++ b/core/src/main/scala/kafka/migration/MigrationPropagator.scala
@@ -26,7 +26,6 @@ import org.apache.kafka.common.utils.Time
 import org.apache.kafka.image.{ClusterImage, MetadataDelta, MetadataImage, TopicsImage}
 import org.apache.kafka.metadata.PartitionRegistration
 import org.apache.kafka.metadata.migration.LegacyPropagator
-import org.apache.kafka.server.common.MetadataVersion
 
 import java.util
 import scala.jdk.CollectionConverters._
@@ -57,7 +56,6 @@ class MigrationPropagator(
   config: KafkaConfig
 ) extends LegacyPropagator {
   @volatile private var _image = MetadataImage.EMPTY
-  @volatile private var metadataVersion = MetadataVersion.IBP_3_4_IV0
   val stateChangeLogger = new StateChangeLogger(nodeId, inControllerContext = true, None)
   val channelManager = new ControllerChannelManager(
     () => _image.highestOffsetAndEpoch().epoch(),
@@ -70,7 +68,7 @@ class MigrationPropagator(
   val requestBatch = new MigrationPropagatorBatch(
     config,
     metadataProvider,
-    () => metadataVersion,
+    () => _image.features().metadataVersion(),
     channelManager,
     stateChangeLogger
   )
@@ -247,9 +245,5 @@ class MigrationPropagator(
 
   override def clear(): Unit = {
     requestBatch.clear()
-  }
-
-  override def setMetadataVersion(newMetadataVersion: MetadataVersion): Unit = {
-    metadataVersion = newMetadataVersion
   }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
@@ -623,12 +623,6 @@ public class KRaftMigrationDriver implements MetadataPublisher {
             KRaftMigrationDriver.this.image = image;
             String metadataType = isSnapshot ? "snapshot" : "delta";
 
-            // Propagator should be aware of any MV updates since it depends on this version to
-            // send the appropriate requests to the Zk brokers during migration.
-            if (delta.featuresDelta() != null) {
-                propagator.setMetadataVersion(image.features().metadataVersion());
-            }
-
             if (migrationState != MigrationDriverState.DUAL_WRITE) {
                 log.trace("Received metadata {}, but the controller is not in dual-write " +
                     "mode. Ignoring the change to be replicated to Zookeeper", metadataType);

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/LegacyPropagator.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/LegacyPropagator.java
@@ -18,7 +18,6 @@ package org.apache.kafka.metadata.migration;
 
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
-import org.apache.kafka.server.common.MetadataVersion;
 
 public interface LegacyPropagator {
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/LegacyPropagator.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/LegacyPropagator.java
@@ -35,6 +35,4 @@ public interface LegacyPropagator {
     void sendRPCsToBrokersFromMetadataImage(MetadataImage image, int zkControllerEpoch);
 
     void clear();
-
-    void setMetadataVersion(MetadataVersion metadataVersion);
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
@@ -46,7 +46,6 @@ import org.apache.kafka.metadata.RecordTestUtils;
 import org.apache.kafka.raft.LeaderAndEpoch;
 import org.apache.kafka.raft.OffsetAndEpoch;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
-import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.server.fault.MockFaultHandler;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Assertions;

--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
@@ -163,11 +163,6 @@ public class KRaftMigrationDriverTest {
         public void clear() {
 
         }
-
-        @Override
-        public void setMetadataVersion(MetadataVersion metadataVersion) {
-
-        }
     }
 
     RegisterBrokerRecord zkBrokerRecord(int id) {


### PR DESCRIPTION
Even if the MigrationDriver is not in DUAL_WRITE mode, it should pass the MV changes to the MetadataPropagator.  If not, the propagator might not have the right version to send UMR, LISR and StopReplica requests when the migration is in DUAL_WRITE mode.