### PR TITLE
KAFKA-13337: Plugin loader error handling is done separately, per plugin

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -188,7 +188,7 @@ public class PluginUtils {
         return path.toString().toLowerCase(Locale.ROOT).endsWith(".class");
     }
 
-    public static List<Path> pluginLocations(Path topPath) throws IOException {
+    public static List<Path> pluginLocations(Path topPath) {
         List<Path> locations = new ArrayList<>();
         try (
                 DirectoryStream<Path> listing = Files.newDirectoryStream(
@@ -199,6 +199,8 @@ public class PluginUtils {
             for (Path dir : listing) {
                 locations.add(dir);
             }
+        } catch (IOException e) {
+            log.error("Could not get listing for plugin path: {}. Ignoring.", topPath, e);
         }
         return locations;
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoaderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoaderTest.java
@@ -138,14 +138,15 @@ public class DelegatingClassLoaderTest {
             Files.copy(source, pluginPath.resolve(source.getFileName()));
         }
 
-        DelegatingClassLoader classLoader = new DelegatingClassLoader(
+        try (DelegatingClassLoader classLoader = new DelegatingClassLoader(
                 Collections.singletonList(pluginDir.getRoot().getAbsolutePath()),
                 DelegatingClassLoader.class.getClassLoader()
-        );
-        classLoader.initLoaders();
-        for (String pluginClassName : TestPlugins.pluginClasses()) {
-            assertNotNull(classLoader.loadClass(pluginClassName));
-            assertNotNull(classLoader.pluginClassLoader(pluginClassName));
+        )) {
+            classLoader.initLoaders();
+            for (String pluginClassName : TestPlugins.pluginClasses()) {
+                assertNotNull(classLoader.loadClass(pluginClassName));
+                assertNotNull(classLoader.pluginClassLoader(pluginClassName));
+            }
         }
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoaderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoaderTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -52,27 +53,29 @@ public class DelegatingClassLoaderTest {
     }
 
     @Test
-    public void testLoadingUnloadedPluginClass() {
-        DelegatingClassLoader classLoader = new DelegatingClassLoader(
+    public void testLoadingUnloadedPluginClass() throws IOException {
+        try (DelegatingClassLoader classLoader = new DelegatingClassLoader(
                 Collections.emptyList(),
                 DelegatingClassLoader.class.getClassLoader()
-        );
-        classLoader.initLoaders();
-        for (String pluginClassName : TestPlugins.pluginClasses()) {
-            assertThrows(ClassNotFoundException.class, () -> classLoader.loadClass(pluginClassName));
+        )) {
+            classLoader.initLoaders();
+            for (String pluginClassName : TestPlugins.pluginClasses()) {
+                assertThrows(ClassNotFoundException.class, () -> classLoader.loadClass(pluginClassName));
+            }
         }
     }
 
     @Test
-    public void testLoadingPluginClass() throws ClassNotFoundException {
-        DelegatingClassLoader classLoader = new DelegatingClassLoader(
+    public void testLoadingPluginClass() throws ClassNotFoundException, IOException {
+        try (DelegatingClassLoader classLoader = new DelegatingClassLoader(
                 TestPlugins.pluginPath(),
                 DelegatingClassLoader.class.getClassLoader()
-        );
-        classLoader.initLoaders();
-        for (String pluginClassName : TestPlugins.pluginClasses()) {
-            assertNotNull(classLoader.loadClass(pluginClassName));
-            assertNotNull(classLoader.pluginClassLoader(pluginClassName));
+        )) {
+            classLoader.initLoaders();
+            for (String pluginClassName : TestPlugins.pluginClasses()) {
+                assertNotNull(classLoader.loadClass(pluginClassName));
+                assertNotNull(classLoader.pluginClassLoader(pluginClassName));
+            }
         }
     }
 
@@ -80,11 +83,12 @@ public class DelegatingClassLoaderTest {
     public void testLoadingInvalidUberJar() throws Exception {
         pluginDir.newFile("invalid.jar");
 
-        DelegatingClassLoader classLoader = new DelegatingClassLoader(
+        try (DelegatingClassLoader classLoader = new DelegatingClassLoader(
                 Collections.singletonList(pluginDir.getRoot().getAbsolutePath()),
                 DelegatingClassLoader.class.getClassLoader()
-        );
-        classLoader.initLoaders();
+        )) {
+            classLoader.initLoaders();
+        }
     }
 
     @Test
@@ -92,31 +96,34 @@ public class DelegatingClassLoaderTest {
         pluginDir.newFolder("my-plugin");
         pluginDir.newFile("my-plugin/invalid.jar");
 
-        DelegatingClassLoader classLoader = new DelegatingClassLoader(
+        try (DelegatingClassLoader classLoader = new DelegatingClassLoader(
                 Collections.singletonList(pluginDir.getRoot().getAbsolutePath()),
                 DelegatingClassLoader.class.getClassLoader()
-        );
-        classLoader.initLoaders();
+        )) {
+            classLoader.initLoaders();
+        }
     }
 
     @Test
-    public void testLoadingNoPlugins() {
-        DelegatingClassLoader classLoader = new DelegatingClassLoader(
+    public void testLoadingNoPlugins() throws IOException {
+        try (DelegatingClassLoader classLoader = new DelegatingClassLoader(
                 Collections.singletonList(pluginDir.getRoot().getAbsolutePath()),
                 DelegatingClassLoader.class.getClassLoader()
-        );
-        classLoader.initLoaders();
+        )) {
+            classLoader.initLoaders();
+        }
     }
 
     @Test
     public void testLoadingPluginDirEmpty() throws Exception {
         pluginDir.newFolder("my-plugin");
 
-        DelegatingClassLoader classLoader = new DelegatingClassLoader(
+        try (DelegatingClassLoader classLoader = new DelegatingClassLoader(
                 Collections.singletonList(pluginDir.getRoot().getAbsolutePath()),
                 DelegatingClassLoader.class.getClassLoader()
-        );
-        classLoader.initLoaders();
+        )) {
+            classLoader.initLoaders();
+        }
     }
 
     @Test


### PR DESCRIPTION

org.apache.kafka.connect.runtime.isolation.PluginUtils.pluginUrls scans a path and collects plugin candidates from there. However, if a directory is not readable, it fails with AccessDeniedException instead of skipping it. This commit fixes this minor problem with the change of plugin path filter used during scanning.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
