### PR TITLE
KAFKA-14862 (HOTFIX): Fix ConcurrentModificationException

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -49,6 +49,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.apache.kafka.streams.internals.ApiUtils.prepareMillisCheckFailMsgPrefix;
 import static org.apache.kafka.streams.internals.ApiUtils.validateMillisecondDuration;
@@ -60,7 +61,7 @@ class KStreamImplJoin {
     private final boolean rightOuter;
 
     static class TimeTrackerSupplier {
-        private final Map<TaskId, TimeTracker> tracker = new HashMap<>();
+        private final Map<TaskId, TimeTracker> tracker = new ConcurrentHashMap<>();
 
         public TimeTracker get(final TaskId taskId) {
             return tracker.computeIfAbsent(taskId, taskId1 -> new TimeTracker());

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -44,7 +44,6 @@ import org.apache.kafka.streams.state.internals.LeftOrRightValueSerde;
 
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;


### PR DESCRIPTION
We observed a ConcurrentModificationException. Need to use ConcurrentHashMap to fix it.
```
Caused by: java.util.ConcurrentModificationException: null
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1221)
	at org.apache.kafka.streams.kstream.internals.KStreamImplJoin$TimeTrackerSupplier.get(KStreamImplJoin.java:65)
	at org.apache.kafka.streams.kstream.internals.KStreamKStreamJoin$KStreamKStreamJoinProcessor.init(KStreamKStreamJoin.java:110)
```