### PR TITLE
KAFKA-15004: While handling snapshot during DUAL_WRITE in migration, …

### DIFF
--- a/core/src/main/scala/kafka/zk/migration/ZkConfigMigrationClient.scala
+++ b/core/src/main/scala/kafka/zk/migration/ZkConfigMigrationClient.scala
@@ -23,6 +23,7 @@ import kafka.zk.ZkMigrationClient.{logAndRethrow, wrapZkException}
 import kafka.zk._
 import kafka.zookeeper.{CreateRequest, DeleteRequest, SetDataRequest}
 import org.apache.kafka.clients.admin.ScramMechanism
+import org.apache.kafka.common.config.types.Password
 import org.apache.kafka.common.config.{ConfigDef, ConfigResource}
 import org.apache.kafka.common.errors.InvalidRequestException
 import org.apache.kafka.common.metadata.ClientQuotaRecord.EntityData
@@ -145,6 +146,23 @@ class ZkConfigMigrationClient(
     }
   }
 
+  override def iterateTopicConfigs(configConsumer: BiConsumer[String, util.Map[String, String]]): Unit = {
+    val topicEntities = zkClient.getAllEntitiesWithConfig(ConfigType.Topic)
+    zkClient.getEntitiesConfigs(ConfigType.Topic, topicEntities.toSet).foreach { case (topic, props) =>
+      val topicResource = fromZkEntityName(topic)
+      val decodedProps = props.asScala.map { case (key, value) =>
+        if (DynamicBrokerConfig.isPasswordConfig(key))
+          key -> passwordEncoder.decode(value).value
+        else
+          key -> value
+      }.toMap.asJava
+
+      logAndRethrow(this, s"Error in topic config consumer. Broker was $topicResource.") {
+        configConsumer.accept(topicResource, decodedProps)
+      }
+    }
+  }
+
   override def writeConfigs(
     configResource: ConfigResource,
     configMap: util.Map[String, String],
@@ -159,7 +177,12 @@ class ZkConfigMigrationClient(
     val configName = toZkEntityName(configResource.name())
     if (configType.isDefined) {
       val props = new Properties()
-      configMap.forEach { case (key, value) => props.put(key, value) }
+      configMap.forEach { case (key, value) =>
+        if (DynamicBrokerConfig.isPasswordConfig(key)) {
+          props.put(key, passwordEncoder.encode(new Password(value)))
+        } else
+          props.put(key, value)
+      }
       tryWriteEntityConfig(configType.get, configName, props, create = false, state) match {
         case Some(newState) =>
           newState

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkConfigMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkConfigMigrationClientTest.scala
@@ -33,6 +33,7 @@ import org.apache.kafka.server.util.MockRandom
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.Test
 
+import java.util
 import java.util.Properties
 import scala.collection.Map
 import scala.jdk.CollectionConverters._
@@ -68,9 +69,27 @@ class ZkConfigMigrationClientTest extends ZkMigrationTestHarness {
       }
     })
 
+    // Update the sensitive config value from the config client and check that the value
+    // persisted in Zookeeper is encrypted.
+    val newProps = new util.HashMap[String, String]()
+    newProps.put(KafkaConfig.DefaultReplicationFactorProp, "2") // normal config
+    newProps.put(KafkaConfig.SslKeystorePasswordProp, NEW_SECRET) // sensitive config
+    migrationState = migrationClient.configClient().writeConfigs(
+      new ConfigResource(ConfigResource.Type.BROKER, "1"), newProps, migrationState)
+    assertEquals(0, zkClient.getEntityConfigs(ConfigType.Broker, "1").size())
+    val actualPropsInZk = zkClient.getEntityConfigs(ConfigType.Broker, "1")
+    assertEquals(2, actualPropsInZk.size())
+    actualPropsInZk.forEach { case (key, value) =>
+      if (key == KafkaConfig.SslKeystorePasswordProp) {
+        assertEquals(NEW_SECRET, encoder.decode(value.toString).value)
+      } else {
+        assertEquals(newProps.get(key), value)
+      }
+    }
+
     migrationState = migrationClient.configClient().deleteConfigs(
       new ConfigResource(ConfigResource.Type.BROKER, "1"), migrationState)
-    assertEquals(0, zkClient.getEntityConfigs(ConfigType.Broker, "1").size())
+    assertEquals(1, zkClient.getEntityConfigs(ConfigType.Broker, "1").size())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
@@ -17,14 +17,15 @@
 package kafka.zk.migration
 
 import kafka.api.LeaderAndIsr
-import kafka.controller.LeaderIsrAndControllerEpoch
+import kafka.controller.{LeaderIsrAndControllerEpoch, ReplicaAssignment}
 import kafka.coordinator.transaction.ProducerIdManager
-import kafka.zk.migration.ZkMigrationTestHarness
-import org.apache.kafka.common.config.TopicConfig
+import kafka.server.{ConfigType, KafkaConfig}
+import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.errors.ControllerMovedException
-import org.apache.kafka.common.metadata.{ConfigRecord, MetadataRecordType, ProducerIdsRecord}
+import org.apache.kafka.common.metadata._
 import org.apache.kafka.common.{TopicPartition, Uuid}
-import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
+import org.apache.kafka.image.{MetadataDelta, MetadataImage, MetadataProvenance}
+import org.apache.kafka.metadata.migration.{KRaftMigrationZkWriter, ZkMigrationLeadershipState}
 import org.apache.kafka.metadata.{LeaderRecoveryState, PartitionRegistration}
 import org.apache.kafka.server.common.ApiMessageAndVersion
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue, fail}
@@ -258,5 +259,108 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals("60000", configs.head.value())
     assertEquals(TopicConfig.RETENTION_MS_CONFIG, configs.last.name())
     assertEquals("300000", configs.last.value())
+  }
+
+  @Test
+  def testTopicAndBrokerConfigsMigrationWithSnapshots(): Unit = {
+    val kraftWriter = new KRaftMigrationZkWriter(migrationClient, (_, operation) => {
+      migrationState = operation.apply(migrationState)
+    })
+
+    // Add add some topics and broker configs and create new image.
+    val topicName = "testTopic"
+    val partition = 0
+    val tp = new TopicPartition(topicName, partition)
+    val leaderPartition = 1
+    val leaderEpoch = 100
+    val partitionEpoch = 10
+    val brokerId = "1"
+    val replicas = List(1, 2, 3).map(int2Integer).asJava
+    val topicId = Uuid.randomUuid()
+    val props = new Properties()
+    props.put(KafkaConfig.DefaultReplicationFactorProp, "1") // normal config
+    props.put(KafkaConfig.SslKeystorePasswordProp, SECRET) // sensitive config
+
+//    // Leave Zk in an incomplete state.
+//    zkClient.createTopicAssignment(topicName, Some(topicId), Map(tp -> Seq(1)))
+
+    val delta = new MetadataDelta(MetadataImage.EMPTY)
+    delta.replay(new TopicRecord()
+      .setTopicId(topicId)
+      .setName(topicName)
+    )
+    delta.replay(new PartitionRecord()
+      .setTopicId(topicId)
+      .setIsr(replicas)
+      .setLeader(leaderPartition)
+      .setReplicas(replicas)
+      .setAddingReplicas(List.empty.asJava)
+      .setRemovingReplicas(List.empty.asJava)
+      .setLeaderEpoch(leaderEpoch)
+      .setPartitionEpoch(partitionEpoch)
+      .setPartitionId(partition)
+      .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED.value())
+    )
+    // Use same props for the broker and topic.
+    props.asScala.foreach { case (key, value) =>
+      delta.replay(new ConfigRecord()
+        .setName(key)
+        .setValue(value)
+        .setResourceName(topicName)
+        .setResourceType(ConfigResource.Type.TOPIC.id())
+      )
+      delta.replay(new ConfigRecord()
+        .setName(key)
+        .setValue(value)
+        .setResourceName(brokerId)
+        .setResourceType(ConfigResource.Type.BROKER.id())
+      )
+    }
+    val image = delta.apply(MetadataProvenance.EMPTY)
+
+    // Handle migration using the generated snapshot.
+    kraftWriter.handleLoadSnapshot(image)
+
+    // Verify topic state.
+    val topicIdReplicaAssignment =
+      zkClient.getReplicaAssignmentAndTopicIdForTopics(Set(topicName))
+    assertEquals(1, topicIdReplicaAssignment.size)
+    topicIdReplicaAssignment.foreach { assignment =>
+      assertEquals(topicName, assignment.topic)
+      assertEquals(Some(topicId), assignment.topicId)
+      assertEquals(Map(tp-> ReplicaAssignment(replicas.asScala.map(Integer2int).toSeq)),
+        assignment.assignment)
+    }
+
+    // Verify the topic partition states.
+    val topicPartitionState = zkClient.getTopicPartitionState(tp)
+    assertTrue(topicPartitionState.isDefined)
+    topicPartitionState.foreach { state =>
+      assertEquals(leaderPartition, state.leaderAndIsr.leader)
+      assertEquals(leaderEpoch, state.leaderAndIsr.leaderEpoch)
+      assertEquals(LeaderRecoveryState.RECOVERED, state.leaderAndIsr.leaderRecoveryState)
+      assertEquals(replicas.asScala.map(Integer2int).toList, state.leaderAndIsr.isr)
+    }
+
+    // Verify the broker and topic configs (including sensitive configs).
+    val brokerProps = zkClient.getEntityConfigs(ConfigType.Broker, brokerId)
+    val topicProps = zkClient.getEntityConfigs(ConfigType.Topic, topicName)
+    assertEquals(2, brokerProps.size())
+
+    brokerProps.asScala.foreach { case (key, value) =>
+      if (key == KafkaConfig.SslKeystorePasswordProp) {
+        assertEquals(SECRET, encoder.decode(value).value)
+      } else {
+        assertEquals(props.getProperty(key), value)
+      }
+    }
+
+    topicProps.asScala.foreach { case (key, value) =>
+      if (key == KafkaConfig.SslKeystorePasswordProp) {
+        assertEquals(SECRET, encoder.decode(value).value)
+      } else {
+        assertEquals(props.getProperty(key), value)
+      }
+    }
   }
 }

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationTestHarness.scala
@@ -36,6 +36,8 @@ class ZkMigrationTestHarness extends QuorumTestHarness {
 
   val SECRET = "secret"
 
+  val NEW_SECRET = "newSecret"
+
   val encoder: PasswordEncoder = {
     val encoderProps = new Properties()
     encoderProps.put(KafkaConfig.ZkConnectProp, "localhost:1234") // Get around the config validation

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/ConfigMigrationClient.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/ConfigMigrationClient.java
@@ -38,6 +38,8 @@ public interface ConfigMigrationClient {
 
     void iterateBrokerConfigs(BiConsumer<String, Map<String, String>> configConsumer);
 
+    void iterateTopicConfigs(BiConsumer<String, Map<String, String>> configConsumer);
+
     ZkMigrationLeadershipState writeConfigs(
         ConfigResource configResource,
         Map<String, String> configMap,

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
@@ -17,7 +17,6 @@
 
 package org.apache.kafka.metadata.migration;
 
-import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ScramMechanism;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
@@ -200,6 +200,7 @@ public class KRaftMigrationZkWriter {
             .collect(Collectors.toSet());
         Set<ConfigResource> resourcesToUpdate = new HashSet<>();
         BiConsumer<ConfigResource, Map<String, String>> processConfigsForResource = (ConfigResource resource, Map<String, String> configs) -> {
+            newResources.remove(resource);
             Map<String, String> kraftProps = configsImage.configMapForResource(resource);
             if (!kraftProps.equals(configs)) {
                 resourcesToUpdate.add(resource);
@@ -213,7 +214,6 @@ public class KRaftMigrationZkWriter {
             ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
             processConfigsForResource.accept(topicResource, configs);
         });
-        newResources.removeAll(resourcesToUpdate);
 
         newResources.forEach(resource -> {
             Map<String, String> props = configsImage.configMapForResource(resource);

--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/CapturingConfigMigrationClient.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/CapturingConfigMigrationClient.java
@@ -45,6 +45,11 @@ public class CapturingConfigMigrationClient implements ConfigMigrationClient {
     }
 
     @Override
+    public void iterateTopicConfigs(BiConsumer<String, Map<String, String>> configConsumer) {
+
+    }
+
+    @Override
     public ZkMigrationLeadershipState writeConfigs(ConfigResource configResource, Map<String, String> configMap, ZkMigrationLeadershipState state) {
         writtenConfigs.put(configResource, configMap);
         return state;


### PR DESCRIPTION
…we might miss updating configs or incorrectly update them in Zookeeper.

Issue#1: Topic configs are not sycned while handling snapshot.
Issue#2: Any broker or topic config resource that is new and not already present in Zookeeper will never be updated in Zookeeper.
Issue#3: The sensitive configs are not encoded while writing them to Zookeeper.

Added tests to ensure we no longer have the above mentioned issues.