### PR TITLE
KAFKA-14982: Improve the kafka-metadata-quorum output

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
@@ -104,7 +104,7 @@ public class MetadataQuorumCommand {
                     handleDescribeReplication(admin, humanReadable);
                 } else if (namespace.getBoolean("status")) {
                     if (namespace.getBoolean("human_readable")) {
-                        throw new TerseException("The option -hr/--human-readable is only supported along with --replication");
+                        throw new TerseException("The option --human-readable is only supported along with --replication");
                     }
                     handleDescribeStatus(admin);
                 } else {

--- a/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
@@ -175,10 +175,10 @@ public class MetadataQuorumCommand {
                                                        boolean humanReadable) {
         return infos.map(info -> {
             String lastFetchTimestamp = !info.lastFetchTimestamp().isPresent() ? "-1" :
-                humanReadable ? format("%d ms ago", delayMs(info.lastFetchTimestamp().getAsLong(), "last fetch")) :
+                humanReadable ? format("%d ms ago", relativeTimeMs(info.lastFetchTimestamp().getAsLong(), "last fetch")) :
                     valueOf(info.lastFetchTimestamp().getAsLong());
             String lastCaughtUpTimestamp = !info.lastCaughtUpTimestamp().isPresent() ? "-1" :
-                humanReadable ? format("%d ms ago", delayMs(info.lastCaughtUpTimestamp().getAsLong(), "last caught up")) :
+                humanReadable ? format("%d ms ago", relativeTimeMs(info.lastCaughtUpTimestamp().getAsLong(), "last caught up")) :
                     valueOf(info.lastCaughtUpTimestamp().getAsLong());
             return Stream.of(
                 info.replicaId(),
@@ -191,12 +191,13 @@ public class MetadataQuorumCommand {
         }).collect(Collectors.toList());
     }
 
-    /* test */ static long delayMs(long timestampMs, String desc) {
+    // visible for testing
+    static long relativeTimeMs(long timestampMs, String desc) {
         Instant lastTimestamp = Instant.ofEpochMilli(timestampMs);
         Instant now = Instant.now();
         if (!(lastTimestamp.isAfter(Instant.EPOCH) && lastTimestamp.isBefore(now))) {
             throw new KafkaException(
-                format("Error while computing delay, possible drift in system clock.%n" +
+                format("Error while computing relative time, possible drift in system clock.%n" +
                     "Current timestamp is %d, %s timestamp is %d", now.toEpochMilli(), desc, timestampMs)
             );
         }

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandErrorTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandErrorTest.java
@@ -16,9 +16,15 @@
  */
 package org.apache.kafka.tools;
 
+import org.apache.kafka.common.KafkaException;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MetadataQuorumCommandErrorTest {
 
@@ -43,6 +49,16 @@ public class MetadataQuorumCommandErrorTest {
         assertEquals("Only one of --status or --replication should be specified with describe sub-command",
             ToolsTestUtils.captureStandardErr(() ->
                 MetadataQuorumCommand.mainNoExit("--bootstrap-server", "localhost:9092", "describe", "--status", "--replication")));
+    }
+
+    @Test
+    public void testDelayMs() {
+        long nowMs = Instant.now().toEpochMilli();
+        assertTrue(MetadataQuorumCommand.delayMs(nowMs, "test") >= 0);
+        long invalidEpochMs = Instant.EPOCH.minus(1, ChronoUnit.DAYS).toEpochMilli();
+        assertThrows(KafkaException.class, () -> MetadataQuorumCommand.delayMs(invalidEpochMs, "test"));
+        long futureTimestampMs = Instant.now().plus(1, ChronoUnit.DAYS).toEpochMilli();
+        assertThrows(KafkaException.class, () -> MetadataQuorumCommand.delayMs(futureTimestampMs, "test"));
     }
 
 }

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandErrorTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandErrorTest.java
@@ -52,13 +52,13 @@ public class MetadataQuorumCommandErrorTest {
     }
 
     @Test
-    public void testDelayMs() {
+    public void testRelativeTimeMs() {
         long nowMs = Instant.now().toEpochMilli();
-        assertTrue(MetadataQuorumCommand.delayMs(nowMs, "test") >= 0);
+        assertTrue(MetadataQuorumCommand.relativeTimeMs(nowMs, "test") >= 0);
         long invalidEpochMs = Instant.EPOCH.minus(1, ChronoUnit.DAYS).toEpochMilli();
-        assertThrows(KafkaException.class, () -> MetadataQuorumCommand.delayMs(invalidEpochMs, "test"));
+        assertThrows(KafkaException.class, () -> MetadataQuorumCommand.relativeTimeMs(invalidEpochMs, "test"));
         long futureTimestampMs = Instant.now().plus(1, ChronoUnit.DAYS).toEpochMilli();
-        assertThrows(KafkaException.class, () -> MetadataQuorumCommand.delayMs(futureTimestampMs, "test"));
+        assertThrows(KafkaException.class, () -> MetadataQuorumCommand.relativeTimeMs(futureTimestampMs, "test"));
     }
 
 }

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
@@ -183,12 +183,24 @@ class MetadataQuorumCommandTest {
         );
         assertFalse(replicationOutput0.split("\n")[1].contains("ms ago"));
         String replicationOutput1 = ToolsTestUtils.captureStandardOut(() ->
-            MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "-hr", "describe", "--replication")
+            MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--replication", "-hr")
         );
-        assertTrue(replicationOutput1.split("\n")[1].contains("ms ago"));
+        assertHumanReadable(replicationOutput1);
         String replicationOutput2 = ToolsTestUtils.captureStandardOut(() ->
-            MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "--human-readable", "describe", "--replication")
+            MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--replication", "--human-readable")
          );
-        assertTrue(replicationOutput2.split("\n")[1].contains("ms ago"));
+        assertHumanReadable(replicationOutput2);
+    }
+
+    private static void assertHumanReadable(String output) {
+        String dataRow = output.split("\n")[1];
+        String lastFetchTimestamp = dataRow.split("\t")[3];
+        String lastFetchTimestampValue = lastFetchTimestamp.split(" ")[0];
+        String lastCaughtUpTimestamp = dataRow.split("\t")[4];
+        String lastCaughtUpTimestampValue = lastCaughtUpTimestamp.split(" ")[0];
+        assertTrue(lastFetchTimestamp.contains("ms ago"));
+        assertTrue(lastFetchTimestampValue.matches("\\d*"));
+        assertTrue(lastCaughtUpTimestamp.contains("ms ago"));
+        assertTrue(lastCaughtUpTimestampValue.matches("\\d*"));
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
@@ -174,22 +174,22 @@ class MetadataQuorumCommandTest {
 
     }
 
-    @ClusterTests({
-        @ClusterTest(clusterType = Type.CO_KRAFT, brokers = 1, controllers = 1),
-    })
+    @ClusterTest(clusterType = Type.CO_KRAFT, brokers = 1, controllers = 1)
     public void testHumanReadableTimestamps() {
-        String replicationOutput0 = ToolsTestUtils.captureStandardOut(() ->
+        assertEquals(1, MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "-hr"));
+        assertEquals(1, MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--status", "-hr"));
+        String out0 = ToolsTestUtils.captureStandardOut(() ->
             MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--replication")
         );
-        assertFalse(replicationOutput0.split("\n")[1].contains("ms ago"));
-        String replicationOutput1 = ToolsTestUtils.captureStandardOut(() ->
+        assertFalse(out0.split("\n")[1].matches("\\d*"));
+        String out1 = ToolsTestUtils.captureStandardOut(() ->
             MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--replication", "-hr")
         );
-        assertHumanReadable(replicationOutput1);
-        String replicationOutput2 = ToolsTestUtils.captureStandardOut(() ->
+        assertHumanReadable(out1);
+        String out2 = ToolsTestUtils.captureStandardOut(() ->
             MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--replication", "--human-readable")
          );
-        assertHumanReadable(replicationOutput2);
+        assertHumanReadable(out2);
     }
 
     private static void assertHumanReadable(String output) {

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
@@ -36,6 +36,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -76,14 +77,14 @@ class MetadataQuorumCommandTest {
         else
           assertEquals(cluster.config().numBrokers() + cluster.config().numControllers(), outputs.size());
 
-        Pattern leaderPattern = Pattern.compile("\\d+\\s+\\d+\\s+\\d+\\s+\\d+\\s+-?\\d+\\s+Leader\\s*");
+        Pattern leaderPattern = Pattern.compile("\\d+\\s+\\d+\\s+\\d+\\s+[\\dmsago\\s]+-?[\\dmsago\\s]+Leader\\s*");
         assertTrue(leaderPattern.matcher(outputs.get(0)).find());
         assertTrue(outputs.stream().skip(1).noneMatch(o -> leaderPattern.matcher(o).find()));
 
-        Pattern followerPattern = Pattern.compile("\\d+\\s+\\d+\\s+\\d+\\s+\\d+\\s+-?\\d+\\s+Follower\\s*");
+        Pattern followerPattern = Pattern.compile("\\d+\\s+\\d+\\s+\\d+\\s+[\\dmsago\\s]+-?[\\dmsago\\s]+Follower\\s*");
         assertEquals(cluster.config().numControllers() - 1, outputs.stream().filter(o -> followerPattern.matcher(o).find()).count());
 
-        Pattern observerPattern = Pattern.compile("\\d+\\s+\\d+\\s+\\d+\\s+\\d+\\s+-?\\d+\\s+Observer\\s*");
+        Pattern observerPattern = Pattern.compile("\\d+\\s+\\d+\\s+\\d+\\s+[\\dmsago\\s]+-?[\\dmsago\\s]+Observer\\s*");
         if (cluster.config().clusterType() == Type.CO_KRAFT)
             assertEquals(Math.max(0, cluster.config().numBrokers() - cluster.config().numControllers()),
                 outputs.stream().filter(o -> observerPattern.matcher(o).find()).count());
@@ -171,5 +172,23 @@ class MetadataQuorumCommandTest {
             ).getCause() instanceof UnsupportedVersionException
         );
 
+    }
+
+    @ClusterTests({
+        @ClusterTest(clusterType = Type.CO_KRAFT, brokers = 1, controllers = 1),
+    })
+    public void testHumanReadableTimestamps() {
+        String replicationOutput0 = ToolsTestUtils.captureStandardOut(() ->
+            MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--replication")
+        );
+        assertFalse(replicationOutput0.split("\n")[1].contains("ms ago"));
+        String replicationOutput1 = ToolsTestUtils.captureStandardOut(() ->
+            MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "-hr", "describe", "--replication")
+        );
+        assertTrue(replicationOutput1.split("\n")[1].contains("ms ago"));
+        String replicationOutput2 = ToolsTestUtils.captureStandardOut(() ->
+            MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "--human-readable", "describe", "--replication")
+         );
+        assertTrue(replicationOutput2.split("\n")[1].contains("ms ago"));
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
@@ -175,19 +175,19 @@ class MetadataQuorumCommandTest {
     }
 
     @ClusterTest(clusterType = Type.CO_KRAFT, brokers = 1, controllers = 1)
-    public void testHumanReadableTimestamps() {
-        assertEquals(1, MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "-hr"));
-        assertEquals(1, MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--status", "-hr"));
+    public void testHumanReadableOutput() {
+        assertEquals(1, MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--human-readable"));
+        assertEquals(1, MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--status", "--human-readable"));
         String out0 = ToolsTestUtils.captureStandardOut(() ->
             MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--replication")
         );
         assertFalse(out0.split("\n")[1].matches("\\d*"));
         String out1 = ToolsTestUtils.captureStandardOut(() ->
-            MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--replication", "-hr")
+            MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--replication", "--human-readable")
         );
         assertHumanReadable(out1);
         String out2 = ToolsTestUtils.captureStandardOut(() ->
-            MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--replication", "--human-readable")
+            MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--re", "--hu")
          );
         assertHumanReadable(out2);
     }


### PR DESCRIPTION
When running kafka-metadata-quorum script to get the quorum replication status, the LastFetchTimestamp and LastCaughtUpTimestamp output is not human-readable.

I will be convenient to add an optional flag (-hr, --human-readable) to enable a human-readable format showing the delay in ms (i.e. 366 ms ago).

This dealy is computed as (now - timestamp), where they are both represented as Unix time (UTC based).

```sh
$ bin/kafka-metadata-quorum.sh --bootstrap-server :9092 describe --replication --human-readable
NodeId	LogEndOffset	Lag	LastFetchTimestamp	LastCaughtUpTimestamp	Status  	
2     	61          	0  	5 ms ago          	5 ms ago             	Leader  	
3     	61          	0  	56 ms ago         	56 ms ago            	Follower	
4     	61          	0  	56 ms ago         	56 ms ago            	Follower
```
Implementation of [KIP-927](https://cwiki.apache.org/confluence/display/KAFKA/KIP-927%3A+Improve+the+kafka-metadata-quorum+output).
