### PR TITLE
MINOR: Fix some typos

### DIFF
--- a/clients/src/test/java/org/apache/kafka/test/Microbenchmarks.java
+++ b/clients/src/test/java/org/apache/kafka/test/Microbenchmarks.java
@@ -154,7 +154,7 @@ public class Microbenchmarks {
             values.put(Integer.toString(i), i);
         System.out.println("HashMap:");
         benchMap(2, 1000000, values);
-        System.out.println("ConcurentHashMap:");
+        System.out.println("ConcurrentHashMap:");
         benchMap(2, 1000000, new ConcurrentHashMap<>(values));
         System.out.println("CopyOnWriteMap:");
         benchMap(2, 1000000, new CopyOnWriteMap<>(values));

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -2339,7 +2339,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     * 2. Change kafka.controller.KafkaController logger to INFO
     * 3. Unset kafka.controller.KafkaController via AlterConfigOp.OpType.DELETE (resets it to the root logger - TRACE)
     * 4. Change ROOT logger to ERROR
-    * 5. Ensure the kafka.controller.KafkaController logger's level is ERROR (the curent root logger level)
+    * 5. Ensure the kafka.controller.KafkaController logger's level is ERROR (the current root logger level)
     */
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
   @ValueSource(strings = Array("zk", "kraft"))

--- a/raft/src/test/java/org/apache/kafka/raft/MockLog.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLog.java
@@ -198,10 +198,6 @@ public class MockLog implements ReplicatedLog {
         return lastOffsetAndEpochFiltered(epochStartOffset -> epochStartOffset.epoch <= epoch);
     }
 
-    private OffsetAndEpoch epochForEndOffset(long endOffset) {
-        return lastOffsetAndEpochFiltered(epochStartOffset -> epochStartOffset.startOffset < endOffset);
-    }
-
     private OffsetAndEpoch lastOffsetAndEpochFiltered(Predicate<EpochStartOffset> predicate) {
         int epochLowerBound = earliestSnapshotId().map(OffsetAndEpoch::epoch).orElse(0);
         for (EpochStartOffset epochStartOffset : epochStartOffsets) {

--- a/raft/src/test/java/org/apache/kafka/raft/MockLog.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLog.java
@@ -525,7 +525,7 @@ public class MockLog implements ReplicatedLog {
         if (startOffset() > snapshotId.offset()) {
             throw new OffsetOutOfRangeException(
                 String.format(
-                    "New log start (%s) is less than the curent log start offset (%s)",
+                    "New log start (%s) is less than the current log start offset (%s)",
                     snapshotId,
                     startOffset()
                 )


### PR DESCRIPTION
Minor typos
 - `curent` -> `current` ( MockLog.java, PlaintextAdminIntegrationTest.scala )
 - `ConcurentHashMap` -> `ConcurrentHashMap` ( Microbenchmarks.java )

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
