### PR TITLE
[BUGFIX] Bugfixed in KAFKA-8713, but it doesn't work properly.

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
@@ -84,7 +84,7 @@ public class Struct {
      */
     public Object get(Field field) {
         Object val = values[field.index()];
-        if (val == null && field.schema().defaultValue() != null) {
+        if (val == null && field.schema().defaultValue() != null && !field.schema().isOptional()) {
             val = field.schema().defaultValue();
         }
         return val;


### PR DESCRIPTION

Through the ticket ["KAFKA-8713"](https://issues.apache.org/jira/browse/KAFKA-8713), a bug that always outputs "default value" when JsonConverter is a nullable schema was fixed.

After applying the bug fix, I set the following settings in kafka connect.

`
"value.converter.replace.null.with.default": "false",
`
However, I found that the same problem still occurred, so I modified the code to fix this bug.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
