### PR TITLE
KAFKA-15016: Update LICENSE-binary file

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -205,64 +205,60 @@
 This project bundles some components that are also licensed under the Apache
 License Version 2.0:
 
-audience-annotations-0.5.0
+audience-annotations-0.13.0
+commons-beanutils-1.9.4
 commons-cli-1.4
+commons-collections-3.2.2
+commons-digester-2.1
 commons-lang3-3.8.1
-jackson-annotations-2.13.4
-jackson-core-2.13.4
-jackson-databind-2.13.4.2
-jackson-dataformat-csv-2.13.4
-jackson-dataformat-yaml-2.13.4
-jackson-datatype-jdk8-2.13.4
-jackson-datatype-jsr310-2.13.4
-jackson-jaxrs-base-2.13.4
-jackson-jaxrs-json-provider-2.13.4
-jackson-module-jaxb-annotations-2.13.4
-jackson-module-scala_2.13-2.13.4
-jackson-module-scala_2.12-2.13.4
+commons-logging-1.2
+commons-validator-1.7
+jackson-annotations-2.13.5
+jackson-core-2.13.5
+jackson-databind-2.13.5
+jackson-dataformat-csv-2.13.5
+jackson-datatype-jdk8-2.13.5
+jackson-jaxrs-base-2.13.5
+jackson-jaxrs-json-provider-2.13.5
+jackson-module-jaxb-annotations-2.13.5
+jackson-module-scala_2.13-2.13.5
+jackson-module-scala_2.12-2.13.5
 jakarta.validation-api-2.0.2
-javassist-3.27.0-GA
-jetty-client-9.4.48.v20220622
-jetty-continuation-9.4.48.v20220622
-jetty-http-9.4.48.v20220622
-jetty-io-9.4.48.v20220622
-jetty-security-9.4.48.v20220622
-jetty-server-9.4.48.v20220622
-jetty-servlet-9.4.48.v20220622
-jetty-servlets-9.4.48.v20220622
-jetty-util-9.4.48.v20220622
-jetty-util-ajax-9.4.48.v20220622
-jersey-common-2.34
-jersey-server-2.34
+javassist-3.29.2-GA
+jetty-client-9.4.51.v20230217
+jetty-continuation-9.4.51.v20230217
+jetty-http-9.4.51.v20230217
+jetty-io-9.4.51.v20230217
+jetty-security-9.4.51.v20230217
+jetty-server-9.4.51.v20230217
+jetty-servlet-9.4.51.v20230217
+jetty-servlets-9.4.51.v20230217
+jetty-util-9.4.51.v20230217
+jetty-util-ajax-9.4.51.v20230217
 jose4j-0.9.3
 lz4-java-1.8.0
 maven-artifact-3.8.4
 metrics-core-4.1.12.1
 metrics-core-2.2.0
-netty-buffer-4.1.78.Final
-netty-codec-4.1.78.Final
-netty-common-4.1.78.Final
-netty-handler-4.1.78.Final
-netty-resolver-4.1.78.Final
-netty-transport-4.1.78.Final
-netty-transport-classes-epoll-4.1.78.Final
-netty-transport-native-epoll-4.1.78.Final
-netty-transport-native-unix-common-4.1.78.Final
+netty-buffer-4.1.92.Final
+netty-codec-4.1.92.Final
+netty-common-4.1.92.Final
+netty-handler-4.1.92.Final
+netty-resolver-4.1.92.Final
+netty-transport-4.1.92.Final
+netty-transport-classes-epoll-4.1.92.Final
+netty-transport-native-epoll-4.1.92.Final
+netty-transport-native-unix-common-4.1.92.Final
 plexus-utils-3.3.0
-reload4j-1.2.19
+reload4j-1.2.25
 rocksdbjni-7.1.2
-scala-collection-compat_2.13-2.6.0
+scala-collection-compat_2.13-2.10.0
 scala-library-2.13.10
 scala-logging_2.13-3.9.4
 scala-reflect-2.13.10
 scala-java8-compat_2.13-1.0.2
-snakeyaml-1.30
-snappy-java-1.1.8.4
-swagger-annotations-2.2.0
-swagger-core-2.2.0
-swagger-integration-2.2.0
-swagger-jaxrs2-2.2.0
-swagger-models-2.2.0
+snappy-java-1.1.9.1
+swagger-annotations-2.2.8
 zookeeper-3.6.4
 zookeeper-jute-3.6.4
 
@@ -284,26 +280,28 @@ see: licenses/eclipse-public-license-2.0
 
 jakarta.annotation-api-1.3.5
 jakarta.ws.rs-api-2.1.6
-javax.annotation-api-1.3.2
-javax.ws.rs-api-2.1.1
 hk2-api-2.6.1
 hk2-locator-2.6.1
 hk2-utils-2.6.1
 osgi-resource-locator-1.0.3
 aopalliance-repackaged-2.6.1
 jakarta.inject-2.6.1
-jersey-container-servlet-2.34
-jersey-container-servlet-core-2.34
-jersey-client-2.34
-jersey-hk2-2.34
-jersey-media-jaxb-2.31
+jersey-client-2.39.1
+jersey-common-2.39.1
+jersey-container-servlet-2.39.1
+jersey-container-servlet-core-2.39.1
+jersey-hk2-2.39.1
+jersey-server-2.39.1
 
 ---------------------------------------
 CDDL 1.1 + GPLv2 with classpath exception
 see: licenses/CDDL+GPL-1.1
 
+javax.activation-api-1.2.0
+javax.annotation-api-1.3.2
 javax.servlet-api-3.1.0
-jaxb-api-2.3.0
+javax.ws.rs-api-2.1.1
+jaxb-api-2.3.1
 activation-1.1.1
 
 ---------------------------------------
@@ -313,18 +311,17 @@ argparse4j-0.7.0, see: licenses/argparse-MIT
 jopt-simple-5.0.4, see: licenses/jopt-simple-MIT
 slf4j-api-1.7.36, see: licenses/slf4j-MIT
 slf4j-reload4j-1.7.36, see: licenses/slf4j-MIT
-classgraph-4.8.138, see: licenses/classgraph-MIT
 pcollections-4.0.1, see: licenses/pcollections-MIT
 
 ---------------------------------------
 BSD 2-Clause
 
-zstd-jni-1.5.2-1 see: licenses/zstd-jni-BSD-2-clause
+zstd-jni-1.5.5-1 see: licenses/zstd-jni-BSD-2-clause
 
 ---------------------------------------
 BSD 3-Clause
 
-jline-3.21.0, see: licenses/jline-BSD-3-clause
+jline-3.22.0, see: licenses/jline-BSD-3-clause
 paranamer-2.8, see: licenses/paranamer-BSD-3-clause
 
 ---------------------------------------


### PR DESCRIPTION
The file was getting a bit out of sync with the actual dependencies we ship. Also the [process we follow each release](https://issues.apache.org/jira/browse/KAFKA-12622) catches missing licenses but does not clear dependencies not used anymore, so this removes a few unnecessary entries too.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
