### PR TITLE
MINOR: Handle the config topic read timeout edge case in DistributedHerder's stopConnector method

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1104,7 +1104,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     writeTaskConfigs(connName, Collections.emptyList());
                     configBackingStore.putTargetState(connName, TargetState.STOPPED);
                     // Force a read of the new target state for the connector
-                    refreshConfigSnapshot(workerSyncTimeoutMs);
+                    if (!refreshConfigSnapshot(workerSyncTimeoutMs)) {
+                        throw new ConnectException("Failed to read to end of config topic");
+                    }
 
                     callback.onCompletion(null, null);
                     return null;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1105,7 +1105,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     configBackingStore.putTargetState(connName, TargetState.STOPPED);
                     // Force a read of the new target state for the connector
                     if (!refreshConfigSnapshot(workerSyncTimeoutMs)) {
-                        throw new ConnectException("Failed to read to end of config topic");
+                        log.warn("Failed to read to end of config topic after writing the STOPPED target state for connector {}", connName);
                     }
 
                     callback.onCompletion(null, null);


### PR DESCRIPTION
- Handle the config topic read timeout edge case in `DistributedHerder::stopConnector`
- https://github.com/apache/kafka/pull/13465#discussion_r1200500990

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
