### PR TITLE
MINOR: fix typo in Connect Config documentation

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -150,7 +150,7 @@ public class ConnectorConfig extends AbstractConfig {
     public static final String ERRORS_LOG_INCLUDE_MESSAGES_CONFIG = "errors.log.include.messages";
     public static final String ERRORS_LOG_INCLUDE_MESSAGES_DISPLAY = "Log Error Details";
     public static final boolean ERRORS_LOG_INCLUDE_MESSAGES_DEFAULT = false;
-    public static final String ERRORS_LOG_INCLUDE_MESSAGES_DOC = "Whether to include in the log the Connect record that resulted in a failure." +
+    public static final String ERRORS_LOG_INCLUDE_MESSAGES_DOC = "Whether to include in the log the Connect record that resulted in a failure. " +
             "For sink records, the topic, partition, offset, and timestamp will be logged. " +
             "For source records, the key and value (and their schemas), all headers, and the timestamp, Kafka topic, Kafka partition, source partition, " +
             "and source offset will be logged. " +


### PR DESCRIPTION
Fix typo in ConnectorConfig.java documentation by adding a whitespace.

### AS-IS

<img width="614" alt="스크린샷 2023-05-24 오후 6 24 16" src="https://github.com/apache/kafka/assets/8033896/40d112b0-6d6f-4441-b82c-72909be6c157">


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
