### PR TITLE
KAFKA-15017 Fix snapshot load in dual write mode for Quotas and SCRAM 

### DIFF
--- a/core/src/test/scala/unit/kafka/zk/migration/ZkConfigMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkConfigMigrationClientTest.scala
@@ -249,7 +249,7 @@ class ZkConfigMigrationClientTest extends ZkMigrationTestHarness {
   }
 
   @Test
-  def testScramChangesInSnapshot(): Unit = {
+  def testScramAndQuotaChangesInSnapshot(): Unit = {
     val random = new MockRandom()
 
     val props = new Properties()
@@ -278,7 +278,7 @@ class ZkConfigMigrationClientTest extends ZkMigrationTestHarness {
       .setRemove(false)
     delta.replay(clientQuotaRecord)
 
-    // Create a new SCRAM credential got george
+    // Create a new SCRAM credential for george
     val scramCredentialRecord = new UserScramCredentialRecord()
       .setName("george")
       .setMechanism(ScramMechanism.SCRAM_SHA_256.`type`)
@@ -288,8 +288,8 @@ class ZkConfigMigrationClientTest extends ZkMigrationTestHarness {
       .setIterations(8192)
     delta.replay(scramCredentialRecord)
 
-    // Add Quota record for user2 but not user1
-    // Add SCRAM record for george but not for alice.
+    // Add Quota record for user2 but not user1 to delete user1
+    // Add SCRAM record for george but not for alice to delete alice
     val image = delta.apply(MetadataProvenance.EMPTY)
 
     // load snapshot to Zookeeper.

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
@@ -290,7 +290,7 @@ public class KRaftMigrationZkWriter {
         changedUsers.forEach(userName -> {
             ClientQuotaEntity entity = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.USER, userName));
             Map<String, Double> quotaMap = clientQuotasImage.entities().
-                getOrDefault(entity,ClientQuotaImage.EMPTY).quotaMap();
+                getOrDefault(entity, ClientQuotaImage.EMPTY).quotaMap();
             Map<String, String> scramMap = getScramCredentialStringsForUser(scramImage, userName);
             operationConsumer.accept("Update scram credentials for " + userName, migrationState ->
                 migrationClient.configClient().writeClientQuotas(entity.entries(), quotaMap, scramMap, migrationState));

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
@@ -289,12 +289,12 @@ public class KRaftMigrationZkWriter {
 
         changedUsers.forEach(userName -> {
             ClientQuotaEntity entity = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.USER, userName));
-            Map<String, Double> quotaMap = clientQuotasImage.entities().get(entity).quotaMap();
+            Map<String, Double> quotaMap = clientQuotasImage.entities().
+                getOrDefault(entity,ClientQuotaImage.EMPTY).quotaMap();
             Map<String, String> scramMap = getScramCredentialStringsForUser(scramImage, userName);
             operationConsumer.accept("Update scram credentials for " + userName, migrationState ->
                 migrationClient.configClient().writeClientQuotas(entity.entries(), quotaMap, scramMap, migrationState));
         });
-
 
     }
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -232,6 +233,27 @@ public class KRaftMigrationZkWriter {
     void handleClientQuotasSnapshot(ClientQuotasImage clientQuotasImage, ScramImage scramImage) {
         Set<ClientQuotaEntity> changedNonUserEntities = new HashSet<>();
         Set<String> changedUsers = new HashSet<>();
+
+        if (clientQuotasImage != null) {
+            for (Entry<ClientQuotaEntity, ClientQuotaImage> entry : clientQuotasImage.entities().entrySet()) {
+                ClientQuotaEntity entity = entry.getKey();
+                if (entity.entries().containsKey(ClientQuotaEntity.USER) &&
+                    !entity.entries().containsKey(ClientQuotaEntity.CLIENT_ID)) {
+                    // Track regular user entities separately
+                    // There should only be 1 entry in the list of type ClientQuotaEntity.USER
+                    changedUsers.add(entity.entries().get(ClientQuotaEntity.USER));
+                } else {
+                    changedNonUserEntities.add(entity);
+                }
+            }
+        }
+        if (scramImage != null) {
+            for (Entry<ScramMechanism, Map<String, ScramCredentialData>> mechanismEntry : scramImage.mechanisms().entrySet()) {
+                for (Entry<String, ScramCredentialData> userEntry : mechanismEntry.getValue().entrySet()) {
+                    changedUsers.add(userEntry.getKey());
+                }
+            }
+        }
         migrationClient.configClient().iterateClientQuotas(new ConfigMigrationClient.ClientQuotaVisitor() {
             @Override
             public void visitClientQuota(List<ClientQuotaRecord.EntityData> entityDataList, Map<String, Double> quotas) {


### PR DESCRIPTION
Create lists of all the objects in the snapshot and add to the lists the objects that
are only in ZK. Then reverse migrate as appropriate. 

Added test to validate for SCRAM and Quota

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
