### PR TITLE
MINOR: Do not print an empty line when no topics exist

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -469,7 +469,7 @@ public abstract class TopicCommand {
                 CreateTopicsResult createResult = adminClient.createTopics(Collections.singleton(newTopic),
                     new CreateTopicsOptions().retryOnQuotaViolation(false));
                 createResult.all().get();
-                System.out.println("Created topic " + topic.name + ".");
+                System.out.println("Created topic " + topic.name.get() + ".");
             } catch (ExecutionException e) {
                 if (e.getCause() == null) {
                     throw e;
@@ -481,10 +481,11 @@ public abstract class TopicCommand {
         }
 
         public void listTopics(TopicCommandOptions opts) throws ExecutionException, InterruptedException {
-            String results = getTopics(opts.topic(), opts.excludeInternalTopics())
-                .stream()
-                .collect(Collectors.joining("\n"));
-            System.out.println(results);
+            List<String> topics = getTopics(opts.topic(), opts.excludeInternalTopics());
+
+            if (!topics.isEmpty()) {
+                System.out.println(String.join("\n", topics));
+            }
         }
 
         public void alterTopic(TopicCommandOptions opts) throws ExecutionException, InterruptedException {
@@ -507,7 +508,7 @@ public abstract class TopicCommand {
             String topicName) {
             if (topic.hasReplicaAssignment()) {
                 try {
-                    Integer startPartitionId = topicsInfo.get(topicName).get().partitions().size();
+                    int startPartitionId = topicsInfo.get(topicName).get().partitions().size();
                     Map<Integer, List<Integer>> replicaMap = topic.replicaAssignment.entrySet().stream()
                         .skip(startPartitionId)
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -540,7 +541,7 @@ public abstract class TopicCommand {
             // If topicId is provided and not zero, will use topicId regardless of topic name
             Optional<Uuid> inputTopicId = opts.topicId()
                 .map(Uuid::fromString).filter(uuid -> uuid != Uuid.ZERO_UUID);
-            Boolean useTopicId = inputTopicId.isPresent();
+            boolean useTopicId = inputTopicId.isPresent();
 
             List<Uuid> topicIds;
             List<String> topics;

--- a/tools/src/test/java/org/apache/kafka/tools/TopicCommandIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TopicCommandIntegrationTest.java
@@ -260,7 +260,7 @@ public class TopicCommandIntegrationTest extends kafka.integration.KafkaServerTe
             .get()
             .get(testTopicName)
             .partitions();
-        
+
         assertEquals(3, partitions.size());
         assertEquals(Arrays.asList(5, 4), getPartitionReplicas(partitions, 0));
         assertEquals(Arrays.asList(3, 2), getPartitionReplicas(partitions, 1));
@@ -311,6 +311,13 @@ public class TopicCommandIntegrationTest extends kafka.integration.KafkaServerTe
 
         String output = captureListTopicStandardOut(buildTopicCommandOptionsWithBootstrap("--list"));
         assertTrue(output.contains(testTopicName));
+    }
+
+    @ParameterizedTest(name = ToolsTestUtils.TEST_WITH_PARAMETERIZED_QUORUM_NAME)
+    @ValueSource(strings = {"zk", "kraft"})
+    public void testListNoTopics(String quorum) {
+        String output = captureListTopicStandardOut(buildTopicCommandOptionsWithBootstrap("--list"));
+        assertTrue(output.isEmpty());
     }
 
     @ParameterizedTest(name = ToolsTestUtils.TEST_WITH_PARAMETERIZED_QUORUM_NAME)


### PR DESCRIPTION
When running `kafka-topics.sh --list`, the command will print an empty line if no topics exist. This can cause some confusion when running with `wc -l`, so it's better to make sure the number of lines is zero in such a case.

This was tested against a cluster with 0 and 1+ topics to make sure the output is correct.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)