### PR TITLE
MINOR: use debug level to log handleCommit

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -315,9 +315,11 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
                         setImage(image).
                         build();
                 LogDeltaManifest manifest = loadLogDelta(delta, reader);
-                log.info("handleSnapshot: generated a metadata delta from a snapshot at offset {} " +
-                        "in {} us.", manifest.provenance().lastContainedOffset(),
-                        NANOSECONDS.toMicros(manifest.elapsedNs()));
+                if (log.isDebugEnabled()) {
+                    log.debug("handleCommit: Generated a metadata delta between {} and {} from {} batch(es) " +
+                                    "in {} us.", image.offset(), manifest.provenance().lastContainedOffset(),
+                            manifest.numBatches(), NANOSECONDS.toMicros(manifest.elapsedNs()));
+                }
                 try {
                     image = delta.apply(manifest.provenance());
                 } catch (Throwable e) {


### PR DESCRIPTION
In this [PR](https://github.com/apache/kafka/pull/13462/files#diff-38a0aec01732a73b638b91b3d88dfb6a074a6e47fac7972d5a8e7dc97c258606R321), we improved the log to make it clear, and backported to 3.4 branch. But in the [backport commit](https://github.com/apache/kafka/commit/8f94b627aea3f6415165b100f5070ba9f2f2eb66#diff-38a0aec01732a73b638b91b3d88dfb6a074a6e47fac7972d5a8e7dc97c258606L278-R317), we accidentally change the debug level to info level, and prefixed as `handleSnapshot`, instead of `handleCommit`. Fix it to avoid log flooding.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
