### PR TITLE
KAFKA-14691; [1/N] Add new fields to OffsetFetchRequest and OffsetFetchResponse - WIP

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
@@ -57,6 +57,14 @@ public class OffsetFetchRequest extends AbstractRequest {
                        boolean requireStable,
                        List<TopicPartition> partitions,
                        boolean throwOnFetchStableOffsetsUnsupported) {
+            this(groupId, requireStable, partitions, throwOnFetchStableOffsetsUnsupported, Collections.emptyMap());
+        }
+
+        public Builder(String groupId,
+                       boolean requireStable,
+                       List<TopicPartition> partitions,
+                       boolean throwOnFetchStableOffsetsUnsupported,
+                       Map<String, Uuid> topicIds) {
             super(ApiKeys.OFFSET_FETCH);
 
             final List<OffsetFetchRequestTopic> topics;
@@ -80,7 +88,7 @@ public class OffsetFetchRequest extends AbstractRequest {
                             .setRequireStable(requireStable)
                             .setTopics(topics);
             this.throwOnFetchStableOffsetsUnsupported = throwOnFetchStableOffsetsUnsupported;
-            this.topicNameToIds = Collections.emptyMap();
+            this.topicNameToIds = topicIds;
         }
 
         boolean isAllTopicPartitions() {

--- a/clients/src/main/resources/common/message/OffsetFetchRequest.json
+++ b/clients/src/main/resources/common/message/OffsetFetchRequest.json
@@ -33,7 +33,10 @@
   // Version 7 is adding the require stable flag.
   //
   // Version 8 is adding support for fetching offsets for multiple groups at a time
-  "validVersions": "0-8",
+  //
+  // Version 9 adds TopicId field (KIP-848).
+  "latestVersionUnstable": true,
+  "validVersions": "0-9",
   "flexibleVersions": "6+",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0-7", "entityType": "groupId",
@@ -51,8 +54,10 @@
         "about": "The group ID."},
       { "name": "Topics", "type": "[]OffsetFetchRequestTopics", "versions": "8+", "nullableVersions": "8+",
         "about": "Each topic we would like to fetch offsets for, or null to fetch offsets for all topics.", "fields": [
-        { "name": "Name", "type": "string", "versions": "8+", "entityType": "topicName",
+        { "name": "Name", "type": "string", "versions": "0-8", "ignorable": true, "entityType": "topicName",
           "about": "The topic name."},
+        { "name": "TopicId", "type": "uuid", "versions": "9+", "ignorable": true,
+          "about": "The unique topic ID" },
         { "name": "PartitionIndexes", "type": "[]int32", "versions": "8+",
           "about": "The partition indexes we would like to fetch offsets for." }
       ]}

--- a/clients/src/main/resources/common/message/OffsetFetchResponse.json
+++ b/clients/src/main/resources/common/message/OffsetFetchResponse.json
@@ -32,6 +32,9 @@
   // Version 7 adds pending offset commit as new error response on partition level.
   //
   // Version 8 is adding support for fetching offsets for multiple groups
+  //
+  // Version 9 adds TopicId field and can return STALE_MEMBER_EPOCH, UNKNOWN_MEMBER_ID,
+  // ILLEGAL_GENERATION, and UNKNOWN_TOPIC_ID errors.
   "validVersions": "0-8",
   "flexibleVersions": "6+",
   "fields": [
@@ -63,8 +66,9 @@
         "about": "The group ID." },
       { "name": "Topics", "type": "[]OffsetFetchResponseTopics", "versions": "8+",
         "about": "The responses per topic.", "fields": [
-        { "name": "Name", "type": "string", "versions": "8+", "entityType": "topicName",
+        { "name": "Name", "type": "string", "versions": "0-8", "ignorable": true, "entityType": "topicName",
           "about": "The topic name." },
+        { "name": "TopicId", "type": "uuid", "versions": "9+", "ignorable": true, "about": "The unique topic ID" },
         { "name": "Partitions", "type": "[]OffsetFetchResponsePartitions", "versions": "8+",
           "about": "The responses per partition", "fields": [
           { "name": "PartitionIndex", "type": "int32", "versions": "8+",

--- a/clients/src/main/resources/common/message/OffsetFetchResponse.json
+++ b/clients/src/main/resources/common/message/OffsetFetchResponse.json
@@ -68,7 +68,8 @@
         "about": "The responses per topic.", "fields": [
         { "name": "Name", "type": "string", "versions": "0-8", "ignorable": true, "entityType": "topicName",
           "about": "The topic name." },
-        { "name": "TopicId", "type": "uuid", "versions": "9+", "ignorable": true, "about": "The unique topic ID" },
+        { "name": "TopicId", "type": "uuid", "versions": "9+", "ignorable": true,
+          "about": "The unique topic ID" },
         { "name": "Partitions", "type": "[]OffsetFetchResponsePartitions", "versions": "8+",
           "about": "The responses per partition", "fields": [
           { "name": "PartitionIndex", "type": "int32", "versions": "8+",

--- a/clients/src/main/resources/common/message/OffsetFetchResponse.json
+++ b/clients/src/main/resources/common/message/OffsetFetchResponse.json
@@ -35,7 +35,7 @@
   //
   // Version 9 adds TopicId field and can return STALE_MEMBER_EPOCH, UNKNOWN_MEMBER_ID,
   // ILLEGAL_GENERATION, and UNKNOWN_TOPIC_ID errors.
-  "validVersions": "0-8",
+  "validVersions": "0-9",
   "flexibleVersions": "6+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "3+", "ignorable": true,

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1460,12 +1460,15 @@ class KafkaApis(val requestChannel: RequestChannel,
           .setErrorCode(Errors.forException(exception).code)
       } else {
         // Clients are not allowed to see offsets for topics that are not authorized for Describe.
-        val (authorizedOffsets, _) = authHelper.partitionSeqByAuthorized(
+
+        val result = authHelper.partitionSeqByAuthorized(
           requestContext,
           DESCRIBE,
           TOPIC,
           offsets.asScala
         )(_.name)
+
+        val (authorizedOffsets, _) = result
 
         new OffsetFetchResponseData.OffsetFetchResponseGroup()
           .setGroupId(groupOffsetFetch.groupId)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4284,6 +4284,9 @@ class KafkaApisTest {
     // in testing this here.
     if (version == 0) return
 
+    val fooId = Uuid.randomUuid()
+    addTopicToMetadataCache("foo", numPartitions = 2, topicId = fooId)
+
     def makeRequest(version: Short): RequestChannel.Request = {
       val groups = Map(
         "group-1" -> List(
@@ -4293,7 +4296,7 @@ class KafkaApisTest {
         "group-2" -> null,
         "group-3" -> null,
       ).asJava
-      buildRequest(new OffsetFetchRequest.Builder(groups, false, false).build(version))
+      buildRequest(new OffsetFetchRequest.Builder(groups, false, false, Map("foo" -> fooId).asJava).build(version))
     }
 
     if (version < 8) {


### PR DESCRIPTION
This is part 1 of [KAFKA-14691](https://issues.apache.org/jira/browse/KAFKA-14691). I change the JSON files which are used to generate the POJOs used during requests and responses.