### PR TITLE
MINOR: Covering all epoch cases in add partitions to txn manager

### DIFF
--- a/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
+++ b/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
@@ -57,12 +57,12 @@ class AddPartitionsToTxnManager(config: KafkaConfig, client: NetworkClient, time
       // 2. Incoming data has the same epoch -- return NETWORK_EXCEPTION for existing data, since the client is likely retrying and we want another retriable exception
       // 3. Incoming data has a lower epoch -- return INVALID_PRODUCER_EPOCH for the incoming data since it is fenced, do not add incoming data to verify
       if (existingTransactionData != null) {
-        if (existingTransactionData.producerEpoch() <= transactionData.producerEpoch()) {
-          val error = if (existingTransactionData.producerEpoch() < transactionData.producerEpoch())
+        if (existingTransactionData.producerEpoch <= transactionData.producerEpoch) {
+          val error = if (existingTransactionData.producerEpoch < transactionData.producerEpoch)
             Errors.INVALID_PRODUCER_EPOCH
           else
             Errors.NETWORK_EXCEPTION
-          val oldCallback = existingNodeAndTransactionData.callbacks(transactionData.transactionalId())
+          val oldCallback = existingNodeAndTransactionData.callbacks(transactionData.transactionalId)
           existingNodeAndTransactionData.transactionData.remove(transactionData)
           oldCallback(topicPartitionsToError(existingTransactionData, error))
         } else {
@@ -73,16 +73,16 @@ class AddPartitionsToTxnManager(config: KafkaConfig, client: NetworkClient, time
       }
 
       existingNodeAndTransactionData.transactionData.add(transactionData)
-      existingNodeAndTransactionData.callbacks.put(transactionData.transactionalId(), callback)
+      existingNodeAndTransactionData.callbacks.put(transactionData.transactionalId, callback)
       wakeup()
     }
   }
 
   private def topicPartitionsToError(transactionData: AddPartitionsToTxnTransaction, error: Errors): Map[TopicPartition, Errors] = {
     val topicPartitionsToError = mutable.Map[TopicPartition, Errors]()
-    transactionData.topics().forEach { topic =>
-      topic.partitions().forEach { partition =>
-        topicPartitionsToError.put(new TopicPartition(topic.name(), partition), error)
+    transactionData.topics.forEach { topic =>
+      topic.partitions.forEach { partition =>
+        topicPartitionsToError.put(new TopicPartition(topic.name, partition), error)
       }
     }
     topicPartitionsToError.toMap
@@ -92,58 +92,58 @@ class AddPartitionsToTxnManager(config: KafkaConfig, client: NetworkClient, time
     override def onComplete(response: ClientResponse): Unit = {
       // Note: Synchronization is not needed on inflightNodes since it is always accessed from this thread.
       inflightNodes.remove(node)
-      if (response.authenticationException() != null) {
-        error(s"AddPartitionsToTxnRequest failed for node ${response.destination()} with an " +
+      if (response.authenticationException != null) {
+        error(s"AddPartitionsToTxnRequest failed for node ${response.destination} with an " +
           "authentication exception.", response.authenticationException)
         transactionDataAndCallbacks.callbacks.foreach { case (txnId, callback) =>
-          callback(buildErrorMap(txnId, Errors.forException(response.authenticationException()).code()))
+          callback(buildErrorMap(txnId, Errors.forException(response.authenticationException).code))
         }
       } else if (response.versionMismatch != null) {
         // We may see unsupported version exception if we try to send a verify only request to a broker that can't handle it.
         // In this case, skip verification.
-        warn(s"AddPartitionsToTxnRequest failed for node ${response.destination()} with invalid version exception. This suggests verification is not supported." +
+        warn(s"AddPartitionsToTxnRequest failed for node ${response.destination} with invalid version exception. This suggests verification is not supported." +
           s"Continuing handling the produce request.")
         transactionDataAndCallbacks.callbacks.values.foreach(_(Map.empty))
-      } else if (response.wasDisconnected() || response.wasTimedOut()) {
-        warn(s"AddPartitionsToTxnRequest failed for node ${response.destination()} with a network exception.")
+      } else if (response.wasDisconnected || response.wasTimedOut) {
+        warn(s"AddPartitionsToTxnRequest failed for node ${response.destination} with a network exception.")
         transactionDataAndCallbacks.callbacks.foreach { case (txnId, callback) =>
-          callback(buildErrorMap(txnId, Errors.NETWORK_EXCEPTION.code()))
+          callback(buildErrorMap(txnId, Errors.NETWORK_EXCEPTION.code))
         }
       } else {
         val addPartitionsToTxnResponseData = response.responseBody.asInstanceOf[AddPartitionsToTxnResponse].data
         if (addPartitionsToTxnResponseData.errorCode != 0) {
-          error(s"AddPartitionsToTxnRequest for node ${response.destination()} returned with error ${Errors.forCode(addPartitionsToTxnResponseData.errorCode)}.")
+          error(s"AddPartitionsToTxnRequest for node ${response.destination} returned with error ${Errors.forCode(addPartitionsToTxnResponseData.errorCode)}.")
           // The client should not be exposed to CLUSTER_AUTHORIZATION_FAILED so modify the error to signify the verification did not complete.
           // Older clients return with INVALID_RECORD and newer ones can return with INVALID_TXN_STATE.
-          val finalError = if (addPartitionsToTxnResponseData.errorCode() == Errors.CLUSTER_AUTHORIZATION_FAILED.code)
+          val finalError = if (addPartitionsToTxnResponseData.errorCode == Errors.CLUSTER_AUTHORIZATION_FAILED.code)
             Errors.INVALID_RECORD.code
           else
-            addPartitionsToTxnResponseData.errorCode()
+            addPartitionsToTxnResponseData.errorCode
 
           transactionDataAndCallbacks.callbacks.foreach { case (txnId, callback) =>
             callback(buildErrorMap(txnId, finalError))
           }
         } else {
-          addPartitionsToTxnResponseData.resultsByTransaction().forEach { transactionResult =>
+          addPartitionsToTxnResponseData.resultsByTransaction.forEach { transactionResult =>
             val unverified = mutable.Map[TopicPartition, Errors]()
-            transactionResult.topicResults().forEach { topicResult =>
-              topicResult.resultsByPartition().forEach { partitionResult =>
-                val tp = new TopicPartition(topicResult.name(), partitionResult.partitionIndex())
-                if (partitionResult.partitionErrorCode() != Errors.NONE.code()) {
+            transactionResult.topicResults.forEach { topicResult =>
+              topicResult.resultsByPartition.forEach { partitionResult =>
+                val tp = new TopicPartition(topicResult.name, partitionResult.partitionIndex)
+                if (partitionResult.partitionErrorCode != Errors.NONE.code) {
                   // Producers expect to handle INVALID_PRODUCER_EPOCH in this scenario.
                   val code =
-                    if (partitionResult.partitionErrorCode() == Errors.PRODUCER_FENCED.code)
+                    if (partitionResult.partitionErrorCode == Errors.PRODUCER_FENCED.code)
                       Errors.INVALID_PRODUCER_EPOCH.code
                     // Older clients return INVALID_RECORD
-                    else if (partitionResult.partitionErrorCode() == Errors.INVALID_TXN_STATE.code)
+                    else if (partitionResult.partitionErrorCode == Errors.INVALID_TXN_STATE.code)
                       Errors.INVALID_RECORD.code
                     else
-                      partitionResult.partitionErrorCode()
+                      partitionResult.partitionErrorCode
                   unverified.put(tp, Errors.forCode(code))
                 }
               }
             }
-            val callback = transactionDataAndCallbacks.callbacks(transactionResult.transactionalId())
+            val callback = transactionDataAndCallbacks.callbacks(transactionResult.transactionalId)
             callback(unverified.toMap)
           }
         }

--- a/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
+++ b/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
@@ -36,43 +36,56 @@ class TransactionDataAndCallbacks(val transactionData: AddPartitionsToTxnTransac
                                   val callbacks: mutable.Map[String, AddPartitionsToTxnManager.AppendCallback])
 
 
-class AddPartitionsToTxnManager(config: KafkaConfig, client: NetworkClient, time: Time) 
+class AddPartitionsToTxnManager(config: KafkaConfig, client: NetworkClient, time: Time)
   extends InterBrokerSendThread("AddPartitionsToTxnSenderThread-" + config.brokerId, client, config.requestTimeoutMs, time) {
-  
+
   private val inflightNodes = mutable.HashSet[Node]()
   private val nodesToTransactions = mutable.Map[Node, TransactionDataAndCallbacks]()
-  
+
   def addTxnData(node: Node, transactionData: AddPartitionsToTxnTransaction, callback: AddPartitionsToTxnManager.AppendCallback): Unit = {
     nodesToTransactions.synchronized {
       // Check if we have already have either node or individual transaction. Add the Node if it isn't there.
-      val currentNodeAndTransactionData = nodesToTransactions.getOrElseUpdate(node,
+      val existingNodeAndTransactionData = nodesToTransactions.getOrElseUpdate(node,
         new TransactionDataAndCallbacks(
           new AddPartitionsToTxnTransactionCollection(1),
           mutable.Map[String, AddPartitionsToTxnManager.AppendCallback]()))
 
-      val currentTransactionData = currentNodeAndTransactionData.transactionData.find(transactionData.transactionalId)
+      val existingTransactionData = existingNodeAndTransactionData.transactionData.find(transactionData.transactionalId)
 
-      // Check if we already have txn ID -- if the epoch is bumped, return invalid producer epoch, otherwise, the client likely disconnected and 
-      // reconnected so return the retriable network exception.
-      if (currentTransactionData != null) {
-        val error = if (currentTransactionData.producerEpoch() < transactionData.producerEpoch())
-          Errors.INVALID_PRODUCER_EPOCH
-        else 
-          Errors.NETWORK_EXCEPTION
-        val topicPartitionsToError = mutable.Map[TopicPartition, Errors]()
-        currentTransactionData.topics().forEach { topic =>
-          topic.partitions().forEach { partition =>
-            topicPartitionsToError.put(new TopicPartition(topic.name(), partition), error)
-          }
+      // There are 3 cases if we already have existing data
+      // 1. Incoming data has a higher epoch -- return INVALID_PRODUCER_EPOCH for existing data since it is fenced
+      // 2. Incoming data has the same epoch -- return NETWORK_EXCEPTION for existing data, since the client is likely retrying and we want another retriable exception
+      // 3. Incoming data has a lower epoch -- return INVALID_PRODUCER_EPOCH for the incoming data since it is fenced, do not add incoming data to verify
+      if (existingTransactionData != null) {
+        if (existingTransactionData.producerEpoch() <= transactionData.producerEpoch()) {
+          val error = if (existingTransactionData.producerEpoch() < transactionData.producerEpoch())
+            Errors.INVALID_PRODUCER_EPOCH
+          else
+            Errors.NETWORK_EXCEPTION
+          val oldCallback = existingNodeAndTransactionData.callbacks(transactionData.transactionalId())
+          existingNodeAndTransactionData.transactionData.remove(transactionData)
+          oldCallback(topicPartitionsToError(existingTransactionData, error))
+        } else {
+          // If the incoming transactionData's epoch is lower, we can return with INVALID_PRODUCER_EPOCH immediately.
+          callback(topicPartitionsToError(transactionData, Errors.INVALID_PRODUCER_EPOCH))
+          return
         }
-        val oldCallback = currentNodeAndTransactionData.callbacks(transactionData.transactionalId())
-        currentNodeAndTransactionData.transactionData.remove(transactionData)
-        oldCallback(topicPartitionsToError.toMap)
       }
-      currentNodeAndTransactionData.transactionData.add(transactionData)
-      currentNodeAndTransactionData.callbacks.put(transactionData.transactionalId(), callback)
+
+      existingNodeAndTransactionData.transactionData.add(transactionData)
+      existingNodeAndTransactionData.callbacks.put(transactionData.transactionalId(), callback)
       wakeup()
     }
+  }
+
+  private def topicPartitionsToError(transactionData: AddPartitionsToTxnTransaction, error: Errors): Map[TopicPartition, Errors] = {
+    val topicPartitionsToError = mutable.Map[TopicPartition, Errors]()
+    transactionData.topics().forEach { topic =>
+      topic.partitions().forEach { partition =>
+        topicPartitionsToError.put(new TopicPartition(topic.name(), partition), error)
+      }
+    }
+    topicPartitionsToError.toMap
   }
 
   private class AddPartitionsToTxnHandler(node: Node, transactionDataAndCallbacks: TransactionDataAndCallbacks) extends RequestCompletionHandler {
@@ -86,7 +99,7 @@ class AddPartitionsToTxnManager(config: KafkaConfig, client: NetworkClient, time
           callback(buildErrorMap(txnId, Errors.forException(response.authenticationException()).code()))
         }
       } else if (response.versionMismatch != null) {
-        // We may see unsupported version exception if we try to send a verify only request to a broker that can't handle it. 
+        // We may see unsupported version exception if we try to send a verify only request to a broker that can't handle it.
         // In this case, skip verification.
         warn(s"AddPartitionsToTxnRequest failed for node ${response.destination()} with invalid version exception. This suggests verification is not supported." +
           s"Continuing handling the produce request.")
@@ -104,9 +117,9 @@ class AddPartitionsToTxnManager(config: KafkaConfig, client: NetworkClient, time
           // Older clients return with INVALID_RECORD and newer ones can return with INVALID_TXN_STATE.
           val finalError = if (addPartitionsToTxnResponseData.errorCode() == Errors.CLUSTER_AUTHORIZATION_FAILED.code)
             Errors.INVALID_RECORD.code
-          else 
+          else
             addPartitionsToTxnResponseData.errorCode()
-          
+
           transactionDataAndCallbacks.callbacks.foreach { case (txnId, callback) =>
             callback(buildErrorMap(txnId, finalError))
           }
@@ -118,13 +131,13 @@ class AddPartitionsToTxnManager(config: KafkaConfig, client: NetworkClient, time
                 val tp = new TopicPartition(topicResult.name(), partitionResult.partitionIndex())
                 if (partitionResult.partitionErrorCode() != Errors.NONE.code()) {
                   // Producers expect to handle INVALID_PRODUCER_EPOCH in this scenario.
-                  val code = 
+                  val code =
                     if (partitionResult.partitionErrorCode() == Errors.PRODUCER_FENCED.code)
                       Errors.INVALID_PRODUCER_EPOCH.code
-                    // Older clients return INVALID_RECORD  
+                    // Older clients return INVALID_RECORD
                     else if (partitionResult.partitionErrorCode() == Errors.INVALID_TXN_STATE.code)
-                      Errors.INVALID_RECORD.code  
-                    else 
+                      Errors.INVALID_RECORD.code
+                    else
                       partitionResult.partitionErrorCode()
                   unverified.put(tp, Errors.forCode(code))
                 }
@@ -137,21 +150,14 @@ class AddPartitionsToTxnManager(config: KafkaConfig, client: NetworkClient, time
       }
       wakeup()
     }
-    
+
     private def buildErrorMap(transactionalId: String, errorCode: Short): Map[TopicPartition, Errors] = {
-      val errors = new mutable.HashMap[TopicPartition, Errors]()
       val transactionData = transactionDataAndCallbacks.transactionData.find(transactionalId)
-      transactionData.topics.forEach { topic =>
-        topic.partitions().forEach { partition =>
-          errors.put(new TopicPartition(topic.name(), partition), Errors.forCode(errorCode))
-        }
-      }
-      errors.toMap
+      topicPartitionsToError(transactionData, Errors.forCode(errorCode))
     }
   }
 
   override def generateRequests(): Iterable[RequestAndCompletionHandler] = {
-    
     // build and add requests to queue
     val buffer = mutable.Buffer[RequestAndCompletionHandler]()
     val currentTimeMs = time.milliseconds()

--- a/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnManagerTest.scala
@@ -91,23 +91,24 @@ class AddPartitionsToTxnManagerTest {
     addPartitionsToTxnManager.addTxnData(node1, transactionData(transactionalId2, producerId2), setErrors(transaction2Errors))
     addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId3, producerId3), setErrors(transaction3Errors))
 
-    val transaction1AgainErrorsOldEpoch = mutable.Map[TopicPartition, Errors]()
-    val transaction1AgainErrorsNewEpoch = mutable.Map[TopicPartition, Errors]()
-    val transaction1AgainErrorsOldEpochAgain = mutable.Map[TopicPartition, Errors]()
+    // We will try to add transaction1 3 more times (retries). One will have the same epoch, one will have a newer epoch, and one will have an older epoch than the new one we just added.
+    val transaction1RetryWithSameEpochErrors = mutable.Map[TopicPartition, Errors]()
+    val transaction1RetryWithNewerEpochErrors = mutable.Map[TopicPartition, Errors]()
+    val transaction1RetryWithOldEpochErrors = mutable.Map[TopicPartition, Errors]()
 
     // Trying to add more transactional data for the same transactional ID, producer ID, and epoch should simply replace the old data and send a retriable response.
-    addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1), setErrors(transaction1AgainErrorsOldEpoch))
+    addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1), setErrors(transaction1RetryWithSameEpochErrors))
     val expectedNetworkErrors = topicPartitions.map(_ -> Errors.NETWORK_EXCEPTION).toMap
     assertEquals(expectedNetworkErrors, transaction1Errors)
 
     // Trying to add more transactional data for the same transactional ID and producer ID, but new epoch should replace the old data and send an error response for it.
-    addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1, producerEpoch = 1), setErrors(transaction1AgainErrorsNewEpoch))
+    addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1, producerEpoch = 1), setErrors(transaction1RetryWithNewerEpochErrors))
     val expectedEpochErrors = topicPartitions.map(_ -> Errors.INVALID_PRODUCER_EPOCH).toMap
-    assertEquals(expectedEpochErrors, transaction1AgainErrorsOldEpoch)
+    assertEquals(expectedEpochErrors, transaction1RetryWithSameEpochErrors)
 
     // Trying to add more transactional data for the same transactional ID and producer ID, but an older epoch should immediately return with error and keep the old data queued to send.
-    addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1, producerEpoch = 0), setErrors(transaction1AgainErrorsOldEpochAgain))
-    assertEquals(expectedEpochErrors, transaction1AgainErrorsOldEpochAgain)
+    addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1, producerEpoch = 0), setErrors(transaction1RetryWithOldEpochErrors))
+    assertEquals(expectedEpochErrors, transaction1RetryWithOldEpochErrors)
 
     val requestsAndHandlers = addPartitionsToTxnManager.generateRequests()
     requestsAndHandlers.foreach { requestAndHandler =>

--- a/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnManagerTest.scala
@@ -93,6 +93,8 @@ class AddPartitionsToTxnManagerTest {
 
     val transaction1AgainErrorsOldEpoch = mutable.Map[TopicPartition, Errors]()
     val transaction1AgainErrorsNewEpoch = mutable.Map[TopicPartition, Errors]()
+    val transaction1AgainErrorsOldEpochAgain = mutable.Map[TopicPartition, Errors]()
+
     // Trying to add more transactional data for the same transactional ID, producer ID, and epoch should simply replace the old data and send a retriable response.
     addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1), setErrors(transaction1AgainErrorsOldEpoch))
     val expectedNetworkErrors = topicPartitions.map(_ -> Errors.NETWORK_EXCEPTION).toMap
@@ -100,9 +102,12 @@ class AddPartitionsToTxnManagerTest {
 
     // Trying to add more transactional data for the same transactional ID and producer ID, but new epoch should replace the old data and send an error response for it.
     addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1, producerEpoch = 1), setErrors(transaction1AgainErrorsNewEpoch))
-    
     val expectedEpochErrors = topicPartitions.map(_ -> Errors.INVALID_PRODUCER_EPOCH).toMap
     assertEquals(expectedEpochErrors, transaction1AgainErrorsOldEpoch)
+
+    // Trying to add more transactional data for the same transactional ID and producer ID, but an older epoch should immediately return with error and keep the old data queued to send.
+    addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1, producerEpoch = 0), setErrors(transaction1AgainErrorsOldEpochAgain))
+    assertEquals(expectedEpochErrors, transaction1AgainErrorsOldEpochAgain)
 
     val requestsAndHandlers = addPartitionsToTxnManager.generateRequests()
     requestsAndHandlers.foreach { requestAndHandler =>
@@ -182,7 +187,7 @@ class AddPartitionsToTxnManagerTest {
     receiveResponse(versionMismatchResponse)
     assertEquals(expectedVersionMismatchErrors, transaction1Errors)
     assertEquals(expectedVersionMismatchErrors, transaction2Errors)
-    
+
     val expectedDisconnectedErrors = topicPartitions.map(_ -> Errors.NETWORK_EXCEPTION).toMap
     addTransactionsToVerify()
     receiveResponse(disconnectedResponse)
@@ -199,7 +204,7 @@ class AddPartitionsToTxnManagerTest {
 
     val preConvertedTransaction1Errors = topicPartitions.map(_ -> Errors.PRODUCER_FENCED).toMap
     val expectedTransaction1Errors = topicPartitions.map(_ -> Errors.INVALID_PRODUCER_EPOCH).toMap
-    val preConvertedTransaction2Errors = Map(new TopicPartition("foo", 1) -> Errors.NONE, 
+    val preConvertedTransaction2Errors = Map(new TopicPartition("foo", 1) -> Errors.NONE,
       new TopicPartition("foo", 2) -> Errors.INVALID_RECORD,
       new TopicPartition("foo", 3) -> Errors.NONE)
     val expectedTransaction2Errors = Map(new TopicPartition("foo", 2) -> Errors.INVALID_RECORD)


### PR DESCRIPTION
Originally part of https://github.com/apache/kafka/pull/13608, Artem made a good point that this change was unrelated, so I'm making a minor PR to cover it.

Cleaning up the AddPartitionsToTxnManager and covering the 3 epoch cases more clearly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
