### PR TITLE
MINOR: Refactor DelegatingClassLoader to emit immutable PluginScanResult

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -380,7 +380,6 @@ public class DelegatingClassLoader extends URLClassLoader {
         }
     }
 
-
     @Override
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
         String fullName = aliases.getOrDefault(name, name);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.runtime.isolation;
 
 import org.apache.kafka.common.config.provider.ConfigProvider;
 import org.apache.kafka.connect.components.Versioned;
+import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.rest.ConnectRestExtension;
 import org.apache.kafka.connect.sink.SinkConnector;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -18,7 +18,6 @@ package org.apache.kafka.connect.runtime.isolation;
 
 import org.apache.kafka.common.config.provider.ConfigProvider;
 import org.apache.kafka.connect.components.Versioned;
-import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.rest.ConnectRestExtension;
 import org.apache.kafka.connect.sink.SinkConnector;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -48,10 +48,11 @@ import java.security.PrivilegedAction;
 import java.sql.Driver;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -79,15 +80,6 @@ public class DelegatingClassLoader extends URLClassLoader {
 
     private final ConcurrentMap<String, SortedMap<PluginDesc<?>, ClassLoader>> pluginLoaders;
     private final ConcurrentMap<String, String> aliases;
-    private final SortedSet<PluginDesc<SinkConnector>> sinkConnectors;
-    private final SortedSet<PluginDesc<SourceConnector>> sourceConnectors;
-    private final SortedSet<PluginDesc<Converter>> converters;
-    private final SortedSet<PluginDesc<HeaderConverter>> headerConverters;
-    private final SortedSet<PluginDesc<Transformation<?>>> transformations;
-    private final SortedSet<PluginDesc<Predicate<?>>> predicates;
-    private final SortedSet<PluginDesc<ConfigProvider>> configProviders;
-    private final SortedSet<PluginDesc<ConnectRestExtension>> restExtensions;
-    private final SortedSet<PluginDesc<ConnectorClientConfigOverridePolicy>> connectorClientConfigPolicies;
     private final List<Path> pluginLocations;
 
     // Although this classloader does not load classes directly but rather delegates loading to a
@@ -103,15 +95,6 @@ public class DelegatingClassLoader extends URLClassLoader {
         this.pluginLocations = pluginLocations;
         this.pluginLoaders = new ConcurrentHashMap<>();
         this.aliases = new ConcurrentHashMap<>();
-        this.sinkConnectors = new TreeSet<>();
-        this.sourceConnectors = new TreeSet<>();
-        this.converters = new TreeSet<>();
-        this.headerConverters = new TreeSet<>();
-        this.transformations = new TreeSet<>();
-        this.predicates = new TreeSet<>();
-        this.configProviders = new TreeSet<>();
-        this.restExtensions = new TreeSet<>();
-        this.connectorClientConfigPolicies = new TreeSet<>();
     }
 
     public DelegatingClassLoader(List<Path> pluginLocations) {
@@ -120,49 +103,6 @@ public class DelegatingClassLoader extends URLClassLoader {
         // environments that control classloading differently (OSGi, Spring and others) and don't
         // depend on the System classloader to load Connect's classes.
         this(pluginLocations, DelegatingClassLoader.class.getClassLoader());
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public Set<PluginDesc<Connector>> connectors() {
-        Set<PluginDesc<Connector>> connectors = new TreeSet<>((Set) sinkConnectors);
-        connectors.addAll((Set) sourceConnectors);
-        return connectors;
-    }
-
-    public Set<PluginDesc<SinkConnector>> sinkConnectors() {
-        return sinkConnectors;
-    }
-
-    public Set<PluginDesc<SourceConnector>> sourceConnectors() {
-        return sourceConnectors;
-    }
-
-    public Set<PluginDesc<Converter>> converters() {
-        return converters;
-    }
-
-    public Set<PluginDesc<HeaderConverter>> headerConverters() {
-        return headerConverters;
-    }
-
-    public Set<PluginDesc<Transformation<?>>> transformations() {
-        return transformations;
-    }
-
-    public Set<PluginDesc<Predicate<?>>> predicates() {
-        return predicates;
-    }
-
-    public Set<PluginDesc<ConfigProvider>> configProviders() {
-        return configProviders;
-    }
-
-    public Set<PluginDesc<ConnectRestExtension>> restExtensions() {
-        return restExtensions;
-    }
-
-    public Set<PluginDesc<ConnectorClientConfigOverridePolicy>> connectorClientConfigPolicies() {
-        return connectorClientConfigPolicies;
     }
 
     /**
@@ -208,24 +148,11 @@ public class DelegatingClassLoader extends URLClassLoader {
         );
     }
 
-    private <T> void addPlugins(Collection<PluginDesc<T>> plugins, ClassLoader loader) {
-        for (PluginDesc<T> plugin : plugins) {
-            String pluginClassName = plugin.className();
-            SortedMap<PluginDesc<?>, ClassLoader> inner = pluginLoaders.get(pluginClassName);
-            if (inner == null) {
-                inner = new TreeMap<>();
-                pluginLoaders.put(pluginClassName, inner);
-                // TODO: once versioning is enabled this line should be moved outside this if branch
-                log.info("Added plugin '{}'", pluginClassName);
-            }
-            inner.put(plugin, loader);
-        }
-    }
-
-    protected void initLoaders() {
+    public PluginScanResult initLoaders() {
+        List<PluginScanResult> results = new ArrayList<>();
         for (Path pluginLocation : pluginLocations) {
             try {
-                registerPlugin(pluginLocation);
+                results.add(registerPlugin(pluginLocation));
             } catch (InvalidPathException | MalformedURLException e) {
                 log.error("Invalid path in plugin path: {}. Ignoring.", pluginLocation, e);
             } catch (IOException e) {
@@ -233,14 +160,16 @@ public class DelegatingClassLoader extends URLClassLoader {
             }
         }
         // Finally add parent/system loader.
-        scanUrlsAndAddPlugins(
+        results.add(scanUrlsAndAddPlugins(
                 getParent(),
                 ClasspathHelper.forJavaClassPath().toArray(new URL[0])
-        );
-        addAllAliases();
+        ));
+        PluginScanResult scanResult = new PluginScanResult(results);
+        installDiscoveredPlugins(scanResult);
+        return scanResult;
     }
 
-    private void registerPlugin(Path pluginLocation)
+    private PluginScanResult registerPlugin(Path pluginLocation)
         throws IOException {
         log.info("Loading plugin from: {}", pluginLocation);
         List<URL> pluginUrls = new ArrayList<>();
@@ -256,37 +185,17 @@ public class DelegatingClassLoader extends URLClassLoader {
                 urls,
                 this
         );
-        scanUrlsAndAddPlugins(loader, urls);
+        return scanUrlsAndAddPlugins(loader, urls);
     }
 
-    private void scanUrlsAndAddPlugins(
+    private PluginScanResult scanUrlsAndAddPlugins(
             ClassLoader loader,
             URL[] urls
     ) {
         PluginScanResult plugins = scanPluginPath(loader, urls);
         log.info("Registered loader: {}", loader);
-        if (!plugins.isEmpty()) {
-            addPlugins(plugins.sinkConnectors(), loader);
-            sinkConnectors.addAll(plugins.sinkConnectors());
-            addPlugins(plugins.sourceConnectors(), loader);
-            sourceConnectors.addAll(plugins.sourceConnectors());
-            addPlugins(plugins.converters(), loader);
-            converters.addAll(plugins.converters());
-            addPlugins(plugins.headerConverters(), loader);
-            headerConverters.addAll(plugins.headerConverters());
-            addPlugins(plugins.transformations(), loader);
-            transformations.addAll(plugins.transformations());
-            addPlugins(plugins.predicates(), loader);
-            predicates.addAll(plugins.predicates());
-            addPlugins(plugins.configProviders(), loader);
-            configProviders.addAll(plugins.configProviders());
-            addPlugins(plugins.restExtensions(), loader);
-            restExtensions.addAll(plugins.restExtensions());
-            addPlugins(plugins.connectorClientConfigPolicies(), loader);
-            connectorClientConfigPolicies.addAll(plugins.connectorClientConfigPolicies());
-        }
-
         loadJdbcDrivers(loader);
+        return plugins;
     }
 
     private void loadJdbcDrivers(final ClassLoader loader) {
@@ -344,16 +253,16 @@ public class DelegatingClassLoader extends URLClassLoader {
     }
 
     @SuppressWarnings({"unchecked"})
-    private Collection<PluginDesc<Predicate<?>>> getPredicatePluginDesc(ClassLoader loader, Reflections reflections) {
-        return (Collection<PluginDesc<Predicate<?>>>) (Collection<?>) getPluginDesc(reflections, Predicate.class, loader);
+    private SortedSet<PluginDesc<Predicate<?>>> getPredicatePluginDesc(ClassLoader loader, Reflections reflections) {
+        return (SortedSet<PluginDesc<Predicate<?>>>) (SortedSet<?>) getPluginDesc(reflections, Predicate.class, loader);
     }
 
     @SuppressWarnings({"unchecked"})
-    private Collection<PluginDesc<Transformation<?>>> getTransformationPluginDesc(ClassLoader loader, Reflections reflections) {
-        return (Collection<PluginDesc<Transformation<?>>>) (Collection<?>) getPluginDesc(reflections, Transformation.class, loader);
+    private SortedSet<PluginDesc<Transformation<?>>> getTransformationPluginDesc(ClassLoader loader, Reflections reflections) {
+        return (SortedSet<PluginDesc<Transformation<?>>>) (SortedSet<?>) getPluginDesc(reflections, Transformation.class, loader);
     }
 
-    private <T> Collection<PluginDesc<T>> getPluginDesc(
+    private <T> SortedSet<PluginDesc<T>> getPluginDesc(
             Reflections reflections,
             Class<T> klass,
             ClassLoader loader
@@ -364,10 +273,10 @@ public class DelegatingClassLoader extends URLClassLoader {
         } catch (ReflectionsException e) {
             log.debug("Reflections scanner could not find any classes for URLs: " +
                     reflections.getConfiguration().getUrls(), e);
-            return Collections.emptyList();
+            return Collections.emptySortedSet();
         }
 
-        Collection<PluginDesc<T>> result = new ArrayList<>();
+        SortedSet<PluginDesc<T>> result = new TreeSet<>();
         for (Class<? extends T> pluginKlass : plugins) {
             if (!PluginUtils.isConcrete(pluginKlass)) {
                 log.debug("Skipping {} as it is not concrete implementation", pluginKlass);
@@ -393,8 +302,8 @@ public class DelegatingClassLoader extends URLClassLoader {
     }
 
     @SuppressWarnings("unchecked")
-    private <T> Collection<PluginDesc<T>> getServiceLoaderPluginDesc(Class<T> klass, ClassLoader loader) {
-        Collection<PluginDesc<T>> result = new ArrayList<>();
+    private <T> SortedSet<PluginDesc<T>> getServiceLoaderPluginDesc(Class<T> klass, ClassLoader loader) {
+        SortedSet<PluginDesc<T>> result = new TreeSet<>();
         ServiceLoader<T> serviceLoader = ServiceLoader.load(klass, loader);
         for (Iterator<T> iterator = serviceLoader.iterator(); iterator.hasNext(); ) {
             try (LoaderSwap loaderSwap = withClassLoader(loader)) {
@@ -460,6 +369,18 @@ public class DelegatingClassLoader extends URLClassLoader {
         }
     }
 
+    private void installDiscoveredPlugins(PluginScanResult scanResult) {
+        pluginLoaders.putAll(computePluginLoaders(scanResult));
+        for (String pluginClassName : pluginLoaders.keySet()) {
+            log.info("Added plugin '{}'", pluginClassName);
+        }
+        aliases.putAll(PluginUtils.computeAliases(scanResult));
+        for (Map.Entry<String, String> alias : aliases.entrySet()) {
+            log.info("Added alias '{}' to plugin '{}'", alias.getKey(), alias.getValue());
+        }
+    }
+
+
     @Override
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
         String fullName = aliases.getOrDefault(name, name);
@@ -472,35 +393,12 @@ public class DelegatingClassLoader extends URLClassLoader {
         return super.loadClass(fullName, resolve);
     }
 
-    private void addAllAliases() {
-        addAliases(connectors());
-        addAliases(converters);
-        addAliases(headerConverters);
-        addAliases(transformations);
-        addAliases(predicates);
-        addAliases(restExtensions);
-        addAliases(connectorClientConfigPolicies);
-    }
-
-    private <S> void addAliases(Collection<PluginDesc<S>> plugins) {
-        for (PluginDesc<S> plugin : plugins) {
-            if (PluginUtils.isAliasUnique(plugin, plugins)) {
-                String simple = PluginUtils.simpleName(plugin);
-                String pruned = PluginUtils.prunedName(plugin);
-                aliases.put(simple, plugin.className());
-                if (simple.equals(pruned)) {
-                    log.info("Added alias '{}' to plugin '{}'", simple, plugin.className());
-                } else {
-                    aliases.put(pruned, plugin.className());
-                    log.info(
-                            "Added aliases '{}' and '{}' to plugin '{}'",
-                            simple,
-                            pruned,
-                            plugin.className()
-                    );
-                }
-            }
-        }
+    private static Map<String, SortedMap<PluginDesc<?>, ClassLoader>> computePluginLoaders(PluginScanResult plugins) {
+        Map<String, SortedMap<PluginDesc<?>, ClassLoader>> pluginLoaders = new HashMap<>();
+        plugins.forEach(pluginDesc ->
+                pluginLoaders.computeIfAbsent(pluginDesc.className(), k -> new TreeMap<>())
+                        .put(pluginDesc, pluginDesc.loader()));
+        return pluginLoaders;
     }
 
     private static class InternalReflections extends Reflections {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginDesc.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginDesc.java
@@ -29,6 +29,7 @@ public class PluginDesc<T> implements Comparable<PluginDesc<T>> {
     private final PluginType type;
     private final String typeName;
     private final String location;
+    private final ClassLoader loader;
 
     public PluginDesc(Class<? extends T> klass, String version, ClassLoader loader) {
         this.klass = klass;
@@ -40,6 +41,7 @@ public class PluginDesc<T> implements Comparable<PluginDesc<T>> {
         this.location = loader instanceof PluginClassLoader
                 ? ((PluginClassLoader) loader).location()
                 : "classpath";
+        this.loader = loader;
     }
 
     @Override
@@ -83,6 +85,14 @@ public class PluginDesc<T> implements Comparable<PluginDesc<T>> {
         return location;
     }
 
+    public ClassLoader loader() {
+        return loader;
+    }
+
+    public boolean isolated() {
+        return loader instanceof PluginClassLoader;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -105,6 +115,9 @@ public class PluginDesc<T> implements Comparable<PluginDesc<T>> {
     @Override
     public int compareTo(PluginDesc<T> other) {
         int nameComp = name.compareTo(other.name);
-        return nameComp != 0 ? nameComp : encodedVersion.compareTo(other.encodedVersion);
+        int versionComp = encodedVersion.compareTo(other.encodedVersion);
+        // isolated plugins appear after classpath plugins when they have identical versions.
+        int isolatedComp = Boolean.compare(other.isolated(), isolated());
+        return nameComp != 0 ? nameComp : (versionComp != 0 ? versionComp : isolatedComp);
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginDesc.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginDesc.java
@@ -89,10 +89,6 @@ public class PluginDesc<T> implements Comparable<PluginDesc<T>> {
         return loader;
     }
 
-    public boolean isolated() {
-        return loader instanceof PluginClassLoader;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -117,7 +113,7 @@ public class PluginDesc<T> implements Comparable<PluginDesc<T>> {
         int nameComp = name.compareTo(other.name);
         int versionComp = encodedVersion.compareTo(other.encodedVersion);
         // isolated plugins appear after classpath plugins when they have identical versions.
-        int isolatedComp = Boolean.compare(other.isolated(), isolated());
+        int isolatedComp = Boolean.compare(other.loader instanceof PluginClassLoader, loader instanceof PluginClassLoader);
         return nameComp != 0 ? nameComp : (versionComp != 0 ? versionComp : isolatedComp);
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanResult.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanResult.java
@@ -27,32 +27,35 @@ import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.predicates.Predicate;
 
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.SortedSet;
 import java.util.List;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 public class PluginScanResult {
-    private final Collection<PluginDesc<SinkConnector>> sinkConnectors;
-    private final Collection<PluginDesc<SourceConnector>> sourceConnectors;
-    private final Collection<PluginDesc<Converter>> converters;
-    private final Collection<PluginDesc<HeaderConverter>> headerConverters;
-    private final Collection<PluginDesc<Transformation<?>>> transformations;
-    private final Collection<PluginDesc<Predicate<?>>> predicates;
-    private final Collection<PluginDesc<ConfigProvider>> configProviders;
-    private final Collection<PluginDesc<ConnectRestExtension>> restExtensions;
-    private final Collection<PluginDesc<ConnectorClientConfigOverridePolicy>> connectorClientConfigPolicies;
+    private final SortedSet<PluginDesc<SinkConnector>> sinkConnectors;
+    private final SortedSet<PluginDesc<SourceConnector>> sourceConnectors;
+    private final SortedSet<PluginDesc<Converter>> converters;
+    private final SortedSet<PluginDesc<HeaderConverter>> headerConverters;
+    private final SortedSet<PluginDesc<Transformation<?>>> transformations;
+    private final SortedSet<PluginDesc<Predicate<?>>> predicates;
+    private final SortedSet<PluginDesc<ConfigProvider>> configProviders;
+    private final SortedSet<PluginDesc<ConnectRestExtension>> restExtensions;
+    private final SortedSet<PluginDesc<ConnectorClientConfigOverridePolicy>> connectorClientConfigPolicies;
 
-    private final List<Collection<?>> allPlugins;
+    private final List<SortedSet<?>> allPlugins;
 
     public PluginScanResult(
-            Collection<PluginDesc<SinkConnector>> sinkConnectors,
-            Collection<PluginDesc<SourceConnector>> sourceConnectors,
-            Collection<PluginDesc<Converter>> converters,
-            Collection<PluginDesc<HeaderConverter>> headerConverters,
-            Collection<PluginDesc<Transformation<?>>> transformations,
-            Collection<PluginDesc<Predicate<?>>> predicates,
-            Collection<PluginDesc<ConfigProvider>> configProviders,
-            Collection<PluginDesc<ConnectRestExtension>> restExtensions,
-            Collection<PluginDesc<ConnectorClientConfigOverridePolicy>> connectorClientConfigPolicies
+            SortedSet<PluginDesc<SinkConnector>> sinkConnectors,
+            SortedSet<PluginDesc<SourceConnector>> sourceConnectors,
+            SortedSet<PluginDesc<Converter>> converters,
+            SortedSet<PluginDesc<HeaderConverter>> headerConverters,
+            SortedSet<PluginDesc<Transformation<?>>> transformations,
+            SortedSet<PluginDesc<Predicate<?>>> predicates,
+            SortedSet<PluginDesc<ConfigProvider>> configProviders,
+            SortedSet<PluginDesc<ConnectRestExtension>> restExtensions,
+            SortedSet<PluginDesc<ConnectorClientConfigOverridePolicy>> connectorClientConfigPolicies
     ) {
         this.sinkConnectors = sinkConnectors;
         this.sourceConnectors = sourceConnectors;
@@ -68,45 +71,88 @@ public class PluginScanResult {
                           connectorClientConfigPolicies);
     }
 
-    public Collection<PluginDesc<SinkConnector>> sinkConnectors() {
+    /**
+     * Merge one or more {@link PluginScanResult results} into one result object
+     */
+    public PluginScanResult(List<PluginScanResult> results) {
+        this(
+                merge(results, PluginScanResult::sinkConnectors),
+                merge(results, PluginScanResult::sourceConnectors),
+                merge(results, PluginScanResult::converters),
+                merge(results, PluginScanResult::headerConverters),
+                merge(results, PluginScanResult::transformations),
+                merge(results, PluginScanResult::predicates),
+                merge(results, PluginScanResult::configProviders),
+                merge(results, PluginScanResult::restExtensions),
+                merge(results, PluginScanResult::connectorClientConfigPolicies)
+        );
+    }
+
+    private static <T, R extends Comparable<R>> SortedSet<R> merge(List<T> results, Function<T, SortedSet<R>> accessor) {
+        SortedSet<R> merged = new TreeSet<>();
+        for (T element : results) {
+            merged.addAll(accessor.apply(element));
+        }
+        return merged;
+    }
+
+    public SortedSet<PluginDesc<SinkConnector>> sinkConnectors() {
         return sinkConnectors;
     }
 
-    public Collection<PluginDesc<SourceConnector>> sourceConnectors() {
+    public SortedSet<PluginDesc<SourceConnector>> sourceConnectors() {
         return sourceConnectors;
     }
 
-    public Collection<PluginDesc<Converter>> converters() {
+    public SortedSet<PluginDesc<Converter>> converters() {
         return converters;
     }
 
-    public Collection<PluginDesc<HeaderConverter>> headerConverters() {
+    public SortedSet<PluginDesc<HeaderConverter>> headerConverters() {
         return headerConverters;
     }
 
-    public Collection<PluginDesc<Transformation<?>>> transformations() {
+    public SortedSet<PluginDesc<Transformation<?>>> transformations() {
         return transformations;
     }
 
-    public Collection<PluginDesc<Predicate<?>>> predicates() {
+    public SortedSet<PluginDesc<Predicate<?>>> predicates() {
         return predicates;
     }
 
-    public Collection<PluginDesc<ConfigProvider>> configProviders() {
+    public SortedSet<PluginDesc<ConfigProvider>> configProviders() {
         return configProviders;
     }
 
-    public Collection<PluginDesc<ConnectRestExtension>> restExtensions() {
+    public SortedSet<PluginDesc<ConnectRestExtension>> restExtensions() {
         return restExtensions;
     }
 
-    public Collection<PluginDesc<ConnectorClientConfigOverridePolicy>> connectorClientConfigPolicies() {
+    public SortedSet<PluginDesc<ConnectorClientConfigOverridePolicy>> connectorClientConfigPolicies() {
         return connectorClientConfigPolicies;
+    }
+
+    public void forEach(Consumer<PluginDesc<?>> consumer) {
+        forEach(sinkConnectors(), consumer);
+        forEach(sourceConnectors(), consumer);
+        forEach(converters(), consumer);
+        forEach(headerConverters(), consumer);
+        forEach(transformations(), consumer);
+        forEach(predicates(), consumer);
+        forEach(configProviders(), consumer);
+        forEach(restExtensions(), consumer);
+        forEach(connectorClientConfigPolicies(), consumer);
+    }
+
+    private static <T> void forEach(SortedSet<PluginDesc<T>> set, Consumer<PluginDesc<?>> consumer) {
+        for (PluginDesc<T> plugin : set) {
+            consumer.accept(plugin);
+        }
     }
 
     public boolean isEmpty() {
         boolean isEmpty = true;
-        for (Collection<?> plugins : allPlugins) {
+        for (SortedSet<?> plugins : allPlugins) {
             isEmpty = isEmpty && plugins.isEmpty();
         }
         return isEmpty;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanResult.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanResult.java
@@ -44,7 +44,7 @@ public class PluginScanResult {
     private final SortedSet<PluginDesc<ConnectRestExtension>> restExtensions;
     private final SortedSet<PluginDesc<ConnectorClientConfigOverridePolicy>> connectorClientConfigPolicies;
 
-    private final List<SortedSet<?>> allPlugins;
+    private final List<SortedSet<? extends PluginDesc<?>>> allPlugins;
 
     public PluginScanResult(
             SortedSet<PluginDesc<SinkConnector>> sinkConnectors,
@@ -88,9 +88,9 @@ public class PluginScanResult {
         );
     }
 
-    private static <T, R extends Comparable<R>> SortedSet<R> merge(List<T> results, Function<T, SortedSet<R>> accessor) {
+    private static <R extends Comparable<R>> SortedSet<R> merge(List<PluginScanResult> results, Function<PluginScanResult, SortedSet<R>> accessor) {
         SortedSet<R> merged = new TreeSet<>();
-        for (T element : results) {
+        for (PluginScanResult element : results) {
             merged.addAll(accessor.apply(element));
         }
         return merged;
@@ -133,21 +133,7 @@ public class PluginScanResult {
     }
 
     public void forEach(Consumer<PluginDesc<?>> consumer) {
-        forEach(sinkConnectors(), consumer);
-        forEach(sourceConnectors(), consumer);
-        forEach(converters(), consumer);
-        forEach(headerConverters(), consumer);
-        forEach(transformations(), consumer);
-        forEach(predicates(), consumer);
-        forEach(configProviders(), consumer);
-        forEach(restExtensions(), consumer);
-        forEach(connectorClientConfigPolicies(), consumer);
-    }
-
-    private static <T> void forEach(SortedSet<PluginDesc<T>> set, Consumer<PluginDesc<?>> consumer) {
-        for (PluginDesc<T> plugin : set) {
-            consumer.accept(plugin);
-        }
+        allPlugins.forEach(plugins -> plugins.forEach(consumer));
     }
 
     public boolean isEmpty() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanResult.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanResult.java
@@ -67,8 +67,8 @@ public class PluginScanResult {
         this.restExtensions = restExtensions;
         this.connectorClientConfigPolicies = connectorClientConfigPolicies;
         this.allPlugins =
-            Arrays.asList(sinkConnectors, sourceConnectors, converters, headerConverters, transformations, configProviders,
-                          connectorClientConfigPolicies);
+            Arrays.asList(sinkConnectors, sourceConnectors, converters, headerConverters, transformations, predicates,
+                    configProviders, restExtensions, connectorClientConfigPolicies);
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -375,7 +375,7 @@ public class PluginUtils {
             if (classNames.size() == 1) {
                 aliases.put(alias, classNames.stream().findAny().get());
             } else {
-                log.warn("Ambiguous alias '{}' refers to multiple distinct plugins {}: ignoring", alias, classNames);
+                log.warn("Ignoring ambiguous alias '{}' since it refers to multiple distinct plugins {}", alias, classNames);
             }
         }
         return aliases;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -36,12 +36,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.function.BiFunction;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Connect plugin utility methods.

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginDescTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginDescTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.sink.SinkConnector;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -223,6 +224,20 @@ public class PluginDescTest {
         );
 
         assertNewer(transformDescPluginPath, transformDescClasspath);
+
+        PluginDesc<Predicate> predicateDescPluginPath = new PluginDesc<>(
+                Predicate.class,
+                regularVersion,
+                pluginLoader
+        );
+
+        PluginDesc<Predicate> predicateDescClasspath = new PluginDesc<>(
+                Predicate.class,
+                regularVersion,
+                systemLoader
+        );
+
+        assertNewer(predicateDescPluginPath, predicateDescClasspath);
     }
 
     private static <T> void assertPluginDesc(

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
@@ -39,6 +39,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
@@ -524,15 +525,16 @@ public class PluginUtilsTest {
                 Collections.emptySortedSet()
         );
         Map<String, String> aliases = PluginUtils.computeAliases(result);
-        assertFalse(aliases.containsKey("Mock"));
-        assertEquals(MockSinkConnector.class.getName(), aliases.get("MockSinkConnector"));
-        assertEquals(MockSinkConnector.class.getName(), aliases.get("MockSink"));
-        assertEquals(MockSourceConnector.class.getName(), aliases.get("MockSourceConnector"));
-        assertEquals(MockSourceConnector.class.getName(), aliases.get("MockSource"));
-        assertEquals(CollidingConverter.class.getName(), aliases.get("CollidingConverter"));
-        assertEquals(CollidingConverter.class.getName(), aliases.get("Colliding"));
+        Map<String, String> actualAliases = PluginUtils.computeAliases(result);
+        Map<String, String> expectedAliases = new HashMap<>();
+        expectedAliases.put("MockSinkConnector", MockSinkConnector.class.getName());
+        expectedAliases.put("MockSink", MockSinkConnector.class.getName());
+        expectedAliases.put("MockSourceConnector", MockSourceConnector.class.getName());
+        expectedAliases.put("MockSource", MockSourceConnector.class.getName());
+        expectedAliases.put("CollidingConverter", CollidingConverter.class.getName());
+        expectedAliases.put("Colliding", CollidingConverter.class.getName());
+        assertEquals(expectedAliases, actualAliases);
     }
-
 
     @Test
     public void testMultiVersionAlias() {
@@ -552,9 +554,11 @@ public class PluginUtilsTest {
                 Collections.emptySortedSet(),
                 Collections.emptySortedSet()
         );
-        Map<String, String> aliases = PluginUtils.computeAliases(result);
-        assertEquals(MockSinkConnector.class.getName(), aliases.get("MockSinkConnector"));
-        assertEquals(MockSinkConnector.class.getName(), aliases.get("MockSink"));
+        Map<String, String> actualAliases = PluginUtils.computeAliases(result);
+        Map<String, String> expectedAliases = new HashMap<>();
+        expectedAliases.put("MockSinkConnector", MockSinkConnector.class.getName());
+        expectedAliases.put("MockSink", MockSinkConnector.class.getName());
+        assertEquals(expectedAliases, actualAliases);
     }
 
     @Test
@@ -574,10 +578,11 @@ public class PluginUtilsTest {
                 Collections.emptySortedSet(),
                 Collections.emptySortedSet()
         );
-        Map<String, String> aliases = PluginUtils.computeAliases(result);
-        assertEquals(CollidingConverter.class.getName(), aliases.get("CollidingConverter"));
-        assertEquals(CollidingHeaderConverter.class.getName(), aliases.get("CollidingHeaderConverter"));
-        assertFalse(aliases.containsKey("Colliding"));
+        Map<String, String> actualAliases = PluginUtils.computeAliases(result);
+        Map<String, String> expectedAliases = new HashMap<>();
+        expectedAliases.put("CollidingConverter", CollidingConverter.class.getName());
+        expectedAliases.put("CollidingHeaderConverter", CollidingHeaderConverter.class.getName());
+        assertEquals(expectedAliases, actualAliases);
     }
 
     @SuppressWarnings("unchecked")
@@ -598,9 +603,10 @@ public class PluginUtilsTest {
                 Collections.emptySortedSet(),
                 Collections.emptySortedSet()
         );
-        Map<String, String> aliases = PluginUtils.computeAliases(result);
-        assertEquals(CollidingConverter.class.getName(), aliases.get("CollidingConverter"));
-        assertFalse(aliases.containsKey("Colliding"));
+        Map<String, String> actualAliases = PluginUtils.computeAliases(result);
+        Map<String, String> expectedAliases = new HashMap<>();
+        expectedAliases.put("CollidingConverter", CollidingConverter.class.getName());
+        assertEquals(expectedAliases, actualAliases);
     }
 
     public static class CollidingConverter implements Converter {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
@@ -16,6 +16,17 @@
  */
 package org.apache.kafka.connect.runtime.isolation;
 
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.sink.SinkConnector;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.apache.kafka.connect.tools.MockSinkConnector;
+import org.apache.kafka.connect.tools.MockSourceConnector;
+import org.apache.kafka.connect.transforms.Transformation;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,6 +40,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -488,6 +502,168 @@ public class PluginUtilsTest {
         );
 
         assertUrls(expectedUrls, PluginUtils.pluginUrls(pluginPath));
+    }
+
+    @Test
+    public void testNonCollidingAliases() {
+        SortedSet<PluginDesc<SinkConnector>> sinkConnectors = new TreeSet<>();
+        sinkConnectors.add(new PluginDesc<>(MockSinkConnector.class, null, MockSinkConnector.class.getClassLoader()));
+        SortedSet<PluginDesc<SourceConnector>> sourceConnectors = new TreeSet<>();
+        sourceConnectors.add(new PluginDesc<>(MockSourceConnector.class, null, MockSourceConnector.class.getClassLoader()));
+        SortedSet<PluginDesc<Converter>> converters = new TreeSet<>();
+        converters.add(new PluginDesc<>(CollidingConverter.class, null, CollidingConverter.class.getClassLoader()));
+        PluginScanResult result = new PluginScanResult(
+                sinkConnectors,
+                sourceConnectors,
+                converters,
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet()
+        );
+        Map<String, String> aliases = PluginUtils.computeAliases(result);
+        assertFalse(aliases.containsKey("Mock"));
+        assertEquals(MockSinkConnector.class.getName(), aliases.get("MockSinkConnector"));
+        assertEquals(MockSinkConnector.class.getName(), aliases.get("MockSink"));
+        assertEquals(MockSourceConnector.class.getName(), aliases.get("MockSourceConnector"));
+        assertEquals(MockSourceConnector.class.getName(), aliases.get("MockSource"));
+        assertEquals(CollidingConverter.class.getName(), aliases.get("CollidingConverter"));
+        assertEquals(CollidingConverter.class.getName(), aliases.get("Colliding"));
+    }
+
+
+    @Test
+    public void testMultiVersionAlias() {
+        SortedSet<PluginDesc<SinkConnector>> sinkConnectors = new TreeSet<>();
+        // distinct versions don't cause an alias collision (the class name is the same)
+        sinkConnectors.add(new PluginDesc<>(MockSinkConnector.class, null, MockSinkConnector.class.getClassLoader()));
+        sinkConnectors.add(new PluginDesc<>(MockSinkConnector.class, "1.0", MockSinkConnector.class.getClassLoader()));
+        assertEquals(2, sinkConnectors.size());
+        PluginScanResult result = new PluginScanResult(
+                sinkConnectors,
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet()
+        );
+        Map<String, String> aliases = PluginUtils.computeAliases(result);
+        assertEquals(MockSinkConnector.class.getName(), aliases.get("MockSinkConnector"));
+        assertEquals(MockSinkConnector.class.getName(), aliases.get("MockSink"));
+    }
+
+    @Test
+    public void testCollidingPrunedAlias() {
+        SortedSet<PluginDesc<Converter>> converters = new TreeSet<>();
+        converters.add(new PluginDesc<>(CollidingConverter.class, null, CollidingConverter.class.getClassLoader()));
+        SortedSet<PluginDesc<HeaderConverter>> headerConverters = new TreeSet<>();
+        headerConverters.add(new PluginDesc<>(CollidingHeaderConverter.class, null, CollidingHeaderConverter.class.getClassLoader()));
+        PluginScanResult result = new PluginScanResult(
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                converters,
+                headerConverters,
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet()
+        );
+        Map<String, String> aliases = PluginUtils.computeAliases(result);
+        assertEquals(CollidingConverter.class.getName(), aliases.get("CollidingConverter"));
+        assertEquals(CollidingHeaderConverter.class.getName(), aliases.get("CollidingHeaderConverter"));
+        assertFalse(aliases.containsKey("Colliding"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testCollidingSimpleAlias() {
+        SortedSet<PluginDesc<Converter>> converters = new TreeSet<>();
+        converters.add(new PluginDesc<>(CollidingConverter.class, null, CollidingConverter.class.getClassLoader()));
+        SortedSet<PluginDesc<Transformation<?>>> transformations = new TreeSet<>();
+        transformations.add(new PluginDesc<>((Class<? extends Transformation<?>>) (Class<?>) Colliding.class, null, Colliding.class.getClassLoader()));
+        PluginScanResult result = new PluginScanResult(
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                converters,
+                Collections.emptySortedSet(),
+                transformations,
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet()
+        );
+        Map<String, String> aliases = PluginUtils.computeAliases(result);
+        assertEquals(CollidingConverter.class.getName(), aliases.get("CollidingConverter"));
+        assertFalse(aliases.containsKey("Colliding"));
+    }
+
+    public static class CollidingConverter implements Converter {
+        @Override
+        public void configure(Map<String, ?> configs, boolean isKey) {
+        }
+
+        @Override
+        public byte[] fromConnectData(String topic, Schema schema, Object value) {
+            return new byte[0];
+        }
+
+        @Override
+        public SchemaAndValue toConnectData(String topic, byte[] value) {
+            return null;
+        }
+    }
+
+    public static class CollidingHeaderConverter implements HeaderConverter {
+
+        @Override
+        public SchemaAndValue toConnectHeader(String topic, String headerKey, byte[] value) {
+            return null;
+        }
+
+        @Override
+        public byte[] fromConnectHeader(String topic, String headerKey, Schema schema, Object value) {
+            return new byte[0];
+        }
+
+        @Override
+        public ConfigDef config() {
+            return null;
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs) {
+        }
+    }
+
+    public static class Colliding<R extends ConnectRecord<R>> implements Transformation<R> {
+
+        @Override
+        public void configure(Map<String, ?> configs) {
+        }
+
+        @Override
+        public R apply(R record) {
+            return null;
+        }
+
+        @Override
+        public ConfigDef config() {
+            return null;
+        }
+
+        @Override
+        public void close() {
+        }
     }
 
     private void createBasicDirectoryLayout() throws IOException {


### PR DESCRIPTION
The DelegatingClassLoader has a large number of fields and methods for keeping track of known PluginDesc objects. It has this in common with the PluginScanResult data object, which has a similar set of fields and methods. On trunk, the PluginScanResult is only used as a return value of one internal function, before it's results are accumulated by the DCL and discarded. To simplify the DCL, we should use the PluginScanResult object as a container to store and accumulate PluginDesc objects, and return it to the caller to allow them to inspect the scanned plugins without interacting with the DCL.

Using the PluginScanResult as an accumulator, we can delay writing scan results to the pluginLoaders and aliases fields until after all scanning has taken place. This is done via the new installDiscoveredPlugins method. This prevents plugins being scanned from having an inconsistent delegation path: Previously, because the accumulators were updated as scanning proceeded, plugins may or may not be able to see one another via the DelegatingClassLoader::loadClass method. Now, plugins will _not_ be able to see one another before installDiscoveredPlugins is applied and scanning is finished.

This is a first-pass refactor, before pulling the scanning logic out of the DCL to further simplify it. Once external scanning is complete, the caller will call installDiscoveredPlugins to finish initialization of the DCL.

In the trunk implementation, there is some order-sensitivity to the scanning process because of the accumulator fields. In particular: 
1. Because the classpath is scanned last, plugins on the classpath automatically take precedence over isolated plugins. In order to replicate this effect, PluginDesc objects now explicitly compare their isolated/non-isolated nature, and order classpath plugins first.
2. The alias mechanism attempts to determine if aliases are unique, but on trunk it allows colliding aliases from different plugin types to overwrite one another. This is changed to prevent alias collisions across plugin types, now that the iteration over PluginDesc objects isn't grouped by plugin type.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
