### PR TITLE
MINOR: Add helper util `Snapshots.lastContainedLogTimestamp`

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -26,7 +26,6 @@ import org.apache.kafka.common.record.{MemoryRecords, Records}
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.{KafkaException, TopicPartition, Uuid}
 import org.apache.kafka.raft.{Isolation, KafkaRaftClient, LogAppendInfo, LogFetchInfo, LogOffsetMetadata, OffsetAndEpoch, OffsetMetadata, ReplicatedLog, ValidOffsetAndEpoch}
-import org.apache.kafka.server.common.serialization.RecordSerde
 import org.apache.kafka.server.util.Scheduler
 import org.apache.kafka.snapshot.{FileRawSnapshotReader, FileRawSnapshotWriter, RawSnapshotReader, RawSnapshotWriter, SnapshotPath, Snapshots}
 import org.apache.kafka.storage.internals
@@ -41,7 +40,6 @@ import scala.compat.java8.OptionConverters._
 
 final class KafkaMetadataLog private (
   val log: UnifiedLog,
-  recordSerde: RecordSerde[_],
   time: Time,
   scheduler: Scheduler,
   // Access to this object needs to be synchronized because it is used by the snapshotting thread to notify the
@@ -549,7 +547,6 @@ object KafkaMetadataLog extends Logging {
     topicPartition: TopicPartition,
     topicId: Uuid,
     dataDir: File,
-    recordSerde: RecordSerde[_],
     time: Time,
     scheduler: Scheduler,
     config: MetadataLogConfig
@@ -599,7 +596,6 @@ object KafkaMetadataLog extends Logging {
 
     val metadataLog = new KafkaMetadataLog(
       log,
-      recordSerde,
       time,
       scheduler,
       recoverSnapshots(log),

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -264,7 +264,6 @@ class KafkaRaftManager[T](
       topicPartition,
       topicId,
       dataDir,
-      recordSerde,
       time,
       scheduler,
       config = MetadataLogConfig(config, KafkaRaftClient.MAX_BATCH_SIZE_BYTES, KafkaRaftClient.MAX_FETCH_SIZE_BYTES)

--- a/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
@@ -1041,7 +1041,6 @@ object KafkaMetadataLogTest {
       KafkaRaftServer.MetadataPartition,
       KafkaRaftServer.MetadataTopicId,
       logDir,
-      new ByteArraySerde,
       time,
       time.scheduler,
       metadataLogConfig

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -303,7 +303,6 @@ class DumpLogSegmentsTest {
       KafkaRaftServer.MetadataPartition,
       KafkaRaftServer.MetadataTopicId,
       logDir,
-      MetadataRecordSerde.INSTANCE,
       time,
       time.scheduler,
       MetadataLogConfig(

--- a/raft/src/main/java/org/apache/kafka/raft/internals/IdentitySerde.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/IdentitySerde.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.protocol.Readable;
+import org.apache.kafka.common.protocol.Writable;
+import org.apache.kafka.server.common.serialization.RecordSerde;
+
+import java.nio.ByteBuffer;
+
+public class IdentitySerde implements RecordSerde<ByteBuffer> {
+    @Override
+    public int recordSize(final ByteBuffer data, final ObjectSerializationCache serializationCache) {
+        return data.remaining();
+    }
+
+    @Override
+    public void write(final ByteBuffer data, final ObjectSerializationCache serializationCache, final Writable out) {
+        out.writeByteBuffer(data);
+    }
+
+    @Override
+    public ByteBuffer read(final Readable input, final int size) {
+        return input.readByteBuffer(size);
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/internals/IdentitySerde.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/IdentitySerde.java
@@ -24,6 +24,8 @@ import org.apache.kafka.server.common.serialization.RecordSerde;
 import java.nio.ByteBuffer;
 
 public class IdentitySerde implements RecordSerde<ByteBuffer> {
+    public static final IdentitySerde INSTANCE = new IdentitySerde();
+
     @Override
     public int recordSize(final ByteBuffer data, final ObjectSerializationCache serializationCache) {
         return data.remaining();

--- a/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
@@ -16,13 +16,17 @@
  */
 package org.apache.kafka.snapshot;
 
+import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.raft.KafkaRaftClient;
 import org.apache.kafka.raft.OffsetAndEpoch;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.raft.internals.IdentitySerde;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.NumberFormat;
@@ -149,6 +153,26 @@ public final class Snapshots {
                 ),
                 e
             );
+        }
+    }
+
+    public static long lastContainedLogTimestamp(RawSnapshotReader reader) {
+        try (RecordsSnapshotReader<ByteBuffer> recordsSnapshotReader =
+                 RecordsSnapshotReader.of(
+                     reader,
+                     new IdentitySerde(),
+                     new BufferSupplier.GrowableBufferSupplier(),
+                     KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
+                     true
+                 )
+        ) {
+            return recordsSnapshotReader.lastContainedLogTimestamp();
+        }
+    }
+
+    public static long lastContainedLogTimestamp(Path logDir, OffsetAndEpoch snapshotId) {
+        try (FileRawSnapshotReader reader = FileRawSnapshotReader.open(logDir, snapshotId)) {
+            return lastContainedLogTimestamp(reader);
         }
     }
 }

--- a/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
@@ -160,7 +160,7 @@ public final class Snapshots {
         try (RecordsSnapshotReader<ByteBuffer> recordsSnapshotReader =
              RecordsSnapshotReader.of(
                  reader,
-                 new IdentitySerde(),
+                 IdentitySerde.INSTANCE,
                  new BufferSupplier.GrowableBufferSupplier(),
                  KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
                  true

--- a/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
@@ -158,13 +158,13 @@ public final class Snapshots {
 
     public static long lastContainedLogTimestamp(RawSnapshotReader reader) {
         try (RecordsSnapshotReader<ByteBuffer> recordsSnapshotReader =
-                 RecordsSnapshotReader.of(
-                     reader,
-                     new IdentitySerde(),
-                     new BufferSupplier.GrowableBufferSupplier(),
-                     KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
-                     true
-                 )
+             RecordsSnapshotReader.of(
+                 reader,
+                 new IdentitySerde(),
+                 new BufferSupplier.GrowableBufferSupplier(),
+                 KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
+                 true
+             )
         ) {
             return recordsSnapshotReader.lastContainedLogTimestamp();
         }

--- a/raft/src/test/java/org/apache/kafka/snapshot/SnapshotWriterReaderTest.java
+++ b/raft/src/test/java/org/apache/kafka/snapshot/SnapshotWriterReaderTest.java
@@ -95,7 +95,6 @@ final public class SnapshotWriterReaderTest {
         RaftClientTestContext context = contextBuilder.build();
 
         context.pollUntil(() -> context.currentLeader().equals(OptionalInt.of(localId)));
-        int epoch = context.currentEpoch();
 
         context.advanceLocalLeaderHighWatermarkToLogEndOffset();
 
@@ -110,6 +109,8 @@ final public class SnapshotWriterReaderTest {
             int recordCount = validateDelimiters(snapshot, magicTimestamp);
             assertEquals((recordsPerBatch * batches) + delimiterCount, recordCount);
             assertSnapshot(expected, reader);
+
+            assertEquals(magicTimestamp, Snapshots.lastContainedLogTimestamp(snapshot));
         }
     }
 
@@ -127,7 +128,6 @@ final public class SnapshotWriterReaderTest {
         RaftClientTestContext context = contextBuilder.build();
 
         context.pollUntil(() -> context.currentLeader().equals(OptionalInt.of(localId)));
-        int epoch = context.currentEpoch();
 
         context.advanceLocalLeaderHighWatermarkToLogEndOffset();
 
@@ -155,7 +155,6 @@ final public class SnapshotWriterReaderTest {
         RaftClientTestContext context = contextBuilder.build();
 
         context.pollUntil(() -> context.currentLeader().equals(OptionalInt.of(localId)));
-        int epoch = context.currentEpoch();
 
         context.advanceLocalLeaderHighWatermarkToLogEndOffset();
 


### PR DESCRIPTION
This PR refactors the `lastContainedLogTimestamp` to the Snapshots class, for reusability
- Introduces `IdentitySerde` based on ByteBuffer, required for using RecordsSnapshotReader
- As a result we also remove `recordSerde: RecordSerde[_]` argument from the `KafkaMetadataLog` constructor
- In addition, we also remove an unused variable in `SnapshotWriterReaderTest.java`

Testing:
Enhanced existing unit test `testWritingSnapshot` for testing

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
