### PR TITLE
KAFKA-15034: Improve performance of the ReplaceField SMT; add JMH benchmark

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2537,6 +2537,8 @@ project(':jmh-benchmarks') {
     implementation project(':storage')
     implementation project(':streams')
     implementation project(':core')
+    implementation project(':connect:api')
+    implementation project(':connect:transforms')
     implementation project(':clients').sourceSets.test.output
     implementation project(':core').sourceSets.test.output
 

--- a/checkstyle/import-control-jmh-benchmarks.xml
+++ b/checkstyle/import-control-jmh-benchmarks.xml
@@ -54,6 +54,7 @@
     <allow pkg="org.apache.kafka.image"/>
     <allow pkg="org.apache.kafka.metadata"/>
     <allow pkg="org.apache.kafka.timeline" />
+    <allow pkg="org.apache.kafka.connect" />
 
     <subpackage name="cache">
     </subpackage>

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ReplaceField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ReplaceField.java
@@ -33,8 +33,10 @@ import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
@@ -80,8 +82,8 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
 
     private static final String PURPOSE = "field replacement";
 
-    private List<String> exclude;
-    private List<String> include;
+    private Set<String> exclude;
+    private Set<String> include;
     private Map<String, String> renames;
     private Map<String, String> reverseRenames;
 
@@ -94,8 +96,8 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
             {ConfigName.EXCLUDE, "blacklist"},
         }));
 
-        exclude = config.getList(ConfigName.EXCLUDE);
-        include = config.getList(ConfigName.INCLUDE);
+        exclude = new HashSet<>(config.getList(ConfigName.EXCLUDE));
+        include = new HashSet<>(config.getList(ConfigName.INCLUDE));
         renames = parseRenameMappings(config.getList(ConfigName.RENAME));
         reverseRenames = invert(renames);
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/connect/ReplaceFieldBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/connect/ReplaceFieldBenchmark.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.connect;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.transforms.ReplaceField;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+
+/**
+ * This benchmark tests the performance of the {@link ReplaceField} {@link org.apache.kafka.connect.transforms.Transformation SMT}
+ * when configured with a large number of include and exclude fields and applied on a {@link SourceRecord} containing a similarly
+ * large number of fields.
+ */
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class ReplaceFieldBenchmark {
+
+    @Param({"100", "1000", "10000"})
+    private int fieldCount;
+    private ReplaceField<SourceRecord> replaceFieldSmt;
+    private SourceRecord record;
+
+    @Setup
+    public void setup() {
+        this.replaceFieldSmt = new ReplaceField.Value<>();
+        Map<String, String> replaceFieldConfigs = new HashMap<>();
+        replaceFieldConfigs.put("exclude",
+                IntStream.range(0, fieldCount).filter(x -> (x & 1) == 0).mapToObj(x -> "Field-" + x).collect(Collectors.joining(",")));
+        replaceFieldConfigs.put("include",
+                IntStream.range(0, fieldCount).filter(x -> (x & 1) == 1).mapToObj(x -> "Field-" + x).collect(Collectors.joining(",")));
+        replaceFieldSmt.configure(replaceFieldConfigs);
+
+        Map<String, Object> value = new HashMap<>();
+        IntStream.range(0, fieldCount).forEach(x -> value.put("Field-" + x, new Object()));
+        this.record = new SourceRecord(null, null, null, null, null, value);
+    }
+
+    @Benchmark
+    public void includeExcludeReplaceFieldBenchmark() {
+        replaceFieldSmt.apply(record);
+    }
+}

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/connect/ReplaceFieldBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/connect/ReplaceFieldBenchmark.java
@@ -53,7 +53,9 @@ import java.util.stream.IntStream;
 public class ReplaceFieldBenchmark {
 
     @Param({"100", "1000", "10000"})
-    private int fieldCount;
+    private int valueFieldCount;
+    @Param({"1", "100", "10000"})
+    private int includeExcludeFieldCount;
     private ReplaceField<SourceRecord> replaceFieldSmt;
     private SourceRecord record;
 
@@ -62,13 +64,13 @@ public class ReplaceFieldBenchmark {
         this.replaceFieldSmt = new ReplaceField.Value<>();
         Map<String, String> replaceFieldConfigs = new HashMap<>();
         replaceFieldConfigs.put("exclude",
-                IntStream.range(0, fieldCount).filter(x -> (x & 1) == 0).mapToObj(x -> "Field-" + x).collect(Collectors.joining(",")));
+                IntStream.range(0, 2 * includeExcludeFieldCount).filter(x -> (x & 1) == 0).mapToObj(x -> "Field-" + x).collect(Collectors.joining(",")));
         replaceFieldConfigs.put("include",
-                IntStream.range(0, fieldCount).filter(x -> (x & 1) == 1).mapToObj(x -> "Field-" + x).collect(Collectors.joining(",")));
+                IntStream.range(0, 2 * includeExcludeFieldCount).filter(x -> (x & 1) == 1).mapToObj(x -> "Field-" + x).collect(Collectors.joining(",")));
         replaceFieldSmt.configure(replaceFieldConfigs);
 
         Map<String, Object> value = new HashMap<>();
-        IntStream.range(0, fieldCount).forEach(x -> value.put("Field-" + x, new Object()));
+        IntStream.range(0, valueFieldCount).forEach(x -> value.put("Field-" + x, new Object()));
         this.record = new SourceRecord(null, null, null, null, null, value);
     }
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/connect/ReplaceFieldBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/connect/ReplaceFieldBenchmark.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.transforms.ReplaceField;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -56,7 +57,7 @@ public class ReplaceFieldBenchmark {
     private ReplaceField<SourceRecord> replaceFieldSmt;
     private SourceRecord record;
 
-    @Setup
+    @Setup(Level.Trial)
     public void setup() {
         this.replaceFieldSmt = new ReplaceField.Value<>();
         Map<String, String> replaceFieldConfigs = new HashMap<>();


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/KAFKA-15034
- The `ReplaceField` SMT can be configured with a list of fields that are to be included or excluded during every record transformation.
- Currently, it uses an `ArrayList` for these fields which causes the filter operations to be of O(N) complexity resulting in poor performance when configured with a large number of include / exclude fields.
- This patch refactors it to use a `HashSet` instead (O(1) expected time complexity) and adds a JMH benchmark to demonstrate the performance improvements.


## JMH Benchmark Result Before (`ArrayList` based implementation):

```
Benchmark                                                  (includeExcludeFieldCount)  (valueFieldCount)  Mode  Cnt          Score         Error  Units
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                           1                100  avgt    5        928.115 ±      20.251  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                           1               1000  avgt    5      10380.401 ±     286.643  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                           1              10000  avgt    5      97058.104 ±    3834.409  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                         100                100  avgt    5      15052.629 ±     112.337  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                         100               1000  avgt    5     301212.390 ±    6400.402  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                         100              10000  avgt    5    2218226.090 ±   38198.098  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                       10000                100  avgt    5     582789.404 ±   11436.565  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                       10000               1000  avgt    5    6263588.619 ±  530370.435  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                       10000              10000  avgt    5  133424024.627 ± 9497024.791  ns/op
```

## JMH Benchmark Result After (`HashSet` based implementation):

```
Benchmark                                                  (includeExcludeFieldCount)  (valueFieldCount)  Mode  Cnt       Score      Error  Units
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                           1                100  avgt    5    1205.928 ±   32.611  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                           1               1000  avgt    5   10124.067 ±  212.876  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                           1              10000  avgt    5  105143.540 ± 1813.534  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                         100                100  avgt    5    1602.392 ±   15.756  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                         100               1000  avgt    5   11543.659 ±  193.129  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                         100              10000  avgt    5  171689.002 ± 5691.014  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                       10000                100  avgt    5    1686.155 ±   21.922  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                       10000               1000  avgt    5   20584.457 ±  429.614  ns/op
ReplaceFieldBenchmark.includeExcludeReplaceFieldBenchmark                       10000              10000  avgt    5  221015.401 ± 8108.798  ns/op
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
