### PR TITLE
KAFKA-15036: Add a test case for controller failover

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -32,6 +32,7 @@ import kafka.utils.{CoreUtils, Logging, PasswordEncoder}
 import kafka.zk.{KafkaZkClient, ZkMigrationClient}
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
+import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
 import org.apache.kafka.common.utils.LogContext
@@ -182,7 +183,8 @@ class ControllerServer(
       tokenCache = new DelegationTokenCache(ScramMechanism.mechanismNames)
       credentialProvider = new CredentialProvider(ScramMechanism.mechanismNames, tokenCache)
       socketServer = new SocketServer(config,
-        metrics,
+        // metrics will be null when restarting a controller, this will only happen in test.
+        if (metrics == null) new Metrics() else metrics,
         time,
         credentialProvider,
         apiVersionManager)

--- a/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KRaftClusterTest.scala
@@ -80,7 +80,7 @@ class KRaftClusterTest {
   }
 
   @Test
-  def testCreateClusterAndRestartNode(): Unit = {
+  def testCreateClusterAndRestartBrokerNode(): Unit = {
     val cluster = new KafkaClusterTestKit.Builder(
       new TestKitNodes.Builder().
         setNumBrokerNodes(1).
@@ -91,6 +91,32 @@ class KRaftClusterTest {
       val broker = cluster.brokers().values().iterator().next()
       broker.shutdown()
       broker.startup()
+    } finally {
+      cluster.close()
+    }
+  }
+
+  @Test
+  def testCreateClusterAndRestartControllerNode(): Unit = {
+    val cluster = new KafkaClusterTestKit.Builder(
+      new TestKitNodes.Builder().
+        setNumBrokerNodes(1).
+        setNumControllerNodes(2).build()).build()
+    try {
+      cluster.format()
+      cluster.startup()
+      val controller = cluster.controllers().values().iterator().asScala.filter(_.controller.isActive).next()
+      val port = controller.socketServer.boundPort(controller.config.controllerListeners.head.listenerName)
+
+      // shutdown active controller
+      controller.shutdown()
+      // Rewrite The `listeners` config to avoid controller socket server init using different port
+      val config = controller.sharedServer.controllerConfig.props
+      config.asInstanceOf[java.util.HashMap[String,String]].put(KafkaConfig.ListenersProp, s"CONTROLLER://localhost:$port")
+      controller.sharedServer.controllerConfig.updateCurrentConfig(new KafkaConfig(config))
+
+      // restart controller
+      controller.startup()
     } finally {
       cluster.close()
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -2028,9 +2028,9 @@ public final class QuorumController implements Controller {
         if (lastCommittedOffset == -1) {
             return CompletableFuture.completedFuture(new FinalizedControllerFeatures(Collections.emptyMap(), -1));
         }
-        // It's possible for a standby controller to receiving ApiVersionRequest and we do not have any timeline snapshot
-        // in a standby controller, in this case we use Long.MAX_VALUE.
-        long epoch = isActive() ? lastCommittedOffset : Long.MAX_VALUE;
+        // It's possible for a standby controller to receive ApiVersionRequest and we do not have any timeline snapshot
+        // in a standby controller, in this case we use SnapshotRegistry.LATEST_EPOCH.
+        long epoch = isActive() ? lastCommittedOffset : SnapshotRegistry.LATEST_EPOCH;
         return appendReadEvent("getFinalizedFeatures", context.deadlineNs(),
             () -> featureControl.finalizedFeatures(epoch));
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -2028,8 +2028,11 @@ public final class QuorumController implements Controller {
         if (lastCommittedOffset == -1) {
             return CompletableFuture.completedFuture(new FinalizedControllerFeatures(Collections.emptyMap(), -1));
         }
+        // It's possible for a standby controller to receiving ApiVersionRequest and we do not have any timeline snapshot
+        // in a standby controller, in this case we use Long.MAX_VALUE.
+        long epoch = isActive() ? lastCommittedOffset : Long.MAX_VALUE;
         return appendReadEvent("getFinalizedFeatures", context.deadlineNs(),
-            () -> featureControl.finalizedFeatures(lastCommittedOffset));
+            () -> featureControl.finalizedFeatures(epoch));
     }
 
     @Override


### PR DESCRIPTION
*More detailed description of your change*
We introduced a bug when updating `handleApiVersionRequest` but it's not detected by CI, the bug has been fixed and we should add a test case for controller failover.

*Summary of testing strategy (including rationale)*
KRaftClusterTest.testCreateClusterAndRestartControllerNode()

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
