### PR TITLE
KAFKA-15039: Reduce logging level to trace in PartitionChangeBuilder.…

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -224,19 +224,11 @@ public class PartitionChangeBuilder {
             // so only log clean elections at TRACE level; log unclean elections at INFO level
             // to ensure the message is emitted since an unclean election can lead to data loss.
             if (electionResult.unclean) {
-                log.info(
-                    "Setting new leader for topicId {}, partition {} to {} using an unclean election",
-                    topicId,
-                    partitionId,
-                    electionResult.node
-                );
-            } else if (log.isTraceEnabled()) {
-                log.trace(
-                    "Setting new leader for topicId {}, partition {} to {} using a clean election",
-                    topicId,
-                    partitionId,
-                    electionResult.node
-                );
+                log.info("Setting new leader for topicId {}, partition {} to {} using an unclean election",
+                    topicId, partitionId, electionResult.node);
+            } else {
+                log.trace("Setting new leader for topicId {}, partition {} to {} using a clean election",
+                    topicId, partitionId, electionResult.node);
             }
             record.setLeader(electionResult.node);
             if (electionResult.unclean) {
@@ -250,9 +242,7 @@ public class PartitionChangeBuilder {
                 }
             }
         } else {
-            if (log.isTraceEnabled()) {
-                log.trace("Failed to find a new leader with current state: {}", this);
-            }
+            log.trace("Failed to find a new leader with current state: {}", this);
         }
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -220,13 +220,15 @@ public class PartitionChangeBuilder {
     private void tryElection(PartitionChangeRecord record) {
         ElectionResult electionResult = electLeader();
         if (electionResult.node != partition.leader) {
-            log.debug(
-                "Setting new leader for topicId {}, partition {} to {} using {} election",
-                topicId,
-                partitionId,
-                electionResult.node,
-                electionResult.unclean ? "an unclean" : "a clean"
-            );
+            if (log.isTraceEnabled()) {
+                log.trace(
+                    "Setting new leader for topicId {}, partition {} to {} using {} election",
+                    topicId,
+                    partitionId,
+                    electionResult.node,
+                    electionResult.unclean ? "an unclean" : "a clean"
+                );
+            }
             record.setLeader(electionResult.node);
             if (electionResult.unclean) {
                 // If the election was unclean, we have to forcibly set the ISR to just the
@@ -239,7 +241,9 @@ public class PartitionChangeBuilder {
                 }
             }
         } else {
-            log.debug("Failed to find a new leader with current state: {}", this);
+            if (log.isTraceEnabled()) {
+                log.trace("Failed to find a new leader with current state: {}", this);
+            }
         }
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -221,10 +221,10 @@ public class PartitionChangeBuilder {
         ElectionResult electionResult = electLeader();
         if (electionResult.node != partition.leader) {
             // generating log messages for partition elections can get expensive on large clusters,
-            // so only log clean elections at TRACE level;
-            // log unclean elections at WARN level since doing so can lead to data loss.
+            // so only log clean elections at TRACE level; log unclean elections at INFO level
+            // to ensure the message is emitted since an unclean election can lead to data loss.
             if (electionResult.unclean) {
-                log.warn(
+                log.info(
                     "Setting new leader for topicId {}, partition {} to {} using an unclean election",
                     topicId,
                     partitionId,


### PR DESCRIPTION
…tryElection()

A CPU profile in a large cluster showed PartitionChangeBuilder.tryElection() taking significant CPU due to logging. Decrease the logging statements in that method from debug level to trace to mitigate the impact of this CPU hog under normal operations.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
