### PR TITLE
KAFKA-8713: JsonConverter replace.null.with.default should apply to Struct fields

### DIFF
--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -661,7 +661,7 @@ public class JsonConverter implements Converter, HeaderConverter {
                         throw new DataException("Mismatching schema.");
                     ObjectNode obj = JSON_NODE_FACTORY.objectNode();
                     for (Field field : schema.fields()) {
-                        obj.set(field.name(), convertToJson(field.schema(), struct.get(field)));
+                        obj.set(field.name(), convertToJson(field.schema(), struct.getWithoutDefault(field.name())));
                     }
                     return obj;
                 }


### PR DESCRIPTION
The "replace.null.with.default" option is a KIP-581 addition that is intended to (when false) prevent the Connect default values from being emitted in the JsonConverter. The current implementation works for root values, but does not work for Structs, as the Struct::get implementation has logic to substitute the default value if no value is present.

Instead, the JsonConverter should call Struct::getWithoutDefault, and hide the default value for Struct fields when "replace.null.with.default" is false.

This should be backported to 3.5
Supersedes #13748

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
