### PR TITLE
MINOR: Remove spurious warning about plugin.path config provider usage when null

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -307,7 +307,7 @@ public class WorkerConfig extends AbstractConfig {
         String rawPluginPath = rawOriginals.get(PLUGIN_PATH_CONFIG);
         // Can't use AbstractConfig::originalsStrings here since some values may be null, which
         // causes that method to fail
-        String transformedPluginPath = Objects.toString(originals().get(PLUGIN_PATH_CONFIG));
+        String transformedPluginPath = Objects.toString(originals().get(PLUGIN_PATH_CONFIG), null);
         if (!Objects.equals(rawPluginPath, transformedPluginPath)) {
             log.warn(
                 "Variables cannot be used in the 'plugin.path' property, since the property is "


### PR DESCRIPTION
If there is no plugin.path specified, this warning prints, and says `null` doesn't match `null`.
This is misleading, and is caused by `rawPluginPath` being `null` and `transformedPluginPath` being `"null"`.
Change the Objects.toString to pass-through the null, so that the condition doesn't fire.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
