### PR TITLE
MINOR: Fix for MetadataQuorumCommandErrorTest.testRelativeTimeMs

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
@@ -195,7 +195,7 @@ public class MetadataQuorumCommand {
     static long relativeTimeMs(long timestampMs, String desc) {
         Instant lastTimestamp = Instant.ofEpochMilli(timestampMs);
         Instant now = Instant.now();
-        if (!(lastTimestamp.isAfter(Instant.EPOCH) && lastTimestamp.isBefore(now))) {
+        if (!(lastTimestamp.isAfter(Instant.EPOCH) && (lastTimestamp.isBefore(now) || lastTimestamp.equals(now)))) {
             throw new KafkaException(
                 format("Error while computing relative time, possible drift in system clock.%n" +
                     "Current timestamp is %d, %s timestamp is %d", now.toEpochMilli(), desc, timestampMs)

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandErrorTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandErrorTest.java
@@ -55,6 +55,8 @@ public class MetadataQuorumCommandErrorTest {
     public void testRelativeTimeMs() {
         long validEpochMs = Instant.now().minusSeconds(5).toEpochMilli();
         assertTrue(MetadataQuorumCommand.relativeTimeMs(validEpochMs, "test") >= 0);
+        long nowMs = Instant.now().toEpochMilli();
+        assertTrue(MetadataQuorumCommand.relativeTimeMs(nowMs, "test") >= 0);
         long invalidEpochMs = Instant.EPOCH.minusSeconds(86400).toEpochMilli();
         assertThrows(KafkaException.class, () -> MetadataQuorumCommand.relativeTimeMs(invalidEpochMs, "test"));
         long futureEpochMs = Instant.now().plus(1, ChronoUnit.DAYS).toEpochMilli();

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandErrorTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandErrorTest.java
@@ -57,7 +57,7 @@ public class MetadataQuorumCommandErrorTest {
         assertTrue(MetadataQuorumCommand.relativeTimeMs(validEpochMs, "test") >= 0);
         long nowMs = Instant.now().toEpochMilli();
         assertTrue(MetadataQuorumCommand.relativeTimeMs(nowMs, "test") >= 0);
-        long invalidEpochMs = Instant.EPOCH.minusSeconds(86400).toEpochMilli();
+        long invalidEpochMs = Instant.EPOCH.minus(1, ChronoUnit.DAYS).toEpochMilli();
         assertThrows(KafkaException.class, () -> MetadataQuorumCommand.relativeTimeMs(invalidEpochMs, "test"));
         long futureEpochMs = Instant.now().plus(1, ChronoUnit.DAYS).toEpochMilli();
         assertThrows(KafkaException.class, () -> MetadataQuorumCommand.relativeTimeMs(futureEpochMs, "test"));

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandErrorTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandErrorTest.java
@@ -53,12 +53,12 @@ public class MetadataQuorumCommandErrorTest {
 
     @Test
     public void testRelativeTimeMs() {
-        long nowMs = Instant.now().toEpochMilli();
-        assertTrue(MetadataQuorumCommand.relativeTimeMs(nowMs, "test") >= 0);
-        long invalidEpochMs = Instant.EPOCH.minus(1, ChronoUnit.DAYS).toEpochMilli();
+        long validEpochMs = Instant.now().minusSeconds(5).toEpochMilli();
+        assertTrue(MetadataQuorumCommand.relativeTimeMs(validEpochMs, "test") >= 0);
+        long invalidEpochMs = Instant.EPOCH.minusSeconds(86400).toEpochMilli();
         assertThrows(KafkaException.class, () -> MetadataQuorumCommand.relativeTimeMs(invalidEpochMs, "test"));
-        long futureTimestampMs = Instant.now().plus(1, ChronoUnit.DAYS).toEpochMilli();
-        assertThrows(KafkaException.class, () -> MetadataQuorumCommand.relativeTimeMs(futureTimestampMs, "test"));
+        long futureEpochMs = Instant.now().plus(1, ChronoUnit.DAYS).toEpochMilli();
+        assertThrows(KafkaException.class, () -> MetadataQuorumCommand.relativeTimeMs(futureEpochMs, "test"));
     }
 
 }


### PR DESCRIPTION
This change should fix the following error on CI/CD.

```sh
org.apache.kafka.common.KafkaException: Error while computing relative time, possible drift in system clock.
Current timestamp is 1685472793724, test timestamp is 1685472793724
```
