### PR TITLE
KAFKA-15044: Upgrade to snappy v1.1.10.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -122,7 +122,7 @@ versions += [
   scalaJava8Compat : "1.0.2",
   scoverage: "1.9.3",
   slf4j: "1.7.36",
-  snappy: "1.1.9.1",
+  snappy: "1.1.10.0",
   spotbugs: "4.7.3",
   swaggerAnnotations: "2.2.8",
   swaggerJaxrs2: "2.2.8",


### PR DESCRIPTION
Snappy v1.1.9.1 has some issues around arm compatibility and glibc library versions shipped by default with certain OS distributions. Snappy v1.1.10.0 uses a glibc LTS version, see: https://github.com/xerial/snappy-java/issues/417 https://github.com/xerial/snappy-java/pull/440

This needs to be cherry-picked to the 3.5 branch as well.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
