### PR TITLE
KAFKA-14791: Create a builder for PartitionRegistration

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -464,16 +464,16 @@ class ReplicaManagerConcurrencyTest {
     leaderEpoch: Int = 0,
     partitionEpoch: Int = 0
   ): PartitionRegistration = {
-    new PartitionRegistration(
-      replicaIds.toArray,
-      isr.toArray,
-      Array.empty[Int],
-      Array.empty[Int],
-      leader,
-      leaderRecoveryState,
-      leaderEpoch,
-      partitionEpoch
-    )
+    new PartitionRegistration.Builder().
+      setReplicas(replicaIds.toArray).
+      setIsr(isr.toArray).
+      setRemovingReplicas(Array.empty[Int]).
+      setAddingReplicas(Array.empty[Int]).
+      setLeader(leader).
+      setLeaderRecoveryState(leaderRecoveryState).
+      setLeaderEpoch(leaderEpoch).
+      setPartitionEpoch(partitionEpoch).
+      build();
   }
 
   private def defaultBrokerEpoch(brokerId: Int): Long = {

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -467,8 +467,6 @@ class ReplicaManagerConcurrencyTest {
     new PartitionRegistration.Builder().
       setReplicas(replicaIds.toArray).
       setIsr(isr.toArray).
-      setRemovingReplicas(Array.empty[Int]).
-      setAddingReplicas(Array.empty[Int]).
       setLeader(leader).
       setLeaderRecoveryState(leaderRecoveryState).
       setLeaderEpoch(leaderEpoch).

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -160,16 +160,16 @@ class BrokerMetadataPublisherTest {
     partitions: Map[Int, Seq[Int]]
   ): TopicImage = {
     val partitionRegistrations = partitions.map { case (partitionId, replicas) =>
-      Int.box(partitionId) -> new PartitionRegistration(
-        replicas.toArray,
-        replicas.toArray,
-        Array.empty[Int],
-        Array.empty[Int],
-        replicas.head,
-        LeaderRecoveryState.RECOVERED,
-        0,
-        0
-      )
+      Int.box(partitionId) -> new PartitionRegistration.Builder().
+        setReplicas(replicas.toArray).
+        setIsr(replicas.toArray).
+        setRemovingReplicas(Array.empty[Int]).
+        setAddingReplicas(Array.empty[Int]).
+        setLeader(replicas.head).
+        setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+        setLeaderEpoch(0).
+        setPartitionEpoch(0).
+        build()
     }
     new TopicImage(topic, topicId, partitionRegistrations.asJava)
   }

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -163,8 +163,6 @@ class BrokerMetadataPublisherTest {
       Int.box(partitionId) -> new PartitionRegistration.Builder().
         setReplicas(replicas.toArray).
         setIsr(replicas.toArray).
-        setRemovingReplicas(Array.empty[Int]).
-        setAddingReplicas(Array.empty[Int]).
         setLeader(replicas.head).
         setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
         setLeaderEpoch(0).

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
@@ -78,8 +78,8 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals(0, migrationState.migrationZkVersion())
 
     val partitions = Map(
-      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(1, 2)).setRemovingReplicas(Array()).setAddingReplicas(Array()).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(6).setPartitionEpoch(-1).build(),
-      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(3)).setRemovingReplicas(Array()).setAddingReplicas(Array()).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(7).setPartitionEpoch(-1).build()
+      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(1, 2)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(6).setPartitionEpoch(-1).build(),
+      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(3)).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(7).setPartitionEpoch(-1).build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().updateTopicPartitions(Map("test" -> partitions).asJava, migrationState)
     assertEquals(1, migrationState.migrationZkVersion())
@@ -105,8 +105,8 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals(0, migrationState.migrationZkVersion())
 
     val partitions = Map(
-      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setRemovingReplicas(Array()).setAddingReplicas(Array()).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
-      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setRemovingReplicas(Array()).setAddingReplicas(Array()).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
+      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
+      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().createTopic("test", Uuid.randomUuid(), partitions, migrationState)
     assertEquals(1, migrationState.migrationZkVersion())
@@ -128,8 +128,8 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals(0, migrationState.migrationZkVersion())
 
     val partitions = Map(
-      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setRemovingReplicas(Array()).setAddingReplicas(Array()).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
-      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setRemovingReplicas(Array()).setAddingReplicas(Array()).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
+      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
+      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     val topicId = Uuid.randomUuid()
     migrationState = migrationClient.topicClient().createTopic("test", topicId, partitions, migrationState)

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
@@ -371,7 +371,7 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
 
     val topicId = Uuid.randomUuid()
     val partitions = Map(
-      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(1).build(),
+      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
       1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().createTopic("test", topicId, partitions, migrationState)

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
@@ -78,8 +78,8 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals(0, migrationState.migrationZkVersion())
 
     val partitions = Map(
-      0 -> new PartitionRegistration(Array(0, 1, 2), Array(1, 2), Array(), Array(), 1, LeaderRecoveryState.RECOVERED, 6, -1),
-      1 -> new PartitionRegistration(Array(1, 2, 3), Array(3), Array(), Array(), 3, LeaderRecoveryState.RECOVERED, 7, -1)
+      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(1, 2)).setRemovingReplicas(Array()).setAddingReplicas(Array()).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(6).setPartitionEpoch(-1).build(),
+      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(3)).setRemovingReplicas(Array()).setAddingReplicas(Array()).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(7).setPartitionEpoch(-1).build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().updateTopicPartitions(Map("test" -> partitions).asJava, migrationState)
     assertEquals(1, migrationState.migrationZkVersion())
@@ -105,8 +105,8 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals(0, migrationState.migrationZkVersion())
 
     val partitions = Map(
-      0 -> new PartitionRegistration(Array(0, 1, 2), Array(0, 1, 2), Array(), Array(), 0, LeaderRecoveryState.RECOVERED, 0, -1),
-      1 -> new PartitionRegistration(Array(1, 2, 3), Array(1, 2, 3), Array(), Array(), 1, LeaderRecoveryState.RECOVERED, 0, -1)
+      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setRemovingReplicas(Array()).setAddingReplicas(Array()).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
+      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setRemovingReplicas(Array()).setAddingReplicas(Array()).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().createTopic("test", Uuid.randomUuid(), partitions, migrationState)
     assertEquals(1, migrationState.migrationZkVersion())
@@ -128,8 +128,8 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals(0, migrationState.migrationZkVersion())
 
     val partitions = Map(
-      0 -> new PartitionRegistration(Array(0, 1, 2), Array(0, 1, 2), Array(), Array(), 0, LeaderRecoveryState.RECOVERED, 0, -1),
-      1 -> new PartitionRegistration(Array(1, 2, 3), Array(1, 2, 3), Array(), Array(), 1, LeaderRecoveryState.RECOVERED, 0, -1)
+      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setRemovingReplicas(Array()).setAddingReplicas(Array()).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
+      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setRemovingReplicas(Array()).setAddingReplicas(Array()).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     val topicId = Uuid.randomUuid()
     migrationState = migrationClient.topicClient().createTopic("test", topicId, partitions, migrationState)

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
@@ -371,8 +371,8 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
 
     val topicId = Uuid.randomUuid()
     val partitions = Map(
-      0 -> new PartitionRegistration(Array(0, 1, 2), Array(0, 1, 2), Array(), Array(), 0, LeaderRecoveryState.RECOVERED, 0, -1),
-      1 -> new PartitionRegistration(Array(1, 2, 3), Array(1, 2, 3), Array(), Array(), 1, LeaderRecoveryState.RECOVERED, 0, -1)
+      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(1).build(),
+      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().createTopic("test", topicId, partitions, migrationState)
     assertEquals(1, migrationState.migrationZkVersion())
@@ -380,8 +380,8 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     // Change assignment in partitions and update the topic assignment. See the change is
     // reflected.
     val changedPartitions = Map(
-      0 -> new PartitionRegistration(Array(1, 2, 3), Array(1, 2, 3), Array(), Array(), 0, LeaderRecoveryState.RECOVERED, 0, -1),
-      1 -> new PartitionRegistration(Array(0, 1, 2), Array(0, 1, 2), Array(), Array(), 1, LeaderRecoveryState.RECOVERED, 0, -1)
+      0 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
+      1 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().updateTopic("test", topicId, changedPartitions, migrationState)
     assertEquals(2, migrationState.migrationZkVersion())
@@ -402,7 +402,7 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
 
     // Add a new Partition.
     val newPartition = Map(
-      2 -> new PartitionRegistration(Array(2, 3, 4), Array(2, 3, 4), Array(), Array(), 1, LeaderRecoveryState.RECOVERED, 0, -1)
+      2 -> new PartitionRegistration.Builder().setReplicas(Array(2, 3, 4)).setIsr(Array(2, 3, 4)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
     ).map { case (k, v) => int2Integer(k) -> v }.asJava
     migrationState = migrationClient.topicClient().createTopicPartitions(Map("test" -> newPartition).asJava, migrationState)
     assertEquals(3, migrationState.migrationZkVersion())

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -639,13 +639,7 @@ public class ReplicationControlManager {
                         "All brokers specified in the manual partition assignment for " +
                         "partition " + assignment.partitionIndex() + " are fenced or in controlled shutdown.");
                 }
-                PartitionRegistration partitionRegistration;
-                try {
-                    partitionRegistration = buildPartitionRegistration(assignment.brokerIds(), isr);
-                } catch (Exception e) {
-                    log.error("Failed to create partition registration.", e);
-                    return new ApiError(Errors.UNKNOWN_SERVER_ERROR, "Failed to create partition registration: " + e.getMessage());
-                }
+                PartitionRegistration partitionRegistration = buildPartitionRegistration(assignment.brokerIds(), isr);
                 newParts.put(assignment.partitionIndex(), partitionRegistration);
             }
             for (int i = 0; i < newParts.size(); i++) {
@@ -692,13 +686,7 @@ public class ReplicationControlManager {
                             "Unable to replicate the partition " + replicationFactor +
                                 " time(s): All brokers are currently fenced or in controlled shutdown.");
                     }
-                    PartitionRegistration partitionRegistration;
-                    try {
-                        partitionRegistration = buildPartitionRegistration(replicas, isr);
-                    } catch (Exception e) {
-                        log.error("Failed to create partition registration.", e);
-                        return new ApiError(Errors.UNKNOWN_SERVER_ERROR, "Failed to create partition registration: " + e.getMessage());
-                    }
+                    PartitionRegistration partitionRegistration = buildPartitionRegistration(replicas, isr);
                     newParts.put(partitionId, partitionRegistration);
                 }
             } catch (InvalidReplicationFactorException e) {
@@ -759,14 +747,12 @@ public class ReplicationControlManager {
     }
 
     private static PartitionRegistration buildPartitionRegistration(
-        List<Integer> assignment,
+        List<Integer> replicas,
         List<Integer> isr
-    ) throws Exception {
+    ) {
         return new PartitionRegistration.Builder().
-            setReplicas(Replicas.toArray(assignment)).
+            setReplicas(Replicas.toArray(replicas)).
             setIsr(Replicas.toArray(isr)).
-            setRemovingReplicas(Replicas.NONE).
-            setAddingReplicas(Replicas.NONE).
             setLeader(isr.get(0)).
             setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
             setLeaderEpoch(0).

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -639,8 +639,10 @@ public class ReplicationControlManager {
                         "All brokers specified in the manual partition assignment for " +
                         "partition " + assignment.partitionIndex() + " are fenced or in controlled shutdown.");
                 }
-                PartitionRegistration partitionRegistration = buildPartitionRegistration(assignment.brokerIds(), isr);
-                newParts.put(assignment.partitionIndex(), partitionRegistration);
+                newParts.put(
+                    assignment.partitionIndex(),
+                    buildPartitionRegistration(assignment.brokerIds(), isr)
+                );
             }
             for (int i = 0; i < newParts.size(); i++) {
                 if (!newParts.containsKey(i)) {
@@ -686,8 +688,10 @@ public class ReplicationControlManager {
                             "Unable to replicate the partition " + replicationFactor +
                                 " time(s): All brokers are currently fenced or in controlled shutdown.");
                     }
-                    PartitionRegistration partitionRegistration = buildPartitionRegistration(replicas, isr);
-                    newParts.put(partitionId, partitionRegistration);
+                    newParts.put(
+                        partitionId,
+                        buildPartitionRegistration(replicas, isr)
+                    );
                 }
             } catch (InvalidReplicationFactorException e) {
                 return new ApiError(Errors.INVALID_REPLICATION_FACTOR,

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -763,10 +763,15 @@ public class ReplicationControlManager {
         List<Integer> isr
     ) throws Exception {
         return new PartitionRegistration.Builder().
-            setReplicas(Replicas.toArray(assignment)).setIsr(Replicas.toArray(isr)).
-            setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
-            setLeader(isr.get(0)).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
-            setLeaderEpoch(0).setPartitionEpoch(0).build();
+            setReplicas(Replicas.toArray(assignment)).
+            setIsr(Replicas.toArray(isr)).
+            setRemovingReplicas(Replicas.NONE).
+            setAddingReplicas(Replicas.NONE).
+            setLeader(isr.get(0)).
+            setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(0).
+            setPartitionEpoch(0).
+            build();
     }
 
     private ApiError maybeCheckCreateTopicPolicy(Supplier<CreateTopicPolicy.RequestMetadata> supplier) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -643,14 +643,10 @@ public class ReplicationControlManager {
                 try {
                     partitionRegistration = new PartitionRegistration.Builder().
                         setReplicas(Replicas.toArray(assignment.brokerIds())).
-                        setIsr(Replicas.toArray(isr)).
-                        setRemovingReplicas(Replicas.NONE).
-                        setAddingReplicas(Replicas.NONE).
-                        setLeader(isr.get(0)).
+                        setIsr(Replicas.toArray(isr)).setRemovingReplicas(Replicas.NONE).
+                        setAddingReplicas(Replicas.NONE).setLeader(isr.get(0)).
                         setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
-                        setLeaderEpoch(0).
-                        setPartitionEpoch(0).
-                        build();
+                        setLeaderEpoch(0).setPartitionEpoch(0).build();
                 } catch (Exception e) {
                     log.error("Failed to create partition registration.", e);
                     return new ApiError(Errors.UNKNOWN_SERVER_ERROR, "Failed to create partition registration: " + e.getMessage());

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -641,12 +641,7 @@ public class ReplicationControlManager {
                 }
                 PartitionRegistration partitionRegistration;
                 try {
-                    partitionRegistration = new PartitionRegistration.Builder().
-                        setReplicas(Replicas.toArray(assignment.brokerIds())).
-                        setIsr(Replicas.toArray(isr)).setRemovingReplicas(Replicas.NONE).
-                        setAddingReplicas(Replicas.NONE).setLeader(isr.get(0)).
-                        setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
-                        setLeaderEpoch(0).setPartitionEpoch(0).build();
+                    partitionRegistration = buildPartitionRegistration(assignment.brokerIds(), isr);
                 } catch (Exception e) {
                     log.error("Failed to create partition registration.", e);
                     return new ApiError(Errors.UNKNOWN_SERVER_ERROR, "Failed to create partition registration: " + e.getMessage());
@@ -699,16 +694,7 @@ public class ReplicationControlManager {
                     }
                     PartitionRegistration partitionRegistration;
                     try {
-                        partitionRegistration = new PartitionRegistration.Builder().
-                            setReplicas(Replicas.toArray(replicas)).
-                            setIsr(Replicas.toArray(isr)).
-                            setRemovingReplicas(Replicas.NONE).
-                            setAddingReplicas(Replicas.NONE).
-                            setLeader(isr.get(0)).
-                            setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
-                            setLeaderEpoch(0).
-                            setPartitionEpoch(0).
-                            build();
+                        partitionRegistration = buildPartitionRegistration(replicas, isr);
                     } catch (Exception e) {
                         log.error("Failed to create partition registration.", e);
                         return new ApiError(Errors.UNKNOWN_SERVER_ERROR, "Failed to create partition registration: " + e.getMessage());
@@ -770,6 +756,17 @@ public class ReplicationControlManager {
             records.add(info.toRecord(topicId, partitionIndex));
         }
         return ApiError.NONE;
+    }
+
+    private static PartitionRegistration buildPartitionRegistration(
+        List<Integer> assignment,
+        List<Integer> isr
+    ) throws Exception {
+        return new PartitionRegistration.Builder().
+            setReplicas(Replicas.toArray(assignment)).setIsr(Replicas.toArray(isr)).
+            setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
+            setLeader(isr.get(0)).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(0).setPartitionEpoch(0).build();
     }
 
     private ApiError maybeCheckCreateTopicPolicy(Supplier<CreateTopicPolicy.RequestMetadata> supplier) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -33,6 +33,92 @@ import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER_CHANGE;
 
 
 public class PartitionRegistration {
+
+    /**
+     * A builder class which creates a PartitionRegistration.
+     */
+    static public class Builder {
+        private int[] replicas;
+        private int[] isr;
+        private int[] removingReplicas;
+        private int[] addingReplicas;
+        private Integer leader;
+        private LeaderRecoveryState leaderRecoveryState;
+        private Integer leaderEpoch;
+        private Integer partitionEpoch;
+
+        public Builder setReplicas(int[] replicas) {
+            this.replicas = replicas;
+            return this;
+        }
+
+        public Builder setIsr(int[] isr) {
+            this.isr = isr;
+            return this;
+        }
+
+        public Builder setRemovingReplicas(int[] removingReplicas) {
+            this.removingReplicas = removingReplicas;
+            return this;
+        }
+
+        public Builder setAddingReplicas(int[] addingReplicas) {
+            this.addingReplicas = addingReplicas;
+            return this;
+        }
+
+        public Builder setLeader(Integer leader) {
+            this.leader = leader;
+            return this;
+        }
+
+        public Builder setLeaderRecoveryState(LeaderRecoveryState leaderRecoveryState) {
+            this.leaderRecoveryState = leaderRecoveryState;
+            return this;
+        }
+
+        public Builder setLeaderEpoch(Integer leaderEpoch) {
+            this.leaderEpoch = leaderEpoch;
+            return this;
+        }
+
+        public Builder setPartitionEpoch(Integer partitionEpoch) {
+            this.partitionEpoch = partitionEpoch;
+            return this;
+        }
+
+        public PartitionRegistration build() throws Exception {
+            if (replicas == null) {
+                throw new IllegalStateException("You must set replicas.");
+            } else if (isr == null) {
+                throw new IllegalStateException("You must set isr.");
+            } else if (removingReplicas == null) {
+                throw new IllegalStateException("You must set removing replicas.");
+            } else if (addingReplicas == null) {
+                throw new IllegalStateException("You must set adding replicas.");
+            } else if (leader == null) {
+                throw new IllegalStateException("You must set leader.");
+            } else if (leaderRecoveryState == null) {
+                throw new IllegalStateException("You must set leader recovery state.");
+            } else if (leaderEpoch == null) {
+                throw new IllegalStateException("You must set leader epoch.");
+            } else if (partitionEpoch == null) {
+                throw new IllegalStateException("You must set partition epoch.");
+            }
+
+            return new PartitionRegistration(
+                replicas,
+                isr,
+                removingReplicas,
+                addingReplicas,
+                leader,
+                leaderRecoveryState,
+                leaderEpoch,
+                partitionEpoch
+            );
+        }
+    }
+
     public final int[] replicas;
     public final int[] isr;
     public final int[] removingReplicas;
@@ -57,7 +143,7 @@ public class PartitionRegistration {
             record.partitionEpoch());
     }
 
-    public PartitionRegistration(int[] replicas, int[] isr, int[] removingReplicas,
+    protected PartitionRegistration(int[] replicas, int[] isr, int[] removingReplicas,
                                  int[] addingReplicas, int leader, LeaderRecoveryState leaderRecoveryState,
                                  int leaderEpoch, int partitionEpoch) {
         this.replicas = replicas;

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -40,8 +40,8 @@ public class PartitionRegistration {
     static public class Builder {
         private int[] replicas;
         private int[] isr;
-        private int[] removingReplicas;
-        private int[] addingReplicas;
+        private int[] removingReplicas = new int[0];
+        private int[] addingReplicas = new int[0];
         private Integer leader;
         private LeaderRecoveryState leaderRecoveryState;
         private Integer leaderEpoch;
@@ -143,7 +143,7 @@ public class PartitionRegistration {
             record.partitionEpoch());
     }
 
-    protected PartitionRegistration(int[] replicas, int[] isr, int[] removingReplicas,
+    private PartitionRegistration(int[] replicas, int[] isr, int[] removingReplicas,
                                  int[] addingReplicas, int leader, LeaderRecoveryState leaderRecoveryState,
                                  int leaderEpoch, int partitionEpoch) {
         this.replicas = replicas;

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -40,8 +40,8 @@ public class PartitionRegistration {
     static public class Builder {
         private int[] replicas;
         private int[] isr;
-        private int[] removingReplicas = new int[0];
-        private int[] addingReplicas = new int[0];
+        private int[] removingReplicas = Replicas.NONE;
+        private int[] addingReplicas = Replicas.NONE;
         private Integer leader;
         private LeaderRecoveryState leaderRecoveryState;
         private Integer leaderEpoch;
@@ -87,7 +87,7 @@ public class PartitionRegistration {
             return this;
         }
 
-        public PartitionRegistration build() throws Exception {
+        public PartitionRegistration build() {
             if (replicas == null) {
                 throw new IllegalStateException("You must set replicas.");
             } else if (isr == null) {

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -80,8 +80,6 @@ public class PartitionChangeBuilderTest {
     private static final PartitionRegistration FOO = new PartitionRegistration.Builder().
         setReplicas(new int[] {2, 1, 3}).
         setIsr(new int[] {2, 1, 3}).
-        setRemovingReplicas(Replicas.NONE).
-        setAddingReplicas(Replicas.NONE).
         setLeader(1).
         setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
         setLeaderEpoch(100).
@@ -114,8 +112,6 @@ public class PartitionChangeBuilderTest {
     private static final PartitionRegistration BAZ = new PartitionRegistration.Builder().
         setReplicas(new int[] {2, 1, 3}).
         setIsr(new int[] {1, 3}).
-        setRemovingReplicas(Replicas.NONE).
-        setAddingReplicas(Replicas.NONE).
         setLeader(3).
         setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
         setLeaderEpoch(100).
@@ -131,8 +127,6 @@ public class PartitionChangeBuilderTest {
     private static final PartitionRegistration OFFLINE = new PartitionRegistration.Builder().
         setReplicas(new int[] {2, 1, 3}).
         setIsr(new int[] {3}).
-        setRemovingReplicas(Replicas.NONE).
-        setAddingReplicas(Replicas.NONE).
         setLeader(-1).
         setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
         setLeaderEpoch(100).
@@ -363,8 +357,6 @@ public class PartitionChangeBuilderTest {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {leaderId, leaderId + 1, leaderId + 2}).
             setIsr(new int[] {leaderId}).
-            setRemovingReplicas(Replicas.NONE).
-            setAddingReplicas(Replicas.NONE).
             setLeader(leaderId).
             setLeaderRecoveryState(recoveryState).
             setLeaderEpoch(100).
@@ -424,8 +416,6 @@ public class PartitionChangeBuilderTest {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {leaderId, leaderId + 1, leaderId + 2}).
             setIsr(new int[] {leaderId + 1, leaderId + 2}).
-            setRemovingReplicas(Replicas.NONE).
-            setAddingReplicas(Replicas.NONE).
             setLeader(NO_LEADER).
             setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
             setLeaderEpoch(100).

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -77,7 +77,7 @@ public class PartitionChangeBuilderTest {
         );
     }
 
-    private static PartitionRegistration FOO = null;
+    private static final PartitionRegistration FOO;
 
     static {
         try {
@@ -92,7 +92,7 @@ public class PartitionChangeBuilderTest {
                 setPartitionEpoch(200).
                 build();
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -102,14 +102,14 @@ public class PartitionChangeBuilderTest {
         return new PartitionChangeBuilder(FOO, FOO_ID, 0, r -> r != 3, true);
     }
 
-    private static PartitionRegistration BAR = null;
+    private static final PartitionRegistration BAR;
 
     static {
         try {
             BAR = new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {4}).
                 setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -119,14 +119,14 @@ public class PartitionChangeBuilderTest {
         return new PartitionChangeBuilder(BAR, BAR_ID, 0, r -> r != 3, true);
     }
 
-    private static PartitionRegistration BAZ = null;
+    private static final PartitionRegistration BAZ;
 
     static {
         try {
             BAZ = new PartitionRegistration.Builder().setReplicas(new int[] {2, 1, 3}).setIsr(new int[] {1, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
                 setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -136,14 +136,14 @@ public class PartitionChangeBuilderTest {
         return new PartitionChangeBuilder(BAZ, BAZ_ID, 0, __ -> true, true);
     }
 
-    private static PartitionRegistration OFFLINE = null;
+    private static final PartitionRegistration OFFLINE;
 
     static {
         try {
             OFFLINE = new PartitionRegistration.Builder().setReplicas(new int[] {2, 1, 3}).setIsr(new int[] {3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
                 setLeader(-1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -493,7 +493,8 @@ public class PartitionChangeBuilderTest {
             setLeader(leader).
             setLeaderRecoveryState(leaderRecoveryState).
             setLeaderEpoch(leaderEpoch).
-            setPartitionEpoch(partitionEpoch).build();
+            setPartitionEpoch(partitionEpoch).
+            build();
 
         Uuid topicId = Uuid.randomUuid();
         // Always return false for valid leader. This is so none of the new replicas are valid leaders. This is so we

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -77,24 +77,16 @@ public class PartitionChangeBuilderTest {
         );
     }
 
-    private static final PartitionRegistration FOO;
-
-    static {
-        try {
-            FOO = new PartitionRegistration.Builder().
-                setReplicas(new int[] {2, 1, 3}).
-                setIsr(new int[] {2, 1, 3}).
-                setRemovingReplicas(Replicas.NONE).
-                setAddingReplicas(Replicas.NONE).
-                setLeader(1).
-                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
-                setLeaderEpoch(100).
-                setPartitionEpoch(200).
-                build();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
+    private static final PartitionRegistration FOO = new PartitionRegistration.Builder().
+        setReplicas(new int[] {2, 1, 3}).
+        setIsr(new int[] {2, 1, 3}).
+        setRemovingReplicas(Replicas.NONE).
+        setAddingReplicas(Replicas.NONE).
+        setLeader(1).
+        setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+        setLeaderEpoch(100).
+        setPartitionEpoch(200).
+        build();
 
     private final static Uuid FOO_ID = Uuid.fromString("FbrrdcfiR-KC2CPSTHaJrg");
 
@@ -102,16 +94,16 @@ public class PartitionChangeBuilderTest {
         return new PartitionChangeBuilder(FOO, FOO_ID, 0, r -> r != 3, true);
     }
 
-    private static final PartitionRegistration BAR;
-
-    static {
-        try {
-            BAR = new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {4}).
-                setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
+    private static final PartitionRegistration BAR = new PartitionRegistration.Builder().
+        setReplicas(new int[] {1, 2, 3, 4}).
+        setIsr(new int[] {1, 2, 3}).
+        setRemovingReplicas(new int[] {1}).
+        setAddingReplicas(new int[] {4}).
+        setLeader(1).
+        setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+        setLeaderEpoch(100).
+        setPartitionEpoch(200).
+        build();
 
     private final static Uuid BAR_ID = Uuid.fromString("LKfUsCBnQKekvL9O5dY9nw");
 
@@ -119,16 +111,16 @@ public class PartitionChangeBuilderTest {
         return new PartitionChangeBuilder(BAR, BAR_ID, 0, r -> r != 3, true);
     }
 
-    private static final PartitionRegistration BAZ;
-
-    static {
-        try {
-            BAZ = new PartitionRegistration.Builder().setReplicas(new int[] {2, 1, 3}).setIsr(new int[] {1, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
-                setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
+    private static final PartitionRegistration BAZ = new PartitionRegistration.Builder().
+        setReplicas(new int[] {2, 1, 3}).
+        setIsr(new int[] {1, 3}).
+        setRemovingReplicas(Replicas.NONE).
+        setAddingReplicas(Replicas.NONE).
+        setLeader(3).
+        setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+        setLeaderEpoch(100).
+        setPartitionEpoch(200).
+        build();
 
     private final static Uuid BAZ_ID = Uuid.fromString("wQzt5gkSTwuQNXZF5gIw7A");
 
@@ -136,16 +128,16 @@ public class PartitionChangeBuilderTest {
         return new PartitionChangeBuilder(BAZ, BAZ_ID, 0, __ -> true, true);
     }
 
-    private static final PartitionRegistration OFFLINE;
-
-    static {
-        try {
-            OFFLINE = new PartitionRegistration.Builder().setReplicas(new int[] {2, 1, 3}).setIsr(new int[] {3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
-                setLeader(-1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
+    private static final PartitionRegistration OFFLINE = new PartitionRegistration.Builder().
+        setReplicas(new int[] {2, 1, 3}).
+        setIsr(new int[] {3}).
+        setRemovingReplicas(Replicas.NONE).
+        setAddingReplicas(Replicas.NONE).
+        setLeader(-1).
+        setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+        setLeaderEpoch(100).
+        setPartitionEpoch(200).
+        build();
 
     private final static Uuid OFFLINE_ID = Uuid.fromString("LKfUsCBnQKekvL9O5dY9nw");
 
@@ -364,7 +356,7 @@ public class PartitionChangeBuilderTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testChangeInLeadershipDoesNotChangeRecoveryState(boolean isLeaderRecoverySupported) throws Exception {
+    public void testChangeInLeadershipDoesNotChangeRecoveryState(boolean isLeaderRecoverySupported) {
         final byte noChange = (byte) -1;
         int leaderId = 1;
         LeaderRecoveryState recoveryState = LeaderRecoveryState.RECOVERING;
@@ -426,7 +418,7 @@ public class PartitionChangeBuilderTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void testUncleanSetsLeaderRecoveringState(boolean isLeaderRecoverySupported) throws Exception {
+    void testUncleanSetsLeaderRecoveringState(boolean isLeaderRecoverySupported) {
         final byte noChange = (byte) -1;
         int leaderId = 1;
         PartitionRegistration registration = new PartitionRegistration.Builder().
@@ -479,7 +471,7 @@ public class PartitionChangeBuilderTest {
     }
 
     @Test
-    public void testStoppedLeaderIsDemotedAfterReassignmentCompletesEvenIfNoNewEligibleLeaders() throws Exception {
+    public void testStoppedLeaderIsDemotedAfterReassignmentCompletesEvenIfNoNewEligibleLeaders() {
         // Set up PartitionRegistration as if there's an ongoing reassignment from [0, 1] to [2, 3]
         int[] replicas = new int[] {2, 3, 0, 1};
         // The ISR starts off with the old replicas

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -77,9 +77,24 @@ public class PartitionChangeBuilderTest {
         );
     }
 
-    private final static PartitionRegistration FOO = new PartitionRegistration(
-        new int[] {2, 1, 3}, new int[] {2, 1, 3}, Replicas.NONE, Replicas.NONE,
-        1, LeaderRecoveryState.RECOVERED, 100, 200);
+    private static PartitionRegistration FOO = null;
+
+    static {
+        try {
+            FOO = new PartitionRegistration.Builder().
+                setReplicas(new int[] {2, 1, 3}).
+                setIsr(new int[] {2, 1, 3}).
+                setRemovingReplicas(Replicas.NONE).
+                setAddingReplicas(Replicas.NONE).
+                setLeader(1).
+                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+                setLeaderEpoch(100).
+                setPartitionEpoch(200).
+                build();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 
     private final static Uuid FOO_ID = Uuid.fromString("FbrrdcfiR-KC2CPSTHaJrg");
 
@@ -87,9 +102,16 @@ public class PartitionChangeBuilderTest {
         return new PartitionChangeBuilder(FOO, FOO_ID, 0, r -> r != 3, true);
     }
 
-    private final static PartitionRegistration BAR = new PartitionRegistration(
-        new int[] {1, 2, 3, 4}, new int[] {1, 2, 3}, new int[] {1}, new int[] {4},
-        1, LeaderRecoveryState.RECOVERED, 100, 200);
+    private static PartitionRegistration BAR = null;
+
+    static {
+        try {
+            BAR = new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {4}).
+                setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 
     private final static Uuid BAR_ID = Uuid.fromString("LKfUsCBnQKekvL9O5dY9nw");
 
@@ -97,9 +119,16 @@ public class PartitionChangeBuilderTest {
         return new PartitionChangeBuilder(BAR, BAR_ID, 0, r -> r != 3, true);
     }
 
-    private final static PartitionRegistration BAZ = new PartitionRegistration(
-        new int[] {2, 1, 3}, new int[] {1, 3}, Replicas.NONE, Replicas.NONE,
-        3, LeaderRecoveryState.RECOVERED, 100, 200);
+    private static PartitionRegistration BAZ = null;
+
+    static {
+        try {
+            BAZ = new PartitionRegistration.Builder().setReplicas(new int[] {2, 1, 3}).setIsr(new int[] {1, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
+                setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 
     private final static Uuid BAZ_ID = Uuid.fromString("wQzt5gkSTwuQNXZF5gIw7A");
 
@@ -107,9 +136,16 @@ public class PartitionChangeBuilderTest {
         return new PartitionChangeBuilder(BAZ, BAZ_ID, 0, __ -> true, true);
     }
 
-    private final static PartitionRegistration OFFLINE = new PartitionRegistration(
-        new int[] {2, 1, 3}, new int[] {3}, Replicas.NONE, Replicas.NONE,
-        -1, LeaderRecoveryState.RECOVERED, 100, 200);
+    private static PartitionRegistration OFFLINE = null;
+
+    static {
+        try {
+            OFFLINE = new PartitionRegistration.Builder().setReplicas(new int[] {2, 1, 3}).setIsr(new int[] {3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
+                setLeader(-1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 
     private final static Uuid OFFLINE_ID = Uuid.fromString("LKfUsCBnQKekvL9O5dY9nw");
 
@@ -328,20 +364,20 @@ public class PartitionChangeBuilderTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testChangeInLeadershipDoesNotChangeRecoveryState(boolean isLeaderRecoverySupported) {
+    public void testChangeInLeadershipDoesNotChangeRecoveryState(boolean isLeaderRecoverySupported) throws Exception {
         final byte noChange = (byte) -1;
         int leaderId = 1;
         LeaderRecoveryState recoveryState = LeaderRecoveryState.RECOVERING;
-        PartitionRegistration registration = new PartitionRegistration(
-            new int[] {leaderId, leaderId + 1, leaderId + 2},
-            new int[] {leaderId},
-            Replicas.NONE,
-            Replicas.NONE,
-            leaderId,
-            recoveryState,
-            100,
-            200
-        );
+        PartitionRegistration registration = new PartitionRegistration.Builder().
+            setReplicas(new int[] {leaderId, leaderId + 1, leaderId + 2}).
+            setIsr(new int[] {leaderId}).
+            setRemovingReplicas(Replicas.NONE).
+            setAddingReplicas(Replicas.NONE).
+            setLeader(leaderId).
+            setLeaderRecoveryState(recoveryState).
+            setLeaderEpoch(100).
+            setPartitionEpoch(200).
+            build();
 
         // Change the partition so that there is no leader
         PartitionChangeBuilder offlineBuilder = new PartitionChangeBuilder(
@@ -390,19 +426,19 @@ public class PartitionChangeBuilderTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void testUncleanSetsLeaderRecoveringState(boolean isLeaderRecoverySupported) {
+    void testUncleanSetsLeaderRecoveringState(boolean isLeaderRecoverySupported) throws Exception {
         final byte noChange = (byte) -1;
         int leaderId = 1;
-        PartitionRegistration registration = new PartitionRegistration(
-            new int[] {leaderId, leaderId + 1, leaderId + 2},
-            new int[] {leaderId + 1, leaderId + 2},
-            Replicas.NONE,
-            Replicas.NONE,
-            NO_LEADER,
-            LeaderRecoveryState.RECOVERED,
-            100,
-            200
-        );
+        PartitionRegistration registration = new PartitionRegistration.Builder().
+            setReplicas(new int[] {leaderId, leaderId + 1, leaderId + 2}).
+            setIsr(new int[] {leaderId + 1, leaderId + 2}).
+            setRemovingReplicas(Replicas.NONE).
+            setAddingReplicas(Replicas.NONE).
+            setLeader(NO_LEADER).
+            setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(100).
+            setPartitionEpoch(200).
+            build();
 
         // Change the partition using unclean leader election
         PartitionChangeBuilder onlineBuilder = new PartitionChangeBuilder(
@@ -443,7 +479,7 @@ public class PartitionChangeBuilderTest {
     }
 
     @Test
-    public void testStoppedLeaderIsDemotedAfterReassignmentCompletesEvenIfNoNewEligibleLeaders() {
+    public void testStoppedLeaderIsDemotedAfterReassignmentCompletesEvenIfNoNewEligibleLeaders() throws Exception {
         // Set up PartitionRegistration as if there's an ongoing reassignment from [0, 1] to [2, 3]
         int[] replicas = new int[] {2, 3, 0, 1};
         // The ISR starts off with the old replicas
@@ -457,16 +493,15 @@ public class PartitionChangeBuilderTest {
         LeaderRecoveryState leaderRecoveryState = LeaderRecoveryState.RECOVERED;
         int leaderEpoch = 0;
         int partitionEpoch = 0;
-        PartitionRegistration part = new PartitionRegistration(
-            replicas,
-            isr,
-            removingReplicas,
-            addingReplicas,
-            leader,
-            leaderRecoveryState,
-            leaderEpoch,
-            partitionEpoch
-        );
+        PartitionRegistration part = new PartitionRegistration.Builder().
+            setReplicas(replicas).
+            setIsr(isr).
+            setRemovingReplicas(removingReplicas).
+            setAddingReplicas(addingReplicas).
+            setLeader(leader).
+            setLeaderRecoveryState(leaderRecoveryState).
+            setLeaderEpoch(leaderEpoch).
+            setPartitionEpoch(partitionEpoch).build();
 
         Uuid topicId = Uuid.randomUuid();
         // Always return false for valid leader. This is so none of the new replicas are valid leaders. This is so we

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentReplicasTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentReplicasTest.java
@@ -131,7 +131,7 @@ public class PartitionReassignmentReplicasTest {
     }
 
     @Test
-    public void testIsReassignmentInProgress() throws Exception {
+    public void testIsReassignmentInProgress() {
         assertTrue(PartitionReassignmentReplicas.isReassignmentInProgress(
             new PartitionRegistration.Builder().
                 setReplicas(new int[]{0, 1, 3, 2}).

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentReplicasTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentReplicasTest.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 
 import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.metadata.PartitionRegistration;
-import org.apache.kafka.metadata.Replicas;
 import org.apache.kafka.metadata.placement.PartitionAssignment;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -148,7 +147,6 @@ public class PartitionReassignmentReplicasTest {
                 setReplicas(new int[]{0, 1, 3, 2}).
                 setIsr(new int[]{0, 1, 3, 2}).
                 setRemovingReplicas(new int[]{2}).
-                setAddingReplicas(Replicas.NONE).
                 setLeader(0).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
                 setLeaderEpoch(0).
@@ -158,7 +156,6 @@ public class PartitionReassignmentReplicasTest {
             new PartitionRegistration.Builder().
                 setReplicas(new int[]{0, 1, 3, 2}).
                 setIsr(new int[]{0, 1, 3, 2}).
-                setRemovingReplicas(Replicas.NONE).
                 setAddingReplicas(new int[]{3}).
                 setLeader(0).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
@@ -169,8 +166,6 @@ public class PartitionReassignmentReplicasTest {
             new PartitionRegistration.Builder().
                 setReplicas(new int[]{0, 1, 2}).
                 setIsr(new int[]{0, 1, 2}).
-                setRemovingReplicas(Replicas.NONE).
-                setAddingReplicas(Replicas.NONE).
                 setLeader(0).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
                 setLeaderEpoch(0).

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentReplicasTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentReplicasTest.java
@@ -131,47 +131,51 @@ public class PartitionReassignmentReplicasTest {
     }
 
     @Test
-    public void testIsReassignmentInProgress() {
+    public void testIsReassignmentInProgress() throws Exception {
         assertTrue(PartitionReassignmentReplicas.isReassignmentInProgress(
-            new PartitionRegistration(
-                new int[]{0, 1, 3, 2},
-                new int[]{0, 1, 3, 2},
-                new int[]{2},
-                new int[]{3},
-                0,
-                LeaderRecoveryState.RECOVERED,
-                0,
-                0)));
+            new PartitionRegistration.Builder().
+                setReplicas(new int[]{0, 1, 3, 2}).
+                setIsr(new int[]{0, 1, 3, 2}).
+                setRemovingReplicas(new int[]{2}).
+                setAddingReplicas(new int[]{3}).
+                setLeader(0).
+                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+                setLeaderEpoch(0).
+                setPartitionEpoch(0).
+                build()));
         assertTrue(PartitionReassignmentReplicas.isReassignmentInProgress(
-            new PartitionRegistration(
-                new int[]{0, 1, 3, 2},
-                new int[]{0, 1, 3, 2},
-                new int[]{2},
-                Replicas.NONE,
-                0,
-                LeaderRecoveryState.RECOVERED,
-                0,
-                0)));
+            new PartitionRegistration.Builder().
+                setReplicas(new int[]{0, 1, 3, 2}).
+                setIsr(new int[]{0, 1, 3, 2}).
+                setRemovingReplicas(new int[]{2}).
+                setAddingReplicas(Replicas.NONE).
+                setLeader(0).
+                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+                setLeaderEpoch(0).
+                setPartitionEpoch(0).
+                build()));
         assertTrue(PartitionReassignmentReplicas.isReassignmentInProgress(
-            new PartitionRegistration(
-                new int[]{0, 1, 2, 3},
-                new int[]{0, 1, 2, 3},
-                Replicas.NONE,
-                new int[]{3},
-                0,
-                LeaderRecoveryState.RECOVERED,
-                0,
-                0)));
+            new PartitionRegistration.Builder().
+                setReplicas(new int[]{0, 1, 3, 2}).
+                setIsr(new int[]{0, 1, 3, 2}).
+                setRemovingReplicas(Replicas.NONE).
+                setAddingReplicas(new int[]{3}).
+                setLeader(0).
+                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+                setLeaderEpoch(0).
+                setPartitionEpoch(0).
+                build()));
         assertFalse(PartitionReassignmentReplicas.isReassignmentInProgress(
-            new PartitionRegistration(
-                new int[]{0, 1, 2},
-                new int[]{0, 1, 2},
-                Replicas.NONE,
-                Replicas.NONE,
-                0,
-                LeaderRecoveryState.RECOVERED,
-                0,
-                0)));
+            new PartitionRegistration.Builder().
+                setReplicas(new int[]{0, 1, 2}).
+                setIsr(new int[]{0, 1, 2}).
+                setRemovingReplicas(Replicas.NONE).
+                setAddingReplicas(Replicas.NONE).
+                setLeader(0).
+                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+                setLeaderEpoch(0).
+                setPartitionEpoch(0).
+                build()));
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentRevertTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentRevertTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Timeout(40)
 public class PartitionReassignmentRevertTest {
     @Test
-    public void testNoneAddedOrRemoved() throws Exception {
+    public void testNoneAddedOrRemoved() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {3, 2, 1}).setIsr(new int[] {3, 2}).
                 setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
@@ -44,7 +44,7 @@ public class PartitionReassignmentRevertTest {
     }
 
     @Test
-    public void testSomeRemoving() throws Exception {
+    public void testSomeRemoving() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {3, 2, 1}).setIsr(new int[] {3, 2}).
             setRemovingReplicas(new int[]{2, 1}).setAddingReplicas(Replicas.NONE).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
@@ -55,7 +55,7 @@ public class PartitionReassignmentRevertTest {
     }
 
     @Test
-    public void testSomeAdding() throws Exception {
+    public void testSomeAdding() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5, 2}).
             setRemovingReplicas(Replicas.NONE).setAddingReplicas(new int[]{4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
@@ -66,7 +66,7 @@ public class PartitionReassignmentRevertTest {
     }
 
     @Test
-    public void testSomeRemovingAndAdding() throws Exception {
+    public void testSomeRemovingAndAdding() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5, 2}).
             setRemovingReplicas(new int[]{2}).setAddingReplicas(new int[]{4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
@@ -77,7 +77,7 @@ public class PartitionReassignmentRevertTest {
     }
 
     @Test
-    public void testIsrSpecialCase() throws Exception {
+    public void testIsrSpecialCase() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5}).
             setRemovingReplicas(new int[]{2}).setAddingReplicas(new int[]{4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentRevertTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentRevertTest.java
@@ -33,10 +33,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Timeout(40)
 public class PartitionReassignmentRevertTest {
     @Test
-    public void testNoneAddedOrRemoved() {
-        PartitionRegistration registration = new PartitionRegistration(
-            new int[] {3, 2, 1}, new int[] {3, 2},
-                Replicas.NONE, Replicas.NONE, 3, LeaderRecoveryState.RECOVERED, 100, 200);
+    public void testNoneAddedOrRemoved() throws Exception {
+        PartitionRegistration registration = new PartitionRegistration.Builder().
+            setReplicas(new int[] {3, 2, 1}).setIsr(new int[] {3, 2}).
+                setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
         assertEquals(Arrays.asList(3, 2), revert.isr());
@@ -44,10 +44,10 @@ public class PartitionReassignmentRevertTest {
     }
 
     @Test
-    public void testSomeRemoving() {
-        PartitionRegistration registration = new PartitionRegistration(
-            new int[] {3, 2, 1}, new int[] {3, 2},
-            new int[] {2, 1}, Replicas.NONE, 3, LeaderRecoveryState.RECOVERED, 100, 200);
+    public void testSomeRemoving() throws Exception {
+        PartitionRegistration registration = new PartitionRegistration.Builder().
+            setReplicas(new int[] {3, 2, 1}).setIsr(new int[] {3, 2}).
+            setRemovingReplicas(new int[]{2, 1}).setAddingReplicas(Replicas.NONE).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
         assertEquals(Arrays.asList(3, 2), revert.isr());
@@ -55,10 +55,10 @@ public class PartitionReassignmentRevertTest {
     }
 
     @Test
-    public void testSomeAdding() {
-        PartitionRegistration registration = new PartitionRegistration(
-            new int[] {4, 5, 3, 2, 1}, new int[] {4, 5, 2},
-            Replicas.NONE, new int[] {4, 5}, 3, LeaderRecoveryState.RECOVERED, 100, 200);
+    public void testSomeAdding() throws Exception {
+        PartitionRegistration registration = new PartitionRegistration.Builder().
+            setReplicas(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5, 2}).
+            setRemovingReplicas(Replicas.NONE).setAddingReplicas(new int[]{4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
         assertEquals(Arrays.asList(2), revert.isr());
@@ -66,10 +66,10 @@ public class PartitionReassignmentRevertTest {
     }
 
     @Test
-    public void testSomeRemovingAndAdding() {
-        PartitionRegistration registration = new PartitionRegistration(
-            new int[] {4, 5, 3, 2, 1}, new int[] {4, 5, 2},
-            new int[] {2}, new int[] {4, 5}, 3, LeaderRecoveryState.RECOVERED, 100, 200);
+    public void testSomeRemovingAndAdding() throws Exception {
+        PartitionRegistration registration = new PartitionRegistration.Builder().
+            setReplicas(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5, 2}).
+            setRemovingReplicas(new int[]{2}).setAddingReplicas(new int[]{4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
         assertEquals(Arrays.asList(2), revert.isr());
@@ -77,10 +77,10 @@ public class PartitionReassignmentRevertTest {
     }
 
     @Test
-    public void testIsrSpecialCase() {
-        PartitionRegistration registration = new PartitionRegistration(
-            new int[] {4, 5, 3, 2, 1}, new int[] {4, 5},
-            new int[] {2}, new int[] {4, 5}, 3, LeaderRecoveryState.RECOVERED, 100, 200);
+    public void testIsrSpecialCase() throws Exception {
+        PartitionRegistration registration = new PartitionRegistration.Builder().
+            setReplicas(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5}).
+            setRemovingReplicas(new int[]{2}).setAddingReplicas(new int[]{4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
         assertEquals(Arrays.asList(3), revert.isr());

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentRevertTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentRevertTest.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 
 import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.metadata.PartitionRegistration;
-import org.apache.kafka.metadata.Replicas;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -36,7 +35,7 @@ public class PartitionReassignmentRevertTest {
     public void testNoneAddedOrRemoved() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {3, 2, 1}).setIsr(new int[] {3, 2}).
-                setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
+            setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
         assertEquals(Arrays.asList(3, 2), revert.isr());
@@ -47,7 +46,7 @@ public class PartitionReassignmentRevertTest {
     public void testSomeRemoving() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {3, 2, 1}).setIsr(new int[] {3, 2}).
-            setRemovingReplicas(new int[]{2, 1}).setAddingReplicas(Replicas.NONE).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
+            setRemovingReplicas(new int[]{2, 1}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
         assertEquals(Arrays.asList(3, 2), revert.isr());
@@ -58,7 +57,7 @@ public class PartitionReassignmentRevertTest {
     public void testSomeAdding() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5, 2}).
-            setRemovingReplicas(Replicas.NONE).setAddingReplicas(new int[]{4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
+            setAddingReplicas(new int[]{4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
         assertEquals(Arrays.asList(2), revert.isr());

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -1391,7 +1391,8 @@ public class ReplicationControlManagerTest {
                 setLeader(0).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
                 setLeaderEpoch(0).
-                setPartitionEpoch(0).build(),
+                setPartitionEpoch(0).
+                build(),
             replicationControl.getPartition(
                 ((TopicRecord) result.records().get(0).message()).topicId(), 1));
     }
@@ -1578,7 +1579,8 @@ public class ReplicationControlManagerTest {
                 setLeader(1).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
                 setLeaderEpoch(1).
-                setPartitionEpoch(1).build(),
+                setPartitionEpoch(1).
+                build(),
             replication.getPartition(fooId, 0));
 
         AlterPartitionRequestData alterIsrRequest = new AlterPartitionRequestData()
@@ -1721,7 +1723,8 @@ public class ReplicationControlManagerTest {
                 setLeader(1).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
                 setLeaderEpoch(0).
-                setPartitionEpoch(0).build(),
+                setPartitionEpoch(0).
+                build(),
             replication.getPartition(fooId, 0));
 
         ctx.inControlledShutdownBrokers(3);

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -510,8 +510,8 @@ public class ReplicationControlManagerTest {
             setTopicId(result3.response().topics().find("foo").topicId()));
         assertEquals(expectedResponse3, result3.response());
         ctx.replay(result3.records());
-        assertEquals(new PartitionRegistration(new int[] {1, 2, 0},
-            new int[] {1, 2, 0}, Replicas.NONE, Replicas.NONE, 1, LeaderRecoveryState.RECOVERED, 0, 0),
+        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 0}).
+            setIsr(new int[] {1, 2, 0}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build(),
             replicationControl.getPartition(
                 ((TopicRecord) result3.records().get(0).message()).topicId(), 0));
         ControllerResult<CreateTopicsResponseData> result4 =
@@ -572,14 +572,14 @@ public class ReplicationControlManagerTest {
         // Broker 2 cannot be in the ISR because it is fenced and broker 1
         // cannot be in the ISR because it is in controlled shutdown.
         assertEquals(
-            new PartitionRegistration(new int[]{1, 0, 2},
-                new int[]{0},
-                Replicas.NONE,
-                Replicas.NONE,
-                0,
-                LeaderRecoveryState.RECOVERED,
-                0,
-                0),
+            new PartitionRegistration.Builder().setReplicas(new int[]{1, 0, 2}).
+                setIsr(new int[]{0}).
+                setRemovingReplicas(Replicas.NONE).
+                setAddingReplicas(Replicas.NONE).
+                setLeader(0).
+                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+                setLeaderEpoch(0).
+                setPartitionEpoch(0).build(),
             replicationControl.getPartition(
                 ((TopicRecord) result.records().get(0).message()).topicId(), 0));
     }
@@ -1362,14 +1362,14 @@ public class ReplicationControlManagerTest {
         // Broker 2 cannot be in the ISR because it is fenced and broker 1
         // cannot be in the ISR because it is in controlled shutdown.
         assertEquals(
-            new PartitionRegistration(new int[]{0, 1, 2},
-                new int[]{0},
-                Replicas.NONE,
-                Replicas.NONE,
-                0,
-                LeaderRecoveryState.RECOVERED,
-                0,
-                0),
+            new PartitionRegistration.Builder().setReplicas(new int[]{0, 1, 2}).
+                setIsr(new int[]{0}).
+                setRemovingReplicas(Replicas.NONE).
+                setAddingReplicas(Replicas.NONE).
+                setLeader(0).
+                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+                setLeaderEpoch(0).
+                setPartitionEpoch(0).build(),
             replicationControl.getPartition(
                 ((TopicRecord) result.records().get(0).message()).topicId(), 1));
     }
@@ -1548,15 +1548,15 @@ public class ReplicationControlManagerTest {
         ctx.replay(fenceRecords);
 
         assertEquals(
-            new PartitionRegistration(
-                new int[] {1, 2, 3, 4},
-                new int[] {1, 2, 4},
-                new int[] {},
-                new int[] {},
-                1,
-                LeaderRecoveryState.RECOVERED,
-                1,
-                1),
+            new PartitionRegistration.Builder().
+                setReplicas(new int[] {1, 2, 3, 4}).
+                setIsr(new int[] {1, 2, 4}).
+                setRemovingReplicas(new int[] {}).
+                setAddingReplicas(new int[] {}).
+                setLeader(1).
+                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+                setLeaderEpoch(1).
+                setPartitionEpoch(1).build(),
             replication.getPartition(fooId, 0));
 
         AlterPartitionRequestData alterIsrRequest = new AlterPartitionRequestData()
@@ -1691,15 +1691,15 @@ public class ReplicationControlManagerTest {
         ).topicId();
 
         assertEquals(
-            new PartitionRegistration(
-                new int[] {1, 2, 3, 4},
-                new int[] {1, 2, 3, 4},
-                new int[] {},
-                new int[] {},
-                1,
-                LeaderRecoveryState.RECOVERED,
-                0,
-                0),
+            new PartitionRegistration.Builder().
+                setReplicas(new int[] {1, 2, 3, 4}).
+                setIsr(new int[] {1, 2, 3, 4}).
+                setRemovingReplicas(new int[] {}).
+                setAddingReplicas(new int[] {}).
+                setLeader(1).
+                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+                setLeaderEpoch(0).
+                setPartitionEpoch(0).build(),
             replication.getPartition(fooId, 0));
 
         ctx.inControlledShutdownBrokers(3);
@@ -1749,8 +1749,8 @@ public class ReplicationControlManagerTest {
         List<ApiMessageAndVersion> fenceRecords = new ArrayList<>();
         replication.handleBrokerFenced(3, fenceRecords);
         ctx.replay(fenceRecords);
-        assertEquals(new PartitionRegistration(new int[] {1, 2, 3, 4}, new int[] {1, 2, 4},
-            new int[] {}, new int[] {}, 1, LeaderRecoveryState.RECOVERED, 1, 1), replication.getPartition(fooId, 0));
+        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).setIsr(new int[] {1, 2, 4}).
+            setRemovingReplicas(new int[] {}).setAddingReplicas(new int[] {}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(1).build(), replication.getPartition(fooId, 0));
         ControllerResult<AlterPartitionReassignmentsResponseData> alterResult =
             replication.alterPartitionReassignments(
                 new AlterPartitionReassignmentsRequestData().setTopics(asList(
@@ -1786,12 +1786,12 @@ public class ReplicationControlManagerTest {
                     setErrorMessage(null))))),
             alterResult.response());
         ctx.replay(alterResult.records());
-        assertEquals(new PartitionRegistration(new int[] {1, 2, 3}, new int[] {1, 2},
-            new int[] {}, new int[] {}, 1, LeaderRecoveryState.RECOVERED, 2, 2), replication.getPartition(fooId, 0));
-        assertEquals(new PartitionRegistration(new int[] {1, 2, 3, 0}, new int[] {0, 1, 2},
-            new int[] {}, new int[] {}, 0, LeaderRecoveryState.RECOVERED, 1, 2), replication.getPartition(fooId, 1));
-        assertEquals(new PartitionRegistration(new int[] {1, 2, 3, 4, 0}, new int[] {4, 2},
-            new int[] {}, new int[] {0, 1}, 4, LeaderRecoveryState.RECOVERED, 1, 2), replication.getPartition(barId, 0));
+        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2}).
+            setRemovingReplicas(new int[] {}).setAddingReplicas(new int[] {}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(2).build(), replication.getPartition(fooId, 0));
+        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 0}).setIsr(new int[] {0, 1, 2}).
+            setRemovingReplicas(new int[] {}).setAddingReplicas(new int[] {}).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(2).build(), replication.getPartition(fooId, 1));
+        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 0}).setIsr(new int[] {4, 2}).
+            setRemovingReplicas(new int[] {}).setAddingReplicas(new int[] {0, 1}).setLeader(4).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(2).build(), replication.getPartition(barId, 0));
         ListPartitionReassignmentsResponseData currentReassigning =
             new ListPartitionReassignmentsResponseData().setErrorMessage(null).
                 setTopics(asList(new OngoingTopicReassignment().
@@ -1849,8 +1849,8 @@ public class ReplicationControlManagerTest {
             cancelResult);
         ctx.replay(cancelResult.records());
         assertEquals(NONE_REASSIGNING, replication.listPartitionReassignments(null));
-        assertEquals(new PartitionRegistration(new int[] {2, 3, 4}, new int[] {4, 2},
-            new int[] {}, new int[] {}, 4, LeaderRecoveryState.RECOVERED, 2, 3), replication.getPartition(barId, 0));
+        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {2, 3, 4}).setIsr(new int[] {4, 2}).
+            setRemovingReplicas(new int[] {}).setAddingReplicas(new int[] {}).setLeader(4).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(3).build(), replication.getPartition(barId, 0));
     }
 
     @Test
@@ -1870,8 +1870,8 @@ public class ReplicationControlManagerTest {
         ctx.createPartitions(2, "foo", new int[][] {new int[] {3, 4, 5}},
             INVALID_REPLICA_ASSIGNMENT.code());
         ctx.createPartitions(2, "foo", new int[][] {new int[] {2, 4, 5}}, NONE.code());
-        assertEquals(new PartitionRegistration(new int[] {2, 4, 5},
-                new int[] {2}, Replicas.NONE, Replicas.NONE, 2, LeaderRecoveryState.RECOVERED, 0, 0),
+        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {2, 4, 5}).
+                setIsr(new int[] {2}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build(),
             ctx.replicationControl.getPartition(fooId, 1));
     }
 

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -532,7 +532,7 @@ public class ReplicationControlManagerTest {
         assertEquals(expectedResponse3, result3.response());
         ctx.replay(result3.records());
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 0}).
-            setIsr(new int[] {1, 2, 0}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build(),
+            setIsr(new int[] {1, 2, 0}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build(),
             replicationControl.getPartition(
                 ((TopicRecord) result3.records().get(0).message()).topicId(), 0));
         ControllerResult<CreateTopicsResponseData> result4 =
@@ -595,8 +595,6 @@ public class ReplicationControlManagerTest {
         assertEquals(
             new PartitionRegistration.Builder().setReplicas(new int[]{1, 0, 2}).
                 setIsr(new int[]{0}).
-                setRemovingReplicas(Replicas.NONE).
-                setAddingReplicas(Replicas.NONE).
                 setLeader(0).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
                 setLeaderEpoch(0).
@@ -1386,8 +1384,6 @@ public class ReplicationControlManagerTest {
         assertEquals(
             new PartitionRegistration.Builder().setReplicas(new int[]{0, 1, 2}).
                 setIsr(new int[]{0}).
-                setRemovingReplicas(Replicas.NONE).
-                setAddingReplicas(Replicas.NONE).
                 setLeader(0).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
                 setLeaderEpoch(0).
@@ -1574,8 +1570,6 @@ public class ReplicationControlManagerTest {
             new PartitionRegistration.Builder().
                 setReplicas(new int[] {1, 2, 3, 4}).
                 setIsr(new int[] {1, 2, 4}).
-                setRemovingReplicas(new int[] {}).
-                setAddingReplicas(new int[] {}).
                 setLeader(1).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
                 setLeaderEpoch(1).
@@ -1718,8 +1712,6 @@ public class ReplicationControlManagerTest {
             new PartitionRegistration.Builder().
                 setReplicas(new int[] {1, 2, 3, 4}).
                 setIsr(new int[] {1, 2, 3, 4}).
-                setRemovingReplicas(new int[] {}).
-                setAddingReplicas(new int[] {}).
                 setLeader(1).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
                 setLeaderEpoch(0).
@@ -1775,7 +1767,7 @@ public class ReplicationControlManagerTest {
         replication.handleBrokerFenced(3, fenceRecords);
         ctx.replay(fenceRecords);
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).setIsr(new int[] {1, 2, 4}).
-            setRemovingReplicas(new int[] {}).setAddingReplicas(new int[] {}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(1).build(), replication.getPartition(fooId, 0));
+            setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(1).build(), replication.getPartition(fooId, 0));
         ControllerResult<AlterPartitionReassignmentsResponseData> alterResult =
             replication.alterPartitionReassignments(
                 new AlterPartitionReassignmentsRequestData().setTopics(asList(
@@ -1812,11 +1804,11 @@ public class ReplicationControlManagerTest {
             alterResult.response());
         ctx.replay(alterResult.records());
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2}).
-            setRemovingReplicas(new int[] {}).setAddingReplicas(new int[] {}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(2).build(), replication.getPartition(fooId, 0));
+            setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(2).build(), replication.getPartition(fooId, 0));
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 0}).setIsr(new int[] {0, 1, 2}).
-            setRemovingReplicas(new int[] {}).setAddingReplicas(new int[] {}).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(2).build(), replication.getPartition(fooId, 1));
+            setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(2).build(), replication.getPartition(fooId, 1));
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 0}).setIsr(new int[] {4, 2}).
-            setRemovingReplicas(new int[] {}).setAddingReplicas(new int[] {0, 1}).setLeader(4).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(2).build(), replication.getPartition(barId, 0));
+            setAddingReplicas(new int[] {0, 1}).setLeader(4).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(2).build(), replication.getPartition(barId, 0));
         ListPartitionReassignmentsResponseData currentReassigning =
             new ListPartitionReassignmentsResponseData().setErrorMessage(null).
                 setTopics(asList(new OngoingTopicReassignment().
@@ -1875,7 +1867,7 @@ public class ReplicationControlManagerTest {
         ctx.replay(cancelResult.records());
         assertEquals(NONE_REASSIGNING, replication.listPartitionReassignments(null));
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {2, 3, 4}).setIsr(new int[] {4, 2}).
-            setRemovingReplicas(new int[] {}).setAddingReplicas(new int[] {}).setLeader(4).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(3).build(), replication.getPartition(barId, 0));
+            setLeader(4).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(3).build(), replication.getPartition(barId, 0));
     }
 
     @Test
@@ -1896,7 +1888,7 @@ public class ReplicationControlManagerTest {
             INVALID_REPLICA_ASSIGNMENT.code());
         ctx.createPartitions(2, "foo", new int[][] {new int[] {2, 4, 5}}, NONE.code());
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {2, 4, 5}).
-                setIsr(new int[] {2}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build(),
+                setIsr(new int[] {2}).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build(),
             ctx.replicationControl.getPartition(fooId, 1));
     }
 

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsTestUtils.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsTestUtils.java
@@ -74,8 +74,6 @@ public class ControllerMetricsTestUtils {
         return new PartitionRegistration.Builder().
             setReplicas(new int[] {0, 1, 2}).
             setIsr(new int[] {0, 1, 2}).
-            setRemovingReplicas(new int[] {}).
-            setAddingReplicas(new int[] {}).
             setLeader(leader).
             setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
             setLeaderEpoch(100).

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsTestUtils.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsTestUtils.java
@@ -71,15 +71,22 @@ public class ControllerMetricsTestUtils {
                 leader = -1;
                 break;
         }
-        return new PartitionRegistration(
-                new int[] {0, 1, 2},
-                new int[] {0, 1, 2},
-                new int[] {},
-                new int[] {},
-                leader,
-                LeaderRecoveryState.RECOVERED,
-                100,
-                200);
+        PartitionRegistration partitionRegistration;
+        try {
+            partitionRegistration =  new PartitionRegistration.Builder().
+                setReplicas(new int[] {0, 1, 2}).
+                setIsr(new int[] {0, 1, 2}).
+                setRemovingReplicas(new int[] {}).
+                setAddingReplicas(new int[] {}).
+                setLeader(leader).
+                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+                setLeaderEpoch(100).
+                setPartitionEpoch(200).
+                build();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return partitionRegistration;
     }
 
     public static TopicImage fakeTopicImage(

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsTestUtils.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsTestUtils.java
@@ -71,22 +71,16 @@ public class ControllerMetricsTestUtils {
                 leader = -1;
                 break;
         }
-        PartitionRegistration partitionRegistration;
-        try {
-            partitionRegistration =  new PartitionRegistration.Builder().
-                setReplicas(new int[] {0, 1, 2}).
-                setIsr(new int[] {0, 1, 2}).
-                setRemovingReplicas(new int[] {}).
-                setAddingReplicas(new int[] {}).
-                setLeader(leader).
-                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
-                setLeaderEpoch(100).
-                setPartitionEpoch(200).
-                build();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        return partitionRegistration;
+        return new PartitionRegistration.Builder().
+            setReplicas(new int[] {0, 1, 2}).
+            setIsr(new int[] {0, 1, 2}).
+            setRemovingReplicas(new int[] {}).
+            setAddingReplicas(new int[] {}).
+            setLeader(leader).
+            setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(100).
+            setPartitionEpoch(200).
+            build();
     }
 
     public static TopicImage fakeTopicImage(

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -137,8 +137,7 @@ public class TopicsImageTest {
         DELTA1 = new TopicsDelta(IMAGE1);
         RecordTestUtils.replayAll(DELTA1, DELTA1_RECORDS);
 
-        List<TopicImage> topics2;
-        topics2 = Arrays.asList(
+        List<TopicImage> topics2 = Arrays.asList(
             newTopicImage("bar", BAR_UUID,
                 new PartitionRegistration.Builder().setReplicas(new int[] {0, 1, 2, 3, 4}).
                     setIsr(new int[] {0, 1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {3, 4}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(346).build()),
@@ -166,8 +165,6 @@ public class TopicsImageTest {
         return new PartitionRegistration.Builder().
             setReplicas(replicas).
             setIsr(replicas).
-            setRemovingReplicas(Replicas.NONE).
-            setAddingReplicas(Replicas.NONE).
             setLeader(replicas[0]).
             setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
             setLeaderEpoch(1).

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -98,21 +98,17 @@ public class TopicsImageTest {
     private static final Uuid BAZ_UUID = Uuid.fromString("tgHBnRglT5W_RlENnuG5vg");
 
     static {
-        try {
-            TOPIC_IMAGES1 = Arrays.asList(
-                newTopicImage("foo", FOO_UUID,
-                    new PartitionRegistration.Builder().setReplicas(new int[] {2, 3, 4}).
-                        setIsr(new int[] {2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(345).build(),
-                    new PartitionRegistration.Builder().setReplicas(new int[] {3, 4, 5}).
-                        setIsr(new int[] {3, 4, 5}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(4).setPartitionEpoch(684).build(),
-                    new PartitionRegistration.Builder().setReplicas(new int[] {2, 4, 5}).
-                        setIsr(new int[] {2, 4, 5}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(10).setPartitionEpoch(84).build()),
-                newTopicImage("bar", BAR_UUID,
-                    new PartitionRegistration.Builder().setReplicas(new int[] {0, 1, 2, 3, 4}).
-                        setIsr(new int[] {0, 1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {3, 4}).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(345).build()));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        TOPIC_IMAGES1 = Arrays.asList(
+            newTopicImage("foo", FOO_UUID,
+                new PartitionRegistration.Builder().setReplicas(new int[] {2, 3, 4}).
+                    setIsr(new int[] {2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(345).build(),
+                new PartitionRegistration.Builder().setReplicas(new int[] {3, 4, 5}).
+                    setIsr(new int[] {3, 4, 5}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(4).setPartitionEpoch(684).build(),
+                new PartitionRegistration.Builder().setReplicas(new int[] {2, 4, 5}).
+                    setIsr(new int[] {2, 4, 5}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(10).setPartitionEpoch(84).build()),
+            newTopicImage("bar", BAR_UUID,
+                new PartitionRegistration.Builder().setReplicas(new int[] {0, 1, 2, 3, 4}).
+                    setIsr(new int[] {0, 1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {3, 4}).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(345).build()));
 
         IMAGE1 = new TopicsImage(newTopicsByIdMap(TOPIC_IMAGES1), newTopicsByNameMap(TOPIC_IMAGES1));
 
@@ -142,17 +138,13 @@ public class TopicsImageTest {
         RecordTestUtils.replayAll(DELTA1, DELTA1_RECORDS);
 
         List<TopicImage> topics2;
-        try {
-            topics2 = Arrays.asList(
-                newTopicImage("bar", BAR_UUID,
-                    new PartitionRegistration.Builder().setReplicas(new int[] {0, 1, 2, 3, 4}).
-                        setIsr(new int[] {0, 1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {3, 4}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(346).build()),
-                newTopicImage("baz", BAZ_UUID,
-                    new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).
-                        setIsr(new int[] {3, 4}).setRemovingReplicas(new int[] {2}).setAddingReplicas(new int[] {1}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(1).build()));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        topics2 = Arrays.asList(
+            newTopicImage("bar", BAR_UUID,
+                new PartitionRegistration.Builder().setReplicas(new int[] {0, 1, 2, 3, 4}).
+                    setIsr(new int[] {0, 1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {3, 4}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(346).build()),
+            newTopicImage("baz", BAZ_UUID,
+                new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).
+                    setIsr(new int[] {3, 4}).setRemovingReplicas(new int[] {2}).setAddingReplicas(new int[] {1}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(1).build()));
         IMAGE2 = new TopicsImage(newTopicsByIdMap(topics2), newTopicsByNameMap(topics2));
     }
 
@@ -171,14 +163,16 @@ public class TopicsImageTest {
     }
 
     private PartitionRegistration newPartition(int[] replicas) {
-        PartitionRegistration partitionRegistration;
-        try {
-            partitionRegistration = new PartitionRegistration.Builder().setReplicas(replicas).setIsr(replicas).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(replicas[0]).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
-                setLeaderEpoch(1).setPartitionEpoch(1).build();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        return partitionRegistration;
+        return new PartitionRegistration.Builder().
+            setReplicas(replicas).
+            setIsr(replicas).
+            setRemovingReplicas(Replicas.NONE).
+            setAddingReplicas(Replicas.NONE).
+            setLeader(replicas[0]).
+            setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(1).
+            setPartitionEpoch(1).
+            build();
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -111,7 +111,7 @@ public class TopicsImageTest {
                     new PartitionRegistration.Builder().setReplicas(new int[] {0, 1, 2, 3, 4}).
                         setIsr(new int[] {0, 1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {3, 4}).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(345).build()));
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
         IMAGE1 = new TopicsImage(newTopicsByIdMap(TOPIC_IMAGES1), newTopicsByNameMap(TOPIC_IMAGES1));
@@ -141,7 +141,7 @@ public class TopicsImageTest {
         DELTA1 = new TopicsDelta(IMAGE1);
         RecordTestUtils.replayAll(DELTA1, DELTA1_RECORDS);
 
-        List<TopicImage> topics2 = null;
+        List<TopicImage> topics2;
         try {
             topics2 = Arrays.asList(
                 newTopicImage("bar", BAR_UUID,
@@ -151,7 +151,7 @@ public class TopicsImageTest {
                     new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).
                         setIsr(new int[] {3, 4}).setRemovingReplicas(new int[] {2}).setAddingReplicas(new int[] {1}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(1).build()));
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
         IMAGE2 = new TopicsImage(newTopicsByIdMap(topics2), newTopicsByNameMap(topics2));
     }

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -28,7 +28,6 @@ import org.apache.kafka.image.writer.RecordListWriter;
 import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.metadata.RecordTestUtils;
-import org.apache.kafka.metadata.Replicas;
 import org.apache.kafka.server.immutable.ImmutableMap;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.junit.jupiter.api.Test;
@@ -101,11 +100,11 @@ public class TopicsImageTest {
         TOPIC_IMAGES1 = Arrays.asList(
             newTopicImage("foo", FOO_UUID,
                 new PartitionRegistration.Builder().setReplicas(new int[] {2, 3, 4}).
-                    setIsr(new int[] {2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(345).build(),
+                    setIsr(new int[] {2, 3}).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(345).build(),
                 new PartitionRegistration.Builder().setReplicas(new int[] {3, 4, 5}).
-                    setIsr(new int[] {3, 4, 5}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(4).setPartitionEpoch(684).build(),
+                    setIsr(new int[] {3, 4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(4).setPartitionEpoch(684).build(),
                 new PartitionRegistration.Builder().setReplicas(new int[] {2, 4, 5}).
-                    setIsr(new int[] {2, 4, 5}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(10).setPartitionEpoch(84).build()),
+                    setIsr(new int[] {2, 4, 5}).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(10).setPartitionEpoch(84).build()),
             newTopicImage("bar", BAR_UUID,
                 new PartitionRegistration.Builder().setReplicas(new int[] {0, 1, 2, 3, 4}).
                     setIsr(new int[] {0, 1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {3, 4}).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(345).build()));

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -58,13 +58,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TopicsImageTest {
     public static final TopicsImage IMAGE1;
 
-    public static final List<ApiMessageAndVersion> DELTA1_RECORDS;
+    public static List<ApiMessageAndVersion> DELTA1_RECORDS;
 
-    static final TopicsDelta DELTA1;
+    static TopicsDelta DELTA1;
 
-    static final TopicsImage IMAGE2;
+    static TopicsImage IMAGE2;
 
-    static final List<TopicImage> TOPIC_IMAGES1;
+    static List<TopicImage> TOPIC_IMAGES1;
 
     private static TopicImage newTopicImage(String name, Uuid id, PartitionRegistration... partitions) {
         Map<Integer, PartitionRegistration> partitionMap = new HashMap<>();
@@ -98,17 +98,21 @@ public class TopicsImageTest {
     private static final Uuid BAZ_UUID = Uuid.fromString("tgHBnRglT5W_RlENnuG5vg");
 
     static {
-        TOPIC_IMAGES1 = Arrays.asList(
-            newTopicImage("foo", FOO_UUID,
-                new PartitionRegistration(new int[] {2, 3, 4},
-                    new int[] {2, 3}, Replicas.NONE, Replicas.NONE, 2, LeaderRecoveryState.RECOVERED, 1, 345),
-                new PartitionRegistration(new int[] {3, 4, 5},
-                    new int[] {3, 4, 5}, Replicas.NONE, Replicas.NONE, 3, LeaderRecoveryState.RECOVERED, 4, 684),
-                new PartitionRegistration(new int[] {2, 4, 5},
-                    new int[] {2, 4, 5}, Replicas.NONE, Replicas.NONE, 2, LeaderRecoveryState.RECOVERED, 10, 84)),
-            newTopicImage("bar", BAR_UUID,
-                new PartitionRegistration(new int[] {0, 1, 2, 3, 4},
-                    new int[] {0, 1, 2, 3}, new int[] {1}, new int[] {3, 4}, 0, LeaderRecoveryState.RECOVERED, 1, 345)));
+        try {
+            TOPIC_IMAGES1 = Arrays.asList(
+                newTopicImage("foo", FOO_UUID,
+                    new PartitionRegistration.Builder().setReplicas(new int[] {2, 3, 4}).
+                        setIsr(new int[] {2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(345).build(),
+                    new PartitionRegistration.Builder().setReplicas(new int[] {3, 4, 5}).
+                        setIsr(new int[] {3, 4, 5}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(4).setPartitionEpoch(684).build(),
+                    new PartitionRegistration.Builder().setReplicas(new int[] {2, 4, 5}).
+                        setIsr(new int[] {2, 4, 5}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(10).setPartitionEpoch(84).build()),
+                newTopicImage("bar", BAR_UUID,
+                    new PartitionRegistration.Builder().setReplicas(new int[] {0, 1, 2, 3, 4}).
+                        setIsr(new int[] {0, 1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {3, 4}).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(345).build()));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
 
         IMAGE1 = new TopicsImage(newTopicsByIdMap(TOPIC_IMAGES1), newTopicsByNameMap(TOPIC_IMAGES1));
 
@@ -137,13 +141,18 @@ public class TopicsImageTest {
         DELTA1 = new TopicsDelta(IMAGE1);
         RecordTestUtils.replayAll(DELTA1, DELTA1_RECORDS);
 
-        List<TopicImage> topics2 = Arrays.asList(
-            newTopicImage("bar", BAR_UUID,
-                new PartitionRegistration(new int[] {0, 1, 2, 3, 4},
-                    new int[] {0, 1, 2, 3}, new int[] {1}, new int[] {3, 4}, 1, LeaderRecoveryState.RECOVERED, 2, 346)),
-            newTopicImage("baz", BAZ_UUID,
-                new PartitionRegistration(new int[] {1, 2, 3, 4},
-                    new int[] {3, 4}, new int[] {2}, new int[] {1}, 3, LeaderRecoveryState.RECOVERED, 2, 1)));
+        List<TopicImage> topics2 = null;
+        try {
+            topics2 = Arrays.asList(
+                newTopicImage("bar", BAR_UUID,
+                    new PartitionRegistration.Builder().setReplicas(new int[] {0, 1, 2, 3, 4}).
+                        setIsr(new int[] {0, 1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {3, 4}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(346).build()),
+                newTopicImage("baz", BAZ_UUID,
+                    new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).
+                        setIsr(new int[] {3, 4}).setRemovingReplicas(new int[] {2}).setAddingReplicas(new int[] {1}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(1).build()));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
         IMAGE2 = new TopicsImage(newTopicsByIdMap(topics2), newTopicsByNameMap(topics2));
     }
 
@@ -162,7 +171,14 @@ public class TopicsImageTest {
     }
 
     private PartitionRegistration newPartition(int[] replicas) {
-        return new PartitionRegistration(replicas, replicas, Replicas.NONE, Replicas.NONE, replicas[0], LeaderRecoveryState.RECOVERED, 1, 1);
+        PartitionRegistration partitionRegistration;
+        try {
+            partitionRegistration = new PartitionRegistration.Builder().setReplicas(replicas).setIsr(replicas).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(replicas[0]).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+                setLeaderEpoch(1).setPartitionEpoch(1).build();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return partitionRegistration;
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -58,13 +58,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TopicsImageTest {
     public static final TopicsImage IMAGE1;
 
-    public static List<ApiMessageAndVersion> DELTA1_RECORDS;
+    public static final List<ApiMessageAndVersion> DELTA1_RECORDS;
 
-    static TopicsDelta DELTA1;
+    static final TopicsDelta DELTA1;
 
-    static TopicsImage IMAGE2;
+    static final TopicsImage IMAGE2;
 
-    static List<TopicImage> TOPIC_IMAGES1;
+    static final List<TopicImage> TOPIC_IMAGES1;
 
     private static TopicImage newTopicImage(String name, Uuid id, PartitionRegistration... partitions) {
         Map<Integer, PartitionRegistration> partitionMap = new HashMap<>();

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -52,7 +52,7 @@ public class PartitionRegistrationTest {
     }
 
     @Test
-    public void testPartitionControlInfoMergeAndDiff() throws Exception {
+    public void testPartitionControlInfoMergeAndDiff() {
         PartitionRegistration a = new PartitionRegistration.Builder().
             setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1, 2}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build();
         PartitionRegistration b = new PartitionRegistration.Builder().
@@ -68,7 +68,7 @@ public class PartitionRegistrationTest {
     }
 
     @Test
-    public void testRecordRoundTrip() throws Exception {
+    public void testRecordRoundTrip() {
         PartitionRegistration registrationA = new PartitionRegistration.Builder().
             setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1, 2}).setRemovingReplicas(new int[]{1}).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build();
         Uuid topicId = Uuid.fromString("OGdAI5nxT_m-ds3rJMqPLA");
@@ -80,7 +80,7 @@ public class PartitionRegistrationTest {
     }
 
     @Test
-    public void testToLeaderAndIsrPartitionState() throws Exception {
+    public void testToLeaderAndIsrPartitionState() {
         PartitionRegistration a = new PartitionRegistration.Builder().
             setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1, 2}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(123).setPartitionEpoch(456).build();
         PartitionRegistration b = new PartitionRegistration.Builder().
@@ -114,7 +114,7 @@ public class PartitionRegistrationTest {
     }
 
     @Test
-    public void testMergePartitionChangeRecordWithReassignmentData() throws Exception {
+    public void testMergePartitionChangeRecordWithReassignmentData() {
         PartitionRegistration partition0 = new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).
             setIsr(new int[] {1, 2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionRegistration partition1 = partition0.merge(new PartitionChangeRecord().
@@ -198,7 +198,7 @@ public class PartitionRegistrationTest {
     }
 
     @Test
-    public void testBuilderSuccess() throws Exception {
+    public void testBuilderSuccess() {
         PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
             setReplicas(new int[]{0, 1}).
             setIsr(new int[]{0, 1}).
@@ -220,7 +220,7 @@ public class PartitionRegistrationTest {
     }
 
     @Test
-    public void testBuilderSetsDefaultAddingAndRemovingReplicas() throws Exception {
+    public void testBuilderSetsDefaultAddingAndRemovingReplicas() {
         PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
             setReplicas(new int[]{0, 1}).
             setIsr(new int[]{0, 1}).
@@ -229,8 +229,8 @@ public class PartitionRegistrationTest {
             setLeaderEpoch(0).
             setPartitionEpoch(0);
         PartitionRegistration partitionRegistration = builder.build();
-        assertEquals(Replicas.toList(new int[]{}), Replicas.toList(partitionRegistration.removingReplicas));
-        assertEquals(Replicas.toList(new int[]{}), Replicas.toList(partitionRegistration.addingReplicas));
+        assertEquals(Replicas.toList(Replicas.NONE), Replicas.toList(partitionRegistration.removingReplicas));
+        assertEquals(Replicas.toList(Replicas.NONE), Replicas.toList(partitionRegistration.addingReplicas));
     }
 
     @Property
@@ -248,7 +248,7 @@ public class PartitionRegistrationTest {
     }
 
     @Provide
-    Arbitrary<PartitionRegistration> uniqueSamples() throws Exception {
+    Arbitrary<PartitionRegistration> uniqueSamples() {
         return Arbitraries.of(
             new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
                 setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build(),

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -54,11 +54,11 @@ public class PartitionRegistrationTest {
     @Test
     public void testPartitionControlInfoMergeAndDiff() {
         PartitionRegistration a = new PartitionRegistration.Builder().
-            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1, 2}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build();
+            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1, 2}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build();
         PartitionRegistration b = new PartitionRegistration.Builder().
-            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(1).build();
+            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{3}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(1).build();
         PartitionRegistration c = new PartitionRegistration.Builder().
-            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(1).build();
+            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(1).build();
         assertEquals(b, a.merge(new PartitionChangeRecord().
             setLeader(3).setIsr(Arrays.asList(3))));
         assertEquals("isr: [1, 2] -> [3], leader: 1 -> 3, leaderEpoch: 0 -> 1, partitionEpoch: 0 -> 1",
@@ -70,7 +70,7 @@ public class PartitionRegistrationTest {
     @Test
     public void testRecordRoundTrip() {
         PartitionRegistration registrationA = new PartitionRegistration.Builder().
-            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1, 2}).setRemovingReplicas(new int[]{1}).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build();
+            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1, 2}).setRemovingReplicas(new int[]{1}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build();
         Uuid topicId = Uuid.fromString("OGdAI5nxT_m-ds3rJMqPLA");
         int partitionId = 4;
         ApiMessageAndVersion record = registrationA.toRecord(topicId, partitionId);
@@ -82,9 +82,9 @@ public class PartitionRegistrationTest {
     @Test
     public void testToLeaderAndIsrPartitionState() {
         PartitionRegistration a = new PartitionRegistration.Builder().
-            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1, 2}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(123).setPartitionEpoch(456).build();
+            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1, 2}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(123).setPartitionEpoch(456).build();
         PartitionRegistration b = new PartitionRegistration.Builder().
-            setReplicas(new int[]{2, 3, 4}).setIsr(new int[]{2, 3, 4}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(234).setPartitionEpoch(567).build();
+            setReplicas(new int[]{2, 3, 4}).setIsr(new int[]{2, 3, 4}).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(234).setPartitionEpoch(567).build();
         assertEquals(new LeaderAndIsrPartitionState().
                 setTopicName("foo").
                 setPartitionIndex(1).
@@ -116,7 +116,7 @@ public class PartitionRegistrationTest {
     @Test
     public void testMergePartitionChangeRecordWithReassignmentData() {
         PartitionRegistration partition0 = new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).
-            setIsr(new int[] {1, 2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
+            setIsr(new int[] {1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionRegistration partition1 = partition0.merge(new PartitionChangeRecord().
             setRemovingReplicas(Collections.singletonList(3)).
             setAddingReplicas(Collections.singletonList(4)).
@@ -129,7 +129,7 @@ public class PartitionRegistrationTest {
             setAddingReplicas(Collections.emptyList()).
             setReplicas(Arrays.asList(1, 2, 4)));
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 4}).
-            setIsr(new int[] {1, 2, 4}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(202).build(), partition2);
+            setIsr(new int[] {1, 2, 4}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(202).build(), partition2);
     }
 
     @Test
@@ -250,23 +250,23 @@ public class PartitionRegistrationTest {
     @Provide
     Arbitrary<PartitionRegistration> uniqueSamples() {
         return Arbitraries.of(
-            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2, 3}).
                 setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build(),
-            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2, 3}).
                 setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(101).setPartitionEpoch(200).build(),
-            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2, 3}).
                 setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(201).build(),
-            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2, 3}).
                 setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build(),
-            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1}).
                 setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERING).setLeaderEpoch(100).setPartitionEpoch(200).build(),
             new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 5, 6}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(new int[] {4, 5, 6}).setAddingReplicas(new int[] {1, 2, 3}).
                 setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build(),
             new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 5, 6}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(new int[] {1, 2, 3}).setAddingReplicas(new int[] {4, 5, 6}).
                 setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build(),
-            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 5, 6}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(new int[] {1, 2, 3}).setAddingReplicas(Replicas.NONE).
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 5, 6}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(new int[] {1, 2, 3}).
                 setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build(),
-            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 5, 6}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(new int[] {4, 5, 6}).
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 5, 6}).setIsr(new int[] {1, 2, 3}).setAddingReplicas(new int[] {4, 5, 6}).
                 setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build()
         );
     }

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -34,10 +34,7 @@ import org.junit.jupiter.api.Timeout;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 @Timeout(40)
@@ -51,13 +48,13 @@ public class PartitionRegistrationTest {
     }
 
     @Test
-    public void testPartitionControlInfoMergeAndDiff() {
-        PartitionRegistration a = new PartitionRegistration(
-            new int[]{1, 2, 3}, new int[]{1, 2}, Replicas.NONE, Replicas.NONE, 1, LeaderRecoveryState.RECOVERED, 0, 0);
-        PartitionRegistration b = new PartitionRegistration(
-            new int[]{1, 2, 3}, new int[]{3}, Replicas.NONE, Replicas.NONE, 3, LeaderRecoveryState.RECOVERED, 1, 1);
-        PartitionRegistration c = new PartitionRegistration(
-            new int[]{1, 2, 3}, new int[]{1}, Replicas.NONE, Replicas.NONE, 1, LeaderRecoveryState.RECOVERED, 0, 1);
+    public void testPartitionControlInfoMergeAndDiff() throws Exception {
+        PartitionRegistration a = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1, 2}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build();
+        PartitionRegistration b = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(1).build();
+        PartitionRegistration c = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(1).build();
         assertEquals(b, a.merge(new PartitionChangeRecord().
             setLeader(3).setIsr(Arrays.asList(3))));
         assertEquals("isr: [1, 2] -> [3], leader: 1 -> 3, leaderEpoch: 0 -> 1, partitionEpoch: 0 -> 1",
@@ -67,9 +64,9 @@ public class PartitionRegistrationTest {
     }
 
     @Test
-    public void testRecordRoundTrip() {
-        PartitionRegistration registrationA = new PartitionRegistration(
-            new int[]{1, 2, 3}, new int[]{1, 2}, new int[]{1}, Replicas.NONE, 1, LeaderRecoveryState.RECOVERED, 0, 0);
+    public void testRecordRoundTrip() throws Exception {
+        PartitionRegistration registrationA = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1, 2}).setRemovingReplicas(new int[]{1}).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build();
         Uuid topicId = Uuid.fromString("OGdAI5nxT_m-ds3rJMqPLA");
         int partitionId = 4;
         ApiMessageAndVersion record = registrationA.toRecord(topicId, partitionId);
@@ -79,11 +76,11 @@ public class PartitionRegistrationTest {
     }
 
     @Test
-    public void testToLeaderAndIsrPartitionState() {
-        PartitionRegistration a = new PartitionRegistration(
-            new int[]{1, 2, 3}, new int[]{1, 2}, Replicas.NONE, Replicas.NONE, 1, LeaderRecoveryState.RECOVERED, 123, 456);
-        PartitionRegistration b = new PartitionRegistration(
-            new int[]{2, 3, 4}, new int[]{2, 3, 4}, Replicas.NONE, Replicas.NONE, 2, LeaderRecoveryState.RECOVERED, 234, 567);
+    public void testToLeaderAndIsrPartitionState() throws Exception {
+        PartitionRegistration a = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setIsr(new int[]{1, 2}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(123).setPartitionEpoch(456).build();
+        PartitionRegistration b = new PartitionRegistration.Builder().
+            setReplicas(new int[]{2, 3, 4}).setIsr(new int[]{2, 3, 4}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(234).setPartitionEpoch(567).build();
         assertEquals(new LeaderAndIsrPartitionState().
                 setTopicName("foo").
                 setPartitionIndex(1).
@@ -113,22 +110,122 @@ public class PartitionRegistrationTest {
     }
 
     @Test
-    public void testMergePartitionChangeRecordWithReassignmentData() {
-        PartitionRegistration partition0 = new PartitionRegistration(new int[] {1, 2, 3},
-            new int[] {1, 2, 3}, Replicas.NONE, Replicas.NONE, 1, LeaderRecoveryState.RECOVERED, 100, 200);
+    public void testMergePartitionChangeRecordWithReassignmentData() throws Exception {
+        PartitionRegistration partition0 = new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).
+            setIsr(new int[] {1, 2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionRegistration partition1 = partition0.merge(new PartitionChangeRecord().
             setRemovingReplicas(Collections.singletonList(3)).
             setAddingReplicas(Collections.singletonList(4)).
             setReplicas(Arrays.asList(1, 2, 3, 4)));
-        assertEquals(new PartitionRegistration(new int[] {1, 2, 3, 4},
-            new int[] {1, 2, 3}, new int[] {3}, new int[] {4}, 1, LeaderRecoveryState.RECOVERED, 100, 201), partition1);
+        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).
+            setIsr(new int[] {1, 2, 3}).setRemovingReplicas(new int[] {3}).setAddingReplicas(new int[] {4}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(201).build(), partition1);
         PartitionRegistration partition2 = partition1.merge(new PartitionChangeRecord().
             setIsr(Arrays.asList(1, 2, 4)).
             setRemovingReplicas(Collections.emptyList()).
             setAddingReplicas(Collections.emptyList()).
             setReplicas(Arrays.asList(1, 2, 4)));
-        assertEquals(new PartitionRegistration(new int[] {1, 2, 4},
-            new int[] {1, 2, 4}, Replicas.NONE, Replicas.NONE, 1, LeaderRecoveryState.RECOVERED, 100, 202), partition2);
+        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 4}).
+            setIsr(new int[] {1, 2, 4}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(202).build(), partition2);
+    }
+
+    @Test
+    public void testBuilderThrowsIllegalStateExceptionWhenMissingReplicas() {
+        PartitionRegistration.Builder builder = new PartitionRegistration.Builder();
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> builder.build());
+        assertEquals("You must set replicas.", exception.getMessage());
+    }
+
+    @Test
+    public void testBuilderThrowsIllegalStateExceptionWhenMissingIsr() {
+        PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
+            setReplicas(new int[]{0});
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> builder.build());
+        assertEquals("You must set isr.", exception.getMessage());
+    }
+
+    @Test
+    public void testBuilderThrowsIllegalStateExceptionWhenMissingRemovingReplicas() {
+        PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
+            setReplicas(new int[]{0}).
+            setIsr(new int[]{0});
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> builder.build());
+        assertEquals("You must set removing replicas.", exception.getMessage());
+    }
+
+    @Test
+    public void testBuilderThrowsIllegalStateExceptionWhenMissingAddingReplicas() {
+        PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
+            setReplicas(new int[]{0}).
+            setIsr(new int[]{0}).setRemovingReplicas(new int[]{0});
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> builder.build());
+        assertEquals("You must set adding replicas.", exception.getMessage());
+    }
+
+    @Test
+    public void testBuilderThrowsIllegalStateExceptionWhenMissingLeader() {
+        PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
+            setReplicas(new int[]{0}).
+            setIsr(new int[]{0}).
+            setRemovingReplicas(new int[]{0}).
+            setAddingReplicas(new int[]{0});
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> builder.build());
+        assertEquals("You must set leader.", exception.getMessage());
+    }
+
+    @Test
+    public void testBuilderThrowsIllegalStateExceptionWhenMissingLeaderRecoveryState() {
+        PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
+            setReplicas(new int[]{0}).
+            setIsr(new int[]{0}).
+            setRemovingReplicas(new int[]{0}).
+            setAddingReplicas(new int[]{0}).
+            setLeader(0);
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> builder.build());
+        assertEquals("You must set leader recovery state.", exception.getMessage());
+    }
+
+    @Test
+    public void testBuilderThrowsIllegalStateExceptionWhenMissingLeaderEpoch() {
+        PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
+            setReplicas(new int[]{0}).
+            setIsr(new int[]{0}).
+            setRemovingReplicas(new int[]{0}).
+            setAddingReplicas(new int[]{0}).
+            setLeader(0).
+            setLeaderRecoveryState(LeaderRecoveryState.RECOVERED);
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> builder.build());
+        assertEquals("You must set leader epoch.", exception.getMessage());
+    }
+
+    @Test
+    public void testBuilderThrowsIllegalStateExceptionWhenMissingPartitionEpoch() {
+        PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
+            setReplicas(new int[]{0}).
+            setIsr(new int[]{0}).
+            setRemovingReplicas(new int[]{0}).
+            setAddingReplicas(new int[]{0}).
+            setLeader(0).
+            setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(0);
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> builder.build());
+        assertEquals("You must set partition epoch.", exception.getMessage());
+    }
+
+    @Test
+    public void testBuilderSuccess() throws Exception {
+        PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
+            setReplicas(new int[]{0}).
+            setIsr(new int[]{0}).
+            setRemovingReplicas(new int[]{0}).
+            setAddingReplicas(new int[]{0}).
+            setLeader(0).
+            setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(0).
+            setPartitionEpoch(0);
+        PartitionRegistration partitionRegistration = builder.build();
+        assertEquals(new PartitionRegistration(
+                new int[]{0}, new int[]{0}, new int[]{0}, new int[]{0}, 0, LeaderRecoveryState.RECOVERED, 0, 0),
+            partitionRegistration);
     }
 
     @Property
@@ -146,26 +243,26 @@ public class PartitionRegistrationTest {
     }
 
     @Provide
-    Arbitrary<PartitionRegistration> uniqueSamples() {
+    Arbitrary<PartitionRegistration> uniqueSamples() throws Exception {
         return Arbitraries.of(
-            new PartitionRegistration(new int[] {1, 2, 3}, new int[] {1, 2, 3}, Replicas.NONE, Replicas.NONE,
-                1, LeaderRecoveryState.RECOVERED, 100, 200),
-            new PartitionRegistration(new int[] {1, 2, 3}, new int[] {1, 2, 3}, Replicas.NONE, Replicas.NONE,
-                1, LeaderRecoveryState.RECOVERED, 101, 200),
-            new PartitionRegistration(new int[] {1, 2, 3}, new int[] {1, 2, 3}, Replicas.NONE, Replicas.NONE,
-                1, LeaderRecoveryState.RECOVERED, 100, 201),
-            new PartitionRegistration(new int[] {1, 2, 3}, new int[] {1, 2, 3}, Replicas.NONE, Replicas.NONE,
-                2, LeaderRecoveryState.RECOVERED, 100, 200),
-            new PartitionRegistration(new int[] {1, 2, 3}, new int[] {1}, Replicas.NONE, Replicas.NONE,
-                1, LeaderRecoveryState.RECOVERING, 100, 200),
-            new PartitionRegistration(new int[] {1, 2, 3, 4, 5, 6}, new int[] {1, 2, 3}, new int[] {4, 5, 6}, new int[] {1, 2, 3},
-                1, LeaderRecoveryState.RECOVERED, 100, 200),
-            new PartitionRegistration(new int[] {1, 2, 3, 4, 5, 6}, new int[] {1, 2, 3}, new int[] {1, 2, 3}, new int[] {4, 5, 6},
-                1, LeaderRecoveryState.RECOVERED, 100, 200),
-            new PartitionRegistration(new int[] {1, 2, 3, 4, 5, 6}, new int[] {1, 2, 3}, new int[] {1, 2, 3}, Replicas.NONE,
-                1, LeaderRecoveryState.RECOVERED, 100, 200),
-            new PartitionRegistration(new int[] {1, 2, 3, 4, 5, 6}, new int[] {1, 2, 3}, Replicas.NONE, new int[] {4, 5, 6},
-                1, LeaderRecoveryState.RECOVERED, 100, 200)
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
+                setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build(),
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
+                setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(101).setPartitionEpoch(200).build(),
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
+                setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(201).build(),
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
+                setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build(),
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(Replicas.NONE).
+                setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERING).setLeaderEpoch(100).setPartitionEpoch(200).build(),
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 5, 6}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(new int[] {4, 5, 6}).setAddingReplicas(new int[] {1, 2, 3}).
+                setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build(),
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 5, 6}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(new int[] {1, 2, 3}).setAddingReplicas(new int[] {4, 5, 6}).
+                setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build(),
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 5, 6}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(new int[] {1, 2, 3}).setAddingReplicas(Replicas.NONE).
+                setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build(),
+            new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 5, 6}).setIsr(new int[] {1, 2, 3}).setRemovingReplicas(Replicas.NONE).setAddingReplicas(new int[] {4, 5, 6}).
+                setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build()
         );
     }
 

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -148,24 +148,6 @@ public class PartitionRegistrationTest {
     }
 
     @Test
-    public void testBuilderThrowsIllegalStateExceptionWhenMissingRemovingReplicas() {
-        PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
-            setReplicas(new int[]{0}).
-            setIsr(new int[]{0});
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> builder.build());
-        assertEquals("You must set removing replicas.", exception.getMessage());
-    }
-
-    @Test
-    public void testBuilderThrowsIllegalStateExceptionWhenMissingAddingReplicas() {
-        PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
-            setReplicas(new int[]{0}).
-            setIsr(new int[]{0}).setRemovingReplicas(new int[]{0});
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> builder.build());
-        assertEquals("You must set adding replicas.", exception.getMessage());
-    }
-
-    @Test
     public void testBuilderThrowsIllegalStateExceptionWhenMissingLeader() {
         PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
             setReplicas(new int[]{0}).
@@ -218,18 +200,37 @@ public class PartitionRegistrationTest {
     @Test
     public void testBuilderSuccess() throws Exception {
         PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
-            setReplicas(new int[]{0}).
-            setIsr(new int[]{0}).
+            setReplicas(new int[]{0, 1}).
+            setIsr(new int[]{0, 1}).
             setRemovingReplicas(new int[]{0}).
-            setAddingReplicas(new int[]{0}).
+            setAddingReplicas(new int[]{1}).
             setLeader(0).
             setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
             setLeaderEpoch(0).
             setPartitionEpoch(0);
         PartitionRegistration partitionRegistration = builder.build();
-        assertEquals(new PartitionRegistration(
-                new int[]{0}, new int[]{0}, new int[]{0}, new int[]{0}, 0, LeaderRecoveryState.RECOVERED, 0, 0),
-            partitionRegistration);
+        assertEquals(Replicas.toList(new int[]{0, 1}), Replicas.toList(partitionRegistration.replicas));
+        assertEquals(Replicas.toList(new int[]{0, 1}), Replicas.toList(partitionRegistration.isr));
+        assertEquals(Replicas.toList(new int[]{0}), Replicas.toList(partitionRegistration.removingReplicas));
+        assertEquals(Replicas.toList(new int[]{1}), Replicas.toList(partitionRegistration.addingReplicas));
+        assertEquals(0, partitionRegistration.leader);
+        assertEquals(LeaderRecoveryState.RECOVERED, partitionRegistration.leaderRecoveryState);
+        assertEquals(0, partitionRegistration.leaderEpoch);
+        assertEquals(0, partitionRegistration.partitionEpoch);
+    }
+
+    @Test
+    public void testBuilderSetsDefaultAddingAndRemovingReplicas() throws Exception {
+        PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
+            setReplicas(new int[]{0, 1}).
+            setIsr(new int[]{0, 1}).
+            setLeader(0).
+            setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(0).
+            setPartitionEpoch(0);
+        PartitionRegistration partitionRegistration = builder.build();
+        assertEquals(Replicas.toList(new int[]{}), Replicas.toList(partitionRegistration.removingReplicas));
+        assertEquals(Replicas.toList(new int[]{}), Replicas.toList(partitionRegistration.addingReplicas));
     }
 
     @Property

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -34,7 +34,11 @@ import org.junit.jupiter.api.Timeout;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 @Timeout(40)


### PR DESCRIPTION
### JIRA
https://issues.apache.org/jira/browse/KAFKA-14791

### Description
This creates a builder for `PartitionRegistration`. The motivation for the builder is that the constructor of `PartitionRegistration` has four arguments all of type `int[]` which makes it easy to make a mistake when using it. Right now the constructor has the signature:
```
public PartitionRegistration(int[] replicas, int[] isr, int[] removingReplicas,
                             int[] addingReplicas, int leader, LeaderRecoveryState leaderRecoveryState,
                             int leaderEpoch, int partitionEpoch) {
```
It's easy to mix up any of `replicas`, `isr`, `removingReplicas` and `addingReplicas`. 

With this change the constructor is made `protected` so only code in the same package can use it, which is helpful for unit testing. All other code must use the builder. That code might look like:
```
partitionRegistration = new PartitionRegistration.Builder().
    setReplicas(Replicas.toArray(assignment.brokerIds())).
    setIsr(Replicas.toArray(isr)).
    setRemovingReplicas(removing).
    setAddingReplicas(adding).
    setLeader(isr.get(0)).
    setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
    setLeaderEpoch(0).
    setPartitionEpoch(0).
    build();
```
This makes it less likely to make a mistake when setting any of `replicas`, `isr`, `removingReplicas` and `addingReplicas`. We also make `addingReplicas` and `removingReplicas` default to `Replicas.NONE` because usually they are empty and are only used during reassignments. 

### Testing
This updates all the unit tests to use the new builder. This also adds unit tests to `PartitionRegistrationTest` testing the builder's validation and object construction.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
