### PR TITLE
KAFKA-14462; [16/N] Add CoordinatorLoader and CoordinatorPlayback interfaces

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorLoader.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorLoader.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.runtime;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Interface to implement a coordinator loader.
+ */
+interface CoordinatorLoader<U> {
+
+    /**
+     * Loads the coordinator by reading all the records from the TopicPartition
+     * and applying them to the Replayable object.
+     *
+     * @param tp            The TopicPartition to read from.
+     * @param replayable    The object to apply records to.
+     */
+    CompletableFuture<Void> load(
+        TopicPartition tp,
+        Replayable<U> replayable
+    );
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorLoader.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorLoader.java
@@ -21,7 +21,10 @@ import org.apache.kafka.common.TopicPartition;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Interface to implement a coordinator loader.
+ * Interface to implement a coordinator loader. A loader reads records
+ * from a partition and replays them to the coordinator.
+ *
+ * @param <U> The type of the record.
  */
 interface CoordinatorLoader<U> {
 
@@ -30,10 +33,10 @@ interface CoordinatorLoader<U> {
      * and applying them to the Replayable object.
      *
      * @param tp            The TopicPartition to read from.
-     * @param replayable    The object to apply records to.
+     * @param coordinator   The object to apply records to.
      */
     CompletableFuture<Void> load(
         TopicPartition tp,
-        Replayable<U> replayable
+        CoordinatorPlayback<U> coordinator
     );
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorPlayback.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorPlayback.java
@@ -17,9 +17,15 @@
 package org.apache.kafka.coordinator.group.runtime;
 
 /**
- * The Replayable interface.
+ * The CoordinatorPlayback interface. This interface is used to replay
+ * records to the coordinator in order to update its state. This is
+ * also used to rebuild a coordinator state from scratch by replaying
+ * all records stored in the partition.
+ *
+ * @param <U> The type of the record.
  */
-public interface Replayable<U> {
+public interface CoordinatorPlayback<U> {
+
     /**
      * Applies the given record to this object.
      *

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/Replayable.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/Replayable.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.runtime;
+
+/**
+ * The Replayable interface.
+ */
+public interface Replayable<U> {
+    /**
+     * Applies the given record to this object.
+     *
+     * @param record A record.
+     * @throws RuntimeException if the record can not be applied.
+     */
+    void replay(U record) throws RuntimeException;
+}


### PR DESCRIPTION
This patch adds the CoordinatorLoader and the CoordinatorPlayback interfaces. The former is used to load (or rebuild) the coordinator state by replaying all the records stored in the partition. The later is the interface that must be implemented by coordinator to support replaying records.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
