### PR TITLE
KAFKA-14034 Idempotent producer should wait for preceding in-flight b…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -101,8 +101,9 @@ public class TransactionManager {
 
     private final Map<TopicPartition, CommittedOffset> pendingTxnOffsetCommits;
 
-    // If a batch bound for a partition expired locally after being sent at least once, the partition is considered
-    // to have an unresolved state. We keep track of such partitions here, and cannot assign any more sequence numbers
+    // If a batch bound for a partition expired locally after being sent at least once, or it failed the last time
+    // without a definitive result, the partition is considered to have an unresolved state.
+    // We keep track of such partitions here, and cannot assign any more sequence numbers
     // for this partition until the unresolved state gets cleared. This may happen if other inflight batches returned
     // successfully (indicating that the expired batch actually made it to the broker). If we don't get any successful
     // responses for the partition once the inflight request count falls to zero, we reset the producer id and
@@ -658,7 +659,10 @@ public class TransactionManager {
         } else {
             if (adjustSequenceNumbers) {
                 if (!isTransactional()) {
-                    requestEpochBumpForPartition(batch.topicPartition);
+                    // Mark the partition unresolved to let any preceding, in-flight batches to properly complete.
+                    // If there are no in-flight batches, maybeResolveSequences() will eventually request an epoch bump
+                    // and rewrite the sequence numbers.
+                    markSequenceUnresolved(batch);
                 } else {
                     adjustSequencesDueToFailedBatch(batch);
                 }
@@ -732,10 +736,12 @@ public class TransactionManager {
                 // next sequence destined for the partition. If so, the partition is fully resolved. If not, we should
                 // reset the sequence number if necessary.
                 if (isNextSequence(topicPartition, sequenceNumber(topicPartition))) {
-                    // This would happen when a batch was expired, but subsequent batches succeeded.
+                    // This would happen when a batch was expired or failed with a non-definitive result,
+                    // but subsequent batches succeeded.
                     iter.remove();
                 } else {
-                    // We would enter this branch if all in flight batches were ultimately expired in the producer.
+                    // We would enter this branch if all in flight batches were ultimately expired in the producer
+                    // or failed with a non-definitive result.
                     if (isTransactional()) {
                         // For the transactional producer, we bump the epoch if possible, otherwise we transition to a fatal error
                         String unackedMessagesErr = "The client hasn't received acknowledgment for some previously " +

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -173,7 +173,7 @@ public class SenderTest {
         }));
         return Collections.unmodifiableMap(partitionRecords);
     }
- 
+
     @Test
     public void testSimple() throws Exception {
         long offset = 0;
@@ -817,6 +817,167 @@ public class SenderTest {
         assertEquals(1, request2.get().offset());
     }
 
+    @Test
+    public void testIdempotenceSendFailureWithRetriedInFlight() throws Exception {
+        // Produce 3, first 2 fails with retryable, 3rd fails with non-retryable, first 2 then retried and succeeds
+        final long producerId = 343434L;
+        TransactionManager transactionManager = createTransactionManager();
+        setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
+
+        assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
+
+        // Send first ProduceRequest
+        Future<RecordMetadata> request1 = appendToAccumulator(tp0);
+        sender.runOnce();
+        String nodeId = client.requests().peek().destination();
+        Node node = new Node(Integer.parseInt(nodeId), "localhost", 0);
+        assertEquals(1, client.inFlightRequestCount());
+        assertEquals(1, transactionManager.sequenceNumber(tp0).longValue());
+        assertEquals(OptionalInt.empty(), transactionManager.lastAckedSequence(tp0));
+
+        // Send second ProduceRequest
+        Future<RecordMetadata> request2 = appendToAccumulator(tp0);
+        sender.runOnce();
+
+        // Send third ProduceRequest
+        Future<RecordMetadata> request3 = appendToAccumulator(tp0);
+        sender.runOnce();
+
+        assertEquals(3, client.inFlightRequestCount());
+        assertEquals(3, transactionManager.sequenceNumber(tp0).longValue());
+        assertEquals(OptionalInt.empty(), transactionManager.lastAckedSequence(tp0));
+        assertFalse(request1.isDone());
+        assertFalse(request2.isDone());
+        assertFalse(request3.isDone());
+        assertTrue(client.isReady(node, time.milliseconds()));
+
+        sendIdempotentProducerResponse(0, tp0, Errors.LEADER_NOT_AVAILABLE, -1L);
+        sender.runOnce(); // receive response 1
+
+        sendIdempotentProducerResponse(1, tp0, Errors.LEADER_NOT_AVAILABLE, -1L);
+        sender.runOnce(); // resend request 1, receive response 2
+
+        sendIdempotentProducerResponse(2, tp0, Errors.UNKNOWN_SERVER_ERROR, -1L);
+        sender.runOnce(); // resend request 2, receive response 3
+
+        assertTrue(transactionManager.hasUnresolvedSequence(tp0));
+        assertEquals(0, transactionManager.producerIdAndEpoch().epoch);
+
+        sendIdempotentProducerResponse(0, tp0, Errors.NONE, 0L);
+        sender.runOnce();  // receive response 1
+        assertEquals(OptionalInt.of(0), transactionManager.lastAckedSequence(tp0));
+        assertTrue(request1.isDone());
+        assertEquals(0, request1.get().offset());
+        assertFalse(client.hasInFlightRequests());
+        assertEquals(0, sender.inFlightBatches(tp0).size());
+
+        sender.runOnce(); // re send request 2;
+        assertEquals(1, client.inFlightRequestCount());
+        assertEquals(1, sender.inFlightBatches(tp0).size());
+
+        assertTrue(transactionManager.hasUnresolvedSequence(tp0));
+        assertEquals(0, transactionManager.producerIdAndEpoch().epoch);
+
+        sendIdempotentProducerResponse(1, tp0, Errors.NONE, 1L);
+        sender.runOnce();  // receive response 2
+        assertEquals(OptionalInt.of(1), transactionManager.lastAckedSequence(tp0));
+        assertTrue(request2.isDone());
+        assertEquals(1, request2.get().offset());
+        assertFalse(client.hasInFlightRequests());
+        assertEquals(0, sender.inFlightBatches(tp0).size());
+
+        assertTrue(transactionManager.hasUnresolvedSequence(tp0));
+        assertEquals(0, transactionManager.producerIdAndEpoch().epoch);
+
+        sender.runOnce(); // resolve unresolved sequences, bump epoch
+
+        // Epoch and sequence should be reset
+        assertFalse(transactionManager.hasUnresolvedSequence(tp0));
+        assertEquals(1, transactionManager.producerIdAndEpoch().epoch);
+        assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
+    }
+
+    @Test
+    public void testIdempotenceSendFailureWithRetriedAndFailedInFlight() throws Exception {
+        // Produce 3, first 2 fails with retryable, 3rd fails with non-retryable, first 2 then retried and fails
+        final long producerId = 343434L;
+        TransactionManager transactionManager = createTransactionManager();
+        setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
+
+        assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
+
+        // Send first ProduceRequest
+        Future<RecordMetadata> request1 = appendToAccumulator(tp0);
+        sender.runOnce();
+        String nodeId = client.requests().peek().destination();
+        Node node = new Node(Integer.parseInt(nodeId), "localhost", 0);
+        assertEquals(1, client.inFlightRequestCount());
+        assertEquals(1, transactionManager.sequenceNumber(tp0).longValue());
+        assertEquals(OptionalInt.empty(), transactionManager.lastAckedSequence(tp0));
+
+        // Send second ProduceRequest
+        Future<RecordMetadata> request2 = appendToAccumulator(tp0);
+        sender.runOnce();
+
+        // Send third ProduceRequest
+        Future<RecordMetadata> request3 = appendToAccumulator(tp0);
+        sender.runOnce();
+
+        assertEquals(3, client.inFlightRequestCount());
+        assertEquals(3, transactionManager.sequenceNumber(tp0).longValue());
+        assertEquals(OptionalInt.empty(), transactionManager.lastAckedSequence(tp0));
+        assertFalse(request1.isDone());
+        assertFalse(request2.isDone());
+        assertFalse(request3.isDone());
+        assertTrue(client.isReady(node, time.milliseconds()));
+
+        sendIdempotentProducerResponse(0, tp0, Errors.LEADER_NOT_AVAILABLE, -1L);
+        sender.runOnce(); // receive response 1
+
+        sendIdempotentProducerResponse(1, tp0, Errors.LEADER_NOT_AVAILABLE, -1L);
+        sender.runOnce(); // resend request 1, receive response 2
+
+        sendIdempotentProducerResponse(2, tp0, Errors.UNKNOWN_SERVER_ERROR, -1L);
+        sender.runOnce(); // resend request 2, receive response 3
+
+        assertTrue(transactionManager.hasUnresolvedSequence(tp0));
+        assertEquals(0, transactionManager.producerIdAndEpoch().epoch);
+
+        sendIdempotentProducerResponse(0, tp0, Errors.UNKNOWN_SERVER_ERROR, -1L);
+        sender.runOnce();  // receive response 1
+        assertEquals(OptionalInt.empty(), transactionManager.lastAckedSequence(tp0));
+        assertTrue(request1.isDone());
+        assertFalse(client.hasInFlightRequests());
+        assertEquals(0, sender.inFlightBatches(tp0).size());
+
+        sender.runOnce(); // re send request 2;
+        assertEquals(1, client.inFlightRequestCount());
+        assertEquals(1, sender.inFlightBatches(tp0).size());
+
+        assertTrue(transactionManager.hasUnresolvedSequence(tp0));
+        assertEquals(0, transactionManager.producerIdAndEpoch().epoch);
+
+        sendIdempotentProducerResponse(1, tp0, Errors.UNKNOWN_SERVER_ERROR, -1L);
+        sender.runOnce();  // receive response 2
+        assertEquals(OptionalInt.empty(), transactionManager.lastAckedSequence(tp0));
+        assertTrue(request2.isDone());
+        assertFalse(client.hasInFlightRequests());
+        assertEquals(0, sender.inFlightBatches(tp0).size());
+
+        assertTrue(transactionManager.hasUnresolvedSequence(tp0));
+        assertEquals(0, transactionManager.producerIdAndEpoch().epoch);
+
+        sender.runOnce(); // resolve unresolved sequences, bump epoch
+
+        // Epoch and sequence should be reset
+        assertFalse(transactionManager.hasUnresolvedSequence(tp0));
+        assertEquals(1, transactionManager.producerIdAndEpoch().epoch);
+        assertEquals(0, transactionManager.sequenceNumber(tp0).longValue());
+    }
 
     @Test
     public void testIdempotenceWithMultipleInflightsRetriedInOrder() throws Exception {
@@ -3193,7 +3354,7 @@ public class SenderTest {
     private TransactionManager createTransactionManager() {
         return new TransactionManager(new LogContext(), null, 0, 100L, new ApiVersions());
     }
-    
+
     private void setupWithTransactionState(TransactionManager transactionManager) {
         setupWithTransactionState(transactionManager, false, null, true, Integer.MAX_VALUE, 0);
     }
@@ -3364,7 +3525,7 @@ public class SenderTest {
         assertTrue(transactionManager.hasProducerId());
         assertEquals(producerIdAndEpoch, transactionManager.producerIdAndEpoch());
     }
-    
+
     private AddPartitionsToTxnResponse buildAddPartitionsToTxnResponseData(int throttleMs, Map<TopicPartition, Errors> errors) {
         AddPartitionsToTxnResponseData.AddPartitionsToTxnResult result = AddPartitionsToTxnResponse.resultForTransaction(
                 AddPartitionsToTxnResponse.V3_AND_BELOW_TXN_ID, errors);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.TransactionalIdAuthorizationException;
+import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnsupportedForMessageFormatException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.header.Header;
@@ -597,6 +598,48 @@ public class TransactionManagerTest {
         assertEquals(1, b3.baseSequence());
         assertEquals(2, b4.baseSequence());
         assertEquals(3, b5.baseSequence());
+    }
+
+    @Test
+    public void testEpochBumpAfterBatchFailureWithInFlightPrecedingBatch() {
+        initializeTransactionManager(Optional.empty());
+        initializeIdempotentProducerId(producerId, epoch);
+
+        ProducerBatch b1 = writeIdempotentBatchWithValue(transactionManager, tp0, "1");
+        ProducerBatch b2 = writeIdempotentBatchWithValue(transactionManager, tp0, "2");
+        ProducerBatch b3 = writeIdempotentBatchWithValue(transactionManager, tp0, "3");
+
+        assertEquals(3, transactionManager.sequenceNumber(tp0).intValue());
+
+        // Third batch fails with non-retriable
+        b3.completeExceptionally(new UnknownServerException(), i -> null);
+        transactionManager.handleFailedBatch(b3, new UnknownServerException(), true);
+
+        // Producer epoch and sequence number should not be reset for the preceding batches
+        assertEquals(epoch, b1.producerEpoch());
+        assertEquals(0, b1.baseSequence());
+        assertEquals(epoch, b2.producerEpoch());
+        assertEquals(1, b2.baseSequence());
+
+        assertTrue(transactionManager.hasUnresolvedSequence(tp0));
+
+        // First batch succeeds
+        long b1AppendTime = time.milliseconds();
+        ProduceResponse.PartitionResponse b1Response = new ProduceResponse.PartitionResponse(
+                Errors.NONE, 500L, b1AppendTime, 0L);
+        b1.complete(500L, b1AppendTime);
+        transactionManager.handleCompletedBatch(b1, b1Response);
+
+        // Second batch succeeds
+        long b2AppendTime = time.milliseconds();
+        ProduceResponse.PartitionResponse b2Response = new ProduceResponse.PartitionResponse(
+                Errors.NONE, 501L, b2AppendTime, 0L);
+        b2.complete(502L, b2AppendTime);
+        transactionManager.handleCompletedBatch(b2, b2Response);
+
+        transactionManager.maybeResolveSequences();
+
+        assertFalse(transactionManager.hasUnresolvedSequence(tp0));
     }
 
     @Test


### PR DESCRIPTION
…atches to complete before resetting the sequence number

The idempotent producer resets the sequence number when a batch fails with a non-retriable error. This can violate the idempotent guarantee if there are preceding, in-flight requests which are being retried, as their producer epoch and sequence number gets rewritten, effectively granting those messages a new "identity".

Instead, the producer should wait for the preceding, retried batches to complete before resetting the sequence number. This ensures that the sequence numbers can only get reset after the preceding batches are definitely completed.

By calling markSequenceUnresolved instead of requestEpochBumpForPartition, draining batches from the partition is halted, and the epoch bump is delayed until all in-flight requests are completed.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
