### PR TITLE
KAFKA-14863: Fix failing tests for invalid plugins that are no longer visible

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/TestPlugins.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/TestPlugins.java
@@ -69,7 +69,7 @@ public class TestPlugins {
         /**
          * A plugin which will always throw an exception during loading
          */
-        ALWAYS_THROW_EXCEPTION("always-throw-exception", "test.plugins.AlwaysThrowException"),
+        ALWAYS_THROW_EXCEPTION("always-throw-exception", "test.plugins.AlwaysThrowException", false),
         /**
          * A plugin which samples information about its initialization.
          */

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
@@ -133,7 +133,7 @@ public class ConnectorPluginsResourceTest {
             HEADER_CONVERTER_PLUGINS.add(new MockConnectorPluginDesc<>(LongConverter.class));
 
             TRANSFORMATION_PLUGINS.add(new MockConnectorPluginDesc<>(RegexRouter.class));
-            TRANSFORMATION_PLUGINS.add(new MockConnectorPluginDesc<>(TimestampConverter.class));
+            TRANSFORMATION_PLUGINS.add(new MockConnectorPluginDesc<>(TimestampConverter.Key.class));
 
             PREDICATE_PLUGINS.add(new MockConnectorPluginDesc<>(HasHeaderKey.class));
             PREDICATE_PLUGINS.add(new MockConnectorPluginDesc<>(RecordIsTombstone.class));


### PR DESCRIPTION
1. DelegatingClassLoaderTest asserts that all of the "includeByDefault" plugins are visible, so update TestPlugins' AlwaysThrowException to not be included by default.
2. ConnectorPluginsResourceTest referenced the abstract TimestampConverter instead of the concrete TimestampConverter.Key or .Value

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
