### PR TITLE
MINOR: Fix flaky DistributedHerderTest cases related to zombie fencing

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -2215,10 +2215,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         // We don't need to synchronize here
         // If the condition evaluates to true, we can and should trigger a wakeup
         // If it evaluates to false because our request has suddenly been popped off of the queue, then
-        //     the herder is already running the request and no wakeup is necessary
+        // the herder is already running the request and no wakeup is necessary
         // If it evaluates to false because our request was not at the head of the queue, then a wakeup
-        //     should already have been triggered when the request that is currently at the head of the
-        //     queue was added
+        // should already have been triggered when the request that is currently at the head of the
+        // queue was added
         if (peekWithoutException() == req)
             member.wakeup();
         return req;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -2212,6 +2212,13 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     DistributedHerderRequest addRequest(long delayMs, Callable<Void> action, Callback<Void> callback) {
         DistributedHerderRequest req = new DistributedHerderRequest(time.milliseconds() + delayMs, requestSeqNum.incrementAndGet(), action, callback);
         requests.add(req);
+        // We don't need to synchronize here
+        // If the condition evaluates to true, we can and should trigger a wakeup
+        // If it evaluates to false because our request has suddenly been popped off of the queue, then
+        //     the herder is already running the request and no wakeup is necessary
+        // If it evaluates to false because our request was not at the head of the queue, then a wakeup
+        //     should already have been triggered when the request that is currently at the head of the
+        //     queue was added
         if (peekWithoutException() == req)
             member.wakeup();
         return req;


### PR DESCRIPTION
I frequently see failures when running these test cases locally caused by fewer-than-expected (2 instead of 3) invocations of `member::wakeup`.

This turns out to be due to a benign race condition in `DistributedHerder::addRequest`, which is documented in a comment in that method. A comment is also added to `DistributedHerderTest::testTaskRequestedZombieFencingForwardingToLeader` explaining why we relax our expectations about how many invocations of `member::wakeup` take place.

As an alternative, we could consider adding synchronization around access to the herder request queue. But the additional implementation complexity and risks of deadlock don't seem worth the finer-grained testing logic we'd be able to write.