### PR TITLE
MINOR: Re-introduce Transformation import to fix TransformationChain Javadoc

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.runtime;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator;
 import org.apache.kafka.connect.runtime.errors.Stage;
+import org.apache.kafka.connect.transforms.Transformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
- The `TransformationChain` Javadoc has a reference to the `Transformation` class
- The import was removed (likely accidentally) in https://github.com/apache/kafka/pull/13184/files#diff-be87d8114b5870f9b881cf8c0e6b110951aa990a7d2ad74c886f3a2adb2350db
- It doesn't break the build since we don't generate public Javadocs for this class, but it does affect things like code navigation in IDEs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
