### PR TITLE
MINOR: Remove reference to 'offset backing store' from exception message in KafkaBasedLog

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -257,7 +257,7 @@ public class KafkaBasedLog<K, V> {
             partitionInfos = consumer.partitionsFor(topic);
         }
         if (partitionInfos.isEmpty())
-            throw new ConnectException("Could not look up partition metadata for offset backing store topic in" +
+            throw new ConnectException("Could not look up partition metadata for topic '" + topic + "' in the" +
                     " allotted period. This could indicate a connectivity issue, unavailable topic partitions, or if" +
                     " this is your first use of the topic it may have taken too long to create.");
 


### PR DESCRIPTION
- The `KafkaBasedLog` abstraction is used by Kafka Connect's three metadata topics - offsets, configs, and statuses.
- This generic `KafkaBasedLog` was split off from the `KafkaOffsetBackingStore` [here](https://github.com/apache/kafka/pull/241/files#diff-bd393ce25d7e04ff71f9f5b65bfdc87eac40e378a83cbfc96fd68d227ea07da4) when adding support for the distributed mode in Kafka Connect (specifically for supporting the Kafka topic based config backing store)
- The exception message in question here wasn't refactored to account for the `KafkaBasedLog`'s generic functionality (versus the offsets topic specific logic in the `KafkaOffsetBackingStore`)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
