### PR TITLE
KAFKA-14278: Fix InvalidProducerEpochException and InvalidTxnStateException handling in producer clients

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1376,7 +1376,7 @@ public class TransactionManager {
                     fatalError(error.exception());
                     return;
                 } else if (error == Errors.INVALID_TXN_STATE) {
-                    fatalError(new KafkaException(error.exception()));
+                    fatalError(error.exception());
                     return;
                 } else if (error == Errors.TOPIC_AUTHORIZATION_FAILED) {
                     unauthorizedTopics.add(topicPartition.topic());
@@ -1598,6 +1598,8 @@ public class TransactionManager {
                 // just treat it the same as PRODUCE_FENCED.
                 fatalError(Errors.PRODUCER_FENCED.exception());
             } else if (error == Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED) {
+                fatalError(error.exception());
+            } else if (error == Errors.INVALID_TXN_STATE) {
                 fatalError(error.exception());
             } else if (error == Errors.GROUP_AUTHORIZATION_FAILED) {
                 abortableError(GroupAuthorizationException.forGroupId(builder.data.groupId()));

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1676,7 +1676,8 @@ public class TransactionManager {
                     abortableError(new CommitFailedException("Transaction offset Commit failed " +
                         "due to consumer group metadata mismatch: " + error.exception().getMessage()));
                     break;
-                } else if (isFatalException(error)) {
+                } else if (error == Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED
+                        || error == Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT) {
                     fatalError(error.exception());
                     break;
                 } else {
@@ -1694,11 +1695,6 @@ public class TransactionManager {
                 reenqueue();
             }
         }
-    }
-
-    private boolean isFatalException(Errors error) {
-        return error == Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED
-                   || error == Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT;
     }
 
     private static final class PendingStateTransition {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1661,6 +1661,10 @@ public class TransactionManager {
                         || error == Errors.COORDINATOR_LOAD_IN_PROGRESS) {
                     // If the topic is unknown or the coordinator is loading, retry with the current coordinator
                     continue;
+                } else if (error == Errors.INVALID_PRODUCER_EPOCH
+                        || error == Errors.PRODUCER_FENCED) {
+                    // Treat INVALID_PRODUCER_EPOCH as PRODUCE_FENCED, since it is fatal here.
+                    fatalError(Errors.PRODUCER_FENCED.exception());
                 } else if (error == Errors.GROUP_AUTHORIZATION_FAILED) {
                     abortableError(GroupAuthorizationException.forGroupId(builder.data.groupId()));
                     break;
@@ -1694,8 +1698,6 @@ public class TransactionManager {
 
     private boolean isFatalException(Errors error) {
         return error == Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED
-                   || error == Errors.INVALID_PRODUCER_EPOCH
-                   || error == Errors.PRODUCER_FENCED
                    || error == Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitResponse.java
@@ -42,6 +42,7 @@ import java.util.function.Function;
  *   - {@link Errors#GROUP_AUTHORIZATION_FAILED}
  *   - {@link Errors#INVALID_COMMIT_OFFSET_SIZE}
  *   - {@link Errors#TRANSACTIONAL_ID_AUTHORIZATION_FAILED}
+ *   - {@link Errors#UNSUPPORTED_FOR_MESSAGE_FORMAT}
  *   - {@link Errors#REQUEST_TIMED_OUT}
  *   - {@link Errors#UNKNOWN_MEMBER_ID}
  *   - {@link Errors#FENCED_INSTANCE_ID}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -2241,7 +2241,7 @@ public class TransactionManagerTest {
 
     @Test
     public void testHandlingOfInvalidProducerEpochErrorOnTxnOffsetCommit() {
-        testFatalErrorInTxnOffsetCommit(Errors.INVALID_PRODUCER_EPOCH);
+        testFatalErrorInTxnOffsetCommit(Errors.INVALID_PRODUCER_EPOCH, Errors.PRODUCER_FENCED);
     }
 
     @Test
@@ -2250,6 +2250,10 @@ public class TransactionManagerTest {
     }
 
     private void testFatalErrorInTxnOffsetCommit(final Errors error) {
+        testFatalErrorInTxnOffsetCommit(error, error);
+    }
+
+    private void testFatalErrorInTxnOffsetCommit(final Errors triggeredError, final Errors resultingError) {
         doInitTransactions();
 
         transactionManager.beginTransaction();
@@ -2266,14 +2270,14 @@ public class TransactionManagerTest {
 
         Map<TopicPartition, Errors> txnOffsetCommitResponse = new HashMap<>();
         txnOffsetCommitResponse.put(tp0, Errors.NONE);
-        txnOffsetCommitResponse.put(tp1, error);
+        txnOffsetCommitResponse.put(tp1, triggeredError);
 
         prepareFindCoordinatorResponse(Errors.NONE, false, CoordinatorType.GROUP, consumerGroupId);
         prepareTxnOffsetCommitResponse(consumerGroupId, producerId, epoch, txnOffsetCommitResponse);
 
         runUntil(addOffsetsResult::isCompleted);
         assertFalse(addOffsetsResult.isSuccessful());
-        assertEquals(error.exception().getClass(), addOffsetsResult.error().getClass());
+        assertEquals(resultingError.exception().getClass(), addOffsetsResult.error().getClass());
     }
 
     @Test


### PR DESCRIPTION
This PR fixes three issues:

* `InvalidProducerEpochException` was not handled consistently. `InvalidProducerEpochException` used to be able to be return via both transactional response and produce response, but as of KIP-588 (2.7+), transactional responses should not return `InvalidProducerEpochException` anymore, only produce responses can. It can happen that older brokers may still return `InvalidProducerEpochException` for transactional responses; these must be converted to the newer `ProducerFencedException`. This conversion wasn't done for `TxnOffsetCommit` (sent to the group coordinator).

* `InvalidTxnStateException` was double-wrapped in `KafkaException`, whereas other exceptions are usually wrapped only once. Furthermore, `InvalidTxnStateException` was not handled at all for in `AddOffsetsToTxn` response, where it should be a possible error as well, according to API documentation.

 * According to API documentation, `UNSUPPORTED_FOR_MESSAGE_FORMAT` is not possible for `TxnOffsetCommit`, but it looks like it is, and it is being handled there, so I updated the API documentation.