### PR TITLE
KAFKA-14784: Connect offset reset REST API

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -169,7 +169,7 @@
               files="(RequestResponse|WorkerSinkTask)Test.java"/>
 
     <suppress checks="JavaNCSS"
-              files="DistributedHerderTest.java"/>
+              files="(DistributedHerder|Worker)Test.java"/>
 
     <!-- Raft -->
     <suppress checks="NPathComplexity"

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkConnector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkConnector.java
@@ -73,6 +73,7 @@ public abstract class SinkConnector extends Connector {
      * @throws UnsupportedOperationException if it is impossible to alter/reset the offsets for this connector
      * @throws org.apache.kafka.connect.errors.ConnectException if the offsets for this connector cannot be
      * reset for any other reason (for example, they have failed custom validation logic specific to this connector)
+     * @since 3.6
      */
     public boolean alterOffsets(Map<String, String> connectorConfig, Map<TopicPartition, Long> offsets) {
         return false;

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkConnector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkConnector.java
@@ -60,7 +60,9 @@ public abstract class SinkConnector extends Connector {
      * @param connectorConfig the configuration of the connector
      * @param offsets a map from topic partition to offset, containing the offsets that the user has requested to
      *                alter/reset. For any topic partitions whose offsets are being reset instead of altered, their
-     *                corresponding value in the map will be {@code null}.
+     *                corresponding value in the map will be {@code null}. This map may be empty, but never null. An
+     *                empty offsets map could indicate that the offsets were reset previously or that no offsets have
+     *                been committed yet.
      * @return whether this method has been overridden by the connector; the default implementation returns
      * {@code false}, and all other implementations (that do not unconditionally throw exceptions) should return
      * {@code true}

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkConnector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkConnector.java
@@ -54,6 +54,10 @@ public abstract class SinkConnector extends Connector {
      * User requests to alter/reset offsets will be handled by the Connect runtime and will be reflected in the offsets
      * for this connector's consumer group.
      * <p>
+     * Note that altering / resetting offsets is expected to be an idempotent operation and this method should be able
+     * to handle being called more than once with the same arguments (which could occur if a user retries the request
+     * due to a failure in altering the consumer group offsets, for example).
+     * <p>
      * Similar to {@link #validate(Map) validate}, this method may be called by the runtime before the
      * {@link #start(Map) start} method is invoked.
      *

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceConnector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceConnector.java
@@ -91,7 +91,9 @@ public abstract class SourceConnector extends Connector {
      * @param connectorConfig the configuration of the connector
      * @param offsets a map from source partition to source offset, containing the offsets that the user has requested
      *                to alter/reset. For any source partitions whose offsets are being reset instead of altered, their
-     *                corresponding source offset value in the map will be {@code null}
+     *                corresponding source offset value in the map will be {@code null}. This map may be empty, but
+     *                never null. An empty offsets map could indicate that the offsets were reset previously or that no
+     *                offsets have been committed yet.
      * @return whether this method has been overridden by the connector; the default implementation returns
      * {@code false}, and all other implementations (that do not unconditionally throw exceptions) should return
      * {@code true}

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceConnector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceConnector.java
@@ -104,6 +104,7 @@ public abstract class SourceConnector extends Connector {
      * @throws UnsupportedOperationException if it is impossible to alter/reset the offsets for this connector
      * @throws org.apache.kafka.connect.errors.ConnectException if the offsets for this connector cannot be
      * reset for any other reason (for example, they have failed custom validation logic specific to this connector)
+     * @since 3.6
      */
     public boolean alterOffsets(Map<String, String> connectorConfig, Map<Map<String, ?>, Map<String, ?>> offsets) {
         return false;

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceConnector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceConnector.java
@@ -85,6 +85,10 @@ public abstract class SourceConnector extends Connector {
      * returned by any {@link org.apache.kafka.connect.storage.OffsetStorageReader OffsetStorageReader instances}
      * provided to this connector and its tasks.
      * <p>
+     * Note that altering / resetting offsets is expected to be an idempotent operation and this method should be able
+     * to handle being called more than once with the same arguments (which could occur if a user retries the request
+     * due to a failure in writing the new offsets to the offsets store, for example).
+     * <p>
      * Similar to {@link #validate(Map) validate}, this method may be called by the runtime before the
      * {@link #start(Map) start} method is invoked.
      *

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -44,6 +44,7 @@ import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorOffsets;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
+import org.apache.kafka.connect.runtime.rest.entities.Message;
 import org.apache.kafka.connect.runtime.rest.errors.BadRequestException;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.apache.kafka.connect.source.SourceConnector;
@@ -902,4 +903,22 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
             cb.onCompletion(t, null);
         }
     }
+
+    @Override
+    public void alterConnectorOffsets(String connName, Map<Map<String, ?>, Map<String, ?>> offsets, Callback<Message> callback) {
+        modifyConnectorOffsets(connName, offsets, callback);
+    }
+
+    @Override
+    public void resetConnectorOffsets(String connName, Callback<Message> callback) {
+        modifyConnectorOffsets(connName, null, callback);
+    }
+
+    /**
+     * Service external requests to alter or reset connector offsets.
+     * @param connName the name of the connector whose offsets are to be modified
+     * @param offsets the offsets to be written; this should be {@code null} for offsets reset requests
+     * @param cb callback to invoke upon completion
+     */
+    protected abstract void modifyConnectorOffsets(String connName, Map<Map<String, ?>, Map<String, ?>> offsets, Callback<Message> cb);
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -906,6 +906,10 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
     @Override
     public void alterConnectorOffsets(String connName, Map<Map<String, ?>, Map<String, ?>> offsets, Callback<Message> callback) {
+        if (offsets == null || offsets.isEmpty()) {
+            callback.onCompletion(new ConnectException("The offsets to be altered may not be null or empty"), null);
+            return;
+        }
         modifyConnectorOffsets(connName, offsets, callback);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -311,6 +311,13 @@ public interface Herder {
      */
     void alterConnectorOffsets(String connName, Map<Map<String, ?>, Map<String, ?>> offsets, Callback<Message> cb);
 
+    /**
+     * Reset a connector's offsets.
+     * @param connName the name of the connector whose offsets are to be reset
+     * @param cb callback to invoke upon completion
+     */
+    void resetConnectorOffsets(String connName, Callback<Message> cb);
+
     enum ConfigReloadAction {
         NONE,
         RESTART

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.admin.AlterConsumerGroupOffsetsOptions;
 import org.apache.kafka.clients.admin.AlterConsumerGroupOffsetsResult;
 import org.apache.kafka.clients.admin.DeleteConsumerGroupOffsetsOptions;
 import org.apache.kafka.clients.admin.DeleteConsumerGroupOffsetsResult;
+import org.apache.kafka.clients.admin.DeleteConsumerGroupsOptions;
 import org.apache.kafka.clients.admin.FenceProducersOptions;
 import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions;
 import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
@@ -38,9 +39,10 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.config.provider.ConfigProvider;
-import org.apache.kafka.common.utils.ThreadUtils;
+import org.apache.kafka.common.errors.GroupNotEmptyException;
 import org.apache.kafka.common.errors.GroupSubscribedToTopicException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
+import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.Connector;
@@ -1268,39 +1270,55 @@ public class Worker {
             connector = plugins.newConnector(connectorClassOrAlias);
             if (ConnectUtils.isSinkConnector(connector)) {
                 log.debug("Altering consumer group offsets for sink connector: {}", connName);
-                alterSinkConnectorOffsets(connName, connector, connectorConfig, offsets, connectorLoader, cb);
+                modifySinkConnectorOffsets(connName, connector, connectorConfig, offsets, connectorLoader, cb);
             } else {
                 log.debug("Altering offsets for source connector: {}", connName);
-                alterSourceConnectorOffsets(connName, connector, connectorConfig, offsets, connectorLoader, cb);
+                modifySourceConnectorOffsets(connName, connector, connectorConfig, offsets, connectorLoader, cb);
             }
         }
     }
 
     /**
-     * Alter a sink connector's consumer group offsets.
+     * Reset a connector's offsets.
+     *
+     * @param connName the name of the connector whose offsets are to be reset
+     * @param connectorConfig the connector's configurations
+     * @param cb callback to invoke upon completion
+     */
+    public void resetConnectorOffsets(String connName, Map<String, String> connectorConfig, Callback<Message> cb) {
+        String connectorClassOrAlias = connectorConfig.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
+        ClassLoader connectorLoader = plugins.connectorLoader(connectorClassOrAlias);
+        Connector connector;
+
+        try (LoaderSwap loaderSwap = plugins.withClassLoader(connectorLoader)) {
+            connector = plugins.newConnector(connectorClassOrAlias);
+            if (ConnectUtils.isSinkConnector(connector)) {
+                log.debug("Resetting consumer group offsets for sink connector: {}", connName);
+                modifySinkConnectorOffsets(connName, connector, connectorConfig, null, connectorLoader, cb);
+            } else {
+                log.debug("Resetting offsets for source connector: {}", connName);
+                modifySourceConnectorOffsets(connName, connector, connectorConfig, null, connectorLoader, cb);
+            }
+        }
+    }
+
+    /**
+     * Modify (alter / reset) a sink connector's consumer group offsets.
      * <p>
      * Visible for testing.
      *
-     * @param connName the name of the sink connector whose offsets are to be altered
+     * @param connName the name of the sink connector whose offsets are to be modified
      * @param connector an instance of the sink connector
      * @param connectorConfig the sink connector's configuration
-     * @param offsets a mapping from topic partitions to offsets that need to be written; may not be null or empty
+     * @param offsets a mapping from topic partitions to offsets that need to be written; this should be null for offset reset requests
      * @param connectorLoader the connector plugin's classloader to be used as the thread context classloader
      * @param cb callback to invoke upon completion
      */
-    void alterSinkConnectorOffsets(String connName, Connector connector, Map<String, String> connectorConfig,
-                                   Map<Map<String, ?>, Map<String, ?>> offsets, ClassLoader connectorLoader, Callback<Message> cb) {
+    void modifySinkConnectorOffsets(String connName, Connector connector, Map<String, String> connectorConfig,
+                                    Map<Map<String, ?>, Map<String, ?>> offsets, ClassLoader connectorLoader, Callback<Message> cb) {
         executor.submit(plugins.withClassLoader(connectorLoader, () -> {
             try {
-                Map<TopicPartition, Long> parsedOffsets = SinkUtils.parseSinkConnectorOffsets(offsets);
-                boolean alterOffsetsResult;
-                try {
-                    alterOffsetsResult = ((SinkConnector) connector).alterOffsets(connectorConfig, parsedOffsets);
-                } catch (UnsupportedOperationException e) {
-                    throw new ConnectException("Failed to alter offsets for connector " + connName + " because it doesn't support external " +
-                            "modification of offsets", e);
-                }
-
+                boolean isReset = offsets == null;
                 SinkConnectorConfig sinkConnectorConfig = new SinkConnectorConfig(plugins, connectorConfig);
                 Class<? extends Connector> sinkConnectorClass = connector.getClass();
                 Map<String, Object> adminConfig = adminConfigs(
@@ -1320,89 +1338,188 @@ public class Worker {
                 Admin admin = adminFactory.apply(adminConfig);
 
                 try {
-                    List<KafkaFuture<Void>> adminFutures = new ArrayList<>();
-
-                    Map<TopicPartition, OffsetAndMetadata> offsetsToAlter = parsedOffsets.entrySet()
-                            .stream()
-                            .filter(entry -> entry.getValue() != null)
-                            .collect(Collectors.toMap(Map.Entry::getKey, e -> new OffsetAndMetadata(e.getValue())));
-
-                    if (!offsetsToAlter.isEmpty()) {
-                        log.debug("Committing the following consumer group offsets using an admin client for sink connector {}: {}.",
-                                connName, offsetsToAlter);
-                        AlterConsumerGroupOffsetsOptions alterConsumerGroupOffsetsOptions = new AlterConsumerGroupOffsetsOptions().timeoutMs(
+                    Map<TopicPartition, Long> offsetsToWrite;
+                    if (isReset) {
+                        offsetsToWrite = new HashMap<>();
+                        ListConsumerGroupOffsetsOptions listConsumerGroupOffsetsOptions = new ListConsumerGroupOffsetsOptions().timeoutMs(
                                 (int) ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS);
-                        AlterConsumerGroupOffsetsResult alterConsumerGroupOffsetsResult = admin.alterConsumerGroupOffsets(groupId, offsetsToAlter,
-                                alterConsumerGroupOffsetsOptions);
+                        try {
+                            admin.listConsumerGroupOffsets(groupId, listConsumerGroupOffsetsOptions)
+                                    .partitionsToOffsetAndMetadata()
+                                    .get(ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                                    .forEach((topicPartition, offsetAndMetadata) -> offsetsToWrite.put(topicPartition, null));
 
-                        adminFutures.add(alterConsumerGroupOffsetsResult.all());
-                    }
-
-                    Set<TopicPartition> partitionsToReset = parsedOffsets.entrySet()
-                            .stream()
-                            .filter(entry -> entry.getValue() == null)
-                            .map(Map.Entry::getKey)
-                            .collect(Collectors.toSet());
-
-                    if (!partitionsToReset.isEmpty()) {
-                        log.debug("Deleting the consumer group offsets for the following topic partitions using an admin client for sink connector {}: {}.",
-                                connName, partitionsToReset);
-                        DeleteConsumerGroupOffsetsOptions deleteConsumerGroupOffsetsOptions = new DeleteConsumerGroupOffsetsOptions().timeoutMs(
-                                (int) ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS);
-                        DeleteConsumerGroupOffsetsResult deleteConsumerGroupOffsetsResult = admin.deleteConsumerGroupOffsets(groupId, partitionsToReset,
-                                deleteConsumerGroupOffsetsOptions);
-
-                        adminFutures.add(deleteConsumerGroupOffsetsResult.all());
-                    }
-
-                    @SuppressWarnings("rawtypes")
-                    KafkaFuture<Void> compositeAdminFuture = KafkaFuture.allOf(adminFutures.toArray(new KafkaFuture[0]));
-
-                    compositeAdminFuture.whenComplete((ignored, error) -> {
-                        if (error != null) {
-                            // When a consumer group is non-empty, only group members can commit offsets. An attempt to alter offsets via the admin client
-                            // will result in an UnknownMemberIdException if the consumer group is non-empty (i.e. if the sink tasks haven't stopped
-                            // completely or if the connector is resumed while the alter offsets request is being processed). Similarly, an attempt to
-                            // delete consumer group offsets for a non-empty consumer group will result in a GroupSubscribedToTopicException
-                            if (error instanceof UnknownMemberIdException || error instanceof GroupSubscribedToTopicException) {
-                                cb.onCompletion(new ConnectException("Failed to alter consumer group offsets for connector " + connName + " either because its tasks " +
-                                                "haven't stopped completely yet or the connector was resumed before the request to alter its offsets could be successfully " +
-                                                "completed. If the connector is in a stopped state, this operation can be safely retried. If it doesn't eventually succeed, the " +
-                                                "Connect cluster may need to be restarted to get rid of the zombie sink tasks."),
-                                        null);
-                            } else {
-                                cb.onCompletion(new ConnectException("Failed to alter consumer group offsets for connector " + connName, error), null);
-                            }
-                        } else {
-                            completeAlterOffsetsCallback(alterOffsetsResult, cb);
+                            log.debug("Found the following topic partitions (to reset offsets) for sink connector {} and consumer group ID {}: {}",
+                                    connName, groupId, offsetsToWrite.keySet());
+                        } catch (Exception e) {
+                            Utils.closeQuietly(admin, "Offset reset admin for sink connector " + connName);
+                            log.error("Failed to list offsets prior to resetting sink connector offsets", e);
+                            cb.onCompletion(new ConnectException("Failed to list offsets prior to resetting sink connector offsets", e), null);
+                            return;
                         }
-                    }).whenComplete((ignored, ignoredError) -> {
-                        // errors originating from the original future are handled in the prior whenComplete invocation which isn't expected to throw
-                        // an exception itself, and we can thus ignore the error here
-                        Utils.closeQuietly(admin, "Offset alter admin for sink connector " + connName);
-                    });
+                    } else {
+                        offsetsToWrite = SinkUtils.parseSinkConnectorOffsets(offsets);
+                    }
+
+                    boolean alterOffsetsResult;
+                    try {
+                        alterOffsetsResult = ((SinkConnector) connector).alterOffsets(connectorConfig, offsetsToWrite);
+                    } catch (UnsupportedOperationException e) {
+                        throw new ConnectException("Failed to modify offsets for connector " + connName + " because it doesn't support external " +
+                                "modification of offsets", e);
+                    }
+
+                    // This should only occur for an offset reset request when:
+                    // 1. There was a prior attempt to reset offsets
+                    // OR
+                    // 2. No offsets have been committed yet
+                    if (offsetsToWrite.isEmpty()) {
+                        completeAlterOffsetsCallback(alterOffsetsResult, isReset, cb);
+                        return;
+                    }
+
+                    if (isReset) {
+                        resetSinkConnectorOffsets(connName, groupId, admin, cb, alterOffsetsResult);
+                    } else {
+                        alterSinkConnectorOffsets(connName, groupId, admin, offsetsToWrite, cb, alterOffsetsResult);
+                    }
                 } catch (Throwable t) {
-                    Utils.closeQuietly(admin, "Offset alter admin for sink connector " + connName);
+                    Utils.closeQuietly(admin, "Offset modification admin for sink connector " + connName);
                     throw t;
                 }
             } catch (Throwable t) {
-                cb.onCompletion(ConnectUtils.maybeWrap(t, "Failed to alter offsets for sink connector " + connName), null);
+                cb.onCompletion(ConnectUtils.maybeWrap(t, "Failed to modify offsets for sink connector " + connName), null);
             }
         }));
     }
 
     /**
-     * Alter a source connector's offsets.
+     * Alter a sink connector's consumer group offsets. This is done via calls to {@link Admin#alterConsumerGroupOffsets}
+     * and / or {@link Admin#deleteConsumerGroupOffsets}.
      *
-     * @param connName the name of the source connector whose offsets are to be altered
+     * @param connName the name of the sink connector whose offsets are to be altered
+     * @param groupId the sink connector's consumer group ID
+     * @param admin the {@link Admin admin client} to be used for altering the consumer group offsets; should be closed after use
+     * @param offsetsToWrite a mapping from topic partitions to offsets that need to be written; may not be null or empty
+     * @param cb callback to invoke upon completion
+     * @param alterOffsetsResult the result of the call to {@link SinkConnector#alterOffsets} for the connector
+     */
+    private void alterSinkConnectorOffsets(String connName, String groupId, Admin admin, Map<TopicPartition, Long> offsetsToWrite,
+                                           Callback<Message> cb, boolean alterOffsetsResult) {
+        List<KafkaFuture<Void>> adminFutures = new ArrayList<>();
+
+        Map<TopicPartition, OffsetAndMetadata> offsetsToAlter = offsetsToWrite.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue() != null)
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> new OffsetAndMetadata(e.getValue())));
+
+        if (!offsetsToAlter.isEmpty()) {
+            log.debug("Committing the following consumer group offsets using an admin client for sink connector {}: {}.",
+                    connName, offsetsToAlter);
+            AlterConsumerGroupOffsetsOptions alterConsumerGroupOffsetsOptions = new AlterConsumerGroupOffsetsOptions().timeoutMs(
+                    (int) ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS);
+            AlterConsumerGroupOffsetsResult alterConsumerGroupOffsetsResult = admin.alterConsumerGroupOffsets(groupId, offsetsToAlter,
+                    alterConsumerGroupOffsetsOptions);
+
+            adminFutures.add(alterConsumerGroupOffsetsResult.all());
+        }
+
+        Set<TopicPartition> partitionsToReset = offsetsToWrite.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue() == null)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+
+        if (!partitionsToReset.isEmpty()) {
+            log.debug("Deleting the consumer group offsets for the following topic partitions using an admin client for sink connector {}: {}.",
+                    connName, partitionsToReset);
+            DeleteConsumerGroupOffsetsOptions deleteConsumerGroupOffsetsOptions = new DeleteConsumerGroupOffsetsOptions().timeoutMs(
+                    (int) ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS);
+            DeleteConsumerGroupOffsetsResult deleteConsumerGroupOffsetsResult = admin.deleteConsumerGroupOffsets(groupId, partitionsToReset,
+                    deleteConsumerGroupOffsetsOptions);
+
+            adminFutures.add(deleteConsumerGroupOffsetsResult.all());
+        }
+
+        @SuppressWarnings("rawtypes")
+        KafkaFuture<Void> compositeAdminFuture = KafkaFuture.allOf(adminFutures.toArray(new KafkaFuture[0]));
+
+        compositeAdminFuture.whenComplete((ignored, error) -> {
+            if (error != null) {
+                // When a consumer group is non-empty, only group members can commit offsets. An attempt to alter offsets via the admin client
+                // will result in an UnknownMemberIdException if the consumer group is non-empty (i.e. if the sink tasks haven't stopped
+                // completely or if the connector is resumed while the alter offsets request is being processed). Similarly, an attempt to
+                // delete consumer group offsets for a non-empty consumer group will result in a GroupSubscribedToTopicException
+                if (error instanceof UnknownMemberIdException || error instanceof GroupSubscribedToTopicException) {
+                    cb.onCompletion(new ConnectException("Failed to alter consumer group offsets for connector " + connName + " either because its tasks " +
+                                    "haven't stopped completely yet or the connector was resumed before the request to alter its offsets could be successfully " +
+                                    "completed. If the connector is in a stopped state, this operation can be safely retried. If it doesn't eventually succeed, the " +
+                                    "Connect cluster may need to be restarted to get rid of the zombie sink tasks."),
+                            null);
+                } else {
+                    cb.onCompletion(new ConnectException("Failed to alter consumer group offsets for connector " + connName, error), null);
+                }
+            } else {
+                completeAlterOffsetsCallback(alterOffsetsResult, false, cb);
+            }
+        }).whenComplete((ignored, ignoredError) -> {
+            // errors originating from the original future are handled in the prior whenComplete invocation which isn't expected to throw
+            // an exception itself, and we can thus ignore the error here
+            Utils.closeQuietly(admin, "Offset alter admin for sink connector " + connName);
+        });
+    }
+
+    /**
+     * Reset a sink connector's consumer group offsets. This is done by deleting the consumer group via a call to
+     * {@link Admin#deleteConsumerGroups}
+     *
+     * @param connName the name of the sink connector whose offsets are to be reset
+     * @param groupId the sink connector's consumer group ID
+     * @param admin the {@link Admin admin client} to be used for resetting the consumer group offsets; should be closed after use
+     * @param cb callback to invoke upon completion
+     * @param alterOffsetsResult the result of the call to {@link SinkConnector#alterOffsets} for the connector
+     */
+    private void resetSinkConnectorOffsets(String connName, String groupId, Admin admin, Callback<Message> cb, boolean alterOffsetsResult) {
+        DeleteConsumerGroupsOptions deleteConsumerGroupsOptions = new DeleteConsumerGroupsOptions()
+                .timeoutMs((int) ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS);
+
+        admin.deleteConsumerGroups(Collections.singleton(groupId), deleteConsumerGroupsOptions)
+                .all()
+                .whenComplete((ignored, error) -> {
+                    if (error != null) {
+                        // When a consumer group is non-empty, attempts to delete it via the admin client result in a GroupNotEmptyException. This can occur
+                        // if the sink tasks haven't stopped completely or if the connector is resumed while the reset offsets request is being processed
+                        if (error instanceof GroupNotEmptyException) {
+                            cb.onCompletion(new ConnectException("Failed to reset consumer group offsets for connector " + connName + " either because its tasks " +
+                                    "haven't stopped completely yet or the connector was resumed before the request to reset its offsets could be successfully " +
+                                    "completed. If the connector is in a stopped state, this operation can be safely retried. If it doesn't eventually succeed, the " +
+                                    "Connect cluster may need to be restarted to get rid of the zombie sink tasks."),
+                                    null);
+                        } else {
+                            cb.onCompletion(new ConnectException("Failed to reset consumer group offsets for connector " + connName, error), null);
+                        }
+                    } else {
+                        completeAlterOffsetsCallback(alterOffsetsResult, true, cb);
+                    }
+                }).whenComplete((ignored, ignoredError) -> {
+                    // errors originating from the original future are handled in the prior whenComplete invocation which isn't expected to throw
+                    // an exception itself, and we can thus ignore the error here
+                    Utils.closeQuietly(admin, "Offset reset admin for sink connector " + connName);
+                });
+    }
+
+    /**
+     * Modify (alter / reset) a source connector's offsets.
+     *
+     * @param connName the name of the source connector whose offsets are to be modified
      * @param connector an instance of the source connector
      * @param connectorConfig the source connector's configuration
-     * @param offsets a mapping from partitions to offsets that need to be written; may not be null or empty
+     * @param offsets a mapping from partitions to offsets that need to be written; this should be null for offset reset requests
      * @param connectorLoader the connector plugin's classloader to be used as the thread context classloader
      * @param cb callback to invoke upon completion
      */
-    private void alterSourceConnectorOffsets(String connName, Connector connector, Map<String, String> connectorConfig,
-                                             Map<Map<String, ?>, Map<String, ?>> offsets, ClassLoader connectorLoader, Callback<Message> cb) {
+    private void modifySourceConnectorOffsets(String connName, Connector connector, Map<String, String> connectorConfig,
+                                              Map<Map<String, ?>, Map<String, ?>> offsets, ClassLoader connectorLoader, Callback<Message> cb) {
         SourceConnectorConfig sourceConfig = new SourceConnectorConfig(plugins, connectorConfig, config.topicCreationEnable());
         Map<String, Object> producerProps = config.exactlyOnceSourceEnabled()
                 ? exactlyOnceSourceTaskProducerConfigs(new ConnectorTaskId(connName, 0), config, sourceConfig,
@@ -1417,29 +1534,54 @@ public class Worker {
         offsetStore.configure(config);
 
         OffsetStorageWriter offsetWriter = new OffsetStorageWriter(offsetStore, connName, internalKeyConverter, internalValueConverter);
-        alterSourceConnectorOffsets(connName, connector, connectorConfig, offsets, offsetStore, producer, offsetWriter, connectorLoader, cb);
+        modifySourceConnectorOffsets(connName, connector, connectorConfig, offsets, offsetStore, producer, offsetWriter, connectorLoader, cb);
     }
 
     // Visible for testing
-    void alterSourceConnectorOffsets(String connName, Connector connector, Map<String, String> connectorConfig,
-                                     Map<Map<String, ?>, Map<String, ?>> offsets, ConnectorOffsetBackingStore offsetStore,
-                                     KafkaProducer<byte[], byte[]> producer, OffsetStorageWriter offsetWriter,
-                                     ClassLoader connectorLoader, Callback<Message> cb) {
+    void modifySourceConnectorOffsets(String connName, Connector connector, Map<String, String> connectorConfig,
+                                      Map<Map<String, ?>, Map<String, ?>> offsets, ConnectorOffsetBackingStore offsetStore,
+                                      KafkaProducer<byte[], byte[]> producer, OffsetStorageWriter offsetWriter,
+                                      ClassLoader connectorLoader, Callback<Message> cb) {
         executor.submit(plugins.withClassLoader(connectorLoader, () -> {
             try {
-                boolean alterOffsetsResult;
-                try {
-                    alterOffsetsResult = ((SourceConnector) connector).alterOffsets(connectorConfig, offsets);
-                } catch (UnsupportedOperationException e) {
-                    throw new ConnectException("Failed to alter offsets for connector " + connName + " because it doesn't support external " +
-                            "modification of offsets", e);
-                }
                 // This reads to the end of the offsets topic and can be a potentially time-consuming operation
                 offsetStore.start();
+                Map<Map<String, ?>, Map<String, ?>> offsetsToWrite;
 
-                // The alterSourceConnectorOffsets method should only be called after all the connector's tasks have been stopped, and it's
+                // If the offsets argument is null, it indicates an offsets reset operation - i.e. a null offset should
+                // be written for every source partition of the connector
+                boolean isReset;
+                if (offsets == null) {
+                    isReset = true;
+                    offsetsToWrite = new HashMap<>();
+                    offsetStore.connectorPartitions(connName).forEach(partition -> offsetsToWrite.put(partition, null));
+                    log.debug("Found the following partitions (to reset offsets) for source connector {}: {}", connName, offsetsToWrite.keySet());
+                } else {
+                    isReset = false;
+                    offsetsToWrite = offsets;
+                }
+
+                boolean alterOffsetsResult;
+                try {
+                    alterOffsetsResult = ((SourceConnector) connector).alterOffsets(connectorConfig, offsetsToWrite);
+                } catch (UnsupportedOperationException e) {
+                    throw new ConnectException("Failed to modify offsets for connector " + connName + " because it doesn't support external " +
+                            "modification of offsets", e);
+                }
+
+                // This should only occur for an offset reset request when there are no source partitions found for the source connector in the
+                // offset store - either because there was a prior attempt to reset offsets or if there are no offsets committed by this source
+                // connector so far
+                if (offsetsToWrite.isEmpty()) {
+                    log.debug("No offsets found for source connector {} - this can occur due to a prior attempt to reset offsets or if the " +
+                            "source connector hasn't committed any offsets yet", connName);
+                    completeAlterOffsetsCallback(alterOffsetsResult, isReset, cb);
+                    return;
+                }
+
+                // The modifySourceConnectorOffsets method should only be called after all the connector's tasks have been stopped, and it's
                 // safe to write offsets via an offset writer
-                offsets.forEach(offsetWriter::offset);
+                offsetsToWrite.forEach(offsetWriter::offset);
 
                 // We can call begin flush without a timeout because this newly created single-purpose offset writer can't do concurrent
                 // offset writes. We can also ignore the return value since it returns false if and only if there is no data to be flushed,
@@ -1450,7 +1592,7 @@ public class Worker {
                     producer.initTransactions();
                     producer.beginTransaction();
                 }
-                log.debug("Committing the following offsets for source connector {}: {}", connName, offsets);
+                log.debug("Committing the following offsets for source connector {}: {}", connName, offsetsToWrite);
                 FutureCallback<Void> offsetWriterCallback = new FutureCallback<>();
                 offsetWriter.doFlush(offsetWriterCallback);
                 if (config.exactlyOnceSourceEnabled()) {
@@ -1460,30 +1602,31 @@ public class Worker {
                 try {
                     offsetWriterCallback.get(ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                 } catch (ExecutionException e) {
-                    throw new ConnectException("Failed to alter offsets for source connector " + connName, e.getCause());
+                    throw new ConnectException("Failed to modify offsets for source connector " + connName, e.getCause());
                 } catch (TimeoutException e) {
-                    throw new ConnectException("Timed out while attempting to alter offsets for source connector " + connName, e);
+                    throw new ConnectException("Timed out while attempting to modify offsets for source connector " + connName, e);
                 } catch (InterruptedException e) {
-                    throw new ConnectException("Unexpectedly interrupted while attempting to alter offsets for source connector " + connName, e);
+                    throw new ConnectException("Unexpectedly interrupted while attempting to modify offsets for source connector " + connName, e);
                 }
 
-                completeAlterOffsetsCallback(alterOffsetsResult, cb);
+                completeAlterOffsetsCallback(alterOffsetsResult, isReset, cb);
             } catch (Throwable t) {
-                log.error("Failed to alter offsets for source connector {}", connName, t);
-                cb.onCompletion(ConnectUtils.maybeWrap(t, "Failed to alter offsets for source connector " + connName), null);
+                log.error("Failed to modify offsets for source connector {}", connName, t);
+                cb.onCompletion(ConnectUtils.maybeWrap(t, "Failed to modify offsets for source connector " + connName), null);
             } finally {
-                Utils.closeQuietly(offsetStore::stop, "Offset store for offset alter request for connector " + connName);
+                Utils.closeQuietly(offsetStore::stop, "Offset store for offset modification request for connector " + connName);
             }
         }));
     }
 
-    private void completeAlterOffsetsCallback(boolean alterOffsetsResult, Callback<Message> cb) {
+    private void completeAlterOffsetsCallback(boolean alterOffsetsResult, boolean isReset, Callback<Message> cb) {
+        String modificationType = isReset ? "reset" : "altered";
         if (alterOffsetsResult) {
-            cb.onCompletion(null, new Message("The offsets for this connector have been altered successfully"));
+            cb.onCompletion(null, new Message("The offsets for this connector have been " + modificationType + " successfully"));
         } else {
             cb.onCompletion(null, new Message("The Connect framework-managed offsets for this connector have been " +
-                    "altered successfully. However, if this connector manages offsets externally, they will need to be " +
-                    "manually altered in the system that the connector uses."));
+                    modificationType + " successfully. However, if this connector manages offsets externally, they will need to be " +
+                    "manually " + modificationType + " in the system that the connector uses."));
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1523,60 +1523,68 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     }
 
     @Override
-    public void alterConnectorOffsets(String connName, Map<Map<String, ?>, Map<String, ?>> offsets, Callback<Message> callback) {
-        log.trace("Submitting alter offsets request for connector '{}'", connName);
+    protected void modifyConnectorOffsets(String connName, Map<Map<String, ?>, Map<String, ?>> offsets, Callback<Message> callback) {
+        boolean isReset = offsets == null;
+        log.trace("Submitting {} offsets request for connector '{}'", isReset ? "reset" : "alter", connName);
 
         addRequest(() -> {
-            if (!alterConnectorOffsetsChecks(connName, callback)) {
+            if (!modifyConnectorOffsetsChecks(connName, callback)) {
                 return null;
             }
-            // At this point, we should be the leader (the call to alterConnectorOffsetsChecks makes sure of that) and can safely run
+            // At this point, we should be the leader (the call to modifyConnectorOffsetsChecks makes sure of that) and can safely run
             // a zombie fencing request
             if (isSourceConnector(connName) && config.exactlyOnceSourceEnabled()) {
-                log.debug("Performing a round of zombie fencing before altering offsets for source connector {} with exactly-once support enabled.", connName);
+                log.debug("Performing a round of zombie fencing before modifying offsets for source connector {} with exactly-once support enabled.", connName);
                 doFenceZombieSourceTasks(connName, (error, ignored) -> {
                     if (error != null) {
-                        log.error("Failed to perform zombie fencing for source connector prior to altering offsets", error);
-                        callback.onCompletion(new ConnectException("Failed to perform zombie fencing for source connector prior to altering offsets",
-                                error), null);
+                        log.error("Failed to perform zombie fencing for source connector prior to modifying offsets", error);
+                        callback.onCompletion(new ConnectException("Failed to perform zombie fencing for source connector prior to modifying offsets", error), null);
                     } else {
-                        log.debug("Successfully completed zombie fencing for source connector {}; proceeding to alter offsets.", connName);
-                        // We need to ensure that we perform the necessary checks again before proceeding to actually altering the connector offsets since
+                        log.debug("Successfully completed zombie fencing for source connector {}; proceeding to modify offsets.", connName);
+                        // We need to ensure that we perform the necessary checks again before proceeding to actually altering / resetting the connector offsets since
                         // zombie fencing is done asynchronously and the conditions could have changed since the previous check
                         addRequest(() -> {
-                            if (alterConnectorOffsetsChecks(connName, callback)) {
-                                worker.alterConnectorOffsets(connName, configState.connectorConfig(connName), offsets, callback);
+                            if (modifyConnectorOffsetsChecks(connName, callback)) {
+                                if (isReset) {
+                                    worker.resetConnectorOffsets(connName, configState.connectorConfig(connName), callback);
+                                } else {
+                                    worker.alterConnectorOffsets(connName, configState.connectorConfig(connName), offsets, callback);
+                                }
                             }
                             return null;
                         }, forwardErrorCallback(callback));
                     }
                 });
             } else {
-                worker.alterConnectorOffsets(connName, configState.connectorConfig(connName), offsets, callback);
+                if (isReset) {
+                    worker.resetConnectorOffsets(connName, configState.connectorConfig(connName), callback);
+                } else {
+                    worker.alterConnectorOffsets(connName, configState.connectorConfig(connName), offsets, callback);
+                }
             }
             return null;
         }, forwardErrorCallback(callback));
     }
 
     /**
-     * This method performs a few checks for alter connector offsets request and completes the callback exceptionally
-     * if any check fails.
-     * @param connName the name of the connector whose offsets are to be altered
+     * This method performs a few checks for external requests to modify (alter or reset) connector offsets and
+     * completes the callback exceptionally if any check fails.
+     * @param connName the name of the connector whose offsets are to be modified
      * @param callback callback to invoke upon completion
      * @return true if all the checks passed, false otherwise
      */
-    private boolean alterConnectorOffsetsChecks(String connName, Callback<Message> callback) {
+    private boolean modifyConnectorOffsetsChecks(String connName, Callback<Message> callback) {
         if (checkRebalanceNeeded(callback)) {
             return false;
         }
 
         if (!isLeader()) {
-            callback.onCompletion(new NotLeaderException("Only the leader can process alter offsets requests", leaderUrl()), null);
+            callback.onCompletion(new NotLeaderException("Only the leader can process external offsets modification requests", leaderUrl()), null);
             return false;
         }
 
         if (!refreshConfigSnapshot(workerSyncTimeoutMs)) {
-            throw new ConnectException("Failed to read to end of config topic before altering connector offsets");
+            throw new ConnectException("Failed to read to end of config topic before modifying connector offsets");
         }
 
         if (!configState.contains(connName)) {
@@ -1587,10 +1595,11 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         // If the target state for the connector is stopped, its task count is 0, and there is no rebalance pending (checked above),
         // we can be sure that the tasks have at least been attempted to be stopped (or cancelled if they took too long to stop).
         // Zombie tasks are handled by a round of zombie fencing for exactly once source connectors. Zombie sink tasks are handled
-        // naturally because requests to alter consumer group offsets will fail if there are still active members in the group.
+        // naturally because requests to alter consumer group offsets / delete consumer groups will fail if there are still active members
+        // in the group.
         if (configState.targetState(connName) != TargetState.STOPPED || configState.taskCount(connName) != 0) {
-            callback.onCompletion(new BadRequestException("Connectors must be in the STOPPED state before their offsets can be altered. This " +
-                    "can be done for the specified connector by issuing a PUT request to the /connectors/" + connName + "/stop endpoint"), null);
+            callback.onCompletion(new BadRequestException("Connectors must be in the STOPPED state before their offsets can be modified externally. " +
+                    "This can be done for the specified connector by issuing a 'PUT' request to the '/connectors/" + connName + "/stop' endpoint"), null);
             return false;
         }
         return true;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1524,8 +1524,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
     @Override
     protected void modifyConnectorOffsets(String connName, Map<Map<String, ?>, Map<String, ?>> offsets, Callback<Message> callback) {
-        boolean isReset = offsets == null;
-        log.trace("Submitting {} offsets request for connector '{}'", isReset ? "reset" : "alter", connName);
+        log.trace("Submitting {} offsets request for connector '{}'", offsets == null ? "reset" : "alter", connName);
 
         addRequest(() -> {
             if (!modifyConnectorOffsetsChecks(connName, callback)) {
@@ -1545,22 +1544,14 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                         // zombie fencing is done asynchronously and the conditions could have changed since the previous check
                         addRequest(() -> {
                             if (modifyConnectorOffsetsChecks(connName, callback)) {
-                                if (isReset) {
-                                    worker.resetConnectorOffsets(connName, configState.connectorConfig(connName), callback);
-                                } else {
-                                    worker.alterConnectorOffsets(connName, configState.connectorConfig(connName), offsets, callback);
-                                }
+                                worker.modifyConnectorOffsets(connName, configState.connectorConfig(connName), offsets, callback);
                             }
                             return null;
                         }, forwardErrorCallback(callback));
                     }
                 });
             } else {
-                if (isReset) {
-                    worker.resetConnectorOffsets(connName, configState.connectorConfig(connName), callback);
-                } else {
-                    worker.alterConnectorOffsets(connName, configState.connectorConfig(connName), offsets, callback);
-                }
+                worker.modifyConnectorOffsets(connName, configState.connectorConfig(connName), offsets, callback);
             }
             return null;
         }, forwardErrorCallback(callback));

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1598,8 +1598,8 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         // naturally because requests to alter consumer group offsets / delete consumer groups will fail if there are still active members
         // in the group.
         if (configState.targetState(connName) != TargetState.STOPPED || configState.taskCount(connName) != 0) {
-            callback.onCompletion(new BadRequestException("Connectors must be in the STOPPED state before their offsets can be modified externally. " +
-                    "This can be done for the specified connector by issuing a 'PUT' request to the '/connectors/" + connName + "/stop' endpoint"), null);
+            callback.onCompletion(new BadRequestException("Connectors must be in the STOPPED state before their offsets can be modified. This can be done " +
+                    "for the specified connector by issuing a 'PUT' request to the '/connectors/" + connName + "/stop' endpoint"), null);
             return false;
         }
         return true;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorOffsets.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorOffsets.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.runtime.rest.entities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.kafka.connect.runtime.rest.resources.ConnectorsResource;
 
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +46,9 @@ import java.util.Objects;
  *       ]
  *     }
  * </pre>
+ *
+ * @see ConnectorsResource#getOffsets
+ * @see ConnectorsResource#alterConnectorOffsets
  */
 public class ConnectorOffsets {
     private final List<ConnectorOffset> offsets;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -367,6 +367,18 @@ public class ConnectorsResource implements ConnectResource {
         return Response.ok().entity(msg).build();
     }
 
+    @DELETE
+    @Path("/{connector}/offsets")
+    @Operation(summary = "Reset the offsets for the specified connector")
+    public Response resetConnectorOffsets(final @Parameter(hidden = true) @QueryParam("forward") Boolean forward,
+                                          final @Context HttpHeaders headers, final @PathParam("connector") String connector) throws Throwable {
+        FutureCallback<Message> cb = new FutureCallback<>();
+        herder.resetConnectorOffsets(connector, cb);
+        Message msg = requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/offsets", "DELETE", headers, null,
+                new TypeReference<Message>() { }, new IdentityTranslator<>(), forward);
+        return Response.ok().entity(msg).build();
+    }
+
     // Check whether the connector name from the url matches the one (if there is one) provided in the connectorConfig
     // object. Throw BadRequestException on mismatch, otherwise put connectorName in config
     private void checkAndPutConnectorConfigName(String connectorName, Map<String, String> connectorConfig) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -379,11 +379,7 @@ public class StandaloneHerder extends AbstractHerder {
             return;
         }
 
-        if (offsets == null) {
-            worker.resetConnectorOffsets(connName, configState.connectorConfig(connName), cb);
-        } else {
-            worker.alterConnectorOffsets(connName, configState.connectorConfig(connName), offsets, cb);
-        }
+        worker.modifyConnectorOffsets(connName, configState.connectorConfig(connName), offsets, cb);
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -400,8 +400,8 @@ public class StandaloneHerder extends AbstractHerder {
         }
 
         if (configState.targetState(connName) != TargetState.STOPPED || configState.taskCount(connName) != 0) {
-            cb.onCompletion(new BadRequestException("Connectors must be in the STOPPED state before their offsets can be modified externally. " +
-                    "This can be done for the specified connector by issuing a 'PUT' request to the '/connectors/" + connName + "/stop' endpoint"), null);
+            cb.onCompletion(new BadRequestException("Connectors must be in the STOPPED state before their offsets can be modified. This can be done " +
+                    "for the specified connector by issuing a 'PUT' request to the '/connectors/" + connName + "/stop' endpoint"), null);
             return false;
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -374,19 +374,38 @@ public class StandaloneHerder extends AbstractHerder {
     }
 
     @Override
-    public synchronized void alterConnectorOffsets(String connName, Map<Map<String, ?>, Map<String, ?>> offsets, Callback<Message> cb) {
+    protected synchronized void modifyConnectorOffsets(String connName, Map<Map<String, ?>, Map<String, ?>> offsets, Callback<Message> cb) {
+        if (!modifyConnectorOffsetsChecks(connName, cb)) {
+            return;
+        }
+
+        if (offsets == null) {
+            worker.resetConnectorOffsets(connName, configState.connectorConfig(connName), cb);
+        } else {
+            worker.alterConnectorOffsets(connName, configState.connectorConfig(connName), offsets, cb);
+        }
+    }
+
+    /**
+     * This method performs a few checks for external requests to modify (alter or reset) connector offsets and
+     * completes the callback exceptionally if any check fails.
+     * @param connName the name of the connector whose offsets are to be modified
+     * @param cb callback to invoke upon completion
+     * @return true if all the checks passed, false otherwise
+     */
+    private boolean modifyConnectorOffsetsChecks(String connName, Callback<Message> cb) {
         if (!configState.contains(connName)) {
             cb.onCompletion(new NotFoundException("Connector " + connName + " not found", null), null);
-            return;
+            return false;
         }
 
         if (configState.targetState(connName) != TargetState.STOPPED || configState.taskCount(connName) != 0) {
-            cb.onCompletion(new BadRequestException("Connectors must be in the STOPPED state before their offsets can be altered. " +
-                    "This can be done for the specified connector by issuing a PUT request to the /connectors/" + connName + "/stop endpoint"), null);
-            return;
+            cb.onCompletion(new BadRequestException("Connectors must be in the STOPPED state before their offsets can be modified externally. " +
+                    "This can be done for the specified connector by issuing a 'PUT' request to the '/connectors/" + connName + "/stop' endpoint"), null);
+            return false;
         }
 
-        worker.alterConnectorOffsets(connName, configState.connectorConfig(connName), offsets, cb);
+        return true;
     }
 
     private void startConnector(String connName, Callback<TargetState> onStart) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/SinkUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/SinkUtils.java
@@ -73,8 +73,8 @@ public final class SinkUtils {
      * and then parse them into a mapping from {@link TopicPartition}s to their corresponding {@link Long}
      * valued offsets.
      *
-     * @param partitionOffsets the partitions to offset map that needs to be validated and parsed.
-     * @return the parsed mapping from {@link TopicPartition} to its corresponding {@link Long} valued offset.
+     * @param partitionOffsets the partitions to offset map that needs to be validated and parsed; may not be null or empty
+     * @return the parsed mapping from {@link TopicPartition}s to their corresponding {@link Long} valued offsets; may not be null or empty
      *
      * @throws BadRequestException if the provided offsets aren't in the expected format
      */

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
@@ -156,7 +156,7 @@ public class OffsetsApiIntegrationTest {
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
                 "Connector tasks did not start in time.");
 
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, "test-topic", 5, 10,
+        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, 5, 10,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");
 
         // Produce 10 more messages to each partition
@@ -166,7 +166,7 @@ public class OffsetsApiIntegrationTest {
             }
         }
 
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, "test-topic", 5, 20,
+        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, 5, 20,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");
     }
 
@@ -310,7 +310,7 @@ public class OffsetsApiIntegrationTest {
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
                 "Connector tasks did not start in time.");
 
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, "test-topic", numPartitions, numMessages,
+        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions, numMessages,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");
 
         connect.stopConnector(CONNECTOR_NAME);
@@ -337,7 +337,7 @@ public class OffsetsApiIntegrationTest {
         assertThat(response, containsString("The Connect framework-managed offsets for this connector have been altered successfully. " +
                 "However, if this connector manages offsets externally, they will need to be manually altered in the system that the connector uses."));
 
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, "test-topic", numPartitions - 1, 5,
+        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions - 1, 5,
                 "Sink connector consumer group offsets should reflect the altered offsets");
 
         // Update the connector's configs; this time expect SinkConnector::alterOffsets to return true
@@ -356,7 +356,7 @@ public class OffsetsApiIntegrationTest {
         response = connect.alterConnectorOffsets(CONNECTOR_NAME, new ConnectorOffsets(offsetsToAlter));
         assertThat(response, containsString("The offsets for this connector have been altered successfully"));
 
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, "test-topic", numPartitions - 1, 3,
+        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions - 1, 3,
                 "Sink connector consumer group offsets should reflect the altered offsets");
 
         // Resume the connector and expect its offsets to catch up to the latest offsets
@@ -366,7 +366,7 @@ public class OffsetsApiIntegrationTest {
                 NUM_TASKS,
                 "Connector tasks did not resume in time"
         );
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, "test-topic", numPartitions, 10,
+        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions, 10,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");
     }
 
@@ -688,7 +688,7 @@ public class OffsetsApiIntegrationTest {
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
                 "Connector tasks did not start in time.");
 
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, "test-topic", numPartitions, numMessages,
+        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions, numMessages,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");
 
         connect.stopConnector(CONNECTOR_NAME);
@@ -718,7 +718,7 @@ public class OffsetsApiIntegrationTest {
                 NUM_TASKS,
                 "Connector tasks did not resume in time"
         );
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, "test-topic", numPartitions, 10,
+        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions, 10,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
@@ -67,29 +67,33 @@ import static org.junit.Assert.assertTrue;
  */
 @Category(IntegrationTest.class)
 public class OffsetsApiIntegrationTest {
-
-    private static final String CONNECTOR_NAME = "test-connector";
-    private static final String TOPIC = "test-topic";
-    private static final Integer NUM_TASKS = 2;
     private static final long OFFSET_COMMIT_INTERVAL_MS = TimeUnit.SECONDS.toMillis(1);
     private static final long OFFSET_READ_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
     private static final int NUM_WORKERS = 3;
+    private static final String CONNECTOR_NAME = "test-connector";
+    private static final String TOPIC = "test-topic";
+    private static final int NUM_TASKS = 2;
+    private static final int NUM_RECORDS_PER_PARTITION = 10;
     private Map<String, String> workerProps;
+    private EmbeddedConnectCluster.Builder connectBuilder;
     private EmbeddedConnectCluster connect;
 
     @Before
     public void setup() {
+        Properties brokerProps = new Properties();
+        brokerProps.put("transaction.state.log.replication.factor", "1");
+        brokerProps.put("transaction.state.log.min.isr", "1");
+
         // setup Connect worker properties
         workerProps = new HashMap<>();
         workerProps.put(OFFSET_COMMIT_INTERVAL_MS_CONFIG, String.valueOf(OFFSET_COMMIT_INTERVAL_MS));
 
         // build a Connect cluster backed by Kafka and Zk
-        connect = new EmbeddedConnectCluster.Builder()
+        connectBuilder = new EmbeddedConnectCluster.Builder()
                 .name("connect-cluster")
                 .numWorkers(NUM_WORKERS)
-                .workerProps(workerProps)
-                .build();
-        connect.start();
+                .brokerProps(brokerProps)
+                .workerProps(workerProps);
     }
 
     @After
@@ -99,6 +103,8 @@ public class OffsetsApiIntegrationTest {
 
     @Test
     public void testGetNonExistentConnectorOffsets() {
+        connect = connectBuilder.build();
+        connect.start();
         ConnectRestException e = assertThrows(ConnectRestException.class,
                 () -> connect.connectorOffsets("non-existent-connector"));
         assertEquals(404, e.errorCode());
@@ -106,11 +112,15 @@ public class OffsetsApiIntegrationTest {
 
     @Test
     public void testGetSinkConnectorOffsets() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         getAndVerifySinkConnectorOffsets(baseSinkConnectorConfigs(), connect.kafka());
     }
 
     @Test
     public void testGetSinkConnectorOffsetsOverriddenConsumerGroupId() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         Map<String, String> connectorConfigs = baseSinkConnectorConfigs();
         connectorConfigs.put(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + CommonClientConfigs.GROUP_ID_CONFIG,
                 "overridden-group-id");
@@ -126,6 +136,8 @@ public class OffsetsApiIntegrationTest {
 
     @Test
     public void testGetSinkConnectorOffsetsDifferentKafkaClusterTargeted() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         EmbeddedKafkaCluster kafkaCluster = new EmbeddedKafkaCluster(1, new Properties());
 
         try (AutoCloseable ignored = kafkaCluster::stop) {
@@ -144,9 +156,9 @@ public class OffsetsApiIntegrationTest {
     private void getAndVerifySinkConnectorOffsets(Map<String, String> connectorConfigs, EmbeddedKafkaCluster kafkaCluster) throws Exception {
         kafkaCluster.createTopic(TOPIC, 5);
 
-        // Produce 10 messages to each partition
+        // Produce records to each partition
         for (int partition = 0; partition < 5; partition++) {
-            for (int message = 0; message < 10; message++) {
+            for (int record = 0; record < NUM_RECORDS_PER_PARTITION; record++) {
                 kafkaCluster.produce(TOPIC, partition, "key", "value");
             }
         }
@@ -156,27 +168,31 @@ public class OffsetsApiIntegrationTest {
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
                 "Connector tasks did not start in time.");
 
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, 5, 10,
+        verifyExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, 5, NUM_RECORDS_PER_PARTITION,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");
 
-        // Produce 10 more messages to each partition
+        // Produce more records to each partition
         for (int partition = 0; partition < 5; partition++) {
-            for (int message = 0; message < 10; message++) {
+            for (int record = 0; record < NUM_RECORDS_PER_PARTITION; record++) {
                 kafkaCluster.produce(TOPIC, partition, "key", "value");
             }
         }
 
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, 5, 20,
+        verifyExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, 5, 2 * NUM_RECORDS_PER_PARTITION,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");
     }
 
     @Test
     public void testGetSourceConnectorOffsets() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         getAndVerifySourceConnectorOffsets(baseSourceConnectorConfigs());
     }
 
     @Test
     public void testGetSourceConnectorOffsetsCustomOffsetsTopic() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         Map<String, String> connectorConfigs = baseSourceConnectorConfigs();
         connectorConfigs.put(SourceConnectorConfig.OFFSETS_TOPIC_CONFIG, "custom-offsets-topic");
         getAndVerifySourceConnectorOffsets(connectorConfigs);
@@ -184,6 +200,8 @@ public class OffsetsApiIntegrationTest {
 
     @Test
     public void testGetSourceConnectorOffsetsDifferentKafkaClusterTargeted() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         EmbeddedKafkaCluster kafkaCluster = new EmbeddedKafkaCluster(1, new Properties());
 
         try (AutoCloseable ignored = kafkaCluster::stop) {
@@ -205,19 +223,21 @@ public class OffsetsApiIntegrationTest {
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
                 "Connector tasks did not start in time.");
 
-        waitForExpectedSourceConnectorOffsets(connect, CONNECTOR_NAME, NUM_TASKS, 10,
+        verifyExpectedSourceConnectorOffsets(CONNECTOR_NAME, NUM_TASKS, NUM_RECORDS_PER_PARTITION,
                 "Source connector offsets should reflect the expected number of records produced");
 
-        // Each task should produce 10 more records
-        connectorConfigs.put(MonitorableSourceConnector.MAX_MESSAGES_PRODUCED_CONFIG, "20");
+        // Each task should produce more records
+        connectorConfigs.put(MonitorableSourceConnector.MAX_MESSAGES_PRODUCED_CONFIG, String.valueOf(2 * NUM_RECORDS_PER_PARTITION));
         connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
 
-        waitForExpectedSourceConnectorOffsets(connect, CONNECTOR_NAME, NUM_TASKS, 20,
+        verifyExpectedSourceConnectorOffsets(CONNECTOR_NAME, NUM_TASKS, 2 * NUM_RECORDS_PER_PARTITION,
                 "Source connector offsets should reflect the expected number of records produced");
     }
 
     @Test
     public void testAlterOffsetsNonExistentConnector() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         ConnectRestException e = assertThrows(ConnectRestException.class,
                 () -> connect.alterConnectorOffsets("non-existent-connector", new ConnectorOffsets(Collections.singletonList(
                         new ConnectorOffset(Collections.emptyMap(), Collections.emptyMap())))));
@@ -226,6 +246,8 @@ public class OffsetsApiIntegrationTest {
 
     @Test
     public void testAlterOffsetsNonStoppedConnector() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         // Create source connector
         connect.configureConnector(CONNECTOR_NAME, baseSourceConnectorConfigs());
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
@@ -260,11 +282,15 @@ public class OffsetsApiIntegrationTest {
 
     @Test
     public void testAlterSinkConnectorOffsets() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         alterAndVerifySinkConnectorOffsets(baseSinkConnectorConfigs(), connect.kafka());
     }
 
     @Test
     public void testAlterSinkConnectorOffsetsOverriddenConsumerGroupId() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         Map<String, String> connectorConfigs = baseSinkConnectorConfigs();
         connectorConfigs.put(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + CommonClientConfigs.GROUP_ID_CONFIG,
                 "overridden-group-id");
@@ -279,6 +305,8 @@ public class OffsetsApiIntegrationTest {
 
     @Test
     public void testAlterSinkConnectorOffsetsDifferentKafkaClusterTargeted() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         EmbeddedKafkaCluster kafkaCluster = new EmbeddedKafkaCluster(1, new Properties());
 
         try (AutoCloseable ignored = kafkaCluster::stop) {
@@ -296,12 +324,11 @@ public class OffsetsApiIntegrationTest {
 
     private void alterAndVerifySinkConnectorOffsets(Map<String, String> connectorConfigs, EmbeddedKafkaCluster kafkaCluster) throws Exception {
         int numPartitions = 3;
-        int numMessages = 10;
         kafkaCluster.createTopic(TOPIC, numPartitions);
 
-        // Produce numMessages messages to each partition
+        // Produce records to each partition
         for (int partition = 0; partition < numPartitions; partition++) {
-            for (int message = 0; message < numMessages; message++) {
+            for (int record = 0; record < NUM_RECORDS_PER_PARTITION; record++) {
                 kafkaCluster.produce(TOPIC, partition, "key", "value");
             }
         }
@@ -310,7 +337,7 @@ public class OffsetsApiIntegrationTest {
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
                 "Connector tasks did not start in time.");
 
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions, numMessages,
+        verifyExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions, NUM_RECORDS_PER_PARTITION,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");
 
         connect.stopConnector(CONNECTOR_NAME);
@@ -337,7 +364,7 @@ public class OffsetsApiIntegrationTest {
         assertThat(response, containsString("The Connect framework-managed offsets for this connector have been altered successfully. " +
                 "However, if this connector manages offsets externally, they will need to be manually altered in the system that the connector uses."));
 
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions - 1, 5,
+        verifyExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions - 1, 5,
                 "Sink connector consumer group offsets should reflect the altered offsets");
 
         // Update the connector's configs; this time expect SinkConnector::alterOffsets to return true
@@ -356,7 +383,7 @@ public class OffsetsApiIntegrationTest {
         response = connect.alterConnectorOffsets(CONNECTOR_NAME, new ConnectorOffsets(offsetsToAlter));
         assertThat(response, containsString("The offsets for this connector have been altered successfully"));
 
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions - 1, 3,
+        verifyExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions - 1, 3,
                 "Sink connector consumer group offsets should reflect the altered offsets");
 
         // Resume the connector and expect its offsets to catch up to the latest offsets
@@ -366,16 +393,18 @@ public class OffsetsApiIntegrationTest {
                 NUM_TASKS,
                 "Connector tasks did not resume in time"
         );
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions, 10,
+        verifyExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions, NUM_RECORDS_PER_PARTITION,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");
     }
 
     @Test
     public void testAlterSinkConnectorOffsetsZombieSinkTasks() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         connect.kafka().createTopic(TOPIC, 1);
 
-        // Produce 10 messages
-        for (int message = 0; message < 10; message++) {
+        // Produce records
+        for (int record = 0; record < NUM_RECORDS_PER_PARTITION; record++) {
             connect.kafka().produce(TOPIC, 0, "key", "value");
         }
 
@@ -404,6 +433,8 @@ public class OffsetsApiIntegrationTest {
 
     @Test
     public void testAlterSinkConnectorOffsetsInvalidRequestBody() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         // Create a sink connector and stop it
         connect.configureConnector(CONNECTOR_NAME, baseSinkConnectorConfigs());
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
@@ -466,18 +497,24 @@ public class OffsetsApiIntegrationTest {
 
     @Test
     public void testAlterSourceConnectorOffsets() throws Exception {
-        alterAndVerifySourceConnectorOffsets(connect, baseSourceConnectorConfigs());
+        connect = connectBuilder.build();
+        connect.start();
+        alterAndVerifySourceConnectorOffsets(baseSourceConnectorConfigs());
     }
 
     @Test
     public void testAlterSourceConnectorOffsetsCustomOffsetsTopic() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         Map<String, String> connectorConfigs = baseSourceConnectorConfigs();
         connectorConfigs.put(SourceConnectorConfig.OFFSETS_TOPIC_CONFIG, "custom-offsets-topic");
-        alterAndVerifySourceConnectorOffsets(connect, connectorConfigs);
+        alterAndVerifySourceConnectorOffsets(connectorConfigs);
     }
 
     @Test
     public void testAlterSourceConnectorOffsetsDifferentKafkaClusterTargeted() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         EmbeddedKafkaCluster kafkaCluster = new EmbeddedKafkaCluster(1, new Properties());
 
         try (AutoCloseable ignored = kafkaCluster::stop) {
@@ -489,36 +526,26 @@ public class OffsetsApiIntegrationTest {
             connectorConfigs.put(ConnectorConfig.CONNECTOR_CLIENT_ADMIN_OVERRIDES_PREFIX + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
                     kafkaCluster.bootstrapServers());
 
-            alterAndVerifySourceConnectorOffsets(connect, connectorConfigs);
+            alterAndVerifySourceConnectorOffsets(connectorConfigs);
         }
     }
 
     @Test
     public void testAlterSourceConnectorOffsetsExactlyOnceSupportEnabled() throws Exception {
-        Properties brokerProps = new Properties();
-        brokerProps.put("transaction.state.log.replication.factor", "1");
-        brokerProps.put("transaction.state.log.min.isr", "1");
         workerProps.put(DistributedConfig.EXACTLY_ONCE_SOURCE_SUPPORT_CONFIG, "enabled");
-        EmbeddedConnectCluster exactlyOnceSupportEnabledConnectCluster = new EmbeddedConnectCluster.Builder()
-                .name("connect-cluster")
-                .brokerProps(brokerProps)
-                .numWorkers(NUM_WORKERS)
-                .workerProps(workerProps)
-                .build();
-        exactlyOnceSupportEnabledConnectCluster.start();
+        connect = connectBuilder.workerProps(workerProps).build();
+        connect.start();
 
-        try (AutoCloseable ignored = exactlyOnceSupportEnabledConnectCluster::stop) {
-            alterAndVerifySourceConnectorOffsets(exactlyOnceSupportEnabledConnectCluster, baseSourceConnectorConfigs());
-        }
+        alterAndVerifySourceConnectorOffsets(baseSourceConnectorConfigs());
     }
 
-    public void alterAndVerifySourceConnectorOffsets(EmbeddedConnectCluster connect, Map<String, String> connectorConfigs) throws Exception {
+    public void alterAndVerifySourceConnectorOffsets(Map<String, String> connectorConfigs) throws Exception {
         // Create source connector
         connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
                 "Connector tasks did not start in time.");
 
-        waitForExpectedSourceConnectorOffsets(connect, CONNECTOR_NAME, NUM_TASKS, 10,
+        verifyExpectedSourceConnectorOffsets(CONNECTOR_NAME, NUM_TASKS, NUM_RECORDS_PER_PARTITION,
                 "Source connector offsets should reflect the expected number of records produced");
 
         connect.stopConnector(CONNECTOR_NAME);
@@ -540,7 +567,7 @@ public class OffsetsApiIntegrationTest {
         assertThat(response, containsString("The Connect framework-managed offsets for this connector have been altered successfully. " +
                 "However, if this connector manages offsets externally, they will need to be manually altered in the system that the connector uses."));
 
-        waitForExpectedSourceConnectorOffsets(connect, CONNECTOR_NAME, NUM_TASKS, 5,
+        verifyExpectedSourceConnectorOffsets(CONNECTOR_NAME, NUM_TASKS, 5,
                 "Source connector offsets should reflect the altered offsets");
 
         // Update the connector's configs; this time expect SourceConnector::alterOffsets to return true
@@ -560,7 +587,7 @@ public class OffsetsApiIntegrationTest {
         response = connect.alterConnectorOffsets(CONNECTOR_NAME, new ConnectorOffsets(offsetsToAlter));
         assertThat(response, containsString("The offsets for this connector have been altered successfully"));
 
-        waitForExpectedSourceConnectorOffsets(connect, CONNECTOR_NAME, NUM_TASKS, 7,
+        verifyExpectedSourceConnectorOffsets(CONNECTOR_NAME, NUM_TASKS, 7,
                 "Source connector offsets should reflect the altered offsets");
 
         // Resume the connector and expect its offsets to catch up to the latest offsets
@@ -570,12 +597,14 @@ public class OffsetsApiIntegrationTest {
                 NUM_TASKS,
                 "Connector tasks did not resume in time"
         );
-        waitForExpectedSourceConnectorOffsets(connect, CONNECTOR_NAME, NUM_TASKS, 10,
+        verifyExpectedSourceConnectorOffsets(CONNECTOR_NAME, NUM_TASKS, NUM_RECORDS_PER_PARTITION,
                 "Source connector offsets should reflect the expected number of records produced");
     }
 
     @Test
     public void testAlterSourceConnectorOffsetsInvalidRequestBody() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         // Create a source connector and stop it
         connect.configureConnector(CONNECTOR_NAME, baseSourceConnectorConfigs());
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
@@ -638,11 +667,15 @@ public class OffsetsApiIntegrationTest {
 
     @Test
     public void testResetSinkConnectorOffsets() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         resetAndVerifySinkConnectorOffsets(baseSinkConnectorConfigs(), connect.kafka());
     }
 
     @Test
     public void testResetSinkConnectorOffsetsOverriddenConsumerGroupId() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         Map<String, String> connectorConfigs = baseSinkConnectorConfigs();
         connectorConfigs.put(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + CommonClientConfigs.GROUP_ID_CONFIG,
                 "overridden-group-id");
@@ -657,6 +690,8 @@ public class OffsetsApiIntegrationTest {
 
     @Test
     public void testResetSinkConnectorOffsetsDifferentKafkaClusterTargeted() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         EmbeddedKafkaCluster kafkaCluster = new EmbeddedKafkaCluster(1, new Properties());
 
         try (AutoCloseable ignored = kafkaCluster::stop) {
@@ -674,12 +709,11 @@ public class OffsetsApiIntegrationTest {
 
     private void resetAndVerifySinkConnectorOffsets(Map<String, String> connectorConfigs, EmbeddedKafkaCluster kafkaCluster) throws Exception {
         int numPartitions = 3;
-        int numMessages = 10;
         kafkaCluster.createTopic(TOPIC, numPartitions);
 
-        // Produce numMessages messages to each partition
+        // Produce records to each partition
         for (int partition = 0; partition < numPartitions; partition++) {
-            for (int message = 0; message < numMessages; message++) {
+            for (int record = 0; record < NUM_RECORDS_PER_PARTITION; record++) {
                 kafkaCluster.produce(TOPIC, partition, "key", "value");
             }
         }
@@ -688,7 +722,7 @@ public class OffsetsApiIntegrationTest {
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
                 "Connector tasks did not start in time.");
 
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions, numMessages,
+        verifyExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions, NUM_RECORDS_PER_PARTITION,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");
 
         connect.stopConnector(CONNECTOR_NAME);
@@ -702,14 +736,14 @@ public class OffsetsApiIntegrationTest {
         assertThat(response, containsString("The Connect framework-managed offsets for this connector have been reset successfully. " +
                 "However, if this connector manages offsets externally, they will need to be manually reset in the system that the connector uses."));
 
-        waitForEmptySinkConnectorOffsets(CONNECTOR_NAME);
+        verifyEmptyConnectorOffsets(CONNECTOR_NAME);
 
         // Reset the sink connector's offsets again while it is still in a STOPPED state and ensure that there is no error
         response = connect.resetConnectorOffsets(CONNECTOR_NAME);
         assertThat(response, containsString("The Connect framework-managed offsets for this connector have been reset successfully. " +
                 "However, if this connector manages offsets externally, they will need to be manually reset in the system that the connector uses."));
 
-        waitForEmptySinkConnectorOffsets(CONNECTOR_NAME);
+        verifyEmptyConnectorOffsets(CONNECTOR_NAME);
 
         // Resume the connector and expect its offsets to catch up to the latest offsets
         connect.resumeConnector(CONNECTOR_NAME);
@@ -718,16 +752,18 @@ public class OffsetsApiIntegrationTest {
                 NUM_TASKS,
                 "Connector tasks did not resume in time"
         );
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions, 10,
+        verifyExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, numPartitions, NUM_RECORDS_PER_PARTITION,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");
     }
 
     @Test
     public void testResetSinkConnectorOffsetsZombieSinkTasks() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         connect.kafka().createTopic(TOPIC, 1);
 
-        // Produce 10 messages
-        for (int message = 0; message < 10; message++) {
+        // Produce records
+        for (int record = 0; record < NUM_RECORDS_PER_PARTITION; record++) {
             connect.kafka().produce(TOPIC, 0, "key", "value");
         }
 
@@ -741,7 +777,7 @@ public class OffsetsApiIntegrationTest {
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
                 "Connector tasks did not start in time.");
 
-        waitForExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, 1, 10,
+        verifyExpectedSinkConnectorOffsets(CONNECTOR_NAME, TOPIC, 1, NUM_RECORDS_PER_PARTITION,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");
 
         connect.stopConnector(CONNECTOR_NAME);
@@ -753,18 +789,24 @@ public class OffsetsApiIntegrationTest {
 
     @Test
     public void testResetSourceConnectorOffsets() throws Exception {
-        resetAndVerifySourceConnectorOffsets(connect, baseSourceConnectorConfigs());
+        connect = connectBuilder.build();
+        connect.start();
+        resetAndVerifySourceConnectorOffsets(baseSourceConnectorConfigs());
     }
 
     @Test
     public void testResetSourceConnectorOffsetsCustomOffsetsTopic() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         Map<String, String> connectorConfigs = baseSourceConnectorConfigs();
         connectorConfigs.put(SourceConnectorConfig.OFFSETS_TOPIC_CONFIG, "custom-offsets-topic");
-        resetAndVerifySourceConnectorOffsets(connect, connectorConfigs);
+        resetAndVerifySourceConnectorOffsets(connectorConfigs);
     }
 
     @Test
     public void testResetSourceConnectorOffsetsDifferentKafkaClusterTargeted() throws Exception {
+        connect = connectBuilder.build();
+        connect.start();
         EmbeddedKafkaCluster kafkaCluster = new EmbeddedKafkaCluster(1, new Properties());
 
         try (AutoCloseable ignored = kafkaCluster::stop) {
@@ -776,39 +818,26 @@ public class OffsetsApiIntegrationTest {
             connectorConfigs.put(ConnectorConfig.CONNECTOR_CLIENT_ADMIN_OVERRIDES_PREFIX + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
                     kafkaCluster.bootstrapServers());
 
-            resetAndVerifySourceConnectorOffsets(connect, connectorConfigs);
+            resetAndVerifySourceConnectorOffsets(connectorConfigs);
         }
     }
 
     @Test
     public void testResetSourceConnectorOffsetsExactlyOnceSupportEnabled() throws Exception {
-        Properties brokerProps = new Properties();
-        brokerProps.put("transaction.state.log.replication.factor", "1");
-        brokerProps.put("transaction.state.log.min.isr", "1");
         workerProps.put(DistributedConfig.EXACTLY_ONCE_SOURCE_SUPPORT_CONFIG, "enabled");
+        connect = connectBuilder.workerProps(workerProps).build();
+        connect.start();
 
-        // This embedded Connect cluster will internally spin up its own embedded Kafka cluster
-        EmbeddedConnectCluster exactlyOnceSupportEnabledConnectCluster = new EmbeddedConnectCluster.Builder()
-                .name("eos-enabled-connect-cluster")
-                .brokerProps(brokerProps)
-                .numWorkers(NUM_WORKERS)
-                .workerProps(workerProps)
-                .build();
-        exactlyOnceSupportEnabledConnectCluster.start();
-
-        try (AutoCloseable ignored = exactlyOnceSupportEnabledConnectCluster::stop) {
-            Map<String, String> connectorConfigs = baseSourceConnectorConfigs();
-            resetAndVerifySourceConnectorOffsets(exactlyOnceSupportEnabledConnectCluster, connectorConfigs);
-        }
+        resetAndVerifySourceConnectorOffsets(baseSourceConnectorConfigs());
     }
 
-    public void resetAndVerifySourceConnectorOffsets(EmbeddedConnectCluster connect, Map<String, String> connectorConfigs) throws Exception {
+    public void resetAndVerifySourceConnectorOffsets(Map<String, String> connectorConfigs) throws Exception {
         // Create source connector
         connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
                 "Connector tasks did not start in time.");
 
-        waitForExpectedSourceConnectorOffsets(connect, CONNECTOR_NAME, NUM_TASKS, 10,
+        verifyExpectedSourceConnectorOffsets(CONNECTOR_NAME, NUM_TASKS, NUM_RECORDS_PER_PARTITION,
                 "Source connector offsets should reflect the expected number of records produced");
 
         connect.stopConnector(CONNECTOR_NAME);
@@ -822,14 +851,14 @@ public class OffsetsApiIntegrationTest {
         assertThat(response, containsString("The Connect framework-managed offsets for this connector have been reset successfully. " +
                 "However, if this connector manages offsets externally, they will need to be manually reset in the system that the connector uses."));
 
-        waitForEmptySourceConnectorOffsets(connect, CONNECTOR_NAME);
+        verifyEmptyConnectorOffsets(CONNECTOR_NAME);
 
         // Reset the source connector's offsets again while it is still in a STOPPED state and ensure that there is no error
         response = connect.resetConnectorOffsets(CONNECTOR_NAME);
         assertThat(response, containsString("The Connect framework-managed offsets for this connector have been reset successfully. " +
                 "However, if this connector manages offsets externally, they will need to be manually reset in the system that the connector uses."));
 
-        waitForEmptySourceConnectorOffsets(connect, CONNECTOR_NAME);
+        verifyEmptyConnectorOffsets(CONNECTOR_NAME);
 
         // Resume the connector and expect its offsets to catch up to the latest offsets
         connect.resumeConnector(CONNECTOR_NAME);
@@ -838,7 +867,7 @@ public class OffsetsApiIntegrationTest {
                 NUM_TASKS,
                 "Connector tasks did not resume in time"
         );
-        waitForExpectedSourceConnectorOffsets(connect, CONNECTOR_NAME, NUM_TASKS, 10,
+        verifyExpectedSourceConnectorOffsets(CONNECTOR_NAME, NUM_TASKS, NUM_RECORDS_PER_PARTITION,
                 "Source connector offsets should reflect the expected number of records produced");
     }
 
@@ -858,7 +887,7 @@ public class OffsetsApiIntegrationTest {
         props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
         props.put(TOPIC_CONFIG, TOPIC);
         props.put(MonitorableSourceConnector.MESSAGES_PER_POLL_CONFIG, "3");
-        props.put(MonitorableSourceConnector.MAX_MESSAGES_PRODUCED_CONFIG, "10");
+        props.put(MonitorableSourceConnector.MAX_MESSAGES_PRODUCED_CONFIG, String.valueOf(NUM_RECORDS_PER_PARTITION));
         props.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
         props.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
         props.put(DEFAULT_TOPIC_CREATION_PREFIX + REPLICATION_FACTOR_CONFIG, "1");
@@ -868,8 +897,8 @@ public class OffsetsApiIntegrationTest {
 
     /**
      * Verify whether the actual consumer group offsets for a sink connector match the expected offsets. The verification
-     * is done using the `GET /connectors/{connector}/offsets` REST API which is repeatedly queried until the offsets match
-     * or the {@link #OFFSET_READ_TIMEOUT_MS timeout} is reached. Note that this assumes the following:
+     * is done using the <strong><em>GET /connectors/{connector}/offsets</em></strong> REST API which is repeatedly queried
+     * until the offsets match or the {@link #OFFSET_READ_TIMEOUT_MS timeout} is reached. Note that this assumes the following:
      * <ol>
      *     <li>The sink connector is consuming from a single Kafka topic</li>
      *     <li>The expected offset for each partition in the topic is the same</li>
@@ -883,8 +912,8 @@ public class OffsetsApiIntegrationTest {
      *                         10 records)
      * @throws InterruptedException if the thread is interrupted while waiting for the actual offsets to match the expected offsets
      */
-    private void waitForExpectedSinkConnectorOffsets(String connectorName, String expectedTopic, int expectedPartitions,
-                                                     int expectedOffset, String conditionDetails) throws InterruptedException {
+    private void verifyExpectedSinkConnectorOffsets(String connectorName, String expectedTopic, int expectedPartitions,
+                                                    int expectedOffset, String conditionDetails) throws InterruptedException {
         TestUtils.waitForCondition(() -> {
             ConnectorOffsets offsets = connect.connectorOffsets(connectorName);
             if (offsets.offsets().size() != expectedPartitions) {
@@ -902,11 +931,10 @@ public class OffsetsApiIntegrationTest {
 
     /**
      * Verify whether the actual offsets for a source connector match the expected offsets. The verification is done using the
-     * `GET /connectors/{connector}/offsets` REST API which is repeatedly queried until the offsets match or the
-     * {@link #OFFSET_READ_TIMEOUT_MS timeout} is reached. Note that this assumes that the source connector is a
+     * <strong><em>GET /connectors/{connector}/offsets</em></strong> REST API which is repeatedly queried until the offsets match
+     * or the {@link #OFFSET_READ_TIMEOUT_MS timeout} is reached. Note that this assumes that the source connector is a
      * {@link MonitorableSourceConnector}
      *
-     * @param connect the Connect cluster that is running the source connector
      * @param connectorName the name of the source connector whose offsets are to be verified
      * @param numTasks the number of tasks for the source connector
      * @param expectedOffset the expected offset for each source partition
@@ -914,8 +942,8 @@ public class OffsetsApiIntegrationTest {
      *                         10 records)
      * @throws InterruptedException if the thread is interrupted while waiting for the actual offsets to match the expected offsets
      */
-    private void waitForExpectedSourceConnectorOffsets(EmbeddedConnectCluster connect, String connectorName, int numTasks,
-                                                       int expectedOffset, String conditionDetails) throws InterruptedException {
+    private void verifyExpectedSourceConnectorOffsets(String connectorName, int numTasks,
+                                                      int expectedOffset, String conditionDetails) throws InterruptedException {
         TestUtils.waitForCondition(() -> {
             ConnectorOffsets offsets = connect.connectorOffsets(connectorName);
             // The MonitorableSourceConnector has a source partition per task
@@ -932,17 +960,18 @@ public class OffsetsApiIntegrationTest {
         }, OFFSET_READ_TIMEOUT_MS, conditionDetails);
     }
 
-    private void waitForEmptySinkConnectorOffsets(String connectorName) throws InterruptedException {
+    /**
+     * Verify whether the <strong><em>GET /connectors/{connector}/offsets</em></strong> returns empty offsets for a source
+     * or sink connector whose offsets have been reset via the <strong><em>DELETE /connectors/{connector}/offsets</em></strong>
+     * REST API
+     *
+     * @param connectorName the name of the connector whose offsets are to be verified
+     * @throws InterruptedException if the thread is interrupted while waiting for the offsets to be empty
+     */
+    private void verifyEmptyConnectorOffsets(String connectorName) throws InterruptedException {
         TestUtils.waitForCondition(() -> {
             ConnectorOffsets offsets = connect.connectorOffsets(connectorName);
             return offsets.offsets().isEmpty();
-        }, OFFSET_READ_TIMEOUT_MS, "Sink connector offsets should be empty after resetting offsets");
-    }
-
-    private void waitForEmptySourceConnectorOffsets(EmbeddedConnectCluster connect, String connectorName) throws InterruptedException {
-        TestUtils.waitForCondition(() -> {
-            ConnectorOffsets offsets = connect.connectorOffsets(connectorName);
-            return offsets.offsets().isEmpty();
-        }, OFFSET_READ_TIMEOUT_MS, "Source connector offsets should be empty after resetting offsets");
+        }, OFFSET_READ_TIMEOUT_MS, "Connector offsets should be empty after resetting offsets");
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -1839,10 +1839,9 @@ public class WorkerTest {
             adminFuture.complete(consumerGroupOffsets);
         }
         when(result.partitionsToOffsetAndMetadata()).thenAnswer(invocation -> {
-            if (time == null) {
-                return adminFuture;
+            if (time != null) {
+                time.sleep(delayMs);
             }
-            time.sleep(delayMs);
             return adminFuture;
         });
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -90,6 +90,7 @@ import static org.apache.kafka.connect.runtime.TopicCreationConfig.REPLICATION_F
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.isNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
@@ -990,7 +991,9 @@ public class StandaloneHerderTest {
         PowerMock.replayAll();
 
         FutureCallback<Message> alterOffsetsCallback = new FutureCallback<>();
-        herder.alterConnectorOffsets("unknown-connector", new HashMap<>(), alterOffsetsCallback);
+        herder.alterConnectorOffsets("unknown-connector",
+                Collections.singletonMap(Collections.singletonMap("partitionKey", "partitionValue"), Collections.singletonMap("offsetKey", "offsetValue")),
+                alterOffsetsCallback);
         ExecutionException e = assertThrows(ExecutionException.class, () -> alterOffsetsCallback.get(1000L, TimeUnit.MILLISECONDS));
         assertTrue(e.getCause() instanceof NotFoundException);
 
@@ -1020,7 +1023,9 @@ public class StandaloneHerderTest {
         );
 
         FutureCallback<Message> alterOffsetsCallback = new FutureCallback<>();
-        herder.alterConnectorOffsets(CONNECTOR_NAME, new HashMap<>(), alterOffsetsCallback);
+        herder.alterConnectorOffsets(CONNECTOR_NAME,
+                Collections.singletonMap(Collections.singletonMap("partitionKey", "partitionValue"), Collections.singletonMap("offsetKey", "offsetValue")),
+                alterOffsetsCallback);
         ExecutionException e = assertThrows(ExecutionException.class, () -> alterOffsetsCallback.get(1000L, TimeUnit.MILLISECONDS));
         assertTrue(e.getCause() instanceof BadRequestException);
 
@@ -1036,7 +1041,7 @@ public class StandaloneHerderTest {
     public void testAlterConnectorOffsets() throws Exception {
         Capture<Callback<Message>> workerCallbackCapture = Capture.newInstance();
         Message msg = new Message("The offsets for this connector have been altered successfully");
-        worker.alterConnectorOffsets(eq(CONNECTOR_NAME), eq(connectorConfig(SourceSink.SOURCE)), anyObject(Map.class), capture(workerCallbackCapture));
+        worker.modifyConnectorOffsets(eq(CONNECTOR_NAME), eq(connectorConfig(SourceSink.SOURCE)), anyObject(Map.class), capture(workerCallbackCapture));
         EasyMock.expectLastCall().andAnswer(() -> {
             workerCallbackCapture.getValue().onCompletion(null, msg);
             return null;
@@ -1056,7 +1061,9 @@ public class StandaloneHerderTest {
                 Collections.emptySet()
         );
         FutureCallback<Message> alterOffsetsCallback = new FutureCallback<>();
-        herder.alterConnectorOffsets(CONNECTOR_NAME, new HashMap<>(), alterOffsetsCallback);
+        herder.alterConnectorOffsets(CONNECTOR_NAME,
+                Collections.singletonMap(Collections.singletonMap("partitionKey", "partitionValue"), Collections.singletonMap("offsetKey", "offsetValue")),
+                alterOffsetsCallback);
         assertEquals(msg, alterOffsetsCallback.get(1000, TimeUnit.MILLISECONDS));
         PowerMock.verifyAll();
     }
@@ -1065,7 +1072,7 @@ public class StandaloneHerderTest {
     public void testResetConnectorOffsets() throws Exception {
         Capture<Callback<Message>> workerCallbackCapture = Capture.newInstance();
         Message msg = new Message("The offsets for this connector have been reset successfully");
-        worker.resetConnectorOffsets(eq(CONNECTOR_NAME), eq(connectorConfig(SourceSink.SOURCE)), capture(workerCallbackCapture));
+        worker.modifyConnectorOffsets(eq(CONNECTOR_NAME), eq(connectorConfig(SourceSink.SOURCE)), isNull(), capture(workerCallbackCapture));
         EasyMock.expectLastCall().andAnswer(() -> {
             workerCallbackCapture.getValue().onCompletion(null, msg);
             return null;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -647,7 +647,8 @@ public class EmbeddedConnectCluster {
 
     /**
      * Get the offsets for a connector via the <strong><em>GET /connectors/{connector}/offsets</em></strong> endpoint
-     * @param connectorName name of the connector
+     *
+     * @param connectorName name of the connector whose offsets are to be retrieved
      * @return the connector's offsets
      */
     public ConnectorOffsets connectorOffsets(String connectorName) {
@@ -668,7 +669,8 @@ public class EmbeddedConnectCluster {
 
     /**
      * Alter a connector's offsets via the <strong><em>PATCH /connectors/{connector}/offsets</em></strong> endpoint
-     * @param connectorName name of the connector
+     *
+     * @param connectorName name of the connector whose offsets are to be altered
      * @param offsets offsets to alter
      */
     public String alterConnectorOffsets(String connectorName, ConnectorOffsets offsets) {
@@ -686,7 +688,23 @@ public class EmbeddedConnectCluster {
             return responseToString(response);
         } else {
             throw new ConnectRestException(response.getStatus(),
-                    "Could not execute PATCH request. Error response: " + responseToString(response));
+                    "Could not alter connector offsets. Error response: " + responseToString(response));
+        }
+    }
+
+    /**
+     * Reset a connector's offsets via the <strong><em>DELETE /connectors/{connector}/offsets</em></strong> endpoint
+     *
+     * @param connectorName name of the connector whose offsets are to be reset
+     */
+    public String resetConnectorOffsets(String connectorName) {
+        String url = endpointForResource(String.format("connectors/%s/offsets", connectorName));
+        Response response = requestDelete(url);
+        if (response.getStatus() < Response.Status.BAD_REQUEST.getStatusCode()) {
+            return responseToString(response);
+        } else {
+            throw new ConnectRestException(response.getStatus(),
+                    "Could not reset connector offsets. Error response: " + responseToString(response));
         }
     }
 


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/KAFKA-14784
- [KIP-875: First-class offsets support in Kafka Connect](https://cwiki.apache.org/confluence/display/KAFKA/KIP-875%3A+First-class+offsets+support+in+Kafka+Connect)
- Implements the new `DELETE /connectors/{connector}/offsets` REST API
- Relevant PRs: https://github.com/apache/kafka/pull/13434, https://github.com/apache/kafka/pull/13424, https://github.com/apache/kafka/pull/13465

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
