### PR TITLE
KAFKA-15073: Add a Github action to mark PRs as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -45,4 +45,8 @@ jobs:
           days-before-stale: 90
           days-before-close: -1
           stale-issue-label: 'stale'
-          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity.'
+          stale-pr-message: >
+            This PR is being marked as stale since it has not had any activity in 90 days. If you
+            would like to keep this PR alive, please update it with the latest from trunk and ask
+            a committer for a review.
+            

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -45,3 +45,4 @@ jobs:
           days-before-stale: 90
           days-before-close: -1
           stale-issue-label: 'stale'
+          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -47,6 +47,6 @@ jobs:
           stale-issue-label: 'stale'
           stale-pr-message: >
             This PR is being marked as stale since it has not had any activity in 90 days. If you
-            would like to keep this PR alive, please update it with the latest from trunk and ask
-            a committer for a review.
+            would like to keep this PR alive, please ask a committer for review. If the PR has 
+            merge conflicts, please update it with the latest from trunk (or appropriate release branch)
             

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,7 @@ on:
       dryRun:
         description: 'Dry Run'
         required: true
-        default: true
+        default: false
         type: boolean
       operationsPerRun:
         description: 'Max GitHub API operations'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 3 * * *'
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Dry Run'
+        required: true
+        default: true
+        type: boolean
+      operationsPerRun:
+        description: 'Max GitHub API operations'
+        required: true
+        default: 30
+        type: number
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          debug-only: ${{ inputs.dryRun }}
+          operations-per-run: ${{ inputs.operationsPerRun }}
+          days-before-stale: 90
+          days-before-close: -1
+          stale-issue-label: 'stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,14 +15,14 @@
 
 name: 'Close stale issues and PRs'
 on:
-  schedule:
-    - cron: '30 3 * * *'
+  #schedule:
+  #  - cron: '30 3 * * *'
   workflow_dispatch:
     inputs:
       dryRun:
         description: 'Dry Run'
         required: true
-        default: false
+        default: true
         type: boolean
       operationsPerRun:
         description: 'Max GitHub API operations'


### PR DESCRIPTION
This patch uses a Github workflow to mark inactive PRs with the `stale` label. The workflow uses the ["stale" action](https://github.com/actions/stale) which has many features including a number of filtering options and the ability to auto-closing issues.

For this patch, I've disable auto-closing PRs and just have it add the label for PRs with more than 90 days of inactivity. 

I've also only included a manual trigger. We can eventually include a cron schedule for automatic nightly running of the workflow.

I have tested this out on my fork of Kafka and it worked as expected: https://github.com/mumrah/kafka/actions/workflows/stale.yml

Here you can see when it actually marked an old PR as stale https://github.com/mumrah/kafka/actions/runs/5203928815/jobs/9387453473

<img width="649" alt="image" src="https://github.com/apache/kafka/assets/55116/fc27f962-8789-485c-8eae-a18e8a45fc45">
