### PR TITLE
KAFKA-10199: Re-add revived tasks to the state updater after handling

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -1274,6 +1274,7 @@ class DefaultStateUpdaterTest {
         verifyUpdatingTasks(task3);
         verifyRestoredActiveTasks();
         verifyRemovedTasks();
+        verify(changelogReader).unregister(mkSet(TOPIC_PARTITION_A_0, TOPIC_PARTITION_B_0));
     }
 
     @Test


### PR DESCRIPTION
Fixes a bug regarding the state updater where tasks that experience corruption during restoration are passed from the state updater to the stream thread for closing and reviving but then the revived tasks are not re-added to the state updater.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
