### PR TITLE
KAFKA-15077: Added code to trim token in FileTokenRetriever, added test.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/FileTokenRetriever.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/FileTokenRetriever.java
@@ -41,6 +41,8 @@ public class FileTokenRetriever implements AccessTokenRetriever {
     @Override
     public void init() throws IOException {
         this.accessToken = Utils.readFileAsString(accessTokenFile.toFile().getPath());
+        // always non-null; to remove any newline chars or backend will report err
+        this.accessToken = this.accessToken.trim();
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerLoginCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerLoginCallbackHandlerTest.java
@@ -25,13 +25,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Base64;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import org.apache.kafka.common.config.ConfigException;
@@ -162,6 +165,32 @@ public class OAuthBearerLoginCallbackHandlerTest extends OAuthBearerTest {
             assertThrowsWithMessage(IOException.class,
                 () -> handler.handle(new Callback[]{callback}),
                 "token endpoint response access_token value must be non-null");
+        } finally {
+            handler.close();
+        }
+    }
+
+    @Test
+    public void testFileTokenRetrieverHandlesNewline() throws IOException {
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        long cur = cal.getTimeInMillis() / 1000;
+        String exp = "" + (cur + 60 * 60);  // 1 hour in future
+        String iat = "" + cur;
+
+        String expected = createAccessKey("{}", String.format("{\"exp\":%s, \"iat\":%s, \"sub\":\"subj\"}", exp, iat), "sign");
+        String withNewline = expected + "\n";
+
+        File tmpDir = createTempDir("access-token");
+        File accessTokenFile = createTempFile(tmpDir, "access-token-", ".json", withNewline);
+
+        Map<String, ?> configs = getSaslConfigs();
+        OAuthBearerLoginCallbackHandler handler = createHandler(new FileTokenRetriever(accessTokenFile.toPath()), configs);
+        OAuthBearerTokenCallback callback = new OAuthBearerTokenCallback();
+        try {
+            handler.handle(new Callback[]{callback});
+            assertEquals(callback.token().value(), expected);
+        } catch (Exception e) {
+            fail(e);
         } finally {
             handler.close();
         }


### PR DESCRIPTION
* The `FileTokenRetriever` class is used to read the access_token from a file on the clients system and then it is passed along with the jaas config to the `OAuthBearerSaslServer`.
* The server uses the class `OAuthBearerClientInitialResponse` to validate the token format.
* In case the token was sent using `FileTokenRetriever` on the client side, some EOL character is getting appended to the token, causing authentication to fail with the message:
```
ERROR org.apache.kafka.common.errors.SaslAuthenticationException: Authentication failed during authentication due to invalid credentials with SASL mechanism OAUTHBEARER
 (kafka.admin.TopicCommand$)
```
* To remedy, we must trim the token before using it.