### PR TITLE
KAFKA-14218: Replace temp file handler with JUnit 5 Temporary Directory Support

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/config/provider/DirectoryConfigProviderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/provider/DirectoryConfigProviderTest.java
@@ -17,11 +17,10 @@
 package org.apache.kafka.common.config.provider;
 
 import org.apache.kafka.common.config.ConfigData;
-import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class DirectoryConfigProviderTest {
 
     private DirectoryConfigProvider provider;
-    private File parent;
     private File dir;
     private File bar;
     private File foo;
@@ -51,6 +49,8 @@ public class DirectoryConfigProviderTest {
     private File siblingDir;
     private File siblingDirFile;
     private File siblingFile;
+    @TempDir
+    private File parent;
 
     private static File writeFile(File file) throws IOException {
         Files.write(file.toPath(), file.getName().toUpperCase(Locale.ENGLISH).getBytes(StandardCharsets.UTF_8));
@@ -61,7 +61,6 @@ public class DirectoryConfigProviderTest {
     public void setup() throws IOException {
         provider = new DirectoryConfigProvider();
         provider.configure(Collections.emptyMap());
-        parent = TestUtils.tempDirectory();
         dir = new File(parent, "dir");
         dir.mkdir();
         foo = writeFile(new File(dir, "foo"));
@@ -78,7 +77,6 @@ public class DirectoryConfigProviderTest {
     @AfterEach
     public void close() throws IOException {
         provider.close();
-        Utils.delete(parent);
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/snapshot/FileRawSnapshotTest.java
+++ b/raft/src/test/java/org/apache/kafka/snapshot/FileRawSnapshotTest.java
@@ -27,9 +27,8 @@ import org.apache.kafka.common.record.UnalignedMemoryRecords;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.raft.OffsetAndEpoch;
 import org.apache.kafka.test.TestUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -46,17 +45,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class FileRawSnapshotTest {
-    private Path tempDir = null;
-
-    @BeforeEach
-    public void setUp() {
-        tempDir = TestUtils.tempDirectory().toPath();
-    }
-
-    @AfterEach
-    public void tearDown() throws IOException {
-        Utils.delete(tempDir.toFile());
-    }
+    @TempDir
+    private Path tempDir;
 
     @Test
     public void testWritingSnapshot() throws IOException {
@@ -129,8 +119,7 @@ public final class FileRawSnapshotTest {
     }
 
     @Test
-    public void testPartialWriteReadSnapshot() throws IOException {
-        Path tempDir = TestUtils.tempDirectory().toPath();
+    public void testPartialWriteReadSnapshot(@TempDir final Path tempDir) throws IOException {
         OffsetAndEpoch offsetAndEpoch = new OffsetAndEpoch(10L, 3);
 
         ByteBuffer records = buildRecords(ByteBuffer.wrap(Utils.utf8("foo"))).buffer();

--- a/raft/src/test/java/org/apache/kafka/snapshot/SnapshotsTest.java
+++ b/raft/src/test/java/org/apache/kafka/snapshot/SnapshotsTest.java
@@ -20,9 +20,11 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.raft.OffsetAndEpoch;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -36,12 +38,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 final public class SnapshotsTest {
 
     @Test
-    public void testValidSnapshotFilename() {
+    public void testValidSnapshotFilename(@TempDir File logDir) {
         OffsetAndEpoch snapshotId = new OffsetAndEpoch(
             TestUtils.RANDOM.nextInt(Integer.MAX_VALUE),
             TestUtils.RANDOM.nextInt(Integer.MAX_VALUE)
         );
-        Path path = Snapshots.snapshotPath(TestUtils.tempDirectory().toPath(), snapshotId);
+        Path path = Snapshots.snapshotPath(logDir.toPath(), snapshotId);
         SnapshotPath snapshotPath = Snapshots.parse(path).get();
 
         assertEquals(path, snapshotPath.path);
@@ -51,13 +53,13 @@ final public class SnapshotsTest {
     }
 
     @Test
-    public void testValidPartialSnapshotFilename() throws IOException {
+    public void testValidPartialSnapshotFilename(@TempDir final File logDir) throws IOException {
         OffsetAndEpoch snapshotId = new OffsetAndEpoch(
             TestUtils.RANDOM.nextInt(Integer.MAX_VALUE),
             TestUtils.RANDOM.nextInt(Integer.MAX_VALUE)
         );
 
-        Path path = Snapshots.createTempFile(TestUtils.tempDirectory().toPath(), snapshotId);
+        Path path = Snapshots.createTempFile(logDir.toPath(), snapshotId);
         // Delete it as we only need the path for testing
         Files.delete(path);
 
@@ -69,12 +71,12 @@ final public class SnapshotsTest {
     }
 
     @Test
-    public void testValidDeletedSnapshotFilename() {
+    public void testValidDeletedSnapshotFilename(@TempDir final File logDir) {
         OffsetAndEpoch snapshotId = new OffsetAndEpoch(
             TestUtils.RANDOM.nextInt(Integer.MAX_VALUE),
             TestUtils.RANDOM.nextInt(Integer.MAX_VALUE)
         );
-        Path path = Snapshots.snapshotPath(TestUtils.tempDirectory().toPath(), snapshotId);
+        Path path = Snapshots.snapshotPath(logDir.toPath(), snapshotId);
         Path deletedPath = Snapshots.deleteRenamePath(path, snapshotId);
         SnapshotPath snapshotPath = Snapshots.parse(deletedPath).get();
 

--- a/storage/api/src/test/java/org/apache/kafka/server/log/remote/storage/LogSegmentDataTest.java
+++ b/storage/api/src/test/java/org/apache/kafka/server/log/remote/storage/LogSegmentDataTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.kafka.server.log.remote.storage;
 
-import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -29,24 +29,23 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class LogSegmentDataTest {
 
     @Test
-    public void testOptionalTransactionIndex() {
-        File dir = TestUtils.tempDirectory();
+    public void testOptionalTransactionIndex(@TempDir File tempDir) {
         LogSegmentData logSegmentDataWithTransactionIndex = new LogSegmentData(
-                new File(dir, "log-segment").toPath(),
-                new File(dir, "offset-index").toPath(),
-                new File(dir, "time-index").toPath(),
-                Optional.of(new File(dir, "transaction-index").toPath()),
-                new File(dir, "producer-snapshot").toPath(),
+                new File(tempDir, "log-segment").toPath(),
+                new File(tempDir, "offset-index").toPath(),
+                new File(tempDir, "time-index").toPath(),
+                Optional.of(new File(tempDir, "transaction-index").toPath()),
+                new File(tempDir, "producer-snapshot").toPath(),
                 ByteBuffer.allocate(1)
         );
         Assertions.assertTrue(logSegmentDataWithTransactionIndex.transactionIndex().isPresent());
 
         LogSegmentData logSegmentDataWithNoTransactionIndex = new LogSegmentData(
-                new File(dir, "log-segment").toPath(),
-                new File(dir, "offset-index").toPath(),
-                new File(dir, "time-index").toPath(),
+                new File(tempDir, "log-segment").toPath(),
+                new File(tempDir, "offset-index").toPath(),
+                new File(tempDir, "time-index").toPath(),
                 Optional.empty(),
-                new File(dir, "producer-snapshot").toPath(),
+                new File(tempDir, "producer-snapshot").toPath(),
                 ByteBuffer.allocate(1)
         );
         assertFalse(logSegmentDataWithNoTransactionIndex.transactionIndex().isPresent());

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/FileBasedRemoteLogMetadataCacheTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/FileBasedRemoteLogMetadataCacheTest.java
@@ -23,8 +23,8 @@ import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadataUpdate;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentState;
-import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 import java.util.Collections;
@@ -36,13 +36,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class FileBasedRemoteLogMetadataCacheTest {
 
     @Test
-    public void testFileBasedRemoteLogMetadataCacheWithUnreferencedSegments() throws Exception {
+    public void testFileBasedRemoteLogMetadataCacheWithUnreferencedSegments(@TempDir final Path tempDirPath) throws Exception {
         TopicIdPartition partition = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("test", 0));
         int brokerId = 0;
-        Path path = TestUtils.tempDirectory().toPath();
 
         // Create file based metadata cache.
-        FileBasedRemoteLogMetadataCache cache = new FileBasedRemoteLogMetadataCache(partition, path);
+        FileBasedRemoteLogMetadataCache cache = new FileBasedRemoteLogMetadataCache(partition, tempDirPath);
 
         // Add a segment with start offset as 0 for leader epoch 0.
         RemoteLogSegmentId segmentId1 = new RemoteLogSegmentId(partition, Uuid.randomUuid());
@@ -75,7 +74,7 @@ public class FileBasedRemoteLogMetadataCacheTest {
         cache.flushToFile(0, 0L);
 
         // Create a new cache with loading from the stored path.
-        FileBasedRemoteLogMetadataCache loadedCache = new FileBasedRemoteLogMetadataCache(partition, path);
+        FileBasedRemoteLogMetadataCache loadedCache = new FileBasedRemoteLogMetadataCache(partition, tempDirPath);
 
         // Fetch segment for leader epoch:0 and start offset:0, it should be metadata2.
         // This ensures that the ordering of metadata is taken care after loading from the stored snapshots.

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataSnapshotFileTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataSnapshotFileTest.java
@@ -18,9 +18,9 @@ package org.apache.kafka.server.log.remote.metadata.storage;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentState;
-import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -32,8 +32,7 @@ import java.util.Optional;
 public class RemoteLogMetadataSnapshotFileTest {
 
     @Test
-    public void testEmptyCommittedLogMetadataFile() throws Exception {
-        File metadataStoreDir = TestUtils.tempDirectory("_rlmm_committed");
+    public void testEmptyCommittedLogMetadataFile(@TempDir File metadataStoreDir) throws Exception {
         RemoteLogMetadataSnapshotFile snapshotFile = new RemoteLogMetadataSnapshotFile(metadataStoreDir.toPath());
 
         // There should be an empty snapshot as nothing is written into it.
@@ -41,8 +40,7 @@ public class RemoteLogMetadataSnapshotFileTest {
     }
 
     @Test
-    public void testEmptySnapshotWithCommittedLogMetadataFile() throws Exception {
-        File metadataStoreDir = TestUtils.tempDirectory("_rlmm_committed");
+    public void testEmptySnapshotWithCommittedLogMetadataFile(@TempDir File metadataStoreDir) throws Exception {
         RemoteLogMetadataSnapshotFile snapshotFile = new RemoteLogMetadataSnapshotFile(metadataStoreDir.toPath());
 
         snapshotFile.write(new RemoteLogMetadataSnapshotFile.Snapshot(0, 0L, Collections.emptyList()));
@@ -53,8 +51,7 @@ public class RemoteLogMetadataSnapshotFileTest {
     }
 
     @Test
-    public void testWriteReadCommittedLogMetadataFile() throws Exception {
-        File metadataStoreDir = TestUtils.tempDirectory("_rlmm_committed");
+    public void testWriteReadCommittedLogMetadataFile(@TempDir File metadataStoreDir) throws Exception {
         RemoteLogMetadataSnapshotFile snapshotFile = new RemoteLogMetadataSnapshotFile(metadataStoreDir.toPath());
 
         List<RemoteLogSegmentMetadataSnapshot> remoteLogSegmentMetadatas = new ArrayList<>();

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerRestartTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerRestartTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
@@ -51,7 +52,9 @@ public class TopicBasedRemoteLogMetadataManagerRestartTest {
     private static final int SEG_SIZE = 1024 * 1024;
 
     private final Time time = new MockTime(1);
-    private final String logDir = TestUtils.tempDirectory("_rlmm_segs_").getAbsolutePath();
+    
+    @TempDir
+    private File logDir;
 
     private TopicBasedRemoteLogMetadataManagerHarness remoteLogMetadataManagerHarness;
 
@@ -61,7 +64,7 @@ public class TopicBasedRemoteLogMetadataManagerRestartTest {
         remoteLogMetadataManagerHarness = new TopicBasedRemoteLogMetadataManagerHarness() {
             protected Map<String, Object> overrideRemoteLogMetadataManagerProps() {
                 Map<String, Object> props = new HashMap<>();
-                props.put(LOG_DIR, logDir);
+                props.put(LOG_DIR, logDir.getAbsolutePath());
                 return props;
             }
         };
@@ -149,7 +152,7 @@ public class TopicBasedRemoteLogMetadataManagerRestartTest {
         Assertions.assertTrue(TestUtils.sameElementsWithoutOrder(Collections.singleton(followerSegmentMetadata).iterator(),
                                                                  topicBasedRlmm().listRemoteLogSegments(followerTopicIdPartition)));
         // Check whether the check-pointed consumer offsets are stored or not.
-        Path committedOffsetsPath = new File(logDir, COMMITTED_OFFSETS_FILE_NAME).toPath();
+        Path committedOffsetsPath = new File(logDir.getAbsolutePath(), COMMITTED_OFFSETS_FILE_NAME).toPath();
         Assertions.assertTrue(committedOffsetsPath.toFile().exists());
         CommittedOffsetsFile committedOffsetsFile = new CommittedOffsetsFile(committedOffsetsPath.toFile());
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/InmemoryRemoteStorageManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/InmemoryRemoteStorageManagerTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,8 +47,10 @@ public class InmemoryRemoteStorageManagerTest {
     private static final Logger log = LoggerFactory.getLogger(InmemoryRemoteStorageManagerTest.class);
 
     private static final TopicPartition TP = new TopicPartition("foo", 1);
-    private static final File DIR = TestUtils.tempDirectory("inmem-rsm-");
     private static final Random RANDOM = new Random();
+    
+    @TempDir
+    private static File dir;
 
     @Test
     public void testCopyLogSegment() throws Exception {
@@ -230,19 +233,19 @@ public class InmemoryRemoteStorageManagerTest {
 
     private LogSegmentData createLogSegmentData(int segSize) throws Exception {
         int prefix = Math.abs(RANDOM.nextInt());
-        Path segment = new File(DIR, prefix + ".seg").toPath();
+        Path segment = new File(dir, prefix + ".seg").toPath();
         Files.write(segment, TestUtils.randomBytes(segSize));
 
-        Path offsetIndex = new File(DIR, prefix + ".oi").toPath();
+        Path offsetIndex = new File(dir, prefix + ".oi").toPath();
         Files.write(offsetIndex, TestUtils.randomBytes(10));
 
-        Path timeIndex = new File(DIR, prefix + ".ti").toPath();
+        Path timeIndex = new File(dir, prefix + ".ti").toPath();
         Files.write(timeIndex, TestUtils.randomBytes(10));
 
-        Path txnIndex = new File(DIR, prefix + ".txni").toPath();
+        Path txnIndex = new File(dir, prefix + ".txni").toPath();
         Files.write(txnIndex, TestUtils.randomBytes(10));
 
-        Path producerSnapshotIndex = new File(DIR, prefix + ".psi").toPath();
+        Path producerSnapshotIndex = new File(dir, prefix + ".psi").toPath();
         Files.write(producerSnapshotIndex, TestUtils.randomBytes(10));
 
         ByteBuffer leaderEpochIndex = ByteBuffer.wrap(TestUtils.randomBytes(10));

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -67,7 +67,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.After;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
@@ -78,7 +77,6 @@ import org.mockito.Mock;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.io.File;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collections;
@@ -180,7 +178,7 @@ public class KafkaStreamsTest {
     }
 
     @Before
-    public void before(@TempDir final File stateDir) throws Exception {
+    public void before() throws Exception {
         time = new MockTime();
         adminClient = new MockAdminClient();
         supplier = new MockClientSupplier();
@@ -191,7 +189,7 @@ public class KafkaStreamsTest {
         props.put(StreamsConfig.CLIENT_ID_CONFIG, CLIENT_ID);
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2018");
         props.put(StreamsConfig.METRIC_REPORTER_CLASSES_CONFIG, MockMetricsReporter.class.getName());
-        props.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
+        props.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
         props.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, NUM_THREADS);
 
         prepareStreams();

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -67,6 +67,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.After;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
@@ -77,6 +78,7 @@ import org.mockito.Mock;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.File;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collections;
@@ -178,7 +180,7 @@ public class KafkaStreamsTest {
     }
 
     @Before
-    public void before() throws Exception {
+    public void before(@TempDir final File stateDir) throws Exception {
         time = new MockTime();
         adminClient = new MockAdminClient();
         supplier = new MockClientSupplier();
@@ -189,7 +191,7 @@ public class KafkaStreamsTest {
         props.put(StreamsConfig.CLIENT_ID_CONFIG, CLIENT_ID);
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2018");
         props.put(StreamsConfig.METRIC_REPORTER_CLASSES_CONFIG, MockMetricsReporter.class.getName());
-        props.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        props.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
         props.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, NUM_THREADS);
 
         prepareStreams();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AdjustStreamThreadCountTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AdjustStreamThreadCountTest.java
@@ -44,7 +44,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import java.io.IOException;
@@ -99,7 +101,7 @@ public class AdjustStreamThreadCountTest {
     public static final Duration DEFAULT_DURATION = Duration.ofSeconds(30);
 
     @BeforeEach
-    public void setup(final TestInfo testInfo) {
+    public void setup(final TestInfo testInfo, @TempDir final File stateDir) {
         final String testId = safeUniqueTestName(getClass(), testInfo);
         appId = "appId_" + testId;
         inputTopic = "input" + testId;
@@ -112,7 +114,7 @@ public class AdjustStreamThreadCountTest {
             mkMap(
                 mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
                 mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+                mkEntry(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath()),
                 mkEntry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2),
                 mkEntry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
                 mkEntry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EmitOnChangeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EmitOnChangeIntegrationTest.java
@@ -38,7 +38,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Properties;
@@ -82,12 +84,12 @@ public class EmitOnChangeIntegrationTest {
     }
 
     @Test
-    public void shouldEmitSameRecordAfterFailover() throws Exception {
+    public void shouldEmitSameRecordAfterFailover(@TempDir final File tempDir) throws Exception {
         final Properties properties  = mkObjectProperties(
             mkMap(
                 mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
                 mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+                mkEntry(StreamsConfig.STATE_DIR_CONFIG, tempDir.getPath()),
                 mkEntry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1),
                 mkEntry(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0),
                 mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 300000L),

--- a/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableEOSIntegrationTest.java
@@ -54,7 +54,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
@@ -129,14 +128,14 @@ public class GlobalKTableEOSIntegrationTest {
     public TestName testName = new TestName();
 
     @Before
-    public void before(@TempDir final File stateDir) throws Exception {
+    public void before() throws Exception {
         builder = new StreamsBuilder();
         createTopics();
         streamsConfiguration = new Properties();
         final String safeTestName = safeUniqueTestName(getClass(), testName);
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
         streamsConfiguration.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0L);
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         streamsConfiguration.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, eosConfig);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableEOSIntegrationTest.java
@@ -54,6 +54,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
@@ -128,14 +129,14 @@ public class GlobalKTableEOSIntegrationTest {
     public TestName testName = new TestName();
 
     @Before
-    public void before() throws Exception {
+    public void before(@TempDir final File stateDir) throws Exception {
         builder = new StreamsBuilder();
         createTopics();
         streamsConfiguration = new Properties();
         final String safeTestName = safeUniqueTestName(getClass(), testName);
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
         streamsConfiguration.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0L);
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         streamsConfiguration.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, eosConfig);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableIntegrationTest.java
@@ -51,7 +51,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
@@ -98,7 +100,7 @@ public class GlobalKTableIntegrationTest {
     private MockApiProcessorSupplier<String, String, Void, Void> supplier;
 
     @BeforeEach
-    public void before(final TestInfo testInfo) throws Exception {
+    public void before(final TestInfo testInfo, @TempDir final File stateDir) throws Exception {
         builder = new StreamsBuilder();
         createTopics(testInfo);
         streamsConfiguration = new Properties();
@@ -106,7 +108,7 @@ public class GlobalKTableIntegrationTest {
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
         streamsConfiguration.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         globalTable = builder.globalTable(globalTableTopic, Consumed.with(Serdes.Long(), Serdes.String()),

--- a/streams/src/test/java/org/apache/kafka/streams/integration/GlobalThreadShutDownOrderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/GlobalThreadShutDownOrderTest.java
@@ -46,7 +46,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -106,7 +108,7 @@ public class GlobalThreadShutDownOrderTest {
     private boolean firstRecordProcessed;
 
     @BeforeEach
-    public void before(final TestInfo testInfo) throws Exception {
+    public void before(final TestInfo testInfo, @TempDir final File stateDir) throws Exception {
         builder = new StreamsBuilder();
         createTopics();
         streamsConfiguration = new Properties();
@@ -114,7 +116,7 @@ public class GlobalThreadShutDownOrderTest {
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
         streamsConfiguration.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationDedupIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationDedupIntegrationTest.java
@@ -50,7 +50,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -94,7 +96,7 @@ public class KStreamAggregationDedupIntegrationTest {
     private KStream<Integer, String> stream;
 
     @BeforeEach
-    public void before(final TestInfo testInfo) throws InterruptedException {
+    public void before(final TestInfo testInfo, @TempDir final File stateDir) throws InterruptedException {
         builder = new StreamsBuilder();
         createTopics(testInfo);
         streamsConfiguration = new Properties();
@@ -102,7 +104,7 @@ public class KStreamAggregationDedupIntegrationTest {
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, COMMIT_INTERVAL_MS);
         streamsConfiguration.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 10 * 1024 * 1024L);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
@@ -70,8 +70,10 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.time.Duration;
@@ -130,7 +132,7 @@ public class KStreamAggregationIntegrationTest {
     private KStream<Integer, String> stream;
 
     @BeforeEach
-    public void before(final TestInfo testInfo) throws InterruptedException {
+    public void before(final TestInfo testInfo, @TempDir final File stateDir) throws InterruptedException {
         builder = new StreamsBuilder();
         createTopics(testInfo);
         streamsConfiguration = new Properties();
@@ -138,7 +140,7 @@ public class KStreamAggregationIntegrationTest {
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
         streamsConfiguration.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.streams.integration;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
@@ -60,6 +61,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.io.TempDir;
 
 import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
@@ -150,8 +152,8 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
     }
 
     @BeforeEach
-    public void before(final TestInfo testInfo) throws IOException {
-        final String stateDirBasePath = TestUtils.tempDirectory().getPath();
+    public void before(final TestInfo testInfo, @TempDir final File stateDir) throws IOException {
+        final String stateDirBasePath = stateDir.getPath();
         final String safeTestName = safeUniqueTestName(getClass(), testInfo);
         streamsConfig = getStreamsConfig(safeTestName);
         streamsConfigTwo = getStreamsConfig(safeTestName);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
@@ -51,7 +51,6 @@ import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.utils.UniqueTopicSerdeScope;
-import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinMultiIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinMultiIntegrationTest.java
@@ -41,7 +41,6 @@ import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.utils.UniqueTopicSerdeScope;
 import org.apache.kafka.test.IntegrationTest;
-import org.apache.kafka.test.TestUtils;
 import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -49,7 +48,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -153,8 +154,8 @@ public class KTableKTableForeignKeyInnerJoinMultiIntegrationTest {
     }
 
     @BeforeEach
-    public void before() throws IOException {
-        final String stateDirBasePath = TestUtils.tempDirectory().getPath();
+    public void before(@TempDir final File stateDir) throws IOException {
+        final String stateDirBasePath = stateDir.getPath();
         streamsConfig.put(StreamsConfig.STATE_DIR_CONFIG, stateDirBasePath + "-1");
         streamsConfigTwo.put(StreamsConfig.STATE_DIR_CONFIG, stateDirBasePath + "-2");
         streamsConfigThree.put(StreamsConfig.STATE_DIR_CONFIG, stateDirBasePath + "-3");

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
@@ -42,7 +42,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -63,12 +65,12 @@ public class KTableSourceTopicRestartIntegrationTest {
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
 
     @BeforeAll
-    public static void startCluster() throws IOException {
+    public static void startCluster(@TempDir final File stateDir) throws IOException {
         CLUSTER.start();
         STREAMS_CONFIG.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         STREAMS_CONFIG.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         STREAMS_CONFIG.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
-        STREAMS_CONFIG.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        STREAMS_CONFIG.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
         STREAMS_CONFIG.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
         STREAMS_CONFIG.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 5L);
         STREAMS_CONFIG.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, WallclockTimestampExtractor.class);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -254,7 +255,7 @@ public class LagFetchIntegrationTest {
     }
 
     @Test
-    public void shouldFetchLagsDuringRestoration() throws Exception {
+    public void shouldFetchLagsDuringRestoration(@TempDir final File stateDir) throws Exception {
         IntegrationTestUtils.produceKeyValuesSynchronously(
             inputTopicName,
             mkSet(new KeyValue<>("k1", 1L), new KeyValue<>("k2", 2L), new KeyValue<>("k3", 3L), new KeyValue<>("k4", 4L), new KeyValue<>("k5", 5L)),
@@ -267,7 +268,6 @@ public class LagFetchIntegrationTest {
 
         // create stream threads
         final Properties props = (Properties) streamsConfiguration.clone();
-        final File stateDir = TestUtils.tempDirectory(stateStoreName + "0");
         props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:0");
         props.put(StreamsConfig.CLIENT_ID_CONFIG, "instance-0");
         props.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getAbsolutePath());

--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
@@ -258,7 +258,7 @@ public class MetricsIntegrationTest {
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         streamsConfiguration.put(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, Sensor.RecordingLevel.DEBUG.name);
         streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, NUM_THREADS);
-        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDir);
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
     }
 
     @AfterEach

--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
@@ -51,7 +51,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -242,7 +244,7 @@ public class MetricsIntegrationTest {
     private String appId;
 
     @BeforeEach
-    public void before(final TestInfo testInfo) throws InterruptedException {
+    public void before(final TestInfo testInfo, @TempDir final File stateDir) throws InterruptedException {
         builder = new StreamsBuilder();
         CLUSTER.createTopics(STREAM_INPUT, STREAM_OUTPUT_1, STREAM_OUTPUT_2, STREAM_OUTPUT_3, STREAM_OUTPUT_4);
 
@@ -256,7 +258,7 @@ public class MetricsIntegrationTest {
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         streamsConfiguration.put(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, Sensor.RecordingLevel.DEBUG.name);
         streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, NUM_THREADS);
-        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDir);
     }
 
     @AfterEach

--- a/streams/src/test/java/org/apache/kafka/streams/integration/PurgeRepartitionTopicIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/PurgeRepartitionTopicIntegrationTest.java
@@ -44,7 +44,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -153,7 +155,7 @@ public class PurgeRepartitionTopicIntegrationTest {
     }
 
     @BeforeEach
-    public void setup() {
+    public void setup(@TempDir final File stateDir) {
         // create admin client for verification
         final Properties adminConfig = new Properties();
         adminConfig.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
@@ -166,7 +168,7 @@ public class PurgeRepartitionTopicIntegrationTest {
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
-        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(APPLICATION_ID).getPath());
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
         streamsConfiguration.put(StreamsConfig.topicPrefix(TopicConfig.SEGMENT_MS_CONFIG), PURGE_INTERVAL_MS);
         streamsConfiguration.put(StreamsConfig.topicPrefix(TopicConfig.SEGMENT_BYTES_CONFIG), PURGE_SEGMENT_BYTES);
         streamsConfiguration.put(StreamsConfig.producerPrefix(ProducerConfig.BATCH_SIZE_CONFIG), PURGE_SEGMENT_BYTES / 2);    // we cannot allow batch size larger than segment size

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -69,6 +69,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -214,14 +215,14 @@ public class QueryableStateIntegrationTest {
     }
 
     @BeforeEach
-    public void before(final TestInfo testInfo) throws Exception {
+    public void before(final TestInfo testInfo, @TempDir final File stateDir) throws Exception {
         createTopics(testInfo);
         streamsConfiguration = new Properties();
         final String safeTestName = safeUniqueTestName(getClass(), testInfo);
 
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -54,6 +54,7 @@ import org.apache.kafka.streams.test.TestRecord;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.time.Duration;
@@ -1431,7 +1432,7 @@ public abstract class TopologyTestDriverTest {
     }
 
     @Test
-    public void shouldCleanUpPersistentStateStoresOnClose() {
+    public void shouldCleanUpPersistentStateStoresOnClose(@TempDir final File stateDir) {
         final Topology topology = new Topology();
         topology.addSource("sourceProcessor", "input-topic");
         topology.addProcessor(
@@ -1462,7 +1463,7 @@ public abstract class TopologyTestDriverTest {
 
         final Properties config = new Properties();
         config.put(StreamsConfig.APPLICATION_ID_CONFIG, "test-TopologyTestDriver-cleanup");
-        config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
+        config.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getAbsolutePath());
         config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Long().getClass().getName());
 

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextStateStoreTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextStateStoreTest.java
@@ -30,7 +30,6 @@ import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
-import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextStateStoreTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextStateStoreTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -155,8 +156,7 @@ public class MockProcessorContextStateStoreTest {
     public void shouldEitherInitOrThrow(final StoreBuilder<StateStore> builder,
                                         final boolean timestamped,
                                         final boolean caching,
-                                        final boolean logging) {
-        final File stateDir = TestUtils.tempDirectory();
+                                        final boolean logging, @TempDir final File stateDir) {
         try {
             final MockProcessorContext<Void, Void> context = new MockProcessorContext<>(
                 mkProperties(mkMap(

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/wordcount/WindowedWordCountProcessorTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/wordcount/WindowedWordCountProcessorTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowStore;
-import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/wordcount/WindowedWordCountProcessorTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/wordcount/WindowedWordCountProcessorTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -89,9 +90,7 @@ public class WindowedWordCountProcessorTest {
     }
 
     @Test
-    public void shouldWorkWithPersistentStore() throws IOException {
-        final File stateDir = TestUtils.tempDirectory();
-
+    public void shouldWorkWithPersistentStore(@TempDir final File stateDir) throws IOException {
         try {
             final MockProcessorContext<String, String> context = new MockProcessorContext<>(
                 new Properties(),


### PR DESCRIPTION
### Description
We created many temp files in tests, and sometimes we forgot to delete them after usage. Instead of polluting @AfterEach for each test, we should consider to use JUnit 5 TempDirectory Extension. I have replaced it almost everywhere(if didn't miss something), except places where it's not appropriate to do so and JUnit 4 is still being used.

### Testing
`./gradlew integrationTes`t and `./gradlew unitTest` is successful locally.
