### PR TITLE
KAFKA-14995: Automate asf.yaml collaborators refresh

### DIFF
--- a/.github/workflows/refresh-collaborators.yaml
+++ b/.github/workflows/refresh-collaborators.yaml
@@ -1,0 +1,24 @@
+name: Refresh asf.yaml collaborators every 3 months
+
+on:
+  schedule:
+    - cron: '0 0 1 */3 *'  # Runs on the 1st day of every 3rd month at midnight UTC
+
+jobs:
+  refresh-collaborators:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install PyGithub BeautifulSoup4 PyYAML
+
+      - name: Run refresh-collaborators.py script
+        run: python refresh-collaborators.py

--- a/.github/workflows/refresh-collaborators.yaml
+++ b/.github/workflows/refresh-collaborators.yaml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: Refresh asf.yaml collaborators every 3 months
 
 on:

--- a/refresh-collaborators.py
+++ b/refresh-collaborators.py
@@ -1,0 +1,44 @@
+import os
+from bs4 import BeautifulSoup
+from github import Github
+import yaml
+
+### GET THE NAMES OF THE KAFKA COMMITTERS FROM THE apache/kafka-site REPO ###
+github_token = os.environ.get('GITHUB_TOKEN')
+g = Github(github_token)
+repo = g.get_repo("apache/kafka-site")
+contents = repo.get_contents("committers.html")
+content = contents.decoded_content
+soup = BeautifulSoup(content, "html.parser")
+committer_logins = [login.text for login in soup.find_all('div', class_='github_login')]
+
+### GET THE CONTRIBUTORS OF THE apache/kafka REPO ###
+n = 10
+repo = g.get_repo("apache/kafka")
+contributors = repo.get_contributors()
+collaborators = []
+for contributor in contributors:
+    if contributor.login not in committer_logins:
+        collaborators += [contributor.login]
+refreshed_collaborators = collaborators[:n]
+
+### UPDATE asf.yaml ###
+file_path = ".asf.yaml"
+file = repo.get_contents(file_path)
+yaml_content = yaml.safe_load(file.decoded_content)
+
+# Update 'github_whitelist' list
+github_whitelist = refreshed_collaborators[:10]  # New users to be added
+yaml_content["jenkins"]["github_whitelist"] = github_whitelist
+
+# Update 'collaborators' list
+collaborators = refreshed_collaborators[:10]  # New collaborators to be added
+yaml_content["github"]["collaborators"] = collaborators
+
+# Convert the updated content back to YAML
+updated_yaml = yaml.safe_dump(yaml_content)
+
+# Commit and push the changes
+commit_message = "Update .asf.yaml file with refreshed github_whitelist, and collaborators"
+repo.update_file(file_path, commit_message, updated_yaml, file.sha)
+

--- a/refresh-collaborators.py
+++ b/refresh-collaborators.py
@@ -1,7 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import os
 from bs4 import BeautifulSoup
 from github import Github
 import yaml
+from datetime import datetime, timedelta
 
 ### GET THE NAMES OF THE KAFKA COMMITTERS FROM THE apache/kafka-site REPO ###
 github_token = os.environ.get('GITHUB_TOKEN')
@@ -12,14 +30,19 @@ content = contents.decoded_content
 soup = BeautifulSoup(content, "html.parser")
 committer_logins = [login.text for login in soup.find_all('div', class_='github_login')]
 
-### GET THE CONTRIBUTORS OF THE apache/kafka REPO ###
+### GET THE CONTRIBUTORS AND THEIR COMMIT VOLUME OVER THE LAST YEAR TO THE apache/kafka REPO ###
 n = 10
-repo = g.get_repo("apache/kafka")
-contributors = repo.get_contributors()
+contributors_login_to_commit_volume = {}
+end_date = datetime.now()
+start_date = end_date - timedelta(days=365)
+for commit in repo.get_commits(since=start_date, until=end_date):
+    login = commit.author.login
+    contributors_login_to_commit_volume[login] = contributors_login_to_commit_volume.get(login, 0) + 1
+contributors_login_to_commit_volume = dict(sorted(contributors_login_to_commit_volume.items(), key=lambda x: x[1], reverse=True))
 collaborators = []
-for contributor in contributors:
-    if contributor.login not in committer_logins:
-        collaborators += [contributor.login]
+for contributor_login in contributors_login_to_commit_volume:
+    if contributor_login not in committer_logins:
+        collaborators += [contributor_login]
 refreshed_collaborators = collaborators[:n]
 
 ### UPDATE asf.yaml ###
@@ -28,17 +51,17 @@ file = repo.get_contents(file_path)
 yaml_content = yaml.safe_load(file.decoded_content)
 
 # Update 'github_whitelist' list
-github_whitelist = refreshed_collaborators[:10]  # New users to be added
+github_whitelist = refreshed_collaborators  # New users to be added
 yaml_content["jenkins"]["github_whitelist"] = github_whitelist
 
 # Update 'collaborators' list
-collaborators = refreshed_collaborators[:10]  # New collaborators to be added
+collaborators = refreshed_collaborators  # New collaborators to be added
 yaml_content["github"]["collaborators"] = collaborators
 
 # Convert the updated content back to YAML
 updated_yaml = yaml.safe_dump(yaml_content)
 
 # Commit and push the changes
-commit_message = "Update .asf.yaml file with refreshed github_whitelist, and collaborators"
+commit_message = "MINOR: Update .asf.yaml file with refreshed github_whitelist, and collaborators"
 repo.update_file(file_path, commit_message, updated_yaml, file.sha)
 


### PR DESCRIPTION
Create Github Action workflow to run Python script which will automate the asf.yaml collaborators refresh.

Tested the workflow locally using https://github.com/nektos/act.

### Committer Checklist (excluded from commit message)
- [NA] Verify design and implementation 
- [X] Verify test coverage and CI build status
- [X] Verify documentation (including upgrade notes)
