### PR TITLE
KAFKA-15082: The log retention policy doesn't take effect after altering log dir

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -819,7 +819,7 @@ class LogManager(logDirs: Seq[File],
   /**
    * Resume cleaning of the provided partition and log a message about it.
    */
-  private def resumeCleaning(topicPartition: TopicPartition): Unit = {
+  def resumeCleaning(topicPartition: TopicPartition): Unit = {
     if (cleaner != null) {
       cleaner.resumeCleaning(Seq(topicPartition))
       info(s"Cleaning for partition $topicPartition is resumed")

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -1099,7 +1099,6 @@ class LogManager(logDirs: Seq[File],
       currentLogs.put(topicPartition, destLog)
       if (cleaner != null) {
         cleaner.alterCheckpointDir(topicPartition, sourceLog.parentDirFile, destLog.parentDirFile)
-        resumeCleaning(topicPartition)
       }
 
       try {

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -91,10 +91,25 @@ class ReplicaAlterLogDirsThread(name: String,
       val filteredFetchStates = initialFetchStates.filter { case (tp, _) =>
         replicaMgr.futureLogExists(tp)
       }
+      filteredFetchStates.foreach { case (tp, _) =>
+        if (fetchState(tp).isEmpty)
+          replicaMgr.logManager.abortAndPauseCleaning(tp)
+      }
       super.addPartitions(filteredFetchStates)
     } finally {
       partitionMapLock.unlock()
     }
+  }
+
+  override def removePartitions(topicPartitions: Set[TopicPartition]): Map[TopicPartition, PartitionFetchState] = {
+    partitionMapLock.lockInterruptibly()
+    try {
+      val fetchStates = super.removePartitions(topicPartitions)
+      fetchStates.foreach { case (tp, _) =>
+        replicaMgr.logManager.resumeCleaning(tp)
+      }
+      fetchStates
+    } finally partitionMapLock.unlock()
   }
 
   override protected val isOffsetForLeaderEpochSupported: Boolean = true

--- a/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
@@ -77,8 +77,10 @@ class ReplicaAlterLogDirsThreadTest {
 
     val replicaManager = Mockito.mock(classOf[ReplicaManager])
     val quotaManager = Mockito.mock(classOf[ReplicationQuotaManager])
+    val logManager = Mockito.mock(classOf[LogManager])
 
     when(replicaManager.futureLogExists(t1p0)).thenReturn(false)
+    when(replicaManager.logManager).thenReturn(logManager)
 
     val endPoint = new BrokerEndPoint(0, "localhost", 1000)
     val leader = new LocalLeaderEndPoint(endPoint, config, replicaManager, quotaManager)
@@ -107,6 +109,7 @@ class ReplicaAlterLogDirsThreadTest {
     val replicaManager = Mockito.mock(classOf[ReplicaManager])
     val quotaManager = Mockito.mock(classOf[ReplicationQuotaManager])
     val futureLog = Mockito.mock(classOf[UnifiedLog])
+    val logManager = Mockito.mock(classOf[LogManager])
 
     val leaderEpoch = 5
     val logEndOffset = 0
@@ -117,6 +120,7 @@ class ReplicaAlterLogDirsThreadTest {
     when(replicaManager.futureLogExists(t1p0)).thenReturn(true)
     when(replicaManager.onlinePartition(t1p0)).thenReturn(Some(partition))
     when(replicaManager.getPartitionOrException(t1p0)).thenReturn(partition)
+    when(replicaManager.logManager).thenReturn(logManager)
 
     when(quotaManager.isQuotaExceeded).thenReturn(false)
 
@@ -206,6 +210,7 @@ class ReplicaAlterLogDirsThreadTest {
     val replicaManager = Mockito.mock(classOf[ReplicaManager])
     val quotaManager = Mockito.mock(classOf[ReplicationQuotaManager])
     val futureLog = Mockito.mock(classOf[UnifiedLog])
+    val logManager = Mockito.mock(classOf[LogManager])
 
     val leaderEpoch = 5
     val logEndOffset = 0
@@ -216,6 +221,7 @@ class ReplicaAlterLogDirsThreadTest {
     when(replicaManager.futureLogExists(t1p0)).thenReturn(true)
     when(replicaManager.onlinePartition(t1p0)).thenReturn(Some(partition))
     when(replicaManager.getPartitionOrException(t1p0)).thenReturn(partition)
+    when(replicaManager.logManager).thenReturn(logManager)
 
     when(quotaManager.isQuotaExceeded).thenReturn(false)
 


### PR DESCRIPTION
There are two scenarios where the log retention policy doesn't take effect:

1.During altering log dir, if a LeaderAndISR request of partition being moved is sent to the broker, the broker will never resume the cleaning of log segment.
2.Cancel altering log dir.

In those scenarios, the stale log segment files will never be deleted, which can cause the disk full issue. 