### PR TITLE
KAFKA-15084: Remove lock contention from RemoteIndexCache

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -206,6 +206,7 @@ This project bundles some components that are also licensed under the Apache
 License Version 2.0:
 
 audience-annotations-0.13.0
+caffeine-2.9.3
 commons-beanutils-1.9.4
 commons-cli-1.4
 commons-collections-3.2.2

--- a/build.gradle
+++ b/build.gradle
@@ -873,6 +873,7 @@ project(':core') {
 
 
     implementation libs.argparse4j
+    implementation libs.caffeine
     implementation libs.commonsValidator
     implementation libs.jacksonDatabind
     implementation libs.jacksonModuleScala

--- a/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
@@ -73,6 +73,14 @@ class Entry(val offsetIndex: OffsetIndex, val timeIndex: TimeIndex, val txnIndex
   }
 
   /**
+   * Deletes the index files from the disk. Invoking #close is not required prior to this function.
+   */
+  def cleanup(): Unit = {
+    markForCleanup()
+    CoreUtils.tryAll(Seq(() => offsetIndex.deleteIfExists(), () => timeIndex.deleteIfExists(), () => txnIndex.deleteIfExists()))
+  }
+
+  /**
    * Calls the underlying close method for each index which may lead to releasing resources such as mmap.
    * This function does not delete the index files.
    */
@@ -80,13 +88,6 @@ class Entry(val offsetIndex: OffsetIndex, val timeIndex: TimeIndex, val txnIndex
     Utils.closeQuietly(offsetIndex, "Closing the offset index.")
     Utils.closeQuietly(timeIndex, "Closing the time index.")
     Utils.closeQuietly(txnIndex, "Closing the transaction index.")
-  }
-
-  /**
-   * Deletes the index files from the disk. Invoking #close is not required prior to this function.
-   */
-  def cleanup(): Unit = {
-    CoreUtils.tryAll(Seq(() => offsetIndex.deleteIfExists(), () => timeIndex.deleteIfExists(), () => txnIndex.deleteIfExists()))
   }
 }
 

--- a/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
@@ -157,7 +157,7 @@ class RemoteIndexCache(maxSize: Int = 1024, remoteStorageManager: RemoteStorageM
         info(s"RemoteIndexCache directory $cacheDir already exists. Re-using the same directory.")
       case e: Exception =>
         error(s"Unable to create directory $cacheDir for RemoteIndexCache.", e)
-        throw new IllegalArgumentException(e)
+        throw e
     }
 
     // Delete any .deleted files remained from the earlier run of the broker.

--- a/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
@@ -100,6 +100,9 @@ class Entry(val offsetIndex: OffsetIndex, val timeIndex: TimeIndex, val txnIndex
  * the cache.
  *
  * Note that closing this cache does not delete the index files on disk.
+ * Note that this cache is not strictly based on a LRU policy. It is based on the default implementation of Caffeine i.e.
+ * <a href="https://github.com/ben-manes/caffeine/wiki/Efficiency">Window TinyLfu</a>. TinyLfu relies on a frequency
+ * sketch to probabilistically estimate the historic usage of an entry.
  *
  * @param maxSize              maximum number of segment index entries to be cached.
  * @param remoteStorageManager RemoteStorageManager instance, to be used in fetching indexes.

--- a/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
@@ -173,7 +173,7 @@ class RemoteIndexCache(maxSize: Int = 1024, remoteStorageManager: RemoteStorageM
       val offset = name.substring(0, firstIndex).toInt
       val uuid = Uuid.fromString(name.substring(firstIndex + 1, name.lastIndexOf('_')))
 
-      if (internalCache.getIfPresent(uuid) != null) {
+      if (internalCache.getIfPresent(uuid) == null) {
         val offsetIndexFile = new File(cacheDir, name + UnifiedLog.IndexFileSuffix)
         val timestampIndexFile = new File(cacheDir, name + UnifiedLog.TimeIndexFileSuffix)
         val txnIndexFile = new File(cacheDir, name + UnifiedLog.TxnIndexFileSuffix)

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -159,7 +159,7 @@ class RemoteIndexCacheTest {
 
     // getting index for last expired entry should call rsm#fetchIndex as that entry was expired earlier
     val missingEntryOpt = {
-      metadataList.findLast(segmentMetadata => {
+      metadataList.find(segmentMetadata => {
         val segmentId = segmentMetadata.remoteLogSegmentId().id()
         !cache.internalCache.asMap().containsKey(segmentId)
       })

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -279,7 +279,7 @@ class RemoteIndexCacheTest {
       .thenAnswer(_ => {
         logger.debug(s"Signaling CacheHit to begin read from ${Thread.currentThread()}")
         latchForCacheHit.countDown()
-        logger.debug("Waiting for signal to complete rsm fetch from" + Thread.currentThread())
+        logger.debug(s"Waiting for signal to complete rsm fetch from ${Thread.currentThread()}")
         latchForCacheMiss.await()
       })
 

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -192,12 +192,12 @@ class RemoteIndexCacheTest {
 
   @Test
   def testCloseIsIdempotent(): Unit = {
-    val spyInternalCache = spy(cache.internalCache)
-    cache.internalCache = spyInternalCache
+    val spyCleanerThread = spy(cache.cleanerThread)
+    cache.cleanerThread = spyCleanerThread
     cache.close()
     cache.close()
     // verify that cleanup is only called once
-    verify(spyInternalCache).cleanUp()
+    verify(spyCleanerThread).initiateShutdown()
   }
 
   @Test
@@ -227,9 +227,6 @@ class RemoteIndexCacheTest {
     // cleaner thread should be closed properly
     verify(spyCleanerThread).initiateShutdown()
     verify(spyCleanerThread).awaitShutdown()
-
-    // internal cache cleanup should be called
-    verify(spyInternalCache).cleanUp()
 
     // close for all index entries must be invoked
     verify(spyTxnIndex).close()

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -128,7 +128,7 @@ class RemoteIndexCacheTest {
 
   @Test
   def testCacheEntryExpiry(): Unit = {
-    // close exiting cache created in test setup before creating a new one
+    // close existing cache created in test setup before creating a new one
     Utils.closeQuietly(cache, "RemoteIndexCache created for unit test")
     cache = new RemoteIndexCache(maxSize = 2, rsm, logDir = logDir.toString)
     val tpId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 0))
@@ -172,7 +172,7 @@ class RemoteIndexCacheTest {
 
   @Test
   def testGetIndexAfterCacheClose(): Unit = {
-    // close exiting cache created in test setup before creating a new one
+    // close existing cache created in test setup before creating a new one
     Utils.closeQuietly(cache, "RemoteIndexCache created for unit test")
 
     cache = new RemoteIndexCache(maxSize = 2, rsm, logDir = logDir.toString)
@@ -300,7 +300,7 @@ class RemoteIndexCacheTest {
 
   @Test
   def testReloadCacheAfterClose(): Unit = {
-    // close exiting cache created in test setup before creating a new one
+    // close existing cache created in test setup before creating a new one
     Utils.closeQuietly(cache, "RemoteIndexCache created for unit test")
     cache = new RemoteIndexCache(maxSize = 2, rsm, logDir = logDir.toString)
     val tpId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 0))

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -61,6 +61,7 @@ versions += [
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
   bcpkix: "1.73",
+  caffeine: "2.9.3", // 3.x supports JDK 11 and above
   checkstyle: "8.36.2",
   commonsCli: "1.4",
   commonsValidator: "1.7",
@@ -145,6 +146,7 @@ libs += [
   apachedsJdbmPartition: "org.apache.directory.server:apacheds-jdbm-partition:$versions.apacheds",
   argparse4j: "net.sourceforge.argparse4j:argparse4j:$versions.argparse4j",
   bcpkix: "org.bouncycastle:bcpkix-jdk18on:$versions.bcpkix",
+  caffeine: "com.github.ben-manes.caffeine:caffeine:$versions.caffeine",
   commonsCli: "commons-cli:commons-cli:$versions.commonsCli",
   commonsValidator: "commons-validator:commons-validator:$versions.commonsValidator",
   easymock: "org.easymock:easymock:$versions.easymock",

--- a/server-common/src/main/java/org/apache/kafka/server/util/ShutdownableThread.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/ShutdownableThread.java
@@ -76,6 +76,9 @@ public abstract class ShutdownableThread extends Thread {
         return isShutdownComplete() && !isShutdownInitiated();
     }
 
+    /**
+     * @return true if the thread hasn't initiated shutdown already
+     */
     public boolean initiateShutdown() {
         synchronized (this) {
             if (isRunning()) {


### PR DESCRIPTION
## Problem
RemoteIndexCache cache is accessed from multiple threads concurrently in the fetch from consumer code path [1]. 

Currently, the RemoteIndexCache uses LinkedHashMap as the cache implementation internally. Since LinkedHashMap is not a thread safe data structure, we use coarse grained lock on the entire map/cache when writing to the cache.

This means that if a thread if fetching information from a particular segment from RemoteStorageManager, other threads who are trying to access a different segment from the cache will also wait for the former thread to complete. This is due to the usage of global lock in the cache.

This lock contentions leads to decrease in throughput for fetch from consumer for cases where RSM network call may take more time.

## Solution
We need a data structure for the cache which satisfies the following requirements:
1. Multiple threads should be able to read concurrently.
2. Fetch for missing keys should not block read for available keys.
3. Only one thread should fetch for a specific key.
4. Should support LRU policy.

In Java, all non concurrent data structures (such as LinkedHashMap) violate condition 2. We can potentially use Concurrent data structures such as ConcurrentHashMap but we will have to implement the LRU eviction ourselves on top of this. OR we can implement a LRU cache from scratch ourselves which satisfy the above constraints.

Alternatively, (approach taken in this PR), we can use [Caffeine cache](https://github.com/ben-manes/caffeine) which satisfies all the requirements mentioned above. Caffeine performs better than Google Guava cache [2] and is used by major open source projects such as Cassandra, HBase etc. Hence, it is safe to consider this a stable dependency.

## Changes
- This PR uses Caffeine as the underlying cache for RemoteIndexCache. 
- Old `File` API has been replaces with `Files` API introduced since JDK 7.

## Testing
- A test has been added which verifies requirement 2 above. The test fails prior to the change and is successful after it.
- New tests have been added to improve overall test coverage.

[1] https://github.com/apache/kafka/blob/dfe050c8bfaf312f1ccc89a1ae2d6cbd0761b88e/core/src/main/java/kafka/log/remote/RemoteLogManager.java#L747

[2] https://github.com/ben-manes/caffeine/wiki/Benchmarks