### PR TITLE
KAFKA-15088: Fixing Incorrect Reference Usage in Connector State Changes

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -173,7 +173,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
     @Override
     public void onStop(String connector) {
-        statusBackingStore.put(new ConnectorStatus(connector, AbstractStatus.State.STOPPED,
+        statusBackingStore.put(new ConnectorStatus(connector, ConnectorStatus.State.STOPPED,
                 workerId, generation()));
     }
 
@@ -185,7 +185,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
     @Override
     public void onResume(String connector) {
-        statusBackingStore.put(new ConnectorStatus(connector, TaskStatus.State.RUNNING,
+        statusBackingStore.put(new ConnectorStatus(connector, ConnectorStatus.State.RUNNING,
                 workerId, generation()));
     }
 


### PR DESCRIPTION
Currently, in the AbstractHerder class, the behavior of state changes for Connectors and Tasks is handled by implementing Listener using the ConnectorStatus and TaskStatus classes, which inherit from AbstractStatus. However, the code implementing the state change behavior in ConnectorStatus refers to and uses an inappropriate State enum class.

Both ConnectorStatus and TaskStatus inherit and implement AbstractStatus, and as a result, they share the State class. However, there is a need to make modifications for clear referencing. We need to fix the implementation in ConnectorStatus to use the appropriate reference for state changes.

This bug ticket will address the task of modifying the code to use the correct reference for Connector state changes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
