### PR TITLE
MINOR: rat should depend on processMessages task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -976,6 +976,7 @@ project(':core') {
 
   compileJava.dependsOn 'processMessages'
   srcJar.dependsOn 'processMessages'
+  rat.dependsOn ':core:processMessages'
 
   task genProtocolErrorDocs(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
@@ -1210,6 +1211,7 @@ project(':metadata') {
 
   compileJava.dependsOn 'processMessages'
   srcJar.dependsOn 'processMessages'
+  rat.dependsOn ':metadata:processMessages'
 
   sourceSets {
     main {
@@ -1290,6 +1292,7 @@ project(':group-coordinator') {
 
   compileJava.dependsOn 'processMessages'
   srcJar.dependsOn 'processMessages'
+  rat.dependsOn ':group-coordinator:processMessages'
 }
 
 project(':examples') {
@@ -1428,8 +1431,10 @@ project(':clients') {
 
   compileJava.dependsOn 'processMessages'
   srcJar.dependsOn 'processMessages'
+  rat.dependsOn ':clients:processMessages'
 
   compileTestJava.dependsOn 'processTestMessages'
+  rat.dependsOn ':clients:processTestMessages'
 
   javadoc {
     include "**/org/apache/kafka/clients/admin/*"
@@ -1531,6 +1536,7 @@ project(':raft') {
 
   compileJava.dependsOn 'processMessages'
   srcJar.dependsOn 'processMessages'
+  rat.dependsOn ':raft:processMessages'
 
   jar {
     dependsOn createVersionFile
@@ -1760,6 +1766,7 @@ project(':storage') {
 
   compileJava.dependsOn 'processMessages'
   srcJar.dependsOn 'processMessages'
+  rat.dependsOn ':storage:processMessages'
 
   jar {
     dependsOn createVersionFile
@@ -2057,6 +2064,7 @@ project(':streams') {
 
   compileJava.dependsOn 'processMessages'
   srcJar.dependsOn 'processMessages'
+  rat.dependsOn ':streams:processMessages'
 
   javadoc {
     include "**/org/apache/kafka/streams/**"

--- a/build.gradle
+++ b/build.gradle
@@ -180,6 +180,12 @@ apply from: file('wrapper.gradle')
 
 if (file('.git').exists()) {
   rat {
+    dependsOn subprojects.collect {
+      it.tasks.matching {
+        it.name == "processMessages" || it.name == "processTestMessages"
+      }
+    }
+
     verbose.set(true)
     reportDir.set(project.file('build/rat'))
     stylesheet.set(file('gradle/resources/rat-output-to-html.xsl'))
@@ -976,7 +982,6 @@ project(':core') {
 
   compileJava.dependsOn 'processMessages'
   srcJar.dependsOn 'processMessages'
-  rat.dependsOn ':core:processMessages'
 
   task genProtocolErrorDocs(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
@@ -1211,7 +1216,6 @@ project(':metadata') {
 
   compileJava.dependsOn 'processMessages'
   srcJar.dependsOn 'processMessages'
-  rat.dependsOn ':metadata:processMessages'
 
   sourceSets {
     main {
@@ -1292,7 +1296,6 @@ project(':group-coordinator') {
 
   compileJava.dependsOn 'processMessages'
   srcJar.dependsOn 'processMessages'
-  rat.dependsOn ':group-coordinator:processMessages'
 }
 
 project(':examples') {
@@ -1431,10 +1434,8 @@ project(':clients') {
 
   compileJava.dependsOn 'processMessages'
   srcJar.dependsOn 'processMessages'
-  rat.dependsOn ':clients:processMessages'
 
   compileTestJava.dependsOn 'processTestMessages'
-  rat.dependsOn ':clients:processTestMessages'
 
   javadoc {
     include "**/org/apache/kafka/clients/admin/*"
@@ -1536,7 +1537,6 @@ project(':raft') {
 
   compileJava.dependsOn 'processMessages'
   srcJar.dependsOn 'processMessages'
-  rat.dependsOn ':raft:processMessages'
 
   jar {
     dependsOn createVersionFile
@@ -1766,7 +1766,6 @@ project(':storage') {
 
   compileJava.dependsOn 'processMessages'
   srcJar.dependsOn 'processMessages'
-  rat.dependsOn ':storage:processMessages'
 
   jar {
     dependsOn createVersionFile
@@ -2064,7 +2063,6 @@ project(':streams') {
 
   compileJava.dependsOn 'processMessages'
   srcJar.dependsOn 'processMessages'
-  rat.dependsOn ':streams:processMessages'
 
   javadoc {
     include "**/org/apache/kafka/streams/**"


### PR DESCRIPTION
This fix the following issue that we occasionally see in [builds](https://ci-builds.apache.org/blue/organizations/jenkins/Kafka%2Fkafka-pr/detail/PR-13848/4/pipeline/13/).

```
[2023-06-14T11:41:50.769Z] * What went wrong:
[2023-06-14T11:41:50.769Z] A problem was found with the configuration of task ':rat' (type 'RatTask').
[2023-06-14T11:41:50.769Z]   - Gradle detected a problem with the following location: '/home/jenkins/jenkins-agent/workspace/Kafka_kafka-pr_PR-13848'.
[2023-06-14T11:41:50.769Z]     
[2023-06-14T11:41:50.769Z]     Reason: Task ':rat' uses this output of task ':clients:processTestMessages' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
[2023-06-14T11:41:50.769Z]     
[2023-06-14T11:41:50.769Z]     Possible solutions:
[2023-06-14T11:41:50.769Z]       1. Declare task ':clients:processTestMessages' as an input of ':rat'.
[2023-06-14T11:41:50.769Z]       2. Declare an explicit dependency on ':clients:processTestMessages' from ':rat' using Task#dependsOn.
[2023-06-14T11:41:50.769Z]       3. Declare an explicit dependency on ':clients:processTestMessages' from ':rat' using Task#mustRunAfter.
[2023-06-14T11:41:50.769Z]     
[2023-06-14T11:41:50.769Z]     Please refer to https://docs.gradle.org/8.1.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```

Validated manually as well:

```
% ./gradlew rat

> Configure project :
Starting build with version 3.6.0-SNAPSHOT (commit id 874081ca) using Gradle 8.1.1, Java 17 and Scala 2.13.10
Build properties: maxParallelForks=10, maxScalacThreads=8, maxTestRetries=0

> Task :storage:processMessages
MessageGenerator: processed 4 Kafka message JSON files(s).

> Task :raft:processMessages
MessageGenerator: processed 1 Kafka message JSON files(s).

> Task :core:processMessages
MessageGenerator: processed 2 Kafka message JSON files(s).

> Task :group-coordinator:processMessages
MessageGenerator: processed 16 Kafka message JSON files(s).

> Task :streams:processMessages
MessageGenerator: processed 1 Kafka message JSON files(s).

> Task :metadata:processMessages
MessageGenerator: processed 20 Kafka message JSON files(s).

> Task :clients:processMessages
MessageGenerator: processed 146 Kafka message JSON files(s).

> Task :clients:processTestMessages
MessageGenerator: processed 4 Kafka message JSON files(s).

BUILD SUCCESSFUL in 8s
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
