### PR TITLE
MINOR: Reduce flakiness of testRackAwareRangeAssignor, second try

### DIFF
--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -205,7 +205,8 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
         executor.submit(() => {
           val expectedAssignment = assignments(i)
           TestUtils.pollUntilTrue(consumer, () => consumer.assignment() == expectedAssignment.asJava,
-            s"Timed out while awaiting expected assignment $expectedAssignment. The current assignment is ${consumer.assignment()}")
+            s"Timed out while awaiting expected assignment $expectedAssignment. The current assignment is ${consumer.assignment()}",
+            waitTimeMs = 30000)
         }, 0)
       }
       assignmentFutures.foreach(future => assertEquals(0, future.get(30, TimeUnit.SECONDS)))
@@ -247,7 +248,7 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
         val newAssignment = new NewPartitionReassignment(Collections.singletonList(p))
         reassignments.put(new TopicPartition(topicWithSingleRackPartitions, p), util.Optional.of(newAssignment))
       }
-      admin.alterPartitionReassignments(reassignments).all().get(15, TimeUnit.SECONDS)
+      admin.alterPartitionReassignments(reassignments).all().get(30, TimeUnit.SECONDS)
       verifyAssignments(partitionList, topicWithAllPartitionsOnAllRacks, topicWithSingleRackPartitions)
 
     } finally {


### PR DESCRIPTION
This test still fails regularly with the following error:

```
Error
java.util.concurrent.ExecutionException: org.opentest4j.AssertionFailedError: Timed out while awaiting expected assignment Set(topicWithAllPartitionsOnAllRacks-0, topicWithSingleRackPartitions-0). The current assignment is []
Stacktrace
java.util.concurrent.ExecutionException: org.opentest4j.AssertionFailedError: Timed out while awaiting expected assignment Set(topicWithAllPartitionsOnAllRacks-0, topicWithSingleRackPartitions-0). The current assignment is []
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:205)
	at integration.kafka.server.FetchFromFollowerIntegrationTest.$anonfun$testRackAwareRangeAssignor$9(FetchFromFollowerIntegrationTest.scala:211)
	at integration.kafka.server.FetchFromFollowerIntegrationTest.$anonfun$testRackAwareRangeAssignor$9$adapted(FetchFromFollowerIntegrationTest.scala:211)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:575)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:573)
```

I propose to increase the timeouts to 30 secs to mitigate it. The test already uses 30 secs timeouts in many places. This patch uses 30 secs everywhere. This solution is not optimal but this is better than having a flaky test.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
