### PR TITLE
Revert "MINOR: Reduce MM2 integration test flakiness due to missing dummy offset commits"

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsWithCustomForwardingAdminIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsWithCustomForwardingAdminIntegrationTest.java
@@ -192,7 +192,7 @@ public class MirrorConnectorsWithCustomForwardingAdminIntegrationTest extends Mi
         String consumerGroupName = "consumer-group-testReplication";
         Map<String, Object> consumerProps = Collections.singletonMap("group.id", consumerGroupName);
         // warm up consumers before starting the connectors so we don't need to wait for discovery
-        prepareConsumerGroup(consumerProps);
+        warmUpConsumer(consumerProps);
 
         mm2Config = new MirrorMakerConfig(mm2Props);
 
@@ -229,7 +229,7 @@ public class MirrorConnectorsWithCustomForwardingAdminIntegrationTest extends Mi
         String consumerGroupName = "consumer-group-testReplication";
         Map<String, Object> consumerProps = Collections.singletonMap("group.id", consumerGroupName);
         // warm up consumers before starting the connectors so we don't need to wait for discovery
-        prepareConsumerGroup(consumerProps);
+        warmUpConsumer(consumerProps);
 
         waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);
         waitUntilMirrorMakerIsRunning(primary, CONNECTOR_LIST, mm2Config, BACKUP_CLUSTER_ALIAS, PRIMARY_CLUSTER_ALIAS);
@@ -262,7 +262,7 @@ public class MirrorConnectorsWithCustomForwardingAdminIntegrationTest extends Mi
         String consumerGroupName = "consumer-group-testReplication";
         Map<String, Object> consumerProps = Collections.singletonMap("group.id", consumerGroupName);
         // warm up consumers before starting the connectors so we don't need to wait for discovery
-        prepareConsumerGroup(consumerProps);
+        warmUpConsumer(consumerProps);
 
         waitUntilMirrorMakerIsRunning(primary, CONNECTOR_LIST, mm2Config, BACKUP_CLUSTER_ALIAS, PRIMARY_CLUSTER_ALIAS);
         waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);


### PR DESCRIPTION
Reverts apache/kafka#13838

This PR led to an increase in test failures in Jenkins. We can revert the commit temporarily until those failures are addressed.