### PR TITLE
KAFKA-15096: Update snappy-java to 1.1.10.1

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -257,7 +257,7 @@ scala-library-2.13.10
 scala-logging_2.13-3.9.4
 scala-reflect-2.13.10
 scala-java8-compat_2.13-1.0.2
-snappy-java-1.1.10.0
+snappy-java-1.1.10.1
 swagger-annotations-2.2.8
 zookeeper-3.6.4
 zookeeper-jute-3.6.4

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -124,7 +124,7 @@ versions += [
   scalaJava8Compat : "1.0.2",
   scoverage: "1.9.3",
   slf4j: "1.7.36",
-  snappy: "1.1.10.0",
+  snappy: "1.1.10.1",
   spotbugs: "4.7.3",
   swaggerAnnotations: "2.2.8",
   swaggerJaxrs2: "2.2.8",


### PR DESCRIPTION
Upgrade to 1.1.10.1 to fix CVE 2023-34455

The release notes are available at https://github.com/xerial/snappy-java/releases/tag/v1.1.10.1

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
