### PR TITLE
MINOR: Fix help message for kafka-metadata-shell.

### DIFF
--- a/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
@@ -177,9 +177,9 @@ public final class MetadataShell {
 
     public static void main(String[] args) throws Exception {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("metadata-tool")
+            .newArgumentParser("kafka-metadata-shell")
             .defaultHelp(true)
-            .description("The Apache Kafka metadata tool");
+            .description("The Apache Kafka metadata shell");
         parser.addArgument("--snapshot", "-s")
             .type(String.class)
             .help("The snapshot file to read.");


### PR DESCRIPTION
The current help message for kafka-metadata-shell.sh is as follows.

```
$ ~/kafka_2.13-3.5.0/bin/kafka-metadata-shell.sh -h
usage: metadata-tool [-h] [--snapshot SNAPSHOT] [command [command ...]]

The Apache Kafka metadata tool

(omitted.)
```

However, it should be as follows.

```
$ ~/kafka_2.13-3.5.0/bin/kafka-metadata-shell.sh -h
usage: kafka-metadata-shell [-h] [--snapshot SNAPSHOT] [command [command ...]]

The Apache Kafka metadata shell

(omitted.)
```


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
