### PR TITLE
KAFKA-14133: Migrate Consumer mock in TaskManagerTest to Mockito

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -4669,7 +4669,7 @@ public class TaskManagerTest {
         Mockito.verify(consumer, atLeastOnce()).resume(assignment);
     }
 
-    private static void verifyResumeWasCalledWith(final Consumer<byte[], byte[]> consumer, Set<TopicPartition> assignment) {
+    private static void verifyResumeWasCalledWith(final Consumer<byte[], byte[]> consumer, final Set<TopicPartition> assignment) {
         Mockito.verify(consumer, atLeastOnce()).resume(assignment);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -55,7 +55,6 @@ import org.apache.kafka.streams.state.internals.OffsetCheckpoint;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
-import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
 import org.easymock.MockType;


### PR DESCRIPTION
This pull requests migrates the Consumer mock in TaskManagerTest from EasyMock to Mockito.
The change is restricted to a single mock to minimize the scope and make it easier for review.

The reasoning as to why we would like to migrate a single mock rather than all mocks in the file at the same time has been discussed in https://github.com/apache/kafka/pull/12607#issuecomment-1500829973

It takes the same approach as in:
https://github.com/apache/kafka/pull/13529
https://github.com/apache/kafka/pull/13621
https://github.com/apache/kafka/pull/13681
https://github.com/apache/kafka/pull/13711