### PR TITLE
KAFKA-10733: Clean up producer exceptions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1741,11 +1741,11 @@ public class TransactionManager {
                     abortableError(GroupAuthorizationException.forGroupId(builder.data.groupId()));
                     break;
                 } else if (error == Errors.FENCED_INSTANCE_ID) {
-                    abortableError(error.exception());
+                    fatalError(error.exception());
                     break;
                 } else if (error == Errors.UNKNOWN_MEMBER_ID
                         || error == Errors.ILLEGAL_GENERATION) {
-                    abortableError(new CommitFailedException("Transaction offset Commit failed " +
+                    fatalError(new CommitFailedException("Transaction offset Commit failed " +
                         "due to consumer group metadata mismatch: " + error.exception().getMessage()));
                     break;
                 } else if (error == Errors.INVALID_PRODUCER_EPOCH

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -56,6 +56,7 @@ import org.apache.kafka.common.requests.AddOffsetsToTxnRequest;
 import org.apache.kafka.common.requests.AddOffsetsToTxnResponse;
 import org.apache.kafka.common.requests.AddPartitionsToTxnRequest;
 import org.apache.kafka.common.requests.AddPartitionsToTxnResponse;
+import org.apache.kafka.common.requests.CorrelationIdMismatchException;
 import org.apache.kafka.common.requests.EndTxnRequest;
 import org.apache.kafka.common.requests.EndTxnResponse;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
@@ -1279,7 +1280,8 @@ public class TransactionManager {
         @Override
         public void onComplete(ClientResponse response) {
             if (response.requestHeader().correlationId() != inFlightRequestCorrelationId) {
-                fatalError(new RuntimeException("Detected more than one in-flight transactional request."));
+                fatalError(new CorrelationIdMismatchException("Detected more than one in-flight transactional request.",
+                    inFlightRequestCorrelationId, response.requestHeader().correlationId()));
             } else {
                 clearInFlightCorrelationId();
                 if (response.wasDisconnected()) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1084,6 +1084,9 @@ public class TransactionManager {
         if (!hasError()) {
             return;
         }
+        if (lastError instanceof IllegalStateException) {
+            throw lastError;
+        }
         // for ProducerFencedException, do not wrap it as a KafkaException
         // but create a new instance without the call trace since it was not thrown because of the current call
         if (lastError instanceof ProducerFencedException) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1296,7 +1296,7 @@ public class TransactionManager {
                         handleResponse(response.responseBody());
                     }
                 } else {
-                    fatalError(new KafkaException("Could not execute transactional request for unknown reasons"));
+                    fatalError(new IllegalStateException("Could not execute transactional request for unknown reasons"));
                 }
             }
         }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -950,11 +950,12 @@ public class TransactionManagerTest {
         }, new TxnOffsetCommitResponse(0, singletonMap(tp, Errors.FENCED_INSTANCE_ID)));
 
         runUntil(transactionManager::hasError);
+        assertTrue(transactionManager.hasFatalError());
         assertTrue(transactionManager.lastError() instanceof FencedInstanceIdException);
         assertTrue(sendOffsetsResult.isCompleted());
         assertFalse(sendOffsetsResult.isSuccessful());
         assertTrue(sendOffsetsResult.error() instanceof FencedInstanceIdException);
-        assertAbortableError(FencedInstanceIdException.class);
+        assertFatalError(FencedInstanceIdException.class);
     }
 
     @Test
@@ -983,11 +984,12 @@ public class TransactionManagerTest {
         }, new TxnOffsetCommitResponse(0, singletonMap(tp, Errors.UNKNOWN_MEMBER_ID)));
 
         runUntil(transactionManager::hasError);
+        assertTrue(transactionManager.hasFatalError());
         assertTrue(transactionManager.lastError() instanceof CommitFailedException);
         assertTrue(sendOffsetsResult.isCompleted());
         assertFalse(sendOffsetsResult.isSuccessful());
         assertTrue(sendOffsetsResult.error() instanceof CommitFailedException);
-        assertAbortableError(CommitFailedException.class);
+        assertFatalError(CommitFailedException.class);
     }
 
     @Test
@@ -1018,11 +1020,12 @@ public class TransactionManagerTest {
         }, new TxnOffsetCommitResponse(0, singletonMap(tp, Errors.ILLEGAL_GENERATION)));
 
         runUntil(transactionManager::hasError);
+        assertTrue(transactionManager::hasFatalError);
         assertTrue(transactionManager.lastError() instanceof CommitFailedException);
         assertTrue(sendOffsetsResult.isCompleted());
         assertFalse(sendOffsetsResult.isSuccessful());
         assertTrue(sendOffsetsResult.error() instanceof CommitFailedException);
-        assertAbortableError(CommitFailedException.class);
+        assertFatalError(CommitFailedException.class);
     }
 
     @Test


### PR DESCRIPTION
This PR cleans up some exception handling inconsistencies as described in [KIP-691](https://cwiki.apache.org/confluence/display/KAFKA/KIP-691%3A+Enhance+Transactional+Producer+Exception+Handling).

 - In one case, throw `CorrelationIdMismatchException` instead of `RuntimeException`.
 - Use `IllegalStateException` for all states that should be impossible to reach.
 - `FENCED_INSTANCE_ID`, `UNKNOWN_MEMBER_ID`, `ILLEGAL_GENERATION` should be treated as fatal errors, since they indicate fencing situations.
 - Always throw `IllegalStateException` directly instead of wrapping it. These indicate a bug, we should not wrap but directly throw.