### PR TITLE
KAFKA-15109 Don't skip leader epoch bump while in migration mode

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -283,8 +283,8 @@ public class PartitionChangeBuilder {
      * bump is not required when the ISR shrinks. Note, that the leader epoch is never increased if
      * the ISR expanded.
      *
-     * When the controller is in ZK migration mode, the leader epoch must be bumped during ISR
-     * shrink for compatability with ZK brokers.
+     * In MV 3.6 and beyond, if the controller is in ZK migration mode, the leader epoch must
+     * be bumped during ISR shrink for compatability with ZK brokers.
      */
     void triggerLeaderEpochBumpIfNeeded(PartitionChangeRecord record) {
         if (record.leader() == NO_LEADER_CHANGE) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -993,9 +993,9 @@ public class ReplicationControlManager {
                     topic.id,
                     partitionId,
                     clusterControl::isActive,
-                    featureControl.metadataVersion(),
-                    clusterControl.zkRegistrationAllowed()
+                    featureControl.metadataVersion()
                 );
+                builder.setBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
                 if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name())) {
                     builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
                 }
@@ -1381,10 +1381,9 @@ public class ReplicationControlManager {
             topicId,
             partitionId,
             clusterControl::isActive,
-            featureControl.metadataVersion(),
-            clusterControl.zkRegistrationAllowed()
+            featureControl.metadataVersion()
         );
-        builder.setElection(election);
+        builder.setElection(election).setBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
         Optional<ApiMessageAndVersion> record = builder.build();
         if (!record.isPresent()) {
             if (electionType == ElectionType.PREFERRED) {
@@ -1517,10 +1516,10 @@ public class ReplicationControlManager {
                 topicPartition.topicId(),
                 topicPartition.partitionId(),
                 clusterControl::isActive,
-                featureControl.metadataVersion(),
-                clusterControl.zkRegistrationAllowed()
+                featureControl.metadataVersion()
             );
-            builder.setElection(PartitionChangeBuilder.Election.PREFERRED);
+            builder.setElection(PartitionChangeBuilder.Election.PREFERRED)
+                .setBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
             builder.build().ifPresent(records::add);
         }
 
@@ -1739,9 +1738,9 @@ public class ReplicationControlManager {
                 topicIdPart.topicId(),
                 topicIdPart.partitionId(),
                 isAcceptableLeader,
-                featureControl.metadataVersion(),
-                clusterControl.zkRegistrationAllowed()
+                featureControl.metadataVersion()
             );
+            builder.setBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
             if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
                 builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
             }
@@ -1852,9 +1851,9 @@ public class ReplicationControlManager {
             tp.topicId(),
             tp.partitionId(),
             clusterControl::isActive,
-            featureControl.metadataVersion(),
-            clusterControl.zkRegistrationAllowed()
+            featureControl.metadataVersion()
         );
+        builder.setBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
         if (configurationControl.uncleanLeaderElectionEnabledForTopic(topicName)) {
             builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
         }
@@ -1910,9 +1909,9 @@ public class ReplicationControlManager {
             tp.topicId(),
             tp.partitionId(),
             clusterControl::isActive,
-            featureControl.metadataVersion(),
-            clusterControl.zkRegistrationAllowed()
+            featureControl.metadataVersion()
         );
+        builder.setBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
         if (!reassignment.replicas().equals(currentReplicas)) {
             builder.setTargetReplicas(reassignment.replicas());
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -993,7 +993,8 @@ public class ReplicationControlManager {
                     topic.id,
                     partitionId,
                     clusterControl::isActive,
-                    featureControl.metadataVersion()
+                    featureControl.metadataVersion(),
+                    clusterControl.zkRegistrationAllowed()
                 );
                 if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name())) {
                     builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
@@ -1380,7 +1381,8 @@ public class ReplicationControlManager {
             topicId,
             partitionId,
             clusterControl::isActive,
-            featureControl.metadataVersion()
+            featureControl.metadataVersion(),
+            clusterControl.zkRegistrationAllowed()
         );
         builder.setElection(election);
         Optional<ApiMessageAndVersion> record = builder.build();
@@ -1515,7 +1517,8 @@ public class ReplicationControlManager {
                 topicPartition.topicId(),
                 topicPartition.partitionId(),
                 clusterControl::isActive,
-                featureControl.metadataVersion()
+                featureControl.metadataVersion(),
+                clusterControl.zkRegistrationAllowed()
             );
             builder.setElection(PartitionChangeBuilder.Election.PREFERRED);
             builder.build().ifPresent(records::add);
@@ -1736,7 +1739,8 @@ public class ReplicationControlManager {
                 topicIdPart.topicId(),
                 topicIdPart.partitionId(),
                 isAcceptableLeader,
-                featureControl.metadataVersion()
+                featureControl.metadataVersion(),
+                clusterControl.zkRegistrationAllowed()
             );
             if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
                 builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
@@ -1848,7 +1852,8 @@ public class ReplicationControlManager {
             tp.topicId(),
             tp.partitionId(),
             clusterControl::isActive,
-            featureControl.metadataVersion()
+            featureControl.metadataVersion(),
+            clusterControl.zkRegistrationAllowed()
         );
         if (configurationControl.uncleanLeaderElectionEnabledForTopic(topicName)) {
             builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
@@ -1905,7 +1910,8 @@ public class ReplicationControlManager {
             tp.topicId(),
             tp.partitionId(),
             clusterControl::isActive,
-            featureControl.metadataVersion()
+            featureControl.metadataVersion(),
+            clusterControl.zkRegistrationAllowed()
         );
         if (!reassignment.replicas().equals(currentReplicas)) {
             builder.setTargetReplicas(reassignment.replicas());

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -229,7 +229,7 @@ public class PartitionChangeBuilderTest {
             1
         );
 
-        // Shrinking the ISR while in ZK migration mode does increase the leader epoch
+        // KAFKA-15109: Shrinking the ISR while in ZK migration mode does increase the leader epoch
         testTriggerLeaderEpochBumpIfNeededLeader(
             createFooBuilder()
                 .setTargetIsrWithBrokerStates(


### PR DESCRIPTION
Since the KRaft controller is sending LISR to ZK brokers while in migration mode, we can't skip the leader epoch bump introduced in #13765. 

This patch creates an exception for the new logic if we're running in ZK migration mode.