### PR TITLE
MINOR: Increase Github API operations for stale PR check

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/stale@v8
         with:
           debug-only: ${{ inputs.dryRun || false }}
-          operations-per-run: ${{ inputs.operationsPerRun || 30 }}
+          operations-per-run: ${{ inputs.operationsPerRun || 100 }}
           days-before-stale: 90
           days-before-close: -1
           stale-pr-label: 'stale'


### PR DESCRIPTION
The default of 30 operations isn't enough to iterate through all of our old PRs. Increasing to 100 to capture more of the stale PRs. 