### PR TITLE
MINOR: Fix generated client ids for Connect

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
@@ -204,7 +204,7 @@ public final class ConnectUtils {
         String result = Optional.ofNullable(config.groupId())
                 .orElse("connect");
         String userSpecifiedClientId = config.getString(CLIENT_ID_CONFIG);
-        if (userSpecifiedClientId != null) {
+        if (userSpecifiedClientId != null && !userSpecifiedClientId.trim().isEmpty()) {
             result += "-" + userSpecifiedClientId;
         }
         return result + "-";

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConnectUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConnectUtilsTest.java
@@ -153,6 +153,9 @@ public class ConnectUtilsTest {
 
         expectedClientIdBase = "connect-" + userSpecifiedClientId + "-";
         assertClientIdBase(null, userSpecifiedClientId, expectedClientIdBase);
+
+        expectedClientIdBase = "connect-";
+        assertClientIdBase(null, "", expectedClientIdBase);
     }
 
     private void assertClientIdBase(String groupId, String userSpecifiedClientId, String expectedClientIdBase) {


### PR DESCRIPTION
`CLIENT_ID_CONFIG` defaults to empty string: https://github.com/apache/kafka/blob/trunk/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java#L332-L336

So when it's not set explicitly, we end up with internal clients with client-ids like `connect-cluster--shared-admin` or `connect-cluster--offsets`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
