### PR TITLE
KAFKA-3821: Allowing source offsets to be updated without sending SourceRecords

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -178,7 +178,8 @@ public abstract class SourceTask implements Task {
      * hook to update the offsets for any source partition which isn't part of the offsets about to be committed or update
      * the offsets for any source partition. If any source partition is dropped, then it has no effect on the offsets committed.
      * The offsets passed as input per partition would be of the latest SourceRecord amongst all the records accumulated for it.
-     * @param offsets the offsets that are about to be committed. Since there could be multiple SourceRecords
+     * @param offsets the offsets that are about to be committed. Could be empty, never null.
+     *                Since there could be multiple SourceRecords
      *                Note that this could mean different things based upon the mode:
      *                At Least Once Mode: The offsets that are about to be committed based on the previous poll
      *                EOS: The offsets about to be committed based on the transaction boundary.

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -19,10 +19,7 @@ package org.apache.kafka.connect.source;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.connector.Task;
 
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * SourceTask is a Task that pulls records from another system for storage in Kafka.
@@ -174,5 +171,21 @@ public abstract class SourceTask implements Task {
             throws InterruptedException {
         // by default, just call other method for backwards compatibility
         commitRecord(record);
+    }
+
+    /**
+     * Hook to update the offsets for source partitions before offsets are committed. Source tasks can use this
+     * hook to update the offsets for any source partition which isn't part of the offsets about to be committed or update
+     * the offsets for any source partition. If any source partition is dropped, then it has no effect on the offsets committed.
+     * The offsets passed as input per partition would be of the latest SourceRecord amongst all the records accumulated for it.
+     * @param offsets the offsets that are about to be committed. Since there could be multiple SourceRecords
+     *                Note that this could mean different things based upon the mode:
+     *                At Least Once Mode: The offsets that are about to be committed based on the previous poll
+     *                EOS: The offsets about to be committed based on the transaction boundary.
+     *
+     * @return An optional map of updated Source partitions and offsets.
+     */
+    public Optional<Map<Map<String, Object>, Map<String, Object>>> updateOffsets(Map<Map<String, Object>, Map<String, Object>> offsets) {
+        return Optional.empty();
     }
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -19,7 +19,11 @@ package org.apache.kafka.connect.source;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.connector.Task;
 
-import java.util.*;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * SourceTask is a Task that pulls records from another system for storage in Kafka.
@@ -176,10 +180,9 @@ public abstract class SourceTask implements Task {
     /**
      * Hook to update the offsets for source partitions before offsets are committed. Source tasks can use this
      * hook to update the offsets for any source partition which isn't part of the offsets about to be committed or update
-     * the offsets for any source partition. If any source partition is dropped, then it has no effect on the offsets committed.
-     * The offsets passed as input per partition would be of the latest SourceRecord amongst all the records accumulated for it.
-     * @param offsets the offsets that are about to be committed. Could be empty, never null.
-     *                Since there could be multiple SourceRecords
+     * the offsets for any source partition. If any source partition is dropped, or has been set to a null offset,
+     * then it has no effect on the offsets committed.
+     * @param offsets the offsets that were accumulated as per last poll or iteration. Could be empty, never null.
      *                Note that this could mean different things based upon the mode:
      *                At Least Once Mode: The offsets that are about to be committed based on the previous poll
      *                EOS: The offsets about to be committed based on the transaction boundary.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
@@ -198,6 +198,8 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
 
     // Visible for testing
     List<SourceRecord> toSend;
+
+    // Visible for testing
     Map<Map<String, Object>, Map<String, Object>> polledSourceOffsets = new HashMap<>();
     protected Map<String, String> taskConfig;
     protected boolean started = false;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
@@ -256,6 +256,14 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
 
         long started = time.milliseconds();
 
+        Optional<Map<Map<String, Object>, Map<String, Object>>> mayBeUpdatedOffsets = task.updateOffsets(offsetWriter);
+        if (mayBeUpdatedOffsets.isPresent() && !mayBeUpdatedOffsets.get().isEmpty()) {
+            Map<Map<String, Object>, Map<String, Object>> updatedOffsets = mayBeUpdatedOffsets.get();
+            for (Map.Entry<Map<String, Object>, Map<String, Object>> offset : updatedOffsets.entrySet()) {
+                SubmittedRecords.SubmittedRecord submittedRecord = submittedRecords.submit(offset.getKey(), offset.getValue());
+                submittedRecord.ack();
+            }
+        }
         AtomicReference<Throwable> flushError = new AtomicReference<>();
         boolean shouldFlush = false;
         try {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -321,7 +321,13 @@ class WorkerSourceTask extends AbstractWorkerSourceTask {
     }
 
     private void updateCommittableOffsets() {
-        updateOffsets();
+        // We invoke updateOffsets only when
+        // 1) Either the last poll invocation didn't return any records or
+        // 2) All the records returned by the previous poll invocation got processed successfully
+        // 3) First iteration of task because toSend would be null initially.
+        if (toSend == null) {
+            updateOffsets();
+        }
         CommittableOffsets newOffsets = submittedRecords.committableOffsets();
         synchronized (this) {
             this.committableOffsets = this.committableOffsets.updatedWith(newOffsets);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -321,21 +321,17 @@ class WorkerSourceTask extends AbstractWorkerSourceTask {
     }
 
     private void updateCommittableOffsets() {
-        if (sourceOffsets != null) {
-            Optional<Map<Map<String, Object>, Map<String, Object>>> mayBeUpdatedOffsets = task.updateOffsets(sourceOffsets);
-            if (mayBeUpdatedOffsets.isPresent() && !mayBeUpdatedOffsets.get().isEmpty()) {
-                Map<Map<String, Object>, Map<String, Object>> updatedOffsets = mayBeUpdatedOffsets.get();
-                for (Map.Entry<Map<String, Object>, Map<String, Object>> offset : updatedOffsets.entrySet()) {
-                    SubmittedRecords.SubmittedRecord submittedRecord = submittedRecords.submit(offset.getKey(), offset.getValue());
-                    submittedRecord.ack();
-                }
-            }
-        }
+        updateOffsets();
         CommittableOffsets newOffsets = submittedRecords.committableOffsets();
         synchronized (this) {
             this.committableOffsets = this.committableOffsets.updatedWith(newOffsets);
         }
-        sourceOffsets = null;
+    }
+
+    @Override
+    protected void updateOffset(Map<String, Object> partition, Map<String, Object> offset) {
+        SubmittedRecords.SubmittedRecord submittedRecord = submittedRecords.submit(partition, offset);
+        submittedRecord.ack();
     }
 
     private void maybeThrowProducerSendException() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTaskTest.java
@@ -814,6 +814,10 @@ public class AbstractWorkerSourceTaskTest {
             @Override
             protected void finalOffsetCommit(boolean failed) {
             }
+
+            @Override
+            protected void updateOffset(Map<String, Object> partition, Map<String, Object> offset) {
+            }
         };
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
@@ -222,6 +222,7 @@ public class ExactlyOnceWorkerSourceTaskTest {
         verify(sourceTask, MockitoUtils.anyTimes()).poll();
         verify(sourceTask, MockitoUtils.anyTimes()).commit();
         verify(sourceTask, MockitoUtils.anyTimes()).commitRecord(any(), any());
+        verify(sourceTask, MockitoUtils.anyTimes()).updateOffsets(any());
 
         verify(offsetWriter, MockitoUtils.anyTimes()).offset(PARTITION, OFFSET);
         verify(offsetWriter, MockitoUtils.anyTimes()).beginFlush();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTaskTest.java
@@ -67,7 +67,14 @@ import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.verification.VerificationMode;
 
 import java.time.Duration;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -115,7 +122,7 @@ import static org.mockito.Mockito.when;
 @RunWith(Parameterized.class)
 public class ExactlyOnceWorkerSourceTaskTest {
     private static final String TOPIC = "topic";
-    private static final Map<String, byte[]> PARTITION = Collections.singletonMap("key", "partition".getBytes());
+    private static final Map<String, Object> PARTITION = Collections.singletonMap("key", "partition".getBytes());
     private static final Map<String, ?> OFFSET = offset(12);
 
     // Connect-format data
@@ -561,41 +568,6 @@ public class ExactlyOnceWorkerSourceTaskTest {
     }
 
     @Test
-    public void testUpdateOffsetsPollBasedCommit() throws Exception {
-        // Test that the task handles an empty list of records
-        createWorkerTask();
-
-        // Make sure the task returns empty batches from poll before we start polling it
-        pollRecords.set(Collections.emptyList());
-
-        when(offsetWriter.beginFlush()).thenReturn(false);
-
-        startTaskThread();
-
-        awaitEmptyPolls(10);
-
-        for (int count = 0; count < 5; count++) {
-            when(sourceTask.updateOffsets(workerTask.polledSourceOffsets)).thenReturn(Optional.empty());
-        }
-        when(sourceTask.updateOffsets(workerTask.polledSourceOffsets))
-                .thenAnswer(emptyPollOffset -> Optional.of(mkMap(mkEntry(PARTITION, OFFSET))));
-
-        for (int count = 0; count < 4; count++) {
-            when(sourceTask.updateOffsets(workerTask.polledSourceOffsets)).thenReturn(Optional.empty());
-        }
-
-        awaitShutdown();
-
-        // task commits for each empty poll, plus the final commit
-        verifyTransactions(pollCount() + 1, 1);
-
-        verifyPreflight();
-        verifyStartup();
-        verifyCleanShutdown();
-        assertPollMetrics(0);
-    }
-
-    @Test
     public void testPollBasedCommit() throws Exception {
         Map<String, String> connectorProps = sourceConnectorProps(SourceTask.TransactionBoundary.POLL);
         sourceConfig = new SourceConnectorConfig(plugins, connectorProps, enableTopicCreation);
@@ -621,6 +593,47 @@ public class ExactlyOnceWorkerSourceTaskTest {
         verifyCleanShutdown();
         assertPollMetrics(1);
         assertTransactionMetrics(RECORDS.size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testUpdateOffsetsPollBasedCommit() throws Exception {
+        Map<String, String> connectorProps = sourceConnectorProps(SourceTask.TransactionBoundary.POLL);
+        sourceConfig = new SourceConnectorConfig(plugins, connectorProps, enableTopicCreation);
+
+        // Make sure the task returns empty batches from poll before we start polling it
+        pollRecords.set(Collections.emptyList());
+
+        createWorkerTask();
+
+        startTaskThread();
+
+        when(offsetWriter.beginFlush())
+                .thenReturn(false)
+                .thenReturn(false)
+                .thenReturn(true)
+                .thenReturn(false);
+        // 5 empty polls
+        awaitEmptyPolls(5);
+        // After 3rd poll, updateOffsets sends out an offset to commit.
+        when(sourceTask.updateOffsets(workerTask.polledSourceOffsets))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(mkMap(mkEntry(PARTITION, (Map<String, Object>) OFFSET))))
+                .thenReturn(Optional.empty());
+
+        assertEquals("Only one flush should take place due to updateOffsets updating offsets", 1, flushCount());
+
+        awaitShutdown();
+
+        // Task should have flushed offsets for the only time when updateOffsets returned offsets
+        verifyTransactions(6, 1);
+
+        verifyPreflight();
+        verifyStartup();
+        verifyCleanShutdown();
+        assertPollMetrics(0);
+        assertTransactionMetrics(0);
     }
 
     @Test
@@ -665,8 +678,63 @@ public class ExactlyOnceWorkerSourceTaskTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    public void testUpdateOffsetsIntervalBasedCommit() throws Exception {
+        long commitInterval = 618;
+        Map<String, String> connectorProps = sourceConnectorProps(SourceTask.TransactionBoundary.INTERVAL);
+        connectorProps.put(TRANSACTION_BOUNDARY_INTERVAL_CONFIG, Long.toString(commitInterval));
+        sourceConfig = new SourceConnectorConfig(plugins, connectorProps, enableTopicCreation);
+
+        // Make sure the task returns empty batches from poll before we start polling it
+        pollRecords.set(Collections.emptyList());
+
+        time = new MockTime();
+
+        createWorkerTask();
+
+        startTaskThread();
+
+        when(offsetWriter.beginFlush())
+                .thenReturn(true)
+                .thenReturn(false);
+
+        awaitEmptyPolls(1);
+        assertEquals("No flushes should have taken place before offset commit interval has elapsed", 0, flushCount());
+        time.sleep(commitInterval);
+
+        // The placement of this mock seems to be order dependent. If I place it above the
+        // first awaitEmptyPolls, it tends to throw weird ClassCaseExceptions citing task.poll().
+        when(sourceTask.updateOffsets(workerTask.polledSourceOffsets))
+                .thenReturn(Optional.of(mkMap(mkEntry(PARTITION, (Map<String, Object>) OFFSET))));
+
+        awaitEmptyPolls(1);
+        assertEquals("One flush should have taken place after offset commit interval has elapsed and updateOffsets sent updated offsets once", 1, flushCount());
+        time.sleep(commitInterval * 2);
+
+        awaitEmptyPolls(1);
+        assertEquals("No new flushes should have taken place after offset commit interval has elapsed again due to empty polls", 1, flushCount());
+
+        awaitShutdown();
+
+        // Task should have flushed offsets for the only time when updateOffsets returned offsets
+        verifyTransactions(3, 1);
+
+        verifyPreflight();
+        verifyStartup();
+        verifyCleanShutdown();
+        assertPollMetrics(0);
+        assertTransactionMetrics(0);
+    }
+
+
+    @Test
     public void testConnectorCommitOnBatch() throws Exception {
         testConnectorBasedCommit(TransactionContext::commitTransaction, false);
+    }
+
+    @Test
+    public void testConnectorCommitOnBatchWithUpdateOffsets() throws Exception {
+        testUpdateOffsetsConnectorBasedCommit(TransactionContext::commitTransaction, false, false);
     }
 
     @Test
@@ -675,13 +743,28 @@ public class ExactlyOnceWorkerSourceTaskTest {
     }
 
     @Test
+    public void testConnectorCommitOnRecordWithUpdateOffsets() throws Exception {
+        testUpdateOffsetsConnectorBasedCommit(ctx -> ctx.commitTransaction(SOURCE_RECORD_2), false, true);
+    }
+
+    @Test
     public void testConnectorAbortOnBatch() throws Exception {
         testConnectorBasedCommit(TransactionContext::abortTransaction, true);
     }
 
     @Test
+    public void testConnectorAbortOnBatchWithUpdateOffsets() throws Exception {
+        testUpdateOffsetsConnectorBasedCommit(TransactionContext::abortTransaction, true, false);
+    }
+
+    @Test
     public void testConnectorAbortOnRecord() throws Exception {
         testConnectorBasedCommit(ctx -> ctx.abortTransaction(SOURCE_RECORD_2), true);
+    }
+
+    @Test
+    public void testConnectorAbortOnRecordWithUpdateOffsets() throws Exception {
+        testUpdateOffsetsConnectorBasedCommit(ctx -> ctx.abortTransaction(SOURCE_RECORD_2), true, true);
     }
 
     private void testConnectorBasedCommit(Consumer<TransactionContext> requestCommit, boolean abort) throws Exception {
@@ -727,6 +810,62 @@ public class ExactlyOnceWorkerSourceTaskTest {
         verifyPossibleTopicCreation();
         assertPollMetrics(1);
         assertTransactionMetrics(abort ? 0 : (3 * RECORDS.size()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void testUpdateOffsetsConnectorBasedCommit(Consumer<TransactionContext> requestCommit, boolean abort, boolean recordBasedCommitOrAbort) throws Exception {
+        Map<String, String> connectorProps = sourceConnectorProps(SourceTask.TransactionBoundary.CONNECTOR);
+        sourceConfig = new SourceConnectorConfig(plugins, connectorProps, enableTopicCreation);
+        createWorkerTask();
+
+        expectSuccessfulSends();
+
+        TransactionContext transactionContext = workerTask.sourceTaskContext.transactionContext();
+
+        startTaskThread();
+
+        awaitEmptyPolls(3);
+        assertEquals("No flushes should have taken place without connector requesting transaction commit",
+                0, flushCount());
+
+        requestCommit.accept(transactionContext);
+        when(offsetWriter.beginFlush())
+                .thenReturn(true);
+        when(sourceTask.updateOffsets(workerTask.polledSourceOffsets))
+                .thenReturn(Optional.of(mkMap(mkEntry(PARTITION, (Map<String, Object>) OFFSET))));
+        awaitEmptyPolls(3);
+        if (recordBasedCommitOrAbort) {
+            assertEquals("No flush should have taken place after transaction commit/abort was requested for a record which is neither committable nor abortable", 0, flushCount());
+            requestCommit.accept(transactionContext);
+            awaitPolls(3);
+            assertEquals("One flush should have taken place after transaction commit/abort was requested", 1, flushCount());
+            awaitPolls(1);
+            assertEquals("Only one flush should still have taken place without connector re-requesting commit/abort, even on identical records", 1, flushCount());
+        } else {
+            assertEquals("One flush should have taken place after transaction commit/abort was requested and there are offsets to commit", 1, flushCount());
+            awaitPolls(1);
+            requestCommit.accept(transactionContext);
+            awaitPolls(2);
+            assertEquals("One more flush should have taken place after transaction commit/abort was requested", 2, flushCount());
+            awaitPolls(1);
+            assertEquals("Only one flush should still have taken place without connector re-requesting commit/abort, even on identical records", 2, flushCount());
+        }
+        awaitShutdown();
+        // We begin a new transaction after connector-requested aborts so that we can still write offsets for the source records that were aborted
+        if (recordBasedCommitOrAbort) {
+            verify(producer, times(abort ? 3 : 2)).beginTransaction();
+        } else {
+            verify(producer, times(abort ? 4 : 3)).beginTransaction();
+        }
+        if (abort) {
+            verify(producer).abortTransaction();
+        }
+        verify(producer, times(flushCount())).commitTransaction();
+        verifySends(8);
+        verifyPreflight();
+        verifyStartup();
+        verifyCleanShutdown();
+        verifyPossibleTopicCreation();
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -72,13 +72,7 @@ import org.powermock.reflect.Whitebox;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -104,6 +98,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 
 @PowerMockIgnore({"javax.management.*",
                   "org.apache.log4j.*"})
@@ -290,6 +286,9 @@ public class WorkerSourceTaskTest {
         offsetWriter.offset(PARTITION, OFFSET);
         PowerMock.expectLastCall();
         expectOffsetFlush(true);
+
+        sourceTask.updateOffsets(workerTask.polledSourceOffsets);
+        EasyMock.expectLastCall().andReturn(Optional.of(workerTask.polledSourceOffsets));
 
         statusListener.onShutdown(taskId);
         EasyMock.expectLastCall();


### PR DESCRIPTION
This PR is an implementation of [KIP-910](https://cwiki.apache.org/confluence/display/KAFKA/KIP-910%3A+Update+Source+offsets+for+Source+Connectors+without+producing+records) which allows updating source offsets for partitions without necessarily needing to send SourceRecords. 