### PR TITLE
KAFKA-15114: Minor: Update help in StorageTool for creating SCRAM credentials for KRaft bootstrap.

### DIFF
--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -119,8 +119,8 @@ object StorageTool extends Logging {
     formatParser.addArgument("--add-scram", "-S").
       action(append()).
       help("""A SCRAM_CREDENTIAL to add to the __cluster_metadata log e.g.
-              |'SCRAM-SHA-256=[user=alice,password=alice-secret]'
-              |'SCRAM-SHA-512=[user=alice,iterations=8192,salt="N3E=",saltedpassword="YCE="]'""".stripMargin)
+              |'SCRAM-SHA-256=[name=alice,password=alice-secret]'
+              |'SCRAM-SHA-512=[name=alice,iterations=8192,salt="N3E=",saltedpassword="YCE="]'""".stripMargin)
     formatParser.addArgument("--ignore-formatted", "-g").
       action(storeTrue())
     formatParser.addArgument("--release-version", "-r").


### PR DESCRIPTION
The choice of using name vs. user as a parameter is because internally the record uses name, all tests using the StorageTool use name as a parameter, KafkaPrincipals are created with name and because creating SCRAM credentials is done with --entity-name

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
