### PR TITLE
KAFKA-13988: Fix MM2 not consuming from latest when "auto.offset.reset=latest" is set

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2968,6 +2968,7 @@ project(':connect:mirror') {
     testImplementation libs.junitJupiter
     testImplementation libs.log4j
     testImplementation libs.mockitoCore
+    testImplementation libs.mockitoInline // supports mocking static methods, final classes, etc.
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':connect:runtime').sourceSets.test.output
     testImplementation project(':core')


### PR DESCRIPTION
**Motivation**

This PR will fix the bug reported on [JIRA](https://issues.apache.org/jira/projects/KAFKA/issues/KAFKA-13988). There was a previous PR submitted for this but there wasn't any movement on it for an year, so filing a new one. 

**Testing Instructions**

**Manual testing**

1.  Produce 'n' messages to topic 'T1' on source cluster.
2.  Setup MM2 replication with config "consumer.auto.offset.reset": "latest" to replicate from topic 'T1'
3.  Produce 'n+y' messages to topic 'T1' on source cluster.
4.  Consume from 'TargetCluster' from replicated topic: 'SourceCluster.T1'
5.  The consumed messages should only contain latest 'y' messages but not the old ones. ✅
6.  Produce 'n' messages to topic 'T2' on source cluster.
7.  Setup MM2 replication with config "consumer.auto.offset.reset": "earliest" to replicate from topic 'T2'
8.  Produce 'n+y' messages to topic 'T2' on source cluster.
9.  Consume from 'TargetCluster' from replicated topic: 'SourceCluster.T2'
10. The consumed messages should contain all the 'n+y' messages. ✅

**Unit Tests**

Wrote a unit-test to test this behavior successfully.

### Committer Checklist (excluded from commit message)
- [X] Verify design and implementation 
- [X] Verify test coverage and CI build status
- [X] Verify documentation (including upgrade notes)
