### PR TITLE
KAFKA-15109 Ensure the leader epoch bump occurs for older MetadataVersions

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -144,8 +144,20 @@ public class PartitionChangeBuilder {
         return this;
     }
 
-    public PartitionChangeBuilder setBumpLeaderEpochOnIsrShrink(boolean bumpLeaderEpochOnIsrShrink) {
-        this.bumpLeaderEpochOnIsrShrink = bumpLeaderEpochOnIsrShrink;
+    /**
+     * If skipping the leader epoch bump on ISR shrink is supported by the MetadataVersion (3.6-IV0), allow
+     * the caller to override it. This is used during ZK migrations.
+     *
+     * @param bumpLeaderEpochOnIsrShrink true to force a leader epoch bump on ISR shrink, false to use the
+     *                                   default behavior based on the MetadataVersion.
+     * @return this builder object.
+     * @see #triggerLeaderEpochBumpIfNeeded
+     */
+    public PartitionChangeBuilder enableBumpLeaderEpochOnIsrShrink(boolean bumpLeaderEpochOnIsrShrink) {
+        // If the MV doesn't support skipping leader epoch bump the caller cannot override it.
+        if (metadataVersion.isSkipLeaderEpochBumpSupported()) {
+            this.bumpLeaderEpochOnIsrShrink = bumpLeaderEpochOnIsrShrink;
+        }
         return this;
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -293,7 +293,7 @@ public class PartitionChangeBuilder {
             if (!Replicas.contains(targetReplicas, partition.replicas)) {
                 // Reassignment
                 record.setLeader(partition.leader);
-            } else if (!Replicas.contains(targetIsr, partition.isr) && bumpLeaderEpochOnIsrShrink) {
+            } else if (bumpLeaderEpochOnIsrShrink && !Replicas.contains(targetIsr, partition.isr)) {
                 // ISR shrink
                 record.setLeader(partition.leader);
             }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -995,7 +995,7 @@ public class ReplicationControlManager {
                     clusterControl::isActive,
                     featureControl.metadataVersion()
                 );
-                builder.setBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
+                builder.enableBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
                 if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name())) {
                     builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
                 }
@@ -1383,7 +1383,7 @@ public class ReplicationControlManager {
             clusterControl::isActive,
             featureControl.metadataVersion()
         );
-        builder.setElection(election).setBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
+        builder.setElection(election).enableBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
         Optional<ApiMessageAndVersion> record = builder.build();
         if (!record.isPresent()) {
             if (electionType == ElectionType.PREFERRED) {
@@ -1519,7 +1519,7 @@ public class ReplicationControlManager {
                 featureControl.metadataVersion()
             );
             builder.setElection(PartitionChangeBuilder.Election.PREFERRED)
-                .setBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
+                .enableBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
             builder.build().ifPresent(records::add);
         }
 
@@ -1740,7 +1740,7 @@ public class ReplicationControlManager {
                 isAcceptableLeader,
                 featureControl.metadataVersion()
             );
-            builder.setBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
+            builder.enableBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
             if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
                 builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
             }
@@ -1853,7 +1853,7 @@ public class ReplicationControlManager {
             clusterControl::isActive,
             featureControl.metadataVersion()
         );
-        builder.setBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
+        builder.enableBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
         if (configurationControl.uncleanLeaderElectionEnabledForTopic(topicName)) {
             builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
         }
@@ -1911,7 +1911,7 @@ public class ReplicationControlManager {
             clusterControl::isActive,
             featureControl.metadataVersion()
         );
-        builder.setBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
+        builder.enableBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
         if (!reassignment.replicas().equals(currentReplicas)) {
             builder.setTargetReplicas(reassignment.replicas());
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -995,7 +995,7 @@ public class ReplicationControlManager {
                     clusterControl::isActive,
                     featureControl.metadataVersion()
                 );
-                builder.enableBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
+                builder.setZkMigrationEnabled(clusterControl.zkRegistrationAllowed());
                 if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name())) {
                     builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
                 }
@@ -1383,7 +1383,7 @@ public class ReplicationControlManager {
             clusterControl::isActive,
             featureControl.metadataVersion()
         );
-        builder.setElection(election).enableBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
+        builder.setElection(election).setZkMigrationEnabled(clusterControl.zkRegistrationAllowed());
         Optional<ApiMessageAndVersion> record = builder.build();
         if (!record.isPresent()) {
             if (electionType == ElectionType.PREFERRED) {
@@ -1519,7 +1519,7 @@ public class ReplicationControlManager {
                 featureControl.metadataVersion()
             );
             builder.setElection(PartitionChangeBuilder.Election.PREFERRED)
-                .enableBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
+                .setZkMigrationEnabled(clusterControl.zkRegistrationAllowed());
             builder.build().ifPresent(records::add);
         }
 
@@ -1740,7 +1740,7 @@ public class ReplicationControlManager {
                 isAcceptableLeader,
                 featureControl.metadataVersion()
             );
-            builder.enableBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
+            builder.setZkMigrationEnabled(clusterControl.zkRegistrationAllowed());
             if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
                 builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
             }
@@ -1853,7 +1853,7 @@ public class ReplicationControlManager {
             clusterControl::isActive,
             featureControl.metadataVersion()
         );
-        builder.enableBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
+        builder.setZkMigrationEnabled(clusterControl.zkRegistrationAllowed());
         if (configurationControl.uncleanLeaderElectionEnabledForTopic(topicName)) {
             builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
         }
@@ -1911,7 +1911,7 @@ public class ReplicationControlManager {
             clusterControl::isActive,
             featureControl.metadataVersion()
         );
-        builder.enableBumpLeaderEpochOnIsrShrink(clusterControl.zkRegistrationAllowed());
+        builder.setZkMigrationEnabled(clusterControl.zkRegistrationAllowed());
         if (!reassignment.replicas().equals(currentReplicas)) {
             builder.setTargetReplicas(reassignment.replicas());
         }

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -207,11 +207,12 @@ public class PartitionChangeBuilderTest {
             new PartitionChangeRecord(),
             NO_LEADER_CHANGE
         );
+        // Expanding the ISR during migration doesn't increase leader epoch
         testTriggerLeaderEpochBumpIfNeededLeader(
             createFooBuilder()
                 .setTargetIsrWithBrokerStates(
                     AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(Arrays.asList(2, 1, 3, 4)))
-                .enableBumpLeaderEpochOnIsrShrink(true),
+                .setZkMigrationEnabled(true),
             new PartitionChangeRecord(),
             NO_LEADER_CHANGE
         );
@@ -241,7 +242,7 @@ public class PartitionChangeBuilderTest {
             createFooBuilder()
                 .setTargetIsrWithBrokerStates(
                     AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(Arrays.asList(2, 1)))
-                .enableBumpLeaderEpochOnIsrShrink(true),
+                .setZkMigrationEnabled(true),
             new PartitionChangeRecord(),
             1
         );
@@ -250,7 +251,7 @@ public class PartitionChangeBuilderTest {
             createFooBuilder()
                 .setTargetIsrWithBrokerStates(
                     AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(Arrays.asList(2, 1)))
-                .enableBumpLeaderEpochOnIsrShrink(false),
+                .setZkMigrationEnabled(false),
             new PartitionChangeRecord(),
             NO_LEADER_CHANGE
         );
@@ -260,7 +261,7 @@ public class PartitionChangeBuilderTest {
             createFooBuilder(MetadataVersion.IBP_3_5_IV2)
                 .setTargetIsrWithBrokerStates(
                     AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(Arrays.asList(2, 1)))
-                .enableBumpLeaderEpochOnIsrShrink(true),
+                .setZkMigrationEnabled(true),
             new PartitionChangeRecord(),
             1
         );
@@ -269,7 +270,7 @@ public class PartitionChangeBuilderTest {
             createFooBuilder(MetadataVersion.IBP_3_5_IV2)
                 .setTargetIsrWithBrokerStates(
                     AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(Arrays.asList(2, 1)))
-                .enableBumpLeaderEpochOnIsrShrink(false),
+                .setZkMigrationEnabled(false),
             new PartitionChangeRecord(),
             1
         );
@@ -472,7 +473,7 @@ public class PartitionChangeBuilderTest {
             brokerId -> false,
             metadataVersion
         );
-        offlineBuilder.enableBumpLeaderEpochOnIsrShrink(zkMigrationsEnabled);
+        offlineBuilder.setZkMigrationEnabled(zkMigrationsEnabled);
         // Set the target ISR to empty to indicate that the last leader is offline
         offlineBuilder.setTargetIsrWithBrokerStates(Collections.emptyList());
 
@@ -498,7 +499,7 @@ public class PartitionChangeBuilderTest {
             brokerId -> true,
             metadataVersion
         );
-        onlineBuilder.enableBumpLeaderEpochOnIsrShrink(zkMigrationsEnabled);
+        onlineBuilder.setZkMigrationEnabled(zkMigrationsEnabled);
 
         // The only broker in the ISR is elected leader and stays in the recovering
         changeRecord = (PartitionChangeRecord) onlineBuilder.build().get().message();
@@ -535,7 +536,7 @@ public class PartitionChangeBuilderTest {
             brokerId -> brokerId == leaderId,
             metadataVersion
         ).setElection(Election.UNCLEAN);
-        onlineBuilder.enableBumpLeaderEpochOnIsrShrink(zkMigrationsEnabled);
+        onlineBuilder.setZkMigrationEnabled(zkMigrationsEnabled);
         // The partition should stay as recovering
         PartitionChangeRecord changeRecord = (PartitionChangeRecord) onlineBuilder
             .build()

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -263,8 +263,8 @@ public enum MetadataVersion {
         return this.isAtLeast(IBP_3_5_IV2);
     }
 
-    public boolean isSkipLeaderEpochBumpSupported() {
-        return this.isAtLeast(IBP_3_6_IV0);
+    public boolean isLeaderEpochBumpRequiredOnIsrShrink() {
+        return !this.isAtLeast(IBP_3_6_IV0);
     }
 
     public boolean isKRaftSupported() {


### PR DESCRIPTION
This patch fixes a bug introduced in the earlier KAFKA-15109 commit (#13890) where the leader epoch bump would be skipped for older MetadataVersion-s.