### PR TITLE
MINOR: Silence error logs for faulty plugins in integration tests

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
@@ -554,7 +554,7 @@ public class ErrorHandlingTaskTest {
     private abstract static class TestSinkTask extends SinkTask {
     }
 
-    static class FaultyConverter extends JsonConverter {
+    public static class FaultyConverter extends JsonConverter {
         private static final Logger log = LoggerFactory.getLogger(FaultyConverter.class);
         private int invocations = 0;
 
@@ -573,7 +573,7 @@ public class ErrorHandlingTaskTest {
         }
     }
 
-    static class FaultyPassthrough<R extends ConnectRecord<R>> implements Transformation<R> {
+    public static class FaultyPassthrough<R extends ConnectRecord<R>> implements Transformation<R> {
 
         private static final Logger log = LoggerFactory.getLogger(FaultyPassthrough.class);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskTest.java
@@ -554,6 +554,7 @@ public class ErrorHandlingTaskTest {
     private abstract static class TestSinkTask extends SinkTask {
     }
 
+    // Public to allow plugin discovery to complete without errors
     public static class FaultyConverter extends JsonConverter {
         private static final Logger log = LoggerFactory.getLogger(FaultyConverter.class);
         private int invocations = 0;
@@ -573,6 +574,7 @@ public class ErrorHandlingTaskTest {
         }
     }
 
+    // Public to allow plugin discovery to complete without errors
     public static class FaultyPassthrough<R extends ConnectRecord<R>> implements Transformation<R> {
 
         private static final Logger log = LoggerFactory.getLogger(FaultyPassthrough.class);


### PR DESCRIPTION
In #13467 we changed non-connector plugins to be instantiated during plugin scanning. This has the effect that converters and transform classes without a valid (public, no-args) constructor print an error log during worker startup.

These two plugin classes are not marked `public`, so their constructor is not public either, which causes these two classes to print an error during plugin scanning. Because these are used in runtime:test, they will generate log spam for integration tests for ourselves and anyone including the runtime:test artifact, such as downstream projects wishing to use the EmbeddedConnectCluster.

We should change these plugins so that no warnings are printed during scanning. The existing TestPlugins should be the only place in which this error condition is tested.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
