### PR TITLE
KAFKA-15119:Support incremental syncTopicAcls in MirrorSourceConnector

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsResult.java
@@ -33,7 +33,8 @@ import java.util.Map;
 public class CreateAclsResult {
     private final Map<AclBinding, KafkaFuture<Void>> futures;
 
-    CreateAclsResult(Map<AclBinding, KafkaFuture<Void>> futures) {
+    // Visible for testing
+    public CreateAclsResult(Map<AclBinding, KafkaFuture<Void>> futures) {
         this.futures = futures;
     }
 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -596,8 +596,8 @@ public class MirrorSourceConnector extends SourceConnector {
                     failedBindings.add(k);
                 }
             }));
-            bindings.removeAll(failedBindings);
             knownTopicAclBindings = new HashSet<>(bindings);
+            knownTopicAclBindings.removeAll(failedBindings);
         } else {
             log.debug("Not found new topic Acl info, skip sync!");
         }


### PR DESCRIPTION
### Activation
In the “syncTopicAcls” thread of MirrorSourceConnector, full amount of "TopicAclBindings" related to the replicated topics of the source cluster will be regularly listed, and then fully updated to the target cluster. Therefore, a large number of repeated "TopicAclBindings" will be repeatedly sent  by calling "targetAdminClient". This action is redundant. In addition, if too many "TopicAclBindings" are updated at one time, it may also take a long time for the target cluster to handle processing the "createAcls" request, which will affect the accumulation of the request queue of the target cluster and further affect the processing delay of other type requests.

### Solution
"TopicAclBinding" can be like the variable “knownConsumerGroups” in MirrorCheckpointConnector, and only update the incremental added "TopicAclBinding" every time, which can solve the above-mentioned problems.