### PR TITLE
KAFKA-14972: Support async runtimes in consumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -2383,8 +2383,10 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * Conditions:
      * <ol>
      * <li>only one thread can invoke the consumer at a time,</li>
-     * <li>this thread must wait for any other thread to complete before returning from the callback,</li>
-     * <li>the same conditions apply to nested callbacks (to enforce this, every callback uses a different access key).</li>
+     * <li>this thread must wait with returning from the callback until the other thread completed their invocation of
+     *     the consumer,</li>
+     * <li>the same conditions apply to nested callbacks (to enforce this, every callback uses a different access key).
+     * </li>
      * </ol>
      *
      * Violating these conditions leads to a {@code ConcurrentModificationException}.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -2391,7 +2391,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      *
      * Violating these conditions leads to a {@code ConcurrentModificationException}.
      * <p>
-     * See also <a href="https://cwiki.apache.org/confluence/x/chw0Dw">KIP-941</a>.
+     * See also <a href="https://cwiki.apache.org/confluence/x/chw0Dw">KIP-944</a>.
      * @return the access key for the current thread, or {@code null} when the current thread is currently not invoked
      * from a callback and any thread can access the consumer.
      */

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ThreadAccessKey.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ThreadAccessKey.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.clients.consumer;
 
 /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ThreadAccessKey.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ThreadAccessKey.java
@@ -1,0 +1,8 @@
+package org.apache.kafka.clients.consumer;
+
+/**
+ * A key that can be used to pass access to the Kafka consumer to another thread.
+ * Can be obtained via {@link KafkaConsumer#getThreadAccessKey()}.
+ */
+public class ThreadAccessKey {
+}


### PR DESCRIPTION
The JVM based KafkaConsumer contains a check that rejects nested invocations from different threads (in method acquire). For programs that use an async runtime, this is an almost impossible requirement. Also, the check is more strict than is required; we only need to validate that there is no concurrent access to the consumer.

Examples of affected async runtimes are Kotlin co-routines (KAFKA-7143) and Zio.

In this PR we replace the thread-id check with an access-key that allows a callback to pass on its capability to access the Kafka consumer to another thread.

To keep existing programs working without changes, the access key is stored on a thread-local variable. Developers that work in an async runtime can get the access-key via `getThreadAccessKey` and then activate it on the thread-local variable in a thread of their choosing with `setThreadAccessKey`.

Kafka consumer methods that need to be protected against multi-threaded access start with invoking private method `acquire` and end with invoking private method `release`. This commit changes the implementation of `acquire` and `release`.

For programs that are unaware of the access-key, the semantics remain unchanged.

This PR solves KAFKA-14972 and KAFKA-7143.

See also KIP-944 https://cwiki.apache.org/confluence/x/chw0Dw for more information.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
