### PR TITLE
MINOR: Reduce (hopefully) flakiness of testRackAwareRangeAssignor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,8 @@ def isChangeRequest(env) {
   env.CHANGE_ID != null && !env.CHANGE_ID.isEmpty()
 }
 
-def doTest(env, target = "unitTest integrationTest") {
-  sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
+def doTest(env, target = ":core:test") {
+  sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} --tests integration.kafka.server.FetchFromFollowerIntegrationTest.testRackAwareRangeAssignor \
       --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
       -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""
   junit '**/build/test-results/**/TEST-*.xml'
@@ -112,7 +112,7 @@ pipeline {
             SCALA_VERSION=2.12
           }
           steps {
-            doValidation()
+            //doValidation()
             doTest(env)
             tryStreamsArchetype()
           }
@@ -131,7 +131,7 @@ pipeline {
             SCALA_VERSION=2.13
           }
           steps {
-            doValidation()
+            //doValidation()
             doTest(env)
             echo 'Skipping Kafka Streams archetype test for Java 11'
           }
@@ -150,7 +150,7 @@ pipeline {
             SCALA_VERSION=2.13
           }
           steps {
-            doValidation()
+            //doValidation()
             doTest(env)
             echo 'Skipping Kafka Streams archetype test for Java 17'
           }
@@ -179,7 +179,7 @@ pipeline {
             SCALA_VERSION=2.13
           }
           steps {
-            doValidation()
+            //doValidation()
             doTest(env)
             tryStreamsArchetype()
           }
@@ -202,7 +202,7 @@ pipeline {
             SCALA_VERSION=2.12
           }
           steps {
-            doValidation()
+            //doValidation()
             doTest(env)
             echo 'Skipping Kafka Streams archetype test for Java 11'
           }
@@ -225,7 +225,7 @@ pipeline {
             SCALA_VERSION=2.12
           }
           steps {
-            doValidation()
+            //doValidation()
             doTest(env)
             echo 'Skipping Kafka Streams archetype test for Java 17'
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ def isChangeRequest(env) {
 def doTest(env, target = ":core:test") {
   sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} --tests integration.kafka.server.FetchFromFollowerIntegrationTest.testRackAwareRangeAssignor \
       --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
-      -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""
+      -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=0 -PmaxTestRetryFailures=10"""
   junit '**/build/test-results/**/TEST-*.xml'
 }
 

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -18,8 +18,11 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
-log4j.logger.kafka=WARN
-log4j.logger.org.apache.kafka=WARN
+log4j.logger.kafka=INFO
+log4j.logger.org.apache.kafka=INFO
+log4j.logger.org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor=DEBUG
+log4j.logger.org.apache.kafka.clients.consumer.internals.AbstractCoordinator=DEBUG
+log4j.logger.org.apache.kafka.clients.consumer.internals.ConsumerCoordinator=DEBUG
 
 
 # zkclient can be verbose, during debugging it is common to adjust it separately

--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -242,6 +242,7 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
 
       // Perform reassignment for topicWithSingleRackPartitions to reverse the replica racks and
       // verify that change in replica racks results in re-assignment based on new racks.
+      println("START")
       val admin = createAdminClient()
       val reassignments = new util.HashMap[TopicPartition, util.Optional[NewPartitionReassignment]]()
       partitionList.foreach { p =>
@@ -253,7 +254,7 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
         () => admin.listPartitionReassignments().reassignments().get().isEmpty,
         msg = "The reassignment never completed.", waitTimeMs = 30000)
       verifyAssignments(partitionList, topicWithAllPartitionsOnAllRacks, topicWithSingleRackPartitions)
-
+      println("END")
     } finally {
       executor.shutdownNow()
     }

--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -249,6 +249,9 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
         reassignments.put(new TopicPartition(topicWithSingleRackPartitions, p), util.Optional.of(newAssignment))
       }
       admin.alterPartitionReassignments(reassignments).all().get(30, TimeUnit.SECONDS)
+      TestUtils.waitUntilTrue(
+        () => admin.listPartitionReassignments().reassignments().get().isEmpty,
+        msg = "The reassignment never completed.", waitTimeMs = 30000)
       verifyAssignments(partitionList, topicWithAllPartitionsOnAllRacks, topicWithSingleRackPartitions)
 
     } finally {


### PR DESCRIPTION
I have looked at the recent failures of this test and they are always at the same place (L252 before this change). Therefore, I suspect that the partition assignment may be the cause. This patch add logic to wait until it completes before proceeding. Let's see if it helps.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
