### PR TITLE
[MINOR] remove the currentStream.close() statement causing exit code issue 

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/ToolsTestUtils.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ToolsTestUtils.java
@@ -47,7 +47,6 @@ public class ToolsTestUtils {
             else
                 System.setOut(currentStream);
 
-            currentStream.close();
             tempStream.close();
         }
     }


### PR DESCRIPTION
currentStream shouldn't be closed as it is std err or std out. Only tempStream should be closed.

This is related to **MetadataQuorumCommandTest** test, the output ends because stdout was closed. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
