### PR TITLE
KAFKA-15129;[1/N] Remove metrics in LogCleanerManager when LogCleaner shutdown

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -179,6 +179,7 @@ class LogCleaner(initialConfig: CleanerConfig,
    */
   def removeMetrics(): Unit = {
     LogCleaner.MetricNames.foreach(metricsGroup.removeMetric)
+    cleanerManager.removeMetrics()
   }
 
   /**

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -92,16 +92,18 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
   GaugeMetricNameWithTag.clear()
   /* gauges for tracking the number of partitions marked as uncleanable for each log directory */
   for (dir <- logDirs) {
+    val metricTag = Map("logDirectory" -> dir.getAbsolutePath).asJava
     metricsGroup.newGauge(UncleanablePartitionsCountMetricName,
       () => inLock(lock) { uncleanablePartitions.get(dir.getAbsolutePath).map(_.size).getOrElse(0) },
-      Map("logDirectory" -> dir.getAbsolutePath).asJava
+      metricTag
     )
     GaugeMetricNameWithTag.computeIfAbsent(UncleanablePartitionsCountMetricName, k => new java.util.ArrayList[java.util.Map[String, String]]())
-      .add(Map("logDirectory" -> dir.getAbsolutePath).asJava)
+      .add(metricTag)
   }
 
   /* gauges for tracking the number of uncleanable bytes from uncleanable partitions for each log directory */
   for (dir <- logDirs) {
+    val metricTag = Map("logDirectory" -> dir.getAbsolutePath).asJava
     metricsGroup.newGauge(UncleanableBytesMetricName,
       () => inLock(lock) {
         uncleanablePartitions.get(dir.getAbsolutePath) match {
@@ -120,10 +122,10 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
           case None => 0
         }
       },
-      Map("logDirectory" -> dir.getAbsolutePath).asJava
+      metricTag
     )
     GaugeMetricNameWithTag.computeIfAbsent(UncleanableBytesMetricName, k => new java.util.ArrayList[java.util.Map[String, String]]())
-      .add(Map("logDirectory" -> dir.getAbsolutePath).asJava)
+      .add(metricTag)
   }
 
   /* a gauge for tracking the cleanable ratio of the dirtiest log */

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -95,6 +95,7 @@ class LogCleanerTest {
 
       // assert that we have verified all invocations on
       verifyNoMoreInteractions(mockMetricsGroup)
+      verifyNoMoreInteractions(mockLogCleanerManagerMetricsGroup)
     } finally {
       mockMetricsGroupCtor.close()
     }

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -90,8 +90,9 @@ class LogCleanerTest {
       // verify that each metric in `LogCleanerManager` is removed
       val mockLogCleanerManagerMetricsGroup = mockMetricsGroupCtor.constructed.get(1)
       LogCleanerManager.GaugeMetricNameNoTag.foreach(metricName => verify(mockLogCleanerManagerMetricsGroup).newGauge(ArgumentMatchers.eq(metricName), any()))
-      LogCleanerManager.GaugeMetricNameWithTag.foreach(metricName => verify(mockLogCleanerManagerMetricsGroup).newGauge(ArgumentMatchers.eq(metricName), any(), any()))
-      LogCleanerManager.MetricNames.foreach(verify(mockLogCleanerManagerMetricsGroup).removeMetric(_))
+      LogCleanerManager.GaugeMetricNameWithTag.keySet().asScala.foreach(metricName => verify(mockLogCleanerManagerMetricsGroup).newGauge(ArgumentMatchers.eq(metricName), any(), any()))
+      LogCleanerManager.GaugeMetricNameNoTag.foreach(verify(mockLogCleanerManagerMetricsGroup).removeMetric(_))
+      LogCleanerManager.GaugeMetricNameWithTag.keySet().asScala.foreach(metricName => verify(mockLogCleanerManagerMetricsGroup).removeMetric(ArgumentMatchers.eq(metricName), any()))
 
       // assert that we have verified all invocations on
       verifyNoMoreInteractions(mockMetricsGroup)


### PR DESCRIPTION
This pr is used to remove the metrics in LogCleanerManager when logCleaner is closed.
This pr has passed the corresponding unit test, and it is part of KAFKA-15129.