### PR TITLE
KAFKA-15097: prevent server shutdown when source file not exists

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -981,6 +981,8 @@ public final class Utils {
                 Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
                 log.debug("Non-atomic move of {} to {} succeeded after atomic move failed due to {}", source, target,
                         outer.getMessage());
+            } catch (NoSuchFileException noSuch) {
+                log.debug("Source file not exists, supress exception to prevent server shutdown", noSuch);
             } catch (IOException inner) {
                 inner.addSuppressed(outer);
                 throw inner;
@@ -991,6 +993,7 @@ public final class Utils {
             }
         }
     }
+
 
     /**
      * Flushes dirty directories to guarantee crash consistency.

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -982,8 +982,8 @@ public final class Utils {
                 log.debug("Non-atomic move of {} to {} succeeded after atomic move failed due to {}", source, target,
                         outer.getMessage());
             } catch (NoSuchFileException noSuch) {
-                log.debug("Source file not exists, supress exception to prevent server shutdown", noSuch);
-            } catch (IOException inner) {
+                log.debug("Source file {} not exists, supress exception to prevent server shutdown", source, noSuch);
+            } catch (IOException inner) {j
                 inner.addSuppressed(outer);
                 throw inner;
             }

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -983,7 +983,7 @@ public final class Utils {
                         outer.getMessage());
             } catch (NoSuchFileException noSuch) {
                 log.debug("Source file {} not exists, supress exception to prevent server shutdown", source, noSuch);
-            } catch (IOException inner) {j
+            } catch (IOException inner) {
                 inner.addSuppressed(outer);
                 throw inner;
             }

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -981,8 +981,6 @@ public final class Utils {
                 Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
                 log.debug("Non-atomic move of {} to {} succeeded after atomic move failed due to {}", source, target,
                         outer.getMessage());
-            } catch (NoSuchFileException noSuch) {
-                log.debug("Source file {} not exists, supress exception to prevent server shutdown", source, noSuch);
             } catch (IOException inner) {
                 inner.addSuppressed(outer);
                 throw inner;


### PR DESCRIPTION
catch NoSuchFileException on atomicMoveWithFallback this catch block will prevent throws NoSuchFileException and stop kafka server in Kraft Mode

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
