### PR TITLE
KAFKA-15134:Enrich the prompt reason in CommitFailedException

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/CommitFailedException.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/CommitFailedException.java
@@ -28,16 +28,22 @@ public class CommitFailedException extends KafkaException {
 
     private static final long serialVersionUID = 1L;
 
+    private static final String UNREASONABLE_PARAMETERS_REASON = "This means that the time " +
+            "between subsequent calls to poll() was longer than the configured max.poll.interval.ms, " +
+            "which typically implies that the poll loop is spending too much time message processing. " +
+            "You can address this either by increasing max.poll.interval.ms or by reducing the maximum " +
+            "size of batches returned in poll() with max.poll.records.";
+    private static final String CONFLICT_GROUP_ID_REASON = "This means that when the high level consumer is " +
+            "consuming in a stable state, a simple consumer with the same name group id will fail when committing offset.";
+
     public CommitFailedException(final String message) {
         super(message);
     }
 
     public CommitFailedException() {
-        super("Commit cannot be completed since the group has already " +
-                "rebalanced and assigned the partitions to another member. This means that the time " +
-                "between subsequent calls to poll() was longer than the configured max.poll.interval.ms, " +
-                "which typically implies that the poll loop is spending too much time message processing. " +
-                "You can address this either by increasing max.poll.interval.ms or by reducing the maximum " +
-                "size of batches returned in poll() with max.poll.records.");
+        super("Commit cannot be completed since the group has already rebalanced and assigned the partitions to another " +
+                "member. There may be two scenarios, 1: " + UNREASONABLE_PARAMETERS_REASON + "\n" +
+                "2: " + CONFLICT_GROUP_ID_REASON
+        );
     }
 }


### PR DESCRIPTION
### Motivation
Firstly, let me post the exception log of the client running:

_"org.apache.kafka.clients.consumer.CommitFailedException: Commit cannot be completed since the group has already rebalanced and assigned the partitions to another member. This means that the time between subsequent calls to poll() was longer than the configured max.poll.interval.ms, which typically implies that the poll loop is spending too much time message processing. You can address this either by increasing max.poll.interval.ms or by reducing the maximum size of batches returned in poll() with max.poll.records."_

This is the client exception log provided to us by the online business. First, we confirmed that there is no issue on the server brokers. Then according to the exception prompt information, it may be judged that the settings of "max.poll.interval.ms" and "max.poll.records" may be unreasonable, but the actual processing time of business printing is much shorter than "max.poll.interval.ms", so We're sure that's not the reason. In the end, it was found that there is such a case: the business uses a "group id" to subscribe to some partitions of "topic1" through the simple consumer mode, and set "auto.offset.reset=false". When using the same "group id" name to start a high level consumer on "topic2", the original service using simple consumer throws CommitFailedException. And I have reproduced this process.

### Solution
In fact, this is not a bug, but a problem with the way the client is used, but I think the exception message of `CommitFailedException` may have imperfect and  misleading guidance, so I have enriched the message that there may be special situations.