### PR TITLE
KAFKA-14133: Migrate ProcessorStateManagerTest and StreamThreadTest to Mockito

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -41,16 +41,14 @@ import org.apache.kafka.streams.state.internals.StoreQueryUtils;
 import org.apache.kafka.test.MockKeyValueStore;
 import org.apache.kafka.test.MockRestoreCallback;
 import org.apache.kafka.test.TestUtils;
-import org.easymock.EasyMock;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
-import org.easymock.MockType;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -71,12 +69,6 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.apache.kafka.streams.processor.internals.StateManagerUtil.CHECKPOINT_FILE_NAME;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.reset;
-import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -88,8 +80,13 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(EasyMockRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class ProcessorStateManagerTest {
 
     private final String applicationId = "test-application";
@@ -125,11 +122,11 @@ public class ProcessorStateManagerTest {
     private OffsetCheckpoint checkpoint;
     private StateDirectory stateDirectory;
 
-    @Mock(type = MockType.NICE)
+    @Mock
     private StateStore store;
-    @Mock(type = MockType.NICE)
+    @Mock
     private StateStoreMetadata storeMetadata;
-    @Mock(type = MockType.NICE)
+    @Mock
     private InternalProcessorContext context;
 
     @Before
@@ -145,11 +142,6 @@ public class ProcessorStateManagerTest {
         }), new MockTime(), true, true);
         checkpointFile = new File(stateDirectory.getOrCreateDirectoryForTask(taskId), CHECKPOINT_FILE_NAME);
         checkpoint = new OffsetCheckpoint(checkpointFile);
-
-        expect(storeMetadata.changelogPartition()).andReturn(persistentStorePartition).anyTimes();
-        expect(storeMetadata.store()).andReturn(store).anyTimes();
-        expect(store.name()).andReturn(persistentStoreName).anyTimes();
-        replay(storeMetadata, store);
     }
 
     @After
@@ -311,29 +303,21 @@ public class ProcessorStateManagerTest {
     @Test
     public void shouldUnregisterChangelogsDuringClose() {
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
-        reset(storeMetadata);
-        final StateStore store = EasyMock.createMock(StateStore.class);
-        expect(storeMetadata.changelogPartition()).andStubReturn(persistentStorePartition);
-        expect(storeMetadata.store()).andStubReturn(store);
-        expect(store.name()).andStubReturn(persistentStoreName);
-
-        context.uninitialize();
-        store.init((StateStoreContext) context, store);
-        replay(storeMetadata, context, store);
+        final StateStore store = mock(StateStore.class);
+        when(store.name()).thenReturn(persistentStoreName);
 
         stateMgr.registerStateStores(singletonList(store), context);
-        verify(context, store);
+
+        verify(context).uninitialize();
+        verify(store).init((StateStoreContext) context, store);
 
         stateMgr.registerStore(store, noopStateRestoreCallback, null);
         assertTrue(changelogReader.isPartitionRegistered(persistentStorePartition));
 
-        reset(store);
-        expect(store.name()).andStubReturn(persistentStoreName);
-        store.close();
-        replay(store);
+        when(store.name()).thenReturn(persistentStoreName);
 
         stateMgr.close();
-        verify(store);
+        verify(store).close();
 
         assertFalse(changelogReader.isPartitionRegistered(persistentStorePartition));
     }
@@ -341,18 +325,12 @@ public class ProcessorStateManagerTest {
     @Test
     public void shouldRecycleStoreAndReregisterChangelog() {
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
-        reset(storeMetadata);
-        final StateStore store = EasyMock.createMock(StateStore.class);
-        expect(storeMetadata.changelogPartition()).andStubReturn(persistentStorePartition);
-        expect(storeMetadata.store()).andStubReturn(store);
-        expect(store.name()).andStubReturn(persistentStoreName);
-
-        context.uninitialize();
-        store.init((StateStoreContext) context, store);
-        replay(storeMetadata, context, store);
+        final StateStore store = mock(StateStore.class);
+        when(store.name()).thenReturn(persistentStoreName);
 
         stateMgr.registerStateStores(singletonList(store), context);
-        verify(context, store);
+        verify(context).uninitialize();
+        verify(store).init((StateStoreContext) context, store);
 
         stateMgr.registerStore(store, noopStateRestoreCallback, null);
         assertTrue(changelogReader.isPartitionRegistered(persistentStorePartition));
@@ -361,33 +339,23 @@ public class ProcessorStateManagerTest {
         assertFalse(changelogReader.isPartitionRegistered(persistentStorePartition));
         assertThat(stateMgr.getStore(persistentStoreName), equalTo(store));
 
-        reset(context, store);
-        context.uninitialize();
-        expect(store.name()).andStubReturn(persistentStoreName);
-        replay(context, store);
+        when(store.name()).thenReturn(persistentStoreName);
 
         stateMgr.registerStateStores(singletonList(store), context);
 
-        verify(context, store);
+        verify(context, times(2)).uninitialize();
         assertTrue(changelogReader.isPartitionRegistered(persistentStorePartition));
     }
 
     @Test
     public void shouldClearStoreCache() {
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
-        reset(storeMetadata);
-        final CachingStore store = EasyMock.createMock(CachingStore.class);
-        expect(storeMetadata.changelogPartition()).andStubReturn(persistentStorePartition);
-        expect(storeMetadata.store()).andStubReturn(store);
-        expect(store.name()).andStubReturn(persistentStoreName);
-        store.clearCache();
-        expectLastCall().once();
-
-        context.uninitialize();
-        store.init((StateStoreContext) context, store);
-        replay(storeMetadata, context, store);
+        final CachingStore store = mock(CachingStore.class);
+        when(store.name()).thenReturn(persistentStoreName);
 
         stateMgr.registerStateStores(singletonList(store), context);
+        verify(context).uninitialize();
+        verify(store).init((StateStoreContext) context, store);
 
         stateMgr.registerStore(store, noopStateRestoreCallback, null);
         assertTrue(changelogReader.isPartitionRegistered(persistentStorePartition));
@@ -395,7 +363,6 @@ public class ProcessorStateManagerTest {
         stateMgr.recycle();
         assertFalse(changelogReader.isPartitionRegistered(persistentStorePartition));
         assertThat(stateMgr.getStore(persistentStoreName), equalTo(store));
-        verify(context, store);
     }
 
     @Test
@@ -1119,10 +1086,8 @@ public class ProcessorStateManagerTest {
     public void shouldThrowOnFailureToWritePositionCheckpointFile() throws IOException {
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
         final CommitCallback persistentCheckpoint = mock(CommitCallback.class);
-        persistentCheckpoint.onCommit();
         final IOException ioException = new IOException("asdf");
-        expectLastCall().andThrow(ioException);
-        replay(persistentCheckpoint);
+        doThrow(ioException).when(persistentCheckpoint).onCommit();
         stateMgr.registerStore(
             persistentStore,
             persistentStore.stateRestoreCallback,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -123,8 +123,6 @@ public class ProcessorStateManagerTest {
     private StateDirectory stateDirectory;
 
     @Mock
-    private StateStore store;
-    @Mock
     private StateStoreMetadata storeMetadata;
     @Mock
     private InternalProcessorContext context;
@@ -314,8 +312,6 @@ public class ProcessorStateManagerTest {
         stateMgr.registerStore(store, noopStateRestoreCallback, null);
         assertTrue(changelogReader.isPartitionRegistered(persistentStorePartition));
 
-        when(store.name()).thenReturn(persistentStoreName);
-
         stateMgr.close();
         verify(store).close();
 
@@ -339,8 +335,6 @@ public class ProcessorStateManagerTest {
         assertFalse(changelogReader.isPartitionRegistered(persistentStorePartition));
         assertThat(stateMgr.getStore(persistentStoreName), equalTo(store));
 
-        when(store.name()).thenReturn(persistentStoreName);
-
         stateMgr.registerStateStores(singletonList(store), context);
 
         verify(context, times(2)).uninitialize();
@@ -363,6 +357,8 @@ public class ProcessorStateManagerTest {
         stateMgr.recycle();
         assertFalse(changelogReader.isPartitionRegistered(persistentStorePartition));
         assertThat(stateMgr.getStore(persistentStoreName), equalTo(store));
+
+        verify(store).clearCache();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1081,7 +1081,6 @@ public class StreamThreadTest {
         when(activeTaskCreator.producerClientIds()).thenReturn(Collections.singleton("producerClientId"));
 
         final StandbyTaskCreator standbyTaskCreator = mock(StandbyTaskCreator.class);
-        when(standbyTaskCreator.createTasks(any())).thenReturn(Collections.emptySet());
 
         final StateUpdater stateUpdater = Mockito.mock(StateUpdater.class);
         final DefaultTaskManager schedulingTaskManager;
@@ -1390,7 +1389,6 @@ public class StreamThreadTest {
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
         final TaskManager taskManager = mock(TaskManager.class);
-        when(taskManager.producerClientIds()).thenReturn(Collections.emptySet());
         doNothing().when(taskManager).shutdown(true);
 
         final StreamsConfig config = new StreamsConfig(configProps(false));
@@ -1412,7 +1410,6 @@ public class StreamThreadTest {
     @Test
     public void shouldNotReturnDataAfterTaskMigrated() {
         final TaskManager taskManager = mock(TaskManager.class);
-        when(taskManager.producerClientIds()).thenReturn(Collections.emptySet());
         final InternalTopologyBuilder internalTopologyBuilder = mock(InternalTopologyBuilder.class);
         when(internalTopologyBuilder.fullSourceTopicNames()).thenReturn(Collections.singletonList(topic1));
 
@@ -1488,7 +1485,6 @@ public class StreamThreadTest {
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
         final TaskManager taskManager = mock(TaskManager.class);
-        when(taskManager.producerClientIds()).thenReturn(Collections.emptySet());
         doNothing().when(taskManager).shutdown(true);
 
         final StreamsConfig config = new StreamsConfig(configProps(false));
@@ -1507,7 +1503,6 @@ public class StreamThreadTest {
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
         final TaskManager taskManager = mock(TaskManager.class);
-        when(taskManager.producerClientIds()).thenReturn(Collections.emptySet());
         doNothing().when(taskManager).shutdown(true);
 
         final StreamsConfig config = new StreamsConfig(configProps(false));
@@ -2571,7 +2566,6 @@ public class StreamThreadTest {
         final Set<TopicPartition> assignedPartitions = Collections.singleton(t1p1);
 
         final TaskManager taskManager = mock(TaskManager.class);
-        when(taskManager.producerClientIds()).thenReturn(Collections.emptySet());
         final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
         consumer.assign(assignedPartitions);
         consumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
@@ -2601,7 +2595,6 @@ public class StreamThreadTest {
         final Set<TopicPartition> assignedPartitions = Collections.singleton(t1p1);
 
         final TaskManager taskManager = mock(TaskManager.class);
-        when(taskManager.producerClientIds()).thenReturn(Collections.emptySet());
         final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
         consumer.assign(assignedPartitions);
         consumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
@@ -2630,7 +2623,6 @@ public class StreamThreadTest {
     public void shouldCatchHandleCorruptionOnTaskCorruptedExceptionPath() {
         final StreamsConfig config = new StreamsConfig(configProps(false));
         final TaskManager taskManager = mock(TaskManager.class);
-        when(taskManager.producerClientIds()).thenReturn(Collections.emptySet());
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         doNothing().when(consumer).subscribe((Collection<String>) any(), any());
@@ -2689,7 +2681,6 @@ public class StreamThreadTest {
     public void shouldCatchTimeoutExceptionFromHandleCorruptionAndInvokeExceptionHandler() {
         final StreamsConfig config = new StreamsConfig(configProps(false));
         final TaskManager taskManager = mock(TaskManager.class);
-        when(taskManager.producerClientIds()).thenReturn(Collections.emptySet());
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -2754,7 +2745,6 @@ public class StreamThreadTest {
     public void shouldCatchTaskMigratedExceptionOnOnTaskCorruptedExceptionPath() {
         final StreamsConfig config = new StreamsConfig(configProps(false));
         final TaskManager taskManager = mock(TaskManager.class);
-        when(taskManager.producerClientIds()).thenReturn(Collections.emptySet());
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -2818,7 +2808,6 @@ public class StreamThreadTest {
     public void shouldEnforceRebalanceWhenTaskCorruptedExceptionIsThrownForAnActiveTask() {
         final StreamsConfig config = new StreamsConfig(configProps(true));
         final TaskManager taskManager = mock(TaskManager.class);
-        when(taskManager.producerClientIds()).thenReturn(Collections.emptySet());
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -2882,7 +2871,6 @@ public class StreamThreadTest {
         final StreamsConfig config = new StreamsConfig(configProps(true));
         final TaskManager taskManager = mock(TaskManager.class);
         when(taskManager.producerClientIds()).thenReturn(Collections.emptySet());
-
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -3151,7 +3139,6 @@ public class StreamThreadTest {
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
         final TaskManager taskManager = mock(TaskManager.class);
-        when(taskManager.producerClientIds()).thenReturn(Collections.emptySet());
         final StreamsMetricsImpl streamsMetrics =
             new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST, mockTime);
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);


### PR DESCRIPTION
This pull request is an attempt to get what has started in https://github.com/apache/kafka/pull/12524 to completion as part of the Streams project migration to Mockito.
