### PR TITLE
MINOR: Replace synchronization with atomic update in Connect's StateTracker::changeState method

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/StateTracker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/StateTracker.java
@@ -30,16 +30,12 @@ public class StateTracker {
 
     /**
      * Change the current state.
-     * <p>
-     * This method is synchronized to ensure that all state changes are captured correctly and in the same order.
-     * Synchronization is acceptable since it is assumed that state changes will be relatively infrequent.
      *
      * @param newState the current state; may not be null
      * @param now      the current time in milliseconds
      */
-    public synchronized void changeState(State newState, long now) {
-        // JDK8: remove synchronization by using lastState.getAndUpdate(oldState->oldState.newState(newState, now));
-        lastState.set(lastState.get().newState(newState, now));
+    public void changeState(State newState, long now) {
+        lastState.getAndUpdate(oldState -> oldState.newState(newState, now));
     }
 
     /**


### PR DESCRIPTION
- https://github.com/apache/kafka/pull/3911#discussion_r140613801
- Support for Java 7 was dropped in `2.0.0` 5 years ago ([KIP-118](https://cwiki.apache.org/confluence/display/KAFKA/KIP-118%3A+Drop+Support+for+Java+7)).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
