### PR TITLE
MINOR: Fix debug logs to display TimeIndexOffset

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TimeIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TimeIndex.java
@@ -66,7 +66,7 @@ public class TimeIndex extends AbstractIndex {
         this.lastEntry = lastEntryFromIndexFile();
 
         log.debug("Loaded index file {} with maxEntries = {}, maxIndexSize = {}, entries = {}, lastOffset = {}, file position = {}",
-            file.getAbsolutePath(), maxEntries(), maxIndexSize, entries(), lastEntry, mmap().position());
+            file.getAbsolutePath(), maxEntries(), maxIndexSize, entries(), lastEntry.offset, mmap().position());
     }
 
     @Override
@@ -278,7 +278,7 @@ public class TimeIndex extends AbstractIndex {
             super.truncateToEntries0(entries);
             this.lastEntry = lastEntryFromIndexFile();
             log.debug("Truncated index {} to {} entries; position is now {} and last entry is now {}",
-                file().getAbsolutePath(), entries, mmap().position(), lastEntry);
+                file().getAbsolutePath(), entries, mmap().position(), lastEntry.offset);
         } finally {
             lock.unlock();
         }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TimestampOffset.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TimestampOffset.java
@@ -67,4 +67,11 @@ public class TimestampOffset implements IndexEntry {
         result = 31 * result + Long.hashCode(offset);
         return result;
     }
+
+    @Override
+    public String toString() {
+        return String.format("TimestampOffset(offset = %d, timestamp = %d)",
+            offset,
+            timestamp);
+    }
 }


### PR DESCRIPTION
This change correctly prints the offset associated with a time index entry instead of printing the reference of the Java object. 

**Debug logs before this change:**
Notice the value of `last entry is now` string in the logs
```
[2023-06-29 16:54:14,753] DEBUG Truncated index /var/folders/b7/gtty4gtx1nxcnd9qwgqr536m0000gr/T/kafka15182151620663328910.tmp to 0 entries; position is now 0 and last entry is now org.apache.kafka.storage.internals.log.TimestampOffset@2d (org.apache.kafka.storage.internals.log.TimeIndex:280)
```

Notice the value of `lastOffset =` string in the logs
```
[2023-06-29 17:00:29,768] DEBUG Loaded index file /var/folders/b7/gtty4gtx1nxcnd9qwgqr536m0000gr/T/kafka12970272451741393509.tmp with maxEntries = 30, maxIndexSize = 360, entries = 0, lastOffset = org.apache.kafka.storage.internals.log.TimestampOffset@2d, file position = 0 (org.apache.kafka.storage.internals.log.TimeIndex:68)
```

**Debug logs after this change:**
```
[2023-06-29 17:06:11,621] DEBUG Truncated index /var/folders/b7/gtty4gtx1nxcnd9qwgqr536m0000gr/T/kafka10329570089261941057.tmp to 0 entries; position is now 0 and last entry is now 45 (org.apache.kafka.storage.internals.log.TimeIndex:280)
```

```
[2023-06-29 17:32:05,351] DEBUG Loaded index file /var/folders/b7/gtty4gtx1nxcnd9qwgqr536m0000gr/T/kafka17205967388538316017.tmp with maxEntries = 30, maxIndexSize = 360, entries = 0, lastOffset = 45, file position = 0 (org.apache.kafka.storage.internals.log.TimeIndex:68)
```