### PR TITLE
MINOR: Refactor & cleanup for RemoteIndexCache

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -571,7 +571,7 @@ public class RemoteLogManager implements Closeable {
             String logFileName = logFile.getName();
 
             logger.info("Copying {} to remote storage.", logFileName);
-            RemoteLogSegmentId id = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
+            RemoteLogSegmentId id = RemoteLogSegmentId.generateNew(topicIdPartition);
 
             long endOffset = nextSegmentBaseOffset - 1;
             File producerStateSnapshotFile = log.producerStateManager().fetchSnapshot(nextSegmentBaseOffset).orElse(null);

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -18,8 +18,8 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
-log4j.logger.kafka=WARN
-log4j.logger.org.apache.kafka=WARN
+log4j.logger.kafka=DEBUG
+log4j.logger.org.apache.kafka=DEBUG
 
 
 # zkclient can be verbose, during debugging it is common to adjust it separately

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -18,8 +18,8 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
-log4j.logger.kafka=DEBUG
-log4j.logger.org.apache.kafka=DEBUG
+log4j.logger.kafka=WARN
+log4j.logger.org.apache.kafka=WARN
 
 
 # zkclient can be verbose, during debugging it is common to adjust it separately

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -17,7 +17,7 @@
 package kafka.log.remote
 
 import kafka.log.UnifiedLog
-import kafka.log.remote.RemoteIndexCache.{RemoteLogIndexCacheCleanerThread, RemoteOffsetIndexFile, RemoteOffsetIndexFileName, RemoteTimeIndexFile, RemoteTimeIndexFileName, RemoteTransactionIndexFile, RemoteTransactionIndexFileName}
+import kafka.log.remote.RemoteIndexCache.{RemoteLogIndexCacheCleanerThread, remoteOffsetIndexFile, remoteOffsetIndexFileName, remoteTimeIndexFile, remoteTimeIndexFileName, remoteTransactionIndexFile, remoteTransactionIndexFileName}
 import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType
 import org.apache.kafka.server.log.remote.storage.{RemoteLogSegmentId, RemoteLogSegmentMetadata, RemoteStorageManager}
@@ -104,9 +104,9 @@ class RemoteIndexCacheTest {
     val txnIndexFile = entry.txnIndex.file().toPath
     val timeIndexFile = entry.timeIndex.file().toPath
 
-    val expectedOffsetIndexFileName: String = RemoteOffsetIndexFileName(rlsMetadata)
-    val expectedTimeIndexFileName: String = RemoteTimeIndexFileName(rlsMetadata)
-    val expectedTxnIndexFileName: String = RemoteTransactionIndexFileName(rlsMetadata)
+    val expectedOffsetIndexFileName: String = remoteOffsetIndexFileName(rlsMetadata)
+    val expectedTimeIndexFileName: String = remoteTimeIndexFileName(rlsMetadata)
+    val expectedTxnIndexFileName: String = remoteTransactionIndexFileName(rlsMetadata)
 
     assertEquals(expectedOffsetIndexFileName, offsetIndexFile.getFileName.toString)
     assertEquals(expectedTxnIndexFileName, txnIndexFile.getFileName.toString)
@@ -479,19 +479,19 @@ class RemoteIndexCacheTest {
   }
 
   private def createTxIndexForSegmentMetadata(metadata: RemoteLogSegmentMetadata): TransactionIndex = {
-    val txnIdxFile = RemoteTransactionIndexFile(tpDir, metadata)
+    val txnIdxFile = remoteTransactionIndexFile(tpDir, metadata)
     txnIdxFile.createNewFile()
     new TransactionIndex(metadata.startOffset(), txnIdxFile)
   }
 
   private def createTimeIndexForSegmentMetadata(metadata: RemoteLogSegmentMetadata): TimeIndex = {
     val maxEntries = (metadata.endOffset() - metadata.startOffset()).asInstanceOf[Int]
-    new TimeIndex(RemoteTimeIndexFile(tpDir, metadata), metadata.startOffset(), maxEntries * 12)
+    new TimeIndex(remoteTimeIndexFile(tpDir, metadata), metadata.startOffset(), maxEntries * 12)
   }
 
   private def createOffsetIndexForSegmentMetadata(metadata: RemoteLogSegmentMetadata) = {
     val maxEntries = (metadata.endOffset() - metadata.startOffset()).asInstanceOf[Int]
-    new OffsetIndex(RemoteOffsetIndexFile(tpDir, metadata), metadata.startOffset(), maxEntries * 8)
+    new OffsetIndex(remoteOffsetIndexFile(tpDir, metadata), metadata.startOffset(), maxEntries * 8)
   }
 
   private def generateRemoteLogSegmentMetadata(size: Int,

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -43,7 +43,7 @@ class RemoteIndexCacheTest {
   private val logger: Logger = LoggerFactory.getLogger(classOf[RemoteIndexCacheTest])
   private val time = new MockTime()
   private val brokerId = 1
-  private val baseOffset: Long = Int.MaxValue.toLong + 10_1337L // start with a base offset which is a long
+  private val baseOffset: Long = Int.MaxValue.toLong + 101337 // start with a base offset which is a long
   private val lastOffset: Long = baseOffset + 30L
   private val segmentSize: Int = 1024
   private val rsm: RemoteStorageManager = mock(classOf[RemoteStorageManager])

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1382,9 +1382,14 @@ object TestUtils extends Logging {
     val nonDaemonThreads = Thread.getAllStackTraces.keySet.asScala.filter { t =>
       !t.isDaemon && t.isAlive && t.getName.startsWith(threadNamePrefix)
     }
-
     val threadCount = nonDaemonThreads.size
     assertEquals(0, threadCount, s"Found unexpected $threadCount NonDaemon threads=${nonDaemonThreads.map(t => t.getName).mkString(", ")}")
+  }
+
+  def numThreadsRunning(threadNamePrefix: String, isDaemon: Boolean): mutable.Set[Thread] = {
+    Thread.getAllStackTraces.keySet.asScala.filter { t =>
+      isDaemon && t.isAlive && t.getName.startsWith(threadNamePrefix)
+    }
   }
 
   def allThreadStackTraces(): String = {

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentId.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentId.java
@@ -33,6 +33,16 @@ public class RemoteLogSegmentId {
     private final TopicIdPartition topicIdPartition;
     private final Uuid id;
 
+    /**
+     * Creates a new {@link RemoteLogSegmentId} for the provided {@link TopicIdPartition} with a random Uuid.
+     *
+     * @param topicIdPartition TopicIdPartition of this remote log segment.
+     * @return generated RemoteLogSegmentId.
+     */
+    public static RemoteLogSegmentId generateNew(TopicIdPartition topicIdPartition) {
+        return new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
+    }
+
     public RemoteLogSegmentId(TopicIdPartition topicIdPartition, Uuid id) {
         this.topicIdPartition = Objects.requireNonNull(topicIdPartition, "topicIdPartition can not be null");
         this.id = Objects.requireNonNull(id, "id can not be null");

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadata.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadata.java
@@ -106,9 +106,9 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
         }
         this.startOffset = startOffset;
 
-        if (endOffset < 0) {
+        if (endOffset < startOffset) {
             throw new IllegalArgumentException(
-                String.format("Unexpected end offset = %d. EndOffset for a remote segment cannot negative", endOffset));
+                String.format("Unexpected end offset = %d. EndOffset for a remote segment cannot be less than startOffset {}", endOffset, startOffset));
         }
         this.endOffset = endOffset;
         this.maxTimestampMs = maxTimestampMs;

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadata.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadata.java
@@ -101,14 +101,13 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
         this.state = Objects.requireNonNull(state, "state can not be null");
 
         if (startOffset < 0) {
-            throw new IllegalArgumentException(
-                String.format("Unexpected start offset = %d. StartOffset for a remote segment cannot negative", startOffset));
+            throw new IllegalArgumentException("Unexpected start offset = " + startOffset + ". StartOffset for a remote segment cannot be negative");
         }
         this.startOffset = startOffset;
 
         if (endOffset < startOffset) {
-            throw new IllegalArgumentException(
-                String.format("Unexpected end offset = %d. EndOffset for a remote segment cannot be less than startOffset %d", endOffset, startOffset));
+            throw new IllegalArgumentException("Unexpected end offset = " + endOffset + 
+                                               ". EndOffset for a remote segment cannot be less than startOffset = " + startOffset);
         }
         this.endOffset = endOffset;
         this.maxTimestampMs = maxTimestampMs;

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadata.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadata.java
@@ -108,7 +108,7 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
 
         if (endOffset < startOffset) {
             throw new IllegalArgumentException(
-                String.format("Unexpected end offset = %d. EndOffset for a remote segment cannot be less than startOffset {}", endOffset, startOffset));
+                String.format("Unexpected end offset = %d. EndOffset for a remote segment cannot be less than startOffset %d", endOffset, startOffset));
         }
         this.endOffset = endOffset;
         this.maxTimestampMs = maxTimestampMs;

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadata.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadata.java
@@ -100,7 +100,16 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
         this.remoteLogSegmentId = Objects.requireNonNull(remoteLogSegmentId, "remoteLogSegmentId can not be null");
         this.state = Objects.requireNonNull(state, "state can not be null");
 
+        if (startOffset < 0) {
+            throw new IllegalArgumentException(
+                String.format("Unexpected start offset = %d. StartOffset for a remote segment cannot negative", startOffset));
+        }
         this.startOffset = startOffset;
+
+        if (endOffset < 0) {
+            throw new IllegalArgumentException(
+                String.format("Unexpected end offset = %d. EndOffset for a remote segment cannot negative", endOffset));
+        }
         this.endOffset = endOffset;
         this.maxTimestampMs = maxTimestampMs;
         this.segmentSizeInBytes = segmentSizeInBytes;


### PR DESCRIPTION
**Changes**
1. Add new unit tests
2. Change the on-disk filename from `<offset>_<uuid>_.<indexSuffix>` to `<offset>_<uuid>.<indexSuffix>` i.e. remove trailing underscore after <uuid>
3. Fix a small bug where we were parsing offset as Int when reading the file name from disk. Offset is long.
4. Perform input validation in RemoteLogSegmentMetadata.
5. Remove an extra loop in cleaner thread. Shutdownable thread already performs looping.