### PR TITLE
KAFKA-15121: Implement the alterOffsets method in the FileStreamSourceConnector and the FileStreamSinkConnector

### DIFF
--- a/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSinkConnector.java
+++ b/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSinkConnector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.file;
 
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -78,5 +79,12 @@ public class FileStreamSinkConnector extends SinkConnector {
     @Override
     public ConfigDef config() {
         return CONFIG_DEF;
+    }
+
+    @Override
+    public boolean alterOffsets(Map<String, String> connectorConfig, Map<TopicPartition, Long> offsets) {
+        // Nothing to do here since FileStreamSinkConnector does not manage offsets externally nor does it require any
+        // custom offset validation
+        return true;
     }
 }

--- a/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceConnector.java
+++ b/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceConnector.java
@@ -110,7 +110,6 @@ public class FileStreamSourceConnector extends SourceConnector {
         AbstractConfig config = new AbstractConfig(CONFIG_DEF, connectorConfig);
         String filename = config.getString(FILE_CONFIG);
         if (filename == null || filename.isEmpty()) {
-            // If the 'file' configuration is unspecified, stdin is used and no offsets are tracked
             throw new ConnectException("Offsets cannot be modified if the '" + FILE_CONFIG + "' configuration is unspecified. " +
                     "This is because stdin is used for input and offsets are not tracked.");
         }
@@ -130,7 +129,7 @@ public class FileStreamSourceConnector extends SourceConnector {
             Map<String, ?> offset = partitionOffset.getValue();
             // null offsets are allowed and represent a deletion of offsets for a partition
             if (offset == null) {
-                return true;
+                continue;
             }
 
             if (!offset.containsKey(POSITION_FIELD)) {

--- a/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceConnector.java
+++ b/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceConnector.java
@@ -137,13 +137,13 @@ public class FileStreamSourceConnector extends SourceConnector {
             }
 
             // The 'position' in the offset represents the position in the file's byte stream and should be a non-negative long value
-            try {
-                long offsetPosition = Long.parseLong(String.valueOf(offset.get(POSITION_FIELD)));
-                if (offsetPosition < 0) {
-                    throw new ConnectException("The value for the '" + POSITION_FIELD + "' key in the offset should be a non-negative number");
-                }
-            } catch (NumberFormatException e) {
-                throw new ConnectException("The value for the '" + POSITION_FIELD + "' key in the offset should be a number");
+            if (!(offset.get(POSITION_FIELD) instanceof Long)) {
+                throw new ConnectException("The value for the '" + POSITION_FIELD + "' key in the offset is expected to be a Long value");
+            }
+
+            long offsetPosition = (Long) offset.get(POSITION_FIELD);
+            if (offsetPosition < 0) {
+                throw new ConnectException("The value for the '" + POSITION_FIELD + "' key in the offset should be a non-negative value");
             }
         }
 

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
@@ -163,29 +163,25 @@ public class FileStreamSourceConnectorTest {
     }
 
     @Test
+    public void testAlterOffsetsIncorrectPartitionKey() {
+        assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, Collections.singletonMap(
+                Collections.singletonMap("invalid_partition_key", FILENAME),
+                Collections.singletonMap(POSITION_FIELD, 0)
+        )));
+
+        // null partitions are invalid
+        assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, Collections.singletonMap(
+                null,
+                Collections.singletonMap(POSITION_FIELD, 0)
+        )));
+    }
+
+    @Test
     public void testAlterOffsetsMultiplePartitions() {
         Map<Map<String, ?>, Map<String, ?>> offsets = new HashMap<>();
         offsets.put(Collections.singletonMap(FILENAME_FIELD, FILENAME), Collections.singletonMap(POSITION_FIELD, 0));
-        offsets.put(Collections.singletonMap(FILENAME_FIELD, "/someotherfilename"), Collections.singletonMap(POSITION_FIELD, 0));
-        assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, offsets));
-    }
-
-    @Test
-    public void testAlterOffsetsIncorrectPartitionKey() {
-        Map<Map<String, ?>, Map<String, ?>> offsets = Collections.singletonMap(
-                Collections.singletonMap("invalid_partition_key", FILENAME),
-                Collections.singletonMap(POSITION_FIELD, 0)
-        );
-        assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, offsets));
-    }
-
-    @Test
-    public void testAlterOffsetsIncorrectPartitionValue() {
-        Map<Map<String, ?>, Map<String, ?>> offsets = Collections.singletonMap(
-                Collections.singletonMap(FILENAME_FIELD, "/someotherfilename"),
-                Collections.singletonMap(POSITION_FIELD, 0)
-        );
-        assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, offsets));
+        offsets.put(Collections.singletonMap(FILENAME_FIELD, "/someotherfilename"), null);
+        connector.alterOffsets(sourceProperties, offsets);
     }
 
     @Test

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import static org.apache.kafka.connect.file.FileStreamSourceTask.FILENAME_FIELD;
 import static org.apache.kafka.connect.file.FileStreamSourceTask.POSITION_FIELD;
@@ -196,45 +197,19 @@ public class FileStreamSourceConnectorTest {
 
     @Test
     public void testAlterOffsetsOffsetPositionValues() {
-        assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, Collections.singletonMap(
+        Function<Object, Boolean> alterOffsets = offset -> connector.alterOffsets(sourceProperties, Collections.singletonMap(
                 Collections.singletonMap(FILENAME_FIELD, FILENAME),
-                Collections.singletonMap(POSITION_FIELD, "nan")
-        )));
+                Collections.singletonMap(POSITION_FIELD, offset)
+        ));
 
-        assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, Collections.singletonMap(
-                Collections.singletonMap(FILENAME_FIELD, FILENAME),
-                Collections.singletonMap(POSITION_FIELD, null)
-        )));
-
-        assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, Collections.singletonMap(
-                Collections.singletonMap(FILENAME_FIELD, FILENAME),
-                Collections.singletonMap(POSITION_FIELD, new Object())
-        )));
-
-        assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, Collections.singletonMap(
-                Collections.singletonMap(FILENAME_FIELD, FILENAME),
-                Collections.singletonMap(POSITION_FIELD, 3.14)
-        )));
-
-        assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, Collections.singletonMap(
-                Collections.singletonMap(FILENAME_FIELD, FILENAME),
-                Collections.singletonMap(POSITION_FIELD, -420)
-        )));
-
-        assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, Collections.singletonMap(
-                Collections.singletonMap(FILENAME_FIELD, FILENAME),
-                Collections.singletonMap(POSITION_FIELD, "-420")
-        )));
-
-        assertTrue(connector.alterOffsets(sourceProperties, Collections.singletonMap(
-                Collections.singletonMap(FILENAME_FIELD, FILENAME),
-                Collections.singletonMap(POSITION_FIELD, 10)
-        )));
-
-        assertTrue(connector.alterOffsets(sourceProperties, Collections.singletonMap(
-                Collections.singletonMap(FILENAME_FIELD, FILENAME),
-                Collections.singletonMap(POSITION_FIELD, "10")
-        )));
+        assertThrows(ConnectException.class, () -> alterOffsets.apply("nan"));
+        assertThrows(ConnectException.class, () -> alterOffsets.apply(null));
+        assertThrows(ConnectException.class, () -> alterOffsets.apply(new Object()));
+        assertThrows(ConnectException.class, () -> alterOffsets.apply(3.14));
+        assertThrows(ConnectException.class, () -> alterOffsets.apply(-420));
+        assertThrows(ConnectException.class, () -> alterOffsets.apply("-420"));
+        assertTrue(() -> alterOffsets.apply(10));
+        assertTrue(() -> alterOffsets.apply("10"));
     }
 
     @Test

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
@@ -159,7 +159,7 @@ public class FileStreamSourceConnectorTest {
         sourceProperties.remove(FileStreamSourceConnector.FILE_CONFIG);
         Map<Map<String, ?>, Map<String, ?>> offsets = Collections.singletonMap(
                 Collections.singletonMap(FILENAME_FIELD, FILENAME),
-                Collections.singletonMap(POSITION_FIELD, 0)
+                Collections.singletonMap(POSITION_FIELD, 0L)
         );
         assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, offsets));
     }
@@ -168,20 +168,20 @@ public class FileStreamSourceConnectorTest {
     public void testAlterOffsetsIncorrectPartitionKey() {
         assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, Collections.singletonMap(
                 Collections.singletonMap("other_partition_key", FILENAME),
-                Collections.singletonMap(POSITION_FIELD, 0)
+                Collections.singletonMap(POSITION_FIELD, 0L)
         )));
 
         // null partitions are invalid
         assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, Collections.singletonMap(
                 null,
-                Collections.singletonMap(POSITION_FIELD, 0)
+                Collections.singletonMap(POSITION_FIELD, 0L)
         )));
     }
 
     @Test
     public void testAlterOffsetsMultiplePartitions() {
         Map<Map<String, ?>, Map<String, ?>> offsets = new HashMap<>();
-        offsets.put(Collections.singletonMap(FILENAME_FIELD, FILENAME), Collections.singletonMap(POSITION_FIELD, 0));
+        offsets.put(Collections.singletonMap(FILENAME_FIELD, FILENAME), Collections.singletonMap(POSITION_FIELD, 0L));
         offsets.put(Collections.singletonMap(FILENAME_FIELD, "/someotherfilename"), null);
         assertTrue(connector.alterOffsets(sourceProperties, offsets));
     }
@@ -190,7 +190,7 @@ public class FileStreamSourceConnectorTest {
     public void testAlterOffsetsIncorrectOffsetKey() {
         Map<Map<String, ?>, Map<String, ?>> offsets = Collections.singletonMap(
                 Collections.singletonMap(FILENAME_FIELD, FILENAME),
-                Collections.singletonMap("other_offset_key", 0)
+                Collections.singletonMap("other_offset_key", 0L)
         );
         assertThrows(ConnectException.class, () -> connector.alterOffsets(sourceProperties, offsets));
     }
@@ -208,15 +208,17 @@ public class FileStreamSourceConnectorTest {
         assertThrows(ConnectException.class, () -> alterOffsets.apply(3.14));
         assertThrows(ConnectException.class, () -> alterOffsets.apply(-420));
         assertThrows(ConnectException.class, () -> alterOffsets.apply("-420"));
-        assertTrue(() -> alterOffsets.apply(10));
-        assertTrue(() -> alterOffsets.apply("10"));
+        assertThrows(ConnectException.class, () -> alterOffsets.apply(10));
+        assertThrows(ConnectException.class, () -> alterOffsets.apply("10"));
+        assertThrows(ConnectException.class, () -> alterOffsets.apply(-10L));
+        assertTrue(() -> alterOffsets.apply(10L));
     }
 
     @Test
     public void testSuccessfulAlterOffsets() {
         Map<Map<String, ?>, Map<String, ?>> offsets = Collections.singletonMap(
                 Collections.singletonMap(FILENAME_FIELD, FILENAME),
-                Collections.singletonMap(POSITION_FIELD, 0)
+                Collections.singletonMap(POSITION_FIELD, 0L)
         );
 
         // Expect no exception to be thrown when a valid offsets map is passed. An empty offsets map is treated as valid


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/KAFKA-15121
- https://cwiki.apache.org/confluence/display/KAFKA/KIP-875%3A+First-class+offsets+support+in+Kafka+Connect#KIP875:FirstclassoffsetssupportinKafkaConnect-ConnectorAPIchanges

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
