### PR TITLE
KAFKA-15091: Fix misleading Javadoc for SourceTask::commit

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -105,9 +105,11 @@ public abstract class SourceTask implements Task {
     public abstract List<SourceRecord> poll() throws InterruptedException;
 
     /**
-     * <p>
-     * Commit the offsets, up to the offsets that have been returned by {@link #poll()}. This
-     * method should block until the commit is complete.
+     * This method is invoked periodically when offsets are committed for this source task. Note that the offsets
+     * being committed won't necessarily correspond to the latest offsets returned by this source task via
+     * {@link #poll()}. When exactly-once support is disabled, offsets are committed periodically and asynchronously
+     * (i.e. on a separate thread from the one which calls {@link #poll()}). When exactly-once support is enabled,
+     * offsets are committed on transaction commits (also see {@link TransactionBoundary}).
      * <p>
      * SourceTasks are not required to implement this functionality; Kafka Connect will record offsets
      * automatically. This hook is provided for systems that also need to store offsets internally

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -107,9 +107,8 @@ public abstract class SourceTask implements Task {
     /**
      * This method is invoked periodically when offsets are committed for this source task. Note that the offsets
      * being committed won't necessarily correspond to the latest offsets returned by this source task via
-     * {@link #poll()}. When exactly-once support is disabled, offsets are committed periodically and asynchronously
-     * (i.e. on a separate thread from the one which calls {@link #poll()}). When exactly-once support is enabled,
-     * offsets are committed on transaction commits (also see {@link TransactionBoundary}).
+     * {@link #poll()}. Also see {@link #commitRecord(SourceRecord, RecordMetadata)} which allows for a more
+     * fine-grained tracking of records that have been successfully delivered.
      * <p>
      * SourceTasks are not required to implement this functionality; Kafka Connect will record offsets
      * automatically. This hook is provided for systems that also need to store offsets internally


### PR DESCRIPTION
From https://issues.apache.org/jira/browse/KAFKA-15091:

> The Javadocs for SourceTask::commit state that the method should:
> 
> Commit the offsets, up to the offsets that have been returned by [poll()](https://kafka.apache.org/34/javadoc/org/apache/kafka/connect/source/SourceTask.html#poll()).
> 
> However, this is obviously incorrect given how the Connect runtime (when not configured with exactly-once support for source connectors) performs polling and offset commits on separate threads. There's also some extensive discussion on the semantics of that method in [KAFKA-5716](https://issues.apache.org/jira/browse/KAFKA-5716) where it's made clear that altering the behavior of the runtime to align with the documented semantics of that method is not a viable option.
> 
> We should update the Javadocs for this method to state that it does not have anything to do with the offsets returned from SourceTask:poll and is instead just a general, periodically-invoked hook to let the task know that an offset commit has taken place (but with no guarantees as to which offsets have been committed and which ones correspond to still-in-flight records).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
