### PR TITLE
KAFKA-15141: init logger statically on hot codepaths

### DIFF
--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -357,12 +357,19 @@ class SessionErrorContext(val error: Errors,
   }
 }
 
+object SessionlessFetchContext {
+  private final val logger = Logger(classOf[SessionlessFetchContext])
+}
+
 /**
   * The fetch context for a sessionless fetch request.
   *
   * @param fetchData          The partition data from the fetch request.
   */
 class SessionlessFetchContext(val fetchData: util.Map[TopicIdPartition, FetchRequest.PartitionData]) extends FetchContext {
+
+  override lazy val logger = SessionlessFetchContext.logger
+
   override def getFetchOffset(part: TopicIdPartition): Option[Long] =
     Option(fetchData.get(part)).map(_.fetchOffset)
 

--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -17,6 +17,7 @@
 
 package kafka.server
 
+import com.typesafe.scalalogging.Logger
 import kafka.utils.Logging
 import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.message.FetchResponseData
@@ -379,6 +380,10 @@ class SessionlessFetchContext(val fetchData: util.Map[TopicIdPartition, FetchReq
   }
 }
 
+object FullFetchContext {
+  private final val logger = Logger(classOf[FullFetchContext])
+}
+
 /**
   * The fetch context for a full fetch request.
   *
@@ -395,6 +400,9 @@ class FullFetchContext(private val time: Time,
                        private val fetchData: util.Map[TopicIdPartition, FetchRequest.PartitionData],
                        private val usesTopicIds: Boolean,
                        private val isFromFollower: Boolean) extends FetchContext {
+
+  override lazy val logger = FullFetchContext.logger
+
   override def getFetchOffset(part: TopicIdPartition): Option[Long] =
     Option(fetchData.get(part)).map(_.fetchOffset)
 
@@ -423,6 +431,10 @@ class FullFetchContext(private val time: Time,
   }
 }
 
+object IncrementalFetchContext {
+  private val logger = Logger(classOf[IncrementalFetchContext])
+}
+
 /**
   * The fetch context for an incremental fetch request.
   *
@@ -435,6 +447,8 @@ class IncrementalFetchContext(private val time: Time,
                               private val reqMetadata: JFetchMetadata,
                               private val session: FetchSession,
                               private val topicNames: FetchSession.TOPIC_NAME_MAP) extends FetchContext {
+
+  override lazy val logger = IncrementalFetchContext.logger
 
   override def getFetchOffset(tp: TopicIdPartition): Option[Long] = session.getFetchOffset(tp)
 


### PR DESCRIPTION
Log4j2 based loggers use
`org.apache.logging.log4j.spi.AbstractLoggerAdapter::getContext` which invokes StackLocatorUtil to walk the stacktrace. This operation is quite CPU intensive and is performed each time during instantiation.

To avoid walking the stack often, this change uses a static variable to initialise the logger for a few classes which seem to be instantiated frequently.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
