### PR TITLE
KAFKA-15140: Improve TopicCommandIntegrationTest to be less flaky

### DIFF
--- a/core/src/test/scala/integration/kafka/admin/TopicCommandIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/TopicCommandIntegrationTest.scala
@@ -545,7 +545,7 @@ class TopicCommandIntegrationTest extends KafkaServerTestHarness with Logging wi
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
   @ValueSource(strings = Array("zk", "kraft"))
   def testDescribeUnavailablePartitions(quorum: String): Unit = {
-    TestUtils.createTopicWithAdmin(adminClient, testTopicName, brokers, 6, 1)
+    TestUtils.createTopicWithAdmin(adminClient, testTopicName, brokers, numBrokers, 1)
 
     try {
       // check which partition is on broker 0 which we'll kill


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-15140
Tests in TopicCommandIntegrationTest get flaky from time to time. The objective of the task is to make them more robust.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
