### PR TITLE
KAFKA-15129;[4/N] Remove metrics in Partition when broker shutdown and stopPartitions

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -111,6 +111,7 @@ object Partition {
   private val LastStableOffsetLagMetricName = "LastStableOffsetLag"
   private val AtMinIsrMetricName = "AtMinIsr"
 
+  // Visible for testing
   private[cluster] val MetricNames = Set(
     UnderReplicatedMetricName,
     UnderMinIsrMetricName,
@@ -157,7 +158,7 @@ object Partition {
       alterIsrManager = replicaManager.alterPartitionManager)
   }
 
-  def removeMetrics(topicPartition: TopicPartition): Unit = {
+  private[kafka] def removeMetrics(topicPartition: TopicPartition): Unit = {
     val tags = Map("topic" -> topicPartition.topic, "partition" -> topicPartition.partition.toString).asJava
     MetricNames.foreach(metricsGroup.removeMetric(_, tags))
   }
@@ -654,7 +655,6 @@ class Partition(val topicPartition: TopicPartition,
       }
       listeners.clear()
     }
-    removeMetrics(topicPartition)
   }
 
   private def clear(): Unit = {
@@ -665,6 +665,7 @@ class Partition(val topicPartition: TopicPartition,
     partitionState = CommittedPartitionState(Set.empty, LeaderRecoveryState.RECOVERED)
     leaderReplicaIdOpt = None
     leaderEpochStartOffsetOpt = None
+    removeMetrics(topicPartition)
   }
 
   def getLeaderEpoch: Int = this.leaderEpoch

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import java.util.Optional
 import java.util.concurrent.{CompletableFuture, CopyOnWriteArrayList}
 import kafka.api.LeaderAndIsr
-import kafka.cluster.Partition.{AtMinIsrMetricName, InSyncReplicasCountMetricName, LastStableOffsetLagMetricName, ReplicasCountMetricName, UnderMinIsrMetricName, UnderReplicatedMetricName, removeMetrics}
+import kafka.cluster.Partition.{AtMinIsrMetricName, InSyncReplicasCountMetricName, LastStableOffsetLagMetricName, MetricNames, ReplicasCountMetricName, UnderMinIsrMetricName, UnderReplicatedMetricName}
 import kafka.common.UnexpectedAppendOffsetException
 import kafka.controller.{KafkaController, StateChangeLogger}
 import kafka.log._
@@ -111,6 +111,7 @@ object Partition {
   private val LastStableOffsetLagMetricName = "LastStableOffsetLag"
   private val AtMinIsrMetricName = "AtMinIsr"
 
+  // Visible for testing
   private[cluster] val MetricNames = Set(
     UnderReplicatedMetricName,
     UnderMinIsrMetricName,
@@ -119,8 +120,6 @@ object Partition {
     LastStableOffsetLagMetricName,
     AtMinIsrMetricName
   )
-
-  private[cluster] val metricsGroup = new KafkaMetricsGroup(classOf[Partition])
 
   def apply(topicPartition: TopicPartition,
             time: Time,
@@ -155,11 +154,6 @@ object Partition {
       metadataCache = replicaManager.metadataCache,
       logManager = replicaManager.logManager,
       alterIsrManager = replicaManager.alterPartitionManager)
-  }
-
-  def removeMetrics(topicPartition: TopicPartition): Unit = {
-    val tags = Map("topic" -> topicPartition.topic, "partition" -> topicPartition.partition.toString).asJava
-    MetricNames.foreach(metricsGroup.removeMetric(_, tags))
   }
 }
 
@@ -304,7 +298,7 @@ class Partition(val topicPartition: TopicPartition,
                 logManager: LogManager,
                 alterIsrManager: AlterPartitionManager) extends Logging {
 
-  import Partition.metricsGroup
+  private[cluster] val metricsGroup = new KafkaMetricsGroup(classOf[Partition])
 
   def topic: String = topicPartition.topic
   def partitionId: Int = topicPartition.partition
@@ -654,7 +648,6 @@ class Partition(val topicPartition: TopicPartition,
       }
       listeners.clear()
     }
-    removeMetrics(topicPartition)
   }
 
   private def clear(): Unit = {
@@ -665,6 +658,12 @@ class Partition(val topicPartition: TopicPartition,
     partitionState = CommittedPartitionState(Set.empty, LeaderRecoveryState.RECOVERED)
     leaderReplicaIdOpt = None
     leaderEpochStartOffsetOpt = None
+    removeMetrics(topicPartition)
+  }
+
+  private[kafka] def removeMetrics(topicPartition: TopicPartition): Unit = {
+    val tags = Map("topic" -> topicPartition.topic, "partition" -> topicPartition.partition.toString).asJava
+    MetricNames.foreach(metricsGroup.removeMetric(_, tags))
   }
 
   def getLeaderEpoch: Int = this.leaderEpoch

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -558,6 +558,9 @@ class ReplicaManager(val config: KafkaConfig,
         }
         partitionsToDelete += topicPartition
       }
+      // Whether the `topicPartition` is deleted or the broker where the `topicPartition` is located is stopped,
+      // the metrics in `Partition` should be removed.
+      Partition.removeMetrics(topicPartition)
       // If we were the leader, we may have some operations still waiting for completion.
       // We force completion to prevent them from timing out.
       completeDelayedFetchOrProduceRequests(topicPartition)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -316,9 +316,6 @@ class ReplicaManager(val config: KafkaConfig,
   // Visible for testing
   private[server] val replicaSelectorOpt: Option[ReplicaSelector] = createReplicaSelector()
 
-  // Visible for testing
-  private[kafka] def getAllPartitions: Pool[TopicPartition, HostedPartition] = allPartitions
-
   metricsGroup.newGauge(LeaderCountMetricName, () => leaderPartitionsIterator.size)
   // Visible for testing
   private[kafka] val partitionCount = metricsGroup.newGauge(PartitionCountMetricName, () => allPartitions.size)
@@ -561,6 +558,9 @@ class ReplicaManager(val config: KafkaConfig,
         }
         partitionsToDelete += topicPartition
       }
+      // Whether the `topicPartition` is deleted or the broker where the `topicPartition` is located is stopped,
+      // the metrics in `Partition` should be removed.
+      Partition.removeMetrics(topicPartition)
       // If we were the leader, we may have some operations still waiting for completion.
       // We force completion to prevent them from timing out.
       completeDelayedFetchOrProduceRequests(topicPartition)
@@ -2221,7 +2221,6 @@ class ReplicaManager(val config: KafkaConfig,
       checkpointHighWatermarks()
     replicaSelectorOpt.foreach(_.close)
     removeAllTopicMetrics()
-    removeAllPartitionMetrics()
     addPartitionsToTxnManager.foreach(_.shutdown())
     info("Shut down completely")
   }
@@ -2232,16 +2231,6 @@ class ReplicaManager(val config: KafkaConfig,
       if (allTopics.add(partition.topic())) {
         brokerTopicStats.removeMetrics(partition.topic())
       })
-  }
-
-  private def removeAllPartitionMetrics(): Unit = {
-    allPartitions.values.foreach { hostedPartition =>
-      hostedPartition match {
-        case HostedPartition.Online(partition) =>
-          partition.removeMetrics(partition.topicPartition)
-        case _ =>    // In the other two cases, the metrics has been removed when the partition state changes
-      }
-    }
   }
 
   protected def createReplicaFetcherManager(metrics: Metrics, time: Time, threadNamePrefix: Option[String], quotaManager: ReplicationQuotaManager) = {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -316,6 +316,9 @@ class ReplicaManager(val config: KafkaConfig,
   // Visible for testing
   private[server] val replicaSelectorOpt: Option[ReplicaSelector] = createReplicaSelector()
 
+  // Visible for testing
+  private[kafka] def getAllPartitions: Pool[TopicPartition, HostedPartition] = allPartitions
+
   metricsGroup.newGauge(LeaderCountMetricName, () => leaderPartitionsIterator.size)
   // Visible for testing
   private[kafka] val partitionCount = metricsGroup.newGauge(PartitionCountMetricName, () => allPartitions.size)
@@ -558,9 +561,6 @@ class ReplicaManager(val config: KafkaConfig,
         }
         partitionsToDelete += topicPartition
       }
-      // Whether the `topicPartition` is deleted or the broker where the `topicPartition` is located is stopped,
-      // the metrics in `Partition` should be removed.
-      Partition.removeMetrics(topicPartition)
       // If we were the leader, we may have some operations still waiting for completion.
       // We force completion to prevent them from timing out.
       completeDelayedFetchOrProduceRequests(topicPartition)
@@ -2221,6 +2221,7 @@ class ReplicaManager(val config: KafkaConfig,
       checkpointHighWatermarks()
     replicaSelectorOpt.foreach(_.close)
     removeAllTopicMetrics()
+    removeAllPartitionMetrics()
     addPartitionsToTxnManager.foreach(_.shutdown())
     info("Shut down completely")
   }
@@ -2231,6 +2232,16 @@ class ReplicaManager(val config: KafkaConfig,
       if (allTopics.add(partition.topic())) {
         brokerTopicStats.removeMetrics(partition.topic())
       })
+  }
+
+  private def removeAllPartitionMetrics(): Unit = {
+    allPartitions.values.foreach { hostedPartition =>
+      hostedPartition match {
+        case HostedPartition.Online(partition) =>
+          partition.removeMetrics(partition.topicPartition)
+        case _ =>    // In the other two cases, the metrics has been removed when the partition state changes
+      }
+    }
   }
 
   protected def createReplicaFetcherManager(metrics: Metrics, time: Time, threadNamePrefix: Option[String], quotaManager: ReplicationQuotaManager) = {

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -2639,13 +2639,6 @@ class PartitionTest extends AbstractPartitionTest {
 
   @Test
   def testAddAndRemoveMetrics(): Unit = {
-    val metricsToCheck = List(
-      "UnderReplicated",
-      "UnderMinIsr",
-      "InSyncReplicasCount",
-      "ReplicasCount",
-      "LastStableOffsetLag",
-      "AtMinIsr")
 
     def getMetric(metric: String): Option[Metric] = {
       KafkaYammerMetrics.defaultRegistry().allMetrics().asScala.find { case (metricName, _) =>
@@ -2653,7 +2646,7 @@ class PartitionTest extends AbstractPartitionTest {
       }.map(_._2)
     }
 
-    assertTrue(metricsToCheck.forall(getMetric(_).isDefined))
+    assertTrue(Partition.MetricNames.forall(getMetric(_).isDefined))
 
     Partition.removeMetrics(topicPartition)
 

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -20,6 +20,7 @@ import java.net.InetAddress
 import com.yammer.metrics.core.Metric
 import kafka.common.UnexpectedAppendOffsetException
 import kafka.log._
+import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server._
 import kafka.server.checkpoints.OffsetCheckpoints
 import kafka.utils._
@@ -46,19 +47,21 @@ import java.util.Optional
 import java.util.concurrent.{CountDownLatch, Semaphore}
 import kafka.server.metadata.{KRaftMetadataCache, ZkMetadataCache}
 import org.apache.kafka.clients.ClientResponse
+import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.replica.ClientMetadata
 import org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.common.MetadataVersion.IBP_2_6_IV0
-import org.apache.kafka.server.metrics.KafkaYammerMetrics
-import org.apache.kafka.server.util.{KafkaScheduler, MockTime}
+import org.apache.kafka.server.metrics.{KafkaMetricsGroup, KafkaYammerMetrics}
+import org.apache.kafka.server.util.{KafkaScheduler, MockScheduler, MockTime}
 import org.apache.kafka.storage.internals.epoch.LeaderEpochFileCache
 import org.apache.kafka.storage.internals.log.{AppendOrigin, CleanerConfig, EpochEntry, FetchIsolation, FetchParams, LogAppendInfo, LogDirFailureChannel, LogReadInfo, LogStartOffsetIncrementReason, ProducerStateManager, ProducerStateManagerConfig}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
+import scala.collection.{Map, Seq}
 import scala.compat.java8.OptionConverters._
 import scala.jdk.CollectionConverters._
 
@@ -2648,9 +2651,57 @@ class PartitionTest extends AbstractPartitionTest {
 
     assertTrue(Partition.MetricNames.forall(getMetric(_).isDefined))
 
-    Partition.removeMetrics(topicPartition)
+    partition.removeMetrics(topicPartition)
 
     assertEquals(Set(), KafkaYammerMetrics.defaultRegistry().allMetrics().asScala.keySet.filter(_.getType == "Partition"))
+  }
+
+  @Test
+  def testRemovePartitionMetricsWhenShutdown(): Unit = {
+    val props = TestUtils.createBrokerConfig(1, TestUtils.MockZkConnect)
+    val config = KafkaConfig.fromProps(props)
+    val mockMetricsGroupCtor = mockConstruction(classOf[KafkaMetricsGroup])
+    try {
+      val rm = new ReplicaManager(
+        metrics = mock(classOf[Metrics]),
+        config = config,
+        time = time,
+        scheduler = new MockScheduler(time),
+        logManager = logManager,
+        quotaManagers = mock(classOf[QuotaManagers]),
+        metadataCache = MetadataCache.zkMetadataCache(config.brokerId, config.interBrokerProtocolVersion),
+        logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size),
+        alterPartitionManager = alterPartitionManager,
+        threadNamePrefix = Option(this.getClass.getName))
+      val partition = new Partition(topicPartition,
+        replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
+        interBrokerProtocolVersion = MetadataVersion.latest,
+        localBrokerId = config.brokerId,
+        () => config.brokerId + 1000L,
+        time,
+        TestUtils.createIsrChangeListener(),
+        mock(classOf[DelayedOperations]),
+        MetadataCache.zkMetadataCache(config.brokerId, config.interBrokerProtocolVersion),
+        logManager,
+        alterPartitionManager)
+      rm.getAllPartitions.put(topicPartition, HostedPartition.Online(partition))
+
+      // shutdown ReplicaManager so that metrics are removed
+      rm.shutdown(checkpointHW = false)
+
+      // Use the last instance of metrics group that is constructed by `new Partition`
+      val mockMetricsGroup = mockMetricsGroupCtor.constructed().get(mockMetricsGroupCtor.constructed().size() - 1)
+      val tag = Map("topic" -> partition.topic, "partition" -> partition.partitionId.toString).asJava
+      Partition.MetricNames.foreach(metricName => verify(mockMetricsGroup).newGauge(ArgumentMatchers.eq(metricName), any(), ArgumentMatchers.eq(tag)))
+      Partition.MetricNames.foreach(metricName => verify(mockMetricsGroup).removeMetric(ArgumentMatchers.eq(metricName), ArgumentMatchers.eq(tag)))
+
+      // assert that we have verified all invocations on
+      verifyNoMoreInteractions(mockMetricsGroup)
+    } finally {
+      if (mockMetricsGroupCtor != null) {
+        mockMetricsGroupCtor.close()
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
This pr is used to remove the metrics in Partition when broker shutdown and stopPartitions.
This pr has passed the corresponding unit test, and it is part of [KAFKA-15129](https://issues.apache.org/jira/browse/KAFKA-15129).

Different from other PRs under this topic, although this issue has a "remove metrics" operation, it will only be performed when the partition is deleted, and metrics will not be removed when the broker is shutdown. This PR solves this situation.