### PR TITLE
MINOR: Remove thread leak from ConsumerBounceTest

### DIFF
--- a/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
@@ -346,7 +346,6 @@ abstract class AbstractConsumerTest extends BaseRequestTest {
                                            partitionsToAssign: Set[TopicPartition],
                                            userRebalanceListener: ConsumerRebalanceListener)
     extends ShutdownableThread("daemon-consumer-assignment", false) {
-    setDaemon(true)
 
     def this(consumer: Consumer[Array[Byte], Array[Byte]], topicsToSubscribe: List[String]) = {
       this(consumer, topicsToSubscribe, Set.empty[TopicPartition], null)

--- a/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
@@ -346,6 +346,7 @@ abstract class AbstractConsumerTest extends BaseRequestTest {
                                            partitionsToAssign: Set[TopicPartition],
                                            userRebalanceListener: ConsumerRebalanceListener)
     extends ShutdownableThread("daemon-consumer-assignment", false) {
+    setDaemon(true)
 
     def this(consumer: Consumer[Array[Byte], Array[Byte]], topicsToSubscribe: List[String]) = {
       this(consumer, topicsToSubscribe, Set.empty[TopicPartition], null)

--- a/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
@@ -502,7 +502,6 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
   }
 
   private class BounceBrokerScheduler(val numIters: Int) extends ShutdownableThread("daemon-bounce-broker", false) {
-    setDaemon(true)
     var iter: Int = 0
 
     override def doWork(): Unit = {

--- a/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
@@ -95,27 +95,30 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
     consumer.subscribe(Collections.singletonList(topic))
 
     val scheduler = new BounceBrokerScheduler(numIters)
-    scheduler.start()
+    try {
+      scheduler.start()
 
-    while (scheduler.isRunning) {
-      val records = consumer.poll(Duration.ofMillis(100)).asScala
+      while (scheduler.isRunning) {
+        val records = consumer.poll(Duration.ofMillis(100)).asScala
 
-      for (record <- records) {
-        assertEquals(consumed, record.offset())
-        consumed += 1
-      }
+        for (record <- records) {
+          assertEquals(consumed, record.offset())
+          consumed += 1
+        }
 
-      if (records.nonEmpty) {
-        consumer.commitSync()
-        assertEquals(consumer.position(tp), consumer.committed(Set(tp).asJava).get(tp).offset)
+        if (records.nonEmpty) {
+          consumer.commitSync()
+          assertEquals(consumer.position(tp), consumer.committed(Set(tp).asJava).get(tp).offset)
 
-        if (consumer.position(tp) == numRecords) {
-          consumer.seekToBeginning(Collections.emptyList())
-          consumed = 0
+          if (consumer.position(tp) == numRecords) {
+            consumer.seekToBeginning(Collections.emptyList())
+            consumed = 0
+          }
         }
       }
+    } finally {
+      scheduler.shutdown()
     }
-    scheduler.shutdown()
   }
 
   @Test
@@ -136,24 +139,28 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
     ), "Failed to update high watermark for followers after timeout")
 
     val scheduler = new BounceBrokerScheduler(numIters)
-    scheduler.start()
+    try {
+      scheduler.start()
 
-    while(scheduler.isRunning) {
-      val coin = TestUtils.random.nextInt(3)
-      if (coin == 0) {
-        info("Seeking to end of log")
-        consumer.seekToEnd(Collections.emptyList())
-        assertEquals(numRecords.toLong, consumer.position(tp))
-      } else if (coin == 1) {
-        val pos = TestUtils.random.nextInt(numRecords).toLong
-        info("Seeking to " + pos)
-        consumer.seek(tp, pos)
-        assertEquals(pos, consumer.position(tp))
-      } else if (coin == 2) {
-        info("Committing offset.")
-        consumer.commitSync()
-        assertEquals(consumer.position(tp), consumer.committed(Set(tp).asJava).get(tp).offset)
+      while (scheduler.isRunning) {
+        val coin = TestUtils.random.nextInt(3)
+        if (coin == 0) {
+          info("Seeking to end of log")
+          consumer.seekToEnd(Collections.emptyList())
+          assertEquals(numRecords.toLong, consumer.position(tp))
+        } else if (coin == 1) {
+          val pos = TestUtils.random.nextInt(numRecords).toLong
+          info("Seeking to " + pos)
+          consumer.seek(tp, pos)
+          assertEquals(pos, consumer.position(tp))
+        } else if (coin == 2) {
+          info("Committing offset.")
+          consumer.commitSync()
+          assertEquals(consumer.position(tp), consumer.committed(Set(tp).asJava).get(tp).offset)
+        }
       }
+    } finally {
+      scheduler.shutdown()
     }
   }
 
@@ -344,21 +351,26 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
     val partitions = createTopicPartitions(topic, numPartitions = maxGroupSize, replicationFactor = brokerCount)
 
     // Create N+1 consumers in the same consumer group and assert that the N+1th consumer receives a fatal error when it tries to join the group
-    addConsumersToGroupAndWaitForGroupAssignment(maxGroupSize, mutable.Buffer[Consumer[Array[Byte], Array[Byte]]](),
-      consumerPollers, List[String](topic), partitions, group)
-    val (_, rejectedConsumerPollers) = addConsumersToGroup(1,
-      mutable.Buffer[Consumer[Array[Byte], Array[Byte]]](), mutable.Buffer[ConsumerAssignmentPoller](), List[String](topic), partitions, group)
-    val rejectedConsumer = rejectedConsumerPollers.head
-    TestUtils.waitUntilTrue(() => {
-      rejectedConsumer.thrownException.isDefined
-    }, "Extra consumer did not throw an exception")
-    assertTrue(rejectedConsumer.thrownException.get.isInstanceOf[GroupMaxSizeReachedException])
+    val consumerPollers = mutable.Buffer[ConsumerAssignmentPoller]()
+    try {
+      addConsumersToGroupAndWaitForGroupAssignment(maxGroupSize, mutable.Buffer[Consumer[Array[Byte], Array[Byte]]](),
+        consumerPollers, List[String](topic), partitions, group)
+      val (_, rejectedConsumerPollers) = addConsumersToGroup(1,
+        mutable.Buffer[Consumer[Array[Byte], Array[Byte]]](), mutable.Buffer[ConsumerAssignmentPoller](), List[String](topic), partitions, group)
+      val rejectedConsumer = rejectedConsumerPollers.head
+      TestUtils.waitUntilTrue(() => {
+        rejectedConsumer.thrownException.isDefined
+      }, "Extra consumer did not throw an exception")
+      assertTrue(rejectedConsumer.thrownException.get.isInstanceOf[GroupMaxSizeReachedException])
 
-    // assert group continues to live
-    producerSend(createProducer(), maxGroupSize * 100, topic, numPartitions = Some(partitions.size))
-    TestUtils.waitUntilTrue(() => {
-      consumerPollers.forall(p => p.receivedMessages >= 100)
-    }, "The consumers in the group could not fetch the expected records", 10000L)
+      // assert group continues to live
+      producerSend(createProducer(), maxGroupSize * 100, topic, numPartitions = Some(partitions.size))
+      TestUtils.waitUntilTrue(() => {
+        consumerPollers.forall(p => p.receivedMessages >= 100)
+      }, "The consumers in the group could not fetch the expected records", 10000L)
+    } finally {
+      consumerPollers.foreach(_.shutdown())
+    }
   }
 
   /**
@@ -437,6 +449,7 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
       else
         subscribeConsumerAndStartPolling(consumer, List(topic))
 
+    consumerPollers += consumerPoller
     receiveExactRecords(consumerPoller, numRecords)
     consumerPoller.shutdown()
     consumer
@@ -489,6 +502,7 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
   }
 
   private class BounceBrokerScheduler(val numIters: Int) extends ShutdownableThread("daemon-bounce-broker", false) {
+    setDaemon(true)
     var iter: Int = 0
 
     override def doWork(): Unit = {


### PR DESCRIPTION
Sometimes, we see a large number of tests suddenly fail in CI. I encountered at least one case where this could be explained.

Test run: https://ci-builds.apache.org/job/Kafka/job/kafka-pr/job/PR-13953/2 

### why do we have cascading failures?
Sequence of events:
1. Some test leaks (does not close properly) the thread `controller-event-thread`
2. This leak is caught at `@AfterAll` method of QuorumTestHarnessScala at https://github.com/apache/kafka/blob/701f924352da1225a881f0f78f19ddf51485030a/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala#L446 
3. The above leads to an assertion failure but does not kill the threads.
4. Other tests that run after it by the same gradle process and before execution check for existing threads all fail due to these leaked threads at https://github.com/apache/kafka/blob/701f924352da1225a881f0f78f19ddf51485030a/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala#L438
5. This leads to a cascading failure

### what specifically failed in this scenario
In the scenario that I looked into, the following things occurred:

1. A ConsumerBounceTest#testConsumptionWithBrokerFailures() fails for unknown reason. I have created a JIRA for it - https://issues.apache.org/jira/browse/KAFKA-15146
```
Gradle Test Run :core:integrationTest > Gradle Test Executor 177 > ConsumerBounceTest > testConsumptionWithBrokerFailures() FAILED
    org.apache.kafka.clients.consumer.CommitFailedException: Offset commit cannot be completed since the consumer is not part of an active group for auto partition assignment; it is likely that the consumer was kicked out of the group.
        at app//org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.sendOffsetCommitRequest(ConsumerCoordinator.java:1351)
        at app//org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.commitOffsetsSync(ConsumerCoordinator.java:1188)
        at app//org.apache.kafka.clients.consumer.KafkaConsumer.commitSync(KafkaConsumer.java:1518)
        at app//org.apache.kafka.clients.consumer.KafkaConsumer.commitSync(KafkaConsumer.java:1417)
        at app//org.apache.kafka.clients.consumer.KafkaConsumer.commitSync(KafkaConsumer.java:1374)
        at app//kafka.api.ConsumerBounceTest.consumeWithBrokerFailures(ConsumerBounceTest.scala:109)
        at app//kafka.api.ConsumerBounceTest.testConsumptionWithBrokerFailures(ConsumerBounceTest.scala:81)
```
2. This test has a bug which leads to leak of `daemon-bounce-broker` thread. This leaked thread along with `controller-event-thread` show up in the trace below.
```
Gradle Test Run :core:integrationTest > Gradle Test Executor 177 > ConsumerBounceTest > executionError FAILED
    org.opentest4j.AssertionFailedError: Found 3 unexpected threads during @AfterAll: `controller-event-thread,daemon-bounce-broker-EventThread,Test worker-EventThread` ==> expected: <true> but was: <false>
        at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
``` 
3. All tests run by `Gradle Test Executor 177` after this fail with an error:
```
Gradle Test Run :core:integrationTest > Gradle Test Executor 177 > PlaintextConsumerTest > initializationError FAILED
    org.opentest4j.AssertionFailedError: Found 3 unexpected threads during @BeforeAll: `controller-event-thread,daemon-bounce-broker-EventThread,Test worker-EventThread` ==> expected: <true> but was: <false>
        at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
```

### what does this PR change?
This changes fixes the leak of `daemon-bounce-broker` thread. It **does not** fix the leak of `controller-event-thread` which is the root cause of failure in `@AfterAll`. Hence, although this will not fix the flaky problems, but it will be a step in the right direction to prevent thread leaks from impacting tests.

### Note to reviewers
I would suggest to use "hide whitespaces" while reviewing since most of the changes in this PR are simply adding code inside try/finally block.