### PR TITLE
KAFKA-15153: Use Python 'is' instead of '==' to compare for None

### DIFF
--- a/release_notes.py
+++ b/release_notes.py
@@ -44,7 +44,7 @@ def get_issues(jira, query, **kwargs):
     results = []
     startAt = 0
     new_results = None
-    while new_results == None or len(new_results) == MAX_RESULTS:
+    while new_results is None or len(new_results) == MAX_RESULTS:
         new_results = jira.search_issues(query, startAt=startAt, maxResults=MAX_RESULTS, **kwargs)
         results += new_results
         startAt += len(new_results)

--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -334,7 +334,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
 
         # stop the partition owner and await its shutdown
         consumer.kill_node(partition_owner, clean_shutdown=clean_shutdown)
-        wait_until(lambda: len(consumer.joined_nodes()) == (self.num_consumers - 1) and consumer.owner(partition) != None,
+        wait_until(lambda: len(consumer.joined_nodes()) == (self.num_consumers - 1) and consumer.owner(partition) is not None,
                    timeout_sec=self.session_timeout_sec*2+5,
                    err_msg="Timed out waiting for consumer to close")
 

--- a/tests/kafkatest/tests/connect/connect_test.py
+++ b/tests/kafkatest/tests/connect/connect_test.py
@@ -79,7 +79,7 @@ class ConnectStandaloneFileTest(Test):
         parameterizations to test different converters (which also test per-connector converter overrides), schema/schemaless
         modes, and security support.
         """
-        assert converter != None, "converter type must be set"
+        assert converter is not None, "converter type must be set"
         # Template parameters. Note that we don't set key/value.converter. These default to JsonConverter and we validate
         # converter overrides via the connector configuration.
         if converter != "org.apache.kafka.connect.json.JsonConverter":


### PR DESCRIPTION
https://issues.apache.org/jira/projects/KAFKA/issues/KAFKA-15153
Use Python 'is' instead of '==' to compare for None

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
