### PR TITLE
MINOR: Update connector status metric description to include 'stopped' as a potential value

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java
@@ -128,7 +128,7 @@ public class ConnectMetricsRegistry {
         connectorTags.add(CONNECTOR_TAG_NAME);
 
         connectorStatus = createTemplate("status", CONNECTOR_GROUP_NAME,
-                                         "The status of the connector. One of 'unassigned', 'running', 'paused', 'failed', or " +
+                                         "The status of the connector. One of 'unassigned', 'running', 'paused', 'stopped', 'failed', or " +
                                          "'restarting'.",
                                          connectorTags);
         connectorType = createTemplate("connector-type", CONNECTOR_GROUP_NAME, "The type of the connector. One of 'source' or 'sink'.",


### PR DESCRIPTION
- [KIP-875](https://cwiki.apache.org/confluence/display/KAFKA/KIP-875%3A+First-class+offsets+support+in+Kafka+Connect) introduced a new `STOPPED` state for connectors (also see https://github.com/apache/kafka/pull/13424).
- This new state is a potential value for the [connector status metric](https://github.com/apache/kafka/blob/4a61b48d3dca81e28b57f10af6052f36c50a05e3/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java#L130) that is computed [here](https://github.com/apache/kafka/blob/4a61b48d3dca81e28b57f10af6052f36c50a05e3/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java#L440) and hence needs to be added to the metric's description.
- Note that this doesn't need to be done for the task status metric since tasks are shutdown when a connector is stopped (i.e. a connector can be in a stopped state, but a task cannot).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
