### PR TITLE
KAFKA-15149: Fix not sending UMR and LISR RPCs in dual-write mode when there are new partitions

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
@@ -291,8 +291,8 @@ public class KRaftMigrationZkWriter {
                             topicId,
                             topicsImage.getTopic(topicId).partitions(),
                             migrationState));
-                Map<Integer, PartitionRegistration> newPartitions = topicDelta.newPartitions();
-                Map<Integer, PartitionRegistration> changedPartitions = topicDelta.partitionChanges();
+                Map<Integer, PartitionRegistration> newPartitions = new HashMap<>(topicDelta.newPartitions());
+                Map<Integer, PartitionRegistration> changedPartitions = new HashMap<>(topicDelta.partitionChanges());
                 if (!newPartitions.isEmpty()) {
                     operationConsumer.accept(
                         UPDATE_PARTITION,


### PR DESCRIPTION
### JIRA
https://issues.apache.org/jira/browse/KAFKA-15149

### Description
Fixes a bug where we don't send UMR and LISR requests in dual-write mode when there are new partitions created/added. By mutating `changedPartitions` the code later on in `MigrationPropagator` does not see there are changed partitions and so does not send LISR requests when it should. This is reproducible by running the enhanced version of `ZkMigrationIntegrationTest.testNewAndChangedTopicsInDualWrite` that is updated as part of this PR. So the fix is to create a copy of the partitions metadata so we can mutate it but just locally. This approach of creating a copy is done in other places in the class already, such as here https://github.com/apache/kafka/blob/trunk/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java#L186.

There are other options to make sure the code in `KRaftMigrationDriver` can't make side effects that affect other components. For example it'd be possible to enhance `TopicDelta` to create the copy. But this is not consistent with the accessors in other places in the `image` package. Or `TopicDelta` could return an immutable copy using something like `Collections.unmodifiableMap(changedTopics)` but this is problematic because the code in `KRaftMigrationDriver` really does need to mutate the collection and so would have to create a copy anyway. 

### Testing
Enhances `ZkMigrationIntegrationTest.testNewAndChangedTopicsInDualWrite` to check the admin client returns the partition increase. This test indeed fails without the changes to `KRaftMigrationZkWriter`


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
