### PR TITLE
MINOR: Check for thread leak at the end of @AfterEach, not at beginning

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -113,10 +113,11 @@ class ReplicaManagerTest {
   @AfterEach
   def tearDown(): Unit = {
     // validate that the shutdown is working correctly by ensuring no lingering threads.
-    TestUtils.assertNoNonDaemonThreads(this.getClass.getName)
     TestUtils.clearYammerMetrics()
     Option(quotaManager).foreach(_.shutdown())
     metrics.close()
+    // assert at the very end otherwise the other tear down steps will not be performed
+    TestUtils.assertNoNonDaemonThreads(this.getClass.getName)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -112,10 +112,10 @@ class ReplicaManagerTest {
 
   @AfterEach
   def tearDown(): Unit = {
-    // validate that the shutdown is working correctly by ensuring no lingering threads.
     TestUtils.clearYammerMetrics()
     Option(quotaManager).foreach(_.shutdown())
     metrics.close()
+    // validate that the shutdown is working correctly by ensuring no lingering threads.
     // assert at the very end otherwise the other tear down steps will not be performed
     TestUtils.assertNoNonDaemonThreads(this.getClass.getName)
   }


### PR DESCRIPTION
This fixes a regression in usage introduced in #13868

`TestUtils.assertNoNonDaemonThreads` should only used at the end of `@AfterEach` so that even if an assertion failure occurs, it does not prevent the other shutdown steps to proceed correctly.