### PR TITLE
MINOR : Changing the invalid domain name of the test code to a meaningful one

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -79,7 +79,7 @@ public class ClientUtilsTest {
 
     @Test
     public void testOnlyBadHostname() {
-        assertThrows(ConfigException.class, () -> checkWithoutLookup("some.invalid.hostname.foo.bar.local:9999"));
+        assertThrows(ConfigException.class, () -> checkWithoutLookup("some.invalid:9999"));
     }
 
     @Test
@@ -103,7 +103,7 @@ public class ClientUtilsTest {
     @Test
     public void testResolveUnknownHostException() {
         assertThrows(UnknownHostException.class,
-            () -> ClientUtils.resolve("some.invalid.hostname.foo.bar.local", hostResolver));
+            () -> ClientUtils.resolve("some.invalid", hostResolver));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -498,7 +498,7 @@ public class KafkaProducerTest {
     public void testConstructorFailureCloseResource() {
         Properties props = new Properties();
         props.setProperty(ProducerConfig.CLIENT_ID_CONFIG, "testConstructorClose");
-        props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "some.invalid.hostname.foo.bar.local:9999");
+        props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "some.invalid:9999");
         props.setProperty(ProducerConfig.METRIC_REPORTER_CLASSES_CONFIG, MockMetricsReporter.class.getName());
 
         final int oldInitCount = MockMetricsReporter.INIT_COUNT.get();

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -178,7 +178,7 @@ public class SelectorTest {
     @Test
     public void testNoRouteToHost() {
         assertThrows(IOException.class,
-            () -> selector.connect("0", new InetSocketAddress("some.invalid.hostname.foo.bar.local", server.port), BUFFER_SIZE, BUFFER_SIZE));
+            () -> selector.connect("0", new InetSocketAddress("some.invalid", server.port), BUFFER_SIZE, BUFFER_SIZE));
     }
 
     /**

--- a/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
@@ -151,7 +151,7 @@ class ServerShutdownTest extends KafkaServerTestHarness {
       verifyCleanShutdownAfterFailedStartup[CancellationException]
     } else {
       propsToChangeUponRestart.setProperty(KafkaConfig.ZkConnectionTimeoutMsProp, "50")
-      propsToChangeUponRestart.setProperty(KafkaConfig.ZkConnectProp, "some.invalid.hostname.foo.bar.local:65535")
+      propsToChangeUponRestart.setProperty(KafkaConfig.ZkConnectProp, "some.invalid:65535")
       verifyCleanShutdownAfterFailedStartup[ZooKeeperClientTimeoutException]
     }
   }

--- a/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
@@ -65,7 +65,7 @@ class ZooKeeperClientTest extends QuorumTestHarness {
   @Test
   def testUnresolvableConnectString(): Unit = {
     try {
-      newZooKeeperClient("some.invalid.hostname.foo.bar.local", connectionTimeoutMs = 10)
+      newZooKeeperClient("some.invalid", connectionTimeoutMs = 10)
     } catch {
       case e: ZooKeeperClientTimeoutException =>
         assertEquals(Set.empty, runningZkSendThreads,  "ZooKeeper client threads still running")


### PR DESCRIPTION
I want to discuss the topics that were previously discussed in the [PR](https://github.com/apache/kafka/pull/2552).
In my opinion, using `.invalid` instead of `.local` would be more appropriate.
The reason is that `.invalid` aligns better with the intended meaning we are using in the tests.
`.local` is a domain reserved for Multicast DNS usage and does not match the current purpose according to [RFC6762](https://www.rfc-editor.org/rfc/rfc6762.html#section-3).
[Apple](https://support.apple.com/en-us/HT207511) actually uses the `.local` domain for its intended purpose and provides guidance in that regard.
Since `.invalid` seems to align with our intended purpose, it would be better to use this domain.
[RFC6761](https://www.rfc-editor.org/rfc/rfc6761.html#section-6.4)
[RFC2606](https://datatracker.ietf.org/doc/html/rfc2606#section-2)

Regarding the name collision issue with the `.invalid` domain mentioned in the [comment](https://github.com/apache/kafka/pull/2552#issuecomment-280829672), it is likely a problem with older versions of JDK.
As seen in the [JDK BUG System](https://bugs.openjdk.org/browse/JDK-8058932), the .invalid domain performs the functionality of an invalid domain correctly.

Therefore, I believe that we should use a domain name that matches the intended meaning.
I suggest modifying `some.invalid.hostname.foo.bar.local` to `some.invalid`.

---

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
