### PR TITLE
[KAFKA-15137] Do not log entire request payload in KRaftControllerChannelManager

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractControlRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractControlRequest.java
@@ -41,6 +41,18 @@ public abstract class AbstractControlRequest extends AbstractRequest {
             this.brokerEpoch = brokerEpoch;
             this.kraftController = kraftController;
         }
+
+        public int controllerId() {
+            return controllerId;
+        }
+
+        public int controllerEpoch() {
+            return controllerEpoch;
+        }
+
+        public long brokerEpoch() {
+            return brokerEpoch;
+        }
     }
 
     protected AbstractControlRequest(ApiKeys api, short version) {

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -91,7 +91,7 @@ class ControllerChannelManager(controllerEpoch: () => Int,
         case Some(stateInfo) =>
           stateInfo.messageQueue.put(QueueItem(request.apiKey, request, callback, time.milliseconds()))
         case None =>
-          warn(s"Not sending request $request to broker $brokerId, since it is offline.")
+          warn(s"Not sending request ${request.apiKey.name} to broker $brokerId, since it is offline.")
       }
     }
   }

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -91,7 +91,9 @@ class ControllerChannelManager(controllerEpoch: () => Int,
         case Some(stateInfo) =>
           stateInfo.messageQueue.put(QueueItem(request.apiKey, request, callback, time.milliseconds()))
         case None =>
-          warn(s"Not sending request ${request.apiKey.name} to broker $brokerId, since it is offline.")
+          warn(s"Not sending request ${request.apiKey.name} with controllerId=${request.controllerId()}, " +
+            s"controllerEpoch=${request.controllerEpoch()}, brokerEpoch=${request.brokerEpoch()} " +
+            s"to broker $brokerId, since it is offline.")
       }
     }
   }


### PR DESCRIPTION
Logging the following
```
[2023-07-10 13:58:19,074] WARN [Channel manager on controller 3000]: Not sending request UpdateMetadata with controllerId=3000, controllerEpoch=4, brokerEpoch=8 to broker 0, since it is offline. (kafka.controller.ControllerChannelManager:70)
[2023-07-10 13:58:19,077] WARN [Channel manager on controller 3000]: Not sending request LeaderAndIsr with controllerId=3000, controllerEpoch=4, brokerEpoch=8 to broker 0, since it is offline. (kafka.controller.ControllerChannelManager:70)
```
vs the entire request
```
[2023-07-10 13:09:53,928] WARN [Channel manager on controller 3000]: Not sending request (type: UpdateMetadataRequest=, controllerId=3000, controllerEpoch=3, brokerEpoch=3, partitionStates=[], liveBrokers=UpdateMetadataBroker(id=0, v0Host='', v0Port=0, endpoints=[UpdateMetadataEndpoint(port=64622, host='localhost', listener='EXTERNAL', securityProtocol=0), UpdateMetadataEndpoint(port=64621, host='localhost', listener='PLAINTEXT', securityProtocol=0)], rack=null, tags=[])) to broker 0, since it is offline. (kafka.controller.KRaftControllerChannelManager:70)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
