### PR TITLE
KAFKA-14937: Refactoring for client code to reduce boilerplate

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
@@ -16,11 +16,16 @@
  */
 package org.apache.kafka.clients;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.network.ChannelBuilders;
+import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
@@ -32,9 +37,11 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.common.utils.Utils.closeQuietly;
 import static org.apache.kafka.common.utils.Utils.getHost;
 import static org.apache.kafka.common.utils.Utils.getPort;
 
@@ -42,6 +49,12 @@ public final class ClientUtils {
     private static final Logger log = LoggerFactory.getLogger(ClientUtils.class);
 
     private ClientUtils() {
+    }
+
+    public static List<InetSocketAddress> parseAndValidateAddresses(AbstractConfig config) {
+        List<String> urls = config.getList(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG);
+        String clientDnsLookupConfig = config.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG);
+        return parseAndValidateAddresses(urls, clientDnsLookupConfig);
     }
 
     public static List<InetSocketAddress> parseAndValidateAddresses(List<String> urls, String clientDnsLookupConfig) {
@@ -133,5 +146,123 @@ public final class ClientUtils {
             }
         }
         return preferredAddresses;
+    }
+
+    public static NetworkClient createNetworkClient(AbstractConfig config,
+                                                    Metrics metrics,
+                                                    String metricsGroupPrefix,
+                                                    LogContext logContext,
+                                                    ApiVersions apiVersions,
+                                                    Time time,
+                                                    int maxInFlightRequestsPerConnection,
+                                                    Metadata metadata,
+                                                    Sensor throttleTimeSensor) {
+        return createNetworkClient(config,
+                config.getString(CommonClientConfigs.CLIENT_ID_CONFIG),
+                metrics,
+                metricsGroupPrefix,
+                logContext,
+                apiVersions,
+                time,
+                maxInFlightRequestsPerConnection,
+                config.getInt(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG),
+                metadata,
+                null,
+                new DefaultHostResolver(),
+                throttleTimeSensor);
+    }
+
+    public static NetworkClient createNetworkClient(AbstractConfig config,
+                                                    String clientId,
+                                                    Metrics metrics,
+                                                    String metricsGroupPrefix,
+                                                    LogContext logContext,
+                                                    ApiVersions apiVersions,
+                                                    Time time,
+                                                    int maxInFlightRequestsPerConnection,
+                                                    int requestTimeoutMs,
+                                                    MetadataUpdater metadataUpdater,
+                                                    HostResolver hostResolver) {
+        return createNetworkClient(config,
+                clientId,
+                metrics,
+                metricsGroupPrefix,
+                logContext,
+                apiVersions,
+                time,
+                maxInFlightRequestsPerConnection,
+                requestTimeoutMs,
+                null,
+                metadataUpdater,
+                hostResolver,
+                null);
+    }
+
+    public static NetworkClient createNetworkClient(AbstractConfig config,
+                                                    String clientId,
+                                                    Metrics metrics,
+                                                    String metricsGroupPrefix,
+                                                    LogContext logContext,
+                                                    ApiVersions apiVersions,
+                                                    Time time,
+                                                    int maxInFlightRequestsPerConnection,
+                                                    int requestTimeoutMs,
+                                                    Metadata metadata,
+                                                    MetadataUpdater metadataUpdater,
+                                                    HostResolver hostResolver,
+                                                    Sensor throttleTimeSensor) {
+        ChannelBuilder channelBuilder = null;
+        Selector selector = null;
+
+        try {
+            channelBuilder = ClientUtils.createChannelBuilder(config, time, logContext);
+            selector = new Selector(config.getLong(CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG),
+                    metrics,
+                    time,
+                    metricsGroupPrefix,
+                    channelBuilder,
+                    logContext);
+            return new NetworkClient(metadataUpdater,
+                    metadata,
+                    selector,
+                    clientId,
+                    maxInFlightRequestsPerConnection,
+                    config.getLong(CommonClientConfigs.RECONNECT_BACKOFF_MS_CONFIG),
+                    config.getLong(CommonClientConfigs.RECONNECT_BACKOFF_MAX_MS_CONFIG),
+                    config.getInt(CommonClientConfigs.SEND_BUFFER_CONFIG),
+                    config.getInt(CommonClientConfigs.RECEIVE_BUFFER_CONFIG),
+                    requestTimeoutMs,
+                    config.getLong(CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG),
+                    config.getLong(CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
+                    time,
+                    true,
+                    apiVersions,
+                    throttleTimeSensor,
+                    logContext,
+                    hostResolver);
+        } catch (Throwable t) {
+            closeQuietly(selector, "Selector");
+            closeQuietly(channelBuilder, "ChannelBuilder");
+            throw new KafkaException("Failed to create new NetworkClient", t);
+        }
+    }
+
+    public static <T> List getConfiguredInterceptors(AbstractConfig config,
+                                                     String interceptorClassesConfigName,
+                                                     Class<T> clazz) {
+        String clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
+        return config.getConfiguredInstances(
+                interceptorClassesConfigName,
+                clazz,
+                Collections.singletonMap(CommonClientConfigs.CLIENT_ID_CONFIG, clientId));
+    }
+
+    public static ClusterResourceListeners configureClusterResourceListeners(List<?>... candidateLists) {
+        ClusterResourceListeners clusterResourceListeners = new ClusterResourceListeners();
+
+        for (List<?> candidateList: candidateLists)
+            clusterResourceListeners.maybeAddAll(candidateList);
+
+        return clusterResourceListeners;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -151,8 +151,6 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.network.ChannelBuilder;
-import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
@@ -482,8 +480,6 @@ public class KafkaAdminClient extends AdminClient {
         NetworkClient networkClient = null;
         Time time = Time.SYSTEM;
         String clientId = generateClientId(config);
-        ChannelBuilder channelBuilder = null;
-        Selector selector = null;
         ApiVersions apiVersions = new ApiVersions();
         LogContext logContext = createLogContext(clientId);
 
@@ -493,9 +489,7 @@ public class KafkaAdminClient extends AdminClient {
             AdminMetadataManager metadataManager = new AdminMetadataManager(logContext,
                 config.getLong(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG),
                 config.getLong(AdminClientConfig.METADATA_MAX_AGE_CONFIG));
-            List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
-                    config.getList(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG),
-                    config.getString(AdminClientConfig.CLIENT_DNS_LOOKUP_CONFIG));
+            List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config);
             metadataManager.update(Cluster.bootstrap(addresses), time.milliseconds());
             List<MetricsReporter> reporters = CommonClientConfigs.metricsReporters(clientId, config);
             Map<String, String> metricTags = Collections.singletonMap("client-id", clientId);
@@ -506,36 +500,22 @@ public class KafkaAdminClient extends AdminClient {
             MetricsContext metricsContext = new KafkaMetricsContext(JMX_PREFIX,
                     config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
             metrics = new Metrics(metricConfig, reporters, time, metricsContext);
-            String metricGrpPrefix = "admin-client";
-            channelBuilder = ClientUtils.createChannelBuilder(config, time, logContext);
-            selector = new Selector(config.getLong(AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
-                    metrics, time, metricGrpPrefix, channelBuilder, logContext);
-            networkClient = new NetworkClient(
-                metadataManager.updater(),
-                null,
-                selector,
-                clientId,
-                1,
-                config.getLong(AdminClientConfig.RECONNECT_BACKOFF_MS_CONFIG),
-                config.getLong(AdminClientConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG),
-                config.getInt(AdminClientConfig.SEND_BUFFER_CONFIG),
-                config.getInt(AdminClientConfig.RECEIVE_BUFFER_CONFIG),
-                (int) TimeUnit.HOURS.toMillis(1),
-                config.getLong(AdminClientConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG),
-                config.getLong(AdminClientConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
-                time,
-                true,
-                apiVersions,
-                null,
-                logContext,
-                (hostResolver == null) ? new DefaultHostResolver() : hostResolver);
+            networkClient = ClientUtils.createNetworkClient(config,
+                    clientId,
+                    metrics,
+                    "admin-client",
+                    logContext,
+                    apiVersions,
+                    time,
+                    1,
+                    (int) TimeUnit.HOURS.toMillis(1),
+                    metadataManager.updater(),
+                    hostResolver == null ? new DefaultHostResolver() : hostResolver);
             return new KafkaAdminClient(config, clientId, time, metadataManager, metrics, networkClient,
                 timeoutProcessorFactory, logContext);
         } catch (Throwable exc) {
             closeQuietly(metrics, "Metrics");
             closeQuietly(networkClient, "NetworkClient");
-            closeQuietly(selector, "Selector");
-            closeQuietly(channelBuilder, "ChannelBuilder");
             throw new KafkaException("Failed to create new KafkaAdminClient", exc);
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -53,7 +53,7 @@ public class CommitRequestManager implements RequestManager {
     // TODO: current in ConsumerConfig but inaccessible in the internal package.
     private static final String THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED = "internal.throw.on.fetch.stable.offset.unsupported";
     // TODO: We will need to refactor the subscriptionState
-    private final SubscriptionState subscriptionState;
+    private final SubscriptionState subscriptions;
     private final Logger log;
     private final Optional<AutoCommitState> autoCommitState;
     private final CoordinatorRequestManager coordinatorRequestManager;
@@ -62,13 +62,12 @@ public class CommitRequestManager implements RequestManager {
     private final boolean throwOnFetchStableOffsetUnsupported;
     final PendingRequests pendingRequests;
 
-    public CommitRequestManager(
-            final Time time,
-            final LogContext logContext,
-            final SubscriptionState subscriptionState,
-            final ConsumerConfig config,
-            final CoordinatorRequestManager coordinatorRequestManager,
-            final GroupState groupState) {
+    public CommitRequestManager(final Time time,
+                                final LogContext logContext,
+                                final SubscriptionState subscriptions,
+                                final ConsumerConfig config,
+                                final CoordinatorRequestManager coordinatorRequestManager,
+                                final GroupState groupState) {
         Objects.requireNonNull(coordinatorRequestManager, "Coordinator is needed upon committing offsets");
         this.log = logContext.logger(getClass());
         this.pendingRequests = new PendingRequests();
@@ -81,7 +80,7 @@ public class CommitRequestManager implements RequestManager {
         }
         this.coordinatorRequestManager = coordinatorRequestManager;
         this.groupState = groupState;
-        this.subscriptionState = subscriptionState;
+        this.subscriptions = subscriptions;
         this.retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
         this.throwOnFetchStableOffsetUnsupported = config.getBoolean(THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED);
     }
@@ -111,7 +110,7 @@ public class CommitRequestManager implements RequestManager {
             return;
         }
 
-        Map<TopicPartition, OffsetAndMetadata> allConsumedOffsets = subscriptionState.allConsumed();
+        Map<TopicPartition, OffsetAndMetadata> allConsumedOffsets = subscriptions.allConsumed();
         sendAutoCommit(allConsumedOffsets);
         autocommit.resetTimer();
         autocommit.setInflightCommitStatus(true);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CompletedFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CompletedFetch.java
@@ -295,9 +295,9 @@ class CompletedFetch<K, V> {
             long timestamp = record.timestamp();
             Headers headers = new RecordHeaders(record.headers());
             ByteBuffer keyBytes = record.key();
-            K key = keyBytes == null ? null : fetchConfig.keyDeserializer.deserialize(partition.topic(), headers, keyBytes);
+            K key = keyBytes == null ? null : fetchConfig.deserializers.keyDeserializer.deserialize(partition.topic(), headers, keyBytes);
             ByteBuffer valueBytes = record.value();
-            V value = valueBytes == null ? null : fetchConfig.valueDeserializer.deserialize(partition.topic(), headers, valueBytes);
+            V value = valueBytes == null ? null : fetchConfig.deserializers.valueDeserializer.deserialize(partition.topic(), headers, valueBytes);
             return new ConsumerRecord<>(partition.topic(), partition.partition(), offset,
                     timestamp, timestampType,
                     keyBytes == null ? ConsumerRecord.NULL_SIZE : keyBytes.remaining(),

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.utils.LogContext;
@@ -44,6 +45,19 @@ public class ConsumerMetadata extends Metadata {
         this.allowAutoTopicCreation = allowAutoTopicCreation;
         this.subscription = subscription;
         this.transientTopics = new HashSet<>();
+    }
+
+    public ConsumerMetadata(ConsumerConfig config,
+                            SubscriptionState subscriptions,
+                            LogContext logContext,
+                            ClusterResourceListeners clusterResourceListeners) {
+        this(config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG),
+                config.getLong(ConsumerConfig.METADATA_MAX_AGE_CONFIG),
+                !config.getBoolean(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG),
+                config.getBoolean(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG),
+                subscriptions,
+                logContext,
+                clusterResourceListeners);
     }
 
     public boolean allowAutoTopicCreation() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
@@ -38,8 +38,8 @@ import java.util.Optional;
  * Whether there is an existing coordinator.
  * Whether there is an inflight request.
  * Whether the backoff timer has expired.
- * The {@link org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult} contains either a wait timer
- * or a singleton list of {@link org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.UnsentRequest}.
+ * The {@link NetworkClientDelegate.PollResult} contains either a wait timer or a singleton list of
+ * {@link NetworkClientDelegate.UnsentRequest}.
  *
  * The {@link FindCoordinatorRequest} will be handled by the {@link #onResponse(long, FindCoordinatorResponse)}  callback, which
  * subsequently invokes {@code onResponse} to handle the exception and response. Note that the coordinator node will be
@@ -57,13 +57,11 @@ public class CoordinatorRequestManager implements RequestManager {
     private long totalDisconnectedMin = 0;
     private Node coordinator;
 
-    public CoordinatorRequestManager(
-        final Time time,
-        final LogContext logContext,
-        final long retryBackoffMs,
-        final ErrorEventHandler errorHandler,
-        final String groupId
-    ) {
+    public CoordinatorRequestManager(final Time time,
+                                     final LogContext logContext,
+                                     final long retryBackoffMs,
+                                     final ErrorEventHandler errorHandler,
+                                     final String groupId) {
         Objects.requireNonNull(groupId);
         this.time = time;
         this.log = logContext.logger(this.getClass());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -16,28 +16,31 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.GroupRebalanceConfig;
-import org.apache.kafka.clients.KafkaClient;
+import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedList;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
+
+import static org.apache.kafka.clients.consumer.internals.Utils.CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION;
+import static org.apache.kafka.clients.consumer.internals.Utils.CONSUMER_METRIC_GROUP_PREFIX;
 
 /**
  * Background thread runnable that consumes {@code ApplicationEvent} and
@@ -48,6 +51,7 @@ import java.util.concurrent.BlockingQueue;
  * initialized by the polling thread.
  */
 public class DefaultBackgroundThread extends KafkaThread {
+
     private static final long MAX_POLL_TIMEOUT_MS = 5000;
     private static final String BACKGROUND_THREAD_NAME = "consumer_background_thread";
     private final Time time;
@@ -61,9 +65,10 @@ public class DefaultBackgroundThread extends KafkaThread {
     private final NetworkClientDelegate networkClientDelegate;
     private final ErrorEventHandler errorEventHandler;
     private final GroupState groupState;
-    private boolean running;
+    private volatile boolean running;
+    private volatile boolean closed;
 
-    private final Map<RequestManager.Type, Optional<RequestManager>> requestManagerRegistry;
+    private final RequestManagers requestManagers;
 
     // Visible for testing
     DefaultBackgroundThread(final Time time,
@@ -71,16 +76,15 @@ public class DefaultBackgroundThread extends KafkaThread {
                             final LogContext logContext,
                             final BlockingQueue<ApplicationEvent> applicationEventQueue,
                             final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                            final ErrorEventHandler errorEventHandler,
-                            final ApplicationEventProcessor processor,
                             final ConsumerMetadata metadata,
                             final NetworkClientDelegate networkClient,
                             final GroupState groupState,
+                            final ErrorEventHandler errorEventHandler,
+                            final ApplicationEventProcessor processor,
                             final CoordinatorRequestManager coordinatorManager,
                             final CommitRequestManager commitRequestManager) {
         super(BACKGROUND_THREAD_NAME, true);
         this.time = time;
-        this.running = true;
         this.log = logContext.logger(getClass());
         this.applicationEventQueue = applicationEventQueue;
         this.backgroundEventQueue = backgroundEventQueue;
@@ -91,18 +95,21 @@ public class DefaultBackgroundThread extends KafkaThread {
         this.errorEventHandler = errorEventHandler;
         this.groupState = groupState;
 
-        this.requestManagerRegistry = new HashMap<>();
-        this.requestManagerRegistry.put(RequestManager.Type.COORDINATOR, Optional.ofNullable(coordinatorManager));
-        this.requestManagerRegistry.put(RequestManager.Type.COMMIT, Optional.ofNullable(commitRequestManager));
+        this.requestManagers = new RequestManagers(Optional.ofNullable(coordinatorManager),
+                Optional.ofNullable(commitRequestManager));
     }
+
     public DefaultBackgroundThread(final Time time,
                                    final ConsumerConfig config,
-                                   final GroupRebalanceConfig rebalanceConfig,
                                    final LogContext logContext,
                                    final BlockingQueue<ApplicationEvent> applicationEventQueue,
                                    final BlockingQueue<BackgroundEvent> backgroundEventQueue,
                                    final ConsumerMetadata metadata,
-                                   final KafkaClient networkClient) {
+                                   final ApiVersions apiVersions,
+                                   final Metrics metrics,
+                                   final Sensor fetcherThrottleTimeSensor,
+                                   final SubscriptionState subscriptions,
+                                   final GroupRebalanceConfig rebalanceConfig) {
         super(BACKGROUND_THREAD_NAME, true);
         try {
             this.time = time;
@@ -110,50 +117,58 @@ public class DefaultBackgroundThread extends KafkaThread {
             this.applicationEventQueue = applicationEventQueue;
             this.backgroundEventQueue = backgroundEventQueue;
             this.config = config;
-            // subscriptionState is initialized by the polling thread
             this.metadata = metadata;
-            this.networkClientDelegate = new NetworkClientDelegate(
-                    this.time,
-                    this.config,
+
+            final NetworkClient networkClient = ClientUtils.createNetworkClient(config,
+                    metrics,
+                    CONSUMER_METRIC_GROUP_PREFIX,
                     logContext,
-                    networkClient);
-            this.running = true;
+                    apiVersions,
+                    time,
+                    CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION,
+                    metadata,
+                    fetcherThrottleTimeSensor);
+
+            this.networkClientDelegate = new NetworkClientDelegate(this.time, this.config, logContext, networkClient);
             this.errorEventHandler = new ErrorEventHandler(this.backgroundEventQueue);
             this.groupState = new GroupState(rebalanceConfig);
-            this.requestManagerRegistry = Collections.unmodifiableMap(buildRequestManagerRegistry(logContext));
-            this.applicationEventProcessor = new ApplicationEventProcessor(backgroundEventQueue, requestManagerRegistry);
+            long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
+
+            if (groupState.groupId != null) {
+                CoordinatorRequestManager coordinatorManager = new CoordinatorRequestManager(this.time,
+                        logContext,
+                        retryBackoffMs,
+                        this.errorEventHandler,
+                        groupState.groupId);
+                CommitRequestManager commitRequestManager = new CommitRequestManager(this.time,
+                        logContext,
+                        subscriptions,
+                        config,
+                        coordinatorManager,
+                        groupState);
+                this.requestManagers = new RequestManagers(Optional.of(coordinatorManager),
+                        Optional.of(commitRequestManager));
+            } else {
+                this.requestManagers = new RequestManagers(Optional.empty(), Optional.empty());
+            }
+
+            this.applicationEventProcessor = new ApplicationEventProcessor(backgroundEventQueue, requestManagers, metadata);
         } catch (final Exception e) {
             close();
             throw new KafkaException("Failed to construct background processor", e.getCause());
         }
     }
 
-    private Map<RequestManager.Type, Optional<RequestManager>> buildRequestManagerRegistry(final LogContext logContext) {
-        Map<RequestManager.Type, Optional<RequestManager>> registry = new HashMap<>();
-        CoordinatorRequestManager coordinatorManager = groupState.groupId == null ?
-                null :
-                new CoordinatorRequestManager(
-                        time,
-                        logContext,
-                        config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG),
-                        errorEventHandler,
-                        groupState.groupId);
-        // Add subscriptionState
-        CommitRequestManager commitRequestManager = coordinatorManager == null ?
-                null :
-                new CommitRequestManager(time,
-                        logContext, null, config,
-                        coordinatorManager,
-                        groupState);
-        registry.put(RequestManager.Type.COORDINATOR, Optional.ofNullable(coordinatorManager));
-        registry.put(RequestManager.Type.COMMIT, Optional.ofNullable(commitRequestManager));
-        return registry;
-    }
-
     @Override
     public void run() {
+        if (closed)
+            throw new IllegalStateException("Background consumer thread is closed");
+
+        running = true;
+
         try {
             log.debug("Background thread started");
+
             while (running) {
                 try {
                     runOnce();
@@ -167,7 +182,7 @@ public class DefaultBackgroundThread extends KafkaThread {
             throw new RuntimeException(t);
         } finally {
             close();
-            log.debug("{} closed", getClass());
+            log.debug("Exited run loop");
         }
     }
 
@@ -178,22 +193,25 @@ public class DefaultBackgroundThread extends KafkaThread {
      * 3. Poll the networkClient to send and retrieve the response.
      */
     void runOnce() {
-        drain();
+        if (!applicationEventQueue.isEmpty()) {
+            LinkedList<ApplicationEvent> res = new LinkedList<>();
+            this.applicationEventQueue.drainTo(res);
+
+            for (ApplicationEvent event : res) {
+                log.debug("Consuming application event: {}", event);
+                Objects.requireNonNull(event);
+                applicationEventProcessor.process(event);
+            }
+        }
+
         final long currentTimeMs = time.milliseconds();
-        final long pollWaitTimeMs = requestManagerRegistry.values().stream()
+        final long pollWaitTimeMs = requestManagers.entries().stream()
                 .filter(Optional::isPresent)
                 .map(m -> m.get().poll(currentTimeMs))
+                .filter(Objects::nonNull)
                 .map(this::handlePollResult)
                 .reduce(MAX_POLL_TIMEOUT_MS, Math::min);
         networkClientDelegate.poll(pollWaitTimeMs, currentTimeMs);
-    }
-
-    private void drain() {
-        Queue<ApplicationEvent> events = pollApplicationEvent();
-        for (ApplicationEvent event : events) {
-            log.debug("Consuming application event: {}", event);
-            consumeApplicationEvent(event);
-        }
     }
 
     long handlePollResult(NetworkClientDelegate.PollResult res) {
@@ -203,23 +221,8 @@ public class DefaultBackgroundThread extends KafkaThread {
         return res.timeUntilNextPollMs;
     }
 
-    private Queue<ApplicationEvent> pollApplicationEvent() {
-        if (this.applicationEventQueue.isEmpty()) {
-            return new LinkedList<>();
-        }
-
-        LinkedList<ApplicationEvent> res = new LinkedList<>();
-        this.applicationEventQueue.drainTo(res);
-        return res;
-    }
-
-    private void consumeApplicationEvent(final ApplicationEvent event) {
-        Objects.requireNonNull(event);
-        applicationEventProcessor.process(event);
-    }
-
     public boolean isRunning() {
-        return this.running;
+        return running;
     }
 
     public void wakeup() {
@@ -227,8 +230,12 @@ public class DefaultBackgroundThread extends KafkaThread {
     }
 
     public void close() {
-        this.running = false;
-        this.wakeup();
+        if (closed)
+            return;
+
+        closed = true;
+        running = false;
+        wakeup();
         Utils.closeQuietly(networkClientDelegate, "network client utils");
         Utils.closeQuietly(metadata, "consumer metadata client");
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -19,8 +19,6 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.GroupRebalanceConfig;
-import org.apache.kafka.clients.KafkaClient;
-import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
@@ -28,8 +26,6 @@ import org.apache.kafka.clients.consumer.internals.events.EventHandler;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.network.ChannelBuilder;
-import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 
@@ -41,10 +37,10 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * An {@code EventHandler} that uses a single background thread to consume {@code ApplicationEvent} and produce
- * {@code BackgroundEvent} from the {@ConsumerBackgroundThread}.
+ * {@code BackgroundEvent} from the {@link DefaultBackgroundThread}.
  */
 public class DefaultEventHandler implements EventHandler {
-    private static final String METRIC_GRP_PREFIX = "consumer";
+
     private final BlockingQueue<ApplicationEvent> applicationEventQueue;
     private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
     private final DefaultBackgroundThread backgroundThread;
@@ -52,18 +48,18 @@ public class DefaultEventHandler implements EventHandler {
     public DefaultEventHandler(final ConsumerConfig config,
                                final GroupRebalanceConfig groupRebalanceConfig,
                                final LogContext logContext,
-                               final SubscriptionState subscriptionState,
+                               final SubscriptionState subscriptions,
                                final ApiVersions apiVersions,
                                final Metrics metrics,
                                final ClusterResourceListeners clusterResourceListeners,
                                final Sensor fetcherThrottleTimeSensor) {
         this(Time.SYSTEM,
                 config,
-                groupRebalanceConfig,
                 logContext,
                 new LinkedBlockingQueue<>(),
                 new LinkedBlockingQueue<>(),
-                subscriptionState,
+                subscriptions,
+                groupRebalanceConfig,
                 apiVersions,
                 metrics,
                 clusterResourceListeners,
@@ -72,85 +68,39 @@ public class DefaultEventHandler implements EventHandler {
 
     public DefaultEventHandler(final Time time,
                                final ConsumerConfig config,
-                               final GroupRebalanceConfig groupRebalanceConfig,
                                final LogContext logContext,
                                final BlockingQueue<ApplicationEvent> applicationEventQueue,
                                final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                               final SubscriptionState subscriptionState,
+                               final SubscriptionState subscriptions,
+                               final GroupRebalanceConfig groupRebalanceConfig,
                                final ApiVersions apiVersions,
                                final Metrics metrics,
                                final ClusterResourceListeners clusterResourceListeners,
                                final Sensor fetcherThrottleTimeSensor) {
         this.applicationEventQueue = applicationEventQueue;
         this.backgroundEventQueue = backgroundEventQueue;
-        final ConsumerMetadata metadata = bootstrapMetadata(
-            logContext,
-            clusterResourceListeners,
-            config,
-            subscriptionState
-        );
-        final ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config, time, logContext);
-        final Selector selector = new Selector(
-            config.getLong(
-            ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
-            metrics,
-            time,
-            METRIC_GRP_PREFIX,
-            channelBuilder,
-            logContext
-        );
-        final NetworkClient networkClient = new NetworkClient(
-            selector,
-            metadata,
-            config.getString(ConsumerConfig.CLIENT_ID_CONFIG),
-            100, // a fixed large enough value will suffice for max
-            // in-flight requests
-            config.getLong(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG),
-            config.getLong(ConsumerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG),
-            config.getInt(ConsumerConfig.SEND_BUFFER_CONFIG),
-            config.getInt(ConsumerConfig.RECEIVE_BUFFER_CONFIG),
-            config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
-            config.getLong(ConsumerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG),
-            config.getLong(ConsumerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
-            time,
-            true,
-            apiVersions,
-            fetcherThrottleTimeSensor,
-            logContext
-        );
-        this.backgroundThread = new DefaultBackgroundThread(
-            time,
-            config,
-            groupRebalanceConfig,
-            logContext,
-            this.applicationEventQueue,
-            this.backgroundEventQueue,
-            metadata,
-            networkClient);
-        this.backgroundThread.start();
-    }
 
-    // VisibleForTesting
-    DefaultEventHandler(final Time time,
-                        final ConsumerConfig config,
-                        final GroupRebalanceConfig groupRebalanceConfig,
-                        final LogContext logContext,
-                        final BlockingQueue<ApplicationEvent> applicationEventQueue,
-                        final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                        final ConsumerMetadata metadata,
-                        final KafkaClient networkClient) {
-        this.applicationEventQueue = applicationEventQueue;
-        this.backgroundEventQueue = backgroundEventQueue;
-        this.backgroundThread = new DefaultBackgroundThread(
-            time,
-            config,
-            groupRebalanceConfig,
-            logContext,
-            this.applicationEventQueue,
-            this.backgroundEventQueue,
-            metadata,
-            networkClient);
-        backgroundThread.start();
+        // Bootstrap a metadata object with the bootstrap server IP address, which will be used once for the
+        // subsequent metadata refresh once the background thread has started up.
+        final ConsumerMetadata metadata = new ConsumerMetadata(config,
+                subscriptions,
+                logContext,
+                clusterResourceListeners);
+        final List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config);
+        metadata.bootstrap(addresses);
+
+        this.backgroundThread = new DefaultBackgroundThread(time,
+                config,
+                logContext,
+                this.applicationEventQueue,
+                this.backgroundEventQueue,
+                metadata,
+                apiVersions,
+                metrics,
+                fetcherThrottleTimeSensor,
+                subscriptions,
+                groupRebalanceConfig);
+        this.backgroundThread.start();
     }
 
     // VisibleForTesting
@@ -177,27 +127,6 @@ public class DefaultEventHandler implements EventHandler {
     public boolean add(final ApplicationEvent event) {
         backgroundThread.wakeup();
         return applicationEventQueue.add(event);
-    }
-
-    // bootstrap a metadata object with the bootstrap server IP address,
-    // which will be used once for the subsequent metadata refresh once the
-    // background thread has started up.
-    private ConsumerMetadata bootstrapMetadata(
-        final LogContext logContext,
-        final ClusterResourceListeners clusterResourceListeners,
-        final ConsumerConfig config,
-        final SubscriptionState subscriptions) {
-        final ConsumerMetadata metadata = new ConsumerMetadata(
-            config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG),
-            config.getLong(ConsumerConfig.METADATA_MAX_AGE_CONFIG),
-            !config.getBoolean(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG),
-            config.getBoolean(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG),
-            subscriptions,
-            logContext, clusterResourceListeners);
-        final List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
-            config.getList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG), config.getString(ConsumerConfig.CLIENT_DNS_LOOKUP_CONFIG));
-        metadata.bootstrap(addresses);
-        return metadata;
     }
 
     public void close() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Deserializers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Deserializers.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.errors.InterruptException;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.utils.Utils;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class Deserializers<K, V> implements AutoCloseable {
+
+    public final Deserializer<K> keyDeserializer;
+    public final Deserializer<V> valueDeserializer;
+
+    public Deserializers(Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
+        this.keyDeserializer = Objects.requireNonNull(keyDeserializer, "Key deserializer provided to Deserializers should not be null");
+        this.valueDeserializer = Objects.requireNonNull(valueDeserializer, "Value deserializer provided to Deserializers should not be null");
+    }
+
+    public Deserializers(ConsumerConfig config) {
+        this(config, null, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Deserializers(ConsumerConfig config, Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
+        String clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
+
+        if (keyDeserializer == null) {
+            this.keyDeserializer = config.getConfiguredInstance(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, Deserializer.class);
+            this.keyDeserializer.configure(config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId)), true);
+        } else {
+            config.ignore(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG);
+            this.keyDeserializer = keyDeserializer;
+        }
+
+        if (valueDeserializer == null) {
+            this.valueDeserializer = config.getConfiguredInstance(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, Deserializer.class);
+            this.valueDeserializer.configure(config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId)), false);
+        } else {
+            config.ignore(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG);
+            this.valueDeserializer = valueDeserializer;
+        }
+    }
+
+    @Override
+    public void close() {
+        AtomicReference<Throwable> firstException = new AtomicReference<>();
+        Utils.closeQuietly(keyDeserializer, "key deserializer", firstException);
+        Utils.closeQuietly(valueDeserializer, "value deserializer", firstException);
+        Throwable exception = firstException.get();
+
+        if (exception != null) {
+            if (exception instanceof InterruptException) {
+                throw (InterruptException) exception;
+            }
+            throw new KafkaException("Failed to close deserializers", exception);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchConfig.java
@@ -41,8 +41,9 @@ import java.util.Objects;
  *     <li>{@link #maxPollRecords}: {@link ConsumerConfig#MAX_POLL_RECORDS_CONFIG}</li>
  *     <li>{@link #checkCrcs}: {@link ConsumerConfig#CHECK_CRCS_CONFIG}</li>
  *     <li>{@link #clientRackId}: {@link ConsumerConfig#CLIENT_RACK_CONFIG}</li>
- *     <li>{@link #keyDeserializer}: {@link ConsumerConfig#KEY_DESERIALIZER_CLASS_CONFIG}</li>
- *     <li>{@link #valueDeserializer}: {@link ConsumerConfig#VALUE_DESERIALIZER_CLASS_CONFIG}</li>
+ *     <li>{@link #deserializers}:
+ *         {@link ConsumerConfig#KEY_DESERIALIZER_CLASS_CONFIG}/{@link ConsumerConfig#VALUE_DESERIALIZER_CLASS_CONFIG}
+ *     </li>
  *     <li>{@link #isolationLevel}: {@link ConsumerConfig#ISOLATION_LEVEL_CONFIG}</li>
  * </ul>
  *
@@ -66,8 +67,7 @@ public class FetchConfig<K, V> {
     final int maxPollRecords;
     final boolean checkCrcs;
     final String clientRackId;
-    final Deserializer<K> keyDeserializer;
-    final Deserializer<V> valueDeserializer;
+    final Deserializers<K, V> deserializers;
     final IsolationLevel isolationLevel;
 
     public FetchConfig(int minBytes,
@@ -77,8 +77,7 @@ public class FetchConfig<K, V> {
                        int maxPollRecords,
                        boolean checkCrcs,
                        String clientRackId,
-                       Deserializer<K> keyDeserializer,
-                       Deserializer<V> valueDeserializer,
+                       Deserializers<K, V> deserializers,
                        IsolationLevel isolationLevel) {
         this.minBytes = minBytes;
         this.maxBytes = maxBytes;
@@ -87,14 +86,12 @@ public class FetchConfig<K, V> {
         this.maxPollRecords = maxPollRecords;
         this.checkCrcs = checkCrcs;
         this.clientRackId = clientRackId;
-        this.keyDeserializer = Objects.requireNonNull(keyDeserializer, "Message key deserializer provided to FetchConfig should not be null");
-        this.valueDeserializer = Objects.requireNonNull(valueDeserializer, "Message value deserializer provided to FetchConfig should not be null");
+        this.deserializers = Objects.requireNonNull(deserializers, "Message deserializers provided to FetchConfig should not be null");
         this.isolationLevel = isolationLevel;
     }
 
     public FetchConfig(ConsumerConfig config,
-                       Deserializer<K> keyDeserializer,
-                       Deserializer<V> valueDeserializer,
+                       Deserializers<K, V> deserializers,
                        IsolationLevel isolationLevel) {
         this.minBytes = config.getInt(ConsumerConfig.FETCH_MIN_BYTES_CONFIG);
         this.maxBytes = config.getInt(ConsumerConfig.FETCH_MAX_BYTES_CONFIG);
@@ -103,8 +100,7 @@ public class FetchConfig<K, V> {
         this.maxPollRecords = config.getInt(ConsumerConfig.MAX_POLL_RECORDS_CONFIG);
         this.checkCrcs = config.getBoolean(ConsumerConfig.CHECK_CRCS_CONFIG);
         this.clientRackId = config.getString(ConsumerConfig.CLIENT_RACK_CONFIG);
-        this.keyDeserializer = Objects.requireNonNull(keyDeserializer, "Message key deserializer provided to FetchConfig should not be null");
-        this.valueDeserializer = Objects.requireNonNull(valueDeserializer, "Message value deserializer provided to FetchConfig should not be null");
+        this.deserializers = Objects.requireNonNull(deserializers, "Message deserializers provided to FetchConfig should not be null");
         this.isolationLevel = isolationLevel;
     }
 
@@ -118,8 +114,7 @@ public class FetchConfig<K, V> {
                 ", maxPollRecords=" + maxPollRecords +
                 ", checkCrcs=" + checkCrcs +
                 ", clientRackId='" + clientRackId + '\'' +
-                ", keyDeserializer=" + keyDeserializer +
-                ", valueDeserializer=" + valueDeserializer +
+                ", deserializers=" + deserializers +
                 ", isolationLevel=" + isolationLevel +
                 '}';
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -202,16 +202,13 @@ public class NetworkClientDelegate implements AutoCloseable {
         private Optional<Node> node; // empty if random node can be chosen
         private Timer timer;
 
-        public UnsentRequest(
-                final AbstractRequest.Builder<?> requestBuilder,
-                final Optional<Node> node) {
+        public UnsentRequest(final AbstractRequest.Builder<?> requestBuilder, final Optional<Node> node) {
             this(requestBuilder, node, new FutureCompletionHandler());
         }
 
-        public UnsentRequest(
-                final AbstractRequest.Builder<?> requestBuilder,
-                final Optional<Node> node,
-                final FutureCompletionHandler handler) {
+        public UnsentRequest(final AbstractRequest.Builder<?> requestBuilder,
+                             final Optional<Node> node,
+                             final FutureCompletionHandler handler) {
             Objects.requireNonNull(requestBuilder);
             this.requestBuilder = requestBuilder;
             this.node = node;
@@ -241,6 +238,7 @@ public class NetworkClientDelegate implements AutoCloseable {
     }
 
     public static class FutureCompletionHandler implements RequestCompletionHandler {
+
         private final CompletableFuture<ClientResponse> future;
 
         FutureCompletionHandler() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.ApiVersions;
-import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.GroupRebalanceConfig;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -28,11 +28,12 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.CommitApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.EventHandler;
+import org.apache.kafka.clients.consumer.internals.events.MetadataUpdateApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.OffsetFetchApplicationEvent;
+import org.apache.kafka.clients.consumer.internals.events.UnsubscribeApplicationEvent;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
@@ -42,24 +43,19 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
-import org.apache.kafka.common.metrics.KafkaMetricsContext;
-import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.metrics.MetricsContext;
-import org.apache.kafka.common.metrics.MetricsReporter;
-import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -74,6 +70,14 @@ import java.util.regex.Pattern;
 
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.internals.Utils.createLogContext;
+import static org.apache.kafka.clients.consumer.internals.Utils.createMetrics;
+import static org.apache.kafka.clients.consumer.internals.Utils.createSubscriptionState;
+import static org.apache.kafka.clients.consumer.internals.Utils.getConfiguredConsumerInterceptors;
+import static org.apache.kafka.common.utils.Utils.closeQuietly;
+import static org.apache.kafka.common.utils.Utils.isBlank;
+import static org.apache.kafka.common.utils.Utils.join;
+import static org.apache.kafka.common.utils.Utils.propsToMap;
 
 /**
  * This prototype consumer uses the EventHandler to process application
@@ -82,33 +86,30 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZE
  * for detail implementation.
  */
 public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
-    private static final String CLIENT_ID_METRIC_TAG = "client-id";
-    private static final String JMX_PREFIX = "kafka.consumer";
     static final long DEFAULT_CLOSE_TIMEOUT_MS = 30 * 1000;
 
     private final LogContext logContext;
     private final EventHandler eventHandler;
     private final Time time;
     private final Optional<String> groupId;
-    private final String clientId;
     private final Logger log;
+    private final Deserializers<K, V> deserializers;
     private final SubscriptionState subscriptions;
     private final Metrics metrics;
     private final long defaultApiTimeoutMs;
 
-    public PrototypeAsyncConsumer(Properties properties,
-                         Deserializer<K> keyDeserializer,
-                         Deserializer<V> valueDeserializer) {
-        this(Utils.propsToMap(properties), keyDeserializer, valueDeserializer);
+    public PrototypeAsyncConsumer(final Properties properties,
+                                  final Deserializer<K> keyDeserializer,
+                                  final Deserializer<V> valueDeserializer) {
+        this(propsToMap(properties), keyDeserializer, valueDeserializer);
     }
 
     public PrototypeAsyncConsumer(final Map<String, Object> configs,
                                   final Deserializer<K> keyDeser,
                                   final Deserializer<V> valDeser) {
-        this(new ConsumerConfig(appendDeserializerToConfig(configs, keyDeser, valDeser)), keyDeser,
-                valDeser);
+        this(new ConsumerConfig(appendDeserializerToConfig(configs, keyDeser, valDeser)), keyDeser, valDeser);
     }
-    @SuppressWarnings("unchecked")
+
     public PrototypeAsyncConsumer(final ConsumerConfig config,
                                   final Deserializer<K> keyDeserializer,
                                   final Deserializer<V> valueDeserializer) {
@@ -116,25 +117,16 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
                 GroupRebalanceConfig.ProtocolType.CONSUMER);
         this.groupId = Optional.ofNullable(groupRebalanceConfig.groupId);
-        this.clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
         this.defaultApiTimeoutMs = config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
-        // If group.instance.id is set, we will append it to the log context.
-        if (groupRebalanceConfig.groupInstanceId.isPresent()) {
-            logContext = new LogContext("[Consumer instanceId=" + groupRebalanceConfig.groupInstanceId.get() +
-                    ", clientId=" + clientId + ", groupId=" + groupId.orElse("null") + "] ");
-        } else {
-            logContext = new LogContext("[Consumer clientId=" + clientId + ", groupId=" + groupId.orElse("null") + "] ");
-        }
+        this.logContext = createLogContext(config, groupRebalanceConfig);
         this.log = logContext.logger(getClass());
-        OffsetResetStrategy offsetResetStrategy = OffsetResetStrategy.valueOf(config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).toUpperCase(Locale.ROOT));
-        this.subscriptions = new SubscriptionState(logContext, offsetResetStrategy);
-        this.metrics = buildMetrics(config, time, clientId);
-        List<ConsumerInterceptor<K, V>> interceptorList = (List) config.getConfiguredInstances(
-                ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
-                ConsumerInterceptor.class,
-                Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId));
-        ClusterResourceListeners clusterResourceListeners = configureClusterResourceListeners(keyDeserializer,
-                valueDeserializer, metrics.reporters(), interceptorList);
+        this.deserializers = new Deserializers<>(config, keyDeserializer, valueDeserializer);
+        this.subscriptions = createSubscriptionState(config, logContext);
+        this.metrics = createMetrics(config, time);
+        List<ConsumerInterceptor<K, V>> interceptorList = getConfiguredConsumerInterceptors(config);
+        ClusterResourceListeners clusterResourceListeners = ClientUtils.configureClusterResourceListeners(metrics.reporters(),
+                interceptorList,
+                Arrays.asList(deserializers.keyDeserializer, deserializers.valueDeserializer));
         this.eventHandler = new DefaultEventHandler(
                 config,
                 groupRebalanceConfig,
@@ -148,28 +140,24 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     }
 
     // Visible for testing
-    PrototypeAsyncConsumer(
-            Time time,
-            LogContext logContext,
-            ConsumerConfig config,
-            SubscriptionState subscriptionState,
-            EventHandler eventHandler,
-            Metrics metrics,
-            ClusterResourceListeners clusterResourceListeners,
-            Optional<String> groupId,
-            String clientId,
-            int defaultApiTimeoutMs) {
+    PrototypeAsyncConsumer(Time time,
+                           LogContext logContext,
+                           ConsumerConfig config,
+                           SubscriptionState subscriptions,
+                           EventHandler eventHandler,
+                           Metrics metrics,
+                           Optional<String> groupId,
+                           int defaultApiTimeoutMs) {
         this.time = time;
         this.logContext = logContext;
         this.log = logContext.logger(getClass());
-        this.subscriptions = subscriptionState;
+        this.subscriptions = subscriptions;
         this.metrics = metrics;
         this.groupId = groupId;
         this.defaultApiTimeoutMs = defaultApiTimeoutMs;
-        this.clientId = clientId;
+        this.deserializers = new Deserializers<>(config);
         this.eventHandler = eventHandler;
     }
-
 
     /**
      * poll implementation using {@link EventHandler}.
@@ -448,7 +436,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     @Override
     public void close(Duration timeout) {
         AtomicReference<Throwable> firstException = new AtomicReference<>();
-        Utils.closeQuietly(this.eventHandler, "event handler", firstException);
+        closeQuietly(this.eventHandler, "event handler", firstException);
         log.debug("Kafka consumer has been closed");
         Throwable exception = firstException.get();
         if (exception != null) {
@@ -497,7 +485,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public Set<TopicPartition> assignment() {
-        throw new KafkaException("method not implemented");
+        return Collections.unmodifiableSet(this.subscriptions.assignedPartitions());
     }
 
     /**
@@ -522,7 +510,35 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void assign(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        if (partitions == null) {
+            throw new IllegalArgumentException("Topic partitions collection to assign to cannot be null");
+        }
+
+        if (partitions.isEmpty()) {
+            this.unsubscribe();
+            return;
+        }
+
+        for (TopicPartition tp : partitions) {
+            String topic = (tp != null) ? tp.topic() : null;
+            if (isBlank(topic))
+                throw new IllegalArgumentException("Topic partitions to assign to cannot have null or empty topic");
+        }
+        // TODO: implement fetcher
+        // fetcher.clearBufferedDataForUnassignedPartitions(partitions);
+
+        // make sure the offsets of topic partitions the consumer is unsubscribing from
+        // are committed since there will be no following rebalance
+        commit(subscriptions.allConsumed());
+
+        log.info("Assigned to partition(s): {}", join(partitions, ", "));
+        if (this.subscriptions.assignFromUser(new HashSet<>(partitions)))
+           updateMetadata(time.milliseconds());
+    }
+
+    private void updateMetadata(long milliseconds) {
+        final MetadataUpdateApplicationEvent event = new MetadataUpdateApplicationEvent(milliseconds);
+        eventHandler.add(event);
     }
 
     @Override
@@ -537,26 +553,15 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void unsubscribe() {
-        throw new KafkaException("method not implemented");
+        // fetcher.clearBufferedDataForUnassignedPartitions(Collections.emptySet());
+        eventHandler.add(new UnsubscribeApplicationEvent());
+        this.subscriptions.unsubscribe();
     }
 
     @Override
     @Deprecated
     public ConsumerRecords<K, V> poll(long timeout) {
         throw new KafkaException("method not implemented");
-    }
-
-    private static <K, V> ClusterResourceListeners configureClusterResourceListeners(
-            final Deserializer<K> keyDeserializer,
-            final Deserializer<V> valueDeserializer,
-            final List<?>... candidateLists) {
-        ClusterResourceListeners clusterResourceListeners = new ClusterResourceListeners();
-        for (List<?> candidateList: candidateLists)
-            clusterResourceListeners.maybeAddAll(candidateList);
-
-        clusterResourceListeners.maybeAdd(keyDeserializer);
-        clusterResourceListeners.maybeAdd(valueDeserializer);
-        return clusterResourceListeners;
     }
 
     // This is here temporary as we don't have public access to the ConsumerConfig in this module.
@@ -574,23 +579,6 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         else if (newConfigs.get(VALUE_DESERIALIZER_CLASS_CONFIG) == null)
             throw new ConfigException(VALUE_DESERIALIZER_CLASS_CONFIG, null, "must be non-null.");
         return newConfigs;
-    }
-
-    private static Metrics buildMetrics(
-            final ConsumerConfig config,
-            final Time time,
-            final String clientId) {
-        Map<String, String> metricsTags = Collections.singletonMap(CLIENT_ID_METRIC_TAG, clientId);
-        MetricConfig metricConfig = new MetricConfig()
-                .samples(config.getInt(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG))
-                .timeWindow(config.getLong(ConsumerConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
-                .recordLevel(Sensor.RecordingLevel.forName(config.getString(ConsumerConfig.METRICS_RECORDING_LEVEL_CONFIG)))
-                .tags(metricsTags);
-        List<MetricsReporter> reporters = CommonClientConfigs.metricsReporters(clientId, config);
-        MetricsContext metricsContext = new KafkaMetricsContext(
-                JMX_PREFIX,
-                config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
-        return new Metrics(metricConfig, reporters, time, metricsContext);
     }
 
     private class DefaultOffsetCommitCallback implements OffsetCommitCallback {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@code RequestManagers} provides a means to pass around the set of {@link RequestManager} instances in the system.
+ * This allows callers to both use the specific {@link RequestManager} instance, or to iterate over the list via
+ * the {@link #entries()} method.
+ */
+public class RequestManagers {
+
+    public final Optional<CoordinatorRequestManager> coordinatorRequestManager;
+    public final Optional<CommitRequestManager> commitRequestManager;
+    private final List<Optional<? extends RequestManager>> entries;
+
+    public RequestManagers(Optional<CoordinatorRequestManager> coordinatorRequestManager,
+                           Optional<CommitRequestManager> commitRequestManager) {
+        this.coordinatorRequestManager = coordinatorRequestManager;
+        this.commitRequestManager = commitRequestManager;
+
+        List<Optional<? extends RequestManager>> list = new ArrayList<>();
+        list.add(coordinatorRequestManager);
+        list.add(commitRequestManager);
+        entries = Collections.unmodifiableList(list);
+    }
+
+    public List<Optional<? extends RequestManager>> entries() {
+        return entries;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Utils.java
@@ -17,12 +17,138 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.ClientUtils;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.NetworkClient;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerInterceptor;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.KafkaMetricsContext;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.MetricsContext;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
 
 public final class Utils {
+
+    public static final String CONSUMER_JMX_PREFIX = "kafka.consumer";
+    public static final String CONSUMER_METRIC_GROUP_PREFIX = "consumer";
+
+    /**
+     * A fixed, large enough value will suffice for max.
+     */
+    public static final int CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION = 100;
+
+    private static final String CONSUMER_CLIENT_ID_METRIC_TAG = "client-id";
+
+    public static ConsumerNetworkClient createConsumerNetworkClient(ConsumerConfig config,
+                                                                    Metrics metrics,
+                                                                    LogContext logContext,
+                                                                    ApiVersions apiVersions,
+                                                                    Time time,
+                                                                    Metadata metadata,
+                                                                    Sensor throttleTimeSensor,
+                                                                    long retryBackoffMs) {
+        NetworkClient netClient = ClientUtils.createNetworkClient(config,
+                metrics,
+                CONSUMER_METRIC_GROUP_PREFIX,
+                logContext,
+                apiVersions,
+                time,
+                CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION,
+                metadata,
+                throttleTimeSensor);
+
+        // Will avoid blocking an extended period of time to prevent heartbeat thread starvation
+        int heartbeatIntervalMs = config.getInt(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG);
+
+        return new ConsumerNetworkClient(
+                logContext,
+                netClient,
+                metadata,
+                time,
+                retryBackoffMs,
+                config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
+                heartbeatIntervalMs);
+    }
+
+    public static LogContext createLogContext(ConsumerConfig config, GroupRebalanceConfig groupRebalanceConfig) {
+        Optional<String> groupId = Optional.ofNullable(groupRebalanceConfig.groupId);
+        String clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
+
+        // If group.instance.id is set, we will append it to the log context.
+        if (groupRebalanceConfig.groupInstanceId.isPresent()) {
+            return new LogContext("[Consumer instanceId=" + groupRebalanceConfig.groupInstanceId.get() +
+                    ", clientId=" + clientId + ", groupId=" + groupId.orElse("null") + "] ");
+        } else {
+            return new LogContext("[Consumer clientId=" + clientId + ", groupId=" + groupId.orElse("null") + "] ");
+        }
+    }
+
+    public static IsolationLevel getConfiguredIsolationLevel(ConsumerConfig config) {
+        String s = config.getString(ConsumerConfig.ISOLATION_LEVEL_CONFIG).toUpperCase(Locale.ROOT);
+        return IsolationLevel.valueOf(s);
+    }
+
+    public static SubscriptionState createSubscriptionState(ConsumerConfig config, LogContext logContext) {
+        String s = config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).toUpperCase(Locale.ROOT);
+        OffsetResetStrategy strategy = OffsetResetStrategy.valueOf(s);
+        return new SubscriptionState(logContext, strategy);
+    }
+
+    public static Metrics createMetrics(ConsumerConfig config, Time time) {
+        String clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
+        Map<String, String> metricsTags = Collections.singletonMap(CONSUMER_CLIENT_ID_METRIC_TAG, clientId);
+        MetricConfig metricConfig = new MetricConfig()
+                .samples(config.getInt(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG))
+                .timeWindow(config.getLong(ConsumerConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
+                .recordLevel(Sensor.RecordingLevel.forName(config.getString(ConsumerConfig.METRICS_RECORDING_LEVEL_CONFIG)))
+                .tags(metricsTags);
+        List<MetricsReporter> reporters = CommonClientConfigs.metricsReporters(clientId, config);
+        MetricsContext metricsContext = new KafkaMetricsContext(CONSUMER_JMX_PREFIX,
+                config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
+        return new Metrics(metricConfig, reporters, time, metricsContext);
+    }
+
+    public static FetchMetricsManager createFetchMetricsManager(Metrics metrics) {
+        Set<String> metricsTags = Collections.singleton(CONSUMER_CLIENT_ID_METRIC_TAG);
+        FetchMetricsRegistry metricsRegistry = new FetchMetricsRegistry(metricsTags, CONSUMER_METRIC_GROUP_PREFIX);
+        return new FetchMetricsManager(metrics, metricsRegistry);
+    }
+
+    public static <K, V> FetchConfig<K, V> createFetchConfig(ConsumerConfig config, Deserializers<K, V> deserializers) {
+        IsolationLevel isolationLevel = getConfiguredIsolationLevel(config);
+        return new FetchConfig<>(config, deserializers, isolationLevel);
+    }
+
+    public static FetchConfig<String, String> createFetchConfig(ConsumerConfig config) {
+        Deserializers<String, String> deserializers = new Deserializers<>(new StringDeserializer(), new StringDeserializer());
+        IsolationLevel isolationLevel = getConfiguredIsolationLevel(config);
+        return new FetchConfig<>(config, deserializers, isolationLevel);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <K, V> List<ConsumerInterceptor<K, V>> getConfiguredConsumerInterceptors(ConsumerConfig config) {
+        return (List<ConsumerInterceptor<K, V>>) ClientUtils.getConfiguredInterceptors(config, ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, ConsumerInterceptor.class);
+    }
 
     final static class PartitionComparator implements Comparator<TopicPartition>, Serializable {
         private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
@@ -36,6 +36,6 @@ abstract public class ApplicationEvent {
         return type + " ApplicationEvent";
     }
     public enum Type {
-        NOOP, COMMIT, POLL, FETCH_COMMITTED_OFFSET,
+        NOOP, COMMIT, POLL, FETCH_COMMITTED_OFFSET, METADATA_UPDATE, UNSUBSCRIBE,
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -17,24 +17,28 @@
 package org.apache.kafka.clients.consumer.internals.events;
 
 import org.apache.kafka.clients.consumer.internals.CommitRequestManager;
+import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
 import org.apache.kafka.clients.consumer.internals.NoopBackgroundEvent;
-import org.apache.kafka.clients.consumer.internals.RequestManager;
+import org.apache.kafka.clients.consumer.internals.RequestManagers;
 import org.apache.kafka.common.KafkaException;
 
-import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 
 public class ApplicationEventProcessor {
-    private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
-    private final Map<RequestManager.Type, Optional<RequestManager>> registry;
 
-    public ApplicationEventProcessor(
-            final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-            final Map<RequestManager.Type, Optional<RequestManager>> requestManagerRegistry) {
+    private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
+
+    private final ConsumerMetadata metadata;
+
+    private final RequestManagers requestManagers;
+
+    public ApplicationEventProcessor(final BlockingQueue<BackgroundEvent> backgroundEventQueue,
+                                     final RequestManagers requestManagers,
+                                     final ConsumerMetadata metadata) {
         this.backgroundEventQueue = backgroundEventQueue;
-        this.registry = requestManagerRegistry;
+        this.requestManagers = requestManagers;
+        this.metadata = metadata;
     }
 
     public boolean process(final ApplicationEvent event) {
@@ -48,6 +52,10 @@ public class ApplicationEventProcessor {
                 return process((PollApplicationEvent) event);
             case FETCH_COMMITTED_OFFSET:
                 return process((OffsetFetchApplicationEvent) event);
+            case METADATA_UPDATE:
+                return process((MetadataUpdateApplicationEvent) event);
+            case UNSUBSCRIBE:
+                return process((UnsubscribeApplicationEvent) event);
         }
         return false;
     }
@@ -64,19 +72,17 @@ public class ApplicationEventProcessor {
     }
 
     private boolean process(final PollApplicationEvent event) {
-        Optional<RequestManager> commitRequestManger = registry.get(RequestManager.Type.COMMIT);
-        if (!commitRequestManger.isPresent()) {
+        if (!requestManagers.commitRequestManager.isPresent()) {
             return true;
         }
 
-        CommitRequestManager manager = (CommitRequestManager) commitRequestManger.get();
+        CommitRequestManager manager = requestManagers.commitRequestManager.get();
         manager.updateAutoCommitTimer(event.pollTimeMs);
         return true;
     }
 
     private boolean process(final CommitApplicationEvent event) {
-        Optional<RequestManager> commitRequestManger = registry.get(RequestManager.Type.COMMIT);
-        if (!commitRequestManger.isPresent()) {
+        if (!requestManagers.commitRequestManager.isPresent()) {
             // Leaving this error handling here, but it is a bit strange as the commit API should enforce the group.id
             // upfront so we should never get to this block.
             Exception exception = new KafkaException("Unable to commit offset. Most likely because the group.id wasn't set");
@@ -84,7 +90,7 @@ public class ApplicationEventProcessor {
             return false;
         }
 
-        CommitRequestManager manager = (CommitRequestManager) commitRequestManger.get();
+        CommitRequestManager manager = requestManagers.commitRequestManager.get();
         manager.addOffsetCommitRequest(event.offsets()).whenComplete((r, e) -> {
             if (e != null) {
                 event.future().completeExceptionally(e);
@@ -96,14 +102,26 @@ public class ApplicationEventProcessor {
     }
 
     private boolean process(final OffsetFetchApplicationEvent event) {
-        Optional<RequestManager> commitRequestManger = registry.get(RequestManager.Type.COMMIT);
-        if (!commitRequestManger.isPresent()) {
+        if (!requestManagers.commitRequestManager.isPresent()) {
             event.future.completeExceptionally(new KafkaException("Unable to fetch committed offset because the " +
                     "CommittedRequestManager is not available. Check if group.id was set correctly"));
             return false;
         }
-        CommitRequestManager manager = (CommitRequestManager) commitRequestManger.get();
+        CommitRequestManager manager = requestManagers.commitRequestManager.get();
         manager.addOffsetFetchRequest(event.partitions);
+        return true;
+    }
+
+    private boolean process(final MetadataUpdateApplicationEvent event) {
+        metadata.requestUpdateForNewTopics();
+        return true;
+    }
+
+    private boolean process(final UnsubscribeApplicationEvent event) {
+        /*
+                this.coordinator.onLeavePrepare();
+                this.coordinator.maybeLeaveGroup("the consumer unsubscribed from all topics");
+         */
         return true;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/MetadataUpdateApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/MetadataUpdateApplicationEvent.java
@@ -14,15 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.clients.consumer.internals;
+package org.apache.kafka.clients.consumer.internals.events;
 
-import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
+public class MetadataUpdateApplicationEvent extends ApplicationEvent {
 
-/**
- * {@code PollResult} consist of {@code UnsentRequest} if there are requests to send; otherwise, return the time till
- * the next poll event.
- */
-public interface RequestManager {
-    PollResult poll(long currentTimeMs);
+    private final long timestamp;
 
+    public MetadataUpdateApplicationEvent(final long timestamp) {
+        super(Type.METADATA_UPDATE);
+        this.timestamp = timestamp;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/UnsubscribeApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/UnsubscribeApplicationEvent.java
@@ -14,15 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.clients.consumer.internals;
+package org.apache.kafka.clients.consumer.internals.events;
 
-import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
+public class UnsubscribeApplicationEvent extends ApplicationEvent {
 
-/**
- * {@code PollResult} consist of {@code UnsentRequest} if there are requests to send; otherwise, return the time till
- * the next poll event.
- */
-public interface RequestManager {
-    PollResult poll(long currentTimeMs);
-
+    public UnsubscribeApplicationEvent() {
+        super(Type.UNSUBSCRIBE);
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -20,7 +20,6 @@ import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.KafkaClient;
-import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -61,8 +60,6 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.network.ChannelBuilder;
-import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.record.AbstractRecords;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.RecordBatch;
@@ -77,6 +74,7 @@ import org.slf4j.Logger;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -393,16 +391,16 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 this.valueSerializer = valueSerializer;
             }
 
-            List<ProducerInterceptor<K, V>> interceptorList = (List) config.getConfiguredInstances(
+            List<ProducerInterceptor<K, V>> interceptorList = ClientUtils.getConfiguredInterceptors(config,
                     ProducerConfig.INTERCEPTOR_CLASSES_CONFIG,
-                    ProducerInterceptor.class,
-                    Collections.singletonMap(ProducerConfig.CLIENT_ID_CONFIG, clientId));
+                    ProducerInterceptor.class);
             if (interceptors != null)
                 this.interceptors = interceptors;
             else
                 this.interceptors = new ProducerInterceptors<>(interceptorList);
-            ClusterResourceListeners clusterResourceListeners = configureClusterResourceListeners(this.keySerializer,
-                    this.valueSerializer, interceptorList, reporters);
+            ClusterResourceListeners clusterResourceListeners = ClientUtils.configureClusterResourceListeners(interceptorList,
+                    reporters,
+                    Arrays.asList(this.keySerializer, this.valueSerializer));
             this.maxRequestSize = config.getInt(ProducerConfig.MAX_REQUEST_SIZE_CONFIG);
             this.totalMemorySize = config.getLong(ProducerConfig.BUFFER_MEMORY_CONFIG);
             this.compressionType = CompressionType.forName(config.getString(ProducerConfig.COMPRESSION_TYPE_CONFIG));
@@ -436,9 +434,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                     transactionManager,
                     new BufferPool(this.totalMemorySize, batchSize, metrics, time, PRODUCER_METRIC_GROUP_NAME));
 
-            List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
-                    config.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG),
-                    config.getString(ProducerConfig.CLIENT_DNS_LOOKUP_CONFIG));
+            List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config);
             if (metadata != null) {
                 this.metadata = metadata;
             } else {
@@ -508,27 +504,17 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
     Sender newSender(LogContext logContext, KafkaClient kafkaClient, ProducerMetadata metadata) {
         int maxInflightRequests = producerConfig.getInt(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION);
         int requestTimeoutMs = producerConfig.getInt(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG);
-        ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(producerConfig, time, logContext);
         ProducerMetrics metricsRegistry = new ProducerMetrics(this.metrics);
         Sensor throttleTimeSensor = Sender.throttleTimeSensor(metricsRegistry.senderMetrics);
-        KafkaClient client = kafkaClient != null ? kafkaClient : new NetworkClient(
-                new Selector(producerConfig.getLong(ProducerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
-                        this.metrics, time, "producer", channelBuilder, logContext),
-                metadata,
-                clientId,
-                maxInflightRequests,
-                producerConfig.getLong(ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG),
-                producerConfig.getLong(ProducerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG),
-                producerConfig.getInt(ProducerConfig.SEND_BUFFER_CONFIG),
-                producerConfig.getInt(ProducerConfig.RECEIVE_BUFFER_CONFIG),
-                requestTimeoutMs,
-                producerConfig.getLong(ProducerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG),
-                producerConfig.getLong(ProducerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
-                time,
-                true,
+        KafkaClient client = kafkaClient != null ? kafkaClient : ClientUtils.createNetworkClient(producerConfig,
+                this.metrics,
+                "producer",
+                logContext,
                 apiVersions,
-                throttleTimeSensor,
-                logContext);
+                time,
+                maxInflightRequests,
+                metadata,
+                throttleTimeSensor);
 
         short acks = Short.parseShort(producerConfig.getString(ProducerConfig.ACKS_CONFIG));
         return new Sender(logContext,
@@ -986,7 +972,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         // Append callback takes care of the following:
         //  - call interceptors and user callback on completion
         //  - remember partition that is calculated in RecordAccumulator.append
-        AppendCallbacks<K, V> appendCallbacks = new AppendCallbacks<K, V>(callback, this.interceptors, record);
+        AppendCallbacks appendCallbacks = new AppendCallbacks(callback, this.interceptors, record);
 
         try {
             throwIfProducerClosed();
@@ -1364,16 +1350,6 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         log.debug("Kafka producer has been closed");
     }
 
-    private ClusterResourceListeners configureClusterResourceListeners(Serializer<K> keySerializer, Serializer<V> valueSerializer, List<?>... candidateLists) {
-        ClusterResourceListeners clusterResourceListeners = new ClusterResourceListeners();
-        for (List<?> candidateList: candidateLists)
-            clusterResourceListeners.maybeAddAll(candidateList);
-
-        clusterResourceListeners.maybeAdd(keySerializer);
-        clusterResourceListeners.maybeAdd(valueSerializer);
-        return clusterResourceListeners;
-    }
-
     /**
      * computes partition for given record.
      * if the record has partition returns the value otherwise
@@ -1476,7 +1452,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      *  - interceptor callbacks
      *  - partition callback
      */
-    private class AppendCallbacks<K, V> implements RecordAccumulator.AppendCallbacks {
+    private class AppendCallbacks implements RecordAccumulator.AppendCallbacks {
         private final Callback userCallback;
         private final ProducerInterceptors<K, V> interceptors;
         private final String topic;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
 import org.apache.kafka.clients.consumer.internals.ConsumerMetrics;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
+import org.apache.kafka.clients.consumer.internals.Deserializers;
 import org.apache.kafka.clients.consumer.internals.FetchConfig;
 import org.apache.kafka.clients.consumer.internals.FetchMetricsManager;
 import org.apache.kafka.clients.consumer.internals.Fetcher;
@@ -2679,8 +2680,7 @@ public class KafkaConsumerTest {
                 maxPollRecords,
                 checkCrcs,
                 CommonClientConfigs.DEFAULT_CLIENT_RACK,
-                keyDeserializer,
-                deserializer,
+                new Deserializers<>(keyDeserializer, deserializer),
                 isolationLevel);
         Fetcher<String, String> fetcher = new Fetcher<>(
                 loggerFactory,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class CommitRequestManagerTest {
-    private SubscriptionState subscriptionState;
+    private SubscriptionState subscriptions;
     private GroupState groupState;
     private LogContext logContext;
     private MockTime time;
@@ -72,7 +72,7 @@ public class CommitRequestManagerTest {
     public void setup() {
         this.logContext = new LogContext();
         this.time = new MockTime(0);
-        this.subscriptionState = mock(SubscriptionState.class);
+        this.subscriptions = mock(SubscriptionState.class);
         this.coordinatorRequestManager = mock(CoordinatorRequestManager.class);
         this.groupState = new GroupState("group-1", Optional.empty());
 
@@ -101,7 +101,7 @@ public class CommitRequestManagerTest {
         Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
         offsets.put(new TopicPartition("t1", 0), new OffsetAndMetadata(0));
         commitRequestManger.updateAutoCommitTimer(time.milliseconds());
-        when(subscriptionState.allConsumed()).thenReturn(offsets);
+        when(subscriptions.allConsumed()).thenReturn(offsets);
         time.sleep(100);
         commitRequestManger.updateAutoCommitTimer(time.milliseconds());
         assertPoll(1, commitRequestManger);
@@ -327,10 +327,9 @@ public class CommitRequestManagerTest {
     private CommitRequestManager create(final boolean autoCommitEnabled, final long autoCommitInterval) {
         props.setProperty(AUTO_COMMIT_INTERVAL_MS_CONFIG, String.valueOf(autoCommitInterval));
         props.setProperty(ENABLE_AUTO_COMMIT_CONFIG, String.valueOf(autoCommitEnabled));
-        return new CommitRequestManager(
-                this.time,
+        return new CommitRequestManager(this.time,
                 this.logContext,
-                this.subscriptionState,
+                this.subscriptions,
                 new ConsumerConfig(props),
                 this.coordinatorRequestManager,
                 this.groupState);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CompletedFetchTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CompletedFetchTest.java
@@ -229,8 +229,7 @@ public class CompletedFetchTest {
                 ConsumerConfig.DEFAULT_MAX_POLL_RECORDS,
                 checkCrcs,
                 ConsumerConfig.DEFAULT_CLIENT_RACK,
-                keyDeserializer,
-                valueDeserializer,
+                new Deserializers<>(keyDeserializer, valueDeserializer),
                 isolationLevel
         );
         return new CompletedFetch<>(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchConfigTest.java
@@ -73,7 +73,9 @@ public class FetchConfigTest {
         p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         ConsumerConfig config = new ConsumerConfig(p);
-        new FetchConfig<>(config, keyDeserializer, valueDeserializer, IsolationLevel.READ_UNCOMMITTED);
+        new FetchConfig<>(config,
+                new Deserializers<>(keyDeserializer, valueDeserializer),
+                IsolationLevel.READ_UNCOMMITTED);
     }
 
     private void newFetchConfigFromValues(Deserializer<String> keyDeserializer,
@@ -85,8 +87,7 @@ public class FetchConfigTest {
                 ConsumerConfig.DEFAULT_MAX_POLL_RECORDS,
                 true,
                 ConsumerConfig.DEFAULT_CLIENT_RACK,
-                keyDeserializer,
-                valueDeserializer,
+                new Deserializers<>(keyDeserializer, valueDeserializer),
                 IsolationLevel.READ_UNCOMMITTED);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -2848,8 +2848,7 @@ public class FetcherTest {
                 2 * numPartitions,
                 true, // check crcs
                 CommonClientConfigs.DEFAULT_CLIENT_RACK,
-                new ByteArrayDeserializer(),
-                new ByteArrayDeserializer(),
+                new Deserializers<>(new ByteArrayDeserializer(), new ByteArrayDeserializer()),
                 isolationLevel);
         fetcher = new Fetcher<byte[], byte[]>(
                 logContext,
@@ -3651,8 +3650,7 @@ public class FetcherTest {
                 maxPollRecords,
                 true, // check crc
                 CommonClientConfigs.DEFAULT_CLIENT_RACK,
-                keyDeserializer,
-                valueDeserializer,
+                new Deserializers<>(keyDeserializer, valueDeserializer),
                 isolationLevel);
         fetcher = spy(new Fetcher<>(
                 logContext,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherTest.java
@@ -1254,8 +1254,7 @@ public class OffsetFetcherTest {
                 maxPollRecords,
                 true, // check crc
                 CommonClientConfigs.DEFAULT_CLIENT_RACK,
-                new ByteArrayDeserializer(),
-                new ByteArrayDeserializer(),
+                new Deserializers<>(new ByteArrayDeserializer(), new ByteArrayDeserializer()),
                 isolationLevel);
         Fetcher<byte[], byte[]> fetcher = new Fetcher<>(
                 logContext,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -20,9 +20,11 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.internals.events.CommitApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.EventHandler;
+import org.apache.kafka.clients.consumer.internals.events.MetadataUpdateApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.OffsetFetchApplicationEvent;
-import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
@@ -39,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -46,6 +49,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import static java.util.Collections.singleton;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
@@ -53,6 +57,7 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZE
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -157,9 +162,41 @@ public class PrototypeAsyncConsumerTest {
     }
 
     @Test
-    public void testUnimplementedException() {
+    public void testAssign() {
+        this.subscriptions = new SubscriptionState(logContext, OffsetResetStrategy.EARLIEST);
+        this.consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        final TopicPartition tp = new TopicPartition("foo", 3);
+        consumer.assign(singleton(tp));
+        assertTrue(consumer.subscription().isEmpty());
+        assertTrue(consumer.assignment().contains(tp));
+        verify(eventHandler).add(any(CommitApplicationEvent.class));
+        verify(eventHandler).add(any(MetadataUpdateApplicationEvent.class));
+    }
+
+    @Test
+    public void testAssignOnNullTopicPartition() {
         consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
-        assertThrows(KafkaException.class, consumer::assignment, "not implemented exception");
+        assertThrows(IllegalArgumentException.class, () -> consumer.assign(null));
+    }
+
+    @Test
+    public void testAssignOnEmptyTopicPartition() {
+        consumer = spy(newConsumer(time, new StringDeserializer(), new StringDeserializer()));
+        consumer.assign(Collections.emptyList());
+        assertTrue(consumer.subscription().isEmpty());
+        assertTrue(consumer.assignment().isEmpty());
+    }
+
+    @Test
+    public void testAssignOnNullTopicInPartition() {
+        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        assertThrows(IllegalArgumentException.class, () -> consumer.assign(singleton(new TopicPartition(null, 0))));
+    }
+
+    @Test
+    public void testAssignOnEmptyTopicInPartition() {
+        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        assertThrows(IllegalArgumentException.class, () -> consumer.assign(singleton(new TopicPartition("  ", 0))));
     }
 
     private HashMap<TopicPartition, OffsetAndMetadata> mockTopicPartitionOffset() {
@@ -189,16 +226,13 @@ public class PrototypeAsyncConsumerTest {
         consumerProps.put(KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.getClass());
         consumerProps.put(VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.getClass());
 
-        return new PrototypeAsyncConsumer<>(
-                time,
+        return new PrototypeAsyncConsumer<>(time,
                 logContext,
                 config,
                 subscriptions,
                 eventHandler,
                 metrics,
-                clusterResourceListeners,
                 Optional.ofNullable(this.groupId),
-                clientId,
                 config.getInt(DEFAULT_API_TIMEOUT_MS_CONFIG));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -575,8 +575,8 @@ public class KafkaProducerTest {
         final int targetInterceptor = 3;
         try {
             Properties props = new Properties();
-            props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
-            props.setProperty(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, org.apache.kafka.test.MockProducerInterceptor.class.getName() + ", "
+            props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+            props.setProperty(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, org.apache.kafka.test.MockProducerInterceptor.class.getName() + ", "
                     +  org.apache.kafka.test.MockProducerInterceptor.class.getName() + ", "
                     +  org.apache.kafka.test.MockProducerInterceptor.class.getName());
             props.setProperty(MockProducerInterceptor.APPEND_STRING_PROP, "something");


### PR DESCRIPTION
There are a number of places in the client code where the same basic calls are made by more than one client implementation. Minor refactoring will reduce the amount of boilerplate code necessary for the client to construct its internal state.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
