### PR TITLE
KAFKA-14937: Refactoring for client code to reduce boilerplate

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
@@ -16,11 +16,15 @@
  */
 package org.apache.kafka.clients;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.network.ChannelBuilders;
+import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
@@ -32,9 +36,11 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.common.utils.Utils.closeQuietly;
 import static org.apache.kafka.common.utils.Utils.getHost;
 import static org.apache.kafka.common.utils.Utils.getPort;
 
@@ -42,6 +48,12 @@ public final class ClientUtils {
     private static final Logger log = LoggerFactory.getLogger(ClientUtils.class);
 
     private ClientUtils() {
+    }
+
+    public static List<InetSocketAddress> parseAndValidateAddresses(AbstractConfig config) {
+        List<String> urls = config.getList(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG);
+        String clientDnsLookupConfig = config.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG);
+        return parseAndValidateAddresses(urls, clientDnsLookupConfig);
     }
 
     public static List<InetSocketAddress> parseAndValidateAddresses(List<String> urls, String clientDnsLookupConfig) {
@@ -133,5 +145,114 @@ public final class ClientUtils {
             }
         }
         return preferredAddresses;
+    }
+
+    public static NetworkClient createNetworkClient(AbstractConfig config,
+                                                    Metrics metrics,
+                                                    String metricsGroupPrefix,
+                                                    LogContext logContext,
+                                                    ApiVersions apiVersions,
+                                                    Time time,
+                                                    int maxInFlightRequestsPerConnection,
+                                                    Metadata metadata,
+                                                    Sensor throttleTimeSensor) {
+        return createNetworkClient(config,
+                config.getString(CommonClientConfigs.CLIENT_ID_CONFIG),
+                metrics,
+                metricsGroupPrefix,
+                logContext,
+                apiVersions,
+                time,
+                maxInFlightRequestsPerConnection,
+                config.getInt(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG),
+                metadata,
+                null,
+                new DefaultHostResolver(),
+                throttleTimeSensor);
+    }
+
+    public static NetworkClient createNetworkClient(AbstractConfig config,
+                                                    String clientId,
+                                                    Metrics metrics,
+                                                    String metricsGroupPrefix,
+                                                    LogContext logContext,
+                                                    ApiVersions apiVersions,
+                                                    Time time,
+                                                    int maxInFlightRequestsPerConnection,
+                                                    int requestTimeoutMs,
+                                                    MetadataUpdater metadataUpdater,
+                                                    HostResolver hostResolver) {
+        return createNetworkClient(config,
+                clientId,
+                metrics,
+                metricsGroupPrefix,
+                logContext,
+                apiVersions,
+                time,
+                maxInFlightRequestsPerConnection,
+                requestTimeoutMs,
+                null,
+                metadataUpdater,
+                hostResolver,
+                null);
+    }
+
+    public static NetworkClient createNetworkClient(AbstractConfig config,
+                                                    String clientId,
+                                                    Metrics metrics,
+                                                    String metricsGroupPrefix,
+                                                    LogContext logContext,
+                                                    ApiVersions apiVersions,
+                                                    Time time,
+                                                    int maxInFlightRequestsPerConnection,
+                                                    int requestTimeoutMs,
+                                                    Metadata metadata,
+                                                    MetadataUpdater metadataUpdater,
+                                                    HostResolver hostResolver,
+                                                    Sensor throttleTimeSensor) {
+        ChannelBuilder channelBuilder = null;
+        Selector selector = null;
+
+        try {
+            channelBuilder = ClientUtils.createChannelBuilder(config, time, logContext);
+            selector = new Selector(config.getLong(CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG),
+                    metrics,
+                    time,
+                    metricsGroupPrefix,
+                    channelBuilder,
+                    logContext);
+            return new NetworkClient(metadataUpdater,
+                    metadata,
+                    selector,
+                    clientId,
+                    maxInFlightRequestsPerConnection,
+                    config.getLong(CommonClientConfigs.RECONNECT_BACKOFF_MS_CONFIG),
+                    config.getLong(CommonClientConfigs.RECONNECT_BACKOFF_MAX_MS_CONFIG),
+                    config.getInt(CommonClientConfigs.SEND_BUFFER_CONFIG),
+                    config.getInt(CommonClientConfigs.RECEIVE_BUFFER_CONFIG),
+                    requestTimeoutMs,
+                    config.getLong(CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG),
+                    config.getLong(CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
+                    time,
+                    true,
+                    apiVersions,
+                    throttleTimeSensor,
+                    logContext,
+                    hostResolver);
+        } catch (Throwable t) {
+            closeQuietly(selector, "Selector");
+            closeQuietly(channelBuilder, "ChannelBuilder");
+            throw new KafkaException("Failed to create new NetworkClient", t);
+        }
+    }
+
+    public static <T> List createConfiguredInterceptors(AbstractConfig config,
+                                                        String interceptorClassesConfigName,
+                                                        Class<T> clazz) {
+        String clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
+        return config.getConfiguredInstances(
+                interceptorClassesConfigName,
+                clazz,
+                Collections.singletonMap(CommonClientConfigs.CLIENT_ID_CONFIG, clientId));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.utils.LogContext;
@@ -44,6 +45,19 @@ public class ConsumerMetadata extends Metadata {
         this.allowAutoTopicCreation = allowAutoTopicCreation;
         this.subscription = subscription;
         this.transientTopics = new HashSet<>();
+    }
+
+    public ConsumerMetadata(ConsumerConfig config,
+                            SubscriptionState subscriptions,
+                            LogContext logContext,
+                            ClusterResourceListeners clusterResourceListeners) {
+        this(config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG),
+                config.getLong(ConsumerConfig.METADATA_MAX_AGE_CONFIG),
+                !config.getBoolean(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG),
+                config.getBoolean(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG),
+                subscriptions,
+                logContext,
+                clusterResourceListeners);
     }
 
     public boolean allowAutoTopicCreation() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.ClientUtils;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.NetworkClient;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerInterceptor;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.metrics.KafkaMetricsContext;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.MetricsContext;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public final class ConsumerUtils {
+
+    public static final String CONSUMER_JMX_PREFIX = "kafka.consumer";
+    public static final String CONSUMER_METRIC_GROUP_PREFIX = "consumer";
+
+    /**
+     * A fixed, large enough value will suffice for max.
+     */
+    public static final int CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION = 100;
+
+    private static final String CONSUMER_CLIENT_ID_METRIC_TAG = "client-id";
+
+    public static ConsumerNetworkClient createConsumerNetworkClient(ConsumerConfig config,
+                                                                    Metrics metrics,
+                                                                    LogContext logContext,
+                                                                    ApiVersions apiVersions,
+                                                                    Time time,
+                                                                    Metadata metadata,
+                                                                    Sensor throttleTimeSensor,
+                                                                    long retryBackoffMs) {
+        NetworkClient netClient = ClientUtils.createNetworkClient(config,
+                metrics,
+                CONSUMER_METRIC_GROUP_PREFIX,
+                logContext,
+                apiVersions,
+                time,
+                CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION,
+                metadata,
+                throttleTimeSensor);
+
+        // Will avoid blocking an extended period of time to prevent heartbeat thread starvation
+        int heartbeatIntervalMs = config.getInt(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG);
+
+        return new ConsumerNetworkClient(
+                logContext,
+                netClient,
+                metadata,
+                time,
+                retryBackoffMs,
+                config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
+                heartbeatIntervalMs);
+    }
+
+    public static LogContext createLogContext(ConsumerConfig config, GroupRebalanceConfig groupRebalanceConfig) {
+        String groupId = String.valueOf(groupRebalanceConfig.groupId);
+        String clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
+        String logPrefix;
+        String groupInstanceId = groupRebalanceConfig.groupInstanceId.orElse(null);
+
+        if (groupInstanceId != null) {
+            // If group.instance.id is set, we will append it to the log context.
+            logPrefix = String.format("[Consumer instanceId=%s, clientId=%s, groupId=%s] ", groupInstanceId, clientId, groupId);
+        } else {
+            logPrefix = String.format("[Consumer clientId=%s, groupId=%s] ", clientId, groupId);
+        }
+
+        return new LogContext(logPrefix);
+    }
+
+    public static IsolationLevel createIsolationLevel(ConsumerConfig config) {
+        String s = config.getString(ConsumerConfig.ISOLATION_LEVEL_CONFIG).toUpperCase(Locale.ROOT);
+        return IsolationLevel.valueOf(s);
+    }
+
+    public static SubscriptionState createSubscriptionState(ConsumerConfig config, LogContext logContext) {
+        String s = config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).toUpperCase(Locale.ROOT);
+        OffsetResetStrategy strategy = OffsetResetStrategy.valueOf(s);
+        return new SubscriptionState(logContext, strategy);
+    }
+
+    public static Metrics createMetrics(ConsumerConfig config, Time time) {
+        String clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
+        Map<String, String> metricsTags = Collections.singletonMap(CONSUMER_CLIENT_ID_METRIC_TAG, clientId);
+        MetricConfig metricConfig = new MetricConfig()
+                .samples(config.getInt(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG))
+                .timeWindow(config.getLong(ConsumerConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
+                .recordLevel(Sensor.RecordingLevel.forName(config.getString(ConsumerConfig.METRICS_RECORDING_LEVEL_CONFIG)))
+                .tags(metricsTags);
+        List<MetricsReporter> reporters = CommonClientConfigs.metricsReporters(clientId, config);
+        MetricsContext metricsContext = new KafkaMetricsContext(CONSUMER_JMX_PREFIX,
+                config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
+        return new Metrics(metricConfig, reporters, time, metricsContext);
+    }
+
+    public static FetchMetricsManager createFetchMetricsManager(Metrics metrics) {
+        Set<String> metricsTags = Collections.singleton(CONSUMER_CLIENT_ID_METRIC_TAG);
+        FetchMetricsRegistry metricsRegistry = new FetchMetricsRegistry(metricsTags, CONSUMER_METRIC_GROUP_PREFIX);
+        return new FetchMetricsManager(metrics, metricsRegistry);
+    }
+
+    public static <K, V> FetchConfig<K, V> createFetchConfig(ConsumerConfig config,
+                                                             Deserializer<K> keyDeserializer,
+                                                             Deserializer<V> valueDeserializer) {
+        IsolationLevel isolationLevel = createIsolationLevel(config);
+        return new FetchConfig<>(config, keyDeserializer, valueDeserializer, isolationLevel);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <K, V> List<ConsumerInterceptor<K, V>> createConsumerInterceptors(ConsumerConfig config) {
+        return ClientUtils.createConfiguredInterceptors(config,
+                ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                ConsumerInterceptor.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <K> Deserializer<K> createKeyDeserializer(ConsumerConfig config, Deserializer<K> keyDeserializer) {
+        String clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
+
+        if (keyDeserializer == null) {
+            keyDeserializer = config.getConfiguredInstance(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, Deserializer.class);
+            keyDeserializer.configure(config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId)), true);
+        } else {
+            config.ignore(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG);
+        }
+
+        return keyDeserializer;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <V> Deserializer<V> createValueDeserializer(ConsumerConfig config, Deserializer<V> valueDeserializer) {
+        String clientId = config.getString(ConsumerConfig.CLIENT_ID_CONFIG);
+
+        if (valueDeserializer == null) {
+            valueDeserializer = config.getConfiguredInstance(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, Deserializer.class);
+            valueDeserializer.configure(config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId)), false);
+        } else {
+            config.ignore(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG);
+        }
+
+        return valueDeserializer;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -19,8 +19,6 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.GroupRebalanceConfig;
-import org.apache.kafka.clients.KafkaClient;
-import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
@@ -28,8 +26,6 @@ import org.apache.kafka.clients.consumer.internals.events.EventHandler;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.network.ChannelBuilder;
-import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 
@@ -44,7 +40,6 @@ import java.util.concurrent.LinkedBlockingQueue;
  * {@code BackgroundEvent} from the {@ConsumerBackgroundThread}.
  */
 public class DefaultEventHandler implements EventHandler {
-    private static final String METRIC_GRP_PREFIX = "consumer";
     private final BlockingQueue<ApplicationEvent> applicationEventQueue;
     private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
     private final DefaultBackgroundThread backgroundThread;
@@ -83,66 +78,16 @@ public class DefaultEventHandler implements EventHandler {
                                final Sensor fetcherThrottleTimeSensor) {
         this.applicationEventQueue = applicationEventQueue;
         this.backgroundEventQueue = backgroundEventQueue;
-        final ConsumerMetadata metadata = bootstrapMetadata(
-            logContext,
-            clusterResourceListeners,
-            config,
-            subscriptionState
-        );
-        final ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config, time, logContext);
-        final Selector selector = new Selector(
-            config.getLong(
-            ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
-            metrics,
-            time,
-            METRIC_GRP_PREFIX,
-            channelBuilder,
-            logContext
-        );
-        final NetworkClient networkClient = new NetworkClient(
-            selector,
-            metadata,
-            config.getString(ConsumerConfig.CLIENT_ID_CONFIG),
-            100, // a fixed large enough value will suffice for max
-            // in-flight requests
-            config.getLong(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG),
-            config.getLong(ConsumerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG),
-            config.getInt(ConsumerConfig.SEND_BUFFER_CONFIG),
-            config.getInt(ConsumerConfig.RECEIVE_BUFFER_CONFIG),
-            config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
-            config.getLong(ConsumerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG),
-            config.getLong(ConsumerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
-            time,
-            true,
-            apiVersions,
-            fetcherThrottleTimeSensor,
-            logContext
-        );
-        this.backgroundThread = new DefaultBackgroundThread(
-            time,
-            config,
-            groupRebalanceConfig,
-            logContext,
-            this.applicationEventQueue,
-            this.backgroundEventQueue,
-            metadata,
-            subscriptionState,
-            networkClient);
-        this.backgroundThread.start();
-    }
 
-    // VisibleForTesting
-    DefaultEventHandler(final Time time,
-                        final ConsumerConfig config,
-                        final GroupRebalanceConfig groupRebalanceConfig,
-                        final LogContext logContext,
-                        final BlockingQueue<ApplicationEvent> applicationEventQueue,
-                        final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                        final SubscriptionState subscriptionState,
-                        final ConsumerMetadata metadata,
-                        final KafkaClient networkClient) {
-        this.applicationEventQueue = applicationEventQueue;
-        this.backgroundEventQueue = backgroundEventQueue;
+        // Bootstrap a metadata object with the bootstrap server IP address, which will be used once for the
+        // subsequent metadata refresh once the background thread has started up.
+        final ConsumerMetadata metadata = new ConsumerMetadata(config,
+                subscriptionState,
+                logContext,
+                clusterResourceListeners);
+        final List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config);
+        metadata.bootstrap(addresses);
+
         this.backgroundThread = new DefaultBackgroundThread(
             time,
             config,
@@ -152,7 +97,9 @@ public class DefaultEventHandler implements EventHandler {
             this.backgroundEventQueue,
             metadata,
             subscriptionState,
-            networkClient);
+            apiVersions,
+            metrics,
+            fetcherThrottleTimeSensor);
         backgroundThread.start();
     }
 
@@ -180,27 +127,6 @@ public class DefaultEventHandler implements EventHandler {
     public boolean add(final ApplicationEvent event) {
         backgroundThread.wakeup();
         return applicationEventQueue.add(event);
-    }
-
-    // bootstrap a metadata object with the bootstrap server IP address,
-    // which will be used once for the subsequent metadata refresh once the
-    // background thread has started up.
-    private ConsumerMetadata bootstrapMetadata(
-        final LogContext logContext,
-        final ClusterResourceListeners clusterResourceListeners,
-        final ConsumerConfig config,
-        final SubscriptionState subscriptions) {
-        final ConsumerMetadata metadata = new ConsumerMetadata(
-            config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG),
-            config.getLong(ConsumerConfig.METADATA_MAX_AGE_CONFIG),
-            !config.getBoolean(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG),
-            config.getBoolean(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG),
-            subscriptions,
-            logContext, clusterResourceListeners);
-        final List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
-            config.getList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG), config.getString(ConsumerConfig.CLIENT_DNS_LOOKUP_CONFIG));
-        metadata.bootstrap(addresses);
-        return metadata;
     }
 
     public void close() {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -20,7 +20,6 @@ import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.KafkaClient;
-import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -61,8 +60,6 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.network.ChannelBuilder;
-import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.record.AbstractRecords;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.RecordBatch;
@@ -393,10 +390,9 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 this.valueSerializer = valueSerializer;
             }
 
-            List<ProducerInterceptor<K, V>> interceptorList = (List) config.getConfiguredInstances(
+            List<ProducerInterceptor<K, V>> interceptorList = ClientUtils.createConfiguredInterceptors(config,
                     ProducerConfig.INTERCEPTOR_CLASSES_CONFIG,
-                    ProducerInterceptor.class,
-                    Collections.singletonMap(ProducerConfig.CLIENT_ID_CONFIG, clientId));
+                    ProducerInterceptor.class);
             if (interceptors != null)
                 this.interceptors = interceptors;
             else
@@ -436,9 +432,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                     transactionManager,
                     new BufferPool(this.totalMemorySize, batchSize, metrics, time, PRODUCER_METRIC_GROUP_NAME));
 
-            List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
-                    config.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG),
-                    config.getString(ProducerConfig.CLIENT_DNS_LOOKUP_CONFIG));
+            List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config);
             if (metadata != null) {
                 this.metadata = metadata;
             } else {
@@ -508,27 +502,17 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
     Sender newSender(LogContext logContext, KafkaClient kafkaClient, ProducerMetadata metadata) {
         int maxInflightRequests = producerConfig.getInt(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION);
         int requestTimeoutMs = producerConfig.getInt(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG);
-        ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(producerConfig, time, logContext);
         ProducerMetrics metricsRegistry = new ProducerMetrics(this.metrics);
         Sensor throttleTimeSensor = Sender.throttleTimeSensor(metricsRegistry.senderMetrics);
-        KafkaClient client = kafkaClient != null ? kafkaClient : new NetworkClient(
-                new Selector(producerConfig.getLong(ProducerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
-                        this.metrics, time, "producer", channelBuilder, logContext),
-                metadata,
-                clientId,
-                maxInflightRequests,
-                producerConfig.getLong(ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG),
-                producerConfig.getLong(ProducerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG),
-                producerConfig.getInt(ProducerConfig.SEND_BUFFER_CONFIG),
-                producerConfig.getInt(ProducerConfig.RECEIVE_BUFFER_CONFIG),
-                requestTimeoutMs,
-                producerConfig.getLong(ProducerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG),
-                producerConfig.getLong(ProducerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
-                time,
-                true,
+        KafkaClient client = kafkaClient != null ? kafkaClient : ClientUtils.createNetworkClient(producerConfig,
+                this.metrics,
+                "producer",
+                logContext,
                 apiVersions,
-                throttleTimeSensor,
-                logContext);
+                time,
+                maxInflightRequests,
+                metadata,
+                throttleTimeSensor);
 
         short acks = Short.parseShort(producerConfig.getString(ProducerConfig.ACKS_CONFIG));
         return new Sender(logContext,
@@ -986,7 +970,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         // Append callback takes care of the following:
         //  - call interceptors and user callback on completion
         //  - remember partition that is calculated in RecordAccumulator.append
-        AppendCallbacks<K, V> appendCallbacks = new AppendCallbacks<K, V>(callback, this.interceptors, record);
+        AppendCallbacks appendCallbacks = new AppendCallbacks(callback, this.interceptors, record);
 
         try {
             throwIfProducerClosed();
@@ -1476,7 +1460,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      *  - interceptor callbacks
      *  - partition callback
      */
-    private class AppendCallbacks<K, V> implements RecordAccumulator.AppendCallbacks {
+    private class AppendCallbacks implements RecordAccumulator.AppendCallbacks {
         private final Callback userCallback;
         private final ProducerInterceptors<K, V> interceptors;
         private final String topic;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -252,9 +252,7 @@ public class PrototypeAsyncConsumerTest {
                 subscriptions,
                 eventHandler,
                 metrics,
-                clusterResourceListeners,
                 Optional.ofNullable(this.groupId),
-                clientId,
                 config.getInt(DEFAULT_API_TIMEOUT_MS_CONFIG));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -575,8 +575,8 @@ public class KafkaProducerTest {
         final int targetInterceptor = 3;
         try {
             Properties props = new Properties();
-            props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
-            props.setProperty(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, org.apache.kafka.test.MockProducerInterceptor.class.getName() + ", "
+            props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+            props.setProperty(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, org.apache.kafka.test.MockProducerInterceptor.class.getName() + ", "
                     +  org.apache.kafka.test.MockProducerInterceptor.class.getName() + ", "
                     +  org.apache.kafka.test.MockProducerInterceptor.class.getName());
             props.setProperty(MockProducerInterceptor.APPEND_STRING_PROP, "something");


### PR DESCRIPTION
Move common code from the client implementations to the `ClientUtils` class or the new `ConsumerUtils` class, where possible.

There are a number of places in the client code where the same basic calls are made by more than one client implementation. Minor refactoring will reduce the amount of boilerplate code necessary for the client to construct its internal state.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
