### PR TITLE
MINOR:Avoid slow Set.removeAll(List) in MirrorSourceConnector

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -320,7 +320,7 @@ public class MirrorSourceConnector extends SourceConnector {
         // or if topic-partitions are missing from the target cluster
         if (!knownSourceTopicPartitionsSet.equals(sourceTopicPartitionsSet) || !missingInTarget.isEmpty()) {
 
-            Set<TopicPartition> newTopicPartitions = sourceTopicPartitionsSet;
+            Set<TopicPartition> newTopicPartitions = new HashSet<>(sourceTopicPartitions);
             newTopicPartitions.removeAll(knownSourceTopicPartitionsSet);
 
             Set<TopicPartition> deletedTopicPartitions = knownSourceTopicPartitionsSet;

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -321,10 +321,10 @@ public class MirrorSourceConnector extends SourceConnector {
         if (!knownSourceTopicPartitionsSet.equals(sourceTopicPartitionsSet) || !missingInTarget.isEmpty()) {
 
             Set<TopicPartition> newTopicPartitions = sourceTopicPartitionsSet;
-            newTopicPartitions.removeAll(knownSourceTopicPartitions);
+            newTopicPartitions.removeAll(knownSourceTopicPartitionsSet);
 
             Set<TopicPartition> deletedTopicPartitions = knownSourceTopicPartitionsSet;
-            deletedTopicPartitions.removeAll(sourceTopicPartitions);
+            deletedTopicPartitions.removeAll(sourceTopicPartitionsSet);
 
             log.info("Found {} new topic-partitions on {}. " +
                      "Found {} deleted topic-partitions on {}. " +


### PR DESCRIPTION
similar to https://github.com/apache/kafka/pull/13946. The `refreshTopicPartitions` method is called periodically. When the number of partitions involved in replication is large, performance problems may occur.