### PR TITLE
KAFKA-15178: Improve ConsumerCoordinator.poll perf

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import java.util.LinkedHashSet;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import org.apache.kafka.clients.GroupRebalanceConfig;
@@ -1654,7 +1655,8 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             for (final String topic : subscription.metadataTopics()) {
                 final List<PartitionInfo> partitions = cluster.partitionsForTopic(topic);
                 if (partitions != null) {
-                    final Set<PartitionRack> partitionRacks = new HashSet<>(partitions.size() * 3);
+                    // we use a LinkedHashSet to improve iteration performance, even though we don't care about the order
+                    final Set<PartitionRack> partitionRacks = new LinkedHashSet<>(partitions.size() * 3);
                     for (final PartitionInfo p : partitions) {
                         if (clientRack.isPresent() && p.replicas() != null) {
                             for (final Node node : p.replicas()) {


### PR DESCRIPTION
When there are many topic-partitions being consumed by the application, the `rejoinNeededOrPending` method can perform poorly, due to the deep equality comparison of `metadataSnapshot` with `assignmentSnapshot`.

Since these snapshots can only diverge in `maybeUpdateSubscriptionMetadata`, we can use a `boolean` to cache whether they are already known to be "dirty", and therefore need to be compared.

This should shortcut the deep comparison in the common-case that the snapshot hasn't been updated.

Fixes KAFKA-15178

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
