### PR TITLE
MINOR: Remove StreamsProducer flush under EOS

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -413,7 +413,11 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                     //
                     // TODO: this should be removed after we decouple caching with emitting
                     stateMgr.flushCache();
-                    recordCollector.flush();
+                    if (!eosEnabled) {
+                        // under EOS, commitTransaction will implicitly flush the Producer, so there's no need to flush
+                        // it explicitly and add an extra round-trip to the brokers
+                        recordCollector.flush();
+                    }
                     hasPendingTxCommit = eosEnabled;
 
                     log.debug("Prepared {} task for committing", state());


### PR DESCRIPTION
`KafkaProducer.flush` does not need to be called under EOS, because `KafkaProducer.commitTransaction` implicitly flushes the record buffer during the transaction commit.

This should reduce the number of round-trips to the Kafka brokers needed by the Streams EOS Producer, improving throughput under EOS.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
