### PR TITLE
MINOR: Fix Jmxtool to enforce wait option when Object is not yet available in MBean server

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/JmxTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/JmxTool.java
@@ -169,7 +169,7 @@ public class JmxTool {
         long waitTimeoutMs = 10_000;
         Set<ObjectName> result = new HashSet<>();
         Set<ObjectName> querySet = new HashSet<>(queries);
-        BiPredicate<Set<ObjectName>, Set<ObjectName>> foundAllObjects = Set::containsAll;
+        BiPredicate<Set<ObjectName>, Set<ObjectName>> foundAllObjects = Set::equals;
         long start = System.currentTimeMillis();
         do {
             if (!result.isEmpty()) {

--- a/tools/src/test/java/org/apache/kafka/tools/JmxToolTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/JmxToolTest.java
@@ -337,6 +337,19 @@ public class JmxToolTest {
         assertTrue(validDateFormat(dateFormat, csv.get("time")));
     }
 
+    @Test
+    public void unknownObjectName() {
+        String[] args = new String[]{
+            "--jmx-url", jmxUrl,
+            "--object-name", "kafka.server:type=DummyMetrics,name=MessagesInPerSec",
+            "--wait"
+        };
+
+        String err = executeAndGetErr(args);
+        assertCommandFailure();
+        assertTrue(err.contains("Could not find all requested object names after 10000 ms"));
+    }
+
     private static int findRandomOpenPortOnAllLocalInterfaces() throws Exception {
         try (ServerSocket socket = new ServerSocket(0)) {
             return socket.getLocalPort();


### PR DESCRIPTION
In [JmxTool.scala](https://github.com/apache/kafka/blob/3.4/core/src/main/scala/kafka/tools/JmxTool.scala#L172 ), we will wait till all the object names are available from MBean server.  [But in the newer version](https://github.com/apache/kafka/blob/trunk/tools/src/main/java/org/apache/kafka/tools/JmxTool.java#L172), we only wait for subset of object names. Due to this, we may not enforce wait option and prematurely return the result if the objects are not yet registered in MBean sever.

Ran the system tests with the fix.