### PR TITLE
KAFKA-12495: IncrementalCooperativeAssignor#handleLostAssignments invokes logic for lost Assignments even when there are no Lost assignments

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -240,6 +240,13 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
             previousRevocation.tasks().clear();
         }
 
+        final long now = time.milliseconds();
+        // Before any operations, check if the rebalance delay has expired. In that case,
+        // we will reset the revoking rebalance state.
+        if (scheduledRebalance > 0 && now >= scheduledRebalance) {
+            resetPreviousRevocationsState();
+        }
+
         // Derived set: The set of deleted connectors-and-tasks is a derived set from the set
         // difference of previous - configured
         ConnectorsAndTasks deleted = diff(previousAssignment, configured);
@@ -324,15 +331,14 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                 // have converged to a balanced load. We can reset the rebalance clock
                 log.debug("Previous round had revocations but this round didn't. Probably, the cluster has reached a " +
                         "balanced load. Resetting the exponential backoff clock");
-                revokedInPrevious = false;
-                numSuccessiveRevokingRebalances = 0;
+                resetPreviousRevocationsState();
             } else {
                 // no-op
                 log.debug("No revocations in previous and current round.");
             }
         } else {
             log.debug("Delayed rebalance is active. Delaying {}ms before revoking connectors and tasks: {}", delay, toRevoke);
-            revokedInPrevious = false;
+            resetPreviousRevocationsState();
         }
 
         // The complete set of connectors and tasks that should be newly-assigned during this round
@@ -442,8 +448,8 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
     protected void handleLostAssignments(ConnectorsAndTasks lostAssignments,
                                          ConnectorsAndTasks.Builder lostAssignmentsToReassign,
                                          List<WorkerLoad> completeWorkerAssignment) {
-        // There are no lost assignments and there were no revocations in the previous round
-        if (lostAssignments.isEmpty() && !revokedInPrevious) {
+
+        if (lostAssignments.isEmpty()) {
             resetDelay();
             return;
         }
@@ -502,9 +508,6 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                 lostAssignmentsToReassign.addTasks(lostAssignments.tasks());
             }
             resetDelay();
-            // Resetting the flag as now we can permit successive revoking rebalances.
-            // since we have gone through the full rebalance delay
-            revokedInPrevious = false;
         } else {
             candidateWorkersForReassignment
                     .addAll(candidateWorkersForReassignment(completeWorkerAssignment));
@@ -533,6 +536,11 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
             log.debug("Resetting delay from previous value: {} to 0", delay);
         }
         delay = 0;
+    }
+
+    private void resetPreviousRevocationsState() {
+        revokedInPrevious = false;
+        numSuccessiveRevokingRebalances = 0;
     }
 
     private Set<String> candidateWorkersForReassignment(List<WorkerLoad> completeWorkerAssignment) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -442,7 +442,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
     protected void handleLostAssignments(ConnectorsAndTasks lostAssignments,
                                          ConnectorsAndTasks.Builder lostAssignmentsToReassign,
                                          List<WorkerLoad> completeWorkerAssignment) {
-        // There are no lost assignments and there have been no successive revoking rebalances
+        // There are no lost assignments and there were no revocations in the previous round
         if (lostAssignments.isEmpty() && !revokedInPrevious) {
             resetDelay();
             return;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -151,7 +151,7 @@ public class IncrementalCooperativeAssignorTest {
         // in this round
         addNewEmptyWorkers("worker3");
         performStandardRebalance();
-        assertTrue(assignor.delay > 0);
+        assertEquals(40, assignor.delay); // First successive revoking rebalance.
         assertWorkers("worker1", "worker2", "worker3");
         assertConnectorAllocations(0, 1, 2);
         assertTaskAllocations(3, 3, 6);
@@ -161,30 +161,38 @@ public class IncrementalCooperativeAssignorTest {
         time.sleep(assignor.delay);
         addNewEmptyWorkers("worker4");
         performStandardRebalance();
+        assertEquals(0, assignor.delay); // No revocations in this round.
         assertWorkers("worker1", "worker2", "worker3", "worker4");
         assertConnectorAllocations(0, 0, 1, 1);
         assertTaskAllocations(0, 3, 3, 3);
 
         // Fifth assignment and a fifth worker joining after a revoking rebalance.
-        // We shouldn't revoke and set a delay > initial interval
+        // We shouldn't revoke and set a delay equal to initial interval
         addNewEmptyWorkers("worker5");
         performStandardRebalance();
-        assertTrue(assignor.delay > 40);
+        assertEquals(40, assignor.delay); // First successive revoking rebalance.
         assertWorkers("worker1", "worker2", "worker3", "worker4", "worker5");
         assertConnectorAllocations(0, 0, 1, 1, 1);
         assertTaskAllocations(1, 2, 3, 3, 3);
 
-        // Sixth assignment with sixth worker joining after the expiry.
-        // Should revoke
-        time.sleep(assignor.delay);
+        // Sixth assignment with sixth worker joining within rebalance interval
+        // There should not be any revocations and delay should be extended further.
         addNewEmptyWorkers("worker6");
         performStandardRebalance();
-        assertDelay(0);
+        assertTrue(assignor.delay > 40); // Second successive revoking rebalance.
+        assertWorkers("worker1", "worker2", "worker3", "worker4", "worker5", "worker6");
+        assertConnectorAllocations(0, 0, 0, 1, 1, 1);
+        assertTaskAllocations(0, 1, 2, 3, 3, 3);
+
+        // Follow up rebalance after delay expires.
+        time.sleep(assignor.delay);
+        performStandardRebalance();
+        assertEquals(0, assignor.delay); // Delay reset
         assertWorkers("worker1", "worker2", "worker3", "worker4", "worker5", "worker6");
         assertConnectorAllocations(0, 0, 0, 1, 1, 1);
         assertTaskAllocations(0, 1, 2, 2, 2, 2);
 
-        // Follow up rebalance since there were revocations
+        // Final rebalance because of revocations in the previous round
         performStandardRebalance();
         assertWorkers("worker1", "worker2", "worker3", "worker4", "worker5", "worker6");
         assertConnectorAllocations(0, 0, 0, 1, 1, 1);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -142,6 +142,7 @@ public class IncrementalCooperativeAssignorTest {
         // We should revoke.
         addNewEmptyWorkers("worker2");
         performStandardRebalance();
+        assertEquals(0, assignor.delay); // First revoking rebalance
         assertWorkers("worker1", "worker2");
         assertConnectorAllocations(0, 2);
         assertTaskAllocations(0, 6);
@@ -161,7 +162,7 @@ public class IncrementalCooperativeAssignorTest {
         time.sleep(assignor.delay);
         addNewEmptyWorkers("worker4");
         performStandardRebalance();
-        assertEquals(0, assignor.delay); // No revocations in this round.
+        assertEquals(0, assignor.delay); // First revoking rebalance after delay
         assertWorkers("worker1", "worker2", "worker3", "worker4");
         assertConnectorAllocations(0, 0, 1, 1);
         assertTaskAllocations(0, 3, 3, 3);
@@ -170,7 +171,7 @@ public class IncrementalCooperativeAssignorTest {
         // We shouldn't revoke and set a delay equal to initial interval
         addNewEmptyWorkers("worker5");
         performStandardRebalance();
-        assertEquals(40, assignor.delay); // First successive revoking rebalance.
+        assertEquals(40, assignor.delay); // First successive revoking rebalance after delay
         assertWorkers("worker1", "worker2", "worker3", "worker4", "worker5");
         assertConnectorAllocations(0, 0, 1, 1, 1);
         assertTaskAllocations(1, 2, 3, 3, 3);
@@ -179,7 +180,7 @@ public class IncrementalCooperativeAssignorTest {
         // There should not be any revocations and delay should be extended further.
         addNewEmptyWorkers("worker6");
         performStandardRebalance();
-        assertTrue(assignor.delay > 40); // Second successive revoking rebalance.
+        assertTrue(assignor.delay > 40); // Second successive revoking rebalance after delay
         assertWorkers("worker1", "worker2", "worker3", "worker4", "worker5", "worker6");
         assertConnectorAllocations(0, 0, 0, 1, 1, 1);
         assertTaskAllocations(0, 1, 2, 3, 3, 3);


### PR DESCRIPTION
This PR addresses a few issues I noticed with https://github.com/apache/kafka/pull/12561. To provide some context, https://github.com/apache/kafka/pull/12561 provided a mechanism to allow successive revoking rebalances as long as those successive rebalances happened after an exponential backoff timer set after 1 successive revoking rebalance. However, there were some things I noticed while doing some testing which need fixing. These are :

1. [This](https://github.com/apache/kafka/pull/12561/files#diff-e24067b121eb960feebfa099bd9c30382e330eaf5db39302a9d7a50e29b3acb4R446) condition checks if there are lost assignments and exits only if there are no lost assignments and the previous round did not have revocations. Consider a case when a connector or a few connectors are deleted and that leads to load balancing revocations. That would mean that the `revokedInPrevious` flag would be set to true post that. But, on the follow up rebalance, when there are no lost assignments, the condition `lostAssignments.isEmpty() && !revokedInPrevious` would no longer be true because `revokedInPrevious` would be true. This typically culminates in printing this line `No worker seems to have departed the group during the rebalance....` which doesn't make sense. Ideally we should exit this condition as soon as lost assignments are empty. Note that this change as such is harmless but this line's presence can seem very confusing. This can be checked in the logs as follows:

Log lines after connector deletions:
```
2023-07-12 13:35:30,531] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Member configs: {worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897=WorkerState{url='http://127.0.0.1:8084/', offset=29, Assignment{error=0, leader='worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897', leaderUrl='http://127.0.0.1:8084/', offset=27, connectorIds=[kafka-connect-redis-1], taskIds=[kafka-connect-redis-1-0, kafka-connect-redis-1-1], revokedConnectorIds=[], revokedTaskIds=[], delay=0}}, worker-1-946364e9-6efd-492a-badc-fab26507c9dd=WorkerState{url='http://127.0.0.1:8083/', offset=29, Assignment{error=0, leader='worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897', leaderUrl='http://127.0.0.1:8084/', offset=27, connectorIds=[kafka-connect-redis], taskIds=[kafka-connect-redis-0, kafka-connect-redis-1], revokedConnectorIds=[], revokedTaskIds=[], delay=0}}} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:117)
[2023-07-12 13:35:30,531] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Max config offset root: 29, local snapshot config offsets root: 29 (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:123)
[2023-07-12 13:35:30,531] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Performing task assignment during generation: 30 with memberId:  (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:177)
[2023-07-12 13:35:30,531] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Previous assignments: { connectorIds=[kafka-connect-redis-1, kafka-connect-redis], taskIds=[kafka-connect-redis-1-0, kafka-connect-redis-1-1, kafka-connect-redis-0, kafka-connect-redis-1]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:213)
[2023-07-12 13:35:30,531] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Configured assignments: { connectorIds=[kafka-connect-redis], taskIds=[kafka-connect-redis-1, kafka-connect-redis-0]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:232)
[2023-07-12 13:35:30,531] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Received assignments: {worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897={ connectorIds=[kafka-connect-redis-1], taskIds=[kafka-connect-redis-1-0, kafka-connect-redis-1-1]}, worker-1-946364e9-6efd-492a-badc-fab26507c9dd={ connectorIds=[kafka-connect-redis], taskIds=[kafka-connect-redis-0, kafka-connect-redis-1]}} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:625)
[2023-07-12 13:35:30,531] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Active assignments: { connectorIds=[kafka-connect-redis-1, kafka-connect-redis], taskIds=[kafka-connect-redis-1-0, kafka-connect-redis-1-1, kafka-connect-redis-0, kafka-connect-redis-1]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:237)
[2023-07-12 13:35:30,531] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Deleted assignments: { connectorIds=[kafka-connect-redis-1], taskIds=[kafka-connect-redis-1-0, kafka-connect-redis-1-1]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:253)
[2023-07-12 13:35:30,532] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Lost assignments: { connectorIds=[], taskIds=[]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:262)
[2023-07-12 13:35:30,532] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Created: { connectorIds=[], taskIds=[]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:267)
[2023-07-12 13:35:30,532] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Deleted connectors and tasks to revoke from each worker: {worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897={ connectorIds=[kafka-connect-redis-1], taskIds=[kafka-connect-redis-1-1, kafka-connect-redis-1-0]}, worker-1-946364e9-6efd-492a-badc-fab26507c9dd={ connectorIds=[], taskIds=[]}} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:275)
[2023-07-12 13:35:30,532] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Duplicated connectors and tasks to revoke from each worker: {worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897={ connectorIds=[], taskIds=[]}, worker-1-946364e9-6efd-492a-badc-fab26507c9dd={ connectorIds=[], taskIds=[]}} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:280)
[2023-07-12 13:35:30,532] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Performing allocation-balancing revocation immediately as no revocations took place during the previous rebalance (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:325)
[2023-07-12 13:35:30,532] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Incremental connector assignments: {worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897=[], worker-1-946364e9-6efd-492a-badc-fab26507c9dd=[]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:382)
[2023-07-12 13:35:30,532] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Incremental task assignments: {worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897=[], worker-1-946364e9-6efd-492a-badc-fab26507c9dd=[]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:383)
[2023-07-12 13:35:30,533] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Filling assignment: worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897 -> Assignment{error=0, leader='worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897', leaderUrl='http://127.0.0.1:8084/', offset=29, connectorIds=[], taskIds=[], revokedConnectorIds=[kafka-connect-redis-1], revokedTaskIds=[kafka-connect-redis-1-1, kafka-connect-redis-1-0], delay=0} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:579)
```

Log lines in the subsequent rebalance:
```
[2023-07-12 13:35:30,742] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Performing task assignment (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:109)
[2023-07-12 13:35:30,742] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Member configs: {worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897=WorkerState{url='http://127.0.0.1:8084/', offset=29, Assignment{error=0, leader='worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897', leaderUrl='http://127.0.0.1:8084/', offset=29, connectorIds=[], taskIds=[], revokedConnectorIds=[], revokedTaskIds=[], delay=0}}, worker-1-946364e9-6efd-492a-badc-fab26507c9dd=WorkerState{url='http://127.0.0.1:8083/', offset=29, Assignment{error=0, leader='worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897', leaderUrl='http://127.0.0.1:8084/', offset=29, connectorIds=[kafka-connect-redis], taskIds=[kafka-connect-redis-1], revokedConnectorIds=[], revokedTaskIds=[], delay=0}}} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:117)
[2023-07-12 13:35:30,742] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Max config offset root: 29, local snapshot config offsets root: 29 (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:123)
[2023-07-12 13:35:30,742] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Performing task assignment during generation: 31 with memberId:  (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:177)
[2023-07-12 13:35:30,742] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Previous assignments: { connectorIds=[kafka-connect-redis], taskIds=[kafka-connect-redis-1]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:213)
[2023-07-12 13:35:30,743] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Configured assignments: { connectorIds=[kafka-connect-redis], taskIds=[kafka-connect-redis-1, kafka-connect-redis-0]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:232)
[2023-07-12 13:35:30,743] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Received assignments: {worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897={ connectorIds=[], taskIds=[]}, worker-1-946364e9-6efd-492a-badc-fab26507c9dd={ connectorIds=[kafka-connect-redis], taskIds=[kafka-connect-redis-1]}} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:625)
[2023-07-12 13:35:30,743] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Active assignments: { connectorIds=[kafka-connect-redis], taskIds=[kafka-connect-redis-1]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:237)
[2023-07-12 13:35:30,743] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Deleted assignments: { connectorIds=[], taskIds=[]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:253)
[2023-07-12 13:35:30,743] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Lost assignments: { connectorIds=[], taskIds=[]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:262)
[2023-07-12 13:35:30,743] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Created: { connectorIds=[], taskIds=[kafka-connect-redis-0]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:267)
[2023-07-12 13:35:30,743] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Deleted connectors and tasks to revoke from each worker: {worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897={ connectorIds=[], taskIds=[]}, worker-1-946364e9-6efd-492a-badc-fab26507c9dd={ connectorIds=[], taskIds=[]}} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:275)
[2023-07-12 13:35:30,743] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Duplicated connectors and tasks to revoke from each worker: {worker-2-ec04a27d-64a5-4d39-a1f2-77ff1b6f5897={ connectorIds=[], taskIds=[]}, worker-1-946364e9-6efd-492a-badc-fab26507c9dd={ connectorIds=[], taskIds=[]}} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:280)
[2023-07-12 13:35:30,743] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Found the following connectors and tasks missing from previous assignments: { connectorIds=[], taskIds=[]} (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:459)
[2023-07-12 13:35:30,743] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] **No worker seems to have departed the group during the rebalance. The missing assignments that the leader is detecting are probably due to some workers failing to receive the new assignments in the previous rebalance. Will reassign missing tasks as new tasks** (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:466)
[2023-07-12 13:35:30,743] DEBUG [Worker clientId=connect-1, groupId=connect-cluster] Previous round had revocations but this round didn't. Probably, the cluster has reached a balanced load. Resetting the exponential backoff clock (org.apache.kafka.connect.runtime.distributed.IncrementalCooperativeAssignor:332)
```
This PR fixes it by removing the check on `revokedInPrevious` flag from that condition.

2) This [unsetting of the flag](https://github.com/apache/kafka/pull/12561/files#diff-e24067b121eb960feebfa099bd9c30382e330eaf5db39302a9d7a50e29b3acb4R507) `revokedInPrevious` within `handleLostAssignments` has been removed. Instead now it has been moved to the beginning of the rebalance start loop. That makes the changes a lot easier to reason about with no loss of functionality that the original PR aimed to solved.

3) There was also an inconsistency in the flag and the counter being used for unsetting the revocations state. Over [here](https://github.com/apache/kafka/pull/14000/files#diff-e24067b121eb960feebfa099bd9c30382e330eaf5db39302a9d7a50e29b3acb4L335) only the flag is being unset but at a couple of other places, the counter is also reset. IMO both should be done as we are signifying that this round has no revoking rebalance. This PR addresses that concern as well.

4) Some general refactoring to move the revoking rebalance unsetting to a separate method.

5) Modified one of the tests. Note that only of the tests needed modifications which was failing due to 3 IMO. Other tests worked w/o any changes.

