### PR TITLE
KAFKA-15326: [5/N] Processing thread punctuation

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -1075,7 +1075,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         if (streamTime == RecordQueue.UNKNOWN) {
             return false;
         } else {
-            final boolean punctuated = streamTimePunctuationQueue.mayPunctuate(streamTime, PunctuationType.STREAM_TIME, this);
+            final boolean punctuated = streamTimePunctuationQueue.maybePunctuate(streamTime, PunctuationType.STREAM_TIME, this);
 
             if (punctuated) {
                 commitNeeded = true;
@@ -1083,6 +1083,11 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
 
             return punctuated;
         }
+    }
+
+    public boolean canPunctuateStreamTime() {
+        final long streamTime = partitionGroup.streamTime();
+        return streamTimePunctuationQueue.canPunctuate(streamTime);
     }
 
     /**
@@ -1095,13 +1100,18 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     public boolean maybePunctuateSystemTime() {
         final long systemTime = time.milliseconds();
 
-        final boolean punctuated = systemTimePunctuationQueue.mayPunctuate(systemTime, PunctuationType.WALL_CLOCK_TIME, this);
+        final boolean punctuated = systemTimePunctuationQueue.maybePunctuate(systemTime, PunctuationType.WALL_CLOCK_TIME, this);
 
         if (punctuated) {
             commitNeeded = true;
         }
 
         return punctuated;
+    }
+
+    public boolean canPunctuateSystemTime() {
+        final long systemTime = time.milliseconds();
+        return systemTimePunctuationQueue.canPunctuate(systemTime);
     }
 
     void maybeRecordE2ELatency(final long recordTimestamp, final long now, final String nodeName) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.internals.ReadOnlyTask;
 import org.apache.kafka.streams.processor.internals.StreamTask;
+import org.apache.kafka.streams.processor.internals.TaskExecutionMetadata;
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -87,11 +88,29 @@ public class DefaultTaskExecutor implements TaskExecutor {
             if (currentTask == null) {
                 currentTask = taskManager.assignNextTask(DefaultTaskExecutor.this);
             } else {
+                boolean progressed = false;
+
+                // First, attempt to punctuate
+                if (taskExecutionMetadata.canPunctuateTask(currentTask)) {
+                    if (currentTask.maybePunctuateStreamTime()) {
+                        log.trace("punctuated stream time for task {} ", currentTask.id());
+                        progressed = true;
+                    }
+                    if (currentTask.maybePunctuateSystemTime()) {
+                        log.trace("punctuated system time for task {} ", currentTask.id());
+                        progressed = true;
+                    }
+                }
+
                 // if a task is no longer processable, ask task-manager to give it another
                 // task in the next iteration
-                if (currentTask.isProcessable(nowMs)) {
+                if (taskExecutionMetadata.canProcessTask(currentTask, nowMs) && currentTask.isProcessable(nowMs)) {
+                    log.trace("processing record for task {}", currentTask.id());
                     currentTask.process(nowMs);
-                } else {
+                    progressed = true;
+                }
+
+                if (!progressed) {
                     unassignCurrentTask();
                 }
             }
@@ -119,13 +138,16 @@ public class DefaultTaskExecutor implements TaskExecutor {
     private StreamTask currentTask = null;
     private TaskExecutorThread taskExecutorThread = null;
     private CountDownLatch shutdownGate;
+    private TaskExecutionMetadata taskExecutionMetadata;
 
     public DefaultTaskExecutor(final TaskManager taskManager,
                                final String name,
-                               final Time time) {
+                               final Time time,
+                               final TaskExecutionMetadata taskExecutionMetadata) {
         this.time = time;
         this.name = name;
         this.taskManager = taskManager;
+        this.taskExecutionMetadata = taskExecutionMetadata;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskExecutorCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskExecutorCreator.java
@@ -17,8 +17,10 @@
 package org.apache.kafka.streams.processor.internals.tasks;
 
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.processor.internals.TaskExecutionMetadata;
 
 public interface TaskExecutorCreator {
 
-    TaskExecutor create(final TaskManager taskManager, String name, Time time);
+    TaskExecutor create(final TaskManager taskManager, String name, Time time, TaskExecutionMetadata taskExecutionMetadata);
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/PunctuationQueueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/PunctuationQueueTest.java
@@ -23,6 +23,8 @@ import org.apache.kafka.test.MockProcessorNode;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class PunctuationQueueTest {
 
@@ -36,32 +38,41 @@ public class PunctuationQueueTest {
         final long now = sched.timestamp - 100L;
 
         queue.schedule(sched);
+        assertCanPunctuateAtPrecisely(now + 100L);
 
         final ProcessorNodePunctuator processorNodePunctuator = (node, timestamp, type, punctuator) -> punctuator.punctuate(timestamp);
 
-        queue.mayPunctuate(now, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(0, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 100L);
 
-        queue.mayPunctuate(now + 99L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 99L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(0, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 100L);
 
-        queue.mayPunctuate(now + 100L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 100L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(1, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 200L);
 
-        queue.mayPunctuate(now + 199L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 199L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(1, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 200L);
 
-        queue.mayPunctuate(now + 200L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 200L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(2, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 300L);
 
-        queue.mayPunctuate(now + 1001L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 1001L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(3, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 1100L);
 
-        queue.mayPunctuate(now + 1002L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 1002L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(3, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 1100L);
 
-        queue.mayPunctuate(now + 1100L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 1100L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(4, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 1200L);
     }
 
     @Test
@@ -70,33 +81,42 @@ public class PunctuationQueueTest {
         final long now = sched.timestamp - 50L;
 
         queue.schedule(sched);
+        assertCanPunctuateAtPrecisely(now + 50L);
 
         final ProcessorNodePunctuator processorNodePunctuator =
             (node, timestamp, type, punctuator) -> punctuator.punctuate(timestamp);
 
-        queue.mayPunctuate(now, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(0, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 50L);
 
-        queue.mayPunctuate(now + 49L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 49L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(0, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 50L);
 
-        queue.mayPunctuate(now + 50L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 50L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(1, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 150L);
 
-        queue.mayPunctuate(now + 149L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 149L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(1, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 150L);
 
-        queue.mayPunctuate(now + 150L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 150L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(2, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 250L);
 
-        queue.mayPunctuate(now + 1051L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 1051L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(3, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 1150L);
 
-        queue.mayPunctuate(now + 1052L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 1052L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(3, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 1150L);
 
-        queue.mayPunctuate(now + 1150L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 1150L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(4, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 1250L);
     }
 
     @Test
@@ -105,6 +125,7 @@ public class PunctuationQueueTest {
         final long now = sched.timestamp - 100L;
 
         final Cancellable cancellable = queue.schedule(sched);
+        assertCanPunctuateAtPrecisely(now + 100L);
 
         final ProcessorNodePunctuator processorNodePunctuator = (node, timestamp, type, punctuator) -> {
             punctuator.punctuate(timestamp);
@@ -112,13 +133,23 @@ public class PunctuationQueueTest {
             cancellable.cancel();
         };
 
-        queue.mayPunctuate(now, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(0, node.mockProcessor.punctuatedStreamTime().size());
+        assertCanPunctuateAtPrecisely(now + 100L);
 
-        queue.mayPunctuate(now + 100L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 100L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(1, node.mockProcessor.punctuatedStreamTime().size());
+        assertFalse(queue.canPunctuate(Long.MAX_VALUE));
 
-        queue.mayPunctuate(now + 200L, PunctuationType.STREAM_TIME, processorNodePunctuator);
+        queue.maybePunctuate(now + 200L, PunctuationType.STREAM_TIME, processorNodePunctuator);
         assertEquals(1, node.mockProcessor.punctuatedStreamTime().size());
+        assertFalse(queue.canPunctuate(Long.MAX_VALUE));
     }
+
+    private void assertCanPunctuateAtPrecisely(final long now) {
+        assertFalse(queue.canPunctuate(now - 1));
+        assertTrue(queue.canPunctuate(now));
+        assertTrue(queue.canPunctuate(now + 1));
+    }
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutorTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.internals.StreamTask;
+import org.apache.kafka.streams.processor.internals.TaskExecutionMetadata;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,8 +33,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,13 +49,15 @@ public class DefaultTaskExecutorTest {
     private final Time time = new MockTime(1L);
     private final StreamTask task = mock(StreamTask.class);
     private final TaskManager taskManager = mock(TaskManager.class);
+    private final TaskExecutionMetadata taskExecutionMetadata = mock(TaskExecutionMetadata.class);
 
-    private final DefaultTaskExecutor taskExecutor = new DefaultTaskExecutor(taskManager, "TaskExecutor", time);
+    private final DefaultTaskExecutor taskExecutor = new DefaultTaskExecutor(taskManager, "TaskExecutor", time, taskExecutionMetadata);
 
     @BeforeEach
     public void setUp() {
         // only assign a task for the first time
         when(taskManager.assignNextTask(taskExecutor)).thenReturn(task).thenReturn(null);
+        when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
         when(task.isProcessable(anyLong())).thenReturn(true);
         when(task.process(anyLong())).thenReturn(true);
         when(task.prepareCommit()).thenReturn(Collections.emptyMap());
@@ -79,14 +85,82 @@ public class DefaultTaskExecutorTest {
     }
 
     @Test
-    public void shouldUnassignTaskWhenNotProcessable() {
+    public void shouldUnassignTaskWhenNotProgressing() {
         when(task.isProcessable(anyLong())).thenReturn(false);
+        when(task.maybePunctuateStreamTime()).thenReturn(false);
+        when(task.maybePunctuateSystemTime()).thenReturn(false);
 
         taskExecutor.start();
 
         verify(taskManager, timeout(VERIFICATION_TIMEOUT)).unassignTask(task, taskExecutor);
         verify(task).prepareCommit();
         assertNull(taskExecutor.currentTask());
+    }
+
+    @Test
+    public void shouldProcessTasks() {
+        when(taskExecutionMetadata.canProcessTask(any(), anyLong())).thenReturn(true);
+        when(task.isProcessable(anyLong())).thenReturn(true);
+
+        taskExecutor.start();
+
+        verify(task, timeout(VERIFICATION_TIMEOUT).atLeast(2)).process(anyLong());
+    }
+
+    @Test
+    public void shouldPunctuateStreamTime() {
+        when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(false);
+        when(taskExecutionMetadata.canPunctuateTask(task)).thenReturn(true);
+        when(task.maybePunctuateStreamTime()).thenReturn(true);
+
+        taskExecutor.start();
+
+        verify(task, timeout(VERIFICATION_TIMEOUT).atLeast(2)).maybePunctuateStreamTime();
+    }
+
+    @Test
+    public void shouldPunctuateSystemTime() {
+        when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(false);
+        when(taskExecutionMetadata.canPunctuateTask(task)).thenReturn(true);
+        when(task.maybePunctuateSystemTime()).thenReturn(true);
+
+        taskExecutor.start();
+
+        verify(task, timeout(VERIFICATION_TIMEOUT).atLeast(2)).maybePunctuateSystemTime();
+    }
+
+    @Test
+    public void shouldRespectPunctuationDisabledByTaskExecutionMetadata() {
+        when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
+        when(taskExecutionMetadata.canPunctuateTask(task)).thenReturn(false);
+        when(task.isProcessable(anyLong())).thenReturn(true);
+
+        taskExecutor.start();
+
+        verify(task, timeout(VERIFICATION_TIMEOUT).atLeast(2)).process(anyLong());
+
+        taskExecutor.unassign();
+
+        verify(taskManager, timeout(VERIFICATION_TIMEOUT)).unassignTask(task, taskExecutor);
+        verify(task, never()).maybePunctuateStreamTime();
+        verify(task, never()).maybePunctuateSystemTime();
+    }
+
+    @Test
+    public void shouldRespectProcessingDisabledByTaskExecutionMetadata() {
+        when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(false);
+        when(taskExecutionMetadata.canPunctuateTask(task)).thenReturn(true);
+        when(task.isProcessable(anyLong())).thenReturn(true);
+
+        taskExecutor.start();
+
+        verify(task, timeout(VERIFICATION_TIMEOUT)).maybePunctuateSystemTime();
+        verify(task, timeout(VERIFICATION_TIMEOUT)).maybePunctuateStreamTime();
+
+        taskExecutor.unassign();
+
+        verify(taskManager, timeout(VERIFICATION_TIMEOUT)).unassignTask(task, taskExecutor);
+        verify(task, never()).process(anyLong());
     }
 
     @Test


### PR DESCRIPTION
Implements punctuation inside processing threads. The scheduler
algorithm checks if a task that is not assigned currently can
be punctuated, and returns it when a worker thread asks for the
next task to be processed. Then, the processing thread runs all
punctuations in the punctionation queue.

Piggy-backed: take TaskExecutionMetadata into account when
processing records.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
