### PR TITLE
KAFKA-15182: Normalize source connector offsets before invoking SourceConnector::alterOffsets

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -83,8 +83,10 @@ import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.HeaderConverter;
 import org.apache.kafka.connect.storage.KafkaOffsetBackingStore;
 import org.apache.kafka.connect.storage.OffsetBackingStore;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
 import org.apache.kafka.connect.storage.OffsetStorageReaderImpl;
 import org.apache.kafka.connect.storage.OffsetStorageWriter;
+import org.apache.kafka.connect.storage.OffsetUtils;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.ConnectUtils;
 import org.apache.kafka.connect.util.ConnectorTaskId;
@@ -1547,9 +1549,11 @@ public class Worker {
                     offsetsToWrite = offsets;
                 }
 
+                Map<Map<String, ?>, Map<String, ?>> normalizedOffsets = normalizeOffsets(offsetsToWrite);
+
                 boolean alterOffsetsResult;
                 try {
-                    alterOffsetsResult = ((SourceConnector) connector).alterOffsets(connectorConfig, offsetsToWrite);
+                    alterOffsetsResult = ((SourceConnector) connector).alterOffsets(connectorConfig, normalizedOffsets);
                 } catch (UnsupportedOperationException e) {
                     log.error("Failed to modify offsets for connector {} because it doesn't support external modification of offsets",
                             connName, e);
@@ -1561,7 +1565,7 @@ public class Worker {
                 // This should only occur for an offsets reset request when there are no source partitions found for the source connector in the
                 // offset store - either because there was a prior attempt to reset offsets or if there are no offsets committed by this source
                 // connector so far
-                if (offsetsToWrite.isEmpty()) {
+                if (normalizedOffsets.isEmpty()) {
                     log.info("No offsets found for source connector {} - this can occur due to a prior attempt to reset offsets or if the " +
                             "source connector hasn't committed any offsets yet", connName);
                     completeModifyOffsetsCallback(alterOffsetsResult, isReset, cb);
@@ -1570,7 +1574,7 @@ public class Worker {
 
                 // The modifySourceConnectorOffsets method should only be called after all the connector's tasks have been stopped, and it's
                 // safe to write offsets via an offset writer
-                offsetsToWrite.forEach(offsetWriter::offset);
+                normalizedOffsets.forEach(offsetWriter::offset);
 
                 // We can call begin flush without a timeout because this newly created single-purpose offset writer can't do concurrent
                 // offset writes. We can also ignore the return value since it returns false if and only if there is no data to be flushed,
@@ -1581,7 +1585,7 @@ public class Worker {
                     producer.initTransactions();
                     producer.beginTransaction();
                 }
-                log.debug("Committing the following offsets for source connector {}: {}", connName, offsetsToWrite);
+                log.debug("Committing the following offsets for source connector {}: {}", connName, normalizedOffsets);
                 FutureCallback<Void> offsetWriterCallback = new FutureCallback<>();
                 offsetWriter.doFlush(offsetWriterCallback);
                 if (config.exactlyOnceSourceEnabled()) {
@@ -1606,6 +1610,32 @@ public class Worker {
                 Utils.closeQuietly(offsetStore::stop, "Offset store for offset modification request for connector " + connName);
             }
         }));
+    }
+
+    /**
+     * "Normalize" source connector offsets by serializing and deserializing them using the internal {@link JsonConverter}.
+     * This is done in order to prevent type mismatches between the offsets passed to {@link SourceConnector#alterOffsets(Map, Map)}
+     * and the offsets that connectors and tasks retrieve via an instance of {@link OffsetStorageReader}.
+     * <p>
+     * Visible for testing.
+     *
+     * @param originalOffsets the offsets that are to be normalized
+     * @return the normalized offsets
+     */
+    @SuppressWarnings("unchecked")
+    Map<Map<String, ?>, Map<String, ?>> normalizeOffsets(Map<Map<String, ?>, Map<String, ?>> originalOffsets) {
+        Map<Map<String, ?>, Map<String, ?>> normalizedOffsets = new HashMap<>();
+        for (Map.Entry<Map<String, ?>, Map<String, ?>> entry : originalOffsets.entrySet()) {
+            OffsetUtils.validateFormat(entry.getKey());
+            OffsetUtils.validateFormat(entry.getValue());
+            byte[] serializedKey = internalKeyConverter.fromConnectData("", null, entry.getKey());
+            byte[] serializedValue = internalKeyConverter.fromConnectData("", null, entry.getValue());
+            Object deserializedKey = internalKeyConverter.toConnectData("", serializedKey).value();
+            Object deserializedValue = internalKeyConverter.toConnectData("", serializedValue).value();
+            normalizedOffsets.put((Map<String, ?>) deserializedKey, (Map<String, ?>) deserializedValue);
+        }
+
+        return normalizedOffsets;
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -1549,7 +1549,7 @@ public class Worker {
                     offsetsToWrite = offsets;
                 }
 
-                Map<Map<String, ?>, Map<String, ?>> normalizedOffsets = normalizeOffsets(offsetsToWrite);
+                Map<Map<String, ?>, Map<String, ?>> normalizedOffsets = normalizeSourceConnectorOffsets(offsetsToWrite);
 
                 boolean alterOffsetsResult;
                 try {
@@ -1623,7 +1623,7 @@ public class Worker {
      * @return the normalized offsets
      */
     @SuppressWarnings("unchecked")
-    Map<Map<String, ?>, Map<String, ?>> normalizeOffsets(Map<Map<String, ?>, Map<String, ?>> originalOffsets) {
+    Map<Map<String, ?>, Map<String, ?>> normalizeSourceConnectorOffsets(Map<Map<String, ?>, Map<String, ?>> originalOffsets) {
         Map<Map<String, ?>, Map<String, ?>> normalizedOffsets = new HashMap<>();
         for (Map.Entry<Map<String, ?>, Map<String, ?>> entry : originalOffsets.entrySet()) {
             OffsetUtils.validateFormat(entry.getKey());

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -1629,9 +1629,9 @@ public class Worker {
             OffsetUtils.validateFormat(entry.getKey());
             OffsetUtils.validateFormat(entry.getValue());
             byte[] serializedKey = internalKeyConverter.fromConnectData("", null, entry.getKey());
-            byte[] serializedValue = internalKeyConverter.fromConnectData("", null, entry.getValue());
+            byte[] serializedValue = internalValueConverter.fromConnectData("", null, entry.getValue());
             Object deserializedKey = internalKeyConverter.toConnectData("", serializedKey).value();
-            Object deserializedValue = internalKeyConverter.toConnectData("", serializedValue).value();
+            Object deserializedValue = internalValueConverter.toConnectData("", serializedValue).value();
             normalizedOffsets.put((Map<String, ?>) deserializedKey, (Map<String, ?>) deserializedValue);
         }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -2020,7 +2020,7 @@ public class WorkerTest {
     }
 
     @Test
-    public void testNormalizeOffsets() throws Exception {
+    public void testNormalizeSourceConnectorOffsets() throws Exception {
         Map<Map<String, ?>, Map<String, ?>> offsets = Collections.singletonMap(
                 Collections.singletonMap("filename", "/path/to/filename"),
                 Collections.singletonMap("position", 20)
@@ -2039,7 +2039,7 @@ public class WorkerTest {
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore, executorService,
                 noneConnectorClientConfigOverridePolicy, null);
 
-        Map<Map<String, ?>, Map<String, ?>> normalizedOffsets = worker.normalizeOffsets(offsets);
+        Map<Map<String, ?>, Map<String, ?>> normalizedOffsets = worker.normalizeSourceConnectorOffsets(offsets);
         assertEquals(1, normalizedOffsets.size());
 
         // The integer value 20 gets deserialized as a long value by the JsonConverter

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -2028,12 +2028,7 @@ public class WorkerTest {
 
         assertTrue(offsets.values().iterator().next().get("position") instanceof Integer);
 
-        JsonConverter jsonConverter = new JsonConverter();
-        jsonConverter.configure(Collections.singletonMap(SCHEMAS_ENABLE_CONFIG, false), false);
-        when(plugins.newInternalConverter(eq(true), anyString(), anyMap()))
-                .thenReturn(jsonConverter);
-        when(plugins.newInternalConverter(eq(false), anyString(), anyMap()))
-                .thenReturn(jsonConverter);
+        mockInternalConverters();
 
         mockKafkaClusterId();
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore, executorService,


### PR DESCRIPTION
- From https://issues.apache.org/jira/browse/KAFKA-15182:

>See discussion [here](https://github.com/apache/kafka/pull/13945#discussion_r1260946148)
>
> TLDR: When users attempt to externally modify source connector offsets via the `PATCH /offsets` endpoint (introduced in [KIP-875](https://cwiki.apache.org/confluence/display/KAFKA/KIP-875%3A+First-class+offsets+support+in+Kafka+Connect)), type mismatches can occur between offsets passed to `SourceConnector::alterOffsets` and the offsets that are retrieved by connectors / tasks via an instance of `OffsetStorageReader` after the offsets have been modified. In order to prevent this type mismatch that could lead to subtle bugs in connectors, we could serialize + deserialize the offsets using the worker's internal JSON converter before invoking `SourceConnector::alterOffsets`.

- I've also added a small unit test, verified that the existing offsets API related integration tests are passing, and tested this patch out manually with the `FileStreamSourceConnector`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
