### PR TITLE
KAFKA-15181: fix(storage): wait for consumer to be synced after assigning partitions

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -337,7 +337,7 @@
     <suppress checks="CyclomaticComplexity"
               files="(LogValidator|RemoteLogManagerConfig).java"/>
     <suppress checks="NPathComplexity"
-              files="(LogValidator|RemoteIndexCache).java"/>
+              files="(LogValidator|RemoteIndexCache|TopicBasedRemoteLogMetadataManager).java"/>
     <suppress checks="ParameterNumber"
               files="(LogAppendInfo|RemoteLogManagerConfig).java"/>
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerManager.java
@@ -116,6 +116,8 @@ public class ConsumerManager implements Closeable {
      * @throws TimeoutException if this method execution did not complete with in the given {@code timeoutMs}.
      */
     public void waitTillConsumptionCatchesUp(int partition, long offset, long timeoutMs) throws TimeoutException {
+        log.info("Waiting until consumer is caught up with the target partition [{}]", partition);
+
         final long consumeCheckIntervalMs = Math.min(CONSUME_RECHECK_INTERVAL_MS, timeoutMs);
 
         // If the current assignment does not have the subscription for this partition then return immediately.

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerTask.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerTask.java
@@ -68,12 +68,13 @@ class ConsumerTask implements Runnable, Closeable {
 
     private final RemoteLogMetadataSerde serde = new RemoteLogMetadataSerde();
     private final KafkaConsumer<byte[], byte[]> consumer;
+    private final String metadataTopicName;
     private final RemotePartitionMetadataEventHandler remotePartitionMetadataEventHandler;
     private final RemoteLogMetadataTopicPartitioner topicPartitioner;
     private final Time time;
 
     // It indicates whether the closing process has been started or not. If it is set as true,
-    // consumer will stop consuming messages and it will not allow partition assignments to be updated.
+    // consumer will stop consuming messages, and it will not allow partition assignments to be updated.
     private volatile boolean closing = false;
 
     // It indicates whether the consumer needs to assign the partitions or not. This is set when it is
@@ -101,12 +102,14 @@ class ConsumerTask implements Runnable, Closeable {
     private long lastSyncedTimeMs;
 
     public ConsumerTask(KafkaConsumer<byte[], byte[]> consumer,
+                        String metadataTopicName,
                         RemotePartitionMetadataEventHandler remotePartitionMetadataEventHandler,
                         RemoteLogMetadataTopicPartitioner topicPartitioner,
                         Path committedOffsetsPath,
                         Time time,
                         long committedOffsetSyncIntervalMs) {
         this.consumer = Objects.requireNonNull(consumer);
+        this.metadataTopicName = Objects.requireNonNull(metadataTopicName);
         this.remotePartitionMetadataEventHandler = Objects.requireNonNull(remotePartitionMetadataEventHandler);
         this.topicPartitioner = Objects.requireNonNull(topicPartitioner);
         this.time = Objects.requireNonNull(time);
@@ -143,6 +146,7 @@ class ConsumerTask implements Runnable, Closeable {
 
             // Seek to the committed offsets
             for (Map.Entry<Integer, Long> entry : committedOffsets.entrySet()) {
+                log.debug("Updating consumed offset: [{}] for partition [{}]", entry.getValue(), entry.getKey());
                 partitionToConsumedOffsets.put(entry.getKey(), entry.getValue());
                 consumer.seek(new TopicPartition(REMOTE_LOG_METADATA_TOPIC_NAME, entry.getKey()), entry.getValue());
             }
@@ -187,6 +191,7 @@ class ConsumerTask implements Runnable, Closeable {
             } else {
                 log.debug("This event {} is skipped as the topic partition is not assigned for this instance.", remoteLogMetadata);
             }
+            log.debug("Updating consumed offset: [{}] for partition [{}]", record.offset(), record.partition());
             partitionToConsumedOffsets.put(record.partition(), record.offset());
         }
     }
@@ -209,7 +214,7 @@ class ConsumerTask implements Runnable, Closeable {
                     if (offset != null) {
                         remotePartitionMetadataEventHandler.syncLogMetadataSnapshot(topicIdPartition, metadataPartition, offset);
                     } else {
-                        log.debug("Skipping syncup of the remote-log-metadata-file for partition:{} , with remote log metadata partition{}, and no offset",
+                        log.debug("Skipping sync-up of the remote-log-metadata-file for partition:{} , with remote log metadata partition{}, and no offset",
                                 topicIdPartition, metadataPartition);
                     }
                 }
@@ -313,7 +318,7 @@ class ConsumerTask implements Runnable, Closeable {
                 updatedAssignedMetaPartitions.add(topicPartitioner.metadataPartition(tp));
             }
 
-            // Clear removed topic partitions from inmemory cache.
+            // Clear removed topic partitions from in-memory cache.
             for (TopicIdPartition removedPartition : removedPartitions) {
                 remotePartitionMetadataEventHandler.clearTopicPartition(removedPartition);
             }
@@ -352,5 +357,11 @@ class ConsumerTask implements Runnable, Closeable {
                 assignPartitionsLock.notifyAll();
             }
         }
+    }
+
+    public Set<TopicPartition> metadataPartitionsAssigned() {
+        return assignedMetaPartitions.stream()
+                    .map(partitionNum -> new TopicPartition(metadataTopicName, partitionNum))
+                    .collect(Collectors.toSet());
     }
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataStore.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataStore.java
@@ -47,11 +47,9 @@ public class RemotePartitionMetadataStore extends RemotePartitionMetadataEventHa
 
     private final Path logDir;
 
-    private Map<TopicIdPartition, RemotePartitionDeleteMetadata> idToPartitionDeleteMetadata =
-            new ConcurrentHashMap<>();
+    private Map<TopicIdPartition, RemotePartitionDeleteMetadata> idToPartitionDeleteMetadata = new ConcurrentHashMap<>();
 
-    private Map<TopicIdPartition, FileBasedRemoteLogMetadataCache> idToRemoteLogMetadataCache =
-            new ConcurrentHashMap<>();
+    private Map<TopicIdPartition, FileBasedRemoteLogMetadataCache> idToRemoteLogMetadataCache = new ConcurrentHashMap<>();
 
     public RemotePartitionMetadataStore(Path logDir) {
         this.logDir = logDir;

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -169,7 +168,8 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
      *
      * @param topicIdPartition partition of the given remoteLogMetadata.
      * @param remoteLogMetadata RemoteLogMetadata to be stored.
-     * @return
+     * @return a future with acknowledge and potentially waiting also for consumer to catch up.
+     * This ensures cache is synchronized with backing topic.
      * @throws RemoteStorageException if there are any storage errors occur.
      */
     private CompletableFuture<Void> storeRemoteLogMetadata(TopicIdPartition topicIdPartition,
@@ -182,13 +182,12 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
             CompletableFuture<RecordMetadata> produceFuture = producerManager.publishMessage(remoteLogMetadata);
 
             // Create and return a `CompletableFuture` instance which completes when the consumer is caught up with the produced record's offset.
-            return produceFuture.thenApplyAsync(recordMetadata -> {
+            return produceFuture.thenAcceptAsync(recordMetadata -> {
                 try {
-                    consumerManager.waitTillConsumptionCatchesUp(recordMetadata);
+                    consumerManager.waitTillConsumptionCatchesUp(recordMetadata.partition(), recordMetadata.offset());
                 } catch (TimeoutException e) {
                     throw new KafkaException(e);
                 }
-                return null;
             });
         } catch (KafkaException e) {
             if (e instanceof RetriableException) {
@@ -338,18 +337,18 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
                 return;
             }
 
-            log.info("Started initializing with configs: {}", configs);
+            log.info("Started configuring topic-based RLMM with configs: {}", configs);
 
             rlmmConfig = new TopicBasedRemoteLogMetadataManagerConfig(configs);
             rlmmTopicPartitioner = new RemoteLogMetadataTopicPartitioner(rlmmConfig.metadataTopicPartitionsCount());
             remotePartitionMetadataStore = new RemotePartitionMetadataStore(new File(rlmmConfig.logDir()).toPath());
             configured = true;
-            log.info("Successfully initialized with rlmmConfig: {}", rlmmConfig);
+            log.info("Successfully configured topic-based RLMM with config: {}", rlmmConfig);
 
             // Scheduling the initialization producer/consumer managers in a separate thread. Required resources may
             // not yet be available now. This thread makes sure that it is retried at regular intervals until it is
             // successful.
-            initializationThread = KafkaThread.nonDaemon("RLMMInitializationThread", () -> initializeResources());
+            initializationThread = KafkaThread.nonDaemon("RLMMInitializationThread", this::initializeResources);
             initializationThread.start();
         } finally {
             lock.writeLock().unlock();
@@ -357,14 +356,11 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
     }
 
     private void initializeResources() {
-        log.info("Initializing the resources.");
+        log.info("Initializing topic-based RLMM resources");
         final NewTopic remoteLogMetadataTopicRequest = createRemoteLogMetadataTopicRequest();
         boolean topicCreated = false;
         long startTimeMs = time.milliseconds();
-        AdminClient adminClient = null;
-        try {
-            adminClient = AdminClient.create(rlmmConfig.producerProperties());
-
+        try (AdminClient adminClient = AdminClient.create(rlmmConfig.commonProperties())) {
             // Stop if it is already initialized or closing.
             while (!(initialized.get() || closing.get())) {
 
@@ -417,22 +413,12 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
                     }
 
                     initialized.set(true);
-                    log.info("Initialized resources successfully.");
+                    log.info("Initialized topic-based RLMM resources successfully");
                 } catch (Exception e) {
                     log.error("Encountered error while initializing producer/consumer", e);
                     return;
                 } finally {
                     lock.writeLock().unlock();
-                }
-            }
-
-        } finally {
-            if (adminClient != null) {
-                try {
-                    adminClient.close(Duration.ofSeconds(10));
-                } catch (Exception e) {
-                    // Ignore the error.
-                    log.debug("Error occurred while closing the admin client", e);
                 }
             }
         }
@@ -515,7 +501,7 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
     @Override
     public void close() throws IOException {
         // Close all the resources.
-        log.info("Closing the resources.");
+        log.info("Closing topic-based RLMM resources");
         if (closing.compareAndSet(false, true)) {
             lock.writeLock().lock();
             try {
@@ -532,7 +518,7 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
                 Utils.closeQuietly(remotePartitionMetadataStore, "RemotePartitionMetadataStore");
             } finally {
                 lock.writeLock().unlock();
-                log.info("Closed the resources.");
+                log.info("Closed topic-based RLMM resources");
             }
         }
     }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
@@ -105,6 +105,7 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
     private final long initializationRetryMaxTimeoutMs;
     private final long initializationRetryIntervalMs;
 
+    private Map<String, Object> commonProps;
     private Map<String, Object> consumerProps;
     private Map<String, Object> producerProps;
 
@@ -149,6 +150,8 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
             }
         }
 
+        commonProps = new HashMap<>(commonClientConfigs);
+
         HashMap<String, Object> allProducerConfigs = new HashMap<>(commonClientConfigs);
         allProducerConfigs.putAll(producerOnlyConfigs);
         producerProps = createProducerProps(allProducerConfigs);
@@ -188,6 +191,10 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
 
     public String logDir() {
         return logDir;
+    }
+
+    public Map<String, Object> commonProperties() {
+        return commonProps;
     }
 
     public Map<String, Object> consumerProperties() {
@@ -232,6 +239,7 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
                 ", metadataTopicReplicationFactor=" + metadataTopicReplicationFactor +
                 ", initializationRetryMaxTimeoutMs=" + initializationRetryMaxTimeoutMs +
                 ", initializationRetryIntervalMs=" + initializationRetryIntervalMs +
+                ", commonProps=" + commonProps +
                 ", consumerProps=" + consumerProps +
                 ", producerProps=" + producerProps +
                 '}';

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
@@ -271,11 +271,13 @@ public class RemoteLogSegmentLifecycleTest {
             throws RemoteStorageException {
         // cache.listRemoteLogSegments(leaderEpoch) should contain the above segment.
         Iterator<RemoteLogSegmentMetadata> segmentsIter = remoteLogSegmentLifecycleManager.listRemoteLogSegments(leaderEpoch);
-        Assertions.assertTrue(segmentsIter.hasNext() && Objects.equals(segmentsIter.next(), expectedSegment));
+        Assertions.assertTrue(segmentsIter.hasNext());
+        Assertions.assertEquals(expectedSegment, segmentsIter.next());
 
         // cache.listAllRemoteLogSegments() should contain the above segment.
         Iterator<RemoteLogSegmentMetadata> allSegmentsIter = remoteLogSegmentLifecycleManager.listAllRemoteLogSegments();
-        Assertions.assertTrue(allSegmentsIter.hasNext() && Objects.equals(allSegmentsIter.next(), expectedSegment));
+        Assertions.assertTrue(allSegmentsIter.hasNext());
+        Assertions.assertEquals(expectedSegment, allSegmentsIter.next());
     }
 
     @ParameterizedTest(name = "remoteLogSegmentLifecycleManager = {0}")
@@ -285,7 +287,7 @@ public class RemoteLogSegmentLifecycleTest {
         try {
             remoteLogSegmentLifecycleManager.initialize(topicIdPartition);
 
-                // Create a segment with state COPY_SEGMENT_STARTED, and check for searching that segment and listing the
+            // Create a segment with state COPY_SEGMENT_STARTED, and check for searching that segment and listing the
             // segments.
             RemoteLogSegmentId segmentId = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
             RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(segmentId, 0L, 50L, -1L, BROKER_ID_0,

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfigTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfigTest.java
@@ -39,13 +39,12 @@ import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemo
 import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_TOPIC_RETENTION_MS_PROP;
 
 public class TopicBasedRemoteLogMetadataManagerConfigTest {
-    private static final  Logger log = LoggerFactory.getLogger(TopicBasedRemoteLogMetadataManagerConfigTest.class);
+    private static final Logger log = LoggerFactory.getLogger(TopicBasedRemoteLogMetadataManagerConfigTest.class);
 
     private static final String BOOTSTRAP_SERVERS = "localhost:9091";
 
     @Test
     public void testValidConfig() {
-
         Map<String, Object> commonClientConfig = new HashMap<>();
         commonClientConfig.put(CommonClientConfigs.RETRIES_CONFIG, 10);
         commonClientConfig.put(CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG, 1000L);
@@ -64,11 +63,14 @@ public class TopicBasedRemoteLogMetadataManagerConfigTest {
         Assertions.assertEquals(props.get(REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP), rlmmConfig.metadataTopicPartitionsCount());
 
         // Check for common client configs.
+        Assertions.assertEquals(BOOTSTRAP_SERVERS, rlmmConfig.commonProperties().get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG));
         Assertions.assertEquals(BOOTSTRAP_SERVERS, rlmmConfig.producerProperties().get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG));
         Assertions.assertEquals(BOOTSTRAP_SERVERS, rlmmConfig.consumerProperties().get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG));
 
         for (Map.Entry<String, Object> entry : commonClientConfig.entrySet()) {
             log.info("Checking config: " + entry.getKey());
+            Assertions.assertEquals(entry.getValue(),
+                                    rlmmConfig.commonProperties().get(entry.getKey()));
             Assertions.assertEquals(entry.getValue(),
                                     rlmmConfig.producerProperties().get(entry.getKey()));
             Assertions.assertEquals(entry.getValue(),
@@ -91,12 +93,13 @@ public class TopicBasedRemoteLogMetadataManagerConfigTest {
     }
 
     @Test
-    public void testProducerConsumerOverridesConfig() {
+    public void testCommonProducerConsumerOverridesConfig() {
         Map.Entry<String, Long> overrideEntry = new AbstractMap.SimpleImmutableEntry<>(CommonClientConfigs.METADATA_MAX_AGE_CONFIG, 60000L);
         Map<String, Object> commonClientConfig = new HashMap<>();
         commonClientConfig.put(CommonClientConfigs.RETRIES_CONFIG, 10);
         commonClientConfig.put(CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG, 1000L);
-        commonClientConfig.put(overrideEntry.getKey(), overrideEntry.getValue());
+        Long overrideCommonPropValue = overrideEntry.getValue();
+        commonClientConfig.put(overrideEntry.getKey(), overrideCommonPropValue);
 
         Map<String, Object> producerConfig = new HashMap<>();
         producerConfig.put(ProducerConfig.ACKS_CONFIG, -1);
@@ -111,6 +114,8 @@ public class TopicBasedRemoteLogMetadataManagerConfigTest {
         Map<String, Object> props = createValidConfigProps(commonClientConfig, producerConfig, consumerConfig);
         TopicBasedRemoteLogMetadataManagerConfig rlmmConfig = new TopicBasedRemoteLogMetadataManagerConfig(props);
 
+        Assertions.assertEquals(overrideCommonPropValue,
+                                rlmmConfig.commonProperties().get(overrideEntry.getKey()));
         Assertions.assertEquals(overriddenProducerPropValue,
                                 rlmmConfig.producerProperties().get(overrideEntry.getKey()));
         Assertions.assertEquals(overriddenConsumerPropValue,

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerRestartTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerRestartTest.java
@@ -120,7 +120,7 @@ public class TopicBasedRemoteLogMetadataManagerRestartTest {
         // Register these partitions to RLMM.
         topicBasedRlmm().onPartitionLeadershipChanges(Collections.singleton(leaderTopicIdPartition), Collections.singleton(followerTopicIdPartition));
 
-        // Add segments for these partitions but they are not available as they have not yet been subscribed.
+        // Add segments for these partitions, but they are not available as they have not yet been subscribed.
         RemoteLogSegmentMetadata leaderSegmentMetadata = new RemoteLogSegmentMetadata(
                 new RemoteLogSegmentId(leaderTopicIdPartition, Uuid.randomUuid()),
                 0, 100, -1L, 0,

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerTest.java
@@ -124,15 +124,15 @@ public class TopicBasedRemoteLogMetadataManagerTest {
 
         // RemoteLogSegmentMetadata events are already published, and topicBasedRlmm's consumer manager will start
         // fetching those events and build the cache.
-        waitUntilConsumerCatchesup(newLeaderTopicIdPartition, newFollowerTopicIdPartition, 30_000L);
+        waitUntilConsumerCatchesUp(newLeaderTopicIdPartition, newFollowerTopicIdPartition, 30_000L);
 
         Assertions.assertTrue(topicBasedRlmm().listRemoteLogSegments(newLeaderTopicIdPartition).hasNext());
         Assertions.assertTrue(topicBasedRlmm().listRemoteLogSegments(newFollowerTopicIdPartition).hasNext());
     }
 
-    private void waitUntilConsumerCatchesup(TopicIdPartition newLeaderTopicIdPartition,
-                                          TopicIdPartition newFollowerTopicIdPartition,
-                                          long timeoutMs) throws TimeoutException {
+    private void waitUntilConsumerCatchesUp(TopicIdPartition newLeaderTopicIdPartition,
+                                            TopicIdPartition newFollowerTopicIdPartition,
+                                            long timeoutMs) throws TimeoutException {
         int leaderMetadataPartition = topicBasedRlmm().metadataPartition(newLeaderTopicIdPartition);
         int followerMetadataPartition = topicBasedRlmm().metadataPartition(newFollowerTopicIdPartition);
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerTest.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
 import org.apache.kafka.server.log.remote.storage.RemoteResourceNotFoundException;
@@ -39,7 +38,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.TimeoutException;
 
 @SuppressWarnings("deprecation") // Added for Scala 2.12 compatibility for usages of JavaConverters
 public class TopicBasedRemoteLogMetadataManagerTest {


### PR DESCRIPTION
This fixes a race condition where cache is not ready but TBRLMM is marked as initialized anyway, causing replica to fail as remote log metadata is not found.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
