### PR TITLE
MINOR: Fix compilation error on ReplicationControlManagerTest 

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -2574,7 +2574,7 @@ public class ReplicationControlManagerTest {
 
     @Test
     public void testDuplicateTopicIdReplay() {
-        ReplicationControlTestContext ctx = new ReplicationControlTestContext();
+        final ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
         ReplicationControlManager replicationControl = ctx.replicationControl;
         replicationControl.replay(new TopicRecord().
                 setName("foo").


### PR DESCRIPTION
Compilation fails when trying to make a build or try to run tests on local machine, and jenkin  and testing tool, the default constructor does not exists see the following error for more details 


  /home/jenkins/jenkins-agent/workspace/Kafka_kafka_trunk/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java:2577: error: constructor ReplicationControlTestContext in class ReplicationControlTestContext cannot be applied to given types;

        ReplicationControlTestContext ctx = new ReplicationControlTestContext();



### Committer Checklist (excluded from commit message)
- [] Verify design and implementation 
- [] Verify test coverage and CI build status
- [] Verify documentation (including upgrade notes)
