### PR TITLE
KAFKA-14500; [6/6] Implement SyncGroup protocol in new GroupCoordinator

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -342,7 +342,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
             coordinator -> coordinator.genericGroupSync(context, request, responseFuture)
         ).exceptionally(exception -> {
             if (!(exception instanceof KafkaException)) {
-                log.error("Request {} hit an unexpected exception: {}",
+                log.error("SyncGroup request {} hit an unexpected exception: {}",
                     request, exception.getMessage());
             }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -330,9 +330,30 @@ public class GroupCoordinatorService implements GroupCoordinator {
             return FutureUtils.failedFuture(Errors.COORDINATOR_NOT_AVAILABLE.exception());
         }
 
-        return FutureUtils.failedFuture(Errors.UNSUPPORTED_VERSION.exception(
-            "This API is not implemented yet."
-        ));
+        if (!isGroupIdNotEmpty(request.groupId())) {
+            return CompletableFuture.completedFuture(new SyncGroupResponseData()
+                .setErrorCode(Errors.INVALID_GROUP_ID.code()));
+        }
+
+        CompletableFuture<SyncGroupResponseData> responseFuture = new CompletableFuture<>();
+
+        runtime.scheduleWriteOperation("generic-group-sync",
+            topicPartitionFor(request.groupId()),
+            coordinator -> coordinator.genericGroupSync(context, request, responseFuture)
+        ).exceptionally(exception -> {
+            if (!(exception instanceof KafkaException)) {
+                log.error("Request {} hit an unexpected exception: {}",
+                    request, exception.getMessage());
+            }
+
+            if (!responseFuture.isDone()) {
+                responseFuture.complete(new SyncGroupResponseData()
+                    .setErrorCode(Errors.forException(exception).code()));
+            }
+            return null;
+        });
+
+        return responseFuture;
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -76,7 +76,6 @@ import org.apache.kafka.timeline.TimelineHashSet;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2836,7 +2836,6 @@ public class GroupMetadataManager {
             } else {
                 if (request.generationId() != group.generationId()) {
                     return Optional.of(Errors.ILLEGAL_GENERATION);
-
                 } else if (isProtocolInconsistent(request.protocolType(), group.protocolType().orElse(null)) ||
                     isProtocolInconsistent(request.protocolName(), group.protocolName().orElse(null))) {
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1973,9 +1973,8 @@ public class GroupMetadataManager {
                     }
                 });
 
-                List<Record> records = Collections.singletonList(
-                    RecordHelpers.newGroupMetadataRecord(group, metadataImage.features().metadataVersion())
-                );
+                List<Record> records = Collections.singletonList(RecordHelpers.newGroupMetadataRecord(
+                    group, Collections.emptyMap(), metadataImage.features().metadataVersion()));
 
                 return new CoordinatorResult<>(records, appendFuture);
 
@@ -2607,6 +2606,7 @@ public class GroupMetadataManager {
                 log.info("Static member which joins during Stable stage and doesn't affect " +
                     "the selected protocol will not trigger a rebalance.");
 
+                Map<String, byte[]> groupAssignment = group.groupAssignment();
                 CompletableFuture<Void> appendFuture = new CompletableFuture<>();
                 appendFuture.whenComplete((__, t) -> {
                     if (t != null) {
@@ -2656,7 +2656,7 @@ public class GroupMetadataManager {
                 });
 
                 List<Record> records = Collections.singletonList(
-                    RecordHelpers.newGroupMetadataRecord(group, metadataImage.features().metadataVersion())
+                    RecordHelpers.newGroupMetadataRecord(group, groupAssignment, metadataImage.features().metadataVersion())
                 );
 
                 return new CoordinatorResult<>(records, appendFuture);
@@ -2772,7 +2772,7 @@ public class GroupMetadataManager {
                 });
 
                 List<Record> records = Collections.singletonList(
-                    RecordHelpers.newGroupMetadataRecord(group, metadataImage.features().metadataVersion())
+                    RecordHelpers.newGroupMetadataRecord(group, assignment, metadataImage.features().metadataVersion())
                 );
                 return new CoordinatorResult<>(records, appendFuture);
             }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProt
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocolCollection;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.message.JoinGroupResponseData;
+import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.JoinGroupRequest;
@@ -75,6 +76,7 @@ import org.apache.kafka.timeline.TimelineHashSet;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1491,8 +1493,9 @@ public class GroupMetadataManager {
     /**
      * Handle a JoinGroupRequest.
      *
-     * @param context The request context.
-     * @param request The actual JoinGroup request.
+     * @param context        The request context.
+     * @param request        The actual JoinGroup request.
+     * @param responseFuture The join group response future.
      *
      * @return The result that contains records to append if the join group phase completes.
      */
@@ -1619,7 +1622,7 @@ public class GroupMetadataManager {
             // finding the correct coordinator and rejoin.
             responseFuture.complete(new JoinGroupResponseData()
                 .setMemberId(UNKNOWN_MEMBER_ID)
-                .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code())
+                .setErrorCode(COORDINATOR_NOT_AVAILABLE.code())
             );
         } else if (!group.supportsProtocols(request.protocolType(), request.protocols())) {
             responseFuture.complete(new JoinGroupResponseData()
@@ -1678,7 +1681,7 @@ public class GroupMetadataManager {
                     "group {} in {} state. Replacing previously mapped member {} with this groupInstanceId.",
                 groupInstanceId, group.groupId(), group.currentState(), existingMemberId);
 
-            return updateStaticMemberAndRebalance(
+            return updateStaticMemberThenRebalanceOrCompleteJoin(
                 context,
                 request,
                 group,
@@ -1691,7 +1694,7 @@ public class GroupMetadataManager {
                     "group {} in {} state. Created a new member id {} for this member and added to the group.",
                 groupInstanceId, group.groupId(), group.currentState(), newMemberId);
 
-            return addMemberAndRebalance(context, request, group, newMemberId, responseFuture);
+            return addMemberThenRebalanceOrCompleteJoin(context, request, group, newMemberId, responseFuture);
         }
     }
 
@@ -1744,7 +1747,7 @@ public class GroupMetadataManager {
                     "Created a new member id {} and added the member to the group.",
                 group.groupId(), group.currentState(), newMemberId);
 
-            return addMemberAndRebalance(context, request, group, newMemberId, responseFuture);
+            return addMemberThenRebalanceOrCompleteJoin(context, request, group, newMemberId, responseFuture);
         }
 
         return EMPTY_RESULT;
@@ -1776,7 +1779,7 @@ public class GroupMetadataManager {
             // finding the correct coordinator and rejoin.
             responseFuture.complete(new JoinGroupResponseData()
                 .setMemberId(memberId)
-                .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code())
+                .setErrorCode(COORDINATOR_NOT_AVAILABLE.code())
             );
         } else if (!group.supportsProtocols(request.protocolType(), request.protocols())) {
             responseFuture.complete(new JoinGroupResponseData()
@@ -1793,7 +1796,7 @@ public class GroupMetadataManager {
             log.debug("Pending dynamic member with id {} joins group {} in {} state. Adding to the group now.",
                 memberId, group.groupId(), group.currentState());
 
-            return addMemberAndRebalance(
+            return addMemberThenRebalanceOrCompleteJoin(
                 context,
                 request,
                 group,
@@ -1812,6 +1815,8 @@ public class GroupMetadataManager {
                 responseFuture.complete(new JoinGroupResponseData()
                     .setMemberId(memberId)
                     .setErrorCode(memberError.get().code())
+                    .setProtocolType(null)
+                    .setProtocolName(null)
                 );
             } else {
                 GenericGroupMember member = group.member(memberId);
@@ -2015,6 +2020,7 @@ public class GroupMetadataManager {
      * @param group The group.
      */
     private void schedulePendingSync(GenericGroup group) {
+        group.setPendingSyncGenerationId(group.generationId());
         timer.schedule(genericGroupSyncKey(group.groupId()),
             group.rebalanceTimeoutMs(),
             TimeUnit.MILLISECONDS,
@@ -2188,7 +2194,7 @@ public class GroupMetadataManager {
     }
 
     /**
-     * Add a member and rebalance.
+     * Add a member then rebalance or complete join.
      *
      * @param context         The request context.
      * @param request         The join group request.
@@ -2198,7 +2204,7 @@ public class GroupMetadataManager {
      *
      * @return The coordinator result that will be appended to the log.
      */
-    private CoordinatorResult<Void, Record> addMemberAndRebalance(
+    private CoordinatorResult<Void, Record> addMemberThenRebalanceOrCompleteJoin(
         RequestContext context,
         JoinGroupRequestData request,
         GenericGroup group,
@@ -2536,7 +2542,7 @@ public class GroupMetadataManager {
     }
 
     /**
-     * Update a static member and rebalance.
+     * Update a static member then rebalance or complete join.
      *
      * @param context         The request context.
      * @param request         The join group request.
@@ -2547,7 +2553,7 @@ public class GroupMetadataManager {
      *
      * @return The coordinator result that will be appended to the log.
      */
-    private CoordinatorResult<Void, Record> updateStaticMemberAndRebalance(
+    private CoordinatorResult<Void, Record> updateStaticMemberThenRebalanceOrCompleteJoin(
         RequestContext context,
         JoinGroupRequestData request,
         GenericGroup group,
@@ -2660,6 +2666,116 @@ public class GroupMetadataManager {
                 group.stateAsString() + " when the unknown static member " + request.groupInstanceId() + " rejoins.");
 
         }
+        return maybeCompleteJoinPhase(group);
+    }
+
+    /**
+     * Handle a SyncGroupRequest.
+     *
+     * @param context        The request context.
+     * @param request        The actual SyncGroup request.
+     * @param responseFuture The sync group response future.
+     *
+     * @return The result that contains records to append if the group metadata manager received assignments.
+     */
+    public CoordinatorResult<Void, Record> genericGroupSync(
+        RequestContext context,
+        SyncGroupRequestData request,
+        CompletableFuture<SyncGroupResponseData> responseFuture
+    ) throws UnknownMemberIdException, GroupIdNotFoundException {
+        String groupId = request.groupId();
+        String memberId = request.memberId();
+        GenericGroup group;
+        try {
+            group = getOrMaybeCreateGenericGroup(groupId, false);
+        } catch (Throwable t) {
+            responseFuture.complete(new SyncGroupResponseData()
+                .setErrorCode(Errors.forException(t).code())
+            );
+            return EMPTY_RESULT;
+        }
+
+        Optional<Errors> errorOpt = validateSyncGroup(group, request);
+        if (errorOpt.isPresent()) {
+            responseFuture.complete(new SyncGroupResponseData()
+                .setErrorCode(errorOpt.get().code()));
+        } else if (group.isInState(EMPTY)) {
+            responseFuture.complete(new SyncGroupResponseData()
+                .setErrorCode(Errors.UNKNOWN_MEMBER_ID.code()));
+        } else if (group.isInState(PREPARING_REBALANCE)) {
+            responseFuture.complete(new SyncGroupResponseData()
+                .setErrorCode(Errors.REBALANCE_IN_PROGRESS.code()));
+        } else if (group.isInState(COMPLETING_REBALANCE)) {
+            group.member(memberId).setAwaitingSyncFuture(responseFuture);
+            removePendingSyncMember(group, request.memberId());
+
+            // If this is the leader, then we can attempt to persist state and transition to stable
+            if (group.isLeader(memberId)) {
+                log.info("Assignment received from leader {} for group {} for generation {}. " +
+                    "The group has {} members, {} of which are static.",
+                    memberId, groupId, group.generationId(), group.size(), group.allStaticMemberIds().size());
+
+                // Fill all members with corresponding assignment. Reset members not specified in
+                // the assignment to empty assignments.
+                Map<String, byte[]> assignments = new HashMap<>();
+                request.assignments().forEach(assignment ->
+                    assignments.put(assignment.memberId(), assignment.assignment())
+                );
+
+                Set<String> membersWithMissingAssignment = new HashSet<>();
+                group.allMembers().forEach(member -> {
+                    byte[] assignment = assignments.get(member.memberId());
+                    if (assignment != null) {
+                        member.setAssignment(assignment);
+                    } else {
+                        membersWithMissingAssignment.add(member.memberId());
+                        member.setAssignment(new byte[0]);
+                    }
+                });
+
+                if (!membersWithMissingAssignment.isEmpty()) {
+                    log.warn("Setting empty assignments for members {} of {} for generation {}.",
+                        membersWithMissingAssignment, groupId, group.generationId());
+                }
+
+                CompletableFuture<Void> appendFuture = new CompletableFuture<>();
+                appendFuture.whenComplete((__, t) -> {
+                    // Another member may have joined the group while we were awaiting this callback,
+                    // so we must ensure we are still in the CompletingRebalance state and the same generation
+                    // when it gets invoked. if we have transitioned to another state, then do nothing
+                    if (group.isInState(COMPLETING_REBALANCE) && request.generationId() == group.generationId()) {
+                        if (t != null) {
+                            Errors error = Errors.forException(t);
+                            resetAndPropagateAssignmentWithError(group, error);
+                            maybePrepareRebalanceOrCompleteJoin(group, "Error " + error + " when storing group assignment" +
+                                "during SyncGroup (member: " + memberId + ").");
+                        } else {
+                            // Members' assignments were already updated. Propagate and transition to Stable.
+                            propagateAssignment(group, Errors.NONE);
+                            group.transitionTo(STABLE);
+                        }
+                    }
+                });
+
+                List<Record> records = Collections.singletonList(
+                    RecordHelpers.newGroupMetadataRecord(group, metadataImage.features().metadataVersion())
+                );
+                return new CoordinatorResult<>(records, appendFuture);
+            }
+        } else if (group.isInState(STABLE)) {
+            removePendingSyncMember(group, memberId);
+
+            // If the group is stable, we just return the current assignment
+            GenericGroupMember member = group.member(memberId);
+            responseFuture.complete(new SyncGroupResponseData()
+                .setProtocolType(group.protocolType().orElse(null))
+                .setProtocolName(group.protocolName().orElse(null))
+                .setAssignment(member.assignment())
+                .setErrorCode(Errors.NONE.code()));
+        } else if (group.isInState(DEAD)) {
+            throw new IllegalStateException("Reached unexpected condition for Dead group " + groupId);
+        }
+
         return EMPTY_RESULT;
     }
 
@@ -2684,8 +2800,88 @@ public class GroupMetadataManager {
         }
     }
 
+    private Optional<Errors> validateSyncGroup(
+        GenericGroup group,
+        SyncGroupRequestData request
+    ) {
+        if (group.isInState(DEAD)) {
+            // If the group is marked as dead, it means some other thread has just removed the group
+            // from the coordinator metadata; this is likely that the group has migrated to some other
+            // coordinator OR the group is in a transient unstable phase. Let the member retry
+            // finding the correct coordinator and rejoin.
+            return Optional.of(COORDINATOR_NOT_AVAILABLE);
+        } else {
+            Optional<Errors> memberError = validateExistingMember(
+                group,
+                request.memberId(),
+                request.groupInstanceId(),
+                "sync-group"
+            );
+            if (memberError.isPresent()) {
+                return memberError;
+            } else {
+                if (request.generationId() != group.generationId()) {
+                    return Optional.of(Errors.ILLEGAL_GENERATION);
+
+                } else if (isProtocolInconsistent(request.protocolType(), group.protocolType().orElse(null)) ||
+                    isProtocolInconsistent(request.protocolName(), group.protocolName().orElse(null))) {
+
+                    return Optional.of(Errors.INCONSISTENT_GROUP_PROTOCOL);
+                } else {
+                    return Optional.empty();
+                }
+            }
+        }
+    }
+
+    private void removePendingSyncMember(
+        GenericGroup group,
+        String memberId
+    ) {
+        group.removePendingSyncMember(memberId);
+
+        String syncKey = genericGroupSyncKey(group.groupId());
+
+        if (group.generationId() != group.pendingSyncGenerationId()) {
+            timer.cancel(syncKey);
+        } else {
+            switch (group.currentState()) {
+                case DEAD:
+                case EMPTY:
+                case PREPARING_REBALANCE:
+                    timer.cancel(syncKey);
+                    break;
+                case COMPLETING_REBALANCE:
+                case STABLE:
+                    if (group.hasReceivedSyncFromAllMembers()) {
+                        timer.cancel(syncKey);
+                    }
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown group state: " + group.stateAsString());
+            }
+        }
+    }
+
     /**
-     * Generate a heartbeat key for the timer.
+     * Checks whether the given protocol type or name in the request is inconsistent with the group's.
+     *
+     * @param protocolTypeOrName       The request's protocol type or name.
+     * @param groupProtocolTypeOrName  The group's protoocl type or name.
+     *
+     * @return  True if protocol is inconsistent, false otherwise.
+     */
+    private boolean isProtocolInconsistent(
+        String protocolTypeOrName,
+        String groupProtocolTypeOrName
+    ) {
+        return protocolTypeOrName != null
+            && groupProtocolTypeOrName != null
+            && !groupProtocolTypeOrName.equals(protocolTypeOrName);
+    }
+
+    /**
+     * Generate a generic group heartbeat key for the timer.
      *
      * Package private for testing.
      *
@@ -2699,7 +2895,7 @@ public class GroupMetadataManager {
     }
 
     /**
-     * Generate a join key for the timer.
+     * Generate a generic group join key for the timer.
      *
      * Package private for testing.
      *
@@ -2712,7 +2908,7 @@ public class GroupMetadataManager {
     }
 
     /**
-     * Generate a sync key for the timer.
+     * Generate a generic group sync key for the timer.
      *
      * Package private for testing.
      *

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
@@ -366,11 +366,13 @@ public class RecordHelpers {
      * Creates a GroupMetadata record.
      *
      * @param group              The generic group.
+     * @param assignment         The generic group assignment.
      * @param metadataVersion    The metadata version.
      * @return The record.
      */
     public static Record newGroupMetadataRecord(
         GenericGroup group,
+        Map<String, byte[]> assignment,
         MetadataVersion metadataVersion
     ) {
         List<GroupMetadataValue.MemberMetadata> members = new ArrayList<>(group.allMembers().size());
@@ -380,10 +382,10 @@ public class RecordHelpers {
                 throw new IllegalStateException("Attempted to write non-empty group metadata with no defined protocol.");
             }
 
-            byte[] assignment = member.assignment();
-            if (assignment == null) {
+            byte[] memberAssignment = assignment.get(member.memberId());
+            if (memberAssignment == null) {
                 throw new IllegalStateException("Attempted to write member " + member.memberId() +
-                    " of group + " + group.groupId() + " with no assignment.");
+                    " of group " + group.groupId() + " with no assignment.");
             }
 
             members.add(
@@ -395,7 +397,7 @@ public class RecordHelpers {
                     .setSessionTimeout(member.sessionTimeoutMs())
                     .setGroupInstanceId(member.groupInstanceId().orElse(null))
                     .setSubscription(subscription)
-                    .setAssignment(assignment)
+                    .setAssignment(memberAssignment)
             );
         });
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/ReplicatedGroupCoordinator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/ReplicatedGroupCoordinator.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.message.JoinGroupResponseData;
+import org.apache.kafka.common.message.SyncGroupRequestData;
+import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.utils.LogContext;
@@ -187,6 +189,18 @@ public class ReplicatedGroupCoordinator implements Coordinator<Record> {
         CompletableFuture<JoinGroupResponseData> responseFuture
     ) {
         return groupMetadataManager.genericGroupJoin(
+            context,
+            request,
+            responseFuture
+        );
+    }
+
+    public CoordinatorResult<Void, Record> genericGroupSync(
+        RequestContext context,
+        SyncGroupRequestData request,
+        CompletableFuture<SyncGroupResponseData> responseFuture
+    ) {
+        return groupMetadataManager.genericGroupSync(
             context,
             request,
             responseFuture

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/ReplicatedGroupCoordinator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/ReplicatedGroupCoordinator.java
@@ -183,6 +183,15 @@ public class ReplicatedGroupCoordinator implements Coordinator<Record> {
         return groupMetadataManager.consumerGroupHeartbeat(context, request);
     }
 
+    /**
+     * Handles a JoinGroup request.
+     *
+     * @param context The request context.
+     * @param request The actual JoinGroup request.
+     *
+     * @return A Result containing the JoinGroup response and
+     *         a list of records to update the state machine.
+     */
     public CoordinatorResult<Void, Record> genericGroupJoin(
         RequestContext context,
         JoinGroupRequestData request,
@@ -195,6 +204,15 @@ public class ReplicatedGroupCoordinator implements Coordinator<Record> {
         );
     }
 
+    /**
+     * Handles a SyncGroup request.
+     *
+     * @param context The request context.
+     * @param request The actual SyncGroup request.
+     *
+     * @return A Result containing the SyncGroup response and
+     *         a list of records to update the state machine.
+     */
     public CoordinatorResult<Void, Record> genericGroupSync(
         RequestContext context,
         SyncGroupRequestData request,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
@@ -1076,6 +1076,15 @@ public class GenericGroup implements Group {
     }
 
     /**
+     * @return All member assignments keyed by member id.
+     */
+    public Map<String, byte[]> groupAssignment() {
+        return allMembers().stream().collect(Collectors.toMap(
+            GenericGroupMember::memberId, GenericGroupMember::assignment
+        ));
+    }
+
+    /**
      * Checks whether the transition to the target state is valid.
      *
      * @param targetState the target state to transition to.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
@@ -127,6 +127,12 @@ public class GenericGroup implements Group {
     private int generationId;
 
     /**
+     * The group's generation id when the current
+     * pending sync operation was scheduled.
+     */
+    private int pendingSyncGenerationId = -1;
+
+    /**
      * The id of the group's leader.
      */
     private Optional<String> leaderId;
@@ -252,6 +258,13 @@ public class GenericGroup implements Group {
     }
 
     /**
+     * @return the pending sync generation id.
+     */
+    public int pendingSyncGenerationId() {
+        return this.pendingSyncGenerationId;
+    }
+
+    /**
      * @return the protocol name.
      */
     public Optional<String> protocolName() {
@@ -360,6 +373,15 @@ public class GenericGroup implements Group {
      */
     public void setSubscribedTopics(Optional<Set<String>> subscribedTopics) {
         this.subscribedTopics = subscribedTopics;
+    }
+
+    /**
+     * Sets pendingSyncGenerationId.
+     *
+     * @param generationId the value to set.
+     */
+    public void setPendingSyncGenerationId(int generationId) {
+        this.pendingSyncGenerationId = generationId;
     }
 
     /**
@@ -694,7 +716,7 @@ public class GenericGroup implements Group {
     }
 
     // For testing only.
-    Set<String> allDynamicMemberIds() {
+    public Set<String> allDynamicMemberIds() {
         Set<String> dynamicMemberSet = new HashSet<>(allMemberIds());
         staticMembers.values().forEach(dynamicMemberSet::remove);
         return dynamicMemberSet;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
@@ -127,12 +127,6 @@ public class GenericGroup implements Group {
     private int generationId;
 
     /**
-     * The group's generation id when the current
-     * pending sync operation was scheduled.
-     */
-    private int pendingSyncGenerationId = -1;
-
-    /**
      * The id of the group's leader.
      */
     private Optional<String> leaderId;
@@ -258,13 +252,6 @@ public class GenericGroup implements Group {
     }
 
     /**
-     * @return the pending sync generation id.
-     */
-    public int pendingSyncGenerationId() {
-        return this.pendingSyncGenerationId;
-    }
-
-    /**
      * @return the protocol name.
      */
     public Optional<String> protocolName() {
@@ -373,15 +360,6 @@ public class GenericGroup implements Group {
      */
     public void setSubscribedTopics(Optional<Set<String>> subscribedTopics) {
         this.subscribedTopics = subscribedTopics;
-    }
-
-    /**
-     * Sets pendingSyncGenerationId.
-     *
-     * @param generationId the value to set.
-     */
-    public void setPendingSyncGenerationId(int generationId) {
-        this.pendingSyncGenerationId = generationId;
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroupMember.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 /**
  * This class encapsulates a generic group member's metadata.
@@ -400,13 +401,15 @@ public class GenericGroupMember {
     public String toString() {
         return "GenericGroupMember(" +
             "memberId='" + memberId + '\'' +
-            ", groupInstanceId='" + groupInstanceId + '\'' +
+            ", groupInstanceId='" + groupInstanceId.orElse("") + '\'' +
             ", clientId='" + clientId + '\'' +
             ", clientHost='" + clientHost + '\'' +
             ", rebalanceTimeoutMs=" + rebalanceTimeoutMs +
             ", sessionTimeoutMs=" + sessionTimeoutMs +
             ", protocolType='" + protocolType + '\'' +
-            ", supportedProtocols=" + supportedProtocols +
+            ", supportedProtocols=" + supportedProtocols.stream()
+                .map(JoinGroupRequestProtocol::name)
+                .collect(Collectors.toList()) +
             ')';
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroupMember.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProt
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocolCollection;
 import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
+import org.apache.kafka.common.utils.Bytes;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -55,7 +56,7 @@ public class GenericGroupMember {
     /**
      * An empty assignment.
      */
-    public static final byte[] EMPTY_ASSIGNMENT = new byte[0];
+    public static final byte[] EMPTY_ASSIGNMENT = Bytes.EMPTY;
 
     /**
      * The member id.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -8318,9 +8318,9 @@ public class GroupMetadataManagerTest {
             CompletableFuture<SyncGroupResponseData> syncFuture,
             CoordinatorResult<Void, Record> coordinatorResult
         ) {
-           this.syncFuture = syncFuture;
-           this.records = coordinatorResult.records();
-           this.appendFuture = coordinatorResult.appendFuture();
+            this.syncFuture = syncFuture;
+            this.records = coordinatorResult.records();
+            this.appendFuture = coordinatorResult.appendFuture();
         }
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -32,6 +32,10 @@ import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.message.JoinGroupResponseData;
+import org.apache.kafka.common.message.JoinGroupResponseData.JoinGroupResponseMember;
+import org.apache.kafka.common.message.SyncGroupRequestData;
+import org.apache.kafka.common.message.SyncGroupRequestData.SyncGroupRequestAssignment;
+import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.common.metadata.RemoveTopicRecord;
 import org.apache.kafka.common.metadata.TopicRecord;
@@ -44,6 +48,7 @@ import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.coordinator.group.MockCoordinatorTimer.ExpiredTimeout;
@@ -73,6 +78,7 @@ import org.apache.kafka.coordinator.group.generated.GroupMetadataKey;
 import org.apache.kafka.coordinator.group.generated.GroupMetadataValue;
 import org.apache.kafka.coordinator.group.generic.GenericGroup;
 import org.apache.kafka.coordinator.group.generic.GenericGroupMember;
+import org.apache.kafka.coordinator.group.generic.GenericGroupState;
 import org.apache.kafka.coordinator.group.runtime.CoordinatorResult;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
@@ -567,7 +573,7 @@ public class GroupMetadataManagerTest {
             );
         }
 
-        public JoinGroupResponseData joinGenericGroupAsDynamicMemberAndCompleteJoin(
+        public JoinGroupResponseData joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(
             JoinGroupRequestData request
         ) throws ExecutionException, InterruptedException {
             boolean requireKnownMemberId = true;
@@ -615,8 +621,22 @@ public class GroupMetadataManagerTest {
             boolean requireKnownMemberId,
             boolean supportSkippingAssignment
         ) throws ExecutionException, InterruptedException {
+            return joinGenericGroupAndCompleteJoin(
+                request,
+                requireKnownMemberId,
+                supportSkippingAssignment,
+                genericGroupInitialRebalanceDelayMs
+            );
+        }
+
+        public JoinGroupResponseData joinGenericGroupAndCompleteJoin(
+            JoinGroupRequestData request,
+            boolean requireKnownMemberId,
+            boolean supportSkippingAssignment,
+            int advanceClockMs
+        ) throws ExecutionException, InterruptedException {
             if (requireKnownMemberId && request.groupInstanceId().isEmpty()) {
-                return joinGenericGroupAsDynamicMemberAndCompleteJoin(request);
+                return joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(request);
             }
 
             try {
@@ -628,7 +648,7 @@ public class GroupMetadataManagerTest {
                     supportSkippingAssignment
                 );
 
-                sleep(genericGroupInitialRebalanceDelayMs);
+                sleep(advanceClockMs);
                 assertTrue(responseFuture.isDone());
                 assertEquals(Errors.NONE.code(), responseFuture.get().errorCode());
                 return responseFuture.get();
@@ -636,6 +656,33 @@ public class GroupMetadataManagerTest {
                 fail("Failed to due: " + e.getMessage());
             }
             return null;
+        }
+
+        public CoordinatorResult<Void, Record> sendGenericGroupSync(
+            SyncGroupRequestData request,
+            CompletableFuture<SyncGroupResponseData> responseFuture
+        ) {
+            RequestContext context = new RequestContext(
+                new RequestHeader(
+                    ApiKeys.SYNC_GROUP,
+                    ApiKeys.SYNC_GROUP.latestVersion(),
+                    "client",
+                    0
+                ),
+                "1",
+                InetAddress.getLoopbackAddress(),
+                KafkaPrincipal.ANONYMOUS,
+                ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+                SecurityProtocol.PLAINTEXT,
+                ClientInformation.EMPTY,
+                false
+            );
+
+            return groupMetadataManager.genericGroupSync(
+                context,
+                request,
+                responseFuture
+            );
         }
 
         private ApiMessage messageOrNull(ApiMessageAndVersion apiMessageAndVersion) {
@@ -3918,7 +3965,7 @@ public class GroupMetadataManagerTest {
             .withDefaultProtocolTypeAndProtocols()
             .build();
 
-        context.joinGenericGroupAsDynamicMemberAndCompleteJoin(request);
+        context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(request);
 
         request = new JoinGroupRequestBuilder()
             .withGroupId("group-id")
@@ -4005,7 +4052,7 @@ public class GroupMetadataManagerTest {
             .withRebalanceTimeoutMs(2 * context.genericGroupNewMemberJoinTimeoutMs)
             .build();
 
-        JoinGroupResponseData firstResponse = context.joinGenericGroupAsDynamicMemberAndCompleteJoin(request);
+        JoinGroupResponseData firstResponse = context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(request);
         String firstMemberId = firstResponse.memberId();
         assertEquals(firstResponse.leader(), firstMemberId);
         assertEquals(Errors.NONE.code(), firstResponse.errorCode());
@@ -4184,7 +4231,7 @@ public class GroupMetadataManagerTest {
             .withRebalanceTimeoutMs(5000)
             .build();
 
-        JoinGroupResponseData response = context.joinGenericGroupAsDynamicMemberAndCompleteJoin(request);
+        JoinGroupResponseData response = context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(request);
         assertEquals(Errors.NONE.code(), response.errorCode());
 
         CompletableFuture<JoinGroupResponseData> responseFuture = new CompletableFuture<>();
@@ -4518,7 +4565,7 @@ public class GroupMetadataManagerTest {
             .withDefaultProtocolTypeAndProtocols()
             .build();
 
-        JoinGroupResponseData response = context.joinGenericGroupAsDynamicMemberAndCompleteJoin(request);
+        JoinGroupResponseData response = context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(request);
         assertEquals(Errors.NONE.code(), response.errorCode());
         String memberId = response.memberId();
 
@@ -4581,7 +4628,7 @@ public class GroupMetadataManagerTest {
             .withProtocols(protocols)
             .build();
 
-        JoinGroupResponseData response = context.joinGenericGroupAsDynamicMemberAndCompleteJoin(request);
+        JoinGroupResponseData response = context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(request);
 
         assertEquals(Errors.NONE.code(), response.errorCode());
         String memberId = response.memberId();
@@ -4630,7 +4677,7 @@ public class GroupMetadataManagerTest {
             .withDefaultProtocolTypeAndProtocols()
             .build();
 
-        JoinGroupResponseData response = context.joinGenericGroupAsDynamicMemberAndCompleteJoin(request);
+        JoinGroupResponseData response = context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(request);
 
         assertEquals(Errors.NONE.code(), response.errorCode());
         String memberId = response.memberId();
@@ -4672,7 +4719,7 @@ public class GroupMetadataManagerTest {
             .withProtocols(protocols)
             .build();
 
-        JoinGroupResponseData leaderResponse = context.joinGenericGroupAsDynamicMemberAndCompleteJoin(request);
+        JoinGroupResponseData leaderResponse = context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(request);
         assertEquals(Errors.NONE.code(), leaderResponse.errorCode());
         String leaderId = leaderResponse.leader();
         assertEquals(1, group.generationId());
@@ -4744,7 +4791,7 @@ public class GroupMetadataManagerTest {
             .withDefaultProtocolTypeAndProtocols()
             .build();
 
-        JoinGroupResponseData leaderResponse = context.joinGenericGroupAsDynamicMemberAndCompleteJoin(request);
+        JoinGroupResponseData leaderResponse = context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(request);
         assertEquals(Errors.NONE.code(), leaderResponse.errorCode());
         String leaderId = leaderResponse.leader();
         assertEquals(1, group.generationId());
@@ -4795,7 +4842,7 @@ public class GroupMetadataManagerTest {
             .withDefaultProtocolTypeAndProtocols()
             .build();
 
-        JoinGroupResponseData response = context.joinGenericGroupAsDynamicMemberAndCompleteJoin(request);
+        JoinGroupResponseData response = context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(request);
 
         assertEquals(Errors.NONE.code(), response.errorCode());
         String memberId = response.memberId();
@@ -4828,7 +4875,7 @@ public class GroupMetadataManagerTest {
             .withRebalanceTimeoutMs(1000)
             .build();
 
-        JoinGroupResponseData leaderResponse = context.joinGenericGroupAsDynamicMemberAndCompleteJoin(request);
+        JoinGroupResponseData leaderResponse = context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(request);
         assertEquals(Errors.NONE.code(), leaderResponse.errorCode());
         assertEquals(1, group.generationId());
 
@@ -5153,15 +5200,17 @@ public class GroupMetadataManagerTest {
             .withMemberId(UNKNOWN_MEMBER_ID)
             .withProtocolType("consumer")
             .withProtocols(protocols)
+            .withRebalanceTimeoutMs(4000)
+            .withSessionTimeoutMs(3000)
             .build();
 
         JoinGroupResponseData response = context.joinGenericGroupAndCompleteJoin(request, false, false);
         assertEquals(Errors.NONE.code(), response.errorCode());
-        GenericGroupMember oldMember = group.member(response.memberId());
         assertEquals(1, group.size());
         assertEquals(1, group.generationId());
         assertTrue(group.isInState(COMPLETING_REBALANCE));
 
+        String oldMemberId = response.memberId();
         // Simulate successful sync group phase
         group.transitionTo(STABLE);
 
@@ -5187,13 +5236,13 @@ public class GroupMetadataManagerTest {
         );
         assertFalse(responseFuture.isDone());
 
-        // Simulate failed write to log.
+        // Simulate a failed write to the log.
         result.appendFuture().completeExceptionally(new UnknownTopicOrPartitionException());
         assertTrue(responseFuture.isDone());
 
         JoinGroupResponseData expectedResponse = new JoinGroupResponseData()
             .setMembers(Collections.emptyList())
-            .setLeader(oldMember.memberId())
+            .setLeader(oldMemberId)
             .setMemberId(UNKNOWN_MEMBER_ID)
             .setGenerationId(1)
             .setProtocolType("consumer")
@@ -5205,11 +5254,102 @@ public class GroupMetadataManagerTest {
 
         GenericGroupMember revertedMember = group.member(group.staticMemberId("group-instance-id"));
 
-        assertEquals(oldMember.memberId(), revertedMember.memberId());
-        assertEquals(oldMember.groupInstanceId(), revertedMember.groupInstanceId());
-        assertEquals(oldMember.rebalanceTimeoutMs(), revertedMember.rebalanceTimeoutMs());
-        assertEquals(oldMember.sessionTimeoutMs(), revertedMember.sessionTimeoutMs());
-        assertEquals(oldMember.supportedProtocols(), revertedMember.supportedProtocols());
+        assertEquals(oldMemberId, revertedMember.memberId());
+        assertEquals(Optional.of("group-instance-id"), revertedMember.groupInstanceId());
+        assertEquals(4000, revertedMember.rebalanceTimeoutMs());
+        assertEquals(3000, revertedMember.sessionTimeoutMs());
+        assertEquals(protocols, revertedMember.supportedProtocols());
+        assertEquals(1, group.size());
+        assertEquals(1, group.generationId());
+        assertTrue(group.isInState(STABLE));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testReplaceStaticMemberInStableStateSucceeds(
+        boolean supportSkippingAssignment
+    ) throws Exception {
+        // If the append future succeeds, the soft state is updated with the new member.
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        JoinGroupRequestProtocolCollection protocols = new JoinGroupRequestProtocolCollection(0);
+
+        protocols.add(new JoinGroupRequestProtocol()
+            .setName("range")
+            .setMetadata(ConsumerProtocol.serializeSubscription(new ConsumerPartitionAssignor.Subscription(
+                Collections.singletonList("foo"))).array())
+        );
+
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("group-instance-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withProtocolType("consumer")
+            .withProtocols(protocols)
+            .build();
+
+        JoinGroupResponseData response = context.joinGenericGroupAndCompleteJoin(
+            request,
+            true,
+            supportSkippingAssignment
+        );
+
+        assertEquals(Errors.NONE.code(), response.errorCode());
+        assertEquals(1, group.size());
+        assertEquals(1, group.generationId());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+
+        String oldMemberId = response.memberId();
+        // Simulate successful sync group phase
+        group.transitionTo(STABLE);
+
+        // Static member rejoins with UNKNOWN_MEMBER_ID and the append succeeds.
+        protocols.add(new JoinGroupRequestProtocol()
+            .setName("roundrobin")
+            .setMetadata(ConsumerProtocol.serializeSubscription(new ConsumerPartitionAssignor.Subscription(
+                Collections.singletonList("bar"))).array()));
+
+        CompletableFuture<JoinGroupResponseData> responseFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+            request
+                .setProtocols(protocols)
+                .setRebalanceTimeoutMs(7000)
+                .setSessionTimeoutMs(6000),
+            responseFuture,
+            true,
+            supportSkippingAssignment);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        assertFalse(responseFuture.isDone());
+
+        // Simulate a successful write to the log.
+        result.appendFuture().complete(null);
+        assertTrue(responseFuture.isDone());
+
+        JoinGroupResponseData expectedResponse = new JoinGroupResponseData()
+            .setMembers(supportSkippingAssignment ? toJoinResponseMembers(group) : Collections.emptyList())
+            .setLeader(supportSkippingAssignment ? responseFuture.get().memberId() : oldMemberId)
+            .setMemberId(responseFuture.get().memberId())
+            .setGenerationId(1)
+            .setProtocolType("consumer")
+            .setProtocolName("range")
+            .setSkipAssignment(supportSkippingAssignment)
+            .setErrorCode(Errors.NONE.code());
+
+        assertEquals(expectedResponse, responseFuture.get());
+
+        GenericGroupMember newMember = group.member(group.staticMemberId("group-instance-id"));
+
+        assertNotEquals(oldMemberId, newMember.memberId());
+        assertEquals(Optional.of("group-instance-id"), newMember.groupInstanceId());
+        assertEquals(7000, newMember.rebalanceTimeoutMs());
+        assertEquals(6000, newMember.sessionTimeoutMs());
+        assertEquals(protocols, newMember.supportedProtocols());
         assertEquals(1, group.size());
         assertEquals(1, group.generationId());
         assertTrue(group.isInState(STABLE));
@@ -5469,6 +5609,21 @@ public class GroupMetadataManagerTest {
             return this;
         }
 
+        JoinGroupRequestBuilder withProtocolSuperset() {
+            this.protocols.add(new JoinGroupRequestProtocol()
+                .setName("range")
+                .setMetadata(ConsumerProtocol.serializeSubscription(new ConsumerPartitionAssignor.Subscription(
+                    Collections.singletonList("foo"))).array())
+            );
+
+            this.protocols.add(new JoinGroupRequestProtocol()
+                .setName("roundrobin")
+                .setMetadata(ConsumerProtocol.serializeSubscription(new ConsumerPartitionAssignor.Subscription(
+                    Collections.singletonList("bar"))).array())
+            );
+            return this;
+        }
+
         JoinGroupRequestBuilder withProtocolType(String protocolType) {
             this.protocolType = protocolType;
             return this;
@@ -5523,6 +5678,2867 @@ public class GroupMetadataManagerTest {
                 metadataVersion.groupMetadataValueVersion()
             )
         );
+    }
+
+    @Test
+    public void testNewMemberTimeoutCompletion() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .withSessionTimeoutMs(context.genericGroupNewMemberJoinTimeoutMs + 5000)
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> joinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(joinRequest, joinFuture);
+        assertTrue(result.records().isEmpty());
+        assertFalse(joinFuture.isDone());
+
+        context.sleepAndAssertEmptyResult(context.genericGroupInitialRebalanceDelayMs);
+
+        assertTrue(joinFuture.isDone());
+        assertEquals(Errors.NONE.code(), joinFuture.get().errorCode());
+
+        assertEquals(0, group.allMembers().stream().filter(GenericGroupMember::isNew).count());
+
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(joinFuture.get().memberId())
+            .withGenerationId(joinFuture.get().generationId())
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> syncFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(syncRequest, syncFuture);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate a successful write to the log.
+        result.appendFuture().complete(null);
+
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+        assertEquals(1, group.size());
+
+        // Make sure the NewMemberTimeout is not still in effect, and the member is not kicked
+        context.sleepAndAssertEmptyResult(context.genericGroupNewMemberJoinTimeoutMs);
+        assertEquals(1, group.size());
+
+        // Member should be removed as heartbeat expires.
+        List<ExpiredTimeout<Void, Record>> timeouts = context.sleep(5000);
+        List<Record> expectedRecords = Collections.singletonList(newGroupMetadataRecord("group-id",
+                new GroupMetadataValue()
+                    .setMembers(Collections.emptyList())
+                    .setGeneration(2)
+                    .setLeader(null)
+                    .setProtocolType("consumer")
+                    .setProtocol(null)
+                    .setCurrentStateTimestamp(context.time.milliseconds()),
+                MetadataVersion.latest()));
+
+        assertEquals(1, timeouts.size());
+        String memberId = joinFuture.get().memberId();
+        timeouts.forEach(timeout -> {
+            assertEquals(genericGroupHeartbeatKey("group-id", memberId), timeout.key);
+            assertEquals(expectedRecords, timeout.result.records());
+        });
+
+        assertEquals(0, group.size());
+    }
+
+    @Test
+    public void testNewMemberFailureAfterJoinGroupCompletion() throws Exception {
+        // For old versions of the JoinGroup protocol, new members were subject
+        // to expiration if the rebalance took long enough. This test case ensures
+        // that following completion of the JoinGroup phase, new members follow
+        // normal heartbeat expiration logic.
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .withSessionTimeoutMs(5000)
+            .withRebalanceTimeoutMs(10000)
+            .build();
+
+        JoinGroupResponseData joinResponse = context.joinGenericGroupAndCompleteJoin(joinRequest, false, false);
+        assertEquals(Errors.NONE.code(), joinResponse.errorCode());
+
+        String memberId = joinResponse.memberId();
+        assertEquals(memberId, joinResponse.leader());
+        assertEquals(1, joinResponse.generationId());
+
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(memberId)
+            .withGenerationId(1)
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> syncResponseFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupSync(syncRequest, syncResponseFuture);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate a successful write to the log.
+        result.appendFuture().complete(null);
+
+        assertTrue(syncResponseFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncResponseFuture.get().errorCode());
+
+        assertTrue(group.isInState(STABLE));
+        assertEquals(1, group.generationId());
+
+        CompletableFuture<JoinGroupResponseData> otherJoinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> otherJoinResult = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(UNKNOWN_MEMBER_ID),
+            otherJoinFuture);
+
+        CompletableFuture<JoinGroupResponseData> joinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> joinResult = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(memberId),
+            joinFuture);
+
+        assertTrue(otherJoinResult.records().isEmpty());
+        assertTrue(joinResult.records().isEmpty());
+        assertTrue(joinFuture.isDone());
+        assertTrue(otherJoinFuture.isDone());
+
+        verifySessionExpiration(context, group, 5000);
+    }
+
+    @Test
+    public void testStaticMemberFenceDuplicateRejoinedFollower() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        // A third member joins. Trigger a rebalance.
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+
+        context.sendGenericGroupJoin(request, new CompletableFuture<>());
+
+        assertTrue(group.isInState(PREPARING_REBALANCE));
+
+        // Old follower rejoins group will be matching current member.id.
+        CompletableFuture<JoinGroupResponseData> oldFollowerJoinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+            request
+                .setMemberId(rebalanceResult.followerId)
+                .setGroupInstanceId("follower-instance-id"),
+            oldFollowerJoinFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(oldFollowerJoinFuture.isDone());
+
+        // Duplicate follower joins group with unknown member id will trigger member id replacement.
+        result = context.sendGenericGroupJoin(
+            request.setMemberId(UNKNOWN_MEMBER_ID).setGroupInstanceId("follower-instance-id"),
+            new CompletableFuture<>());
+
+        // Old member shall be fenced immediately upon duplicate follower joins.
+        assertTrue(result.records().isEmpty());
+        assertTrue(oldFollowerJoinFuture.isDone());
+
+        JoinGroupResponseData expectedResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.FENCED_INSTANCE_ID.code())
+            .setProtocolName(null)
+            .setProtocolType(null)
+            .setLeader(UNKNOWN_MEMBER_ID)
+            .setMemberId(rebalanceResult.followerId)
+            .setGenerationId(-1);
+
+        checkJoinGroupResponse(
+            expectedResponse,
+            oldFollowerJoinFuture.get(),
+            group,
+            PREPARING_REBALANCE,
+            Collections.emptySet()
+        );
+    }
+
+    @Test
+    public void testStaticMemberFenceDuplicateSyncingFollowerAfterMemberIdChanged() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        // Known leader rejoins will trigger rebalance.
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("leader-instance-id")
+            .withMemberId(rebalanceResult.leaderId)
+            .withDefaultProtocolTypeAndProtocols()
+            .withRebalanceTimeoutMs(10000)
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> leaderJoinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(request, leaderJoinFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(leaderJoinFuture.isDone());
+        assertTrue(group.isInState(PREPARING_REBALANCE));
+
+        // Old follower rejoins group will match current member.id.
+        CompletableFuture<JoinGroupResponseData> oldFollowerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+                request.setMemberId(rebalanceResult.followerId).setGroupInstanceId("follower-instance-id"),
+                oldFollowerJoinFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(oldFollowerJoinFuture.isDone());
+        assertTrue(leaderJoinFuture.isDone());
+
+        JoinGroupResponseData expectedLeaderResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId + 1)
+            .setMemberId(rebalanceResult.leaderId)
+            .setLeader(rebalanceResult.leaderId)
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setMembers(toJoinResponseMembers(group));
+
+        Set<String> expectedGroupInstanceIds = new HashSet<>();
+        expectedGroupInstanceIds.add("leader-instance-id");
+        expectedGroupInstanceIds.add("follower-instance-id");
+
+        checkJoinGroupResponse(
+            expectedLeaderResponse,
+            leaderJoinFuture.get(),
+            group,
+            COMPLETING_REBALANCE,
+            expectedGroupInstanceIds
+        );
+
+        assertEquals(rebalanceResult.leaderId, leaderJoinFuture.get().memberId());
+        assertEquals(rebalanceResult.leaderId, leaderJoinFuture.get().leader());
+
+        // Old follower should get a successful join group response.
+        assertTrue(oldFollowerJoinFuture.isDone());
+
+        JoinGroupResponseData expectedFollowerResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId + 1)
+            .setMemberId(oldFollowerJoinFuture.get().memberId())
+            .setLeader(rebalanceResult.leaderId)
+            .setProtocolName("range")
+            .setProtocolType("consumer");
+
+        checkJoinGroupResponse(
+            expectedFollowerResponse,
+            oldFollowerJoinFuture.get(),
+            group,
+            COMPLETING_REBALANCE,
+            Collections.emptySet()
+        );
+
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+        assertEquals(rebalanceResult.followerId, oldFollowerJoinFuture.get().memberId());
+        assertEquals(rebalanceResult.leaderId, oldFollowerJoinFuture.get().leader());
+
+        // Duplicate follower joins group with unknown member id will trigger member.id replacement,
+        // and will also trigger a rebalance under CompletingRebalance state; the old follower sync callback
+        // will return fenced exception while broker replaces the member identity with the duplicate follower joins.
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("follower-instance-id")
+            .withGenerationId(oldFollowerJoinFuture.get().generationId())
+            .withMemberId(oldFollowerJoinFuture.get().memberId())
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> oldFollowerSyncFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(syncRequest, oldFollowerSyncFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(oldFollowerSyncFuture.isDone());
+
+        CompletableFuture<JoinGroupResponseData> duplicateFollowerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            request.setMemberId(UNKNOWN_MEMBER_ID).setGroupInstanceId("follower-instance-id"),
+            duplicateFollowerJoinFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(group.isInState(PREPARING_REBALANCE));
+        assertFalse(duplicateFollowerJoinFuture.isDone());
+        assertTrue(oldFollowerSyncFuture.isDone());
+        assertEquals(Errors.FENCED_INSTANCE_ID.code(), oldFollowerSyncFuture.get().errorCode());
+
+        // Advance clock by rebalance timeout so that the join phase completes with duplicate follower.
+        // Leader is kicked out.
+        context.sleepAndAssertEmptyResult(10000);
+
+        assertTrue(duplicateFollowerJoinFuture.isDone());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+        assertEquals(3, group.generationId());
+        assertEquals(1, group.size());
+        assertTrue(group.hasMemberId(duplicateFollowerJoinFuture.get().memberId()));
+        assertEquals(duplicateFollowerJoinFuture.get().memberId(), duplicateFollowerJoinFuture.get().leader());
+    }
+
+    @Test
+    public void testStaticMemberFenceDuplicateRejoiningFollowerAfterMemberIdChanged() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        // Known leader rejoins will trigger rebalance.
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("leader-instance-id")
+            .withMemberId(rebalanceResult.leaderId)
+            .withDefaultProtocolTypeAndProtocols()
+            .withRebalanceTimeoutMs(10000)
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> leaderJoinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(request, leaderJoinFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(leaderJoinFuture.isDone());
+        assertTrue(group.isInState(PREPARING_REBALANCE));
+
+        // Duplicate follower joins group will trigger member id replacement.
+        CompletableFuture<JoinGroupResponseData> duplicateFollowerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            request.setMemberId(UNKNOWN_MEMBER_ID).setGroupInstanceId("follower-instance-id"),
+            duplicateFollowerJoinFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(duplicateFollowerJoinFuture.isDone());
+
+        // Old follower rejoins group will fail because member id is already updated.
+        CompletableFuture<JoinGroupResponseData> oldFollowerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            request.setMemberId(rebalanceResult.followerId),
+            oldFollowerJoinFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(oldFollowerJoinFuture.isDone());
+        assertTrue(leaderJoinFuture.isDone());
+
+        JoinGroupResponseData expectedLeaderResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId + 1)
+            .setMemberId(rebalanceResult.leaderId)
+            .setLeader(rebalanceResult.leaderId)
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setMembers(toJoinResponseMembers(group));
+
+        Set<String> expectedGroupInstanceIds = new HashSet<>();
+        expectedGroupInstanceIds.add("leader-instance-id");
+        expectedGroupInstanceIds.add("follower-instance-id");
+
+        checkJoinGroupResponse(
+            expectedLeaderResponse,
+            leaderJoinFuture.get(),
+            group,
+            COMPLETING_REBALANCE,
+            expectedGroupInstanceIds
+        );
+
+        assertTrue(duplicateFollowerJoinFuture.isDone());
+
+        JoinGroupResponseData expectedDuplicateFollowerResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId + 1)
+            .setMemberId(duplicateFollowerJoinFuture.get().memberId())
+            .setLeader(rebalanceResult.leaderId)
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setMembers(Collections.emptyList());
+
+        checkJoinGroupResponse(
+            expectedDuplicateFollowerResponse,
+            duplicateFollowerJoinFuture.get(),
+            group,
+            COMPLETING_REBALANCE,
+            Collections.emptySet()
+        );
+
+        assertTrue(duplicateFollowerJoinFuture.isDone());
+
+        JoinGroupResponseData expectedOldFollowerResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.FENCED_INSTANCE_ID.code())
+            .setGenerationId(-1)
+            .setMemberId(rebalanceResult.followerId)
+            .setLeader(UNKNOWN_MEMBER_ID)
+            .setProtocolName(null)
+            .setProtocolType(null)
+            .setMembers(Collections.emptyList());
+
+        checkJoinGroupResponse(
+            expectedOldFollowerResponse,
+            oldFollowerJoinFuture.get(),
+            group,
+            COMPLETING_REBALANCE,
+            Collections.emptySet()
+        );
+    }
+
+    @Test
+    public void testStaticMemberRejoinWithKnownMemberId() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withGroupInstanceId("group-instance-id")
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+
+        JoinGroupResponseData joinResponse = context.joinGenericGroupAndCompleteJoin(request, false, false);
+        assertEquals(Errors.NONE.code(), joinResponse.errorCode());
+
+        String memberId = joinResponse.memberId();
+
+        CompletableFuture<JoinGroupResponseData> rejoinResponseFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+            request.setMemberId(memberId),
+            rejoinResponseFuture);
+
+        // The second join group should return immediately since we are using the same metadata during CompletingRebalance.
+        assertTrue(result.records().isEmpty());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+        assertTrue(rejoinResponseFuture.isDone());
+        assertEquals(Errors.NONE.code(), rejoinResponseFuture.get().errorCode());
+
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(memberId)
+            .withGenerationId(joinResponse.generationId())
+            .withGroupInstanceId("group-instance-id")
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> syncFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(syncRequest, syncFuture);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Successful write to the log.
+        result.appendFuture().complete(null);
+
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+        assertTrue(group.isInState(STABLE));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testStaticMemberRejoinWithLeaderIdAndUnknownMemberId(
+        boolean supportSkippingAssignment
+    ) throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        // A static leader rejoin with unknown id will not trigger rebalance, and no assignment will be returned.
+        // As the group was in Stable state and the member id was updated, this will generate records.
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("leader-instance-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> joinResponseFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+            joinRequest,
+            joinResponseFuture,
+            true,
+            supportSkippingAssignment);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate a successful write to the log.
+        result.appendFuture().complete(null);
+        assertTrue(joinResponseFuture.isDone());
+
+        Set<String> expectedGroupInstanceIds = new HashSet<>();
+        expectedGroupInstanceIds.add("leader-instance-id");
+        expectedGroupInstanceIds.add("follower-instance-id");
+
+        String leader = supportSkippingAssignment ?
+            joinResponseFuture.get().memberId() : rebalanceResult.leaderId;
+
+        List<JoinGroupResponseMember> members = supportSkippingAssignment ?
+            toJoinResponseMembers(group) : Collections.emptyList();
+
+        JoinGroupResponseData expectedJoinResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId)
+            .setMemberId(joinResponseFuture.get().memberId())
+            .setLeader(leader)
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setSkipAssignment(supportSkippingAssignment)
+            .setMembers(members);
+
+        checkJoinGroupResponse(
+            expectedJoinResponse,
+            joinResponseFuture.get(),
+            group,
+            STABLE,
+            supportSkippingAssignment ? expectedGroupInstanceIds : Collections.emptySet()
+        );
+    }
+
+    @Test
+    public void testStaticMemberRejoinWithLeaderIdAndKnownMemberId() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        // Known static leader rejoin will trigger rebalance.
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("leader-instance-id")
+            .withMemberId(rebalanceResult.leaderId)
+            .withDefaultProtocolTypeAndProtocols()
+            .withRebalanceTimeoutMs(10000)
+            .build();
+
+        JoinGroupResponseData joinResponse = context.joinGenericGroupAndCompleteJoin(request, true, true, 10000);
+
+        JoinGroupResponseData expectedResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId + 1)
+            .setMemberId(rebalanceResult.leaderId)
+            .setLeader(rebalanceResult.leaderId)
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setMembers(toJoinResponseMembers(group));
+
+        checkJoinGroupResponse(
+            expectedResponse,
+            joinResponse,
+            group,
+            COMPLETING_REBALANCE,
+            Collections.singleton("leader-instance-id")
+        );
+    }
+
+    @Test
+    public void testStaticMemberRejoinWithLeaderIdAndUnexpectedDeadGroup() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        group.transitionTo(DEAD);
+
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("leader-instance-id")
+            .withMemberId(rebalanceResult.leaderId)
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> joinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(request, joinFuture, true, true);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(joinFuture.isDone());
+        assertEquals(Errors.COORDINATOR_NOT_AVAILABLE.code(), joinFuture.get().errorCode());
+    }
+
+    @Test
+    public void testStaticMemberRejoinWithLeaderIdAndUnexpectedEmptyGroup() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        group.transitionTo(PREPARING_REBALANCE);
+        group.transitionTo(EMPTY);
+
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("leader-instance-id")
+            .withMemberId(rebalanceResult.leaderId)
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> joinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(request, joinFuture, true, true);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(joinFuture.isDone());
+        assertEquals(Errors.UNKNOWN_MEMBER_ID.code(), joinFuture.get().errorCode());
+    }
+
+    @Test
+    public void testStaticMemberRejoinWithFollowerIdAndChangeOfProtocol() throws Exception {
+        int rebalanceTimeoutMs = 10000;
+        int sessionTimeoutMs = 15000;
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id",
+            rebalanceTimeoutMs,
+            sessionTimeoutMs
+        );
+
+        // A static follower rejoin with changed protocol will trigger rebalance.
+        JoinGroupRequestProtocolCollection protocols = new JoinGroupRequestProtocolCollection(0);
+        protocols.add(new JoinGroupRequestProtocol()
+            .setName("roundrobin")
+            .setMetadata(ConsumerProtocol.serializeSubscription(new ConsumerPartitionAssignor.Subscription(
+                Collections.singletonList("foo"))).array())
+        );
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("follower-instance-id")
+            .withMemberId(rebalanceResult.followerId)
+            .withProtocols(protocols)
+            .withRebalanceTimeoutMs(rebalanceTimeoutMs)
+            .withSessionTimeoutMs(sessionTimeoutMs)
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> responseFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(request, responseFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(responseFuture.isDone());
+
+        // Old leader hasn't joined in the meantime, triggering a re-election.
+        context.sleepAndAssertEmptyResult(rebalanceTimeoutMs);
+
+        assertTrue(responseFuture.isDone());
+        assertEquals(Errors.NONE.code(), responseFuture.get().errorCode());
+        assertTrue(group.hasStaticMember("leader-instance-id"));
+        assertTrue(group.isLeader(rebalanceResult.followerId));
+
+        Set<String> expectedGroupInstanceIds = new HashSet<>();
+        expectedGroupInstanceIds.add("leader-instance-id");
+        expectedGroupInstanceIds.add("follower-instance-id");
+
+        JoinGroupResponseData expectedResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId + 1)
+            .setMemberId(rebalanceResult.followerId)
+            .setLeader(rebalanceResult.followerId)
+            .setProtocolName("roundrobin")
+            .setProtocolType("consumer")
+            .setMembers(toJoinResponseMembers(group));
+
+        checkJoinGroupResponse(
+            expectedResponse,
+            responseFuture.get(),
+            group,
+            COMPLETING_REBALANCE,
+            expectedGroupInstanceIds
+        );
+    }
+
+    @Test
+    public void testStaticMemberRejoinWithUnknownMemberIdAndChangeOfProtocolWithSelectedProtocolChanged()
+        throws Exception {
+
+        int rebalanceTimeoutMs = 10000;
+        int sessionTimeoutMs = 15000;
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id",
+            rebalanceTimeoutMs,
+            sessionTimeoutMs
+        );
+
+        assertNotEquals("roundrobin", group.selectProtocol());
+
+        // A static follower rejoin with changed protocol will trigger rebalance.
+        JoinGroupRequestProtocolCollection protocols = new JoinGroupRequestProtocolCollection(0);
+        protocols.add(new JoinGroupRequestProtocol()
+            .setName("roundrobin")
+            .setMetadata(ConsumerProtocol.serializeSubscription(new ConsumerPartitionAssignor.Subscription(
+                Collections.singletonList("foo"))).array())
+        );
+
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("follower-instance-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withProtocols(protocols)
+            .withRebalanceTimeoutMs(rebalanceTimeoutMs)
+            .withSessionTimeoutMs(sessionTimeoutMs)
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> responseFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(request, responseFuture);
+        assertTrue(result.records().isEmpty());
+        assertFalse(responseFuture.isDone());
+        assertEquals("roundrobin", group.selectProtocol());
+
+        // Old leader hasn't joined in the meantime, triggering a re-election.
+        context.sleepAndAssertEmptyResult(rebalanceTimeoutMs);
+        assertTrue(responseFuture.isDone());
+        assertEquals(Errors.NONE.code(), responseFuture.get().errorCode());
+        assertTrue(group.hasStaticMember("leader-instance-id"));
+        assertTrue(group.isLeader(responseFuture.get().memberId()));
+        assertNotEquals(rebalanceResult.followerId, responseFuture.get().memberId());
+
+        Set<String> expectedGroupInstanceIds = new HashSet<>();
+        expectedGroupInstanceIds.add("leader-instance-id");
+        expectedGroupInstanceIds.add("follower-instance-id");
+
+        JoinGroupResponseData expectedResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId + 1)
+            .setMemberId(responseFuture.get().memberId())
+            .setLeader(responseFuture.get().memberId())
+            .setProtocolName("roundrobin")
+            .setProtocolType("consumer")
+            .setMembers(toJoinResponseMembers(group));
+
+        checkJoinGroupResponse(
+            expectedResponse,
+            responseFuture.get(),
+            group,
+            COMPLETING_REBALANCE,
+            expectedGroupInstanceIds
+        );
+    }
+
+    @Test
+    public void testStaticMemberRejoinWithUnknownMemberIdAndChangeOfProtocolWhileSelectProtocolUnchangedPersistenceFailure()
+        throws Exception {
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        String selectedProtocol = group.selectProtocol();
+        JoinGroupRequestProtocolCollection protocols = new JoinGroupRequestProtocolCollection(0);
+        protocols.add(new JoinGroupRequestProtocol()
+            .setName(selectedProtocol)
+            .setMetadata(ConsumerProtocol.serializeSubscription(new ConsumerPartitionAssignor.Subscription(
+                Collections.singletonList("foo"))).array())
+        );
+
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("follower-instance-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withProtocols(protocols)
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> followerJoinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+            request,
+            followerJoinFuture,
+            true,
+            true);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate a failed write to the log.
+        result.appendFuture().completeExceptionally(Errors.MESSAGE_TOO_LARGE.exception());
+        assertTrue(followerJoinFuture.isDone());
+
+        JoinGroupResponseData expectedResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code())
+            .setGenerationId(rebalanceResult.generationId)
+            .setMemberId(followerJoinFuture.get().memberId())
+            .setLeader(rebalanceResult.leaderId)
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setSkipAssignment(false)
+            .setMembers(Collections.emptyList());
+
+        checkJoinGroupResponse(
+            expectedResponse,
+            followerJoinFuture.get(),
+            group,
+            STABLE,
+            Collections.emptySet()
+        );
+
+        // Join with old member id will not fail because the member id is not updated because of persistence failure
+        assertNotEquals(rebalanceResult.followerId, followerJoinFuture.get().memberId());
+        followerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(request.setMemberId(rebalanceResult.followerId), followerJoinFuture);
+
+        assertTrue(result.records().isEmpty());
+
+        // Join with leader and complete join phase.
+        CompletableFuture<JoinGroupResponseData> leaderJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            request.setGroupInstanceId("leader-instance-id")
+                .setMemberId(rebalanceResult.leaderId),
+            leaderJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(leaderJoinFuture.isDone());
+        assertTrue(followerJoinFuture.isDone());
+        assertEquals(Errors.NONE.code(), leaderJoinFuture.get().errorCode());
+        assertEquals(Errors.NONE.code(), followerJoinFuture.get().errorCode());
+
+        // Sync with leader and receive assignment.
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("leader-instance-id")
+            .withMemberId(rebalanceResult.leaderId)
+            .withGenerationId(rebalanceResult.generationId + 1)
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> leaderSyncFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(syncRequest, leaderSyncFuture);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+
+        // Simulate a successful write to the log.
+        result.appendFuture().complete(null);
+
+        assertTrue(leaderSyncFuture.isDone());
+        assertTrue(group.isInState(STABLE));
+        assertEquals(Errors.NONE.code(), leaderSyncFuture.get().errorCode());
+
+        // Sync with old member id will also not fail because the member id is not updated because of persistence failure
+        CompletableFuture<SyncGroupResponseData> oldMemberSyncFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(
+                syncRequest
+                    .setGroupInstanceId("follower-instance-id")
+                    .setMemberId(rebalanceResult.followerId),
+                oldMemberSyncFuture
+            );
+        assertTrue(result.records().isEmpty());
+        assertTrue(oldMemberSyncFuture.isDone());
+        assertTrue(group.isInState(STABLE));
+        assertEquals(Errors.NONE.code(), oldMemberSyncFuture.get().errorCode());
+    }
+
+    @Test
+    public void testStaticMemberRejoinWithUnknownMemberIdAndChangeOfProtocolWhileSelectProtocolUnchanged()
+        throws Exception {
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        // A static follower rejoin with protocol changing to leader protocol subset won't trigger rebalance if updated
+        // group's selectProtocol remain unchanged.
+        String selectedProtocol = group.selectProtocol();
+        JoinGroupRequestProtocolCollection protocols = new JoinGroupRequestProtocolCollection(0);
+        protocols.add(new JoinGroupRequestProtocol()
+            .setName(selectedProtocol)
+            .setMetadata(ConsumerProtocol.serializeSubscription(new ConsumerPartitionAssignor.Subscription(
+                Collections.singletonList("foo"))).array())
+        );
+
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("follower-instance-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withProtocols(protocols)
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> followerJoinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+            request,
+            followerJoinFuture,
+            true,
+            true);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+
+        // Simulate a successful write to the log.
+        result.appendFuture().complete(null);
+        assertTrue(followerJoinFuture.isDone());
+
+        JoinGroupResponseData expectedResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId)
+            .setMemberId(followerJoinFuture.get().memberId())
+            .setLeader(rebalanceResult.leaderId)
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setSkipAssignment(false)
+            .setMembers(Collections.emptyList());
+
+        checkJoinGroupResponse(
+            expectedResponse,
+            followerJoinFuture.get(),
+            group,
+            STABLE,
+            Collections.emptySet()
+        );
+
+        // Join with old member id will fail because the member id is updated
+        String newFollowerId = followerJoinFuture.get().memberId();
+        assertNotEquals(rebalanceResult.followerId, newFollowerId);
+        followerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(request.setMemberId(rebalanceResult.followerId), followerJoinFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertEquals(Errors.FENCED_INSTANCE_ID.code(), followerJoinFuture.get().errorCode());
+
+        // Sync with old member id will fail because the member id is updated
+        CompletableFuture<SyncGroupResponseData> syncFuture = new CompletableFuture<>();
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("follower-instance-id")
+            .withGenerationId(rebalanceResult.generationId)
+            .withMemberId(rebalanceResult.followerId)
+            .withAssignments(Collections.emptyList())
+            .build();
+
+        CoordinatorResult<Void, Record> syncResult = context.sendGenericGroupSync(syncRequest, syncFuture);
+
+        assertTrue(syncResult.records().isEmpty());
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.FENCED_INSTANCE_ID.code(), syncFuture.get().errorCode());
+
+
+        // Sync with new member id succeeds
+        syncFuture = new CompletableFuture<>();
+        syncResult = context.sendGenericGroupSync(
+            syncRequest.setMemberId(newFollowerId),
+            syncFuture
+        );
+
+        assertTrue(syncResult.records().isEmpty());
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+        assertEquals(rebalanceResult.followerAssignment, syncFuture.get().assignment());
+    }
+
+    @Test
+    public void testStaticMemberRejoinWithKnownLeaderIdToTriggerRebalanceAndFollowerWithChangeofProtocol()
+        throws Exception {
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        // A static leader rejoin with known member id will trigger rebalance.
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("leader-instance-id")
+            .withMemberId(rebalanceResult.leaderId)
+            .withProtocolSuperset()
+            .withRebalanceTimeoutMs(10000)
+            .withSessionTimeoutMs(5000)
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> leaderJoinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+            request,
+            leaderJoinFuture,
+            true,
+            true);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(leaderJoinFuture.isDone());
+
+        // Rebalance completes immediately after follower rejoins.
+        CompletableFuture<JoinGroupResponseData> followerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            request.setGroupInstanceId("follower-instance-id")
+                .setMemberId(rebalanceResult.followerId),
+            followerJoinFuture,
+            true,
+            true);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(leaderJoinFuture.isDone());
+        assertTrue(followerJoinFuture.isDone());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+        assertEquals(2, group.generationId());
+
+        // Leader should get the same assignment as last round.
+        JoinGroupResponseData expectedLeaderResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId + 1) // The group has promoted to the new generation.
+            .setMemberId(leaderJoinFuture.get().memberId())
+            .setLeader(rebalanceResult.leaderId)
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setSkipAssignment(false)
+            .setMembers(toJoinResponseMembers(group));
+
+        Set<String> expectedGroupInstanceIds = new HashSet<>();
+        expectedGroupInstanceIds.add("leader-instance-id");
+        expectedGroupInstanceIds.add("follower-instance-id");
+
+        checkJoinGroupResponse(
+            expectedLeaderResponse,
+            leaderJoinFuture.get(),
+            group,
+            COMPLETING_REBALANCE,
+            expectedGroupInstanceIds
+        );
+
+        JoinGroupResponseData expectedFollowerResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId + 1) // The group has promoted to the new generation.
+            .setMemberId(followerJoinFuture.get().memberId())
+            .setLeader(rebalanceResult.leaderId)
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setSkipAssignment(false)
+            .setMembers(Collections.emptyList());
+
+        checkJoinGroupResponse(
+            expectedFollowerResponse,
+            followerJoinFuture.get(),
+            group,
+            COMPLETING_REBALANCE,
+            Collections.emptySet()
+        );
+
+        // The follower protocol changed from protocolSuperset to general protocols.
+        JoinGroupRequestProtocolCollection protocols = new JoinGroupRequestProtocolCollection();
+        protocols.add(new JoinGroupRequestProtocol()
+            .setName("range")
+            .setMetadata(ConsumerProtocol.serializeSubscription(new ConsumerPartitionAssignor.Subscription(
+                Collections.singletonList("foo"))).array()));
+
+        followerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            request.setGroupInstanceId("follower-instance-id")
+                .setMemberId(rebalanceResult.followerId)
+                .setProtocols(protocols),
+            followerJoinFuture,
+            true,
+            true);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(followerJoinFuture.isDone());
+        // The group will transition to PreparingRebalance due to protocol change from follower.
+        assertTrue(group.isInState(PREPARING_REBALANCE));
+
+        // Advance clock by session timeout to kick leader out and complete join phase.
+        List<ExpiredTimeout<Void, Record>> timeouts = context.sleep(5000);
+        // Both leader and follower heartbeat timers may expire. However, the follower heartbeat expiration
+        // will not kick the follower out because it is awaiting a join response.
+        assertTrue(timeouts.size() <= 2);
+        assertTrue(followerJoinFuture.isDone());
+
+        String newFollowerId = followerJoinFuture.get().memberId();
+        expectedFollowerResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId + 2) // The group has promoted to the new generation.
+            .setMemberId(newFollowerId)
+            .setLeader(newFollowerId)
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setSkipAssignment(false)
+            .setMembers(toJoinResponseMembers(group));
+
+        checkJoinGroupResponse(
+            expectedFollowerResponse,
+            followerJoinFuture.get(),
+            group,
+            COMPLETING_REBALANCE,
+            Collections.singleton("follower-instance-id")
+        );
+    }
+
+    @Test
+    public void testStaticMemberRejoinAsFollowerWithUnknownMemberId() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        // A static follower rejoin with no protocol change will not trigger rebalance.
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("follower-instance-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withProtocolSuperset()
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> followerJoinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+            request,
+            followerJoinFuture,
+            true,
+            true);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate successful write to log.
+        result.appendFuture().complete(null);
+        assertTrue(followerJoinFuture.isDone());
+
+        // Old leader shouldn't be timed out.
+        assertTrue(group.hasStaticMember("leader-instance-id"));
+
+        JoinGroupResponseData expectedFollowerResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId) // The group has not changed.
+            .setMemberId(followerJoinFuture.get().memberId())
+            .setLeader(rebalanceResult.leaderId)
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setSkipAssignment(false)
+            .setMembers(Collections.emptyList());
+
+        checkJoinGroupResponse(
+            expectedFollowerResponse,
+            followerJoinFuture.get(),
+            group,
+            STABLE,
+            Collections.emptySet()
+        );
+        assertNotEquals(rebalanceResult.followerId, followerJoinFuture.get().memberId());
+
+        CompletableFuture<SyncGroupResponseData> syncFuture = new CompletableFuture<>();
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("follower-instance-id")
+            .withGenerationId(rebalanceResult.generationId)
+            .withMemberId(followerJoinFuture.get().memberId())
+            .build();
+
+        result = context.sendGenericGroupSync(syncRequest, syncFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+        assertEquals(rebalanceResult.followerAssignment, syncFuture.get().assignment());
+    }
+
+    @Test
+    public void testStaticMemberRejoinAsFollowerWithKnownMemberIdAndNoProtocolChange() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        // A static follower rejoin with no protocol change will not trigger rebalance.
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("follower-instance-id")
+            .withMemberId(rebalanceResult.followerId)
+            .withProtocolSuperset()
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> followerJoinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+            request,
+            followerJoinFuture,
+            true,
+            true);
+
+        // No records to write because no metadata changed.
+        assertTrue(result.records().isEmpty());
+        assertTrue(followerJoinFuture.isDone());
+
+        // Old leader shouldn't be timed out.
+        assertTrue(group.hasStaticMember("leader-instance-id"));
+
+        JoinGroupResponseData expectedFollowerResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId) // The group has not changed.
+            .setMemberId(rebalanceResult.followerId)
+            .setLeader(rebalanceResult.leaderId)
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setSkipAssignment(false)
+            .setMembers(Collections.emptyList());
+
+        checkJoinGroupResponse(
+            expectedFollowerResponse,
+            followerJoinFuture.get(),
+            group,
+            STABLE,
+            Collections.emptySet()
+        );
+    }
+
+    @Test
+    public void testStaticMemberRejoinAsFollowerWithMismatchedInstanceId() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("leader-instance-id")
+            .withMemberId(rebalanceResult.followerId)
+            .withProtocolSuperset()
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> followerJoinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+            request,
+            followerJoinFuture,
+            true,
+            true);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(followerJoinFuture.isDone());
+        assertEquals(Errors.FENCED_INSTANCE_ID.code(), followerJoinFuture.get().errorCode());
+    }
+
+    @Test
+    public void testStaticMemberRejoinAsLeaderWithMismatchedInstanceId() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("follower-instance-id")
+            .withMemberId(rebalanceResult.leaderId)
+            .withProtocolSuperset()
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> leaderJoinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+            request,
+            leaderJoinFuture,
+            true,
+            true);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(leaderJoinFuture.isDone());
+        assertEquals(Errors.FENCED_INSTANCE_ID.code(), leaderJoinFuture.get().errorCode());
+    }
+
+    @Test
+    public void testStaticMemberSyncAsLeaderWithInvalidMemberId() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        context.createGenericGroup("group-id");
+
+        staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        SyncGroupRequestData request = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("follower-instance-id")
+            .withMemberId("invalid-member-id")
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> leaderSyncFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupSync(
+            request,
+            leaderSyncFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(leaderSyncFuture.isDone());
+        assertEquals(Errors.FENCED_INSTANCE_ID.code(), leaderSyncFuture.get().errorCode());
+    }
+
+    @Test
+    public void testGetDifferentStaticMemberIdAfterEachRejoin() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        String lastMemberId = rebalanceResult.leaderId;
+        for (int i = 0; i < 5; i++) {
+            JoinGroupRequestData request = new JoinGroupRequestBuilder()
+                .withGroupId("group-id")
+                .withGroupInstanceId("leader-instance-id")
+                .withMemberId(UNKNOWN_MEMBER_ID)
+                .withProtocolSuperset()
+                .build();
+
+            CompletableFuture<JoinGroupResponseData> leaderJoinFuture = new CompletableFuture<>();
+            CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+                request,
+                leaderJoinFuture,
+                true,
+                true);
+
+            assertEquals(
+                Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+                result.records()
+            );
+            // Simulate successful write to log.
+            result.appendFuture().complete(null);
+            assertTrue(leaderJoinFuture.isDone());
+            assertEquals(group.staticMemberId("leader-instance-id"), leaderJoinFuture.get().memberId());
+            assertEquals(Errors.NONE.code(), leaderJoinFuture.get().errorCode());
+            assertNotEquals(lastMemberId, leaderJoinFuture.get().memberId());
+
+            lastMemberId = leaderJoinFuture.get().memberId();
+        }
+    }
+
+    @Test
+    public void testStaticMemberJoinWithUnknownInstanceIdAndKnownMemberId() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        context.createGenericGroup("group-id");
+
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("unknown-instance-id")
+            .withMemberId(rebalanceResult.leaderId)
+            .withProtocolSuperset()
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> joinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+            request,
+            joinFuture,
+            true,
+            true);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(joinFuture.isDone());
+        assertEquals(Errors.UNKNOWN_MEMBER_ID.code(), joinFuture.get().errorCode());
+    }
+
+    @Test
+    public void testStaticMemberReJoinWithIllegalStateAsUnknownMember() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id"
+        );
+
+        group.transitionTo(PREPARING_REBALANCE);
+        group.transitionTo(EMPTY);
+
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("follower-instance-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withProtocolSuperset()
+            .build();
+
+        // Illegal state exception shall trigger since follower id resides in pending member bucket.
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> context.sendGenericGroupJoin(
+            request,
+            new CompletableFuture<>(),
+            true,
+            true));
+
+        String message = exception.getMessage();
+        assertTrue(message.contains(group.groupId()));
+        assertTrue(message.contains("follower-instance-id"));
+    }
+
+    @Test
+    public void testStaticMemberFollowerFailToRejoinBeforeRebalanceTimeout() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        // Increase session timeout so that the follower won't be evicted when rebalance timeout is reached.
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id",
+            10000,
+            15000
+        );
+
+        String newMemberInstanceId = "new-member-instance-id";
+        String leaderId = rebalanceResult.leaderId;
+
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId(newMemberInstanceId)
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withProtocolSuperset()
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> newMemberFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+            request,
+            newMemberFuture,
+            true,
+            true);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(newMemberFuture.isDone());
+        assertTrue(group.isInState(PREPARING_REBALANCE));
+
+        CompletableFuture<JoinGroupResponseData> leaderJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            request.setGroupInstanceId("leader-instance-id")
+                .setMemberId(leaderId),
+            leaderJoinFuture,
+            true,
+            true);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(leaderJoinFuture.isDone());
+
+        // Advance clock by rebalance timeout to complete join phase.
+        assertNoOrEmptyResult(context.sleep(10000));
+
+        assertTrue(leaderJoinFuture.isDone());
+        assertTrue(newMemberFuture.isDone());
+
+        JoinGroupResponseData expectedLeaderResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId + 1)
+            .setMemberId(leaderId)
+            .setLeader(leaderId)
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setSkipAssignment(false)
+            .setMembers(toJoinResponseMembers(group));
+
+        Set<String> expectedGroupInstanceIds = new HashSet<>();
+        expectedGroupInstanceIds.add("leader-instance-id");
+        expectedGroupInstanceIds.add("follower-instance-id");
+        expectedGroupInstanceIds.add(newMemberInstanceId);
+
+        checkJoinGroupResponse(
+            expectedLeaderResponse,
+            leaderJoinFuture.get(),
+            group,
+            COMPLETING_REBALANCE,
+            expectedGroupInstanceIds
+        );
+
+        JoinGroupResponseData expectedNewMemberResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId + 1)
+            .setMemberId(newMemberFuture.get().memberId())
+            .setLeader(leaderId)
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setSkipAssignment(false)
+            .setMembers(Collections.emptyList());
+
+        checkJoinGroupResponse(
+            expectedNewMemberResponse,
+            newMemberFuture.get(),
+            group,
+            COMPLETING_REBALANCE,
+            Collections.emptySet()
+        );
+    }
+
+    @Test
+    public void testStaticMemberLeaderFailToRejoinBeforeRebalanceTimeout() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        // Increase session timeout so that the leader won't be evicted when rebalance timeout is reached.
+        RebalanceResult rebalanceResult = staticMembersJoinAndRebalance(
+            context,
+            "group-id",
+            "leader-instance-id",
+            "follower-instance-id",
+            10000,
+            15000
+        );
+
+        String newMemberInstanceId = "new-member-instance-id";
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId(newMemberInstanceId)
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withProtocolSuperset()
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> newMemberFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(
+            request,
+            newMemberFuture,
+            true,
+            true);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(newMemberFuture.isDone());
+        assertTrue(group.isInState(PREPARING_REBALANCE));
+
+        CompletableFuture<JoinGroupResponseData> oldFollowerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            request.setGroupInstanceId("follower-instance-id")
+                .setMemberId(rebalanceResult.followerId),
+            oldFollowerJoinFuture,
+            true,
+            true);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(oldFollowerJoinFuture.isDone());
+
+        // Advance clock by rebalance timeout to complete join phase.
+        assertNoOrEmptyResult(context.sleep(10000));
+
+        assertTrue(oldFollowerJoinFuture.isDone());
+        assertTrue(newMemberFuture.isDone());
+
+        JoinGroupResponseData newLeaderResponse = oldFollowerJoinFuture.get().leader()
+            .equals(oldFollowerJoinFuture.get().memberId()) ? oldFollowerJoinFuture.get() : newMemberFuture.get();
+
+        JoinGroupResponseData newFollowerResponse = oldFollowerJoinFuture.get().leader()
+            .equals(oldFollowerJoinFuture.get().memberId()) ? newMemberFuture.get() : oldFollowerJoinFuture.get();
+
+        JoinGroupResponseData expectedLeaderResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId + 1)
+            .setMemberId(newLeaderResponse.memberId())
+            .setLeader(newLeaderResponse.memberId())
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setSkipAssignment(false)
+            .setMembers(toJoinResponseMembers(group));
+
+        Set<String> expectedGroupInstanceIds = new HashSet<>();
+        expectedGroupInstanceIds.add("leader-instance-id");
+        expectedGroupInstanceIds.add("follower-instance-id");
+        expectedGroupInstanceIds.add(newMemberInstanceId);
+
+        checkJoinGroupResponse(
+            expectedLeaderResponse,
+            newLeaderResponse,
+            group,
+            COMPLETING_REBALANCE,
+            expectedGroupInstanceIds
+        );
+
+        JoinGroupResponseData expectedNewMemberResponse = new JoinGroupResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setGenerationId(rebalanceResult.generationId + 1)
+            .setMemberId(newFollowerResponse.memberId())
+            .setLeader(newLeaderResponse.memberId())
+            .setProtocolName("range")
+            .setProtocolType("consumer")
+            .setSkipAssignment(false)
+            .setMembers(Collections.emptyList());
+
+        checkJoinGroupResponse(
+            expectedNewMemberResponse,
+            newFollowerResponse,
+            group,
+            COMPLETING_REBALANCE,
+            Collections.emptySet()
+        );
+    }
+
+    @Test
+    public void testSyncGroupReturnsAnErrorWhenProtocolTypeIsInconsistent() throws Exception {
+        testSyncGroupProtocolTypeAndNameWith(
+            Optional.of("protocolType"),
+            Optional.empty(),
+            Errors.INCONSISTENT_GROUP_PROTOCOL,
+            Optional.empty(),
+            Optional.empty()
+        );
+    }
+
+    @Test
+    public void testSyncGroupReturnsAnErrorWhenProtocolNameIsInconsistent() throws Exception {
+        testSyncGroupProtocolTypeAndNameWith(
+            Optional.empty(),
+            Optional.of("protocolName"),
+            Errors.INCONSISTENT_GROUP_PROTOCOL,
+            Optional.empty(),
+            Optional.empty()
+        );
+    }
+
+    @Test
+    public void testSyncGroupSucceedWhenProtocolTypeAndNameAreNotProvided() throws Exception {
+        testSyncGroupProtocolTypeAndNameWith(
+            Optional.empty(),
+            Optional.empty(),
+            Errors.NONE,
+            Optional.of("consumer"),
+            Optional.of("range")
+        );
+    }
+
+    @Test
+    public void testSyncGroupSucceedWhenProtocolTypeAndNameAreConsistent() throws Exception {
+        testSyncGroupProtocolTypeAndNameWith(
+            Optional.of("consumer"),
+            Optional.of("range"),
+            Errors.NONE,
+            Optional.of("consumer"),
+            Optional.of("range")
+        );
+    }
+
+    private void testSyncGroupProtocolTypeAndNameWith(
+        Optional<String> protocolType,
+        Optional<String> protocolName,
+        Errors expectedError,
+        Optional<String> expectedProtocolType,
+        Optional<String> expectedProtocolName
+    ) throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        // JoinGroup(leader) with the Protocol Type of the group
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("leader-instance-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withProtocolSuperset()
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> leaderJoinFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(joinRequest, leaderJoinFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(leaderJoinFuture.isDone());
+
+        // JoinGroup(follower) with the Protocol Type of the group
+        CompletableFuture<JoinGroupResponseData> followerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(joinRequest.setGroupInstanceId("follower-instance-id"), followerJoinFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(followerJoinFuture.isDone());
+
+        // Advance clock by rebalance timeout to complete join phase.
+        assertNoOrEmptyResult(context.sleep(10000));
+        assertTrue(leaderJoinFuture.isDone());
+        assertTrue(followerJoinFuture.isDone());
+        assertEquals(Errors.NONE.code(), leaderJoinFuture.get().errorCode());
+        assertEquals(Errors.NONE.code(), followerJoinFuture.get().errorCode());
+
+        String leaderId = leaderJoinFuture.get().memberId();
+        String followerId = followerJoinFuture.get().memberId();
+        int generationId = leaderJoinFuture.get().generationId();
+
+        // SyncGroup with the provided Protocol Type and Name
+        List<SyncGroupRequestAssignment> assignments = new ArrayList<>();
+        assignments.add(new SyncGroupRequestAssignment().setMemberId(leaderId));
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(leaderId)
+            .withProtocolType(protocolType.orElse(null))
+            .withProtocolName(protocolName.orElse(null))
+            .withGenerationId(generationId)
+            .withAssignments(assignments)
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> leaderSyncFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(syncRequest, leaderSyncFuture);
+
+        if (expectedError == Errors.NONE) {
+            assertEquals(
+                Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+                result.records()
+            );
+            // Simulate successful write to log.
+            result.appendFuture().complete(null);
+        } else {
+            assertTrue(result.records().isEmpty());
+        }
+
+        assertTrue(leaderSyncFuture.isDone());
+        assertEquals(expectedError.code(), leaderSyncFuture.get().errorCode());
+        assertEquals(expectedProtocolType.orElse(null), leaderSyncFuture.get().protocolType());
+        assertEquals(expectedProtocolName.orElse(null), leaderSyncFuture.get().protocolName());
+
+        CompletableFuture<SyncGroupResponseData> followerSyncFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(syncRequest.setMemberId(followerId), followerSyncFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(followerSyncFuture.isDone());
+        assertEquals(expectedError.code(), followerSyncFuture.get().errorCode());
+        assertEquals(expectedProtocolType.orElse(null), followerSyncFuture.get().protocolType());
+        assertEquals(expectedProtocolName.orElse(null), followerSyncFuture.get().protocolName());
+    }
+
+    @Test
+    public void testSyncGroupFromUnknownGroup() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+
+        // SyncGroup with the provided Protocol Type and Name
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId("member-id")
+            .withGenerationId(1)
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> syncFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupSync(syncRequest, syncFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.UNKNOWN_MEMBER_ID.code(), syncFuture.get().errorCode());
+    }
+
+    @Test
+    public void testSyncGroupFromUnknownMember() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("leader-instance-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+
+        JoinGroupResponseData joinResponse = context.joinGenericGroupAndCompleteJoin(joinRequest, true, true);
+
+        String memberId = joinResponse.memberId();
+        int generationId = joinResponse.generationId();
+
+        List<SyncGroupRequestAssignment> assignments = new ArrayList<>();
+        assignments.add(new SyncGroupRequestAssignment().setMemberId(memberId));
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(memberId)
+            .withGenerationId(generationId)
+            .withAssignments(assignments)
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> syncFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupSync(syncRequest, syncFuture);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate successful write to log.
+        result.appendFuture().complete(null);
+
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+        assertEquals(assignments.get(0).assignment(), syncFuture.get().assignment());
+
+        syncFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(syncRequest.setMemberId("unknown-member-id"), syncFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.UNKNOWN_MEMBER_ID.code(), syncFuture.get().errorCode());
+        assertEquals(Bytes.EMPTY, syncFuture.get().assignment());
+    }
+
+    @Test
+    public void testSyncGroupFromIllegalGeneration() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withGroupInstanceId("leader-instance-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+
+        JoinGroupResponseData joinResponse = context.joinGenericGroupAndCompleteJoin(joinRequest, true, true);
+
+        String memberId = joinResponse.memberId();
+        int generationId = joinResponse.generationId();
+
+        // Send the sync group with an invalid generation
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(memberId)
+            .withGenerationId(generationId + 1)
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> syncFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupSync(syncRequest, syncFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.ILLEGAL_GENERATION.code(), syncFuture.get().errorCode());
+    }
+
+    @Test
+    public void testJoinGroupFromUnchangedFollowerDoesNotRebalance() throws Exception {
+        // To get a group of two members:
+        // 1. join and sync with a single member (because we can't immediately join with two members)
+        // 2. join and sync with the first member and a new member
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+
+        JoinGroupResponseData leaderJoinResponse =
+            context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(joinRequest);
+
+        String leaderId = leaderJoinResponse.memberId();
+        int generationId = leaderJoinResponse.generationId();
+
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(leaderId)
+            .withGenerationId(generationId)
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> syncFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupSync(syncRequest, syncFuture);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate successful write to log.
+        result.appendFuture().complete(null);
+
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+
+        CompletableFuture<JoinGroupResponseData> followerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(UNKNOWN_MEMBER_ID),
+            followerJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(followerJoinFuture.isDone());
+
+        CompletableFuture<JoinGroupResponseData> leaderJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(leaderId),
+            leaderJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(leaderJoinFuture.isDone());
+        assertTrue(followerJoinFuture.isDone());
+        assertEquals(Errors.NONE.code(), leaderJoinFuture.get().errorCode());
+        assertEquals(Errors.NONE.code(), followerJoinFuture.get().errorCode());
+        assertEquals(leaderJoinFuture.get().generationId(), followerJoinFuture.get().generationId());
+        assertEquals(leaderId, leaderJoinFuture.get().leader());
+        assertEquals(leaderId, followerJoinFuture.get().leader());
+
+        int nextGenerationId = leaderJoinFuture.get().generationId();
+        String followerId = followerJoinFuture.get().memberId();
+
+        // This shouldn't cause a rebalance since protocol information hasn't changed
+        followerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(followerId),
+            followerJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(followerJoinFuture.isDone());
+        assertEquals(Errors.NONE.code(), followerJoinFuture.get().errorCode());
+        assertEquals(nextGenerationId, followerJoinFuture.get().generationId());
+    }
+
+    @Test
+    public void testLeaderFailureInSyncGroup() throws Exception {
+        // To get a group of two members:
+        // 1. join and sync with a single member (because we can't immediately join with two members)
+        // 2. join and sync with the first member and a new member
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .withRebalanceTimeoutMs(10000)
+            .withSessionTimeoutMs(5000)
+            .build();
+
+        JoinGroupResponseData leaderJoinResponse =
+            context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(joinRequest);
+
+        String leaderId = leaderJoinResponse.memberId();
+        int generationId = leaderJoinResponse.generationId();
+
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(leaderId)
+            .withGenerationId(generationId)
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> syncFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupSync(syncRequest, syncFuture);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate successful write to log.
+        result.appendFuture().complete(null);
+
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+
+        CompletableFuture<JoinGroupResponseData> followerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(UNKNOWN_MEMBER_ID),
+            followerJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(followerJoinFuture.isDone());
+
+        CompletableFuture<JoinGroupResponseData> leaderJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(leaderId),
+            leaderJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(leaderJoinFuture.isDone());
+        assertTrue(followerJoinFuture.isDone());
+        assertEquals(Errors.NONE.code(), leaderJoinFuture.get().errorCode());
+        assertEquals(Errors.NONE.code(), followerJoinFuture.get().errorCode());
+        assertEquals(leaderJoinFuture.get().generationId(), followerJoinFuture.get().generationId());
+        assertEquals(leaderId, leaderJoinFuture.get().leader());
+        assertEquals(leaderId, followerJoinFuture.get().leader());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+
+        int nextGenerationId = leaderJoinFuture.get().generationId();
+        String followerId = followerJoinFuture.get().memberId();
+
+        // With no leader SyncGroup, the follower's request should fail with an error indicating
+        // that it should rejoin
+        CompletableFuture<SyncGroupResponseData> followerSyncFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(
+            syncRequest.setMemberId(followerId)
+                .setGenerationId(nextGenerationId),
+            followerSyncFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(followerSyncFuture.isDone());
+
+        // Advance clock by session timeout to expire follower heartbeat and prepare rebalance.
+        // This should complete all pending syncs.
+        assertNoOrEmptyResult(context.sleep(5000));
+
+        assertTrue(followerSyncFuture.isDone());
+        assertEquals(Errors.REBALANCE_IN_PROGRESS.code(), followerSyncFuture.get().errorCode());
+    }
+
+    @Test
+    public void testSyncGroupFollowerAfterLeader() throws Exception {
+        // To get a group of two members:
+        // 1. join and sync with a single member (because we can't immediately join with two members)
+        // 2. join and sync with the first member and a new member
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .withRebalanceTimeoutMs(10000)
+            .withSessionTimeoutMs(5000)
+            .build();
+
+        JoinGroupResponseData leaderJoinResponse =
+            context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(joinRequest);
+
+        String leaderId = leaderJoinResponse.memberId();
+        int generationId = leaderJoinResponse.generationId();
+
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(leaderId)
+            .withGenerationId(generationId)
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> syncFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupSync(syncRequest, syncFuture);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate successful write to log.
+        result.appendFuture().complete(null);
+
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+
+        CompletableFuture<JoinGroupResponseData> followerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(UNKNOWN_MEMBER_ID),
+            followerJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(followerJoinFuture.isDone());
+
+        CompletableFuture<JoinGroupResponseData> leaderJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(leaderId),
+            leaderJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(leaderJoinFuture.isDone());
+        assertTrue(followerJoinFuture.isDone());
+        assertEquals(Errors.NONE.code(), leaderJoinFuture.get().errorCode());
+        assertEquals(Errors.NONE.code(), followerJoinFuture.get().errorCode());
+        assertEquals(leaderJoinFuture.get().generationId(), followerJoinFuture.get().generationId());
+        assertEquals(leaderId, leaderJoinFuture.get().leader());
+        assertEquals(leaderId, followerJoinFuture.get().leader());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+
+        int nextGenerationId = leaderJoinFuture.get().generationId();
+        String followerId = followerJoinFuture.get().memberId();
+        byte[] leaderAssignment = new byte[]{0};
+        byte[] followerAssignment = new byte[]{1};
+
+        // Sync group with leader to get new assignment.
+        List<SyncGroupRequestAssignment> assignments = new ArrayList<>();
+        assignments.add(new SyncGroupRequestAssignment()
+            .setMemberId(leaderId)
+            .setAssignment(leaderAssignment)
+        );
+        assignments.add(new SyncGroupRequestAssignment()
+            .setMemberId(followerId)
+            .setAssignment(followerAssignment)
+        );
+
+        syncFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(
+            syncRequest.setGenerationId(nextGenerationId)
+                .setAssignments(assignments),
+            syncFuture
+        );
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate successful write to log.
+        result.appendFuture().complete(null);
+
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+        assertEquals(leaderAssignment, syncFuture.get().assignment());
+
+        // Sync group with follower to get new assignment.
+        CompletableFuture<SyncGroupResponseData> followerSyncFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(
+            syncRequest.setMemberId(followerId)
+                .setGenerationId(nextGenerationId),
+            followerSyncFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(followerSyncFuture.isDone());
+        assertEquals(Errors.NONE.code(), followerSyncFuture.get().errorCode());
+        assertEquals(followerAssignment, followerSyncFuture.get().assignment());
+        assertTrue(group.isInState(STABLE));
+    }
+
+    @Test
+    public void testSyncGroupLeaderAfterFollower() throws Exception {
+        // To get a group of two members:
+        // 1. join and sync with a single member (because we can't immediately join with two members)
+        // 2. join and sync with the first member and a new member
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .withRebalanceTimeoutMs(10000)
+            .withSessionTimeoutMs(5000)
+            .build();
+
+        JoinGroupResponseData leaderJoinResponse =
+            context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(joinRequest);
+
+        String leaderId = leaderJoinResponse.memberId();
+        int generationId = leaderJoinResponse.generationId();
+
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(leaderId)
+            .withGenerationId(generationId)
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> syncFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupSync(syncRequest, syncFuture);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate successful write to log.
+        result.appendFuture().complete(null);
+
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+
+        CompletableFuture<JoinGroupResponseData> followerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(UNKNOWN_MEMBER_ID),
+            followerJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(followerJoinFuture.isDone());
+
+        CompletableFuture<JoinGroupResponseData> leaderJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(leaderId),
+            leaderJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(leaderJoinFuture.isDone());
+        assertTrue(followerJoinFuture.isDone());
+        assertEquals(Errors.NONE.code(), leaderJoinFuture.get().errorCode());
+        assertEquals(Errors.NONE.code(), followerJoinFuture.get().errorCode());
+        assertEquals(leaderJoinFuture.get().generationId(), followerJoinFuture.get().generationId());
+        assertEquals(leaderId, leaderJoinFuture.get().leader());
+        assertEquals(leaderId, followerJoinFuture.get().leader());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+
+        int nextGenerationId = leaderJoinFuture.get().generationId();
+        String followerId = followerJoinFuture.get().memberId();
+        byte[] leaderAssignment = new byte[]{0};
+        byte[] followerAssignment = new byte[]{1};
+
+        // Sync group with follower to get new assignment.
+        CompletableFuture<SyncGroupResponseData> followerSyncFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(
+            syncRequest.setMemberId(followerId)
+                .setGenerationId(nextGenerationId),
+            followerSyncFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(followerSyncFuture.isDone());
+
+        // Sync group with leader to get new assignment.
+        List<SyncGroupRequestAssignment> assignments = new ArrayList<>();
+        assignments.add(new SyncGroupRequestAssignment()
+            .setMemberId(leaderId)
+            .setAssignment(leaderAssignment)
+        );
+        assignments.add(new SyncGroupRequestAssignment()
+            .setMemberId(followerId)
+            .setAssignment(followerAssignment)
+        );
+
+        syncFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(
+            syncRequest.setMemberId(leaderId)
+                .setGenerationId(nextGenerationId)
+                .setAssignments(assignments),
+            syncFuture
+        );
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate successful write to log.
+        result.appendFuture().complete(null);
+
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+        assertEquals(leaderAssignment, syncFuture.get().assignment());
+
+        // Follower sync group should also be completed.
+        assertEquals(Errors.NONE.code(), followerSyncFuture.get().errorCode());
+        assertEquals(followerAssignment, followerSyncFuture.get().assignment());
+        assertTrue(group.isInState(STABLE));
+    }
+
+    @Test
+    public void testJoinGroupFromUnchangedLeaderShouldRebalance() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+
+        JoinGroupResponseData leaderJoinResponse =
+            context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(joinRequest);
+
+        String leaderId = leaderJoinResponse.memberId();
+        int generationId = leaderJoinResponse.generationId();
+
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(leaderId)
+            .withGenerationId(generationId)
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> syncFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupSync(syncRequest, syncFuture);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate successful write to log.
+        result.appendFuture().complete(null);
+
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+
+        // Join group from the leader should force the group to rebalance, which allows the
+        // leader to push new assignments when local metadata changes
+        CompletableFuture<JoinGroupResponseData> leaderJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(leaderId),
+            leaderJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(leaderJoinFuture.isDone());
+        assertEquals(Errors.NONE.code(), leaderJoinFuture.get().errorCode());
+        assertEquals(generationId + 1, leaderJoinFuture.get().generationId());
+    }
+
+    @Test
+    public void testJoinGroupCompletionWhenPendingMemberJoins() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        // Set up a group in with a pending member. The test checks if the pending member joining
+        // completes the rebalancing operation
+        JoinGroupResponseData pendingMemberResponse = setupGroupWithPendingMember(context, group);
+
+        // Compete join group for the pending member
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(pendingMemberResponse.memberId())
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> responseFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(request, responseFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(responseFuture.isDone());
+        assertEquals(Errors.NONE.code(), responseFuture.get().errorCode());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+        assertEquals(3, group.allMembers().size());
+        assertEquals(0, group.numPendingJoinMembers());
+    }
+
+    @Test
+    public void testJoinGroupCompletionWhenPendingMemberTimesOut() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        // Set up a group in with a pending member. The test checks if the timeout of the pending member will
+        // cause the group to return to a CompletingRebalance state.
+        setupGroupWithPendingMember(context, group);
+
+        // Advancing clock by > 2500 (session timeout for the third member)
+        // and < 5000 (for first and second members). This will force the coordinator to attempt join
+        // completion on heartbeat expiration (since we are in PendingRebalance stage).
+        assertNoOrEmptyResult(context.sleep(3000));
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+        assertEquals(2, group.allMembers().size());
+        assertEquals(0, group.numPendingJoinMembers());
+    }
+
+    private JoinGroupResponseData setupGroupWithPendingMember(
+        GroupMetadataManagerTestContext context,
+        GenericGroup group
+    ) throws Exception {
+        // Add the first member
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .withRebalanceTimeoutMs(10000)
+            .withSessionTimeoutMs(5000)
+            .build();
+
+        JoinGroupResponseData leaderJoinResponse =
+            context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(joinRequest);
+
+        String leaderId = leaderJoinResponse.memberId();
+        int generationId = leaderJoinResponse.generationId();
+
+        List<SyncGroupRequestAssignment> assignments = new ArrayList<>();
+        assignments.add(new SyncGroupRequestAssignment().setMemberId(leaderId));
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(leaderId)
+            .withGenerationId(generationId)
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> syncFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupSync(syncRequest, syncFuture);
+
+        // Now the group is stable, with the one member that joined above
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate successful write to log.
+        result.appendFuture().complete(null);
+
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+
+        // Start the join for the second member
+        CompletableFuture<JoinGroupResponseData> followerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(UNKNOWN_MEMBER_ID),
+            followerJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(followerJoinFuture.isDone());
+
+        CompletableFuture<JoinGroupResponseData> leaderJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(leaderId),
+            leaderJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+        assertTrue(leaderJoinFuture.isDone());
+        assertTrue(followerJoinFuture.isDone());
+        assertEquals(Errors.NONE.code(), leaderJoinFuture.get().errorCode());
+        assertEquals(Errors.NONE.code(), followerJoinFuture.get().errorCode());
+        assertEquals(leaderJoinFuture.get().generationId(), followerJoinFuture.get().generationId());
+        assertEquals(leaderId, leaderJoinFuture.get().leader());
+        assertEquals(leaderId, followerJoinFuture.get().leader());
+
+        int nextGenerationId = leaderJoinFuture.get().generationId();
+        String followerId = followerJoinFuture.get().memberId();
+
+        // Stabilize the group
+        syncFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(syncRequest.setGenerationId(nextGenerationId), syncFuture);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate successful write to log.
+        result.appendFuture().complete(null);
+
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+        assertTrue(group.isInState(STABLE));
+
+        // Re-join an existing member, to transition the group to PreparingRebalance state.
+        leaderJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(leaderId),
+            leaderJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(leaderJoinFuture.isDone());
+        assertTrue(group.isInState(PREPARING_REBALANCE));
+
+        // Create a pending member in the group
+        CompletableFuture<JoinGroupResponseData> pendingMemberJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(UNKNOWN_MEMBER_ID).setSessionTimeoutMs(2500),
+            pendingMemberJoinFuture,
+            true
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(pendingMemberJoinFuture.isDone());
+        assertEquals(Errors.MEMBER_ID_REQUIRED.code(), pendingMemberJoinFuture.get().errorCode());
+        assertEquals(1, group.numPendingJoinMembers());
+
+        // Re-join the second existing member
+        followerJoinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setMemberId(followerId).setSessionTimeoutMs(5000),
+            followerJoinFuture
+        );
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(followerJoinFuture.isDone());
+        assertTrue(group.isInState(PREPARING_REBALANCE));
+        assertEquals(1, group.numPendingJoinMembers());
+
+        return pendingMemberJoinFuture.get();
+    }
+
+    @Test
+    public void testGenerationIdIncrementsOnRebalance() throws Exception {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+
+        JoinGroupResponseData leaderJoinResponse =
+            context.joinGenericGroupAndCompleteJoinAsDynamicMemberAndCompleteJoin(joinRequest);
+
+        String leaderId = leaderJoinResponse.memberId();
+        int generationId = leaderJoinResponse.generationId();
+
+        assertEquals(1, generationId);
+
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(leaderId)
+            .withGenerationId(generationId)
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> syncFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupSync(syncRequest, syncFuture);
+
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        // Simulate successful write to log.
+        result.appendFuture().complete(null);
+
+        assertTrue(syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncFuture.get().errorCode());
+
+        CompletableFuture<JoinGroupResponseData> joinFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(joinRequest.setMemberId(leaderId), joinFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(joinFuture.isDone());
+        assertEquals(2, joinFuture.get().generationId());
+        assertEquals(Errors.NONE.code(), joinFuture.get().errorCode());
+    }
+
+    private List<JoinGroupResponseMember> toJoinResponseMembers(GenericGroup group) {
+        List<JoinGroupResponseMember> members = new ArrayList<>();
+        String protocolName = group.protocolName().get();
+        group.allMembers().forEach(member -> {
+            members.add(new JoinGroupResponseMember()
+                .setMemberId(member.memberId())
+                .setGroupInstanceId(member.groupInstanceId().orElse(""))
+                .setMetadata(member.metadata(protocolName)));
+        });
+
+        return members;
+    }
+
+    private void checkJoinGroupResponse(
+        JoinGroupResponseData expectedResponse,
+        JoinGroupResponseData actualResponse,
+        GenericGroup group,
+        GenericGroupState expectedState,
+        Set<String> expectedGroupInstanceIds
+    ) {
+        assertEquals(expectedResponse, actualResponse);
+        assertTrue(group.isInState(expectedState));
+
+        Set<String> groupInstanceIds = actualResponse.members()
+            .stream()
+            .map(JoinGroupResponseData.JoinGroupResponseMember::groupInstanceId)
+            .collect(Collectors.toSet());
+
+        assertEquals(expectedGroupInstanceIds, groupInstanceIds);
+    }
+
+    private void verifySessionExpiration(
+        GroupMetadataManagerTestContext context,
+        GenericGroup group,
+        int timeoutMs
+    ) {
+        Set<String> expectedHeartbeatKeys = group.allMembers().stream()
+            .map(member -> genericGroupHeartbeatKey(group.groupId(), member.memberId())).collect(Collectors.toSet());
+
+        // Member should be removed as session expires.
+        List<ExpiredTimeout<Void, Record>> timeouts = context.sleep(timeoutMs);
+        List<Record> expectedRecords = Collections.singletonList(newGroupMetadataRecord(
+            "group-id",
+            new GroupMetadataValue()
+                .setMembers(Collections.emptyList())
+                .setGeneration(group.generationId())
+                .setLeader(null)
+                .setProtocolType("consumer")
+                .setProtocol(null)
+                .setCurrentStateTimestamp(context.time.milliseconds()),
+            MetadataVersion.latest()));
+
+
+        Set<String> heartbeatKeys = timeouts.stream().map(timeout -> timeout.key).collect(Collectors.toSet());
+        assertEquals(expectedHeartbeatKeys, heartbeatKeys);
+
+        // Only the last member leaving the group should result in the empty group metadata record.
+        int timeoutsSize = timeouts.size();
+        assertEquals(expectedRecords, timeouts.get(timeoutsSize - 1).result.records());
+        assertNoOrEmptyResult(timeouts.subList(0, timeoutsSize - 1));
+        assertTrue(group.isInState(EMPTY));
+        assertEquals(0, group.size());
+    }
+
+    private static class SyncGroupRequestBuilder {
+        String groupId = null;
+        String groupInstanceId = null;
+        String memberId = null;
+        String protocolType = "consumer";
+        String protocolName = "range";
+        int generationId = 0;
+        List<SyncGroupRequestAssignment> assignments = Collections.emptyList();
+        JoinGroupRequestProtocolCollection protocols = new JoinGroupRequestProtocolCollection(0);
+
+        SyncGroupRequestBuilder withGroupId(String groupId) {
+            this.groupId = groupId;
+            return this;
+        }
+
+        SyncGroupRequestBuilder withGroupInstanceId(String groupInstanceId) {
+            this.groupInstanceId = groupInstanceId;
+            return this;
+        }
+
+        SyncGroupRequestBuilder withMemberId(String memberId) {
+            this.memberId = memberId;
+            return this;
+        }
+
+        SyncGroupRequestBuilder withGenerationId(int generationId) {
+            this.generationId = generationId;
+            return this;
+        }
+
+        SyncGroupRequestBuilder withProtocolType(String protocolType) {
+            this.protocolType = protocolType;
+            return this;
+        }
+
+        SyncGroupRequestBuilder withProtocolName(String protocolName) {
+            this.protocolName = protocolName;
+            return this;
+        }
+
+        SyncGroupRequestBuilder withAssignments(List<SyncGroupRequestAssignment> assignments) {
+            this.assignments = assignments;
+            return this;
+        }
+
+
+        SyncGroupRequestData build() {
+            return new SyncGroupRequestData()
+                .setGroupId(groupId)
+                .setGroupInstanceId(groupInstanceId)
+                .setMemberId(memberId)
+                .setGenerationId(generationId)
+                .setProtocolType(protocolType)
+                .setProtocolName(protocolName)
+                .setAssignments(assignments);
+        }
+    }
+
+    private RebalanceResult staticMembersJoinAndRebalance(
+        GroupMetadataManagerTestContext context,
+        String groupId,
+        String leaderInstanceId,
+        String followerInstanceId
+    ) throws Exception {
+        return staticMembersJoinAndRebalance(
+            context,
+            groupId,
+            leaderInstanceId,
+            followerInstanceId,
+            10000,
+            5000
+        );
+    }
+
+    private RebalanceResult staticMembersJoinAndRebalance(
+        GroupMetadataManagerTestContext context,
+        String groupId,
+        String leaderInstanceId,
+        String followerInstanceId,
+        int rebalanceTimeoutMs,
+        int sessionTimeoutMs
+    ) throws Exception {
+        GenericGroup group = context.createGenericGroup("group-id");
+
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId(groupId)
+            .withGroupInstanceId(leaderInstanceId)
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withProtocolType("consumer")
+            .withProtocolSuperset()
+            .withRebalanceTimeoutMs(rebalanceTimeoutMs)
+            .withSessionTimeoutMs(sessionTimeoutMs)
+            .build();
+
+        CompletableFuture<JoinGroupResponseData> leaderJoinResponseFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> result = context.sendGenericGroupJoin(joinRequest, leaderJoinResponseFuture);
+
+        assertTrue(result.records().isEmpty());
+
+        CompletableFuture<JoinGroupResponseData> followerJoinResponseFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupJoin(
+            joinRequest.setGroupInstanceId(followerInstanceId),
+            followerJoinResponseFuture);
+
+        assertTrue(result.records().isEmpty());
+        assertFalse(leaderJoinResponseFuture.isDone());
+        assertFalse(followerJoinResponseFuture.isDone());
+
+        // The goal for two timer advance is to let first group initial join complete and set newMemberAdded flag to false. Next advance is
+        // to trigger the rebalance as needed for follower delayed join. One large time advance won't help because we could only populate one
+        // delayed join from purgatory and the new delayed op is created at that time and never be triggered.
+        context.sleepAndAssertEmptyResult(context.genericGroupInitialRebalanceDelayMs);
+        context.sleepAndAssertEmptyResult(context.genericGroupInitialRebalanceDelayMs);
+
+        assertTrue(leaderJoinResponseFuture.isDone());
+        assertTrue(followerJoinResponseFuture.isDone());
+        assertEquals(Errors.NONE.code(), leaderJoinResponseFuture.get().errorCode());
+        assertEquals(Errors.NONE.code(), followerJoinResponseFuture.get().errorCode());
+        assertEquals(1, leaderJoinResponseFuture.get().generationId());
+        assertEquals(1, followerJoinResponseFuture.get().generationId());
+        assertEquals(2, group.size());
+        assertEquals(1, group.generationId());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+
+        String leaderId = leaderJoinResponseFuture.get().memberId();
+        List<SyncGroupRequestAssignment> assignments = new ArrayList<>();
+        assignments.add(new SyncGroupRequestAssignment().setMemberId(leaderId));
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId(groupId)
+            .withGroupInstanceId(leaderInstanceId)
+            .withMemberId(leaderId)
+            .withGenerationId(1)
+            .withAssignments(assignments)
+            .build();
+
+        CompletableFuture<SyncGroupResponseData> leaderSyncResponseFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(
+                syncRequest,
+                leaderSyncResponseFuture);
+
+        // Simulate a successful write to the log.
+        assertEquals(
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, MetadataVersion.latest())),
+            result.records()
+        );
+        result.appendFuture().complete(null);
+
+        assertTrue(leaderSyncResponseFuture.isDone());
+        assertEquals(Errors.NONE.code(), leaderSyncResponseFuture.get().errorCode());
+        assertTrue(group.isInState(STABLE));
+
+        String followerId = followerJoinResponseFuture.get().memberId();
+        CompletableFuture<SyncGroupResponseData> followerSyncResponseFuture = new CompletableFuture<>();
+        result = context.sendGenericGroupSync(
+                syncRequest.setGroupInstanceId(followerInstanceId)
+                    .setMemberId(followerId)
+                    .setAssignments(Collections.emptyList()),
+                followerSyncResponseFuture
+            );
+
+        assertTrue(result.records().isEmpty());
+        assertTrue(followerSyncResponseFuture.isDone());
+        assertEquals(Errors.NONE.code(), followerSyncResponseFuture.get().errorCode());
+        assertTrue(group.isInState(STABLE));
+
+        assertEquals(2, group.size());
+        assertEquals(1, group.generationId());
+
+        return new RebalanceResult(
+            1,
+            leaderId,
+            leaderSyncResponseFuture.get().assignment(),
+            followerId,
+            followerSyncResponseFuture.get().assignment()
+        );
+    }
+
+    private static class RebalanceResult {
+        int generationId;
+        String leaderId;
+        byte[] leaderAssignment;
+        String followerId;
+        byte[] followerAssignment;
+
+        RebalanceResult(
+            int generationId,
+            String leaderId,
+            byte[] leaderAssignment,
+            String followerId,
+            byte[] followerAssignment
+        ) {
+            this.generationId = generationId;
+            this.leaderId = leaderId;
+            this.leaderAssignment = leaderAssignment;
+            this.followerId = followerId;
+            this.followerAssignment = followerAssignment;
+        }
     }
 }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -48,7 +48,6 @@ import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.coordinator.group.MockCoordinatorTimer.ExpiredTimeout;
@@ -7566,7 +7565,7 @@ public class GroupMetadataManagerTest {
         assertTrue(result.records().isEmpty());
         assertTrue(syncFuture.isDone());
         assertEquals(Errors.UNKNOWN_MEMBER_ID.code(), syncFuture.get().errorCode());
-        assertEquals(Bytes.EMPTY, syncFuture.get().assignment());
+        assertEquals(GenericGroupMember.EMPTY_ASSIGNMENT, syncFuture.get().assignment());
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
@@ -55,6 +55,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -467,6 +468,8 @@ public class RecordHelpersTest {
             time
         );
 
+        Map<String, byte[]> assignment = new HashMap<>();
+
         expectedMembers.forEach(member -> {
             JoinGroupRequestProtocolCollection protocols = new JoinGroupRequestProtocolCollection();
             protocols.add(new JoinGroupRequestProtocol()
@@ -482,13 +485,16 @@ public class RecordHelpersTest {
                 member.sessionTimeout(),
                 "consumer",
                 protocols,
-                member.assignment()
+                GenericGroupMember.EMPTY_ASSIGNMENT
             ));
+
+            assignment.put(member.memberId(), member.assignment());
         });
 
         group.initNextGeneration();
         Record groupMetadataRecord = RecordHelpers.newGroupMetadataRecord(
             group,
+            assignment,
             metadataVersion
         );
 
@@ -554,6 +560,7 @@ public class RecordHelpersTest {
         assertThrows(IllegalStateException.class, () ->
             RecordHelpers.newGroupMetadataRecord(
                 group,
+                Collections.emptyMap(),
                 MetadataVersion.IBP_3_5_IV2
             ));
     }
@@ -604,6 +611,7 @@ public class RecordHelpersTest {
         assertThrows(IllegalStateException.class, () ->
             RecordHelpers.newGroupMetadataRecord(
                 group,
+                Collections.emptyMap(),
                 MetadataVersion.IBP_3_5_IV2
             ));
     }


### PR DESCRIPTION
built on top of https://github.com/apache/kafka/pull/13870, this PR implements the sync group API

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
