### PR TITLE
MINOR: Optimization of equals methods on implementations of Commands.Handler in shell.command package 

### DIFF
--- a/shell/src/main/java/org/apache/kafka/shell/command/CatCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/CatCommandHandler.java
@@ -120,8 +120,6 @@ public final class CatCommandHandler implements Commands.Handler {
     @Override
     public boolean equals(Object other) {
         if (!(other instanceof CatCommandHandler)) return false;
-        CatCommandHandler o = (CatCommandHandler) other;
-        if (!Objects.equals(o.targets, targets)) return false;
-        return true;
+        return Objects.equals(((CatCommandHandler) other).targets, targets);
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/CdCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/CdCommandHandler.java
@@ -111,8 +111,6 @@ public final class CdCommandHandler implements Commands.Handler {
     @Override
     public boolean equals(Object other) {
         if (!(other instanceof CdCommandHandler)) return false;
-        CdCommandHandler o = (CdCommandHandler) other;
-        if (!o.target.equals(target)) return false;
-        return true;
+        return ((CdCommandHandler) other).target.equals(target);
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/ErroneousCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/ErroneousCommandHandler.java
@@ -51,9 +51,7 @@ public final class ErroneousCommandHandler implements Commands.Handler {
     @Override
     public boolean equals(Object other) {
         if (!(other instanceof ErroneousCommandHandler)) return false;
-        ErroneousCommandHandler o = (ErroneousCommandHandler) other;
-        if (!Objects.equals(o.message, message)) return false;
-        return true;
+        return Objects.equals(((ErroneousCommandHandler) other).message, message);
     }
 
     @Override

--- a/shell/src/main/java/org/apache/kafka/shell/command/ExitCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/ExitCommandHandler.java
@@ -89,7 +89,6 @@ public final class ExitCommandHandler implements Commands.Handler {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ExitCommandHandler)) return false;
-        return true;
+        return other instanceof ExitCommandHandler;
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/FindCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/FindCommandHandler.java
@@ -126,8 +126,6 @@ public final class FindCommandHandler implements Commands.Handler {
     @Override
     public boolean equals(Object other) {
         if (!(other instanceof FindCommandHandler)) return false;
-        FindCommandHandler o = (FindCommandHandler) other;
-        if (!Objects.equals(o.paths, paths)) return false;
-        return true;
+        return Objects.equals(((FindCommandHandler) other).paths, paths);
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/HelpCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/HelpCommandHandler.java
@@ -89,7 +89,6 @@ public final class HelpCommandHandler implements Commands.Handler {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof HelpCommandHandler)) return false;
-        return true;
+        return other instanceof HelpCommandHandler;
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/LsCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/LsCommandHandler.java
@@ -298,8 +298,6 @@ public final class LsCommandHandler implements Commands.Handler {
     @Override
     public boolean equals(Object other) {
         if (!(other instanceof LsCommandHandler)) return false;
-        LsCommandHandler o = (LsCommandHandler) other;
-        if (!Objects.equals(o.targets, targets)) return false;
-        return true;
+        return Objects.equals(((LsCommandHandler) other).targets, targets);
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/ManCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/ManCommandHandler.java
@@ -109,8 +109,6 @@ public final class ManCommandHandler implements Commands.Handler {
     @Override
     public boolean equals(Object other) {
         if (!(other instanceof ManCommandHandler)) return false;
-        ManCommandHandler o = (ManCommandHandler) other;
-        if (!o.cmd.equals(cmd)) return false;
-        return true;
+        return ((ManCommandHandler) other).cmd.equals(cmd);
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/NoOpCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/NoOpCommandHandler.java
@@ -42,7 +42,6 @@ public final class NoOpCommandHandler implements Commands.Handler {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof NoOpCommandHandler)) return false;
-        return true;
+        return other instanceof NoOpCommandHandler;
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/PwdCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/PwdCommandHandler.java
@@ -88,7 +88,6 @@ public final class PwdCommandHandler implements Commands.Handler {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof PwdCommandHandler)) return false;
-        return true;
+        return other instanceof PwdCommandHandler;
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/command/TreeCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/TreeCommandHandler.java
@@ -116,8 +116,6 @@ public final class TreeCommandHandler implements Commands.Handler {
     @Override
     public boolean equals(Object other) {
         if (!(other instanceof TreeCommandHandler)) return false;
-        TreeCommandHandler o = (TreeCommandHandler) other;
-        if (!Objects.equals(o.targets, targets)) return false;
-        return true;
+        return Objects.equals(((TreeCommandHandler) other).targets, targets);
     }
 }

--- a/shell/src/test/java/org/apache/kafka/shell/command/CommandTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/command/CommandTest.java
@@ -31,39 +31,39 @@ import java.util.Optional;
 public class CommandTest {
     @Test
     public void testParseCommands() {
-        assertEquals(new CatCommandHandler(Arrays.asList("foo")),
+        assertEquals(new CatCommandHandler(Collections.singletonList("foo")),
             new Commands(true).parseCommand(Arrays.asList("cat", "foo")));
         assertEquals(new CdCommandHandler(Optional.empty()),
-            new Commands(true).parseCommand(Arrays.asList("cd")));
+            new Commands(true).parseCommand(Collections.singletonList("cd")));
         assertEquals(new CdCommandHandler(Optional.of("foo")),
             new Commands(true).parseCommand(Arrays.asList("cd", "foo")));
         assertEquals(new ExitCommandHandler(),
-            new Commands(true).parseCommand(Arrays.asList("exit")));
+            new Commands(true).parseCommand(Collections.singletonList("exit")));
         assertEquals(new HelpCommandHandler(),
-            new Commands(true).parseCommand(Arrays.asList("help")));
+            new Commands(true).parseCommand(Collections.singletonList("help")));
         assertEquals(new HistoryCommandHandler(3),
             new Commands(true).parseCommand(Arrays.asList("history", "3")));
         assertEquals(new HistoryCommandHandler(Integer.MAX_VALUE),
-            new Commands(true).parseCommand(Arrays.asList("history")));
+            new Commands(true).parseCommand(Collections.singletonList("history")));
         assertEquals(new LsCommandHandler(Collections.emptyList()),
-            new Commands(true).parseCommand(Arrays.asList("ls")));
+            new Commands(true).parseCommand(Collections.singletonList("ls")));
         assertEquals(new LsCommandHandler(Arrays.asList("abc", "123")),
             new Commands(true).parseCommand(Arrays.asList("ls", "abc", "123")));
         assertEquals(new PwdCommandHandler(),
-            new Commands(true).parseCommand(Arrays.asList("pwd")));
+            new Commands(true).parseCommand(Collections.singletonList("pwd")));
     }
 
     @Test
     public void testParseInvalidCommand() {
         assertEquals(new ErroneousCommandHandler("invalid choice: 'blah' (choose " +
             "from 'cat', 'cd', 'exit', 'find', 'help', 'history', 'ls', 'man', 'pwd', 'tree')"),
-            new Commands(true).parseCommand(Arrays.asList("blah")));
+            new Commands(true).parseCommand(Collections.singletonList("blah")));
     }
 
     @Test
     public void testEmptyCommandLine() {
         assertEquals(new NoOpCommandHandler(),
-            new Commands(true).parseCommand(Arrays.asList("")));
+            new Commands(true).parseCommand(Collections.singletonList("")));
         assertEquals(new NoOpCommandHandler(),
             new Commands(true).parseCommand(Collections.emptyList()));
     }


### PR DESCRIPTION
Optimization of  equals  method on  multiple implementations  of `Commands.Handler ` in `shell.command` package ,for making it less verbose 


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
