### PR TITLE
KAFKA-13431: Expose the original pre-transform topic partition and offset in sink records

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -448,6 +448,7 @@
     <subpackage name="sink">
       <allow pkg="org.apache.kafka.clients.consumer" />
       <allow pkg="org.apache.kafka.connect.connector" />
+      <allow pkg="org.apache.kafka.connect.transforms" />
       <allow pkg="org.apache.kafka.connect.storage" />
     </subpackage>
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java
@@ -186,7 +186,7 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
     public SinkRecord newRecord(String topic, Integer kafkaPartition, Schema keySchema, Object key, Schema valueSchema, Object value,
                                 Long timestamp, Iterable<Header> headers) {
         return new SinkRecord(topic, kafkaPartition, keySchema, key, valueSchema, value, kafkaOffset, timestamp, timestampType, headers,
-                originalTopic(), originalKafkaPartition(), originalKafkaOffset());
+                originalTopic, originalKafkaPartition, originalKafkaOffset);
     }
 
     @Override

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java
@@ -55,6 +55,10 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
         this(topic, partition, keySchema, key, valueSchema, value, kafkaOffset, timestamp, timestampType, headers, topic, partition, kafkaOffset);
     }
 
+    /**
+     * This constructor is intended for use by the Connect runtime only and plugins (sink connectors or transformations)
+     * should not use this directly outside testing code.
+     */
     public SinkRecord(String topic, int partition, Schema keySchema, Object key, Schema valueSchema, Object value, long kafkaOffset,
                       Long timestamp, TimestampType timestampType, Iterable<Header> headers, String originalTopic,
                       Integer originalKafkaPartition, long originalKafkaOffset) {
@@ -90,6 +94,7 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
      * try {
      *     originalTopic = record.originalTopic();
      * } catch (NoSuchMethodError | NoClassDefFoundError e) {
+     *     log.warn("This connector is not compatible with SMTs that mutate topic names, topic partitions or offset values on this version of Kafka Connect");
      *     originalTopic = record.topic();
      * }
      * }
@@ -122,6 +127,7 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
      * try {
      *     originalKafkaPartition = record.originalKafkaPartition();
      * } catch (NoSuchMethodError | NoClassDefFoundError e) {
+     *     log.warn("This connector is not compatible with SMTs that mutate topic names, topic partitions or offset values on this version of Kafka Connect");
      *     originalKafkaPartition = record.kafkaPartition();
      * }
      * }
@@ -154,6 +160,7 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
      * try {
      *     originalKafkaOffset = record.originalKafkaOffset();
      * } catch (NoSuchMethodError | NoClassDefFoundError e) {
+     *     log.warn("This connector is not compatible with SMTs that mutate topic names, topic partitions or offset values on this version of Kafka Connect");
      *     originalKafkaOffset = record.kafkaOffset();
      * }
      * }

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java
@@ -27,8 +27,9 @@ import java.util.Objects;
 
 /**
  * SinkRecord is a {@link ConnectRecord} that has been read from Kafka and includes the original Kafka record's
- * topic, partition and offset (before any {@link Transformation}s have been applied) in addition to the standard fields.
- * This information should be used by the {@link SinkTask} to coordinate offset commits.
+ * topic, partition and offset (before any {@link Transformation transformations}
+ * have been applied) in addition to the standard fields. This information should be used by the {@link SinkTask} to coordinate
+ * offset commits.
  * <p>
  * It also includes the {@link TimestampType}, which may be {@link TimestampType#NO_TIMESTAMP_TYPE}, and the relevant
  * timestamp, which may be {@code null}.
@@ -74,11 +75,11 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
     }
 
     /**
-     * Get the original topic for this sink record, corresponding to the topic of the Kafka record before any
-     * {@link org.apache.kafka.connect.transforms.Transformation Transformation}s were applied. This should be used by
-     * sink tasks for any internal offset tracking purposes (that are reported to the framework via
-     * {@link SinkTask#preCommit(Map)} for instance) rather than {@link #topic()}, in order to be compatible with
-     * transformations that mutate the topic name.
+     * Get the original topic for this sink record, before any
+     * {@link Transformation transformations} were applied.
+     * In order to be compatible with transformations that mutate topic names, this method should be used
+     * by sink tasks instead of {@link #topic()} for any internal offset tracking purposes (for instance, reporting offsets to the Connect runtime via
+     * {@link SinkTask#preCommit(Map)}).
      * <p>
      * This method was added in Apache Kafka 3.6. Sink connectors that use this method but want to maintain backward
      * compatibility in order to be able to be deployed on older Connect runtimes should guard the call to this method
@@ -95,10 +96,10 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
      * }
      * </pre>
      * <p>
-     * Note that sink connectors that do their own offset tracking will be incompatible with SMTs that mutate the topic
-     * name when deployed to older Connect runtimes.
+     * Note that sink connectors that do their own offset tracking will be incompatible with SMTs that mutate topic
+     * names when deployed to older Connect runtimes that do not support this method.
      *
-     * @return the topic corresponding to the Kafka record before any transformations were applied
+     * @return the topic for this record before any transformations were applied
      *
      * @since 3.6
      */
@@ -198,8 +199,8 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
         return kafkaOffset == that.kafkaOffset &&
                 timestampType == that.timestampType &&
                 Objects.equals(originalTopic, that.originalTopic) &&
-                Objects.equals(originalKafkaPartition, that.originalKafkaPartition)
-                && originalKafkaOffset == that.originalKafkaOffset;
+                Objects.equals(originalKafkaPartition, that.originalKafkaPartition) &&
+                originalKafkaOffset == that.originalKafkaOffset;
     }
 
     @Override

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java
@@ -20,11 +20,15 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.transforms.Transformation;
+
+import java.util.Map;
+import java.util.Objects;
 
 /**
- * SinkRecord is a {@link ConnectRecord} that has been read from Kafka and includes the kafkaOffset of
- * the record in the Kafka topic-partition in addition to the standard fields. This information
- * should be used by the {@link SinkTask} to coordinate kafkaOffset commits.
+ * SinkRecord is a {@link ConnectRecord} that has been read from Kafka and includes the original Kafka record's
+ * topic, partition and offset (before any {@link Transformation}s have been applied) in addition to the standard fields.
+ * This information should be used by the {@link SinkTask} to coordinate offset commits.
  * <p>
  * It also includes the {@link TimestampType}, which may be {@link TimestampType#NO_TIMESTAMP_TYPE}, and the relevant
  * timestamp, which may be {@code null}.
@@ -32,6 +36,9 @@ import org.apache.kafka.connect.header.Header;
 public class SinkRecord extends ConnectRecord<SinkRecord> {
     private final long kafkaOffset;
     private final TimestampType timestampType;
+    private final String originalTopic;
+    private final Integer originalKafkaPartition;
+    private final long originalKafkaOffset;
 
     public SinkRecord(String topic, int partition, Schema keySchema, Object key, Schema valueSchema, Object value, long kafkaOffset) {
         this(topic, partition, keySchema, key, valueSchema, value, kafkaOffset, null, TimestampType.NO_TIMESTAMP_TYPE);
@@ -44,9 +51,18 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
 
     public SinkRecord(String topic, int partition, Schema keySchema, Object key, Schema valueSchema, Object value, long kafkaOffset,
                       Long timestamp, TimestampType timestampType, Iterable<Header> headers) {
+        this(topic, partition, keySchema, key, valueSchema, value, kafkaOffset, timestamp, timestampType, headers, topic, partition, kafkaOffset);
+    }
+
+    public SinkRecord(String topic, int partition, Schema keySchema, Object key, Schema valueSchema, Object value, long kafkaOffset,
+                      Long timestamp, TimestampType timestampType, Iterable<Header> headers, String originalTopic,
+                      Integer originalKafkaPartition, long originalKafkaOffset) {
         super(topic, partition, keySchema, key, valueSchema, value, timestamp, headers);
         this.kafkaOffset = kafkaOffset;
         this.timestampType = timestampType;
+        this.originalTopic = originalTopic;
+        this.originalKafkaPartition = originalKafkaPartition;
+        this.originalKafkaOffset = originalKafkaOffset;
     }
 
     public long kafkaOffset() {
@@ -57,6 +73,105 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
         return timestampType;
     }
 
+    /**
+     * Get the original topic for this sink record, corresponding to the topic of the Kafka record before any
+     * {@link org.apache.kafka.connect.transforms.Transformation Transformation}s were applied. This should be used by
+     * sink tasks for any internal offset tracking purposes (that are reported to the framework via
+     * {@link SinkTask#preCommit(Map)} for instance) rather than {@link #topic()}, in order to be compatible with
+     * transformations that mutate the topic name.
+     * <p>
+     * This method was added in Apache Kafka 3.6. Sink connectors that use this method but want to maintain backward
+     * compatibility in order to be able to be deployed on older Connect runtimes should guard the call to this method
+     * with a try-catch block, since calling this method will result in a {@link NoSuchMethodException} or
+     * {@link NoClassDefFoundError} when the sink connector is deployed to Connect runtimes older than Kafka 3.6.
+     * For example:
+     * <pre>{@code
+     * String originalTopic;
+     * try {
+     *     originalTopic = record.originalTopic();
+     * } catch (NoSuchMethodError | NoClassDefFoundError e) {
+     *     originalTopic = record.topic();
+     * }
+     * }
+     * </pre>
+     * <p>
+     * Note that sink connectors that do their own offset tracking will be incompatible with SMTs that mutate the topic
+     * name when deployed to older Connect runtimes.
+     *
+     * @return the topic corresponding to the Kafka record before any transformations were applied
+     *
+     * @since 3.6
+     */
+    public String originalTopic() {
+        return originalTopic;
+    }
+
+    /**
+     * Get the original topic partition for this sink record, corresponding to the topic partition of the Kafka record
+     * before any {@link org.apache.kafka.connect.transforms.Transformation Transformation}s were applied. This should
+     * be used by sink tasks for any internal offset tracking purposes (that are reported to the framework via
+     * {@link SinkTask#preCommit(Map)} for instance) rather than {@link #kafkaPartition()}, in order to be compatible
+     * with transformations that mutate the topic partition value.
+     * <p>
+     * This method was added in Apache Kafka 3.6. Sink connectors that use this method but want to maintain backward
+     * compatibility in order to be able to be deployed on older Connect runtimes should guard the call to this method
+     * with a try-catch block, since calling this method will result in a {@link NoSuchMethodException} or
+     * {@link NoClassDefFoundError} when the sink connector is deployed to Connect runtimes older than Kafka 3.6.
+     * For example:
+     * <pre>{@code
+     * String originalKafkaPartition;
+     * try {
+     *     originalKafkaPartition = record.originalKafkaPartition();
+     * } catch (NoSuchMethodError | NoClassDefFoundError e) {
+     *     originalKafkaPartition = record.kafkaPartition();
+     * }
+     * }
+     * </pre>
+     * <p>
+     * Note that sink connectors that do their own offset tracking will be incompatible with SMTs that mutate the topic
+     * partition when deployed to older Connect runtimes.
+     *
+     * @return the topic partition corresponding to the Kafka record before any transformations were applied
+     *
+     * @since 3.6
+     */
+    public Integer originalKafkaPartition() {
+        return originalKafkaPartition;
+    }
+
+    /**
+     * Get the original offset for this sink record, corresponding to the offset of the Kafka record before any
+     * {@link org.apache.kafka.connect.transforms.Transformation Transformation}s were applied. This should be used by
+     * sink tasks for any internal offset tracking purposes (that are reported to the framework via
+     * {@link SinkTask#preCommit(Map)} for instance) rather than {@link #kafkaOffset()}, in order to be
+     * compatible with transformations that mutate the offset value.
+     * <p>
+     * This method was added in Apache Kafka 3.6. Sink connectors that use this method but want to maintain backward
+     * compatibility in order to be able to be deployed on older Connect runtimes should guard the call to this method
+     * with a try-catch block, since calling this method will result in a {@link NoSuchMethodException} or
+     * {@link NoClassDefFoundError} when the sink connector is deployed to Connect runtimes older than Kafka 3.6.
+     * For example:
+     * <pre>{@code
+     * String originalKafkaOffset;
+     * try {
+     *     originalKafkaOffset = record.originalKafkaOffset();
+     * } catch (NoSuchMethodError | NoClassDefFoundError e) {
+     *     originalTopic = record.kafkaOffset();
+     * }
+     * }
+     * </pre>
+     * <p>
+     * Note that sink connectors that do their own offset tracking will be incompatible with SMTs that mutate the offset
+     * value when deployed to older Connect runtimes.
+     *
+     * @return the offset corresponding to the Kafka record before any transformations were applied
+     *
+     * @since 3.6
+     */
+    public long originalKafkaOffset() {
+        return originalKafkaOffset;
+    }
+
     @Override
     public SinkRecord newRecord(String topic, Integer kafkaPartition, Schema keySchema, Object key, Schema valueSchema, Object value, Long timestamp) {
         return newRecord(topic, kafkaPartition, keySchema, key, valueSchema, value, timestamp, headers().duplicate());
@@ -65,7 +180,8 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
     @Override
     public SinkRecord newRecord(String topic, Integer kafkaPartition, Schema keySchema, Object key, Schema valueSchema, Object value,
                                 Long timestamp, Iterable<Header> headers) {
-        return new SinkRecord(topic, kafkaPartition, keySchema, key, valueSchema, value, kafkaOffset, timestamp, timestampType, headers);
+        return new SinkRecord(topic, kafkaPartition, keySchema, key, valueSchema, value, kafkaOffset, timestamp, timestampType, headers,
+                originalTopic(), originalKafkaPartition(), originalKafkaOffset());
     }
 
     @Override
@@ -79,10 +195,11 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
 
         SinkRecord that = (SinkRecord) o;
 
-        if (kafkaOffset != that.kafkaOffset)
-            return false;
-
-        return timestampType == that.timestampType;
+        return kafkaOffset == that.kafkaOffset &&
+                timestampType == that.timestampType &&
+                Objects.equals(originalTopic, that.originalTopic) &&
+                Objects.equals(originalKafkaPartition, that.originalKafkaPartition)
+                && originalKafkaOffset == that.originalKafkaOffset;
     }
 
     @Override
@@ -90,6 +207,9 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
         int result = super.hashCode();
         result = 31 * result + Long.hashCode(kafkaOffset);
         result = 31 * result + timestampType.hashCode();
+        result = 31 * result + originalTopic.hashCode();
+        result = 31 * result + originalKafkaPartition.hashCode();
+        result = 31 * result + Long.hashCode(originalKafkaOffset);
         return result;
     }
 
@@ -98,6 +218,9 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
         return "SinkRecord{" +
                 "kafkaOffset=" + kafkaOffset +
                 ", timestampType=" + timestampType +
+                ", originalTopic=" + originalTopic +
+                ", originalKafkaPartition=" + originalKafkaPartition +
+                ", originalKafkaOffset=" + originalKafkaOffset +
                 "} " + super.toString();
     }
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java
@@ -27,8 +27,8 @@ import java.util.Objects;
 
 /**
  * SinkRecord is a {@link ConnectRecord} that has been read from Kafka and includes the original Kafka record's
- * topic, partition and offset (before any {@link Transformation transformations}
- * have been applied) in addition to the standard fields. This information should be used by the {@link SinkTask} to coordinate
+ * topic, partition and offset (before any {@link Transformation transformations} have been applied)
+ * in addition to the standard fields. This information should be used by the {@link SinkTask} to coordinate
  * offset commits.
  * <p>
  * It also includes the {@link TimestampType}, which may be {@link TimestampType#NO_TIMESTAMP_TYPE}, and the relevant
@@ -75,11 +75,10 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
     }
 
     /**
-     * Get the original topic for this sink record, before any
-     * {@link Transformation transformations} were applied.
+     * Get the original topic for this sink record, before any {@link Transformation transformations} were applied.
      * In order to be compatible with transformations that mutate topic names, this method should be used
-     * by sink tasks instead of {@link #topic()} for any internal offset tracking purposes (for instance, reporting offsets to the Connect runtime via
-     * {@link SinkTask#preCommit(Map)}).
+     * by sink tasks instead of {@link #topic()} for any internal offset tracking purposes (for instance, reporting
+     * offsets to the Connect runtime via {@link SinkTask#preCommit(Map)}).
      * <p>
      * This method was added in Apache Kafka 3.6. Sink connectors that use this method but want to maintain backward
      * compatibility in order to be able to be deployed on older Connect runtimes should guard the call to this method
@@ -108,11 +107,10 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
     }
 
     /**
-     * Get the original topic partition for this sink record, corresponding to the topic partition of the Kafka record
-     * before any {@link org.apache.kafka.connect.transforms.Transformation Transformation}s were applied. This should
-     * be used by sink tasks for any internal offset tracking purposes (that are reported to the framework via
-     * {@link SinkTask#preCommit(Map)} for instance) rather than {@link #kafkaPartition()}, in order to be compatible
-     * with transformations that mutate the topic partition value.
+     * Get the original topic partition for this sink record, before any {@link Transformation transformations} were applied.
+     * In order to be compatible with transformations that mutate topic partitions, this method should be used
+     * by sink tasks instead of {@link #kafkaPartition()} for any internal offset tracking purposes (for instance, reporting
+     * offsets to the Connect runtime via {@link SinkTask#preCommit(Map)}).
      * <p>
      * This method was added in Apache Kafka 3.6. Sink connectors that use this method but want to maintain backward
      * compatibility in order to be able to be deployed on older Connect runtimes should guard the call to this method
@@ -129,10 +127,10 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
      * }
      * </pre>
      * <p>
-     * Note that sink connectors that do their own offset tracking will be incompatible with SMTs that mutate the topic
-     * partition when deployed to older Connect runtimes.
+     * Note that sink connectors that do their own offset tracking will be incompatible with SMTs that mutate topic
+     * partitions when deployed to older Connect runtimes that do not support this method.
      *
-     * @return the topic partition corresponding to the Kafka record before any transformations were applied
+     * @return the topic partition for this record before any transformations were applied
      *
      * @since 3.6
      */
@@ -141,11 +139,10 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
     }
 
     /**
-     * Get the original offset for this sink record, corresponding to the offset of the Kafka record before any
-     * {@link org.apache.kafka.connect.transforms.Transformation Transformation}s were applied. This should be used by
-     * sink tasks for any internal offset tracking purposes (that are reported to the framework via
-     * {@link SinkTask#preCommit(Map)} for instance) rather than {@link #kafkaOffset()}, in order to be
-     * compatible with transformations that mutate the offset value.
+     * Get the original offset for this sink record, before any {@link Transformation transformations} were applied.
+     * In order to be compatible with transformations that mutate offset values, this method should be used
+     * by sink tasks instead of {@link #kafkaOffset()} for any internal offset tracking purposes (for instance, reporting
+     * offsets to the Connect runtime via {@link SinkTask#preCommit(Map)}).
      * <p>
      * This method was added in Apache Kafka 3.6. Sink connectors that use this method but want to maintain backward
      * compatibility in order to be able to be deployed on older Connect runtimes should guard the call to this method
@@ -157,15 +154,15 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
      * try {
      *     originalKafkaOffset = record.originalKafkaOffset();
      * } catch (NoSuchMethodError | NoClassDefFoundError e) {
-     *     originalTopic = record.kafkaOffset();
+     *     originalKafkaOffset = record.kafkaOffset();
      * }
      * }
      * </pre>
      * <p>
-     * Note that sink connectors that do their own offset tracking will be incompatible with SMTs that mutate the offset
-     * value when deployed to older Connect runtimes.
+     * Note that sink connectors that do their own offset tracking will be incompatible with SMTs that mutate offset
+     * values when deployed to older Connect runtimes that do not support this method.
      *
-     * @return the offset corresponding to the Kafka record before any transformations were applied
+     * @return the offset for this record before any transformations were applied
      *
      * @since 3.6
      */

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java
@@ -86,14 +86,14 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
      * <p>
      * This method was added in Apache Kafka 3.6. Sink connectors that use this method but want to maintain backward
      * compatibility in order to be able to be deployed on older Connect runtimes should guard the call to this method
-     * with a try-catch block, since calling this method will result in a {@link NoSuchMethodException} or
-     * {@link NoClassDefFoundError} when the sink connector is deployed to Connect runtimes older than Kafka 3.6.
+     * with a try-catch block, since calling this method will result in a {@link NoSuchMethodError} when the sink
+     * connector is deployed to Connect runtimes older than Kafka 3.6.
      * For example:
      * <pre>{@code
      * String originalTopic;
      * try {
      *     originalTopic = record.originalTopic();
-     * } catch (NoSuchMethodError | NoClassDefFoundError e) {
+     * } catch (NoSuchMethodError e) {
      *     log.warn("This connector is not compatible with SMTs that mutate topic names, topic partitions or offset values on this version of Kafka Connect");
      *     originalTopic = record.topic();
      * }
@@ -119,14 +119,14 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
      * <p>
      * This method was added in Apache Kafka 3.6. Sink connectors that use this method but want to maintain backward
      * compatibility in order to be able to be deployed on older Connect runtimes should guard the call to this method
-     * with a try-catch block, since calling this method will result in a {@link NoSuchMethodException} or
-     * {@link NoClassDefFoundError} when the sink connector is deployed to Connect runtimes older than Kafka 3.6.
+     * with a try-catch block, since calling this method will result in a {@link NoSuchMethodError} when the sink
+     * connector is deployed to Connect runtimes older than Kafka 3.6.
      * For example:
      * <pre>{@code
      * String originalKafkaPartition;
      * try {
      *     originalKafkaPartition = record.originalKafkaPartition();
-     * } catch (NoSuchMethodError | NoClassDefFoundError e) {
+     * } catch (NoSuchMethodError e) {
      *     log.warn("This connector is not compatible with SMTs that mutate topic names, topic partitions or offset values on this version of Kafka Connect");
      *     originalKafkaPartition = record.kafkaPartition();
      * }
@@ -152,14 +152,14 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
      * <p>
      * This method was added in Apache Kafka 3.6. Sink connectors that use this method but want to maintain backward
      * compatibility in order to be able to be deployed on older Connect runtimes should guard the call to this method
-     * with a try-catch block, since calling this method will result in a {@link NoSuchMethodException} or
-     * {@link NoClassDefFoundError} when the sink connector is deployed to Connect runtimes older than Kafka 3.6.
+     * with a try-catch block, since calling this method will result in a {@link NoSuchMethodError} when the sink
+     * connector is deployed to Connect runtimes older than Kafka 3.6.
      * For example:
      * <pre>{@code
      * String originalKafkaOffset;
      * try {
      *     originalKafkaOffset = record.originalKafkaOffset();
-     * } catch (NoSuchMethodError | NoClassDefFoundError e) {
+     * } catch (NoSuchMethodError e) {
      *     log.warn("This connector is not compatible with SMTs that mutate topic names, topic partitions or offset values on this version of Kafka Connect");
      *     originalKafkaOffset = record.kafkaOffset();
      * }

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java
@@ -109,9 +109,10 @@ public abstract class SinkTask implements Task {
      * @param currentOffsets the current offset state as of the last call to {@link #put(Collection)}, provided for
      *                       convenience but could also be determined by tracking all offsets included in the
      *                       {@link SinkRecord}s passed to {@link #put}. Note that the topic, partition and offset
-     *                       here correspond to the original Kafka topic partition and offset, before any {@link Transformation}s
-     *                       have been applied. These can be tracked by the task through the {@link SinkRecord#originalTopic()},
-     *                       {@link SinkRecord#originalKafkaPartition()} and {@link SinkRecord#originalKafkaOffset()} methods.
+     *                       here correspond to the original Kafka topic partition and offset, before any
+     *                       {@link Transformation transformations} have been applied. These can be tracked by the task
+     *                       through the {@link SinkRecord#originalTopic()}, {@link SinkRecord#originalKafkaPartition()}
+     *                       and {@link SinkRecord#originalKafkaOffset()} methods.
      */
     public void flush(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
     }
@@ -125,9 +126,10 @@ public abstract class SinkTask implements Task {
      * @param currentOffsets the current offset state as of the last call to {@link #put(Collection)}, provided for
      *                       convenience but could also be determined by tracking all offsets included in the
      *                       {@link SinkRecord}s passed to {@link #put}. Note that the topic, partition and offset
-     *                       here correspond to the original Kafka topic partition and offset, before any {@link Transformation}s
-     *                       have been applied. These can be tracked by the task through the {@link SinkRecord#originalTopic()},
-     *                       {@link SinkRecord#originalKafkaPartition()} and {@link SinkRecord#originalKafkaOffset()} methods.
+     *                       here correspond to the original Kafka topic partition and offset, before any
+     *                       {@link Transformation transformations} have been applied. These can be tracked by the task
+     *                       through the {@link SinkRecord#originalTopic()}, {@link SinkRecord#originalKafkaPartition()}
+     *                       and {@link SinkRecord#originalKafkaOffset()} methods.
      *
      * @return an empty map if Connect-managed offset commit is not desired, otherwise a map of offsets by topic-partition that are
      *         safe to commit. Note that the returned topic-partition to offsets map should use the original Kafka
@@ -144,7 +146,7 @@ public abstract class SinkTask implements Task {
      * fetching data. Any errors raised from this method will cause the task to stop.
      * <p>
      * Note that the topic partitions here correspond to the original Kafka topic partitions, before any
-     * {@link Transformation}s have been applied.
+     * {@link Transformation transformations} have been applied.
      *
      * @param partitions The list of partitions that are now assigned to the task (may include
      *                   partitions previously assigned to the task)
@@ -168,7 +170,7 @@ public abstract class SinkTask implements Task {
      * from this method will cause the task to stop.
      * <p>
      * Note that the topic partitions here correspond to the original Kafka topic partitions, before any
-     * {@link Transformation}s have been applied.
+     * {@link Transformation transformations} have been applied.
      *
      * @param partitions The list of partitions that should be closed
      */

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.sink;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.transforms.Transformation;
 
 import java.util.Collection;
 import java.util.Map;
@@ -105,9 +106,12 @@ public abstract class SinkTask implements Task {
     /**
      * Flush all records that have been {@link #put(Collection)} for the specified topic-partitions.
      *
-     * @param currentOffsets the current offset state as of the last call to {@link #put(Collection)}},
-     *                       provided for convenience but could also be determined by tracking all offsets included in the {@link SinkRecord}s
-     *                       passed to {@link #put}.
+     * @param currentOffsets the current offset state as of the last call to {@link #put(Collection)}, provided for
+     *                       convenience but could also be determined by tracking all offsets included in the
+     *                       {@link SinkRecord}s passed to {@link #put}. Note that the topic, partition and offset
+     *                       here correspond to the original Kafka topic partition and offset, before any {@link Transformation}s
+     *                       have been applied. These can be tracked by the task through the {@link SinkRecord#originalTopic()},
+     *                       {@link SinkRecord#originalKafkaPartition()} and {@link SinkRecord#originalKafkaOffset()} methods.
      */
     public void flush(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
     }
@@ -118,11 +122,16 @@ public abstract class SinkTask implements Task {
      * The default implementation simply invokes {@link #flush(Map)} and is thus able to assume all {@code currentOffsets}
      * are safe to commit.
      *
-     * @param currentOffsets the current offset state as of the last call to {@link #put(Collection)}},
-     *                       provided for convenience but could also be determined by tracking all offsets included in the {@link SinkRecord}s
-     *                       passed to {@link #put}.
+     * @param currentOffsets the current offset state as of the last call to {@link #put(Collection)}, provided for
+     *                       convenience but could also be determined by tracking all offsets included in the
+     *                       {@link SinkRecord}s passed to {@link #put}. Note that the topic, partition and offset
+     *                       here correspond to the original Kafka topic partition and offset, before any {@link Transformation}s
+     *                       have been applied. These can be tracked by the task through the {@link SinkRecord#originalTopic()},
+     *                       {@link SinkRecord#originalKafkaPartition()} and {@link SinkRecord#originalKafkaOffset()} methods.
      *
-     * @return an empty map if Connect-managed offset commit is not desired, otherwise a map of offsets by topic-partition that are safe to commit.
+     * @return an empty map if Connect-managed offset commit is not desired, otherwise a map of offsets by topic-partition that are
+     *         safe to commit. Note that the returned topic-partition to offsets map should also use the original Kafka
+     *         topic partitions and offsets instead of the transformed values.
      */
     public Map<TopicPartition, OffsetAndMetadata> preCommit(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
         flush(currentOffsets);
@@ -132,7 +141,11 @@ public abstract class SinkTask implements Task {
     /**
      * The SinkTask uses this method to create writers for newly assigned partitions in case of partition
      * rebalance. This method will be called after partition re-assignment completes and before the SinkTask starts
-     * fetching data. Note that any errors raised from this method will cause the task to stop.
+     * fetching data. Any errors raised from this method will cause the task to stop.
+     * <p>
+     * Note that the topic partitions here correspond to the original Kafka topic partitions, before any
+     * {@link Transformation}s have been applied.
+     *
      * @param partitions The list of partitions that are now assigned to the task (may include
      *                   partitions previously assigned to the task)
      */
@@ -151,8 +164,12 @@ public abstract class SinkTask implements Task {
      * The SinkTask uses this method to close writers for partitions that are no
      * longer assigned to the SinkTask. This method will be called before a rebalance operation starts
      * and after the SinkTask stops fetching data. After being closed, Connect will not write
-     * any records to the task until a new set of partitions has been opened. Note that any errors raised
+     * any records to the task until a new set of partitions has been opened. Any errors raised
      * from this method will cause the task to stop.
+     * <p>
+     * Note that the topic partitions here correspond to the original Kafka topic partitions, before any
+     * {@link Transformation}s have been applied.
+     *
      * @param partitions The list of partitions that should be closed
      */
     public void close(Collection<TopicPartition> partitions) {

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java
@@ -130,7 +130,7 @@ public abstract class SinkTask implements Task {
      *                       {@link SinkRecord#originalKafkaPartition()} and {@link SinkRecord#originalKafkaOffset()} methods.
      *
      * @return an empty map if Connect-managed offset commit is not desired, otherwise a map of offsets by topic-partition that are
-     *         safe to commit. Note that the returned topic-partition to offsets map should also use the original Kafka
+     *         safe to commit. Note that the returned topic-partition to offsets map should use the original Kafka
      *         topic partitions and offsets instead of the transformed values.
      */
     public Map<TopicPartition, OffsetAndMetadata> preCommit(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {

--- a/connect/api/src/test/java/org/apache/kafka/connect/sink/SinkRecordTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/sink/SinkRecordTest.java
@@ -125,4 +125,19 @@ public class SinkRecordTest {
         Header header = record.headers().lastWithName("intHeader");
         assertEquals(100, (int) Values.convertToInteger(header.schema(), header.value()));
     }
+
+    @Test
+    public void shouldRetainOriginalTopicPartition() {
+        SinkRecord transformed = record.newRecord("transformed-topic", PARTITION_NUMBER + 1, Schema.STRING_SCHEMA, "key",
+                Schema.BOOLEAN_SCHEMA, false, KAFKA_TIMESTAMP);
+
+        assertEquals(TOPIC_NAME, transformed.originalTopic());
+        assertEquals(PARTITION_NUMBER, transformed.originalKafkaPartition());
+
+        SinkRecord transformed2 = transformed.newRecord("transformed-topic-2", PARTITION_NUMBER + 2, Schema.STRING_SCHEMA, "key",
+                Schema.BOOLEAN_SCHEMA, false, KAFKA_TIMESTAMP);
+
+        assertEquals(TOPIC_NAME, transformed2.originalTopic());
+        assertEquals(PARTITION_NUMBER, transformed2.originalKafkaPartition());
+    }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/sink/SinkRecordTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/sink/SinkRecordTest.java
@@ -46,7 +46,7 @@ public class SinkRecordTest {
     @BeforeEach
     public void beforeEach() {
         record = new SinkRecord(TOPIC_NAME, PARTITION_NUMBER, Schema.STRING_SCHEMA, "key", Schema.BOOLEAN_SCHEMA, false, KAFKA_OFFSET,
-                                KAFKA_TIMESTAMP, TS_TYPE, null);
+                                KAFKA_TIMESTAMP, TS_TYPE, null, TOPIC_NAME, PARTITION_NUMBER, KAFKA_OFFSET);
     }
 
     @Test
@@ -128,6 +128,23 @@ public class SinkRecordTest {
 
     @Test
     public void shouldRetainOriginalTopicPartition() {
+        SinkRecord transformed = record.newRecord("transformed-topic", PARTITION_NUMBER + 1, Schema.STRING_SCHEMA, "key",
+                Schema.BOOLEAN_SCHEMA, false, KAFKA_TIMESTAMP);
+
+        assertEquals(TOPIC_NAME, transformed.originalTopic());
+        assertEquals(PARTITION_NUMBER, transformed.originalKafkaPartition());
+
+        SinkRecord transformed2 = transformed.newRecord("transformed-topic-2", PARTITION_NUMBER + 2, Schema.STRING_SCHEMA, "key",
+                Schema.BOOLEAN_SCHEMA, false, KAFKA_TIMESTAMP);
+
+        assertEquals(TOPIC_NAME, transformed2.originalTopic());
+        assertEquals(PARTITION_NUMBER, transformed2.originalKafkaPartition());
+    }
+
+    @Test
+    public void shouldRetainOriginalTopicPartitionWithOlderConstructor() {
+        SinkRecord record = new SinkRecord(TOPIC_NAME, PARTITION_NUMBER, Schema.STRING_SCHEMA, "key", Schema.BOOLEAN_SCHEMA,
+                false, KAFKA_OFFSET, KAFKA_TIMESTAMP, TS_TYPE, null);
         SinkRecord transformed = record.newRecord("transformed-topic", PARTITION_NUMBER + 1, Schema.STRING_SCHEMA, "key",
                 Schema.BOOLEAN_SCHEMA, false, KAFKA_TIMESTAMP);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/InternalSinkRecord.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/InternalSinkRecord.java
@@ -17,9 +17,6 @@
 package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.record.TimestampType;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 /**
@@ -33,25 +30,10 @@ public class InternalSinkRecord extends SinkRecord {
 
     public InternalSinkRecord(ConsumerRecord<byte[], byte[]> originalRecord, SinkRecord record) {
         super(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(),
-            record.valueSchema(), record.value(), record.kafkaOffset(), record.timestamp(),
-            record.timestampType(), record.headers());
+                record.valueSchema(), record.value(), record.kafkaOffset(), record.timestamp(),
+                record.timestampType(), record.headers(), originalRecord.topic(), originalRecord.partition(),
+                originalRecord.offset());
         this.originalRecord = originalRecord;
-    }
-
-    protected InternalSinkRecord(ConsumerRecord<byte[], byte[]> originalRecord, String topic,
-                                 int partition, Schema keySchema, Object key, Schema valueSchema,
-                                 Object value, long kafkaOffset, Long timestamp,
-                                 TimestampType timestampType, Iterable<Header> headers) {
-        super(topic, partition, keySchema, key, valueSchema, value, kafkaOffset, timestamp, timestampType, headers);
-        this.originalRecord = originalRecord;
-    }
-
-    @Override
-    public SinkRecord newRecord(String topic, Integer kafkaPartition, Schema keySchema, Object key,
-                                Schema valueSchema, Object value, Long timestamp,
-                                Iterable<Header> headers) {
-        return new InternalSinkRecord(originalRecord, topic, kafkaPartition, keySchema, key,
-            valueSchema, value, kafkaOffset(), timestamp, timestampType(), headers);
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/InternalSinkRecord.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/InternalSinkRecord.java
@@ -17,6 +17,9 @@
 package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 /**
@@ -34,6 +37,23 @@ public class InternalSinkRecord extends SinkRecord {
                 record.timestampType(), record.headers(), originalRecord.topic(), originalRecord.partition(),
                 originalRecord.offset());
         this.originalRecord = originalRecord;
+    }
+
+    protected InternalSinkRecord(ConsumerRecord<byte[], byte[]> originalRecord, String topic,
+                                 int partition, Schema keySchema, Object key, Schema valueSchema,
+                                 Object value, long kafkaOffset, Long timestamp,
+                                 TimestampType timestampType, Iterable<Header> headers) {
+        super(topic, partition, keySchema, key, valueSchema, value, kafkaOffset, timestamp, timestampType, headers,
+                originalRecord.topic(), originalRecord.partition(), originalRecord.offset());
+        this.originalRecord = originalRecord;
+    }
+
+    @Override
+    public SinkRecord newRecord(String topic, Integer kafkaPartition, Schema keySchema, Object key,
+                                Schema valueSchema, Object value, Long timestamp,
+                                Iterable<Header> headers) {
+        return new InternalSinkRecord(originalRecord, topic, kafkaPartition, keySchema, key,
+                valueSchema, value, kafkaOffset(), timestamp, timestampType(), headers);
     }
 
     @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/InternalSinkRecordTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/InternalSinkRecordTest.java
@@ -29,16 +29,33 @@ import static org.mockito.Mockito.mock;
 
 public class InternalSinkRecordTest {
 
+    private static final String TOPIC = "test-topic";
+
     @Test
     public void testNewRecordHeaders() {
-        SinkRecord sinkRecord = new SinkRecord("test-topic", 0, null, null, null, null, 10);
+        SinkRecord sinkRecord = new SinkRecord(TOPIC, 0, null, null, null, null, 10);
         ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>("test-topic", 0, 10, null, null);
         InternalSinkRecord internalSinkRecord = new InternalSinkRecord(consumerRecord, sinkRecord);
         assertTrue(internalSinkRecord.headers().isEmpty());
         assertTrue(sinkRecord.headers().isEmpty());
 
-        SinkRecord newRecord = internalSinkRecord.newRecord("test-topic", 0, null, null, null,
+        SinkRecord newRecord = internalSinkRecord.newRecord(TOPIC, 0, null, null, null,
                 null, null, Collections.singletonList(mock(Header.class)));
         assertEquals(1, newRecord.headers().size());
+    }
+
+    @Test
+    public void shouldRetainOriginalTopicPartition() {
+        String transformedTopic = "transformed-test-topic";
+        SinkRecord sinkRecord = new SinkRecord(transformedTopic, 0, null, null, null, null, 10);
+        ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>(TOPIC, 0, 10, null, null);
+        InternalSinkRecord internalSinkRecord = new InternalSinkRecord(consumerRecord, sinkRecord);
+
+        assertEquals(TOPIC, internalSinkRecord.originalTopic());
+        assertEquals(0, internalSinkRecord.originalKafkaPartition().intValue());
+
+        SinkRecord transformedSinkRecord = internalSinkRecord.newRecord(transformedTopic, 1, null, null, null, null, null);
+        assertEquals(TOPIC, transformedSinkRecord.originalTopic());
+        assertEquals(0, transformedSinkRecord.originalKafkaPartition().intValue());
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
@@ -189,7 +189,7 @@ public class WorkerSinkTaskThreadedTest {
                 SinkRecord referenceSinkRecord
                         = new SinkRecord(TOPIC, PARTITION, KEY_SCHEMA, KEY, VALUE_SCHEMA, VALUE, FIRST_OFFSET + offset, TIMESTAMP, TIMESTAMP_TYPE);
                 InternalSinkRecord referenceInternalSinkRecord =
-                    new InternalSinkRecord(null, referenceSinkRecord);
+                    new InternalSinkRecord(new ConsumerRecord<>(TOPIC, PARTITION, FIRST_OFFSET + offset, null, null), referenceSinkRecord);
                 assertEquals(referenceInternalSinkRecord, rec);
                 offset++;
             }


### PR DESCRIPTION
- https://cwiki.apache.org/confluence/display/KAFKA/KIP-793%3A+Allow+sink+connectors+to+be+used+with+topic-mutating+SMTs
- https://issues.apache.org/jira/browse/KAFKA-13431

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
