### PR TITLE
KAFKA-15193: Allow choosing Platform specific rocksDBJNI jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,11 @@ ext {
       "--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED"
     )
 
+  useRocksDbRuntime =  project.hasProperty('useRocksDbRuntime') ? useRocksDbRuntime : ''
+  rocksDbRuntimeValues = ["<empty>", "linux32", "linux64", "osx", "win64"]
+  if (!rocksDbRuntimeValues.contains(useRocksDbRuntime))
+    throw new GradleException("Unexpected value for useRocksDbRuntime property. Expected one of $rocksDbRuntimeValues), but received: $useRocksDbRuntime")
+	
   maxTestForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : Runtime.runtime.availableProcessors()
   maxScalacThreads = project.hasProperty('maxScalacThreads') ? maxScalacThreads.toInteger() :
       Math.min(Runtime.runtime.availableProcessors(), 8)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,11 +70,6 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16))
 else
   easymockVersion = "4.3"
 
-def useRocksDbRuntime =  project.hasProperty('useRocksDbRuntime') ? useRocksDbRuntime : ''
-def rocksDbRuntimeValues = ["<empty>", "linux32", "linux64", "osx", "win64"]
-if (!rocksDbRuntimeValues.contains(useRocksDbRuntime))
-  throw new GradleException("Unexpected value for useRocksDbRuntime property. Expected one of $rocksDbRuntimeValues), but received: $useRocksDbRuntime")
-
 // When adding, removing or updating dependencies, please also update the LICENSE-binary file accordingly.
 // See https://issues.apache.org/jira/browse/KAFKA-12622 for steps to verify the LICENSE-binary file is correct.
 versions += [
@@ -235,7 +230,7 @@ libs += [
   powermockJunit4: "org.powermock:powermock-module-junit4:$versions.powermock",
   powermockEasymock: "org.powermock:powermock-api-easymock:$versions.powermock",
   reflections: "org.reflections:reflections:$versions.reflections",
-  rocksDBJni: "org.rocksdb:rocksdbjni:$versions.rocksDB:${useRocksDbRuntime}",
+  rocksDBJni: "org.rocksdb:rocksdbjni:$versions.rocksDB:${project.useRocksDbRuntime}",
   scalaCollectionCompat: "org.scala-lang.modules:scala-collection-compat_$versions.baseScala:$versions.scalaCollectionCompat",
   scalaJava8Compat: "org.scala-lang.modules:scala-java8-compat_$versions.baseScala:$versions.scalaJava8Compat",
   scalaLibrary: "org.scala-lang:scala-library:$versions.scala",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,6 +70,11 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16))
 else
   easymockVersion = "4.3"
 
+def useRocksDbRuntime =  project.hasProperty('useRocksDbRuntime') ? useRocksDbRuntime : ''
+def rocksDbRuntimeValues = ["<empty>", "linux32", "linux64", "osx", "win64"]
+if (!rocksDbRuntimeValues.contains(useRocksDbRuntime))
+  throw new GradleException("Unexpected value for useRocksDbRuntime property. Expected one of $rocksDbRuntimeValues), but received: $useRocksDbRuntime")
+
 // When adding, removing or updating dependencies, please also update the LICENSE-binary file accordingly.
 // See https://issues.apache.org/jira/browse/KAFKA-12622 for steps to verify the LICENSE-binary file is correct.
 versions += [
@@ -230,7 +235,7 @@ libs += [
   powermockJunit4: "org.powermock:powermock-module-junit4:$versions.powermock",
   powermockEasymock: "org.powermock:powermock-api-easymock:$versions.powermock",
   reflections: "org.reflections:reflections:$versions.reflections",
-  rocksDBJni: "org.rocksdb:rocksdbjni:$versions.rocksDB",
+  rocksDBJni: "org.rocksdb:rocksdbjni:$versions.rocksDB:${useRocksDbRuntime}",
   scalaCollectionCompat: "org.scala-lang.modules:scala-collection-compat_$versions.baseScala:$versions.scalaCollectionCompat",
   scalaJava8Compat: "org.scala-lang.modules:scala-java8-compat_$versions.baseScala:$versions.scalaJava8Compat",
   scalaLibrary: "org.scala-lang:scala-library:$versions.scala",


### PR DESCRIPTION
*Allow Build with Platform-specific rocksDBJNI jar. 
The Fat jar is close to 60 MB in size while the platform-specific ones are much smaller.  This PR allows the user to choose the platform for RocksDB jar with build arguments. The default is still to use the uber jar since we want to be platform-independent by default.  
The overall RPM size reduces drastically if we use this option. This is only a build optimization PR and does not introduce any new functionality in Kafka itself.
https://issues.apache.org/jira/browse/KAFKA-15193*


Testing - 
*Test Builds with -PuseRocksDbRuntime="<platform>" and ensure that the correct RocksDB jar gets picked up. Fail builds if an incorrect/unsupported platform is specified. With no option is chosen or without this argument, the default (fat) jar should be picked up*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
