### PR TITLE
KAFKA-10579: Upgrade reflections from 0.9.12 to 0.10.2

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -251,6 +251,7 @@ netty-transport-classes-epoll-4.1.94.Final
 netty-transport-native-epoll-4.1.94.Final
 netty-transport-native-unix-common-4.1.94.Final
 plexus-utils-3.3.0
+reflections-0.10.2
 reload4j-1.2.25
 rocksdbjni-7.1.2
 scala-collection-compat_2.13-2.10.0
@@ -329,4 +330,4 @@ paranamer-2.8, see: licenses/paranamer-BSD-3-clause
 Do What The F*ck You Want To Public License
 see: licenses/DWTFYWTPL
 
-reflections-0.9.12
+reflections-0.10.2

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -131,7 +131,7 @@ versions += [
   netty: "4.1.94.Final",
   pcollections: "4.0.1",
   powermock: "2.0.9",
-  reflections: "0.9.12",
+  reflections: "0.10.2",
   reload4j: "1.2.25",
   rocksDB: "7.1.2",
   scalaCollectionCompat: "2.10.0",


### PR DESCRIPTION
The prior version of Reflections had two bugs:

1. Errors were propagated differently with parallel execution, which was already locally patched with InternalReflections.
2. An internal data structure had a data race, that requires synchronization.

Both of the above were patched upstream and are included in 0.10.2. This is an alternative to #14020 where we patch it ourselves and keep the old version. Some of the syntax has changed, so adjust the call-sites to accommodate this.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
