### PR TITLE
KAFKA-15022: [3/N] use graph to compute rack aware assignment for active stateful tasks

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -92,7 +92,7 @@
               files="(AbstractRequest|AbstractResponse|KerberosLogin|WorkerSinkTaskTest|TransactionManagerTest|SenderTest|KafkaAdminClient|ConsumerCoordinatorTest|KafkaAdminClientTest|KafkaRaftClientTest).java"/>
 
     <suppress checks="NPathComplexity"
-              files="(ConsumerCoordinator|BufferPool|MetricName|Node|ConfigDef|RecordBatch|SslFactory|SslTransportLayer|MetadataResponse|KerberosLogin|Selector|Sender|Serdes|TokenInformation|Agent|Values|PluginUtils|MiniTrogdorCluster|TasksRequest|KafkaProducer|AbstractStickyAssignor|KafkaRaftClient|Authorizer|FetchSessionHandler).java"/>
+              files="(ConsumerCoordinator|BufferPool|MetricName|Node|ConfigDef|RecordBatch|SslFactory|SslTransportLayer|MetadataResponse|KerberosLogin|Selector|Sender|Serdes|TokenInformation|Agent|Values|PluginUtils|MiniTrogdorCluster|TasksRequest|KafkaProducer|AbstractStickyAssignor|KafkaRaftClient|Authorizer|FetchSessionHandler|RackAwareTaskAssignor).java"/>
 
     <suppress checks="(JavaNCSS|CyclomaticComplexity|MethodLength)"
               files="CoordinatorClient.java"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -92,7 +92,7 @@
               files="(AbstractRequest|AbstractResponse|KerberosLogin|WorkerSinkTaskTest|TransactionManagerTest|SenderTest|KafkaAdminClient|ConsumerCoordinatorTest|KafkaAdminClientTest|KafkaRaftClientTest).java"/>
 
     <suppress checks="NPathComplexity"
-              files="(ConsumerCoordinator|BufferPool|MetricName|Node|ConfigDef|RecordBatch|SslFactory|SslTransportLayer|MetadataResponse|KerberosLogin|Selector|Sender|Serdes|TokenInformation|Agent|Values|PluginUtils|MiniTrogdorCluster|TasksRequest|KafkaProducer|AbstractStickyAssignor|KafkaRaftClient|Authorizer|FetchSessionHandler|RackAwareTaskAssignor).java"/>
+              files="(ConsumerCoordinator|BufferPool|MetricName|Node|ConfigDef|RecordBatch|SslFactory|SslTransportLayer|MetadataResponse|KerberosLogin|Selector|Sender|Serdes|TokenInformation|Agent|Values|PluginUtils|MiniTrogdorCluster|TasksRequest|KafkaProducer|AbstractStickyAssignor|KafkaRaftClient|Authorizer|FetchSessionHandler).java"/>
 
     <suppress checks="(JavaNCSS|CyclomaticComplexity|MethodLength)"
               files="CoordinatorClient.java"/>
@@ -201,7 +201,7 @@
               files="Murmur3.java"/>
 
     <suppress checks="(NPathComplexity|CyclomaticComplexity)"
-              files="KStreamSlidingWindowAggregate.java"/>
+              files="(KStreamSlidingWindowAggregate|RackAwareTaskAssignor).java"/>
 
     <!-- suppress FinalLocalVariable outside of the streams package. -->
     <suppress checks="FinalLocalVariable"

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -267,8 +267,10 @@ public final class AssignorConfiguration {
         public final int numStandbyReplicas;
         public final long probingRebalanceIntervalMs;
         public final List<String> rackAwareAssignmentTags;
-        public final Integer trafficCost = null;
-        public final Integer nonOverlapCost = null;
+
+        // TODO: get from streamsConfig after we add the config
+        public final Integer trafficCost;
+        public final Integer nonOverlapCost;
 
         private AssignmentConfigs(final StreamsConfig configs) {
             acceptableRecoveryLag = configs.getLong(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG);
@@ -276,6 +278,9 @@ public final class AssignorConfiguration {
             numStandbyReplicas = configs.getInt(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG);
             probingRebalanceIntervalMs = configs.getLong(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG);
             rackAwareAssignmentTags = configs.getList(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG);
+            // TODO: get from streamsConfig after we add the config
+            trafficCost = null;
+            nonOverlapCost = null;
         }
 
         AssignmentConfigs(final Long acceptableRecoveryLag,
@@ -283,11 +288,24 @@ public final class AssignorConfiguration {
                           final Integer numStandbyReplicas,
                           final Long probingRebalanceIntervalMs,
                           final List<String> rackAwareAssignmentTags) {
+            this(acceptableRecoveryLag, maxWarmupReplicas, numStandbyReplicas, probingRebalanceIntervalMs, rackAwareAssignmentTags, null, null);
+        }
+
+        AssignmentConfigs(final Long acceptableRecoveryLag,
+                          final Integer maxWarmupReplicas,
+                          final Integer numStandbyReplicas,
+                          final Long probingRebalanceIntervalMs,
+                          final List<String> rackAwareAssignmentTags,
+                          final Integer trafficCost,
+                          final Integer nonOverlapCost) {
             this.acceptableRecoveryLag = validated(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, acceptableRecoveryLag);
             this.maxWarmupReplicas = validated(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, maxWarmupReplicas);
             this.numStandbyReplicas = validated(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, numStandbyReplicas);
             this.probingRebalanceIntervalMs = validated(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, probingRebalanceIntervalMs);
             this.rackAwareAssignmentTags = validated(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG, rackAwareAssignmentTags);
+            // TODO: validate after we add config
+            this.trafficCost = trafficCost;
+            this.nonOverlapCost = nonOverlapCost;
         }
 
         private static <T> T validated(final String configKey, final T value) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -267,6 +267,8 @@ public final class AssignorConfiguration {
         public final int numStandbyReplicas;
         public final long probingRebalanceIntervalMs;
         public final List<String> rackAwareAssignmentTags;
+        public Integer trafficCost;
+        public Integer nonOverlapCost;
 
         private AssignmentConfigs(final StreamsConfig configs) {
             acceptableRecoveryLag = configs.getLong(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -267,8 +267,8 @@ public final class AssignorConfiguration {
         public final int numStandbyReplicas;
         public final long probingRebalanceIntervalMs;
         public final List<String> rackAwareAssignmentTags;
-        public Integer trafficCost;
-        public Integer nonOverlapCost;
+        public final Integer trafficCost = null;
+        public final Integer nonOverlapCost = null;
 
         private AssignmentConfigs(final StreamsConfig configs) {
             acceptableRecoveryLag = configs.getLong(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -268,19 +268,12 @@ public final class AssignorConfiguration {
         public final long probingRebalanceIntervalMs;
         public final List<String> rackAwareAssignmentTags;
 
-        // TODO: get from streamsConfig after we add the config
-        public final Integer trafficCost;
-        public final Integer nonOverlapCost;
-
         private AssignmentConfigs(final StreamsConfig configs) {
             acceptableRecoveryLag = configs.getLong(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG);
             maxWarmupReplicas = configs.getInt(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG);
             numStandbyReplicas = configs.getInt(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG);
             probingRebalanceIntervalMs = configs.getLong(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG);
             rackAwareAssignmentTags = configs.getList(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG);
-            // TODO: get from streamsConfig after we add the config
-            trafficCost = null;
-            nonOverlapCost = null;
         }
 
         AssignmentConfigs(final Long acceptableRecoveryLag,
@@ -288,24 +281,11 @@ public final class AssignorConfiguration {
                           final Integer numStandbyReplicas,
                           final Long probingRebalanceIntervalMs,
                           final List<String> rackAwareAssignmentTags) {
-            this(acceptableRecoveryLag, maxWarmupReplicas, numStandbyReplicas, probingRebalanceIntervalMs, rackAwareAssignmentTags, null, null);
-        }
-
-        AssignmentConfigs(final Long acceptableRecoveryLag,
-                          final Integer maxWarmupReplicas,
-                          final Integer numStandbyReplicas,
-                          final Long probingRebalanceIntervalMs,
-                          final List<String> rackAwareAssignmentTags,
-                          final Integer trafficCost,
-                          final Integer nonOverlapCost) {
             this.acceptableRecoveryLag = validated(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, acceptableRecoveryLag);
             this.maxWarmupReplicas = validated(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, maxWarmupReplicas);
             this.numStandbyReplicas = validated(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, numStandbyReplicas);
             this.probingRebalanceIntervalMs = validated(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, probingRebalanceIntervalMs);
             this.rackAwareAssignmentTags = validated(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG, rackAwareAssignmentTags);
-            // TODO: validate after we add config
-            this.trafficCost = trafficCost;
-            this.nonOverlapCost = nonOverlapCost;
         }
 
         private static <T> T validated(final String configKey, final T value) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/Graph.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/Graph.java
@@ -146,7 +146,7 @@ public class Graph<V extends Comparable<V>> {
         for (final Map.Entry<V, SortedMap<V, Edge>> nodeEdges : adjList.entrySet()) {
             final SortedMap<V, Edge> edges = nodeEdges.getValue();
             for (final Edge nodeEdge : edges.values()) {
-                totalCost += nodeEdge.cost * nodeEdge.flow;
+                totalCost += (long) nodeEdge.cost * nodeEdge.flow;
             }
         }
         return totalCost;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/Graph.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/Graph.java
@@ -42,8 +42,12 @@ public class Graph<V extends Comparable<V>> {
             this(destination, capacity, cost, residualFlow, flow, true);
         }
 
-        public Edge(final V destination, final int capacity, final int cost, final int residualFlow, final int flow,
-            final boolean forwardEdge) {
+        public Edge(final V destination,
+                    final int capacity,
+                    final int cost,
+                    final int residualFlow,
+                    final int flow,
+                    final boolean forwardEdge) {
             Objects.requireNonNull(destination);
             if (capacity < 0) {
                 throw new IllegalArgumentException("Edge capacity cannot be negative");
@@ -72,8 +76,11 @@ public class Graph<V extends Comparable<V>> {
 
             final Graph<?>.Edge otherEdge = (Graph<?>.Edge) other;
 
-            return destination.equals(otherEdge.destination) && capacity == otherEdge.capacity
-                && cost == otherEdge.cost && residualFlow == otherEdge.residualFlow && flow == otherEdge.flow
+            return destination.equals(otherEdge.destination)
+                && capacity == otherEdge.capacity
+                && cost == otherEdge.cost
+                && residualFlow == otherEdge.residualFlow
+                && flow == otherEdge.flow
                 && forwardEdge == otherEdge.forwardEdge;
         }
 
@@ -84,8 +91,15 @@ public class Graph<V extends Comparable<V>> {
 
         @Override
         public String toString() {
-            return "{destination= " + destination + ", capacity=" + capacity + ", cost=" + cost
-                + ", residualFlow=" + residualFlow + ", flow=" + flow + ", forwardEdge=" + forwardEdge;
+            return "Edge {"
+                + "destination= " + destination
+                + ", capacity=" + capacity
+                + ", cost=" + cost
+                + ", residualFlow=" + residualFlow
+                + ", flow=" + flow
+                + ", forwardEdge=" + forwardEdge
+                + "}";
+
         }
     }
 
@@ -106,12 +120,13 @@ public class Graph<V extends Comparable<V>> {
         addEdge(u, new Edge(v, capacity, cost, capacity - flow, flow));
     }
 
-    public Set<V> nodes() {
+    public SortedSet<V> nodes() {
         return nodes;
     }
 
-    public Map<V, Edge> edges(final V node) {
-        return adjList.get(node);
+    public SortedMap<V, Edge> edges(final V node) {
+        final SortedMap<V, Edge> edge = adjList.get(node);
+        return edge == null ? new TreeMap<>() : edge;
     }
 
     public boolean isResidualGraph() {
@@ -127,11 +142,11 @@ public class Graph<V extends Comparable<V>> {
     }
 
     public long totalCost() {
-        int totalCost = 0;
+        long totalCost = 0;
         for (final Map.Entry<V, SortedMap<V, Edge>> nodeEdges : adjList.entrySet()) {
             final SortedMap<V, Edge> edges = nodeEdges.getValue();
-            for (final Entry<V, Edge> nodeEdge : edges.entrySet()) {
-                totalCost += nodeEdge.getValue().cost * nodeEdge.getValue().flow;
+            for (final Edge nodeEdge : edges.values()) {
+                totalCost += nodeEdge.cost * nodeEdge.flow;
             }
         }
         return totalCost;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/Graph.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/Graph.java
@@ -126,7 +126,7 @@ public class Graph<V extends Comparable<V>> {
         sinkNode = node;
     }
 
-    public int totalCost() {
+    public long totalCost() {
         int totalCost = 0;
         for (final Map.Entry<V, SortedMap<V, Edge>> nodeEdges : adjList.entrySet()) {
             final SortedMap<V, Edge> edges = nodeEdges.getValue();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
@@ -43,11 +43,6 @@ import org.slf4j.LoggerFactory;
 
 public class RackAwareTaskAssignor {
     private static final Logger log = LoggerFactory.getLogger(RackAwareTaskAssignor.class);
-    private static final int DEFAULT_STATEFUL_TRAFFIC_COST = 10;
-    private static final int DEFAULT_STATEFUL_NON_OVERLAP_COST = 1;
-
-    private static final int DEFAULT_STATELESS_TRAFFIC_COST = 1;
-    private static final int DEFAULT_STATELESS_NON_OVERLAP_COST = 0;
 
     private static final int SOURCE_ID = -1;
 
@@ -194,14 +189,14 @@ public class RackAwareTaskAssignor {
         return true;
     }
 
-    private int getCost(final TaskId taskId, final UUID clientId, final boolean inCurrentAssignment, final boolean isStateful) {
-        final Map<String, Optional<String>> clientRacks = racksForProcess.get(clientId);
+    private int getCost(final TaskId taskId, final UUID processId, final boolean inCurrentAssignment, final int trafficCost, final int nonOverlapCost) {
+        final Map<String, Optional<String>> clientRacks = racksForProcess.get(processId);
         if (clientRacks == null) {
-            throw new IllegalStateException("Client " + clientId + " doesn't exist in processRacks");
+            throw new IllegalStateException("Client " + processId + " doesn't exist in processRacks");
         }
         final Optional<Optional<String>> clientRackOpt = clientRacks.values().stream().filter(Optional::isPresent).findFirst();
         if (!clientRackOpt.isPresent() || !clientRackOpt.get().isPresent()) {
-            throw new IllegalStateException("Client " + clientId + " doesn't have rack configured. Maybe forgot to call canEnableRackAwareAssignor first");
+            throw new IllegalStateException("Client " + processId + " doesn't have rack configured. Maybe forgot to call canEnableRackAwareAssignor first");
         }
 
         final String clientRack = clientRackOpt.get().get();
@@ -209,11 +204,6 @@ public class RackAwareTaskAssignor {
         if (topicPartitions == null || topicPartitions.isEmpty()) {
             throw new IllegalStateException("Task " + taskId + " has no TopicPartitions");
         }
-
-        final int trafficCost = assignmentConfigs.trafficCost == null ? (isStateful ? DEFAULT_STATEFUL_TRAFFIC_COST : DEFAULT_STATELESS_TRAFFIC_COST)
-            : assignmentConfigs.trafficCost;
-        final int nonOverlapCost = assignmentConfigs.nonOverlapCost == null ? (isStateful ? DEFAULT_STATEFUL_NON_OVERLAP_COST : DEFAULT_STATELESS_NON_OVERLAP_COST)
-            : assignmentConfigs.nonOverlapCost;
 
         int cost = 0;
         for (final TopicPartition tp : topicPartitions) {
@@ -238,26 +228,33 @@ public class RackAwareTaskAssignor {
     }
 
     // For testing. canEnableRackAwareAssignor must be called first
-    long activeTasksCost(final SortedMap<UUID, ClientState> clientStates, final SortedSet<TaskId> activeTasks, final boolean isStateful) {
+    long activeTasksCost(final SortedMap<UUID, ClientState> clientStates, final SortedSet<TaskId> activeTasks, final int trafficCost, final int nonOverlapCost) {
         final List<UUID> clientList = new ArrayList<>(clientStates.keySet());
         final List<TaskId> taskIdList = new ArrayList<>(activeTasks);
-        final Map<TaskId, UUID> taskClientMap = new HashMap<>();
-        final Map<UUID, Integer> originalAssignedTaskNumber = new HashMap<>();
         final Graph<Integer> graph = constructActiveTaskGraph(activeTasks, clientList, taskIdList,
-            clientStates, taskClientMap, originalAssignedTaskNumber, isStateful);
+            clientStates, new HashMap<>(), new HashMap<>(), trafficCost, nonOverlapCost);
         return graph.totalCost();
     }
 
     /**
-     * Optimize active task assignment for rack awareness. canEnableRackAwareAssignor must be called first
+     * Optimize active task assignment for rack awareness. canEnableRackAwareAssignor must be called first.
+     * {@code trafficCost} and {@code nonOverlapCost} balance cross rack traffic optimization and task movement.
+     * If we set {@code trafficCost} to a larger number, we are more likely to compute an assignment with less
+     * cross rack traffic. However, tasks may be shuffled a lot across clients. If we set {@code nonOverlapCost}
+     * to a larger number, we are more likely to compute an assignment with similar to input assignment. However,
+     * cross rack traffic can be higher. In extreme case, if we set {@code nonOverlapCost} to 0 and @{code trafficCost}
+     * to a positive value, the computed assignment will be minimum for cross rack traffic. If we set {@code trafficCost} to 0,
+     * and {@code nonOverlapCost} to a positive value, the computed assignment should be the same as input
      * @param clientStates Client states
      * @param activeTasks Tasks to reassign if needed. They must be assigned already in clientStates
-     * @param isStateful Whether the tasks are stateful
+     * @param trafficCost Cost of cross rack traffic for each TopicPartition
+     * @param nonOverlapCost Cost of assign a task to a different client
      * @return Total cost after optimization
      */
     public long optimizeActiveTasks(final SortedMap<UUID, ClientState> clientStates,
                                     final SortedSet<TaskId> activeTasks,
-                                    final boolean isStateful) {
+                                    final int trafficCost,
+                                    final int nonOverlapCost) {
         if (activeTasks.isEmpty()) {
             return 0;
         }
@@ -267,7 +264,7 @@ public class RackAwareTaskAssignor {
         final Map<TaskId, UUID> taskClientMap = new HashMap<>();
         final Map<UUID, Integer> originalAssignedTaskNumber = new HashMap<>();
         final Graph<Integer> graph = constructActiveTaskGraph(activeTasks, clientList, taskIdList,
-            clientStates, taskClientMap, originalAssignedTaskNumber, isStateful);
+            clientStates, taskClientMap, originalAssignedTaskNumber, trafficCost, nonOverlapCost);
 
         graph.solveMinCostFlow();
         final long cost = graph.totalCost();
@@ -284,7 +281,8 @@ public class RackAwareTaskAssignor {
                                                     final Map<UUID, ClientState> clientStates,
                                                     final Map<TaskId, UUID> taskClientMap,
                                                     final Map<UUID, Integer> originalAssignedTaskNumber,
-                                                    final boolean isStateful) {
+                                                    final int trafficCost,
+                                                    final int nonOverlapCost) {
         final Graph<Integer> graph = new Graph<>();
 
         for (final TaskId taskId : activeTasks) {
@@ -296,20 +294,20 @@ public class RackAwareTaskAssignor {
         }
 
         // Make task and client Node id in graph deterministic
-        for (int taskNodeId  = 0; taskNodeId < taskIdList.size(); taskNodeId++) {
+        for (int taskNodeId = 0; taskNodeId < taskIdList.size(); taskNodeId++) {
             final TaskId taskId = taskIdList.get(taskNodeId);
             for (int j = 0; j < clientList.size(); j++) {
                 final int clientNodeId = taskIdList.size() + j;
-                final UUID clientId = clientList.get(j);
+                final UUID processId = clientList.get(j);
 
-                final int flow = clientStates.get(clientId).hasAssignedTask(taskId) ? 1 : 0;
-                final int cost = getCost(taskId, clientId, flow == 1, isStateful);
+                final int flow = clientStates.get(processId).hasAssignedTask(taskId) ? 1 : 0;
+                final int cost = getCost(taskId, processId, flow == 1, trafficCost, nonOverlapCost);
                 if (flow == 1) {
                     if (taskClientMap.containsKey(taskId)) {
                         throw new IllegalArgumentException("Task " + taskId + " assigned to multiple clients "
-                            + clientId + ", " + taskClientMap.get(taskId));
+                            + processId + ", " + taskClientMap.get(taskId));
                     }
-                    taskClientMap.put(taskId, clientId);
+                    taskClientMap.put(taskId, processId);
                 }
 
                 graph.addEdge(taskNodeId, clientNodeId, 1, cost, flow);
@@ -325,7 +323,7 @@ public class RackAwareTaskAssignor {
         }
 
         // It's possible that some clients have 0 task assign. These clients will have 0 tasks assigned
-        // even though it may have lower traffic cost. This is to maintain the balance requirement.
+        // even though it may have higher traffic cost. This is to maintain the original assigned task count
         for (int i = 0; i < clientList.size(); i++) {
             final int clientNodeId = taskIdList.size() + i;
             final int capacity = originalAssignedTaskNumber.getOrDefault(clientList.get(i), 0);
@@ -344,56 +342,54 @@ public class RackAwareTaskAssignor {
                                                  final List<UUID> clientList,
                                                  final List<TaskId> taskIdList,
                                                  final Map<UUID, ClientState> clientStates,
-                                                 final Map<UUID, Integer> originalClientCapacity,
+                                                 final Map<UUID, Integer> originalAssignedTaskNumber,
                                                  final Map<TaskId, UUID> taskClientMap) {
-        int taskAssigned = 0;
+        int tasksAssigned = 0;
         for (int taskNodeId = 0; taskNodeId < taskIdList.size(); taskNodeId++) {
             final TaskId taskId = taskIdList.get(taskNodeId);
             final Map<Integer, Graph<Integer>.Edge> edges = graph.edges(taskNodeId);
             for (final Graph<Integer>.Edge edge : edges.values()) {
                 if (edge.flow > 0) {
-                    taskAssigned++;
+                    tasksAssigned++;
                     final int clientIndex = edge.destination - taskIdList.size();
-                    final UUID clientId = clientList.get(clientIndex);
-                    final UUID originalClientId = taskClientMap.get(taskId);
+                    final UUID processId = clientList.get(clientIndex);
+                    final UUID originalProcessId = taskClientMap.get(taskId);
 
                     // Don't need to assign this task to other client
-                    if (clientId.equals(originalClientId)) {
+                    if (processId.equals(originalProcessId)) {
                         break;
                     }
 
-                    final ClientState clientState = clientStates.get(clientId);
-                    final ClientState originalClientState = clientStates.get(originalClientId);
-                    originalClientState.unassignActive(taskId);
-                    clientState.assignActive(taskId);
+                    clientStates.get(originalProcessId).unassignActive(taskId);
+                    clientStates.get(processId).assignActive(taskId);
                 }
             }
         }
 
         // Validate task assigned
-        if (taskAssigned != activeTasks.size()) {
+        if (tasksAssigned != activeTasks.size()) {
             throw new IllegalStateException("Computed active task assignment number "
-                + taskAssigned + " is different size " + activeTasks.size());
+                + tasksAssigned + " is different size " + activeTasks.size());
         }
 
-        // Validate capacity constraint
-        final Map<UUID, Integer> clientCapacity = new HashMap<>();
+        // Validate original assigned task number matches
+        final Map<UUID, Integer> assignedTaskNumber = new HashMap<>();
         for (final TaskId taskId : activeTasks) {
             for (final Entry<UUID, ClientState> clientState : clientStates.entrySet()) {
                 if (clientState.getValue().hasAssignedTask(taskId)) {
-                    clientCapacity.merge(clientState.getKey(), 1, Integer::sum);
+                    assignedTaskNumber.merge(clientState.getKey(), 1, Integer::sum);
                 }
             }
         }
 
-        if (originalClientCapacity.size() != clientCapacity.size()) {
-            throw new IllegalStateException("There are " + originalClientCapacity.size() + " clients have "
-                + " active tasks before assignment, but " + clientCapacity.size() + " clients have"
+        if (originalAssignedTaskNumber.size() != assignedTaskNumber.size()) {
+            throw new IllegalStateException("There are " + originalAssignedTaskNumber.size() + " clients have "
+                + " active tasks before assignment, but " + assignedTaskNumber.size() + " clients have"
                 + " active tasks after assignment");
         }
 
-        for (final Entry<UUID, Integer> originalCapacity : originalClientCapacity.entrySet()) {
-            final int capacity = clientCapacity.getOrDefault(originalCapacity.getKey(), 0);
+        for (final Entry<UUID, Integer> originalCapacity : originalAssignedTaskNumber.entrySet()) {
+            final int capacity = assignedTaskNumber.getOrDefault(originalCapacity.getKey(), 0);
             if (!Objects.equals(originalCapacity.getValue(), capacity)) {
                 throw new IllegalStateException("There are " + originalCapacity.getValue() + " tasks assigned to"
                     + " client " + originalCapacity.getKey() + " before assignment, but " + capacity + " tasks "

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
@@ -338,7 +338,7 @@ public class RackAwareTaskAssignor {
 
         // Special case: if we have more clients than tasks. Each client can have 1 task assigned potentially
         // So in this case, all clients should have capacity 1
-        final boolean allUnitCapacity = (maxCapacity == 1 && minCapacity == 0);
+        final boolean allUnitCapacity = maxCapacity == 1 && minCapacity == 0;
         if (minCapacity == 0 && maxCapacity > 1) {
             log.warn("Unbalanced assignment to compute. Some clients have 0 tasks while other "
                 + "clients have more than 1 tasks assigned");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -22,6 +22,8 @@ import java.util.List;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.streams.processor.TaskId;
@@ -69,12 +71,25 @@ public final class AssignmentTestUtils {
     public static final UUID UUID_8 = uuidForInt(8);
     public static final UUID UUID_9 = uuidForInt(9);
 
-    public static final TopicPartition TP_0_0 = new TopicPartition("topic0", 0);
-    public static final TopicPartition TP_0_1 = new TopicPartition("topic0", 1);
-    public static final TopicPartition TP_0_2 = new TopicPartition("topic0", 2);
-    public static final TopicPartition TP_1_0 = new TopicPartition("topic1", 0);
-    public static final TopicPartition TP_1_1 = new TopicPartition("topic1", 1);
-    public static final TopicPartition TP_1_2 = new TopicPartition("topic1", 2);
+    public static final Node NODE_0 = new Node(0, "node0", 1, "rack1");
+    public static final Node NODE_1 = new Node(1, "node1", 1, "rack2");
+    public static final Node NODE_2 = new Node(2, "node2", 1, "rack3");
+    public static final Node NO_RACK_NODE = new Node(3, "node3", 1);
+    public static final Node[] REPLICA_1 = new Node[] {NODE_0, NODE_1};
+    public static final Node[] REPLICA_2 = new Node[] {NODE_1, NODE_2};
+
+    public static final String TP_0_NAME = "topic0";
+    public static final String TP_1_NAME = "topic1";
+
+    public static final TopicPartition TP_0_0 = new TopicPartition(TP_0_NAME, 0);
+    public static final TopicPartition TP_0_1 = new TopicPartition(TP_0_NAME, 1);
+    public static final TopicPartition TP_0_2 = new TopicPartition(TP_0_NAME, 2);
+    public static final TopicPartition TP_1_0 = new TopicPartition(TP_1_NAME, 0);
+    public static final TopicPartition TP_1_1 = new TopicPartition(TP_1_NAME, 1);
+    public static final TopicPartition TP_1_2 = new TopicPartition(TP_1_NAME, 2);
+
+    public static final PartitionInfo PI_0_0 = new PartitionInfo(TP_0_NAME, 0, NODE_0, REPLICA_1, REPLICA_1);
+    public static final PartitionInfo PI_0_1 = new PartitionInfo(TP_0_NAME, 1, NODE_1, REPLICA_2, REPLICA_2);
 
     public static final TaskId TASK_0_0 = new TaskId(0, 0);
     public static final TaskId TASK_0_1 = new TaskId(0, 1);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -71,12 +71,22 @@ public final class AssignmentTestUtils {
     public static final UUID UUID_8 = uuidForInt(8);
     public static final UUID UUID_9 = uuidForInt(9);
 
-    public static final Node NODE_0 = new Node(0, "node0", 1, "rack1");
-    public static final Node NODE_1 = new Node(1, "node1", 1, "rack2");
-    public static final Node NODE_2 = new Node(2, "node2", 1, "rack3");
+    public static final String RACK_0 = "rock0";
+    public static final String RACK_1 = "rock1";
+    public static final String RACK_2 = "rock2";
+    public static final String RACK_3 = "rock3";
+    public static final String RACK_4 = "rock4";
+
+    public static final Node NODE_0 = new Node(0, "node0", 1, RACK_0);
+    public static final Node NODE_1 = new Node(1, "node1", 1, RACK_1);
+    public static final Node NODE_2 = new Node(2, "node2", 1, RACK_2);
+    public static final Node NODE_3 = new Node(2, "node2", 1, RACK_3);
     public static final Node NO_RACK_NODE = new Node(3, "node3", 1);
-    public static final Node[] REPLICA_1 = new Node[] {NODE_0, NODE_1};
-    public static final Node[] REPLICA_2 = new Node[] {NODE_1, NODE_2};
+
+    public static final Node[] REPLICA_0 = new Node[] {NODE_0, NODE_1};
+    public static final Node[] REPLICA_1 = new Node[] {NODE_1, NODE_2};
+    public static final Node[] REPLICA_2 = new Node[] {NODE_0, NODE_2};
+    public static final Node[] REPLICA_3 = new Node[] {NODE_1, NODE_3};
 
     public static final String TP_0_NAME = "topic0";
     public static final String TP_1_NAME = "topic1";
@@ -88,8 +98,10 @@ public final class AssignmentTestUtils {
     public static final TopicPartition TP_1_1 = new TopicPartition(TP_1_NAME, 1);
     public static final TopicPartition TP_1_2 = new TopicPartition(TP_1_NAME, 2);
 
-    public static final PartitionInfo PI_0_0 = new PartitionInfo(TP_0_NAME, 0, NODE_0, REPLICA_1, REPLICA_1);
-    public static final PartitionInfo PI_0_1 = new PartitionInfo(TP_0_NAME, 1, NODE_1, REPLICA_2, REPLICA_2);
+    public static final PartitionInfo PI_0_0 = new PartitionInfo(TP_0_NAME, 0, NODE_0, REPLICA_0, REPLICA_0);
+    public static final PartitionInfo PI_0_1 = new PartitionInfo(TP_0_NAME, 1, NODE_1, REPLICA_1, REPLICA_1);
+    public static final PartitionInfo PI_1_0 = new PartitionInfo(TP_1_NAME, 0, NODE_2, REPLICA_2, REPLICA_2);
+    public static final PartitionInfo PI_1_1 = new PartitionInfo(TP_1_NAME, 1, NODE_3, REPLICA_3, REPLICA_3);
 
     public static final TaskId TASK_0_0 = new TaskId(0, 0);
     public static final TaskId TASK_0_1 = new TaskId(0, 1);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -102,6 +102,7 @@ public final class AssignmentTestUtils {
     public static final PartitionInfo PI_0_1 = new PartitionInfo(TP_0_NAME, 1, NODE_1, REPLICA_1, REPLICA_1);
     public static final PartitionInfo PI_1_0 = new PartitionInfo(TP_1_NAME, 0, NODE_2, REPLICA_2, REPLICA_2);
     public static final PartitionInfo PI_1_1 = new PartitionInfo(TP_1_NAME, 1, NODE_3, REPLICA_3, REPLICA_3);
+    public static final PartitionInfo PI_1_2 = new PartitionInfo(TP_1_NAME, 2, NODE_0, REPLICA_0, REPLICA_0);
 
     public static final TaskId TASK_0_0 = new TaskId(0, 0);
     public static final TaskId TASK_0_1 = new TaskId(0, 1);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/GraphTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/GraphTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -48,19 +47,19 @@ public class GraphTest {
         graph.addEdge(0, 3, 1, 1, 0);
         graph.addEdge(2, 1, 1, 1, 0);
         graph.addEdge(2, 3, 1, 2, 1);
-        graph.addEdge(4, 0, 1, 0, 1);
-        graph.addEdge(4, 2, 1, 0, 1);
-        graph.addEdge(1, 5, 1, 0, 1);
-        graph.addEdge(3, 5, 1, 0, 1);
-        graph.setSourceNode(4);
-        graph.setSinkNode(5);
+        graph.addEdge(-1, 0, 1, 0, 1);
+        graph.addEdge(-1, 2, 1, 0, 1);
+        graph.addEdge(1, 99, 1, 0, 1);
+        graph.addEdge(3, 99, 1, 0, 1);
+        graph.setSourceNode(-1);
+        graph.setSinkNode(99);
     }
 
     @Test
     public void testBasic() {
         final Set<Integer> nodes = graph.nodes();
         assertEquals(6, nodes.size());
-        assertThat(nodes, contains(0, 1, 2, 3, 4, 5));
+        assertThat(nodes, contains(-1, 0, 1, 2, 3, 99));
 
         Map<Integer, Graph<Integer>.Edge> edges = graph.edges(0);
         assertEquals(2, edges.size());
@@ -74,19 +73,19 @@ public class GraphTest {
 
         edges = graph.edges(1);
         assertEquals(1, edges.size());
-        assertEquals(getEdge(5, 1, 0, 0, 1), edges.get(5));
+        assertEquals(getEdge(99, 1, 0, 0, 1), edges.get(99));
 
         edges = graph.edges(3);
         assertEquals(1, edges.size());
-        assertEquals(getEdge(5, 1, 0, 0, 1), edges.get(5));
+        assertEquals(getEdge(99, 1, 0, 0, 1), edges.get(99));
 
-        edges = graph.edges(4);
+        edges = graph.edges(-1);
         assertEquals(2, edges.size());
         assertEquals(getEdge(0, 1, 0, 0, 1), edges.get(0));
         assertEquals(getEdge(2, 1, 0, 0, 1), edges.get(2));
 
-        edges = graph.edges(5);
-        assertNull(edges);
+        edges = graph.edges(99);
+        assertTrue(edges.isEmpty());
 
         assertFalse(graph.isResidualGraph());
     }
@@ -99,31 +98,31 @@ public class GraphTest {
 
         final Set<Integer> nodes = residualGraph.nodes();
         assertEquals(6, nodes.size());
-        assertThat(nodes, contains(0, 1, 2, 3, 4, 5));
+        assertThat(nodes, contains(-1, 0, 1, 2, 3, 99));
 
         Map<Integer, Graph<Integer>.Edge> edges = residualGraph.edges(0);
         assertEquals(3, edges.size());
         assertEquals(getEdge(1, 1, 3, 0, 1), edges.get(1));
         assertEquals(getEdge(3, 1, 1, 1, 0), edges.get(3));
-        assertEquals(getEdge(4, 1, 0, 1, 0, false), edges.get(4));
+        assertEquals(getEdge(-1, 1, 0, 1, 0, false), edges.get(-1));
 
         edges = residualGraph.edges(2);
         assertEquals(3, edges.size());
         assertEquals(getEdge(1, 1, 1, 1, 0), edges.get(1));
         assertEquals(getEdge(3, 1, 2, 0, 1), edges.get(3));
-        assertEquals(getEdge(4, 1, 0, 1, 0, false), edges.get(4));
+        assertEquals(getEdge(-1, 1, 0, 1, 0, false), edges.get(-1));
 
         edges = residualGraph.edges(1);
         assertEquals(3, edges.size());
         assertEquals(getEdge(0, 1, -3, 1, 0, false), edges.get(0));
         assertEquals(getEdge(2, 1, -1, 0, 0, false), edges.get(2));
-        assertEquals(getEdge(5, 1, 0, 0, 1), edges.get(5));
+        assertEquals(getEdge(99, 1, 0, 0, 1), edges.get(99));
 
         edges = residualGraph.edges(3);
         assertEquals(3, edges.size());
         assertEquals(getEdge(0, 1, -1, 0, 0, false), edges.get(0));
         assertEquals(getEdge(2, 1, -2, 1, 0, false), edges.get(2));
-        assertEquals(getEdge(5, 1, 0, 0, 1), edges.get(5));
+        assertEquals(getEdge(99, 1, 0, 0, 1), edges.get(99));
 
         assertTrue(residualGraph.isResidualGraph());
     }
@@ -288,8 +287,8 @@ public class GraphTest {
     public void testMinCostDetectNodeNotInNegativeCycle() {
         final Graph<Integer> graph1 = new Graph<>();
 
-        graph1.addEdge(5, 0, 1, 0, 1);
-        graph1.addEdge(5, 1, 1, 0, 1);
+        graph1.addEdge(-1, 0, 1, 0, 1);
+        graph1.addEdge(-1, 1, 1, 0, 1);
 
         graph1.addEdge(0, 2, 1, 1, 0);
         graph1.addEdge(0, 3, 1, 1, 0);
@@ -299,12 +298,12 @@ public class GraphTest {
         graph1.addEdge(1, 3, 1, 10, 1);
         graph1.addEdge(1, 4, 1, 1, 0);
 
-        graph1.addEdge(2, 6, 0, 0, 0);
-        graph1.addEdge(3, 6, 1, 0, 1);
-        graph1.addEdge(4, 6, 1, 0, 1);
+        graph1.addEdge(2, 99, 0, 0, 0);
+        graph1.addEdge(3, 99, 1, 0, 1);
+        graph1.addEdge(4, 99, 1, 0, 1);
 
-        graph1.setSourceNode(5);
-        graph1.setSinkNode(6);
+        graph1.setSourceNode(-1);
+        graph1.setSinkNode(99);
 
         assertEquals(20, graph1.totalCost());
 
@@ -313,7 +312,7 @@ public class GraphTest {
         graph1.solveMinCostFlow();
         assertEquals(2, graph1.totalCost());
 
-        Map<Integer, Graph<Integer>.Edge> edges = graph1.edges(5);
+        Map<Integer, Graph<Integer>.Edge> edges = graph1.edges(-1);
         assertEquals(getEdge(0, 1, 0, 0, 1), edges.get(0));
         assertEquals(getEdge(1, 1, 0, 0, 1), edges.get(1));
 
@@ -328,13 +327,13 @@ public class GraphTest {
         assertEquals(getEdge(4, 1, 1, 0, 1), edges.get(4));
 
         edges = graph1.edges(2);
-        assertEquals(getEdge(6, 0, 0, 0, 0), edges.get(6));
+        assertEquals(getEdge(99, 0, 0, 0, 0), edges.get(99));
 
         edges = graph1.edges(3);
-        assertEquals(getEdge(6, 1, 0, 0, 1), edges.get(6));
+        assertEquals(getEdge(99, 1, 0, 0, 1), edges.get(99));
 
         edges = graph1.edges(4);
-        assertEquals(getEdge(6, 1, 0, 0, 1), edges.get(6));
+        assertEquals(getEdge(99, 1, 0, 0, 1), edges.get(99));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
@@ -110,7 +110,7 @@ public class RackAwareTaskAssignorTest {
         );
 
         // False since partitionWithoutInfo10 is missing in cluster metadata
-        assertFalse(assignor.canEnableRackAwareAssignorForActiveTasks());
+        assertFalse(assignor.canEnableRackAwareAssignor());
         assertFalse(assignor.populateTopicsToDiscribe(new HashSet<>()));
         assertTrue(assignor.validateClientRack());
     }
@@ -129,7 +129,7 @@ public class RackAwareTaskAssignorTest {
         assertTrue(assignor.validateClientRack());
         assertFalse(assignor.populateTopicsToDiscribe(new HashSet<>()));
         // False since nodeMissingRack has one node which doesn't have rack
-        assertFalse(assignor.canEnableRackAwareAssignorForActiveTasks());
+        assertFalse(assignor.canEnableRackAwareAssignor());
     }
 
     @Test
@@ -145,7 +145,7 @@ public class RackAwareTaskAssignorTest {
 
         // False since process1 doesn't have rackId
         assertFalse(assignor.validateClientRack());
-        assertFalse(assignor.canEnableRackAwareAssignorForActiveTasks());
+        assertFalse(assignor.canEnableRackAwareAssignor());
     }
 
     @Test
@@ -167,7 +167,7 @@ public class RackAwareTaskAssignorTest {
         );
 
         assertFalse(assignor.validateClientRack());
-        assertFalse(assignor.canEnableRackAwareAssignorForActiveTasks());
+        assertFalse(assignor.canEnableRackAwareAssignor());
     }
 
     @Test
@@ -182,7 +182,7 @@ public class RackAwareTaskAssignorTest {
         );
 
         // partitionWithoutInfo00 has rackInfo in cluster metadata
-        assertTrue(assignor.canEnableRackAwareAssignorForActiveTasks());
+        assertTrue(assignor.canEnableRackAwareAssignor());
     }
 
     @Test
@@ -206,7 +206,7 @@ public class RackAwareTaskAssignorTest {
             new AssignorConfiguration(streamsConfig.originals()).assignmentConfigs()
         );
 
-        assertTrue(assignor.canEnableRackAwareAssignorForActiveTasks());
+        assertTrue(assignor.canEnableRackAwareAssignor());
     }
 
     @Test
@@ -223,7 +223,7 @@ public class RackAwareTaskAssignorTest {
             new AssignorConfiguration(streamsConfig.originals()).assignmentConfigs()
         );
 
-        assertFalse(assignor.canEnableRackAwareAssignorForActiveTasks());
+        assertFalse(assignor.canEnableRackAwareAssignor());
         assertTrue(assignor.populateTopicsToDiscribe(new HashSet<>()));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
@@ -16,20 +16,47 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.common.utils.Utils.mkSortedSet;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_CLIENT_TAGS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NODE_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NODE_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NODE_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NODE_3;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NO_RACK_NODE;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PI_0_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PI_0_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PI_1_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PI_1_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.RACK_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.RACK_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.RACK_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.RACK_3;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.RACK_4;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.REPLICA_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_0_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_0_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_0_NAME;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_3;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_4;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_5;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -41,6 +68,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.UUID;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
@@ -56,6 +86,7 @@ import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology
 import org.apache.kafka.test.MockClientSupplier;
 import org.apache.kafka.test.MockInternalTopicManager;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 public class RackAwareTaskAssignorTest {
     private static final String USER_END_POINT = "localhost:8080";
@@ -90,10 +121,10 @@ public class RackAwareTaskAssignorTest {
     }
 
     @Test
-    public void disableActiveSinceMissingClusterInfo() {
+    public void shouldDisableActiveWhenMissingClusterInfo() {
         final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
             getClusterForTopic0(),
-            getTaskTopicPartitionMapForTask1(true),
+            getTaskTopicPartitionMapForTask0(true),
             getTopologyGroupTaskMap(),
             getProcessRacksForProcess0(),
             mockInternalTopicManager,
@@ -107,10 +138,10 @@ public class RackAwareTaskAssignorTest {
     }
 
     @Test
-    public void disableActiveSinceRackMissingInNode() {
+    public void shouldDisableActiveWhenRackMissingInNode() {
         final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
             getClusterWithPartitionMissingRack(),
-            getTaskTopicPartitionMapForTask1(),
+            getTaskTopicPartitionMapForTask0(),
             getTopologyGroupTaskMap(),
             getProcessRacksForProcess0(),
             mockInternalTopicManager,
@@ -124,10 +155,10 @@ public class RackAwareTaskAssignorTest {
     }
 
     @Test
-    public void disableActiveSinceRackMissingInClient() {
+    public void shouldDisableActiveWhenRackMissingInClient() {
         final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
             getClusterForTopic0(),
-            getTaskTopicPartitionMapForTask1(),
+            getTaskTopicPartitionMapForTask0(),
             getTopologyGroupTaskMap(),
             getProcessRacksForProcess0(true),
             mockInternalTopicManager,
@@ -140,7 +171,7 @@ public class RackAwareTaskAssignorTest {
     }
 
     @Test
-    public void disableActiveSinceRackDiffersInSameProcess() {
+    public void shouldDisableActiveWhenRackDiffersInSameProcess() {
         final Map<UUID, Map<String, Optional<String>>> processRacks = new HashMap<>();
 
         // Different consumers in same process have different rack ID. This shouldn't happen.
@@ -150,7 +181,7 @@ public class RackAwareTaskAssignorTest {
 
         final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
             getClusterForTopic0(),
-            getTaskTopicPartitionMapForTask1(),
+            getTaskTopicPartitionMapForTask0(),
             getTopologyGroupTaskMap(),
             processRacks,
             mockInternalTopicManager,
@@ -162,10 +193,10 @@ public class RackAwareTaskAssignorTest {
     }
 
     @Test
-    public void enableRackAwareAssignorForActiveWithoutDescribingTopics() {
+    public void shouldEnableRackAwareAssignorForActiveWithoutDescribingTopics() {
         final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
             getClusterForTopic0(),
-            getTaskTopicPartitionMapForTask1(),
+            getTaskTopicPartitionMapForTask0(),
             getTopologyGroupTaskMap(),
             getProcessRacksForProcess0(),
             mockInternalTopicManager,
@@ -177,7 +208,7 @@ public class RackAwareTaskAssignorTest {
     }
 
     @Test
-    public void enableRackAwareAssignorForActiveWithDescribingTopics() {
+    public void shouldEnableRackAwareAssignorForActiveWithDescribingTopics() {
         final MockInternalTopicManager spyTopicManager = spy(mockInternalTopicManager);
         doReturn(
             Collections.singletonMap(
@@ -190,7 +221,7 @@ public class RackAwareTaskAssignorTest {
 
         final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
             getClusterWithNoNode(),
-            getTaskTopicPartitionMapForTask1(),
+            getTaskTopicPartitionMapForTask0(),
             getTopologyGroupTaskMap(),
             getProcessRacksForProcess0(),
             spyTopicManager,
@@ -201,14 +232,14 @@ public class RackAwareTaskAssignorTest {
     }
 
     @Test
-    public void disableRackAwareAssignorForActiveWithDescribingTopicsFailure() {
+    public void shouldDisableRackAwareAssignorForActiveWithDescribingTopicsFailure() {
         final MockInternalTopicManager spyTopicManager = spy(mockInternalTopicManager);
         doThrow(new TimeoutException("Timeout describing topic")).when(spyTopicManager).getTopicPartitionInfo(Collections.singleton(
             TP_0_NAME));
 
         final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
             getClusterWithNoNode(),
-            getTaskTopicPartitionMapForTask1(),
+            getTaskTopicPartitionMapForTask0(),
             getTopologyGroupTaskMap(),
             getProcessRacksForProcess0(),
             spyTopicManager,
@@ -219,11 +250,311 @@ public class RackAwareTaskAssignorTest {
         assertTrue(assignor.populateTopicsToDiscribe(new HashSet<>()));
     }
 
+    @Test
+    public void shouldOptimizeEmptyStatefulActiveTasks() {
+        final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
+            getClusterForTopic0And1(),
+            getTaskTopicPartitionMapForAllTasks(),
+            getTopologyGroupTaskMap(),
+            getProcessRacksForAllProcess(),
+            mockInternalTopicManager,
+            new AssignorConfiguration(streamsConfig.originals()).assignmentConfigs()
+        );
+
+        final ClientState clientState0 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+
+        clientState0.assignActiveTasks(mkSet(TASK_0_1, TASK_1_1));
+
+        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(UUID_1, clientState0)
+        ));
+        final SortedSet<TaskId> statefulTasks = mkSortedSet();
+
+        if (assignor.canEnableRackAwareAssignor()) {
+            final long originalCost = assignor.activeStatefulTasksCost(clientStateMap, statefulTasks);
+            assertEquals(0, originalCost);
+
+            final long cost = assignor.optimizeActiveStatefulTasks(clientStateMap, statefulTasks);
+            assertEquals(0, cost);
+        }
+
+        assertEquals(mkSet(TASK_0_1, TASK_1_1), clientState0.activeTasks());
+    }
+
+    @Test
+    public void shouldOptimizeStatefulActiveTasks() {
+        final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
+            getClusterForTopic0And1(),
+            getTaskTopicPartitionMapForAllTasks(),
+            getTopologyGroupTaskMap(),
+            getProcessRacksForAllProcess(),
+            mockInternalTopicManager,
+            new AssignorConfiguration(streamsConfig.originals()).assignmentConfigs()
+        );
+
+        final ClientState clientState0 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+
+        clientState0.assignActiveTasks(mkSet(TASK_0_1, TASK_1_1));
+        clientState1.assignActive(TASK_1_0);
+        clientState2.assignActive(TASK_0_0);
+
+        // task_0_0 has same rack as UUID_1
+        // task_0_1 has same rack as UUID_2 and UUID_3
+        // task_1_0 has same rack as UUID_1 and UUID_3
+        // task_1_1 has same rack as UUID_2
+        // Optimal assignment is UUID_1: {0_0, 1_0}, UUID_2: {1_1}, UUID_3: {0_1} which result in no cross rack traffic
+        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(UUID_1, clientState0),
+            mkEntry(UUID_2, clientState1),
+            mkEntry(UUID_3, clientState2)
+        ));
+        final SortedSet<TaskId> statefulTasks = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_0, TASK_1_1);
+
+        if (assignor.canEnableRackAwareAssignor()) {
+            final long originalCost = assignor.activeStatefulTasksCost(clientStateMap, statefulTasks);
+            assertEquals(40, originalCost);
+
+            final long cost = assignor.optimizeActiveStatefulTasks(clientStateMap, statefulTasks);
+            assertEquals(4, cost);
+        }
+
+        assertEquals(mkSet(TASK_0_0, TASK_1_0), clientState0.activeTasks());
+        assertEquals(mkSet(TASK_1_1), clientState1.activeTasks());
+        assertEquals(mkSet(TASK_0_1), clientState2.activeTasks());
+    }
+
+    @Test
+    public void shouldOptimizeStatefulActiveTasksWithMoreClients() {
+        final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
+            getClusterForTopic0And1(),
+            getTaskTopicPartitionMapForAllTasks(),
+            getTopologyGroupTaskMap(),
+            getProcessRacksForAllProcess(),
+            mockInternalTopicManager,
+            new AssignorConfiguration(streamsConfig.originals()).assignmentConfigs()
+        );
+
+        final ClientState clientState0 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+
+        clientState1.assignActive(TASK_1_0);
+        clientState2.assignActive(TASK_0_0);
+
+        // task_0_0 has same rack as UUID_1 and UUID_2
+        // task_1_0 has same rack as UUID_1 and UUID_3
+        // Optimal assignment is UUID_1: {1_0}, UUID_2: {0_0}, UUID_3: {} which result in no cross rack traffic
+        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(UUID_1, clientState0),
+            mkEntry(UUID_2, clientState1),
+            mkEntry(UUID_3, clientState2)
+        ));
+        final SortedSet<TaskId> statefulTasks = mkSortedSet(TASK_0_0, TASK_1_0);
+
+        if (assignor.canEnableRackAwareAssignor()) {
+            final long originalCost = assignor.activeStatefulTasksCost(clientStateMap, statefulTasks);
+            assertEquals(20, originalCost);
+
+            final long cost = assignor.optimizeActiveStatefulTasks(clientStateMap, statefulTasks);
+            assertEquals(2, cost);
+        }
+
+        // UUID_3 becomes empty even though it has one task before
+        assertEquals(mkSet(TASK_1_0), clientState0.activeTasks());
+        assertEquals(mkSet(TASK_0_0), clientState1.activeTasks());
+        assertEquals(mkSet(), clientState2.activeTasks());
+    }
+
+    @Test
+    public void shouldOptimizeStatefulActiveTasksWithMoreClientsWithMoreThanOneTask() {
+        final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
+            getClusterForTopic0And1(),
+            getTaskTopicPartitionMapForAllTasks(),
+            getTopologyGroupTaskMap(),
+            getProcessRacksForAllProcess(),
+            mockInternalTopicManager,
+            new AssignorConfiguration(streamsConfig.originals()).assignmentConfigs()
+        );
+
+        final ClientState clientState0 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState2 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+
+        clientState1.assignActiveTasks(mkSet(TASK_0_1, TASK_1_0));
+        clientState2.assignActive(TASK_0_0);
+
+        // task_0_0 has same rack as UUID_1 and UUID_2
+        // task_0_1 has same rack as UUID_2 and UUID_3
+        // task_1_0 has same rack as UUID_1 and UUID_3
+        // Optimal assignment is UUID_1: {}, UUID_2: {0_0, 0_1}, UUID_3: {1_0} which result in no cross rack traffic
+        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(UUID_1, clientState0),
+            mkEntry(UUID_2, clientState1),
+            mkEntry(UUID_3, clientState2)
+        ));
+        final SortedSet<TaskId> statefulTasks = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_0);
+
+        if (assignor.canEnableRackAwareAssignor()) {
+            final long originalCost = assignor.activeStatefulTasksCost(clientStateMap, statefulTasks);
+            assertEquals(20, originalCost);
+
+            final long cost = assignor.optimizeActiveStatefulTasks(clientStateMap, statefulTasks);
+            assertEquals(2, cost);
+        }
+
+        // Because original assignment is not balanced (3 tasks but client 0 has no task), we maintain it
+        assertEquals(mkSet(), clientState0.activeTasks());
+        assertEquals(mkSet(TASK_0_0, TASK_0_1), clientState1.activeTasks());
+        assertEquals(mkSet(TASK_1_0), clientState2.activeTasks());
+    }
+
+    @Test
+    public void shouldBalanceAssignmentWithMoreCost() {
+        final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
+            getClusterForTopic0And1(),
+            getTaskTopicPartitionMapForAllTasks(),
+            getTopologyGroupTaskMap(),
+            getProcessRacksForAllProcess(),
+            mockInternalTopicManager,
+            new AssignorConfiguration(streamsConfig.originals()).assignmentConfigs()
+        );
+
+        final ClientState clientState0 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+
+        clientState0.assignActiveTasks(mkSet(TASK_0_0, TASK_1_1));
+        clientState1.assignActive(TASK_0_1);
+
+        // task_0_0 has same rack as UUID_2
+        // task_0_1 has same rack as UUID_2
+        // task_1_1 has same rack as UUID_2
+        // UUID_5 is not in same rack as any task
+        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(UUID_2, clientState0),
+            mkEntry(UUID_5, clientState1)
+        ));
+        final SortedSet<TaskId> statefulTasks = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_1);
+
+        if (assignor.canEnableRackAwareAssignor()) {
+            final long originalCost = assignor.activeStatefulTasksCost(clientStateMap, statefulTasks);
+            assertEquals(10, originalCost);
+
+            final long cost = assignor.optimizeActiveStatefulTasks(clientStateMap, statefulTasks);
+            assertEquals(10, cost);
+        }
+
+        // Even though assigning all tasks to UUID_2 will result in min cost, but it's not balanced
+        // assignment. That's why TASK_0_1 is still assigned to UUID_5
+        assertEquals(mkSet(TASK_0_0, TASK_1_1), clientState0.activeTasks());
+        assertEquals(mkSet(TASK_0_1), clientState1.activeTasks());
+    }
+
+    @Test
+    public void shouldThrowIfMissingCallcanEnableRackAwareAssignor() {
+        final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
+            getClusterForTopic0And1(),
+            getTaskTopicPartitionMapForAllTasks(),
+            getTopologyGroupTaskMap(),
+            getProcessRacksForAllProcess(),
+            mockInternalTopicManager,
+            new AssignorConfiguration(streamsConfig.originals()).assignmentConfigs()
+        );
+
+        final ClientState clientState0 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+
+        clientState0.assignActiveTasks(mkSet(TASK_0_0, TASK_1_1));
+        clientState1.assignActive(TASK_0_1);
+
+        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(UUID_2, clientState0),
+            mkEntry(UUID_5, clientState1)
+        ));
+        final SortedSet<TaskId> statefulTasks = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_1);
+        final Exception exception = assertThrows(IllegalStateException.class,
+            () -> assignor.optimizeActiveStatefulTasks(clientStateMap, statefulTasks));
+        Assertions.assertEquals("TopicPartition topic0-0 has no rack information. Maybe forgot to call "
+            + "canEnableRackAwareAssignor first", exception.getMessage());
+    }
+
+    @Test
+    public void shouldThrowIfTaskInMultipleClients() {
+        final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
+            getClusterForTopic0And1(),
+            getTaskTopicPartitionMapForAllTasks(),
+            getTopologyGroupTaskMap(),
+            getProcessRacksForAllProcess(),
+            mockInternalTopicManager,
+            new AssignorConfiguration(streamsConfig.originals()).assignmentConfigs()
+        );
+
+        final ClientState clientState0 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+
+        clientState0.assignActiveTasks(mkSet(TASK_0_0, TASK_1_1));
+        clientState1.assignActiveTasks(mkSet(TASK_0_1, TASK_1_1));
+
+        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(UUID_2, clientState0),
+            mkEntry(UUID_5, clientState1)
+        ));
+        final SortedSet<TaskId> statefulTasks = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_1);
+        if (assignor.canEnableRackAwareAssignor()) {
+            final Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> assignor.optimizeActiveStatefulTasks(clientStateMap, statefulTasks));
+            Assertions.assertEquals(
+                "Task 1_1 assigned to multiple clients 00000000-0000-0000-0000-000000000005, "
+                    + "00000000-0000-0000-0000-000000000002", exception.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldThrowIfTaskMissingInClients() {
+        final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
+            getClusterForTopic0And1(),
+            getTaskTopicPartitionMapForAllTasks(),
+            getTopologyGroupTaskMap(),
+            getProcessRacksForAllProcess(),
+            mockInternalTopicManager,
+            new AssignorConfiguration(streamsConfig.originals()).assignmentConfigs()
+        );
+
+        final ClientState clientState0 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = new ClientState(emptySet(), emptySet(), emptyMap(), EMPTY_CLIENT_TAGS, 1);
+
+        clientState0.assignActiveTasks(mkSet(TASK_0_0, TASK_1_1));
+        clientState1.assignActive(TASK_0_1);
+
+        final SortedMap<UUID, ClientState> clientStateMap = new TreeMap<>(mkMap(
+            mkEntry(UUID_2, clientState0),
+            mkEntry(UUID_5, clientState1)
+        ));
+        final SortedSet<TaskId> statefulTasks = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_0, TASK_1_1);
+        if (assignor.canEnableRackAwareAssignor()) {
+            final Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> assignor.optimizeActiveStatefulTasks(clientStateMap, statefulTasks));
+            Assertions.assertEquals(
+                "Task 1_0 not assigned to any client", exception.getMessage());
+        }
+    }
+
+    private Cluster getClusterForTopic0And1() {
+        return new Cluster(
+            "cluster",
+            mkSet(NODE_0, NODE_1, NODE_2, NODE_3),
+            mkSet(PI_0_0, PI_0_1, PI_1_0, PI_1_1),
+            Collections.emptySet(),
+            Collections.emptySet()
+        );
+    }
+
     private Cluster getClusterForTopic0() {
         return new Cluster(
             "cluster",
-            new HashSet<>(Arrays.asList(NODE_0, NODE_1, NODE_2)),
-            new HashSet<>(Arrays.asList(PI_0_0, PI_0_1)),
+            mkSet(NODE_0, NODE_1, NODE_2),
+            mkSet(PI_0_0, PI_0_1),
             Collections.emptySet(),
             Collections.emptySet()
         );
@@ -234,8 +565,8 @@ public class RackAwareTaskAssignorTest {
         final PartitionInfo partitionInfoMissingNode = new PartitionInfo(TP_0_NAME, 0, NODE_0, nodeMissingRack, nodeMissingRack);
         return new Cluster(
             "cluster",
-            new HashSet<>(Arrays.asList(NODE_0, NODE_1, NODE_2)),
-            new HashSet<>(Arrays.asList(partitionInfoMissingNode, PI_0_1)),
+            mkSet(NODE_0, NODE_1, NODE_2),
+            mkSet(partitionInfoMissingNode, PI_0_1),
             Collections.emptySet(),
             Collections.emptySet()
         );
@@ -246,10 +577,20 @@ public class RackAwareTaskAssignorTest {
 
         return new Cluster(
             "cluster",
-            new HashSet<>(Arrays.asList(NODE_0, NODE_1, NODE_2, Node.noNode())), // mockClientSupplier.setCluster requires noNode
+            mkSet(NODE_0, NODE_1, NODE_2, Node.noNode()), // mockClientSupplier.setCluster requires noNode
             Collections.singleton(noNodeInfo),
             Collections.emptySet(),
             Collections.emptySet()
+        );
+    }
+
+    private Map<UUID, Map<String, Optional<String>>> getProcessRacksForAllProcess() {
+        return mkMap(
+            mkEntry(UUID_1, mkMap(mkEntry("1", Optional.of(RACK_0)))),
+            mkEntry(UUID_2, mkMap(mkEntry("1", Optional.of(RACK_1)))),
+            mkEntry(UUID_3, mkMap(mkEntry("1", Optional.of(RACK_2)))),
+            mkEntry(UUID_4, mkMap(mkEntry("1", Optional.of(RACK_3)))),
+            mkEntry(UUID_5, mkMap(mkEntry("1", Optional.of(RACK_4))))
         );
     }
 
@@ -264,17 +605,26 @@ public class RackAwareTaskAssignorTest {
         return processRacks;
     }
 
-    private Map<TaskId, Set<TopicPartition>> getTaskTopicPartitionMapForTask1() {
-        return getTaskTopicPartitionMapForTask1(false);
+    private Map<TaskId, Set<TopicPartition>> getTaskTopicPartitionMapForTask0() {
+        return getTaskTopicPartitionMapForTask0(false);
     }
 
-    private Map<TaskId, Set<TopicPartition>> getTaskTopicPartitionMapForTask1(final boolean extraTopic) {
+    private Map<TaskId, Set<TopicPartition>> getTaskTopicPartitionMapForTask0(final boolean extraTopic) {
         final Set<TopicPartition> topicPartitions = new HashSet<>();
         topicPartitions.add(TP_0_0);
         if (extraTopic) {
             topicPartitions.add(TP_1_0);
         }
-        return Collections.singletonMap(new TaskId(1, 1), topicPartitions);
+        return Collections.singletonMap(TASK_0_0, topicPartitions);
+    }
+
+    private Map<TaskId, Set<TopicPartition>> getTaskTopicPartitionMapForAllTasks() {
+        return mkMap(
+            mkEntry(TASK_0_0, mkSet(TP_0_0)),
+            mkEntry(TASK_0_1, mkSet(TP_0_1)),
+            mkEntry(TASK_1_0, mkSet(TP_1_0)),
+            mkEntry(TASK_1_1, mkSet(TP_1_1))
+        );
     }
 
     private Map<Subtopology, Set<TaskId>> getTopologyGroupTaskMap() {


### PR DESCRIPTION
## Description
This PR is on top of https://github.com/apache/kafka/pull/13996 and actual changes are in https://github.com/apache/kafka/pull/14030/commits/74ba08ec6acf446c803d51a5a0265a1194272a0c. This PR make use of the graph to compute min cost based on rack awareness for stateful active tasks.

## Testing
Unit test
