### PR TITLE
KAFKA-14920: Address timeouts and out of order sequences

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -577,9 +577,9 @@ class Partition(val topicPartition: TopicPartition,
   }
 
   // Returns a verification guard object if we need to verify. This starts or continues the verification process. Otherwise return null.
-  def maybeStartTransactionVerification(producerId: Long): Object = {
+  def maybeStartTransactionVerification(producerId: Long, sequence: Int, epoch: Short): Object = {
     leaderLogIfLocal match {
-      case Some(log) => log.maybeStartTransactionVerification(producerId)
+      case Some(log) => log.maybeStartTransactionVerification(producerId, sequence, epoch)
       case None => throw new NotLeaderOrFollowerException();
     }
   }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -862,7 +862,8 @@ class ReplicaManager(val config: KafkaConfig,
 
         if (transactionalBatches.nonEmpty) {
           // We return verification guard if the partition needs to be verified. If no state is present, no need to verify.
-          val verificationGuard = getPartitionOrException(topicPartition).maybeStartTransactionVerification(records.firstBatch.producerId)
+          val firstBatch = records.firstBatch
+          val verificationGuard = getPartitionOrException(topicPartition).maybeStartTransactionVerification(firstBatch.producerId, firstBatch.baseSequence, firstBatch.producerEpoch)
           if (verificationGuard != null) {
             verificationGuards.put(topicPartition, verificationGuard)
             unverifiedEntries.put(topicPartition, records)

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -998,7 +998,7 @@ class PartitionTest extends AbstractPartitionTest {
       new SimpleRecord("k3".getBytes, "v3".getBytes)),
       baseOffset = 0L,
       producerId = 2L)
-    val verificationGuard = partition.maybeStartTransactionVerification(2L)
+    val verificationGuard = partition.maybeStartTransactionVerification(2L, 0, 0)
     partition.appendRecordsToLeader(records, origin = AppendOrigin.CLIENT, requiredAcks = 0, RequestLocal.withThreadConfinedCaching, verificationGuard)
 
     def fetchOffset(isolationLevel: Option[IsolationLevel], timestamp: Long): TimestampAndOffset = {
@@ -3390,7 +3390,7 @@ class PartitionTest extends AbstractPartitionTest {
     assertThrows(classOf[InvalidRecordException], () => partition.appendRecordsToLeader(transactionRecords(), origin = AppendOrigin.CLIENT, requiredAcks = 1, RequestLocal.withThreadConfinedCaching))
 
     // Before appendRecordsToLeader is called, ReplicaManager will call maybeStartTransactionVerification. We should get a non-null verification object.
-    val verificationGuard = partition.maybeStartTransactionVerification(producerId)
+    val verificationGuard = partition.maybeStartTransactionVerification(producerId, 3, 0)
     assertNotNull(verificationGuard)
 
     // With the wrong verification guard, append should fail.
@@ -3398,12 +3398,12 @@ class PartitionTest extends AbstractPartitionTest {
       origin = AppendOrigin.CLIENT, requiredAcks = 1, RequestLocal.withThreadConfinedCaching, Optional.of(new Object)))
 
     // We should return the same verification object when we still need to verify. Append should proceed.
-    val verificationGuard2 = partition.maybeStartTransactionVerification(producerId)
+    val verificationGuard2 = partition.maybeStartTransactionVerification(producerId, 3, 0)
     assertEquals(verificationGuard, verificationGuard2)
     partition.appendRecordsToLeader(transactionRecords(), origin = AppendOrigin.CLIENT, requiredAcks = 1, RequestLocal.withThreadConfinedCaching, verificationGuard)
 
     // We should no longer need a verification object. Future appends without verification guard will also succeed.
-    val verificationGuard3 = partition.maybeStartTransactionVerification(producerId)
+    val verificationGuard3 = partition.maybeStartTransactionVerification(producerId, 3, 0)
     assertNull(verificationGuard3)
     partition.appendRecordsToLeader(transactionRecords(), origin = AppendOrigin.CLIENT, requiredAcks = 1, RequestLocal.withThreadConfinedCaching)
   }

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -3677,7 +3677,7 @@ class UnifiedLogTest {
     val logConfig = LogTestUtils.createLogConfig(segmentBytes = 2048 * 5)
     val log = createLog(logDir, logConfig, producerStateManagerConfig = producerStateManagerConfig)
     assertFalse(log.hasOngoingTransaction(producerId))
-    assertNull(log.getOrMaybeCreateVerificationGuard(producerId))
+    assertNull(log.verificationGuard(producerId))
 
     val idempotentRecords = MemoryRecords.withIdempotentRecords(
       CompressionType.NONE,
@@ -3688,14 +3688,14 @@ class UnifiedLogTest {
       new SimpleRecord("2".getBytes)
     )
 
-    val verificationGuard = log.maybeStartTransactionVerification(producerId)
+    val verificationGuard = log.maybeStartTransactionVerification(producerId, sequence, producerEpoch)
     assertNotNull(verificationGuard)
 
     log.appendAsLeader(idempotentRecords, leaderEpoch = 0)
     assertFalse(log.hasOngoingTransaction(producerId))
 
     // Since we wrote idempotent records, we keep verification guard.
-    assertEquals(verificationGuard, log.getOrMaybeCreateVerificationGuard(producerId))
+    assertEquals(verificationGuard, log.verificationGuard(producerId))
 
     val transactionalRecords = MemoryRecords.withTransactionalRecords(
       CompressionType.NONE,
@@ -3709,10 +3709,10 @@ class UnifiedLogTest {
     log.appendAsLeader(transactionalRecords, leaderEpoch = 0, verificationGuard = verificationGuard)
     assertTrue(log.hasOngoingTransaction(producerId))
     // Verification guard should be cleared now.
-    assertNull(log.getOrMaybeCreateVerificationGuard(producerId))
+    assertNull(log.verificationGuard(producerId))
 
     // A subsequent maybeStartTransactionVerification will be empty since we are already verified.
-    assertNull(log.maybeStartTransactionVerification(producerId))
+    assertNull(log.maybeStartTransactionVerification(producerId, sequence + 2, producerEpoch))
 
     val endTransactionMarkerRecord = MemoryRecords.withEndTransactionMarker(
       producerId,
@@ -3722,10 +3722,10 @@ class UnifiedLogTest {
 
     log.appendAsLeader(endTransactionMarkerRecord, origin = AppendOrigin.COORDINATOR, leaderEpoch = 0)
     assertFalse(log.hasOngoingTransaction(producerId))
-    assertNull(log.getOrMaybeCreateVerificationGuard(producerId))
+    assertNull(log.verificationGuard(producerId))
 
     // A new maybeStartTransactionVerification will not be empty, as we need to verify the next transaction.
-    val newVerificationGuard = log.maybeStartTransactionVerification(producerId)
+    val newVerificationGuard = log.maybeStartTransactionVerification(producerId, sequence + 3, producerEpoch)
     assertNotNull(newVerificationGuard)
     assertNotEquals(verificationGuard, newVerificationGuard)
   }
@@ -3739,7 +3739,7 @@ class UnifiedLogTest {
     val logConfig = LogTestUtils.createLogConfig(segmentBytes = 2048 * 5)
     val log = createLog(logDir, logConfig, producerStateManagerConfig = producerStateManagerConfig)
 
-    val verificationGuard = log.maybeStartTransactionVerification(producerId)
+    val verificationGuard = log.maybeStartTransactionVerification(producerId, 0, producerEpoch)
     assertNotNull(verificationGuard)
 
     val endTransactionMarkerRecord = MemoryRecords.withEndTransactionMarker(
@@ -3750,7 +3750,7 @@ class UnifiedLogTest {
 
     log.appendAsLeader(endTransactionMarkerRecord, origin = AppendOrigin.COORDINATOR, leaderEpoch = 0)
     assertFalse(log.hasOngoingTransaction(producerId))
-    assertNull(log.getOrMaybeCreateVerificationGuard(producerId))
+    assertNull(log.verificationGuard(producerId))
   }
 
   @Test
@@ -3763,7 +3763,7 @@ class UnifiedLogTest {
     val logConfig = LogTestUtils.createLogConfig(segmentBytes = 2048 * 5)
     val log = createLog(logDir, logConfig, producerStateManagerConfig = producerStateManagerConfig)
     assertFalse(log.hasOngoingTransaction(producerId))
-    assertNull(log.getOrMaybeCreateVerificationGuard(producerId))
+    assertNull(log.verificationGuard(producerId))
 
     val transactionalRecords = MemoryRecords.withTransactionalRecords(
       CompressionType.NONE,
@@ -3774,7 +3774,7 @@ class UnifiedLogTest {
       new SimpleRecord("2".getBytes)
     )
 
-    val verificationGuard = log.maybeStartTransactionVerification(producerId)
+    val verificationGuard = log.maybeStartTransactionVerification(producerId, sequence, producerEpoch)
     // Append should not throw error.
     log.appendAsLeader(transactionalRecords, leaderEpoch = 0, verificationGuard = verificationGuard)
   }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -2847,7 +2847,7 @@ class ReplicaManagerTest {
   private def getVerificationGuard(replicaManager: ReplicaManager,
                                    tp: TopicPartition,
                                    producerId: Long): Object = {
-    replicaManager.getPartitionOrException(tp).log.get.getOrMaybeCreateVerificationGuard(producerId)
+    replicaManager.getPartitionOrException(tp).log.get.verificationGuard(producerId)
   }
 
   private def setUpReplicaManagerWithMockedAddPartitionsToTxnManager(addPartitionsToTxnManager: AddPartitionsToTxnManager,

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -2247,6 +2247,66 @@ class ReplicaManagerTest {
   }
 
   @Test
+  def testTransactionVerificationBlocksOutOfOrderSequence(): Unit = {
+    val tp0 = new TopicPartition(topic, 0)
+    val producerId = 24L
+    val producerEpoch = 0.toShort
+    val sequence = 6
+    val node = new Node(0, "host1", 0)
+    val addPartitionsToTxnManager = mock(classOf[AddPartitionsToTxnManager])
+
+    val replicaManager = setUpReplicaManagerWithMockedAddPartitionsToTxnManager(addPartitionsToTxnManager, List(tp0), node)
+    try {
+      replicaManager.becomeLeaderOrFollower(1,
+        makeLeaderAndIsrRequest(topicIds(tp0.topic), tp0, Seq(0, 1), LeaderAndIsr(1, List(0, 1))),
+        (_, _) => ())
+
+      // Start with sequence 6
+      val transactionalRecords = MemoryRecords.withTransactionalRecords(CompressionType.NONE, producerId, producerEpoch, sequence,
+        new SimpleRecord("message".getBytes))
+
+      val transactionToAdd = new AddPartitionsToTxnTransaction()
+        .setTransactionalId(transactionalId)
+        .setProducerId(producerId)
+        .setProducerEpoch(producerEpoch)
+        .setVerifyOnly(true)
+        .setTopics(new AddPartitionsToTxnTopicCollection(
+          Seq(new AddPartitionsToTxnTopic().setName(tp0.topic).setPartitions(Collections.singletonList(tp0.partition))).iterator.asJava
+        ))
+
+      // We should add these partitions to the manager to verify.
+      val result = appendRecords(replicaManager, tp0, transactionalRecords, transactionalId = transactionalId, transactionStatePartition = Some(0))
+      val appendCallback = ArgumentCaptor.forClass(classOf[AddPartitionsToTxnManager.AppendCallback])
+      verify(addPartitionsToTxnManager, times(1)).addTxnData(ArgumentMatchers.eq(node), ArgumentMatchers.eq(transactionToAdd), appendCallback.capture())
+      val verificationGuard = getVerificationGuard(replicaManager, tp0, producerId)
+      assertEquals(verificationGuard, getVerificationGuard(replicaManager, tp0, producerId))
+
+      // Confirm we did not write to the log and instead returned error.
+      val callback: AddPartitionsToTxnManager.AppendCallback = appendCallback.getValue()
+      callback(Map(tp0 -> Errors.NOT_COORDINATOR).toMap)
+      assertEquals(Errors.NOT_COORDINATOR, result.assertFired.error)
+      assertEquals(verificationGuard, getVerificationGuard(replicaManager, tp0, producerId))
+
+      // Try to append a higher sequence (7) after the first one failed with a retriable error.
+      val transactionalRecords2 = MemoryRecords.withTransactionalRecords(CompressionType.NONE, producerId, producerEpoch, sequence + 1,
+        new SimpleRecord("message".getBytes))
+
+      val result2 = appendRecords(replicaManager, tp0, transactionalRecords2, transactionalId = transactionalId, transactionStatePartition = Some(0))
+      val appendCallback2 = ArgumentCaptor.forClass(classOf[AddPartitionsToTxnManager.AppendCallback])
+      verify(addPartitionsToTxnManager, times(2)).addTxnData(ArgumentMatchers.eq(node), ArgumentMatchers.eq(transactionToAdd), appendCallback2.capture())
+      assertEquals(verificationGuard, getVerificationGuard(replicaManager, tp0, producerId))
+
+      // Verification should succeed, but we expect to fail with OutOfOrderSequence and for the verification guard to remain.
+      val callback2: AddPartitionsToTxnManager.AppendCallback = appendCallback2.getValue()
+      callback2(Map.empty[TopicPartition, Errors].toMap)
+      assertEquals(verificationGuard, getVerificationGuard(replicaManager, tp0, producerId))
+      assertEquals(Errors.OUT_OF_ORDER_SEQUENCE_NUMBER, result2.assertFired.error)
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
   def testTransactionVerificationGuardOnMultiplePartitions(): Unit = {
     val mockTimer = new MockTimer(time)
     val tp0 = new TopicPartition(topic, 0)

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java
@@ -47,6 +47,7 @@ public class ProducerAppendInfo {
     private final long producerId;
     private final ProducerStateEntry currentEntry;
     private final AppendOrigin origin;
+    private final VerificationStateEntry verificationStateEntry;
 
     private final List<TxnMetadata> transactions = new ArrayList<>();
     private final ProducerStateEntry updatedEntry;
@@ -54,25 +55,28 @@ public class ProducerAppendInfo {
     /**
      * Creates a new instance with the provided parameters.
      *
-     * @param topicPartition topic partition
-     * @param producerId     The id of the producer appending to the log
-     * @param currentEntry   The current entry associated with the producer id which contains metadata for a fixed number of
-     *                       the most recent appends made by the producer. Validation of the first incoming append will
-     *                       be made against the latest append in the current entry. New appends will replace older appends
-     *                       in the current entry so that the space overhead is constant.
-     * @param origin         Indicates the origin of the append which implies the extent of validation. For example, offset
-     *                       commits, which originate from the group coordinator, do not have sequence numbers and therefore
-     *                       only producer epoch validation is done. Appends which come through replication are not validated
-     *                       (we assume the validation has already been done) and appends from clients require full validation.
+     * @param topicPartition         topic partition
+     * @param producerId             The id of the producer appending to the log
+     * @param currentEntry           The current entry associated with the producer id which contains metadata for a fixed number of
+     *                               the most recent appends made by the producer. Validation of the first incoming append will
+     *                               be made against the latest append in the current entry. New appends will replace older appends
+     *                               in the current entry so that the space overhead is constant.
+     * @param origin                 Indicates the origin of the append which implies the extent of validation. For example, offset
+     *                               commits, which originate from the group coordinator, do not have sequence numbers and therefore
+     *                               only producer epoch validation is done. Appends which come through replication are not validated
+     *                               (we assume the validation has already been done) and appends from clients require full validation.
+     * @param verificationStateEntry The most recent entry used for verification if no append has been completed yet otherwise null
      */
     public ProducerAppendInfo(TopicPartition topicPartition,
                               long producerId,
                               ProducerStateEntry currentEntry,
-                              AppendOrigin origin) {
+                              AppendOrigin origin,
+                              VerificationStateEntry verificationStateEntry) {
         this.topicPartition = topicPartition;
         this.producerId = producerId;
         this.currentEntry = currentEntry;
         this.origin = origin;
+        this.verificationStateEntry = verificationStateEntry;
 
         updatedEntry = currentEntry.withProducerIdAndBatchMetadata(producerId, Optional.empty());
     }
@@ -105,6 +109,11 @@ public class ProducerAppendInfo {
     }
 
     private void checkSequence(short producerEpoch, int appendFirstSeq, long offset) {
+        if (verificationStateEntry != null && appendFirstSeq > verificationStateEntry.lowestSequence()) {
+            throw new OutOfOrderSequenceException("Out of order sequence number for producer " + producerId + " at " +
+                    "offset " + offset + " in partition " + topicPartition + ": " + appendFirstSeq +
+                    " (incoming seq. number), " + verificationStateEntry.lowestSequence() + " (earliest seen sequence)");
+        }
         if (producerEpoch != updatedEntry.producerEpoch()) {
             if (appendFirstSeq != 0) {
                 if (updatedEntry.producerEpoch() != RecordBatch.NO_PRODUCER_EPOCH) {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationStateEntry.java
@@ -59,12 +59,12 @@ public class VerificationStateEntry {
 
     /**
      * An OutOfOrderSequence loop can happen for any idempotent/transactional producer when a lower sequence fails with
-     * a retriable error and a higher sequence is successfully written.The lower sequence will fail with
+     * a retriable error and a higher sequence is successfully written. The lower sequence will fail with
      * OutOfOrderSequence and retry until retries run out.
      *
-     * Here, we keep the lowest sequence seen in order to prevent an OutOfOrderSequence loop when verifying. (This does
+     * Here, we keep the lowest sequence seen in order to prevent an OutOfOrderSequence loop when verifying. This does
      * not solve the error loop for idempotent producers or transactional producers that fail before verification
-     * starts.) When verification fails with a retriable error (ie. NOT_COORDINATOR), the VerificationStateEntry
+     * starts. When verification fails with a retriable error (ie. NOT_COORDINATOR), the VerificationStateEntry
      * maintains the lowest sequence number it sees and blocks higher sequences from being written to the log. However,
      * if we encounter a new and lower sequence when verifying, we want to block sequences higher than that new
      * sequence. Additionally, if the epoch is bumped, the sequence is reset and any previous sequence must be disregarded.

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationStateEntry.java
@@ -58,14 +58,16 @@ public class VerificationStateEntry {
     }
 
     /**
-     * We keep the lowest sequence seen in order to prevent an OutOfOrderSequence loop. This occurs in idempotent
-     * producers when a lower sequence fails with a retriable error and a higher sequence is successfully written.
-     * The lower sequence will fail with OutOfOrderSequence and retry until retries run out.
-     * In order to prevent this issue when verification fails with a retriable error (ie. NOT_COORDINATOR),
-     * the VerificationStateEntry maintains the lowest sequence number it sees and blocks higher sequences from being
-     * written to the log. However, if we encounter a new and lower sequence when verifying, we want to block sequences
-     * higher than that new sequence. Additionally, if the epoch is bumped, the sequence is reset and any previous
-     * sequence must be disregarded.
+     * An OutOfOrderSequence loop can happen for any idempotent/transactional producer when a lower sequence fails with
+     * a retriable error and a higher sequence is successfully written.The lower sequence will fail with
+     * OutOfOrderSequence and retry until retries run out.
+     *
+     * Here, we keep the lowest sequence seen in order to prevent an OutOfOrderSequence loop when verifying. (This does
+     * not solve the error loop for idempotent producers or transactional producers that fail before verification
+     * starts.) When verification fails with a retriable error (ie. NOT_COORDINATOR), the VerificationStateEntry
+     * maintains the lowest sequence number it sees and blocks higher sequences from being written to the log. However,
+     * if we encounter a new and lower sequence when verifying, we want to block sequences higher than that new
+     * sequence. Additionally, if the epoch is bumped, the sequence is reset and any previous sequence must be disregarded.
      *
      * Thus, we update the lowest sequence if there is a batch needing verification that has:
      * a) a lower sequence for the same epoch


### PR DESCRIPTION
When creating a verification state entry, we also store sequence and epoch. On subsequent requests, we will take the latest epoch seen and the earliest sequence seen. That way, if we try to append a sequence after the earliest seen sequence, we can block that and retry.  This addresses potential OutOfOrderSequence loops caused by errors during verification (coordinator loading, timeouts, etc).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
