### PR TITLE
KAFKA-14469: Add MirrorMaker 2 configs to table of contents in docs page

### DIFF
--- a/docs/toc.html
+++ b/docs/toc.html
@@ -51,7 +51,8 @@
                     </ul>
                 <li><a href="#streamsconfigs">3.6 Kafka Streams Configs</a>
                 <li><a href="#adminclientconfigs">3.7 AdminClient Configs</a>
-                <li><a href="#systemproperties">3.8 System Properties</a>
+                <li><a href="#mirrormakerconfigs">3.8 MirrorMaker Configs</a>
+                <li><a href="#systemproperties">3.9 System Properties</a>
             </ul>
         </li>
         <li><a href="#design">4. Design</a>


### PR DESCRIPTION
Follow-up for https://github.com/apache/kafka/pull/13658, where we forgot to update the table of contents to include the new 3.8 section for MirrorMaker 2. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
