### PR TITLE
KAFKA-15205:Catch InterruptedException when calling ShutDownableThrea…

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/util/ShutdownableThread.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/ShutdownableThread.java
@@ -99,8 +99,17 @@ public abstract class ShutdownableThread extends Thread {
         if (!isShutdownInitiated())
             throw new IllegalStateException("initiateShutdown() was not called before awaitShutdown()");
         else {
-            if (isStarted)
-                shutdownComplete.await();
+            if (isStarted) {
+                try {
+                    shutdownComplete.await();
+                } catch (InterruptedException e) {
+                    if (isInterruptible)
+                        //ignore
+                        log.debug("interrupted", e);
+                    else
+                        throw e;
+                }
+            }
             log.info("Shutdown completed");
         }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-15205
Catch InterruptedException when calling ShutDownableThread#awaitShutdown()

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
