### PR TITLE
KAFKA-15220: Do not returned fenced brokers from getAliveBrokerNode

### DIFF
--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -219,7 +219,7 @@ class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging w
   }
 
   override def getAliveBrokerNode(brokerId: Int, listenerName: ListenerName): Option[Node] = {
-    Option(_currentImage.cluster().broker(brokerId)).
+    Option(_currentImage.cluster().broker(brokerId)).filterNot(_.fenced()).
       flatMap(_.node(listenerName.value()).asScala)
   }
 


### PR DESCRIPTION
`getAliveBrokerNode` returns fenced brokers as alive which is inconsistent with methods like getAliveBrokerNodes.
Add a filter to not return fenced brokers and adds a test to validate that `getAliveBrokerNode` is consistent with `getAliveBrokerNodes`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
