### PR TITLE
KAFKA-14501: Implement Heartbeat protocol in new GroupCoordinator

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -329,7 +329,7 @@
     <suppress checks="ParameterNumber"
               files="(ConsumerGroupMember|GroupMetadataManager).java"/>
     <suppress checks="ClassDataAbstractionCouplingCheck"
-              files="(RecordHelpersTest|GroupMetadataManagerTest).java"/>
+              files="(RecordHelpersTest|GroupMetadataManagerTest|GroupCoordinatorServiceTest).java"/>
     <suppress checks="JavaNCSS"
               files="GroupMetadataManagerTest.java"/>
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.group;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.CoordinatorLoadInProgressException;
 import org.apache.kafka.common.errors.InvalidFetchSizeException;
 import org.apache.kafka.common.errors.KafkaStorageException;
 import org.apache.kafka.common.errors.NotEnoughReplicasException;
@@ -369,9 +370,29 @@ public class GroupCoordinatorService implements GroupCoordinator {
             return FutureUtils.failedFuture(Errors.COORDINATOR_NOT_AVAILABLE.exception());
         }
 
-        return FutureUtils.failedFuture(Errors.UNSUPPORTED_VERSION.exception(
-            "This API is not implemented yet."
-        ));
+        if (!isGroupIdNotEmpty(request.groupId())) {
+            return CompletableFuture.completedFuture(new HeartbeatResponseData()
+                .setErrorCode(Errors.INVALID_GROUP_ID.code()));
+        }
+
+        return runtime.scheduleReadOperation("generic-group-heartbeat",
+            topicPartitionFor(request.groupId()),
+            (coordinator, offset) -> coordinator.genericGroupHeartbeat(context, request)
+        ).exceptionally(exception -> {
+            if (!(exception instanceof KafkaException)) {
+                log.error("Heartbeat request {} hit an unexpected exception: {}",
+                    request, exception.getMessage());
+            }
+
+            if (exception instanceof CoordinatorLoadInProgressException) {
+                // The group is still loading, so blindly respond
+                return new HeartbeatResponseData()
+                    .setErrorCode(Errors.NONE.code());
+            }
+
+            return new HeartbeatResponseData()
+                .setErrorCode(Errors.forException(exception).code());
+        });
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -375,9 +375,11 @@ public class GroupCoordinatorService implements GroupCoordinator {
                 .setErrorCode(Errors.INVALID_GROUP_ID.code()));
         }
 
+        // Using a read operation is okay here as we ignore the last committed offset in the snapshot registry.
+        // This means we will read whatever is in the latest snapshot, which is how the old coordinator behaves.
         return runtime.scheduleReadOperation("generic-group-heartbeat",
             topicPartitionFor(request.groupId()),
-            (coordinator, offset) -> coordinator.genericGroupHeartbeat(context, request)
+            (coordinator, __) -> coordinator.genericGroupHeartbeat(context, request)
         ).exceptionally(exception -> {
             if (!(exception instanceof KafkaException)) {
                 log.error("Heartbeat request {} hit an unexpected exception: {}",

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -20,9 +20,11 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ApiException;
+import org.apache.kafka.common.errors.CoordinatorNotAvailableException;
 import org.apache.kafka.common.errors.FencedMemberEpochException;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.GroupMaxSizeReachedException;
+import org.apache.kafka.common.errors.IllegalGenerationException;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.NotCoordinatorException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
@@ -30,6 +32,8 @@ import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnsupportedAssignorException;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
+import org.apache.kafka.common.message.HeartbeatRequestData;
+import org.apache.kafka.common.message.HeartbeatResponseData;
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocol;
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocolCollection;
 import org.apache.kafka.common.message.JoinGroupRequestData;
@@ -90,6 +94,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.protocol.Errors.COORDINATOR_NOT_AVAILABLE;
+import static org.apache.kafka.common.protocol.Errors.ILLEGAL_GENERATION;
 import static org.apache.kafka.common.protocol.Errors.NOT_COORDINATOR;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_SERVER_ERROR;
 import static org.apache.kafka.common.requests.JoinGroupRequest.UNKNOWN_MEMBER_ID;
@@ -2832,6 +2837,77 @@ public class GroupMetadataManager {
                 break;
             default:
                 throw new IllegalStateException("Unknown group state: " + group.stateAsString());
+        }
+    }
+
+    /**
+     * Handle a generic group HeartbeatRequest.
+     *
+     * @param context        The request context.
+     * @param request        The actual Heartbeat request.
+     *
+     * @return The Heartbeat response.
+     */
+    public HeartbeatResponseData genericGroupHeartbeat(
+        RequestContext context,
+        HeartbeatRequestData request
+    ) {
+        GenericGroup group = getOrMaybeCreateGenericGroup(request.groupId(), false);
+
+        validateGenericGroupHeartbeat(group, request.memberId(), request.groupInstanceId(), request.generationId());
+
+        switch (group.currentState()) {
+            case EMPTY:
+                return new HeartbeatResponseData().setErrorCode(Errors.UNKNOWN_MEMBER_ID.code());
+
+            case PREPARING_REBALANCE:
+                rescheduleGenericGroupMemberHeartbeat(group, group.member(request.memberId()));
+                return new HeartbeatResponseData().setErrorCode(Errors.REBALANCE_IN_PROGRESS.code());
+
+            case COMPLETING_REBALANCE:
+                // Consumers may start sending heartbeat after join-group response, in which case
+                // we should treat them as normal hb request and reset the timer
+
+            case STABLE:
+                rescheduleGenericGroupMemberHeartbeat(group, group.member(request.memberId()));
+                return new HeartbeatResponseData();
+
+            default:
+                throw new IllegalStateException("Reached unexpected state " +
+                    group.currentState() + " for group " + group.groupId());
+        }
+    }
+
+    /**
+     * Validates a generic group heartbeat request.
+     *
+     * @param group              The group.
+     * @param memberId           The member id.
+     * @param groupInstanceId    The group instance id.
+     * @param generationId       The generation id.
+     *
+     * @throws CoordinatorNotAvailableException If group is Dead.
+     * @throws IllegalGenerationException       If the generation id in the request and the generation id of the
+     *                                          group does not match.
+     */
+    private void validateGenericGroupHeartbeat(
+        GenericGroup group,
+        String memberId,
+        String groupInstanceId,
+        int generationId
+    ) throws CoordinatorNotAvailableException, IllegalGenerationException {
+        if (group.isInState(DEAD)) {
+            throw COORDINATOR_NOT_AVAILABLE.exception();
+        } else {
+            group.validateMember(
+                memberId,
+                groupInstanceId,
+                "heartbeat"
+            );
+
+            if (generationId != group.generationId()) {
+                throw ILLEGAL_GENERATION.exception();
+            }
         }
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2865,10 +2865,10 @@ public class GroupMetadataManager {
                 return new HeartbeatResponseData().setErrorCode(Errors.REBALANCE_IN_PROGRESS.code());
 
             case COMPLETING_REBALANCE:
-                // Consumers may start sending heartbeat after join-group response, in which case
-                // we should treat them as normal hb request and reset the timer
-
             case STABLE:
+                // Consumers may start sending heartbeats after join-group response, while the group
+                // is in CompletingRebalance state. In this case, we should treat them as
+                // normal heartbeat requests and reset the timer
                 rescheduleGenericGroupMemberHeartbeat(group, group.member(request.memberId()));
                 return new HeartbeatResponseData();
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/ReplicatedGroupCoordinator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/ReplicatedGroupCoordinator.java
@@ -19,6 +19,8 @@ package org.apache.kafka.coordinator.group;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
+import org.apache.kafka.common.message.HeartbeatRequestData;
+import org.apache.kafka.common.message.HeartbeatResponseData;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.message.OffsetCommitRequestData;
@@ -246,6 +248,24 @@ public class ReplicatedGroupCoordinator implements Coordinator<Record> {
             context,
             request,
             responseFuture
+        );
+    }
+
+    /**
+     * Handles a generic group HeartbeatRequest.
+     *
+     * @param context The request context.
+     * @param request The actual Heartbeat request.
+     *
+     * @return The HeartbeatResponse.
+     */
+    public HeartbeatResponseData genericGroupHeartbeat(
+        RequestContext context,
+        HeartbeatRequestData request
+    ) {
+        return groupMetadataManager.genericGroupHeartbeat(
+            context,
+            request
         );
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -18,17 +18,21 @@ package org.apache.kafka.coordinator.group;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.CoordinatorLoadInProgressException;
 import org.apache.kafka.common.errors.CoordinatorNotAvailableException;
 import org.apache.kafka.common.errors.InvalidFetchSizeException;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.KafkaStorageException;
 import org.apache.kafka.common.errors.NotEnoughReplicasException;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
+import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.errors.RecordBatchTooLargeException;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
+import org.apache.kafka.common.message.HeartbeatRequestData;
+import org.apache.kafka.common.message.HeartbeatResponseData;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
@@ -495,4 +499,99 @@ public class GroupCoordinatorServiceTest {
 
         assertEquals(expectedResponse, response.get());
     }
-}
+
+    @Test
+    public void testHeartbeat() throws Exception {
+        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        GroupCoordinatorService service = new GroupCoordinatorService(
+            new LogContext(),
+            createConfig(),
+            runtime
+        );
+
+        HeartbeatRequestData request = new HeartbeatRequestData()
+            .setGroupId("foo");
+
+        service.startup(() -> 1);
+
+        when(runtime.scheduleReadOperation(
+            ArgumentMatchers.eq("generic-group-heartbeat"),
+            ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
+            ArgumentMatchers.any()
+        )).thenReturn(CompletableFuture.completedFuture(
+            new HeartbeatResponseData()
+        ));
+
+        CompletableFuture<HeartbeatResponseData> future = service.heartbeat(
+            requestContext(ApiKeys.HEARTBEAT),
+            request
+        );
+
+        assertTrue(future.isDone());
+        assertEquals(new HeartbeatResponseData(), future.get());
+    }
+
+    @Test
+    public void testHeartbeatCoordinatorNotAvailableException() throws Exception {
+        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        GroupCoordinatorService service = new GroupCoordinatorService(
+            new LogContext(),
+            createConfig(),
+            runtime
+        );
+
+        HeartbeatRequestData request = new HeartbeatRequestData()
+            .setGroupId("foo");
+
+        service.startup(() -> 1);
+
+        when(runtime.scheduleReadOperation(
+            ArgumentMatchers.eq("generic-group-heartbeat"),
+            ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
+            ArgumentMatchers.any()
+        )).thenReturn(FutureUtils.failedFuture(
+            new CoordinatorLoadInProgressException(null)
+        ));
+
+        CompletableFuture<HeartbeatResponseData> future = service.heartbeat(
+            requestContext(ApiKeys.HEARTBEAT),
+            request
+        );
+
+        assertTrue(future.isDone());
+        assertEquals(new HeartbeatResponseData(), future.get());
+    }
+
+    @Test
+    public void testHeartbeatCoordinatorException() throws Exception {
+        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        GroupCoordinatorService service = new GroupCoordinatorService(
+            new LogContext(),
+            createConfig(),
+            runtime
+        );
+
+        HeartbeatRequestData request = new HeartbeatRequestData()
+            .setGroupId("foo");
+
+        service.startup(() -> 1);
+
+        when(runtime.scheduleReadOperation(
+            ArgumentMatchers.eq("generic-group-heartbeat"),
+            ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
+            ArgumentMatchers.any()
+        )).thenReturn(FutureUtils.failedFuture(
+            new RebalanceInProgressException()
+        ));
+
+        CompletableFuture<HeartbeatResponseData> future = service.heartbeat(
+            requestContext(ApiKeys.HEARTBEAT),
+            request
+        );
+
+        assertTrue(future.isDone());
+        assertEquals(
+            new HeartbeatResponseData().setErrorCode(Errors.REBALANCE_IN_PROGRESS.code()),
+            future.get()
+        );
+    }}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -594,4 +594,5 @@ public class GroupCoordinatorServiceTest {
             new HeartbeatResponseData().setErrorCode(Errors.REBALANCE_IN_PROGRESS.code()),
             future.get()
         );
-    }}
+    }
+}


### PR DESCRIPTION
This patch implements the existing Heartbeat API in the new Group Coordinator.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
