### PR TITLE
KAFKA-15222: Upgrade zinc Scala incremental compiler plugin version to a latests stable fit version (1.9.2)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -147,7 +147,7 @@ versions += [
   // New version of Swagger 2.2.14 requires minimum JDK 11.
   swaggerAnnotations: "2.2.8",
   swaggerJaxrs2: "2.2.8",
-  zinc: "1.8.0",
+  zinc: "1.9.2",
   zookeeper: "3.6.4",
   zstd: "1.5.5-1"
 ]


### PR DESCRIPTION
The existing version of zinc incremental scala compiler plugin is getting a bit old, upgrading to last stable version 1.9.2

From the version 1.8.0 to 1.9.2 this is a list of all changed https://github.com/sbt/zinc/compare/v1.8.0...v1.9.2  
Link to release notes : https://github.com/sbt/zinc/releases 


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
