### PR TITLE
KAFKA-15251: Add 3.5.1 to system tests

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -124,7 +124,7 @@ versions += [
   kafka_32: "3.2.3",
   kafka_33: "3.3.1",
   kafka_34: "3.4.1",
-  kafka_35: "3.5.0",
+  kafka_35: "3.5.1",
   lz4: "1.8.0",
   mavenArtifact: "3.8.8",
   metrics: "2.2.0",

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -68,7 +68,7 @@ RUN mkdir -p "/opt/kafka-3.1.2" && chmod a+rw /opt/kafka-3.1.2 && curl -s "$KAFK
 RUN mkdir -p "/opt/kafka-3.2.3" && chmod a+rw /opt/kafka-3.2.3 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.2.3.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.2.3"
 RUN mkdir -p "/opt/kafka-3.3.1" && chmod a+rw /opt/kafka-3.3.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.3.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.3.1"
 RUN mkdir -p "/opt/kafka-3.4.1" && chmod a+rw /opt/kafka-3.4.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.4.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.4.1"
-RUN mkdir -p "/opt/kafka-3.5.0" && chmod a+rw /opt/kafka-3.5.0 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.5.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.5.0"
+RUN mkdir -p "/opt/kafka-3.5.1" && chmod a+rw /opt/kafka-3.5.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.5.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.5.1"
 
 
 # Streams test dependencies
@@ -92,7 +92,7 @@ RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.1.2-test.jar" -o /opt/kafka-3.1.2/lib
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.2.3-test.jar" -o /opt/kafka-3.2.3/libs/kafka-streams-3.2.3-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.3.1-test.jar" -o /opt/kafka-3.3.1/libs/kafka-streams-3.3.1-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.4.1-test.jar" -o /opt/kafka-3.4.1/libs/kafka-streams-3.4.1-test.jar
-RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.5.0-test.jar" -o /opt/kafka-3.5.0/libs/kafka-streams-3.5.0-test.jar
+RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.5.1-test.jar" -o /opt/kafka-3.5.1/libs/kafka-streams-3.5.1-test.jar
 
 # The version of Kibosh to use for testing.
 # If you update this, also update vagrant/base.sh

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -250,4 +250,5 @@ LATEST_3_4 = V_3_4_1
 
 # 3.5.x versions
 V_3_5_0 = KafkaVersion("3.5.0")
-LATEST_3_5 = V_3_5_0
+V_3_5_1 = KafkaVersion("3.5.1")
+LATEST_3_5 = V_3_5_1

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -158,8 +158,8 @@ get_kafka 3.3.1 2.12
 chmod a+rw /opt/kafka-3.3.1
 get_kafka 3.4.1 2.12
 chmod a+rw /opt/kafka-3.4.1
-get_kafka 3.5.0 2.12
-chmod a+rw /opt/kafka-3.5.0
+get_kafka 3.5.1 2.12
+chmod a+rw /opt/kafka-3.5.1
 
 
 # For EC2 nodes, we want to use /mnt, which should have the local disk. On local


### PR DESCRIPTION
Adding new version 3.5.1 to system tests as per https://cwiki.apache.org/confluence/display/KAFKA/Release+Process

(search for "In trunk update the following files with the current release number" in the script above)