### PR TITLE
Make acquire and release protected

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -2542,7 +2542,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * supported).
      * @throws ConcurrentModificationException if another thread already has the lock
      */
-    private void acquire() {
+    protected void acquire() {
         final Thread thread = Thread.currentThread();
         final long threadId = thread.getId();
         if (threadId != currentThread.get() && !currentThread.compareAndSet(NO_CURRENT_THREAD, threadId))
@@ -2556,7 +2556,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     /**
      * Release the light lock protecting the consumer from multi-threaded access.
      */
-    private void release() {
+    protected void release() {
         if (refcount.decrementAndGet() == 0)
             currentThread.set(NO_CURRENT_THREAD);
     }


### PR DESCRIPTION
... so that alternative locking mechanisms can be explored. For example PR #13914 could be implemented without changes to the Kafka library.

This idea was brought forward by Chris Egerton on the [mailing list](https://lists.apache.org/thread/bx1k1lfkrg9d78nkqk66248717y6kwdg).

A rationale for this change is described in [KIP-957](https://cwiki.apache.org/confluence/x/lY6zDw).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
