### PR TITLE
KAFKA-15094: RemoteIndexCache stats

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -124,6 +124,7 @@ public class RemoteLogManager implements Closeable {
     private static final Logger LOGGER = LoggerFactory.getLogger(RemoteLogManager.class);
     private static final String REMOTE_LOG_READER_THREAD_NAME_PREFIX = "remote-log-reader";
     public static final String REMOTE_LOG_READER_METRICS_NAME_PREFIX = "RemoteLogReader";
+    public static final String REMOTE_INDEX_CACHE_METRICS_NAME_PREFIX = "RemoteIndexCache";
     public static final String REMOTE_LOG_MANAGER_TASKS_AVG_IDLE_PERCENT = "RemoteLogManagerTasksAvgIdlePercent";
     private final RemoteLogManagerConfig rlmConfig;
     private final int brokerId;
@@ -181,7 +182,7 @@ public class RemoteLogManager implements Closeable {
 
         remoteLogStorageManager = createRemoteStorageManager();
         remoteLogMetadataManager = createRemoteLogMetadataManager();
-        indexCache = new RemoteIndexCache(1024, remoteLogStorageManager, logDir);
+        indexCache = new RemoteIndexCache(1024, remoteLogStorageManager, logDir, REMOTE_INDEX_CACHE_METRICS_NAME_PREFIX);
         delayInMs = rlmConfig.remoteLogManagerTaskIntervalMs();
         rlmScheduledThreadPool = new RLMScheduledThreadPool(rlmConfig.remoteLogManagerThreadPoolSize());
 

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -58,6 +58,7 @@ import org.apache.kafka.storage.internals.log.EpochEntry;
 import org.apache.kafka.storage.internals.log.LazyIndex;
 import org.apache.kafka.storage.internals.log.OffsetIndex;
 import org.apache.kafka.storage.internals.log.ProducerStateManager;
+import org.apache.kafka.storage.internals.log.RemoteIndexCache;
 import org.apache.kafka.storage.internals.log.RemoteStorageThreadPool;
 import org.apache.kafka.storage.internals.log.TimeIndex;
 import org.apache.kafka.storage.internals.log.TransactionIndex;
@@ -92,6 +93,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 
+import static kafka.log.remote.RemoteLogManager.REMOTE_INDEX_CACHE_METRICS_NAME_PREFIX;
 import static kafka.log.remote.RemoteLogManager.REMOTE_LOG_MANAGER_TASKS_AVG_IDLE_PERCENT;
 import static kafka.log.remote.RemoteLogManager.REMOTE_LOG_READER_METRICS_NAME_PREFIX;
 import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_COMMON_CLIENT_PREFIX;
@@ -800,9 +802,14 @@ public class RemoteLogManagerTest {
             remoteLogManager.close();
 
             KafkaMetricsGroup mockRlmMetricsGroup = mockMetricsGroupCtor.constructed().get(0);
-            KafkaMetricsGroup mockThreadPoolMetricsGroup = mockMetricsGroupCtor.constructed().get(1);
+            KafkaMetricsGroup mockIndexCacheMetricsGroup = mockMetricsGroupCtor.constructed().get(1);
+            KafkaMetricsGroup mockThreadPoolMetricsGroup = mockMetricsGroupCtor.constructed().get(2);
 
             List<String> remoteLogManagerMetricNames = Collections.singletonList(REMOTE_LOG_MANAGER_TASKS_AVG_IDLE_PERCENT);
+            List<String> remoteIndexCacheMetricNames = RemoteIndexCache.metricNames()
+                .stream()
+                .map(suffix -> REMOTE_INDEX_CACHE_METRICS_NAME_PREFIX + suffix)
+                .collect(Collectors.toList());
             List<String> remoteStorageThreadPoolMetricNames = RemoteStorageThreadPool.METRIC_SUFFIXES
                 .stream()
                 .map(suffix -> REMOTE_LOG_READER_METRICS_NAME_PREFIX + suffix)
@@ -812,11 +819,16 @@ public class RemoteLogManagerTest {
             // Verify that the RemoteLogManager metrics are removed
             remoteLogManagerMetricNames.forEach(metricName -> verify(mockRlmMetricsGroup).removeMetric(metricName));
 
+            verify(mockIndexCacheMetricsGroup, times(remoteIndexCacheMetricNames.size())).newGauge(anyString(), any());
+            // Verify that the RemoteIndexCache metrics are removed
+            remoteIndexCacheMetricNames.forEach(metricName -> verify(mockIndexCacheMetricsGroup).removeMetric(metricName));
+
             verify(mockThreadPoolMetricsGroup, times(remoteStorageThreadPoolMetricNames.size())).newGauge(anyString(), any());
             // Verify that the RemoteStorageThreadPool metrics are removed
             remoteStorageThreadPoolMetricNames.forEach(metricName -> verify(mockThreadPoolMetricsGroup).removeMetric(metricName));
 
             verifyNoMoreInteractions(mockRlmMetricsGroup);
+            verifyNoMoreInteractions(mockIndexCacheMetricsGroup);
             verifyNoMoreInteractions(mockThreadPoolMetricsGroup);
         } finally {
             mockMetricsGroupCtor.close();


### PR DESCRIPTION
In this PR I have added the metrics for the various RemoteIndexCache stats. The following metrics are being added.

|Name|Description|
|------|-----------|
|HitCount|The number of cache hits for the remote index cache.|
|MissCount|The number of cache misses for the remote index cache.|
|EvictionCount|The number of entries evicted from the remote index cache.|
|LoadSuccessCount|The number of successful cache loads for the remote index cache.|
|LoadFailureCount|The number of failed cache loads for the remote index cache.|
|TotalLoadTime|Total load time (success and failure) for the remote index cache.|
|EvictionWeight|The sum of weights of entries evicted from the remote index cache.|

Added unit tests for all the metrics.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
