### PR TITLE
KAFKA-15235: No test coverage reports for Java due to settings for Jacoco being incompatible with Gradle 8.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -809,7 +809,7 @@ if (userEnableTestCoverage) {
     executionData.from = javaProjects.jacocoTestReport.executionData
 
     reports {
-      xml.required = true
+      html.required = true
       xml.required = true
     }
     // workaround to ignore projects that don't have any tests at all

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ buildscript {
 plugins {
   id 'com.github.ben-manes.versions' version '0.46.0'
   id 'idea'
+  id 'jacoco'
   id 'java-library'
   id 'org.owasp.dependencycheck' version '8.2.1'
   id 'org.nosphere.apache.rat' version "0.8.0"
@@ -735,9 +736,9 @@ subprojects {
         dependsOn tasks.test
         sourceSets sourceSets.main
         reports {
-          html.enabled = true
-          xml.enabled = true
-          csv.enabled = false
+          html.required = true
+          xml.required = true
+          csv.required = false
         }
       }
 
@@ -808,10 +809,9 @@ if (userEnableTestCoverage) {
     executionData.from = javaProjects.jacocoTestReport.executionData
 
     reports {
-      html.enabled = true
-      xml.enabled = true
+      xml.required = true
+      xml.required = true
     }
-
     // workaround to ignore projects that don't have any tests at all
     onlyIf = { true }
     doFirst {


### PR DESCRIPTION
Fixing the Jacoco report generation issue, in the current Gradle version 8.x 

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
