### PR TITLE
MINOR: Use Awaitility for waiting in test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1352,6 +1352,7 @@ project(':clients') {
     testImplementation libs.junitJupiter
     testImplementation libs.log4j
     testImplementation libs.mockitoInline
+    testImplementation libs.awaitility
 
     testRuntimeOnly libs.slf4jlog4j
     testRuntimeOnly libs.jacksonDatabind

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -205,6 +205,7 @@
 
     <subpackage name="consumer">
       <allow pkg="org.apache.kafka.clients.consumer" />
+      <allow pkg="org.awaitility" />
     </subpackage>
 
     <subpackage name="producer">

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -133,6 +133,7 @@
       <subpackage name="oauthbearer">
         <allow pkg="com.fasterxml.jackson.databind" />
         <allow pkg="org.jose4j" />
+        <allow pkg="org.awaitility" />
       </subpackage>
     </subpackage>
 
@@ -202,10 +203,10 @@
     <allow pkg="org.apache.kafka.common" />
     <allow pkg="org.apache.kafka.clients" exact-match="true"/>
     <allow pkg="org.apache.kafka.test" />
+    <allow pkg="org.awaitility" />
 
     <subpackage name="consumer">
       <allow pkg="org.apache.kafka.clients.consumer" />
-      <allow pkg="org.awaitility" />
     </subpackage>
 
     <subpackage name="producer">

--- a/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
@@ -22,12 +22,14 @@ import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
@@ -22,14 +22,12 @@ import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -1020,8 +1020,7 @@ public class AbstractCoordinatorTest {
                 .atMost(Duration.ofMillis(1000))
                 .untilAsserted(() -> assertThrows(
                         FencedInstanceIdException.class, () -> coordinator.pollHeartbeat(mockTime.milliseconds()),
-                        "Expected pollHeartbeat to raise fenced instance id exception in 1 second")
-                );
+                        "Expected pollHeartbeat to raise fenced instance id exception in 1 second"));
     }
 
     @Test
@@ -1212,15 +1211,13 @@ public class AbstractCoordinatorTest {
                 .atMost(Duration.ofMillis(1000))
                 .untilAsserted(() -> assertThrows(
                         e.getClass(), () -> coordinator.timeToNextHeartbeat(0),
-                        "Expected timeToNextHeartbeat to raise an error in 1 second")
-                );
+                        "Expected timeToNextHeartbeat to raise an error in 1 second"));
 
         Awaitility.await()
                 .atMost(Duration.ofMillis(1000))
                 .untilAsserted(() -> assertThrows(
                         e.getClass(), () -> coordinator.pollHeartbeat(mockTime.milliseconds()),
-                        "Expected pollHeartbeat to raise an error in 1 second")
-                );
+                        "Expected pollHeartbeat to raise an error in 1 second"));
     }
 
     @Test

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -77,6 +77,7 @@ versions += [
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
+  awaitility: "4.2.0",
   bcpkix: "1.75",
   caffeine: "2.9.3", // 3.x supports JDK 11 and above
   checkstyle: "8.36.2",
@@ -164,6 +165,7 @@ libs += [
   apachedsMavibotPartition: "org.apache.directory.server:apacheds-mavibot-partition:$versions.apacheds",
   apachedsJdbmPartition: "org.apache.directory.server:apacheds-jdbm-partition:$versions.apacheds",
   argparse4j: "net.sourceforge.argparse4j:argparse4j:$versions.argparse4j",
+  awaitility: "org.awaitility:awaitility:$versions.awaitility",
   bcpkix: "org.bouncycastle:bcpkix-jdk18on:$versions.bcpkix",
   caffeine: "com.github.ben-manes.caffeine:caffeine:$versions.caffeine",
   commonsCli: "commons-cli:commons-cli:$versions.commonsCli",


### PR DESCRIPTION
Awaitility(awaitility.org) is a more reliable way to wait and 
assert conditions in tests. It can prevent flakiness in tests.