### PR TITLE
MINOR: Downgrade log level for conflicting Connect plugin aliases

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -408,7 +408,7 @@ public class PluginUtils {
             if (classNames.size() == 1) {
                 aliases.put(alias, classNames.stream().findAny().get());
             } else {
-                log.warn("Ignoring ambiguous alias '{}' since it refers to multiple distinct plugins {}", alias, classNames);
+                log.debug("Ignoring ambiguous alias '{}' since it refers to multiple distinct plugins {}", alias, classNames);
             }
         }
         return aliases;


### PR DESCRIPTION
We've started to see messages like this on startup:

> [2023-07-24 09:16:34,776] WARN Ignoring ambiguous alias 'Value' since it refers to multiple distinct plugins [org.apache.kafka.connect.transforms.HeaderFrom$Value, org.apache.kafka.connect.transforms.ReplaceField$Value, org.apache.kafka.connect.transforms.SetSchemaMetadata$Value, org.apache.kafka.connect.transforms.Cast$Value, org.apache.kafka.connect.runtime.ConnectorConfigTest$AbstractKeyValueTransformation$Value, org.apache.kafka.connect.transforms.ExtractField$Value, org.apache.kafka.connect.transforms.InsertField$Value, org.apache.kafka.connect.transforms.Flatten$Value, org.apache.kafka.connect.transforms.MaskField$Value, org.apache.kafka.connect.transforms.TimestampConverter$Value, org.apache.kafka.connect.transforms.HoistField$Value] (org.apache.kafka.connect.runtime.isolation.PluginUtils:411)

This is because `Class::simpleName` doesn't include the names of any outer classes when used on a nested class, and many of the SMTs that we ship out of the box with Kafka Connect use inner classes. For example, the `org.apache.kafka.connect.transforms.ReplaceField` SMT has the inner classes `Key` and `Value`, and the simple name for the `Value` inner class is just `Value` (instead of `ReplaceField$Value` or `ReplaceField.Value`, as one may have expected).

We should downgrade to a lower log level since users may think that something is wrong if they start seeing these messages after an upgrade.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
