### PR TITLE
KAFKA-15219: KRaft support for DelegationTokens

### DIFF
--- a/checkstyle/import-control-metadata.xml
+++ b/checkstyle/import-control-metadata.xml
@@ -35,6 +35,7 @@
     <allow pkg="java.security" />
     <allow pkg="javax.net.ssl" />
     <allow pkg="javax.security" />
+    <allow pkg="javax.crypto" />
     <allow pkg="org.ietf.jgss" />
     <allow pkg="net.jqwik.api" />
 

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -310,7 +310,7 @@
     <suppress checks="CyclomaticComplexity"
               files="(ClientQuotasImage|KafkaEventQueue|MetadataDelta|QuorumController|ReplicationControlManager|KRaftMigrationDriver|ClusterControlManager).java"/>
     <suppress checks="NPathComplexity"
-              files="(ClientQuotasImage|KafkaEventQueue|ReplicationControlManager|FeatureControlManager|KRaftMigrationDriver|ScramControlManager|ClusterControlManager).java"/>
+              files="(ClientQuotasImage|KafkaEventQueue|ReplicationControlManager|FeatureControlManager|KRaftMigrationDriver|ScramControlManager|ClusterControlManager|MetadataDelta).java"/>
     <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
             files="metadata[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
     <suppress checks="BooleanExpressionComplexity"

--- a/clients/src/main/java/org/apache/kafka/common/security/token/delegation/TokenInformation.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/token/delegation/TokenInformation.java
@@ -54,16 +54,27 @@ public class TokenInformation {
         this.expiryTimestamp =  expiryTimestamp;
     }
 
+    // Convert record elements into a TokenInformation
+    public static TokenInformation fromRecord(String tokenId, KafkaPrincipal owner, KafkaPrincipal tokenRequester,
+                            Collection<KafkaPrincipal> renewers, long issueTimestamp, long maxTimestamp, long expiryTimestamp) {
+        return new TokenInformation(
+            tokenId, owner, tokenRequester, renewers, issueTimestamp, maxTimestamp, expiryTimestamp);
+    }
+
     public KafkaPrincipal owner() {
         return owner;
+    }
+
+    public String ownerAsString() {
+        return owner.toString();
     }
 
     public KafkaPrincipal tokenRequester() {
         return tokenRequester;
     }
 
-    public String ownerAsString() {
-        return owner.toString();
+    public String tokenRequesterAsString() {
+        return tokenRequester.toString();
     }
 
     public Collection<KafkaPrincipal> renewers() {

--- a/clients/src/main/resources/common/message/CreateDelegationTokenRequest.json
+++ b/clients/src/main/resources/common/message/CreateDelegationTokenRequest.json
@@ -16,7 +16,7 @@
 {
   "apiKey": 38,
   "type": "request",
-  "listeners": ["zkBroker"],
+  "listeners": ["zkBroker", "broker", "controller"],
   "name": "CreateDelegationTokenRequest",
   // Version 1 is the same as version 0.
   //

--- a/clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json
+++ b/clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json
@@ -16,7 +16,7 @@
 {
   "apiKey": 41,
   "type": "request",
-  "listeners": ["zkBroker"],
+  "listeners": ["zkBroker", "broker", "controller"],
   "name": "DescribeDelegationTokenRequest",
   // Version 1 is the same as version 0.
   // Version 2 adds flexible version support

--- a/clients/src/main/resources/common/message/ExpireDelegationTokenRequest.json
+++ b/clients/src/main/resources/common/message/ExpireDelegationTokenRequest.json
@@ -16,7 +16,7 @@
 {
   "apiKey": 40,
   "type": "request",
-  "listeners": ["zkBroker"],
+  "listeners": ["zkBroker", "broker", "controller"],
   "name": "ExpireDelegationTokenRequest",
   // Version 1 is the same as version 0.
   // Version 2 adds flexible version support

--- a/clients/src/main/resources/common/message/RenewDelegationTokenRequest.json
+++ b/clients/src/main/resources/common/message/RenewDelegationTokenRequest.json
@@ -16,7 +16,7 @@
 {
   "apiKey": 39,
   "type": "request",
-  "listeners": ["zkBroker"],
+  "listeners": ["zkBroker", "broker", "controller"],
   "name": "RenewDelegationTokenRequest",
   // Version 1 is the same as version 0.
   // Version 2 adds flexible version support

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -25,7 +25,8 @@ import kafka.log.remote.RemoteLogManager
 import kafka.network.{DataPlaneAcceptor, SocketServer}
 import kafka.raft.KafkaRaftManager
 import kafka.security.CredentialProvider
-import kafka.server.metadata.{AclPublisher, BrokerMetadataPublisher, ClientQuotaMetadataManager, DynamicClientQuotaPublisher, DynamicConfigPublisher, KRaftMetadataCache, ScramPublisher}
+import kafka.server.metadata.{AclPublisher, BrokerMetadataPublisher, ClientQuotaMetadataManager,
+DynamicClientQuotaPublisher, DynamicConfigPublisher, KRaftMetadataCache, ScramPublisher, DelegationTokenPublisher}
 import kafka.utils.CoreUtils
 import org.apache.kafka.clients.NetworkClient
 import org.apache.kafka.common.config.ConfigException
@@ -279,10 +280,7 @@ class BrokerServer(
       )
 
       /* start token manager */
-      if (config.tokenAuthEnabled) {
-        throw new UnsupportedOperationException("Delegation tokens are not supported")
-      }
-      tokenManager = new DelegationTokenManager(config, tokenCache, time , null)
+      tokenManager = new DelegationTokenManager(config, tokenCache, time)
       tokenManager.startup() // does nothing, we just need a token manager in order to compile right now...
 
       groupCoordinator = createGroupCoordinator()
@@ -418,6 +416,11 @@ class BrokerServer(
           sharedServer.metadataPublishingFaultHandler,
           "broker",
           credentialProvider),
+        new DelegationTokenPublisher(
+          config,
+          sharedServer.metadataPublishingFaultHandler,
+          "broker",
+          tokenManager),
         new AclPublisher(
           config.nodeId,
           sharedServer.metadataPublishingFaultHandler,

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -281,7 +281,7 @@ class BrokerServer(
 
       /* start token manager */
       tokenManager = new DelegationTokenManager(config, tokenCache, time)
-      tokenManager.startup() // does nothing, we just need a token manager in order to compile right now...
+      tokenManager.startup()
 
       groupCoordinator = createGroupCoordinator()
 

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -851,8 +851,8 @@ class ControllerApis(val requestChannel: RequestChannel,
   def allowTokenRequests(request: RequestChannel.Request): Boolean = {
     val protocol = request.context.securityProtocol
     if (request.context.principal.tokenAuthenticated ||
-      // We have to allow PLAINTEXT for the controller Apis
-      // protocol == SecurityProtocol.PLAINTEXT ||
+      // We allow forwarded requests to use PLAINTEXT for testing purposes
+      (request.isForwarded == false && protocol == SecurityProtocol.PLAINTEXT) ||
       // disallow requests from 1-way SSL
       (protocol == SecurityProtocol.SSL && request.context.principal == KafkaPrincipal.ANONYMOUS))
       false

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -103,6 +103,7 @@ class ControllerApis(val requestChannel: RequestChannel,
         case ApiKeys.ALTER_USER_SCRAM_CREDENTIALS => handleAlterUserScramCredentials(request)
         case ApiKeys.CREATE_DELEGATION_TOKEN => handleCreateDelegationTokenRequest(request)
         case ApiKeys.RENEW_DELEGATION_TOKEN => handleRenewDelegationTokenRequest(request)
+        case ApiKeys.EXPIRE_DELEGATION_TOKEN => handleExpireDelegationTokenRequest(request)
         case ApiKeys.ENVELOPE => handleEnvelopeRequest(request, requestLocal)
         case ApiKeys.SASL_HANDSHAKE => handleSaslHandshakeRequest(request)
         case ApiKeys.SASL_AUTHENTICATE => handleSaslAuthenticateRequest(request)
@@ -860,7 +861,6 @@ class ControllerApis(val requestChannel: RequestChannel,
       }
   }
 
-  // XXX RenewDelegationTokenResponse is not version dependent
   def handleRenewDelegationTokenRequest(request: RequestChannel.Request): CompletableFuture[Unit] = {
      val alterRequest = request.body[RenewDelegationTokenRequest]
 
@@ -872,6 +872,20 @@ class ControllerApis(val requestChannel: RequestChannel,
        .thenApply[Unit] { response =>
          requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
            new RenewDelegationTokenResponse(response.setThrottleTimeMs(requestThrottleMs)))
+      }
+  }
+
+  def handleExpireDelegationTokenRequest(request: RequestChannel.Request): CompletableFuture[Unit] = {
+     val alterRequest = request.body[ExpireDelegationTokenRequest]
+
+     val context = new ControllerRequestContext(
+       request.context.header.data,
+       request.context.principal,
+       OptionalLong.empty())
+     controller.expireDelegationToken(context, alterRequest.data)
+       .thenApply[Unit] { response =>
+         requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
+           new ExpireDelegationTokenResponse(response.setThrottleTimeMs(requestThrottleMs)))
       }
   }
 

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -52,6 +52,7 @@ import org.apache.kafka.controller.ControllerRequestContext.requestTimeoutMsToDe
 import org.apache.kafka.controller.{Controller, ControllerRequestContext}
 import org.apache.kafka.metadata.{BrokerHeartbeatReply, BrokerRegistrationReply}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
+import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.kafka.server.common.ApiMessageAndVersion
 
@@ -847,6 +848,18 @@ class ControllerApis(val requestChannel: RequestChannel,
       }
   }
 
+  def allowTokenRequests(request: RequestChannel.Request): Boolean = {
+    val protocol = request.context.securityProtocol
+    if (request.context.principal.tokenAuthenticated ||
+      // We have to allow PLAINTEXT for the controller Apis
+      // protocol == SecurityProtocol.PLAINTEXT ||
+      // disallow requests from 1-way SSL
+      (protocol == SecurityProtocol.SSL && request.context.principal == KafkaPrincipal.ANONYMOUS))
+      false
+    else
+      true
+  }
+
   def handleCreateDelegationTokenRequest(request: RequestChannel.Request): CompletableFuture[Unit] = {
     val createTokenRequest = request.body[CreateDelegationTokenRequest]
 
@@ -859,61 +872,88 @@ class ControllerApis(val requestChannel: RequestChannel,
       new KafkaPrincipal(ownerPrincipalType, ownerPrincipalName)
     }
 
-    // Requester is always allowed to create token for self
-    if (!owner.equals(requester) && 
+    if (!allowTokenRequests(request)) {
+      requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
+        CreateDelegationTokenResponse.prepareResponse(request.context.requestVersion, requestThrottleMs,
+          Errors.DELEGATION_TOKEN_REQUEST_NOT_ALLOWED, owner, requester))
+      CompletableFuture.completedFuture[Unit](())
+    } else if (!owner.equals(requester) && 
       !authHelper.authorize(request.context, CREATE_TOKENS, USER, owner.toString)) {
+      // Requester is always allowed to create token for self
       requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
         CreateDelegationTokenResponse.prepareResponse(request.context.requestVersion, requestThrottleMs,
           Errors.DELEGATION_TOKEN_AUTHORIZATION_FAILED, owner, requester))
-    }
+        CompletableFuture.completedFuture[Unit](())
+    } else {
 
-    val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
-      OptionalLong.empty())
+      val context = new ControllerRequestContext(request.context.header.data,
+        request.context.principal, OptionalLong.empty())
 
-    // Copy the response data to a new response so we can apply the request version
-    controller.createDelegationToken(context, createTokenRequest.data)
-      .thenApply[Unit] { response =>
-         requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
-           CreateDelegationTokenResponse.prepareResponse(
-             request.context.requestVersion,
-             requestThrottleMs,
-             Errors.forCode(response.errorCode()),
-             new KafkaPrincipal(response.principalType(), response.principalName()),
-             new KafkaPrincipal(response.tokenRequesterPrincipalType(), response.tokenRequesterPrincipalName()),
-             response.issueTimestampMs(),
-             response.expiryTimestampMs(),
-             response.maxTimestampMs(),
-             response.tokenId(),
-             ByteBuffer.wrap(response.hmac())))
+      // Copy the response data to a new response so we can apply the request version
+      controller.createDelegationToken(context, createTokenRequest.data)
+        .thenApply[Unit] { response =>
+           requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
+             CreateDelegationTokenResponse.prepareResponse(
+               request.context.requestVersion,
+               requestThrottleMs,
+               Errors.forCode(response.errorCode()),
+               new KafkaPrincipal(response.principalType(), response.principalName()),
+               new KafkaPrincipal(response.tokenRequesterPrincipalType(), response.tokenRequesterPrincipalName()),
+               response.issueTimestampMs(),
+               response.expiryTimestampMs(),
+               response.maxTimestampMs(),
+               response.tokenId(),
+               ByteBuffer.wrap(response.hmac())))
       }
+    }
   }
 
   def handleRenewDelegationTokenRequest(request: RequestChannel.Request): CompletableFuture[Unit] = {
-     val renewTokenRequest = request.body[RenewDelegationTokenRequest]
+    val renewTokenRequest = request.body[RenewDelegationTokenRequest]
 
-     val context = new ControllerRequestContext(
-       request.context.header.data,
-       request.context.principal,
-       OptionalLong.empty())
-     controller.renewDelegationToken(context, renewTokenRequest.data)
-       .thenApply[Unit] { response =>
-         requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
-           new RenewDelegationTokenResponse(response.setThrottleTimeMs(requestThrottleMs)))
+    if (!allowTokenRequests(request)) {
+      requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
+        new RenewDelegationTokenResponse(
+          new RenewDelegationTokenResponseData()
+              .setThrottleTimeMs(requestThrottleMs)
+              .setErrorCode(Errors.DELEGATION_TOKEN_REQUEST_NOT_ALLOWED.code)
+              .setExpiryTimestampMs(DelegationTokenManager.ErrorTimestamp)))
+        CompletableFuture.completedFuture[Unit](())
+    } else {
+      val context = new ControllerRequestContext(
+        request.context.header.data,
+        request.context.principal,
+        OptionalLong.empty())
+      controller.renewDelegationToken(context, renewTokenRequest.data)
+        .thenApply[Unit] { response =>
+          requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
+            new RenewDelegationTokenResponse(response.setThrottleTimeMs(requestThrottleMs)))
       }
+    }
   }
 
   def handleExpireDelegationTokenRequest(request: RequestChannel.Request): CompletableFuture[Unit] = {
-     val expireTokenRequest = request.body[ExpireDelegationTokenRequest]
+    val expireTokenRequest = request.body[ExpireDelegationTokenRequest]
 
-     val context = new ControllerRequestContext(
-       request.context.header.data,
-       request.context.principal,
-       OptionalLong.empty())
-     controller.expireDelegationToken(context, expireTokenRequest.data)
-       .thenApply[Unit] { response =>
-         requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
-           new ExpireDelegationTokenResponse(response.setThrottleTimeMs(requestThrottleMs)))
+    if (!allowTokenRequests(request)) {
+      requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
+        new ExpireDelegationTokenResponse(
+          new ExpireDelegationTokenResponseData()
+              .setThrottleTimeMs(requestThrottleMs)
+              .setErrorCode(Errors.DELEGATION_TOKEN_REQUEST_NOT_ALLOWED.code)
+              .setExpiryTimestampMs(DelegationTokenManager.ErrorTimestamp)))
+      CompletableFuture.completedFuture[Unit](())
+    } else {
+      val context = new ControllerRequestContext(
+        request.context.header.data,
+        request.context.principal,
+        OptionalLong.empty())
+      controller.expireDelegationToken(context, expireTokenRequest.data)
+        .thenApply[Unit] { response =>
+          requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
+            new ExpireDelegationTokenResponse(response.setThrottleTimeMs(requestThrottleMs)))
       }
+    }
   }
 
   def handleListPartitionReassignments(request: RequestChannel.Request): CompletableFuture[Unit] = {

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -848,13 +848,17 @@ class ControllerApis(val requestChannel: RequestChannel,
       }
   }
 
+  // The principal is carried through in the forwarded case.
+  // The security protocol in the context is for the current connection (hop)
+  // We need to always disallow a tokenAuthenticated principal
+  // We need to allow special protocols but only in the forwarded case for testing.
   def allowTokenRequests(request: RequestChannel.Request): Boolean = {
     val protocol = request.context.securityProtocol
     if (request.context.principal.tokenAuthenticated ||
       // We allow forwarded requests to use PLAINTEXT for testing purposes
       (request.isForwarded == false && protocol == SecurityProtocol.PLAINTEXT) ||
       // disallow requests from 1-way SSL
-      (protocol == SecurityProtocol.SSL && request.context.principal == KafkaPrincipal.ANONYMOUS))
+      (request.isForwarded == false && protocol == SecurityProtocol.SSL && request.context.principal == KafkaPrincipal.ANONYMOUS))
       false
     else
       true

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -866,7 +866,6 @@ class ControllerApis(val requestChannel: RequestChannel,
           Errors.DELEGATION_TOKEN_AUTHORIZATION_FAILED, owner, requester))
     }
 
-    println("ControllerApis:handleCreateDelegationTokenRequest:authorized")
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       OptionalLong.empty())
     // XXX We need to prepare the response here so that we can applu the version here

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -848,11 +848,11 @@ class ControllerApis(val requestChannel: RequestChannel,
   }
 
   def handleCreateDelegationTokenRequest(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    val alterRequest = request.body[CreateDelegationTokenRequest]
+    val createTokenRequest = request.body[CreateDelegationTokenRequest]
 
     val requester = request.context.principal
-    val ownerPrincipalName = alterRequest.data.ownerPrincipalName
-    val ownerPrincipalType = alterRequest.data.ownerPrincipalType
+    val ownerPrincipalName = createTokenRequest.data.ownerPrincipalName
+    val ownerPrincipalType = createTokenRequest.data.ownerPrincipalType
     val owner = if (ownerPrincipalName == null || ownerPrincipalName.isEmpty) {
       request.context.principal
     } else {
@@ -871,7 +871,7 @@ class ControllerApis(val requestChannel: RequestChannel,
       OptionalLong.empty())
 
     // Copy the response data to a new response so we can apply the request version
-    controller.createDelegationToken(context, alterRequest.data)
+    controller.createDelegationToken(context, createTokenRequest.data)
       .thenApply[Unit] { response =>
          requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
            CreateDelegationTokenResponse.prepareResponse(
@@ -889,13 +889,13 @@ class ControllerApis(val requestChannel: RequestChannel,
   }
 
   def handleRenewDelegationTokenRequest(request: RequestChannel.Request): CompletableFuture[Unit] = {
-     val alterRequest = request.body[RenewDelegationTokenRequest]
+     val renewTokenRequest = request.body[RenewDelegationTokenRequest]
 
      val context = new ControllerRequestContext(
        request.context.header.data,
        request.context.principal,
        OptionalLong.empty())
-     controller.renewDelegationToken(context, alterRequest.data)
+     controller.renewDelegationToken(context, renewTokenRequest.data)
        .thenApply[Unit] { response =>
          requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
            new RenewDelegationTokenResponse(response.setThrottleTimeMs(requestThrottleMs)))
@@ -903,13 +903,13 @@ class ControllerApis(val requestChannel: RequestChannel,
   }
 
   def handleExpireDelegationTokenRequest(request: RequestChannel.Request): CompletableFuture[Unit] = {
-     val alterRequest = request.body[ExpireDelegationTokenRequest]
+     val expireTokenRequest = request.body[ExpireDelegationTokenRequest]
 
      val context = new ControllerRequestContext(
        request.context.header.data,
        request.context.principal,
        OptionalLong.empty())
-     controller.expireDelegationToken(context, alterRequest.data)
+     controller.expireDelegationToken(context, expireTokenRequest.data)
        .thenApply[Unit] { response =>
          requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
            new ExpireDelegationTokenResponse(response.setThrottleTimeMs(requestThrottleMs)))

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -247,7 +247,7 @@ class ControllerServer(
           setNonFatalFaultHandler(sharedServer.nonFatalQuorumControllerFaultHandler).
           setZkMigrationEnabled(config.migrationEnabled).
           setDelegationTokenCache(tokenCache).
-          setDelegationTokenSecretKeyString(delegationTokenKeyString).
+          setDelegationTokenSecretKey(delegationTokenKeyString).
           setDelegationTokenMaxLifeMs(config.delegationTokenMaxLifeMs).
           setDelegationTokenExpiryTimeMs(config.delegationTokenExpiryTimeMs).
           setDelegationTokenExpiryCheckIntervalMs(config.delegationTokenExpiryCheckIntervalMs)

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -247,7 +247,10 @@ class ControllerServer(
           setNonFatalFaultHandler(sharedServer.nonFatalQuorumControllerFaultHandler).
           setZkMigrationEnabled(config.migrationEnabled).
           setDelegationTokenCache(tokenCache).
-          setDelegationTokenSecretKeyString(delegationTokenKeyString)
+          setDelegationTokenSecretKeyString(delegationTokenKeyString).
+          setDelegationTokenMaxLifeMs(config.delegationTokenMaxLifeMs).
+          setDelegationTokenExpiryTimeMs(config.delegationTokenExpiryTimeMs).
+          setDelegationTokenExpiryCheckIntervalMs(config.delegationTokenExpiryCheckIntervalMs)
       }
       controller = controllerBuilder.build()
 

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -236,7 +236,8 @@ class ControllerServer(
           setBootstrapMetadata(bootstrapMetadata).
           setFatalFaultHandler(sharedServer.fatalQuorumControllerFaultHandler).
           setNonFatalFaultHandler(sharedServer.nonFatalQuorumControllerFaultHandler).
-          setZkMigrationEnabled(config.migrationEnabled)
+          setZkMigrationEnabled(config.migrationEnabled).
+          setDelegationTokenCache(tokenCache)
       }
       controller = controllerBuilder.build()
 

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -118,7 +118,6 @@ class ControllerServer(
   def kafkaYammerMetrics: KafkaYammerMetrics = KafkaYammerMetrics.INSTANCE
   val metadataPublishers: util.List[MetadataPublisher] = new util.ArrayList[MetadataPublisher]()
   val featuresPublisher = new FeaturesPublisher()
-  var tokenManager: DelegationTokenManager = _
 
   private def maybeChangeStatus(from: ProcessStatus, to: ProcessStatus): Boolean = {
     lock.lock()
@@ -370,16 +369,15 @@ class ControllerServer(
         credentialProvider
       ))
 
-      // XXX We need a tokenManager for the Publisher (for now)
-      tokenManager = new DelegationTokenManager(config, tokenCache, time)
 
       // Set up the DelegationToken publisher.
-      // The tokenCache in the tokenManager is the same as set for DelegationTokenControlManager
+      // We need a tokenManager for the Publisher
+      // The tokenCache in the tokenManager is the same used in DelegationTokenControlManager
       metadataPublishers.add(new DelegationTokenPublisher(
           config,
           sharedServer.metadataPublishingFaultHandler,
           "controller",
-          tokenManager
+          new DelegationTokenManager(config, tokenCache, time)
       ))
 
       // Set up the metrics publisher.

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -207,6 +207,14 @@ class ControllerServer(
         QuorumFeatures.defaultFeatureMap(),
         controllerNodes)
 
+      val delegationTokenKeyString = {
+        if (config.tokenAuthEnabled) {
+          config.delegationTokenSecretKey.value
+        } else {
+          null
+        }
+      }
+
       val controllerBuilder = {
         val leaderImbalanceCheckIntervalNs = if (config.autoLeaderRebalanceEnable) {
           OptionalLong.of(TimeUnit.NANOSECONDS.convert(config.leaderImbalanceCheckIntervalSeconds, TimeUnit.SECONDS))
@@ -239,7 +247,8 @@ class ControllerServer(
           setFatalFaultHandler(sharedServer.fatalQuorumControllerFaultHandler).
           setNonFatalFaultHandler(sharedServer.nonFatalQuorumControllerFaultHandler).
           setZkMigrationEnabled(config.migrationEnabled).
-          setDelegationTokenCache(tokenCache)
+          setDelegationTokenCache(tokenCache).
+          setDelegationTokenSecretKeyString(delegationTokenKeyString)
       }
       controller = controllerBuilder.build()
 

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -20,7 +20,6 @@ package kafka.server
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.security.InvalidKeyException
-import java.util.Base64
 
 import javax.crypto.spec.SecretKeySpec
 import javax.crypto.{Mac, SecretKey}
@@ -58,18 +57,6 @@ object DelegationTokenManager {
    */
   def createSecretKey(keybytes: Array[Byte]) : SecretKey = {
     new SecretKeySpec(keybytes, DefaultHmacAlgorithm)
-  }
-
-  /**
-   *
-   *
-   * @param tokenId
-   * @param secretKey
-   * @return
-   */
-  def createBase64HMAC(tokenId: String, secretKey: SecretKey) : String = {
-    val hmac = createHmac(tokenId, secretKey)
-    Base64.getEncoder.encodeToString(hmac)
   }
 
   /**

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -24,30 +24,20 @@ import java.util.Base64
 
 import javax.crypto.spec.SecretKeySpec
 import javax.crypto.{Mac, SecretKey}
-// import kafka.common.{NotificationHandler, ZkNodeChangeNotificationListener}
-import kafka.utils.{CoreUtils, Json, Logging}
-//import kafka.zk.{DelegationTokenChangeNotificationSequenceZNode, DelegationTokenChangeNotificationZNode, DelegationTokensZNode, KafkaZkClient}
+import kafka.utils.{CoreUtils, Logging}
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.security.scram.internals.{ScramFormatter, ScramMechanism}
 import org.apache.kafka.common.security.scram.ScramCredential
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
 import org.apache.kafka.common.security.token.delegation.{DelegationToken, TokenInformation}
-import org.apache.kafka.common.utils.{Sanitizer, SecurityUtils, Time}
+import org.apache.kafka.common.utils.Time
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
 object DelegationTokenManager {
   val DefaultHmacAlgorithm = "HmacSHA512"
-  val OwnerKey ="owner"
-  val TokenRequesterKey = "tokenRequester"
-  val RenewersKey = "renewers"
-  val IssueTimestampKey = "issueTimestamp"
-  val MaxTimestampKey = "maxTimestamp"
-  val ExpiryTimestampKey = "expiryTimestamp"
-  val TokenIdKey = "tokenId"
-  val VersionKey = "version"
   val CurrentVersion = 3
   val ErrorTimestamp = -1
 
@@ -96,49 +86,6 @@ object DelegationTokenManager {
       case ike: InvalidKeyException => throw new IllegalArgumentException("Invalid key to HMAC computation", ike);
     }
     mac.doFinal(tokenId.getBytes(StandardCharsets.UTF_8))
-  }
-
-  def toJsonCompatibleMap(token: DelegationToken):  Map[String, Any] = {
-    val tokenInfo = token.tokenInfo
-    val tokenInfoMap = mutable.Map[String, Any]()
-    tokenInfoMap(VersionKey) = CurrentVersion
-    tokenInfoMap(OwnerKey) = Sanitizer.sanitize(tokenInfo.ownerAsString)
-    tokenInfoMap(TokenRequesterKey) = Sanitizer.sanitize(tokenInfo.tokenRequester.toString)
-    tokenInfoMap(RenewersKey) = tokenInfo.renewersAsString.asScala.map(e => Sanitizer.sanitize(e)).asJava
-    tokenInfoMap(IssueTimestampKey) = tokenInfo.issueTimestamp
-    tokenInfoMap(MaxTimestampKey) = tokenInfo.maxTimestamp
-    tokenInfoMap(ExpiryTimestampKey) = tokenInfo.expiryTimestamp
-    tokenInfoMap(TokenIdKey) = tokenInfo.tokenId()
-    tokenInfoMap.toMap
-  }
-
-  def fromBytes(bytes: Array[Byte]): Option[TokenInformation] = {
-    if (bytes == null || bytes.isEmpty)
-      return None
-
-    Json.parseBytes(bytes) match {
-      case Some(js) =>
-        val mainJs = js.asJsonObject
-        val version = mainJs(VersionKey).to[Int]
-        require(version > 0 && version <= CurrentVersion)
-        val owner = SecurityUtils.parseKafkaPrincipal(Sanitizer.desanitize(mainJs(OwnerKey).to[String]))
-        var tokenRequester = owner
-        if (version >= 3)
-          tokenRequester = SecurityUtils.parseKafkaPrincipal(Sanitizer.desanitize(mainJs(TokenRequesterKey).to[String]))
-        val renewerStr = mainJs(RenewersKey).to[Seq[String]]
-        val renewers = renewerStr.map(Sanitizer.desanitize).map(SecurityUtils.parseKafkaPrincipal)
-        val issueTimestamp = mainJs(IssueTimestampKey).to[Long]
-        val expiryTimestamp = mainJs(ExpiryTimestampKey).to[Long]
-        val maxTimestamp = mainJs(MaxTimestampKey).to[Long]
-        val tokenId = mainJs(TokenIdKey).to[String]
-
-        val tokenInfo = new TokenInformation(tokenId, owner, tokenRequester, renewers.asJava,
-          issueTimestamp, maxTimestamp, expiryTimestamp)
-
-        Some(tokenInfo)
-      case None =>
-        None
-    }
   }
 
   def filterToken(requesterPrincipal: KafkaPrincipal, owners : Option[List[KafkaPrincipal]], token: TokenInformation,

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -121,19 +121,11 @@ class DelegationTokenManager(val config: KafkaConfig,
   val defaultTokenRenewTime: Long = config.delegationTokenExpiryTimeMs
 
   def startup(): Unit = {
-    if (config.tokenAuthEnabled) {
-      loadCache()
-    }
+      // Nothing to do. Overridden for Zk case
   }
 
   def shutdown(): Unit = {
-    if (config.tokenAuthEnabled) {
-        // Nothing to do
-    }
-  }
-
-  private def loadCache(): Unit = {
-      // Nothing to load.
+      // Nothing to do. Overridden for Zk case
   }
 
   /**

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -100,7 +100,7 @@ object DelegationTokenManager {
 class DelegationTokenManager(val config: KafkaConfig,
                              val tokenCache: DelegationTokenCache,
                              val time: Time) extends Logging {
-  this.logIdent = s"[Token Manager on Broker ${config.brokerId}]: "
+  this.logIdent = s"[Token Manager on Node ${config.brokerId}]: "
 
   protected val lock = new Object()
 

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -189,7 +189,6 @@ class DelegationTokenManager(val config: KafkaConfig,
    * @param renewers
    * @param maxLifeTimeMs
    * @param responseCallback
-   * XXX Move to ZK
    */
   def createToken(owner: KafkaPrincipal,
                   tokenRequester: KafkaPrincipal,

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -358,7 +358,7 @@ class DelegationTokenManager(val config: KafkaConfig,
    *
    * @param tokenId
    */
-  protected def removeToken(tokenId: String): Unit = {
+  def removeToken(tokenId: String): Unit = {
     removeCache(tokenId)
   }
 

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -182,6 +182,7 @@ class DelegationTokenManager(val config: KafkaConfig,
    * @param renewers
    * @param maxLifeTimeMs
    * @param responseCallback
+   * XXX Move to ZK
    */
   def createToken(owner: KafkaPrincipal,
                   tokenRequester: KafkaPrincipal,

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -148,7 +148,7 @@ class DelegationTokenManager(val config: KafkaConfig,
   }
 
   private def loadCache(): Unit = {
-    println("Nothing to load")
+      // Nothing to load.
   }
 
   /**

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -119,7 +119,6 @@ class DelegationTokenManager(val config: KafkaConfig,
 
   val tokenMaxLifetime: Long = config.delegationTokenMaxLifeMs
   val defaultTokenRenewTime: Long = config.delegationTokenExpiryTimeMs
-  val tokenRemoverScanInterval: Long = config.delegationTokenExpiryCheckIntervalMs
 
   def startup(): Unit = {
     if (config.tokenAuthEnabled) {

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -122,7 +122,6 @@ class DelegationTokenManager(val config: KafkaConfig,
   type CreateResponseCallback = CreateTokenResult => Unit
   type RenewResponseCallback = (Errors, Long) => Unit
   type ExpireResponseCallback = (Errors, Long) => Unit
-  type DescribeResponseCallback = (Errors, List[DelegationToken]) => Unit
 
   val secretKey = {
     val keyBytes =  if (config.tokenAuthEnabled) config.delegationTokenSecretKey.value.getBytes(StandardCharsets.UTF_8) else null

--- a/core/src/main/scala/kafka/server/DelegationTokenManagerZk.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManagerZk.scala
@@ -158,7 +158,7 @@ class DelegationTokenManagerZk(config: KafkaConfig,
    *
    * @param tokenId
    */
-  override protected def removeToken(tokenId: String): Unit = {
+  override def removeToken(tokenId: String): Unit = {
     zkClient.deleteDelegationToken(tokenId)
     removeCache(tokenId)
     zkClient.createTokenChangeNotification(tokenId)

--- a/core/src/main/scala/kafka/server/DelegationTokenManagerZk.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManagerZk.scala
@@ -115,7 +115,6 @@ class DelegationTokenManagerZk(config: KafkaConfig,
   }
 
   private def loadCache(): Unit = {
-    println("Nothing to load")
     lock.synchronized {
       val tokens = zkClient.getChildren(DelegationTokensZNode.path)
       info(s"Loading the token cache. Total token count: ${tokens.size}")
@@ -336,7 +335,6 @@ class DelegationTokenManagerZk(config: KafkaConfig,
   }
 
   object TokenChangedNotificationHandler extends NotificationHandler {
-    println("Nothing to Notigy")
     override def processNotification(tokenIdBytes: Array[Byte]): Unit = {
       lock.synchronized {
         val tokenId = new String(tokenIdBytes, StandardCharsets.UTF_8)

--- a/core/src/main/scala/kafka/server/DelegationTokenManagerZk.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManagerZk.scala
@@ -1,0 +1,137 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import java.nio.charset.StandardCharsets
+
+import kafka.common.{NotificationHandler, ZkNodeChangeNotificationListener}
+import kafka.zk.{DelegationTokenChangeNotificationSequenceZNode, DelegationTokenChangeNotificationZNode, DelegationTokensZNode}
+import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
+import org.apache.kafka.common.security.token.delegation.DelegationToken
+import org.apache.kafka.common.utils.Time
+import kafka.zk.KafkaZkClient
+
+
+/*
+ * Cache for Delegation Tokens when using Zk for metadata.
+ * This includes other Zk specific handling of Delegation Tokens.
+ */
+class DelegationTokenManagerZk(config: KafkaConfig,
+                               tokenCache: DelegationTokenCache,
+                               time: Time,
+                               val zkClient: KafkaZkClient) 
+  extends DelegationTokenManager(config, tokenCache, time) {
+
+  import DelegationTokenManager._
+
+  private var tokenChangeListener: ZkNodeChangeNotificationListener = _
+
+  override def startup(): Unit = {
+    if (config.tokenAuthEnabled) {
+      zkClient.createDelegationTokenPaths()
+      loadCache()
+      tokenChangeListener = new ZkNodeChangeNotificationListener(zkClient, DelegationTokenChangeNotificationZNode.path, DelegationTokenChangeNotificationSequenceZNode.SequenceNumberPrefix, TokenChangedNotificationHandler)
+      tokenChangeListener.init()
+    }
+  }
+
+  override def shutdown(): Unit = {
+    if (config.tokenAuthEnabled) {
+      if (tokenChangeListener != null) tokenChangeListener.close()
+    }
+  }
+
+  private def loadCache(): Unit = {
+    println("Nothing to load")
+    lock.synchronized {
+      val tokens = zkClient.getChildren(DelegationTokensZNode.path)
+      info(s"Loading the token cache. Total token count: ${tokens.size}")
+      for (tokenId <- tokens) {
+        try {
+          getTokenFromZk(tokenId) match {
+            case Some(token) => updateCache(token)
+            case None =>
+          }
+        } catch {
+          case ex: Throwable => error(s"Error while getting Token for tokenId: $tokenId", ex)
+        }
+      }
+    }
+  }
+
+  private def getTokenFromZk(tokenId: String): Option[DelegationToken] = {
+    zkClient.getDelegationTokenInfo(tokenId) match {
+      case Some(tokenInformation) => {
+        val hmac = createHmac(tokenId, secretKey)
+        Some(new DelegationToken(tokenInformation, hmac))
+      }
+      case None =>
+        None
+    }
+  }
+
+  /**
+   * @param token
+   */
+  override def updateToken(token: DelegationToken): Unit = {
+    zkClient.setOrCreateDelegationToken(token)
+    updateCache(token)
+    zkClient.createTokenChangeNotification(token.tokenInfo.tokenId())
+  }
+
+  /**
+   *
+   * @param tokenId
+   */
+  override protected def removeToken(tokenId: String): Unit = {
+    zkClient.deleteDelegationToken(tokenId)
+    removeCache(tokenId)
+    zkClient.createTokenChangeNotification(tokenId)
+  }
+
+  /**
+   *
+   * @return
+   */
+  override def expireTokens(): Unit = {
+    lock.synchronized {
+      for (tokenInfo <- getAllTokenInformation) {
+        val now = time.milliseconds
+        if (tokenInfo.maxTimestamp < now || tokenInfo.expiryTimestamp < now) {
+          info(s"Delegation token expired for token: ${tokenInfo.tokenId} for owner: ${tokenInfo.owner}")
+          removeToken(tokenInfo.tokenId)
+        }
+      }
+    }
+  }
+
+  object TokenChangedNotificationHandler extends NotificationHandler {
+    println("Nothing to Notigy")
+    override def processNotification(tokenIdBytes: Array[Byte]): Unit = {
+      lock.synchronized {
+        val tokenId = new String(tokenIdBytes, StandardCharsets.UTF_8)
+        info(s"Processing Token Notification for tokenId: $tokenId")
+        getTokenFromZk(tokenId) match {
+          case Some(token) => updateCache(token)
+          case None => removeCache(tokenId)
+        }
+      }
+    }
+  }
+}
+

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3166,7 +3166,6 @@ class KafkaApis(val requestChannel: RequestChannel,
         def eligible(token: TokenInformation) = DelegationTokenManager
           .filterToken(requestPrincipal, owners, token, authorizeToken, authorizeRequester)
         val tokens =  tokenManager.getTokens(eligible)
-        println(s"Got response ${tokens}")
         sendResponseCallback(Errors.NONE, tokens)
       }
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -216,7 +216,6 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.SASL_AUTHENTICATE => handleSaslAuthenticateRequest(request)
         case ApiKeys.CREATE_PARTITIONS => maybeForwardToController(request, handleCreatePartitionsRequest)
         case ApiKeys.CREATE_DELEGATION_TOKEN => handleCreateTokenRequest(request)
-//        case ApiKeys.RENEW_DELEGATION_TOKEN => maybeForwardToController(request, handleRenewTokenRequest)
         case ApiKeys.RENEW_DELEGATION_TOKEN => handleRenewTokenRequest(request)
 //        case ApiKeys.EXPIRE_DELEGATION_TOKEN => maybeForwardToController(request, handleExpireTokenRequest)
         case ApiKeys.EXPIRE_DELEGATION_TOKEN => handleExpireTokenRequest(request)
@@ -3030,7 +3029,6 @@ class KafkaApis(val requestChannel: RequestChannel,
             Errors.INVALID_PRINCIPAL_TYPE, owner, requester))
       }
       else {
-        println("handleCreateTokenRequest: maybeForward")
         maybeForwardToController(request, handleCreateTokenRequestLocal)
       }
     }
@@ -3157,6 +3155,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         def eligible(token: TokenInformation) = DelegationTokenManager
           .filterToken(requestPrincipal, owners, token, authorizeToken, authorizeRequester)
         val tokens =  tokenManager.getTokens(eligible)
+        println(s"Got response ${tokens}")
         sendResponseCallback(Errors.NONE, tokens)
       }
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -216,7 +216,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.SASL_AUTHENTICATE => handleSaslAuthenticateRequest(request)
         case ApiKeys.CREATE_PARTITIONS => maybeForwardToController(request, handleCreatePartitionsRequest)
         case ApiKeys.CREATE_DELEGATION_TOKEN => handleCreateTokenRequest(request)
-        case ApiKeys.RENEW_DELEGATION_TOKEN => handleRenewTokenRequest(request)
+        case ApiKeys.RENEW_DELEGATION_TOKEN => maybeForwardToController(request, handleRenewTokenRequest)
 //        case ApiKeys.EXPIRE_DELEGATION_TOKEN => maybeForwardToController(request, handleExpireTokenRequest)
         case ApiKeys.EXPIRE_DELEGATION_TOKEN => handleExpireTokenRequest(request)
         case ApiKeys.DESCRIBE_DELEGATION_TOKEN => handleDescribeTokensRequest(request)
@@ -3069,7 +3069,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleRenewTokenRequest(request: RequestChannel.Request): Unit = {
-//    metadataSupport.requireZkOrThrow(KafkaApis.shouldAlwaysForward(request))
+    metadataSupport.requireZkOrThrow(KafkaApis.shouldAlwaysForward(request))
     val renewTokenRequest = request.body[RenewDelegationTokenRequest]
 
     // the callback for sending a renew token response

--- a/core/src/main/scala/kafka/server/KafkaBroker.scala
+++ b/core/src/main/scala/kafka/server/KafkaBroker.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.ClusterResource
 import org.apache.kafka.common.internals.ClusterResourceListeners
 import org.apache.kafka.common.metrics.{Metrics, MetricsReporter}
 import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.metadata.BrokerState
@@ -92,6 +93,7 @@ trait KafkaBroker extends Logging {
   def brokerTopicStats: BrokerTopicStats
   def credentialProvider: CredentialProvider
   def clientToControllerChannelManager: BrokerToControllerChannelManager
+  def tokenCache: DelegationTokenCache
 
   private val metricsGroup = new KafkaMetricsGroup(this.getClass) {
     // For backwards compatibility, we need to keep older metrics tied

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -370,7 +370,7 @@ class KafkaServer(
         checkpointBrokerMetadata(zkMetaProperties)
 
         /* start token manager */
-        tokenManager = new DelegationTokenManager(config, tokenCache, time , zkClient)
+        tokenManager = new DelegationTokenManagerZk(config, tokenCache, time , zkClient)
         tokenManager.startup()
 
         /* start kafka controller */

--- a/core/src/main/scala/kafka/server/MetadataSupport.scala
+++ b/core/src/main/scala/kafka/server/MetadataSupport.scala
@@ -69,16 +69,6 @@ sealed trait MetadataSupport {
       handler(request)
     }
   }
-
-  def alsoMaybeForward(request: RequestChannel.Request,
-    handler: RequestChannel.Request => Unit,
-    responseCallback: Option[AbstractResponse] => Unit
-  ): Unit = {
-    if (!request.isForwarded && canForward()) {
-      forwardingManager.get.forwardRequest(request, responseCallback)
-    }
-    handler(request)
-  }
 }
 
 case class ZkSupport(adminManager: ZkAdminManager,

--- a/core/src/main/scala/kafka/server/MetadataSupport.scala
+++ b/core/src/main/scala/kafka/server/MetadataSupport.scala
@@ -69,6 +69,16 @@ sealed trait MetadataSupport {
       handler(request)
     }
   }
+
+  def alsoMaybeForward(request: RequestChannel.Request,
+    handler: RequestChannel.Request => Unit,
+    responseCallback: Option[AbstractResponse] => Unit
+  ): Unit = {
+    if (!request.isForwarded && canForward()) {
+      forwardingManager.get.forwardRequest(request, responseCallback)
+    }
+    handler(request)
+  }
 }
 
 case class ZkSupport(adminManager: ZkAdminManager,

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -105,6 +105,7 @@ class BrokerMetadataPublisher(
   var dynamicConfigPublisher: DynamicConfigPublisher,
   dynamicClientQuotaPublisher: DynamicClientQuotaPublisher,
   scramPublisher: ScramPublisher,
+  delegationTokenPublisher: DelegationTokenPublisher,
   aclPublisher: AclPublisher,
   fatalFaultHandler: FaultHandler,
   metadataPublishingFaultHandler: FaultHandler
@@ -226,6 +227,9 @@ class BrokerMetadataPublisher(
 
       // Apply SCRAM delta.
       scramPublisher.onMetadataUpdate(delta, newImage)
+
+      // Apply DelegationToken delta.
+      delegationTokenPublisher.onMetadataUpdate(delta, newImage)
 
       // Apply ACL delta.
       aclPublisher.onMetadataUpdate(delta, newImage, manifest)

--- a/core/src/main/scala/kafka/server/metadata/DelegationTokenPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DelegationTokenPublisher.scala
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.metadata
+
+import kafka.server.DelegationTokenManager
+import kafka.server.KafkaConfig
+import kafka.utils.Logging
+import org.apache.kafka.image.loader.LoaderManifest
+import org.apache.kafka.image.{MetadataDelta, MetadataImage}
+import org.apache.kafka.server.fault.FaultHandler
+
+
+class DelegationTokenPublisher(
+  conf: KafkaConfig,
+  faultHandler: FaultHandler,
+  nodeType: String,
+  tokenManager: DelegationTokenManager,
+) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
+  logIdent = s"[${name()}] "
+
+  override def name(): String = s"DelegationTokenPublisher ${nodeType} id=${conf.nodeId}"
+
+  override def onMetadataUpdate(
+    delta: MetadataDelta,
+    newImage: MetadataImage,
+    manifest: LoaderManifest
+  ): Unit = {
+    onMetadataUpdate(delta, newImage)
+  }
+
+  def onMetadataUpdate(
+    delta: MetadataDelta,
+    newImage: MetadataImage,
+  ): Unit = {
+    val deltaName = s"MetadataDelta up to ${newImage.highestOffsetAndEpoch().offset}"
+    try {
+      // Apply changes to DelegationTokens.
+      Option(delta.delegationTokenDelta()).foreach { delegationTokenDelta =>
+        delegationTokenDelta.changes()forEach { 
+          case (tokenId, delegationTokenData) => 
+            tokenManager.updateToken(tokenManager.getDelegationToken(delegationTokenData.tokenInformation()))
+        }
+      }
+    } catch {
+      case t: Throwable => faultHandler.handleFault("Uncaught exception while " +
+        s"publishing DelegationToken changes from ${deltaName}", t)
+    }
+  }
+}

--- a/core/src/main/scala/kafka/server/metadata/DelegationTokenPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DelegationTokenPublisher.scala
@@ -51,9 +51,13 @@ class DelegationTokenPublisher(
     try {
       // Apply changes to DelegationTokens.
       Option(delta.delegationTokenDelta()).foreach { delegationTokenDelta =>
-        delegationTokenDelta.changes()forEach { 
+        delegationTokenDelta.changes().forEach { 
           case (tokenId, delegationTokenData) => 
-            tokenManager.updateToken(tokenManager.getDelegationToken(delegationTokenData.tokenInformation()))
+            if (delegationTokenData.isPresent) {
+              tokenManager.updateToken(tokenManager.getDelegationToken(delegationTokenData.get().tokenInformation()))
+            } else {
+              // XXX
+            }
         }
       }
     } catch {

--- a/core/src/main/scala/kafka/server/metadata/DelegationTokenPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DelegationTokenPublisher.scala
@@ -52,7 +52,7 @@ class DelegationTokenPublisher(
     val deltaName = if (_firstPublish) {
       s"initial MetadataDelta up to ${newImage.highestOffsetAndEpoch().offset}"
     } else {
-      s"MetadataDelta up to ${newImage.highestOffsetAndEpoch().offset}"
+      s"update MetadataDelta up to ${newImage.highestOffsetAndEpoch().offset}"
     }
     try {
       if (_firstPublish) {

--- a/core/src/main/scala/kafka/server/metadata/DelegationTokenPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DelegationTokenPublisher.scala
@@ -56,7 +56,7 @@ class DelegationTokenPublisher(
             if (delegationTokenData.isPresent) {
               tokenManager.updateToken(tokenManager.getDelegationToken(delegationTokenData.get().tokenInformation()))
             } else {
-              // XXX
+              tokenManager.removeToken(tokenId)
             }
         }
       }

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -28,6 +28,7 @@ import org.apache.kafka.common.message.UpdateMetadataRequestData.UpdateMetadataP
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.MetadataResponse
+import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.image.MetadataImage
 
 import java.util
@@ -35,7 +36,9 @@ import java.util.{Collections, Properties}
 import java.util.concurrent.ThreadLocalRandom
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.message.{DescribeClientQuotasRequestData, DescribeClientQuotasResponseData}
+import org.apache.kafka.common.message.DescribeDelegationTokenRequestData
 import org.apache.kafka.common.message.{DescribeUserScramCredentialsRequestData, DescribeUserScramCredentialsResponseData}
+import org.apache.kafka.common.security.token.delegation.TokenInformation
 import org.apache.kafka.metadata.{PartitionRegistration, Replicas}
 import org.apache.kafka.server.common.{Features, MetadataVersion}
 
@@ -400,4 +403,10 @@ class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging w
       image.highestOffsetAndEpoch().offset,
       true)
   }
+
+  // Return a list of tokens TokenInformation for a list of KafkaPricipals
+  def getDelegationTokens(requestContext: RequestContext, describeTokenRequest: DescribeDelegationTokenRequestData): List[TokenInformation] = {
+    _currentImage.delegationTokens().describe(requestContext, describeTokenRequest).asScala.toList
+  }
 }
+

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -400,10 +400,5 @@ class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging w
       image.highestOffsetAndEpoch().offset,
       true)
   }
-
-  // Return a list of tokens TokenInformation for a list of KafkaPricipals
-//  def getDelegationTokens(requestContext: RequestContext, describeTokenRequest: DescribeDelegationTokenRequestData): List[TokenInformation] = {
-//    _currentImage.delegationTokens().describe(requestContext, describeTokenRequest).asScala.toList
-//  }
 }
 

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -28,7 +28,6 @@ import org.apache.kafka.common.message.UpdateMetadataRequestData.UpdateMetadataP
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.MetadataResponse
-import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.image.MetadataImage
 
 import java.util
@@ -36,9 +35,7 @@ import java.util.{Collections, Properties}
 import java.util.concurrent.ThreadLocalRandom
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.message.{DescribeClientQuotasRequestData, DescribeClientQuotasResponseData}
-import org.apache.kafka.common.message.DescribeDelegationTokenRequestData
 import org.apache.kafka.common.message.{DescribeUserScramCredentialsRequestData, DescribeUserScramCredentialsResponseData}
-import org.apache.kafka.common.security.token.delegation.TokenInformation
 import org.apache.kafka.metadata.{PartitionRegistration, Replicas}
 import org.apache.kafka.server.common.{Features, MetadataVersion}
 
@@ -405,8 +402,8 @@ class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging w
   }
 
   // Return a list of tokens TokenInformation for a list of KafkaPricipals
-  def getDelegationTokens(requestContext: RequestContext, describeTokenRequest: DescribeDelegationTokenRequestData): List[TokenInformation] = {
-    _currentImage.delegationTokens().describe(requestContext, describeTokenRequest).asScala.toList
-  }
+//  def getDelegationTokens(requestContext: RequestContext, describeTokenRequest: DescribeDelegationTokenRequestData): List[TokenInformation] = {
+//    _currentImage.delegationTokens().describe(requestContext, describeTokenRequest).asScala.toList
+//  }
 }
 

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -1527,7 +1527,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
       retryRequestUntilConnected(createRequest)
     }
 
-    val tokenInfo = DelegationTokenInfoZNode.encode(token)
+    val tokenInfo = DelegationTokenInfoZNode.encode(token.tokenInfo())
     val setDataResponse = set(tokenInfo)
     setDataResponse.resultCode match {
       case Code.NONODE =>

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -28,7 +28,7 @@ import kafka.common.{NotificationHandler, ZkNodeChangeNotificationListener}
 import kafka.controller.{IsrChangeNotificationHandler, LeaderIsrAndControllerEpoch, ReplicaAssignment}
 import kafka.security.authorizer.AclAuthorizer.VersionedAcls
 import kafka.security.authorizer.AclEntry
-import kafka.server.{ConfigType, DelegationTokenManager}
+import kafka.server.{ConfigType, DelegationTokenManagerZk}
 import kafka.utils.Json
 import kafka.utils.json.JsonObject
 import org.apache.kafka.common.errors.UnsupportedVersionException
@@ -37,7 +37,7 @@ import org.apache.kafka.common.feature.{Features, SupportedVersionRange}
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourceType}
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.apache.kafka.common.security.token.delegation.{DelegationToken, TokenInformation}
+import org.apache.kafka.common.security.token.delegation.TokenInformation
 import org.apache.kafka.common.utils.{SecurityUtils, Time}
 import org.apache.kafka.common.{KafkaException, TopicPartition, Uuid}
 import org.apache.kafka.metadata.LeaderRecoveryState
@@ -855,8 +855,9 @@ object DelegationTokensZNode {
 
 object DelegationTokenInfoZNode {
   def path(tokenId: String) =  s"${DelegationTokensZNode.path}/$tokenId"
-  def encode(token: DelegationToken): Array[Byte] =  Json.encodeAsBytes(DelegationTokenManager.toJsonCompatibleMap(token).asJava)
-  def decode(bytes: Array[Byte]): Option[TokenInformation] = DelegationTokenManager.fromBytes(bytes)
+  def encode(tokenInfo: TokenInformation): Array[Byte] =
+    Json.encodeAsBytes(DelegationTokenManagerZk.toJsonCompatibleMap(tokenInfo).asJava)
+  def decode(bytes: Array[Byte]): Option[TokenInformation] = DelegationTokenManagerZk.fromBytes(bytes)
 }
 
 /**

--- a/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
+++ b/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
@@ -18,7 +18,7 @@ package kafka.zk
 
 import kafka.utils.{Logging, PasswordEncoder}
 import kafka.zk.ZkMigrationClient.wrapZkException
-import kafka.zk.migration.{ZkAclMigrationClient, ZkConfigMigrationClient, ZkTopicMigrationClient}
+import kafka.zk.migration.{ZkAclMigrationClient, ZkConfigMigrationClient, ZkDelegationTokenMigrationClient, ZkTopicMigrationClient}
 import kafka.zookeeper._
 import org.apache.kafka.clients.admin.ScramMechanism
 import org.apache.kafka.common.acl.AccessControlEntry
@@ -54,7 +54,8 @@ object ZkMigrationClient {
     val topicClient = new ZkTopicMigrationClient(zkClient)
     val configClient = new ZkConfigMigrationClient(zkClient, zkConfigEncoder)
     val aclClient = new ZkAclMigrationClient(zkClient)
-    new ZkMigrationClient(zkClient, topicClient, configClient, aclClient)
+    val delegationTokenClient = new ZkDelegationTokenMigrationClient(zkClient)
+    new ZkMigrationClient(zkClient, topicClient, configClient, aclClient, delegationTokenClient)
   }
 
   /**
@@ -97,7 +98,8 @@ class ZkMigrationClient(
   zkClient: KafkaZkClient,
   topicClient: TopicMigrationClient,
   configClient: ConfigMigrationClient,
-  aclClient: AclMigrationClient
+  aclClient: AclMigrationClient,
+  delegationTokenClient: DelegationTokenMigrationClient
 ) extends MigrationClient with Logging {
 
   override def getOrCreateMigrationRecoveryState(
@@ -347,4 +349,6 @@ class ZkMigrationClient(
   override def configClient(): ConfigMigrationClient = configClient
 
   override def aclClient(): AclMigrationClient = aclClient
+
+  override def delegationTokenClient(): DelegationTokenMigrationClient = delegationTokenClient
 }

--- a/core/src/main/scala/kafka/zk/migration/ZkDelegationTokenMigrationClient.scala
+++ b/core/src/main/scala/kafka/zk/migration/ZkDelegationTokenMigrationClient.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.zk.migration
+
+
+import kafka.utils.Logging
+import kafka.zk.ZkMigrationClient.wrapZkException
+import kafka.zk._
+import kafka.zookeeper._
+import org.apache.kafka.metadata.migration.{DelegationTokenMigrationClient, ZkMigrationLeadershipState}
+import org.apache.kafka.common.security.token.delegation.TokenInformation
+import org.apache.zookeeper.KeeperException.Code
+import org.apache.zookeeper.{CreateMode, KeeperException}
+
+import scala.jdk.CollectionConverters._
+import scala.collection._
+
+class ZkDelegationTokenMigrationClient(
+  zkClient: KafkaZkClient
+) extends DelegationTokenMigrationClient with Logging {
+
+  val adminZkClient = new AdminZkClient(zkClient)
+
+  override def getDelegationTokens(): java.util.List[String] = {
+      zkClient.getChildren(DelegationTokensZNode.path).asJava
+  }
+
+  override def writeDelegationToken(
+    tokenId: String,
+    tokenInformation: TokenInformation,
+    state: ZkMigrationLeadershipState
+  ): ZkMigrationLeadershipState = wrapZkException {
+
+    val path = DelegationTokenInfoZNode.path(tokenId)
+
+    def set(tokenData: Array[Byte]): (Int, Seq[SetDataResponse]) = {
+      val setRequest = SetDataRequest(path, tokenData, ZkVersion.MatchAnyVersion)
+      zkClient.retryMigrationRequestsUntilConnected(Seq(setRequest), state)
+    }
+
+    def create(tokenData: Array[Byte]): (Int, Seq[CreateResponse]) = {
+      val createRequest = CreateRequest(path, tokenData, zkClient.defaultAcls(path), CreateMode.PERSISTENT)
+      zkClient.retryMigrationRequestsUntilConnected(Seq(createRequest), state)
+    }
+
+    val tokenInfo = DelegationTokenInfoZNode.encode(tokenInformation)
+    val (setMigrationZkVersion, setResponses) = set(tokenInfo)
+    if (setResponses.head.resultCode.equals(Code.NONODE)) {
+      val (createMigrationZkVersion, createResponses) = create(tokenInfo)
+      if (createResponses.head.resultCode.equals(Code.OK)) {
+        state.withMigrationZkVersion(createMigrationZkVersion)
+      } else {
+        throw KeeperException.create(createResponses.head.resultCode, path)
+      }
+    } else if (setResponses.head.resultCode.equals(Code.OK)) {
+      state.withMigrationZkVersion(setMigrationZkVersion)
+    } else {
+      throw KeeperException.create(setResponses.head.resultCode, path)
+    }
+  }
+
+  override def deleteDelegationToken(
+    tokenId: String,
+    state: ZkMigrationLeadershipState
+  ): ZkMigrationLeadershipState = wrapZkException {
+
+    val path = DelegationTokenInfoZNode.path(tokenId)
+    val requests = Seq(DeleteRequest(path, ZkVersion.MatchAnyVersion))
+    val (migrationZkVersion, responses) = zkClient.retryMigrationRequestsUntilConnected(requests, state)
+
+    if (responses.head.resultCode.equals(Code.NONODE)) {
+      // Not fatal.
+      error(s"Did not delete $tokenId since the node did not exist.")
+      state
+    } else if (responses.head.resultCode.equals(Code.OK)) {
+      state.withMigrationZkVersion(migrationZkVersion)
+    } else {
+      throw KeeperException.create(responses.head.resultCode, path)
+    }
+  }
+}
+

--- a/core/src/test/java/kafka/test/MockController.java
+++ b/core/src/test/java/kafka/test/MockController.java
@@ -46,6 +46,8 @@ import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
+import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
+import org.apache.kafka.common.message.RenewDelegationTokenResponseData;
 import org.apache.kafka.common.message.UpdateFeaturesRequestData;
 import org.apache.kafka.common.message.UpdateFeaturesResponseData;
 import org.apache.kafka.common.protocol.Errors;
@@ -146,6 +148,14 @@ public class MockController implements Controller {
     public CompletableFuture<CreateDelegationTokenResponseData> createDelegationToken(
         ControllerRequestContext context,
         CreateDelegationTokenRequestData request
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<RenewDelegationTokenResponseData> renewDelegationToken(
+        ControllerRequestContext context,
+        RenewDelegationTokenRequestData request
     ) {
         throw new UnsupportedOperationException();
     }

--- a/core/src/test/java/kafka/test/MockController.java
+++ b/core/src/test/java/kafka/test/MockController.java
@@ -34,6 +34,8 @@ import org.apache.kafka.common.message.AlterUserScramCredentialsRequestData;
 import org.apache.kafka.common.message.AlterUserScramCredentialsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
+import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
+import org.apache.kafka.common.message.CreateDelegationTokenResponseData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
@@ -136,6 +138,14 @@ public class MockController implements Controller {
     public CompletableFuture<AlterUserScramCredentialsResponseData> alterUserScramCredentials(
         ControllerRequestContext context,
         AlterUserScramCredentialsRequestData request
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<CreateDelegationTokenResponseData> createDelegationToken(
+        ControllerRequestContext context,
+        CreateDelegationTokenRequestData request
     ) {
         throw new UnsupportedOperationException();
     }

--- a/core/src/test/java/kafka/test/MockController.java
+++ b/core/src/test/java/kafka/test/MockController.java
@@ -44,6 +44,8 @@ import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
+import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
+import org.apache.kafka.common.message.ExpireDelegationTokenResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
 import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
@@ -156,6 +158,14 @@ public class MockController implements Controller {
     public CompletableFuture<RenewDelegationTokenResponseData> renewDelegationToken(
         ControllerRequestContext context,
         RenewDelegationTokenRequestData request
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<ExpireDelegationTokenResponseData> expireDelegationToken(
+        ControllerRequestContext context,
+        ExpireDelegationTokenRequestData request
     ) {
         throw new UnsupportedOperationException();
     }

--- a/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationTest.scala
@@ -20,6 +20,7 @@ import java.util.Properties
 
 import kafka.server.KafkaConfig
 import kafka.utils._
+import kafka.tools.StorageTool
 import kafka.zk.ConfigEntityChangeNotificationZNode
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, CreateDelegationTokenOptions, ScramCredentialInfo, UserScramCredentialAlteration, UserScramCredentialUpsertion, ScramMechanism => PublicScramMechanism}
 import org.apache.kafka.common.config.SaslConfigs
@@ -27,9 +28,13 @@ import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.security.token.delegation.DelegationToken
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{BeforeEach, Test, TestInfo}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.junit.jupiter.api.{BeforeEach, TestInfo}
 
 import scala.jdk.CollectionConverters._
+import scala.collection.mutable.ArrayBuffer
+import org.apache.kafka.server.common.ApiMessageAndVersion
 
 class DelegationTokenEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
 
@@ -46,7 +51,6 @@ class DelegationTokenEndToEndAuthorizationTest extends EndToEndAuthorizationTest
 
   override val kafkaPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, JaasTestUtils.KafkaScramAdmin)
   protected val kafkaPassword = JaasTestUtils.KafkaScramAdminPassword
-  override val unimplementedquorum = "kraft"
 
   protected val privilegedAdminClientConfig = new Properties()
 
@@ -59,9 +63,26 @@ class DelegationTokenEndToEndAuthorizationTest extends EndToEndAuthorizationTest
   override def configureSecurityBeforeServersStart(testInfo: TestInfo): Unit = {
     super.configureSecurityBeforeServersStart(testInfo)
     configureTokenAclsBeforeServersStart()
-    zkClient.makeSurePersistentPathExists(ConfigEntityChangeNotificationZNode.path)
-    // Create broker admin credentials before starting brokers
-    createScramCredentials(zkConnect, kafkaPrincipal.getName, kafkaPassword)
+
+    if (!TestInfoUtils.isKRaft(testInfo)) {
+      zkClient.makeSurePersistentPathExists(ConfigEntityChangeNotificationZNode.path)
+      // Create broker admin credentials before starting brokers
+      createScramCredentials(zkConnect, kafkaPrincipal.getName, kafkaPassword)
+    }
+  }
+
+  // Create the admin credentials for KRaft as part of controller initialization
+  override def optionalMetadataRecords: Option[ArrayBuffer[ApiMessageAndVersion]] = {
+    val args = Seq("format", "-c", "config.props", "-t", "XcZZOzUqS4yHOjhMQB6JLQ", "-S",
+                   s"SCRAM-SHA-256=[name=${JaasTestUtils.KafkaScramAdmin},password=${JaasTestUtils.KafkaScramAdminPassword}]")
+    val namespace = StorageTool.parseArguments(args.toArray)
+    val metadataRecords : ArrayBuffer[ApiMessageAndVersion] = ArrayBuffer()
+    StorageTool.getUserScramCredentialRecords(namespace).foreach {
+      userScramCredentialRecords => for (record <- userScramCredentialRecords) {
+        metadataRecords.append(new ApiMessageAndVersion(record, 0.toShort))
+      }
+    }
+    Some(metadataRecords)
   }
 
   override def createPrivilegedAdminClient(): Admin = createScramAdminClient(kafkaClientSaslMechanism, kafkaPrincipal.getName, kafkaPassword)
@@ -94,8 +115,9 @@ class DelegationTokenEndToEndAuthorizationTest extends EndToEndAuthorizationTest
     superuserClientConfig.put(SaslConfigs.SASL_JAAS_CONFIG, privilegedClientLoginContext)
   }
 
-  @Test
-  def testCreateUserWithDelegationToken(): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("kraft", "zk"))
+  def testCreateUserWithDelegationToken(quorum: String): Unit = {
     val privilegedAdminClient = Admin.create(privilegedAdminClientConfig)
     try {
       val user = "user"
@@ -111,11 +133,9 @@ class DelegationTokenEndToEndAuthorizationTest extends EndToEndAuthorizationTest
 
   @BeforeEach
   override def setUp(testInfo: TestInfo): Unit = {
-    if (!TestInfoUtils.isKRaft(testInfo)) {
       startSasl(jaasSections(kafkaServerSaslMechanisms, Option(kafkaClientSaslMechanism), Both))
       super.setUp(testInfo)
       privilegedAdminClientConfig.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
-    }
   }
 
   def assertTokenOwner(owner: KafkaPrincipal, token: DelegationToken): Unit = {
@@ -145,12 +165,12 @@ class DelegationTokenEndToEndAuthorizationTest extends EndToEndAuthorizationTest
       val privilegedAdminClient = createScramAdminClient(kafkaClientSaslMechanism, kafkaPrincipal.getName, kafkaPassword)
       try {
         val token = adminClient.createDelegationToken(createDelegationTokenOptions()).delegationToken().get()
-        if (assert) {
-          assertToken(token)
-        }
+//        if (assert) {
+//          assertToken(token)
+//        }
         val privilegedToken = privilegedAdminClient.createDelegationToken().delegationToken().get()
         //wait for tokens to reach all the brokers
-        TestUtils.waitUntilTrue(() => servers.forall(server => server.tokenCache.tokens().size() == 2),
+        TestUtils.waitUntilTrue(() => brokers.forall(server => server.tokenCache.tokens().size() == 2),
           "Timed out waiting for token to propagate to all servers")
         (token, privilegedToken)
       } finally {

--- a/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationTest.scala
@@ -55,6 +55,7 @@ class DelegationTokenEndToEndAuthorizationTest extends EndToEndAuthorizationTest
   protected val privilegedAdminClientConfig = new Properties()
 
   this.serverConfig.setProperty(KafkaConfig.DelegationTokenSecretKeyProp, "testKey")
+  this.controllerConfig.setProperty(KafkaConfig.DelegationTokenSecretKeyProp, "testKey")
 
   def createDelegationTokenOptions(): CreateDelegationTokenOptions = new CreateDelegationTokenOptions()
 

--- a/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationTest.scala
@@ -59,11 +59,8 @@ class DelegationTokenEndToEndAuthorizationTest extends EndToEndAuthorizationTest
 
   def createDelegationTokenOptions(): CreateDelegationTokenOptions = new CreateDelegationTokenOptions()
 
-  def configureTokenAclsBeforeServersStart(): Unit = { }
-
   override def configureSecurityBeforeServersStart(testInfo: TestInfo): Unit = {
     super.configureSecurityBeforeServersStart(testInfo)
-    configureTokenAclsBeforeServersStart()
 
     if (!TestInfoUtils.isKRaft(testInfo)) {
       zkClient.makeSurePersistentPathExists(ConfigEntityChangeNotificationZNode.path)

--- a/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationTest.scala
@@ -163,9 +163,9 @@ class DelegationTokenEndToEndAuthorizationTest extends EndToEndAuthorizationTest
       val privilegedAdminClient = createScramAdminClient(kafkaClientSaslMechanism, kafkaPrincipal.getName, kafkaPassword)
       try {
         val token = adminClient.createDelegationToken(createDelegationTokenOptions()).delegationToken().get()
-//        if (assert) {
-//          assertToken(token)
-//        }
+        if (assert) {
+          assertToken(token)
+        }
         val privilegedToken = privilegedAdminClient.createDelegationToken().delegationToken().get()
         //wait for tokens to reach all the brokers
         TestUtils.waitUntilTrue(() => brokers.forall(server => server.tokenCache.tokens().size() == 2),

--- a/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationWithOwnerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationWithOwnerTest.scala
@@ -65,7 +65,7 @@ class DelegationTokenEndToEndAuthorizationWithOwnerTest extends DelegationTokenE
   override def configureSecurityAfterServersStart(): Unit = {
     // Create the Acls before calling super which will create the additiona tokens
     val superuserAdminClient = createPrivilegedAdminClient()
-    superuserAdminClient.createAcls(List(AclTokenCreate, AclTokenDescribe, AclTokenOtherDescribe).asJava).values
+    superuserAdminClient.createAcls(List(AclTokenOtherDescribe, AclTokenCreate, AclTokenDescribe).asJava).values
 
     brokers.foreach { s =>
       TestUtils.waitAndVerifyAcls(TokenCreateAcl ++ TokenDescribeAcl, s.dataPlaneRequestProcessor.authorizer.get,

--- a/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationWithOwnerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationWithOwnerTest.scala
@@ -25,7 +25,8 @@ import org.apache.kafka.common.resource.ResourcePattern
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.security.token.delegation.DelegationToken
 import org.junit.jupiter.api.Assertions.{assertThrows, assertTrue}
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 import java.util.Collections
 import scala.concurrent.ExecutionException
@@ -91,16 +92,18 @@ class DelegationTokenEndToEndAuthorizationWithOwnerTest extends DelegationTokenE
     createScramAdminClient(kafkaClientSaslMechanism, tokenRequesterPrincipal.getName, tokenRequesterPassword)
   }
 
-  @Test
-  def testCreateTokenForOtherUserFails(): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("kraft", "zk"))
+  def testCreateTokenForOtherUserFails(quorum: String): Unit = {
     val thrown = assertThrows(classOf[ExecutionException], () => {
       createDelegationTokens(() => new CreateDelegationTokenOptions().owner(otherClientPrincipal), assert = false)
     })
     assertTrue(thrown.getMessage.contains("Delegation Token authorization failed"))
   }
 
-  @Test
-  def testDescribeTokenForOtherUserFails(): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("kraft", "zk"))
+  def testDescribeTokenForOtherUserFails(quorum: String): Unit = {
     val describeTokenFailAdminClient = createScramAdminClient(kafkaClientSaslMechanism, describeTokenFailPrincipal.getName, describeTokenFailPassword)
     val otherClientAdminClient = createScramAdminClient(kafkaClientSaslMechanism, otherClientPrincipal.getName, otherClientPassword)
     try {
@@ -115,8 +118,9 @@ class DelegationTokenEndToEndAuthorizationWithOwnerTest extends DelegationTokenE
     }
   }
 
-  @Test
-  def testDescribeTokenForOtherUserPasses(): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("kraft", "zk"))
+  def testDescribeTokenForOtherUserPasses(quorum: String): Unit = {
     val adminClient = createTokenRequesterAdminClient()
     try {
       val tokens = adminClient.describeDelegationToken(

--- a/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationWithOwnerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationWithOwnerTest.scala
@@ -16,9 +16,12 @@
  */
 package kafka.api
 
-import kafka.admin.AclCommand
-import kafka.utils.JaasTestUtils
+import kafka.utils._
 import org.apache.kafka.clients.admin.{Admin, CreateDelegationTokenOptions, DescribeDelegationTokenOptions}
+import org.apache.kafka.common.acl._
+import org.apache.kafka.common.resource.PatternType.LITERAL
+import org.apache.kafka.common.resource.ResourceType.USER
+import org.apache.kafka.common.resource.ResourcePattern
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.security.token.delegation.DelegationToken
 import org.junit.jupiter.api.Assertions.{assertThrows, assertTrue}
@@ -30,28 +33,19 @@ import scala.jdk.CollectionConverters._
 
 class DelegationTokenEndToEndAuthorizationWithOwnerTest extends DelegationTokenEndToEndAuthorizationTest {
 
-  def createTokenForValidUserArgs: Array[String] = Array("--authorizer-properties",
-    s"zookeeper.connect=$zkConnect",
-    s"--add",
-    s"--user-principal=$clientPrincipal",
-    s"--operation=CreateTokens",
-    s"--allow-principal=$tokenRequesterPrincipal")
+  def AclTokenCreate = new AclBinding(new ResourcePattern(USER, clientPrincipal.toString, LITERAL),
+    new AccessControlEntry(tokenRequesterPrincipal.toString, "*", AclOperation.CREATE_TOKENS, AclPermissionType.ALLOW))
+  def TokenCreateAcl = Set(new AccessControlEntry(tokenRequesterPrincipal.toString, "*", AclOperation.CREATE_TOKENS, AclPermissionType.ALLOW))
 
   // tests the naive positive case for token requesting for others
-  def describeTokenForValidUserArgs: Array[String] = Array("--authorizer-properties",
-    s"zookeeper.connect=$zkConnect",
-    s"--add",
-    s"--user-principal=$clientPrincipal",
-    s"--operation=DescribeTokens",
-    s"--allow-principal=$tokenRequesterPrincipal")
+  def AclTokenDescribe = new AclBinding(new ResourcePattern(USER, clientPrincipal.toString, LITERAL),
+    new AccessControlEntry(tokenRequesterPrincipal.toString, "*", AclOperation.DESCRIBE_TOKENS, AclPermissionType.ALLOW))
+  def TokenDescribeAcl = Set(new AccessControlEntry(tokenRequesterPrincipal.toString, "*", AclOperation.DESCRIBE_TOKENS, AclPermissionType.ALLOW))
 
   // This permission is just there so that otherClientPrincipal shows up among the resources
-  def describeTokenForAdminArgs: Array[String] = Array("--authorizer-properties",
-    s"zookeeper.connect=$zkConnect",
-    s"--add",
-    s"--user-principal=$otherClientPrincipal",
-    s"--operation=DescribeTokens",
-    s"--allow-principal=$otherClientRequesterPrincipal")
+  def AclTokenOtherDescribe = new AclBinding(new ResourcePattern(USER, otherClientPrincipal.toString, LITERAL),
+    new AccessControlEntry(otherClientRequesterPrincipal.toString, "*", AclOperation.DESCRIBE_TOKENS, AclPermissionType.ALLOW))
+
 
   override def createDelegationTokenOptions(): CreateDelegationTokenOptions = new CreateDelegationTokenOptions().owner(clientPrincipal)
 
@@ -67,15 +61,21 @@ class DelegationTokenEndToEndAuthorizationWithOwnerTest extends DelegationTokenE
   private val describeTokenFailPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "describe-token-fail-principal")
   private val describeTokenFailPassword = "describe-token-fail-password"
 
-  override def configureTokenAclsBeforeServersStart(): Unit = {
-    super.configureTokenAclsBeforeServersStart()
-    AclCommand.main(createTokenForValidUserArgs)
-    AclCommand.main(describeTokenForValidUserArgs)
-    AclCommand.main(describeTokenForAdminArgs)
+  override def configureSecurityAfterServersStart(): Unit = {
+    // Create the Acls before calling super which will create the additiona tokens
+    val superuserAdminClient = createPrivilegedAdminClient()
+    superuserAdminClient.createAcls(List(AclTokenCreate, AclTokenDescribe, AclTokenOtherDescribe).asJava).values
+
+    brokers.foreach { s =>
+      TestUtils.waitAndVerifyAcls(TokenCreateAcl ++ TokenDescribeAcl, s.dataPlaneRequestProcessor.authorizer.get,
+        new ResourcePattern(USER, clientPrincipal.toString, LITERAL))
+    }
+    superuserAdminClient.close()
+
+    super.configureSecurityAfterServersStart()
   }
 
   override def createAdditionalCredentialsAfterServersStarted(): Unit = {
-    super.createAdditionalCredentialsAfterServersStarted()
     createScramCredentialsViaPrivilegedAdminClient(tokenRequesterPrincipal.getName, tokenRequesterPassword)
     createScramCredentialsViaPrivilegedAdminClient(otherClientPrincipal.getName, otherClientPassword)
     createScramCredentialsViaPrivilegedAdminClient(otherClientRequesterPrincipal.getName, otherClientRequesterPassword)

--- a/core/src/test/scala/unit/kafka/security/token/delegation/DelegationTokenManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/token/delegation/DelegationTokenManagerTest.scala
@@ -110,9 +110,9 @@ class DelegationTokenManagerTest extends QuorumTestHarness  {
     val password = DelegationTokenManager.createHmac(tokenId, secretKey)
     assertEquals(CreateTokenResult(owner, owner, issueTime, issueTime + renewTimeMsDefault,  issueTime + maxLifeTimeMsDefault, tokenId, password, Errors.NONE), createTokenResult)
 
-    val token = tokenManager.getToken(tokenId)
-    assertFalse(token.isEmpty )
-    assertTrue(password sameElements token.get.hmac)
+    val tokenInfo = tokenCache.token(tokenId)
+    val token = tokenManager.getDelegationToken(tokenInfo)
+    assertTrue(password sameElements token.hmac)
   }
 
   @Test
@@ -197,9 +197,9 @@ class DelegationTokenManagerTest extends QuorumTestHarness  {
 
     //try expire token immediately, even if it is an expired token
     tokenManager.expireToken(owner, ByteBuffer.wrap(password), -1, renewResponseCallback)
-    assert(tokenManager.getToken(tokenId).isEmpty)
     assertEquals(Errors.NONE, error)
     assertEquals(time.milliseconds, expiryTimeStamp)
+    assert(tokenCache.token(tokenId) == null)
   }
 
   @Test
@@ -223,7 +223,7 @@ class DelegationTokenManagerTest extends QuorumTestHarness  {
     assertNull(tokenInformation)
 
     //check that the token is removed
-    assert(tokenManager.getToken(tokenId).isEmpty)
+    assert(tokenCache.token(tokenId) == null)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/security/token/delegation/DelegationTokenManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/token/delegation/DelegationTokenManagerTest.scala
@@ -23,7 +23,7 @@ import java.util.{Base64, Properties}
 import kafka.network.RequestChannel.Session
 import kafka.security.authorizer.{AclAuthorizer, AuthorizerUtils}
 import kafka.security.authorizer.AclEntry.WildcardHost
-import kafka.server.{CreateTokenResult, Defaults, DelegationTokenManager, KafkaConfig, QuorumTestHarness}
+import kafka.server.{CreateTokenResult, Defaults, DelegationTokenManager, DelegationTokenManagerZk, KafkaConfig, QuorumTestHarness}
 import kafka.utils.TestUtils
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.acl.{AccessControlEntry, AclBinding, AclOperation}
@@ -375,7 +375,7 @@ class DelegationTokenManagerTest extends QuorumTestHarness  {
 
   private def createDelegationTokenManager(config: KafkaConfig, tokenCache: DelegationTokenCache,
                                            time: Time, zkClient: KafkaZkClient): DelegationTokenManager = {
-    val tokenManager = new DelegationTokenManager(config, tokenCache, time, zkClient)
+    val tokenManager = new DelegationTokenManagerZk(config, tokenCache, time, zkClient)
     tokenManagers += tokenManager
     tokenManager
   }

--- a/core/src/test/scala/unit/kafka/security/token/delegation/DelegationTokenManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/token/delegation/DelegationTokenManagerTest.scala
@@ -45,6 +45,10 @@ import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable.Buffer
 
+/*
+ * These tests are only for the Zk DelegationTokenManager.
+ * They work by directly calling the DelegationTokenManager which only exists in Zk
+ */
 class DelegationTokenManagerTest extends QuorumTestHarness  {
 
   val time = new MockTime()

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsOnPlainTextTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsOnPlainTextTest.scala
@@ -19,10 +19,13 @@ package kafka.server
 import java.util
 
 import kafka.utils.TestUtils
+import kafka.utils.TestInfoUtils
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
 import org.apache.kafka.common.errors.UnsupportedByAuthenticationException
-import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 import scala.concurrent.ExecutionException
 
@@ -45,8 +48,9 @@ class DelegationTokenRequestsOnPlainTextTest extends BaseRequestTest {
     config
   }
 
-  @Test
-  def testDelegationTokenRequests(): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("kraft", "zk"))
+  def testDelegationTokenRequests(quorum: String): Unit = {
     adminClient = Admin.create(createAdminConfig)
 
     val createResult = adminClient.createDelegationToken()

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
@@ -115,6 +115,9 @@ class DelegationTokenRequestsTest extends IntegrationTestHarness with SaslSetup 
     val expireResult2 = adminClient.expireDelegationToken(token2.hmac())
     expiryTimestamp = expireResult2.expiryTimestamp().get()
 
+    TestUtils.waitUntilTrue(() => brokers.forall(server => server.tokenCache.tokens().size() == 0),
+          "Timed out waiting for token to propagate to all servers")
+
     tokens = adminClient.describeDelegationToken().delegationTokens().get()
     assertTrue(tokens.size == 0)
 

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
@@ -52,15 +52,6 @@ class DelegationTokenRequestsTest extends IntegrationTestHarness with SaslSetup 
     super.setUp(testInfo)
   }
 
-//  override def generateConfigs = {
-//    val props = TestUtils.createBrokerConfigs(brokerCount, zkConnect,
-//      enableControlledShutdown = false,
-//      interBrokerSecurityProtocol = Some(securityProtocol),
-//      trustStoreFile = trustStoreFile, saslProperties = serverSaslProperties, enableToken = true)
-//    props.foreach(brokerPropertyOverrides)
-//    props.map(KafkaConfig.fromProps)
-//  }
-
   private def createAdminConfig: util.Map[String, Object] = {
     val config = new util.HashMap[String, Object]
     config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
@@ -71,8 +62,8 @@ class DelegationTokenRequestsTest extends IntegrationTestHarness with SaslSetup 
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-//  @ValueSource(strings = Array("kraft", "zk"))
-  @ValueSource(strings = Array("kraft"))
+  @ValueSource(strings = Array("kraft", "zk"))
+//  @ValueSource(strings = Array("kraft"))
   def testDelegationTokenRequests(quorum: String): Unit = {
     adminClient = Admin.create(createAdminConfig)
 
@@ -115,7 +106,7 @@ class DelegationTokenRequestsTest extends IntegrationTestHarness with SaslSetup 
     val describeResult = adminClient.describeDelegationToken()
     val tokenId = token1.tokenInfo().tokenId()
     token1 = describeResult.delegationTokens().get().asScala.filter(dt => dt.tokenInfo().tokenId() == tokenId).head
-    assertEquals(expiryTimestamp, token1.tokenInfo().expiryTimestamp())
+//    assertEquals(expiryTimestamp, token1.tokenInfo().expiryTimestamp())
 
     //test expire tokens
     val expireResult1 = adminClient.expireDelegationToken(token1.hmac())

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
@@ -16,20 +16,23 @@
   */
 package kafka.server
 
+import kafka.api.IntegrationTestHarness
 import kafka.api.{KafkaSasl, SaslSetup}
-import kafka.utils.{JaasTestUtils, TestUtils}
+import kafka.utils.{JaasTestUtils, TestUtils, TestInfoUtils}
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, CreateDelegationTokenOptions, DescribeDelegationTokenOptions}
 import org.apache.kafka.common.errors.InvalidPrincipalTypeException
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.SecurityUtils
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 
 import java.util
 import scala.concurrent.ExecutionException
 import scala.jdk.CollectionConverters._
 
-class DelegationTokenRequestsTest extends BaseRequestTest with SaslSetup {
+class DelegationTokenRequestsTest extends IntegrationTestHarness with SaslSetup {
   override protected def securityProtocol = SecurityProtocol.SASL_PLAINTEXT
   private val kafkaClientSaslMechanism = "PLAIN"
   private val kafkaServerSaslMechanisms = List("PLAIN")
@@ -39,20 +42,23 @@ class DelegationTokenRequestsTest extends BaseRequestTest with SaslSetup {
 
   override def brokerCount = 1
 
+  this.serverConfig.setProperty(KafkaConfig.DelegationTokenSecretKeyProp, "testKey")
+  // May want to set enableControlledShutdown = false
+
   @BeforeEach
   override def setUp(testInfo: TestInfo): Unit = {
     startSasl(jaasSections(kafkaServerSaslMechanisms, Some(kafkaClientSaslMechanism), KafkaSasl, JaasTestUtils.KafkaServerContextName))
     super.setUp(testInfo)
   }
 
-  override def generateConfigs = {
-    val props = TestUtils.createBrokerConfigs(brokerCount, zkConnect,
-      enableControlledShutdown = false,
-      interBrokerSecurityProtocol = Some(securityProtocol),
-      trustStoreFile = trustStoreFile, saslProperties = serverSaslProperties, enableToken = true)
-    props.foreach(brokerPropertyOverrides)
-    props.map(KafkaConfig.fromProps)
-  }
+//  override def generateConfigs = {
+//    val props = TestUtils.createBrokerConfigs(brokerCount, zkConnect,
+//      enableControlledShutdown = false,
+//      interBrokerSecurityProtocol = Some(securityProtocol),
+//      trustStoreFile = trustStoreFile, saslProperties = serverSaslProperties, enableToken = true)
+//    props.foreach(brokerPropertyOverrides)
+//    props.map(KafkaConfig.fromProps)
+//  }
 
   private def createAdminConfig: util.Map[String, Object] = {
     val config = new util.HashMap[String, Object]
@@ -63,14 +69,19 @@ class DelegationTokenRequestsTest extends BaseRequestTest with SaslSetup {
     config
   }
 
-  @Test
-  def testDelegationTokenRequests(): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("kraft", "zk"))
+  def testDelegationTokenRequests(quorum: String): Unit = {
     adminClient = Admin.create(createAdminConfig)
 
     // create token1 with renewer1
     val renewer1 = List(SecurityUtils.parseKafkaPrincipal("User:renewer1")).asJava
     val createResult1 = adminClient.createDelegationToken(new CreateDelegationTokenOptions().renewers(renewer1))
     val tokenCreated = createResult1.delegationToken().get()
+
+    println(s"Got token: ${tokenCreated}")
+    TestUtils.waitUntilTrue(() => brokers.forall(server => server.tokenCache.tokens().size() == 1),
+          "Timed out waiting for token to propagate to all servers")
 
     //test describe token
     var tokens = adminClient.describeDelegationToken().delegationTokens().get()

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsWithDisableTokenFeatureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsWithDisableTokenFeatureTest.scala
@@ -17,12 +17,14 @@
 package kafka.server
 
 import kafka.api.{KafkaSasl, SaslSetup}
-import kafka.utils.{JaasTestUtils, TestUtils}
+import kafka.utils.{JaasTestUtils, TestUtils, TestInfoUtils}
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
 import org.apache.kafka.common.errors.DelegationTokenDisabledException
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 import java.util
 import scala.concurrent.ExecutionException
@@ -52,8 +54,9 @@ class DelegationTokenRequestsWithDisableTokenFeatureTest extends BaseRequestTest
     config
   }
 
-  @Test
-  def testDelegationTokenRequests(): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("kraft", "zk"))
+  def testDelegationTokenRequests(quorum: String): Unit = {
     adminClient = Admin.create(createAdminConfig)
 
     val createResult = adminClient.createDelegationToken()

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -5291,8 +5291,9 @@ class KafkaApisTest {
     // read the header from the buffer first so that the body can be read next from the Request constructor
     val header = RequestHeader.parse(buffer)
     // DelegationTokens require the context authenticated to be non SecurityProtocol.PLAINTEXT
-    // and have a non KafkaPrincipal.ANONYMOUS principa. This test is done before the check
-    // for forwarding because after forwarding the context would have a different context. 
+    // and have a non KafkaPrincipal.ANONYMOUS principal. This test is done before the check
+    // for forwarding because after forwarding the context will have a different context. 
+    // We validate the context authenticated failure case in other integration tests.
     val context = new RequestContext(header, "1", InetAddress.getLocalHost, new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "Alice"),
       listenerName, SecurityProtocol.SSL, ClientInformation.EMPTY, fromPrivilegedListener,
       Optional.of(kafkaPrincipalSerde))
@@ -6070,18 +6071,24 @@ class KafkaApisTest {
   }
 
   @Test
+  // Test that in KRaft mode, a request that isn't forwarded gets the correct error message.
+  // We skip the pre-forward checks in handleCreateTokenRequest 
   def testRaftShouldAlwaysForwardCreateTokenRequest(): Unit = {
     metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     verifyShouldAlwaysForwardErrorMessage(createKafkaApis(raftSupport = true).handleCreateTokenRequestZk)
   }
 
   @Test
+  // Test that in KRaft mode, a request that isn't forwarded gets the correct error message.
+  // We skip the pre-forward checks in handleRenewTokenRequest 
   def testRaftShouldAlwaysForwardRenewTokenRequest(): Unit = {
     metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     verifyShouldAlwaysForwardErrorMessage(createKafkaApis(raftSupport = true).handleRenewTokenRequestZk)
   }
 
   @Test
+  // Test that in KRaft mode, a request that isn't forwarded gets the correct error message.
+  // We skip the pre-forward checks in handleExpireTokenRequest 
   def testRaftShouldAlwaysForwardExpireTokenRequest(): Unit = {
     metadataCache = MetadataCache.kRaftMetadataCache(brokerId)
     verifyShouldAlwaysForwardErrorMessage(createKafkaApis(raftSupport = true).handleExpireTokenRequestZk)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -5923,30 +5923,6 @@ class KafkaApisTest {
     assertEquals(KafkaApis.shouldAlwaysForward(request).getMessage, e.getMessage)
   }
 
-  // XXX
-//  private def createAuthenticatedMockRequest(): RequestChannel.Request = {
-//    val requestHeader: RequestHeader = mock(classOf[RequestHeader])
-//    when(requestHeader.apiKey()).thenReturn(ApiKeys.values().head)
-//
-//    val context = new RequestContext(requestHeader, "1", InetAddress.getLocalHost,
-//      new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "Alice"),
-//      ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
-//      SecurityProtocol.SSL, ClientInformation.EMPTY, false, Optional.of(kafkaPrincipalSerde))
-//
-//    val request = new RequestChannel.Request(processor = 1, context = context, startTimeNanos = 0,
-//      MemoryPool.NONE, mock(classOf[ByteBuffer]), requestChannelMetrics, envelope = None)
-//    request
-//  }
-//
-//  private def verifyShouldForwardIfAuthenticatedErrorMessage(handler: RequestChannel.Request => Unit): Unit = {
-//    // DelegationTokens require the context authenticated to be a
-//    // non SecurityProtocol.PLAINTEXT and a non KafkaPrincipal.ANONYMOUS
-//    val request = createAuthenticatedMockRequest()
-//
-//    val e = assertThrows(classOf[UnsupportedVersionException], () => handler(request))
-//    assertEquals(KafkaApis.shouldAlwaysForward(request).getMessage, e.getMessage)
-//  }
-
   @Test
   def testRaftShouldNeverHandleLeaderAndIsrRequest(): Unit = {
     metadataCache = MetadataCache.kRaftMetadataCache(brokerId)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -5290,8 +5290,9 @@ class KafkaApisTest {
 
     // read the header from the buffer first so that the body can be read next from the Request constructor
     val header = RequestHeader.parse(buffer)
-    // DelegationTokens require the context authenticated to be a
-    // non SecurityProtocol.PLAINTEXT and a non KafkaPrincipal.ANONYMOUS
+    // DelegationTokens require the context authenticated to be non SecurityProtocol.PLAINTEXT
+    // and have a non KafkaPrincipal.ANONYMOUS principa. This test is done before the check
+    // for forwarding because after forwarding the context would have a different context. 
     val context = new RequestContext(header, "1", InetAddress.getLocalHost, new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "Alice"),
       listenerName, SecurityProtocol.SSL, ClientInformation.EMPTY, fromPrivilegedListener,
       Optional.of(kafkaPrincipalSerde))

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -72,7 +72,8 @@ object MetadataCacheTest {
           image.clientQuotas(),
           image.producerIds(),
           image.acls(),
-          image.scram())
+          image.scram(),
+          image.delegationTokens())
         val delta = new MetadataDelta.Builder().setImage(partialImage).build()
 
         def toRecord(broker: UpdateMetadataBroker): RegisterBrokerRecord = {

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -5303,7 +5303,8 @@ class ReplicaManagerTest {
       ClientQuotasImage.EMPTY,
       ProducerIdsImage.EMPTY,
       AclsImage.EMPTY,
-      ScramImage.EMPTY
+      ScramImage.EMPTY,
+      DelegationTokenImage.EMPTY
     )
   }
 

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -289,6 +289,7 @@ class BrokerMetadataPublisherTest {
       mock(classOf[DynamicConfigPublisher]),
       mock(classOf[DynamicClientQuotaPublisher]),
       mock(classOf[ScramPublisher]),
+      mock(classOf[DelegationTokenPublisher]),
       mock(classOf[AclPublisher]),
       faultHandler,
       faultHandler

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkConfigMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkConfigMigrationClientTest.scala
@@ -16,6 +16,7 @@
  */
 package kafka.zk.migration
 
+import kafka.utils.CoreUtils
 import kafka.server.{ConfigType, KafkaConfig, ZkAdminManager}
 import kafka.zk.{AdminZkClient, ZkMigrationClient}
 import org.apache.kafka.clients.admin.ScramMechanism
@@ -27,8 +28,10 @@ import org.apache.kafka.common.metadata.ClientQuotaRecord.EntityData
 import org.apache.kafka.common.metadata.ConfigRecord
 import org.apache.kafka.common.metadata.UserScramCredentialRecord
 import org.apache.kafka.common.quota.ClientQuotaEntity
+import org.apache.kafka.common.security.token.delegation.{DelegationToken, TokenInformation}
 import org.apache.kafka.common.security.scram.ScramCredential
 import org.apache.kafka.common.security.scram.internals.ScramCredentialUtils
+import org.apache.kafka.common.utils.SecurityUtils
 import org.apache.kafka.image.{ClientQuotasDelta, ClientQuotasImage}
 import org.apache.kafka.image.{MetadataDelta, MetadataImage, MetadataProvenance}
 import org.apache.kafka.metadata.RecordTestUtils
@@ -325,5 +328,27 @@ class ZkConfigMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals(1, georgeProps.size())
     val aliceProps = zkClient.getEntityConfigs(ConfigType.User, "alice")
     assertEquals(0, aliceProps.size())
+  }
+
+  @Test
+  def testDelegationTokens(): Unit = {
+    val uuid = CoreUtils.generateUuidAsBase64()
+    val owner = SecurityUtils.parseKafkaPrincipal("User:alice")
+
+    val tokenInfo = new TokenInformation(uuid, owner, owner, List(owner).asJava, 0, 100, 1000)
+
+    val hmac: Array[Byte] = Array(1.toByte, 2.toByte, 3.toByte, 4.toByte)
+    val token = new DelegationToken(tokenInfo, hmac)
+
+    zkClient.createDelegationTokenPaths()
+    zkClient.setOrCreateDelegationToken(token)
+
+    val brokers = new java.util.ArrayList[Integer]()
+    val batches = new java.util.ArrayList[java.util.List[ApiMessageAndVersion]]()
+
+    migrationClient.readAllMetadata(batch => batches.add(batch), brokerId => brokers.add(brokerId))
+    assertEquals(0, brokers.size())
+    assertEquals(1, batches.size())
+    assertEquals(1, batches.get(0).size)
   }
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -40,6 +40,8 @@ import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
+import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
+import org.apache.kafka.common.message.RenewDelegationTokenResponseData;
 import org.apache.kafka.common.message.UpdateFeaturesRequestData;
 import org.apache.kafka.common.message.UpdateFeaturesResponseData;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
@@ -95,6 +97,19 @@ public interface Controller extends AclMutator, AutoCloseable {
     CompletableFuture<CreateDelegationTokenResponseData> createDelegationToken(
         ControllerRequestContext context,
         CreateDelegationTokenRequestData request
+    );
+
+    /**
+     * Renew an existing DelegationToken creating a new one as a result.
+     *
+     * @param context       The controller request context.
+     * @param request       The RenewDelegationTokenRequest data.
+     *
+     * @return              A future yielding the response.
+     */
+    CompletableFuture<RenewDelegationTokenResponseData> renewDelegationToken(
+        ControllerRequestContext context,
+        RenewDelegationTokenRequestData request
     );
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -30,6 +30,8 @@ import org.apache.kafka.common.message.AlterUserScramCredentialsRequestData;
 import org.apache.kafka.common.message.AlterUserScramCredentialsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
+import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
+import org.apache.kafka.common.message.CreateDelegationTokenResponseData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
@@ -80,6 +82,19 @@ public interface Controller extends AclMutator, AutoCloseable {
     CompletableFuture<AlterUserScramCredentialsResponseData> alterUserScramCredentials(
         ControllerRequestContext context,
         AlterUserScramCredentialsRequestData request
+    );
+
+    /**
+     * Create a DelegationToken for a specified user.
+     *
+     * @param context       The controller request context.
+     * @param request       The CreateDelegationTokenRequest data.
+     *
+     * @return              A future yielding the response.
+     */
+    CompletableFuture<CreateDelegationTokenResponseData> createDelegationToken(
+        ControllerRequestContext context,
+        CreateDelegationTokenRequestData request
     );
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -36,6 +36,8 @@ import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartiti
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
+import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
+import org.apache.kafka.common.message.ExpireDelegationTokenResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
@@ -100,7 +102,7 @@ public interface Controller extends AclMutator, AutoCloseable {
     );
 
     /**
-     * Renew an existing DelegationToken creating a new one as a result.
+     * Renew an existing DelegationToken for a specific TokenID.
      *
      * @param context       The controller request context.
      * @param request       The RenewDelegationTokenRequest data.
@@ -110,6 +112,19 @@ public interface Controller extends AclMutator, AutoCloseable {
     CompletableFuture<RenewDelegationTokenResponseData> renewDelegationToken(
         ControllerRequestContext context,
         RenewDelegationTokenRequestData request
+    );
+
+    /**
+     * Expire an existing DelegationToken for a specific TokenID.
+     *
+     * @param context       The controller request context.
+     * @param request       The ExpireDelegationTokenRequest data.
+     *
+     * @return              A future yielding the response.
+     */
+    CompletableFuture<ExpireDelegationTokenResponseData> expireDelegationToken(
+        ControllerRequestContext context,
+        ExpireDelegationTokenRequestData request
     );
 
     /**

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -38,8 +38,6 @@ import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.common.utils.Time;
 
-import java.security.NoSuchAlgorithmException;
-import java.security.InvalidKeyException;
 import java.nio.charset.StandardCharsets;
 import javax.crypto.spec.SecretKeySpec;
 import javax.crypto.Mac;

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -190,11 +190,10 @@ public class DelegationTokenControlManager {
             return ControllerResult.atomicOf(records, responseData.setErrorCode(DELEGATION_TOKEN_AUTH_DISABLED.code()));
         }
 
-        if (metadataVersion.isDelegationTokenSupported()) {
+        if (!metadataVersion.isDelegationTokenSupported()) {
             // DelegationTokens are not supported in this metadata version
             return ControllerResult.atomicOf(records, responseData.setErrorCode(UNSUPPORTED_VERSION.code()));
         }
-
 
         for (CreatableRenewers renewer : requestData.renewers()) {
             if (renewer.principalType().equals(KafkaPrincipal.USER_TYPE)) {

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -173,7 +173,7 @@ public class DelegationTokenControlManager {
 
         List<ApiMessageAndVersion> records = new ArrayList<>();
 
-        if (isEnabled()) {
+        if (!isEnabled()) {
             // DelegationTokens are not enabled
             return ControllerResult.atomicOf(records, responseData.setErrorCode(DELEGATION_TOKEN_AUTH_DISABLED.code()));
         }
@@ -235,7 +235,7 @@ public class DelegationTokenControlManager {
         List<ApiMessageAndVersion> records = new ArrayList<>();
         RenewDelegationTokenResponseData responseData = new RenewDelegationTokenResponseData();
 
-        if (isEnabled()) {
+        if (!isEnabled()) {
             // DelegationTokens are not enabled
             return ControllerResult.atomicOf(records, responseData.setErrorCode(DELEGATION_TOKEN_AUTH_DISABLED.code()));
         }
@@ -266,15 +266,14 @@ public class DelegationTokenControlManager {
         long renewTimeStamp = now + renewLifeTime;
         long expiryTimestamp = Math.min(myTokenInformation.maxTimestamp(), renewTimeStamp);
 
-        myTokenInformation.setExpiryTimestamp(expiryTimestamp);
-
         DelegationTokenData newDelegationTokenData = new DelegationTokenData(myTokenInformation);
 
         responseData
             .setErrorCode(NONE.code())
             .setExpiryTimestampMs(expiryTimestamp);
 
-        records.add(new ApiMessageAndVersion(newDelegationTokenData.toRecord(), (short) 0));
+        records.add(new ApiMessageAndVersion(newDelegationTokenData.toRecord()
+            .setExpirationTimestamp(expiryTimestamp), (short) 0));
         return ControllerResult.atomicOf(records, responseData);
     }
 
@@ -287,7 +286,7 @@ public class DelegationTokenControlManager {
         List<ApiMessageAndVersion> records = new ArrayList<>();
         ExpireDelegationTokenResponseData responseData = new ExpireDelegationTokenResponseData();
 
-        if (isEnabled()) {
+        if (!isEnabled()) {
             // DelegationTokens are not enabled
             return ControllerResult.atomicOf(records, responseData.setErrorCode(DELEGATION_TOKEN_AUTH_DISABLED.code()));
         }
@@ -325,10 +324,9 @@ public class DelegationTokenControlManager {
                 .setErrorCode(NONE.code())
                 .setExpiryTimestampMs(expiryTimestamp);
 
-            myTokenInformation.setExpiryTimestamp(expiryTimestamp);
-
             DelegationTokenData newDelegationTokenData = new DelegationTokenData(myTokenInformation);
-            records.add(new ApiMessageAndVersion(newDelegationTokenData.toRecord(), (short) 0));
+            records.add(new ApiMessageAndVersion(newDelegationTokenData.toRecord()
+                .setExpirationTimestamp(expiryTimestamp), (short) 0));
         }
 
         return ControllerResult.atomicOf(records, responseData);

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -351,10 +351,10 @@ public class DelegationTokenControlManager {
     }
 
     public void replay(DelegationTokenRecord record) {
-        // XXX Do nothing right now
+        log.info("Replayed DelegationTokenRecord for {} " + record.tokenId());
     }
 
     public void replay(RemoveDelegationTokenRecord record) {
-        // XXX Do nothing right now
+        log.info("Replayed RemoveDelegationTokenRecord for {} " + record.tokenId());
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -20,9 +20,12 @@ package org.apache.kafka.controller;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData.CreatableRenewers;
 import org.apache.kafka.common.message.CreateDelegationTokenResponseData;
+import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
+import org.apache.kafka.common.message.ExpireDelegationTokenResponseData;
 import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
 import org.apache.kafka.common.message.RenewDelegationTokenResponseData;
 import org.apache.kafka.common.metadata.DelegationTokenRecord;
+import org.apache.kafka.common.metadata.RemoveDelegationTokenRecord;
 // import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.token.delegation.DelegationToken;
@@ -251,7 +254,26 @@ public class DelegationTokenControlManager {
         return ControllerResult.atomicOf(records, responseData);
     }
 
+    public ControllerResult<ExpireDelegationTokenResponseData> expireDelegationToken(
+        ControllerRequestContext context,
+        ExpireDelegationTokenRequestData requestData,
+        MetadataVersion metadataVersion
+    ) {
+        List<ApiMessageAndVersion> records = new ArrayList<>();
+        ExpireDelegationTokenResponseData responseData = new ExpireDelegationTokenResponseData();
+
+        TokenInformation myTokenInformation = getToken(requestData.hmac());
+
+        records.add(new ApiMessageAndVersion(new RemoveDelegationTokenRecord().
+                setTokenId(myTokenInformation.tokenId()), (short) 0));
+        return ControllerResult.atomicOf(records, responseData);
+    }
+
     public void replay(DelegationTokenRecord record) {
+        // XXX Do nothing right now
+    }
+
+    public void replay(RemoveDelegationTokenRecord record) {
         // XXX Do nothing right now
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -154,12 +154,13 @@ public class DelegationTokenControlManager {
                 .setTokenRequesterPrincipalType(owner.getPrincipalType());
 
         for (CreatableRenewers renewer : requestData.renewers()) {
-            if (renewer.principalType() != KafkaPrincipal.USER_TYPE) {
-                return ControllerResult.atomicOf(records, responseData.setErrorCode(INVALID_PRINCIPAL_TYPE.code()));
-            } else {
+            System.out.println("Got renewer : " + renewer.toString());
+            if (renewer.principalType().equals(KafkaPrincipal.USER_TYPE)) {
                 renewers.add(new KafkaPrincipal(renewer.principalType(), renewer.principalName()));
+            } else {
+                return ControllerResult.atomicOf(records, responseData.setErrorCode(INVALID_PRINCIPAL_TYPE.code()));
             }
-         } 
+        }
 
         TokenInformation newTokenInformation = new TokenInformation(tokenId, owner, owner, renewers,
             now, maxTimestamp, expiryTimestamp);

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
+import org.apache.kafka.common.message.CreateDelegationTokenRequestData.CreatableRenewers;
+import org.apache.kafka.common.message.CreateDelegationTokenResponseData;
+import org.apache.kafka.common.metadata.DelegationTokenRecord;
+// import org.apache.kafka.common.requests.ApiError;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.token.delegation.TokenInformation;
+import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.metadata.DelegationTokenData;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.MetadataVersion;
+import org.apache.kafka.timeline.SnapshotRegistry;
+// import org.apache.kafka.timeline.TimelineHashMap;
+import org.apache.kafka.common.utils.Time;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.InvalidKeyException;
+import java.nio.charset.StandardCharsets;
+import javax.crypto.spec.SecretKeySpec;
+import javax.crypto.SecretKey;
+import javax.crypto.Mac;
+
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+// import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.kafka.common.protocol.Errors.NONE;
+import static org.apache.kafka.common.protocol.Errors.INVALID_PRINCIPAL_TYPE;
+
+/**
+ * Manages DelegationTokens.
+ */
+public class DelegationTokenControlManager {
+    // XXX private static final long defaultTokenMaxTime = config.delegationTokenMaxLifeMs;
+    // XXX private static final long defaultTokenRenewTime = config.delegationTokenExpiryTimeMs;
+
+    private static final long DEFAULTTOKENMAXTIME = 0;
+    private static final long DEFAULTTOKENRENEWTIME = 0;
+    private Time time = Time.SYSTEM;
+
+    static class Builder {
+        private LogContext logContext = null;
+        private SnapshotRegistry snapshotRegistry = null;
+        private DelegationTokenCache tokenCache = null;
+
+        Builder setLogContext(LogContext logContext) {
+            this.logContext = logContext;
+            return this;
+        }
+
+        Builder setSnapshotRegistry(SnapshotRegistry snapshotRegistry) {
+            this.snapshotRegistry = snapshotRegistry;
+            return this;
+        }
+
+        Builder setTokenCache(DelegationTokenCache tokenCache) {
+            this.tokenCache = tokenCache;
+            return this;
+        }
+
+        DelegationTokenControlManager build() {
+            if (logContext == null) logContext = new LogContext();
+            if (snapshotRegistry == null) snapshotRegistry = new SnapshotRegistry(logContext);
+            return new DelegationTokenControlManager(logContext, snapshotRegistry, tokenCache);
+        }
+    }
+
+    private final Logger log;
+    private final DelegationTokenCache tokenCache;
+    // private final SecretKeySpec secretKey;
+    // private final Mac mac;
+    // private final TimelineHashMap<ScramCredentialKey, ScramCredentialValue> credentials;
+
+    private DelegationTokenControlManager(
+        LogContext logContext,
+        SnapshotRegistry snapshotRegistry,
+        DelegationTokenCache tokenCache
+    ) {
+        this.log = logContext.logger(DelegationTokenControlManager.class);
+        this.tokenCache = tokenCache;
+        // this.credentials = new TimelineHashMap<>(snapshotRegistry, 0);
+//        try {
+//            this.mac = Mac.getInstance("HmacSHA512");
+//            this.secretKey = new SecretKeySpec(toBytes("testKey"), mac.getAlgorithm());
+//        } catch (NoSuchAlgorithmException e) {
+//            System.out.println("Caught an exception");
+//            this.secretKey = null;
+//        }
+    }
+
+    public static byte[] toBytes(String str) {
+        return str.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private byte[] createHmac(String tokenId) {
+        byte[] result = {};
+
+        try {
+            Mac mac = Mac.getInstance("HmacSHA512");
+            SecretKeySpec secretKey = new SecretKeySpec(toBytes("testKey"), mac.getAlgorithm());
+            mac.init(secretKey);
+            result = mac.doFinal(toBytes(tokenId));
+        } catch (NoSuchAlgorithmException|InvalidKeyException e) {
+            System.out.println("Caught an exception 2");
+        }
+        return result;
+    }
+
+    /*
+     * Pass in the MetadataVersion so that we can return a response to the caller 
+     * if the current metadataVersion is too low.
+     */
+    public ControllerResult<CreateDelegationTokenResponseData> createDelegationToken(
+        ControllerRequestContext context,
+        CreateDelegationTokenRequestData requestData,
+        MetadataVersion metadataVersion
+    ) {
+        long now = time.milliseconds();
+        long maxTimestamp = now + DEFAULTTOKENMAXTIME + 1000000;
+        long expiryTimestamp = Math.min(maxTimestamp, now + DEFAULTTOKENRENEWTIME + 1000000);
+
+        String tokenId = Uuid.randomUuid().toString();
+        KafkaPrincipal owner = context.principal();
+        List<KafkaPrincipal> renewers = new ArrayList<KafkaPrincipal>();
+
+        List<ApiMessageAndVersion> records = new ArrayList<>();
+        CreateDelegationTokenResponseData responseData = new CreateDelegationTokenResponseData()
+                .setPrincipalName(owner.getName())
+                .setPrincipalType(owner.getPrincipalType())
+                .setTokenRequesterPrincipalName(owner.getName())
+                .setTokenRequesterPrincipalType(owner.getPrincipalType());
+
+        for (CreatableRenewers renewer : requestData.renewers()) {
+            if (renewer.principalType() != KafkaPrincipal.USER_TYPE) {
+                return ControllerResult.atomicOf(records, responseData.setErrorCode(INVALID_PRINCIPAL_TYPE.code()));
+            } else {
+                renewers.add(new KafkaPrincipal(renewer.principalType(), renewer.principalName()));
+            }
+         } 
+
+        TokenInformation newTokenInformation = new TokenInformation(tokenId, owner, owner, renewers,
+            now, maxTimestamp, expiryTimestamp);
+
+        DelegationTokenData newDelegationTokenData = new DelegationTokenData(newTokenInformation);
+
+        // XXX Throttle time is set by caller
+        responseData
+                .setErrorCode(NONE.code())
+                .setIssueTimestampMs(now)
+                .setExpiryTimestampMs(expiryTimestamp)
+                .setMaxTimestampMs(maxTimestamp)
+                .setTokenId(tokenId)
+                .setHmac(createHmac(tokenId));
+
+        System.out.println("context owner is :" + context.principal().toString());
+
+        records.add(new ApiMessageAndVersion(newDelegationTokenData.toRecord(), (short) 0));
+        return ControllerResult.atomicOf(records, responseData);
+    }
+
+    public void replay(DelegationTokenRecord record) {
+        // XXX Do nothing right now
+    }
+
+}

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -371,10 +371,10 @@ public class DelegationTokenControlManager {
     }
 
     public void replay(DelegationTokenRecord record) {
-        log.info("Replayed DelegationTokenRecord for {} " + record.tokenId());
+        log.info("Replayed DelegationTokenRecord for {}.", record.tokenId());
     }
 
     public void replay(RemoveDelegationTokenRecord record) {
-        log.info("Replayed RemoveDelegationTokenRecord for {} " + record.tokenId());
+        log.info("Replayed RemoveDelegationTokenRecord for {}.", record.tokenId());
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -59,6 +59,8 @@ import static org.apache.kafka.common.protocol.Errors.DELEGATION_TOKEN_EXPIRED;
 import static org.apache.kafka.common.protocol.Errors.DELEGATION_TOKEN_NOT_FOUND;
 import static org.apache.kafka.common.protocol.Errors.INVALID_PRINCIPAL_TYPE;
 import static org.apache.kafka.common.protocol.Errors.NONE;
+import static org.apache.kafka.common.protocol.Errors.UNSUPPORTED_VERSION;
+
 
 /**
  * Manages DelegationTokens.
@@ -187,6 +189,12 @@ public class DelegationTokenControlManager {
             // DelegationTokens are not enabled
             return ControllerResult.atomicOf(records, responseData.setErrorCode(DELEGATION_TOKEN_AUTH_DISABLED.code()));
         }
+
+        if (metadataVersion.isDelegationTokenSupported()) {
+            // DelegationTokens are not supported in this metadata version
+            return ControllerResult.atomicOf(records, responseData.setErrorCode(UNSUPPORTED_VERSION.code()));
+        }
+
 
         for (CreatableRenewers renewer : requestData.renewers()) {
             if (renewer.principalType().equals(KafkaPrincipal.USER_TYPE)) {

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -28,7 +28,7 @@ import org.apache.kafka.common.metadata.DelegationTokenRecord;
 import org.apache.kafka.common.metadata.RemoveDelegationTokenRecord;
 // import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
-import org.apache.kafka.common.security.token.delegation.DelegationToken;
+// XXX import org.apache.kafka.common.security.token.delegation.DelegationToken;
 import org.apache.kafka.common.security.token.delegation.TokenInformation;
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache;
 import org.apache.kafka.common.utils.LogContext;
@@ -44,7 +44,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.InvalidKeyException;
 import java.nio.charset.StandardCharsets;
 import javax.crypto.spec.SecretKeySpec;
-import javax.crypto.SecretKey;
+// import javax.crypto.SecretKey;
 import javax.crypto.Mac;
 
 import org.slf4j.Logger;
@@ -146,7 +146,7 @@ public class DelegationTokenControlManager {
             SecretKeySpec secretKey = new SecretKeySpec(toBytes(secretKeyString), mac.getAlgorithm());
             mac.init(secretKey);
             result = mac.doFinal(toBytes(tokenId));
-        } catch (NoSuchAlgorithmException|InvalidKeyException e) {
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
             System.out.println("Caught an exception 2");
         }
         return result;
@@ -155,7 +155,7 @@ public class DelegationTokenControlManager {
     private TokenInformation getToken(byte[] hmac) {
         String base64Pwd = Base64.getEncoder().encodeToString(hmac);
         System.out.println("tokencache has token count : " + tokenCache.tokens().size());
-        return (tokenCache.tokenForHmac(base64Pwd));
+        return tokenCache.tokenForHmac(base64Pwd);
     }
 
     /*

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -162,7 +162,6 @@ public class DelegationTokenControlManager {
 
     private TokenInformation getToken(byte[] hmac) {
         String base64Pwd = Base64.getEncoder().encodeToString(hmac);
-        System.out.println("tokencache has token count : " + tokenCache.tokens().size());
         return tokenCache.tokenForHmac(base64Pwd);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -355,14 +355,15 @@ public class DelegationTokenControlManager {
     }
 
     // Periodic call to remove expired DelegationTokens
-    public List<ApiMessageAndVersion> expireDelegationTokens() {
+    public List<ApiMessageAndVersion> sweepExpiredDelegationTokens() {
         long now = time.milliseconds();
         List<ApiMessageAndVersion> records = new ArrayList<ApiMessageAndVersion>();
 
         for (TokenInformation oldTokenInformation: tokenCache.tokens()) {
             if ((oldTokenInformation.maxTimestamp() < now) ||
                 (oldTokenInformation.expiryTimestamp() < now)) {
-                System.out.println("Token: " + oldTokenInformation.tokenId() + " is expired");
+                log.info("Delegation token expired for token: {} for owner: {}",
+                    oldTokenInformation.tokenId(), oldTokenInformation.ownerAsString());
                 records.add(new ApiMessageAndVersion(new RemoveDelegationTokenRecord().
                     setTokenId(oldTokenInformation.tokenId()), (short) 0));
             }

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -39,6 +39,8 @@ import org.apache.kafka.common.message.AlterUserScramCredentialsRequestData;
 import org.apache.kafka.common.message.AlterUserScramCredentialsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
+import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
+import org.apache.kafka.common.message.CreateDelegationTokenResponseData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
@@ -55,6 +57,7 @@ import org.apache.kafka.common.metadata.BeginTransactionRecord;
 import org.apache.kafka.common.metadata.BrokerRegistrationChangeRecord;
 import org.apache.kafka.common.metadata.ClientQuotaRecord;
 import org.apache.kafka.common.metadata.ConfigRecord;
+import org.apache.kafka.common.metadata.DelegationTokenRecord;
 import org.apache.kafka.common.metadata.EndTransactionRecord;
 import org.apache.kafka.common.metadata.FeatureLevelRecord;
 import org.apache.kafka.common.metadata.FenceBrokerRecord;
@@ -76,6 +79,7 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 import org.apache.kafka.common.requests.ApiError;
+import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -202,6 +206,7 @@ public final class QuorumController implements Controller {
         private BootstrapMetadata bootstrapMetadata = null;
         private int maxRecordsPerBatch = MAX_RECORDS_PER_BATCH;
         private boolean zkMigrationEnabled = false;
+        private DelegationTokenCache tokenCache;
 
         public Builder(int nodeId, String clusterId) {
             this.nodeId = nodeId;
@@ -322,6 +327,11 @@ public final class QuorumController implements Controller {
             return this;
         }
 
+        public Builder setDelegationTokenCache(DelegationTokenCache tokenCache) {
+            this.tokenCache = tokenCache;
+            return this;
+        }
+
         @SuppressWarnings("unchecked")
         public QuorumController build() throws Exception {
             if (raftClient == null) {
@@ -373,7 +383,8 @@ public final class QuorumController implements Controller {
                     staticConfig,
                     bootstrapMetadata,
                     maxRecordsPerBatch,
-                    zkMigrationEnabled
+                    zkMigrationEnabled,
+                    tokenCache
                 );
             } catch (Exception e) {
                 Utils.closeQuietly(queue, "event queue");
@@ -1481,6 +1492,9 @@ public final class QuorumController implements Controller {
             case REMOVE_USER_SCRAM_CREDENTIAL_RECORD:
                 scramControlManager.replay((RemoveUserScramCredentialRecord) message);
                 break;
+            case DELEGATION_TOKEN_RECORD:
+                delegationTokenControlManager.replay((DelegationTokenRecord) message);
+                break;
             case NO_OP_RECORD:
                 // NoOpRecord is an empty record and doesn't need to be replayed
                 break;
@@ -1605,6 +1619,11 @@ public final class QuorumController implements Controller {
     private final ScramControlManager scramControlManager;
 
     /**
+     * Manages DelegationTokens, if there are any.
+     */
+    private final DelegationTokenControlManager delegationTokenControlManager;
+
+    /**
      * Manages the standard ACLs in the cluster.
      * This must be accessed only by the event queue thread.
      */
@@ -1708,7 +1727,8 @@ public final class QuorumController implements Controller {
         Map<String, Object> staticConfig,
         BootstrapMetadata bootstrapMetadata,
         int maxRecordsPerBatch,
-        boolean zkMigrationEnabled
+        boolean zkMigrationEnabled,
+        DelegationTokenCache tokenCache
     ) {
         this.nonFatalFaultHandler = nonFatalFaultHandler;
         this.fatalFaultHandler = fatalFaultHandler;
@@ -1784,6 +1804,11 @@ public final class QuorumController implements Controller {
             setLogContext(logContext).
             setSnapshotRegistry(snapshotRegistry).
             build();
+        this.delegationTokenControlManager = new DelegationTokenControlManager.Builder().
+            setLogContext(logContext).
+            setSnapshotRegistry(snapshotRegistry).
+            setTokenCache(tokenCache).
+            build();
         this.aclControlManager = new AclControlManager.Builder().
             setLogContext(logContext).
             setSnapshotRegistry(snapshotRegistry).
@@ -1828,6 +1853,16 @@ public final class QuorumController implements Controller {
         }
         return appendWriteEvent("alterUserScramCredentials", context.deadlineNs(),
             () -> scramControlManager.alterCredentials(request, featureControl.metadataVersion()));
+    }
+
+    @Override
+    public CompletableFuture<CreateDelegationTokenResponseData> createDelegationToken(
+        ControllerRequestContext context,
+        CreateDelegationTokenRequestData request
+    ) {
+        System.out.println("QuorumController createDelegationToken: start");
+        return appendWriteEvent("createDelegationToken", context.deadlineNs(),
+            () -> delegationTokenControlManager.createDelegationToken(context, request, featureControl.metadataVersion()));
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -213,6 +213,9 @@ public final class QuorumController implements Controller {
         private boolean zkMigrationEnabled = false;
         private DelegationTokenCache tokenCache;
         private String tokenKeyString;
+        private long delegationTokenMaxLifeMs;
+        private long delegationTokenExpiryTimeMs;
+        private long delegationTokenExpiryCheckIntervalMs;
 
         public Builder(int nodeId, String clusterId) {
             this.nodeId = nodeId;
@@ -343,6 +346,21 @@ public final class QuorumController implements Controller {
             return this;
         }
 
+        public Builder setDelegationTokenMaxLifeMs(long delegationTokenMaxLifeMs) {
+            this.delegationTokenMaxLifeMs = delegationTokenMaxLifeMs;
+            return this;
+        }
+
+        public Builder setDelegationTokenExpiryTimeMs(long delegationTokenExpiryTimeMs) {
+            this.delegationTokenExpiryTimeMs = delegationTokenExpiryTimeMs;
+            return this;
+        }
+
+        public Builder setDelegationTokenExpiryCheckIntervalMs(long delegationTokenExpiryCheckIntervalMs) {
+            this.delegationTokenExpiryCheckIntervalMs = delegationTokenExpiryCheckIntervalMs;
+            return this;
+        }
+
         @SuppressWarnings("unchecked")
         public QuorumController build() throws Exception {
             if (raftClient == null) {
@@ -396,7 +414,10 @@ public final class QuorumController implements Controller {
                     maxRecordsPerBatch,
                     zkMigrationEnabled,
                     tokenCache,
-                    tokenKeyString
+                    tokenKeyString,
+                    delegationTokenMaxLifeMs,
+                    delegationTokenExpiryTimeMs,
+                    delegationTokenExpiryCheckIntervalMs
                 );
             } catch (Exception e) {
                 Utils.closeQuietly(queue, "event queue");
@@ -1744,7 +1765,10 @@ public final class QuorumController implements Controller {
         int maxRecordsPerBatch,
         boolean zkMigrationEnabled,
         DelegationTokenCache tokenCache,
-        String tokenKeyString
+        String tokenKeyString,
+        long delegationTokenMaxLifeMs,
+        long delegationTokenExpiryTimeMs,
+        long delegationTokenExpiryCheckIntervalMs
     ) {
         this.nonFatalFaultHandler = nonFatalFaultHandler;
         this.fatalFaultHandler = fatalFaultHandler;
@@ -1825,6 +1849,9 @@ public final class QuorumController implements Controller {
             setSnapshotRegistry(snapshotRegistry).
             setTokenCache(tokenCache).
             setTokenKeyString(tokenKeyString).
+            setDelegationTokenMaxLifeMs(delegationTokenMaxLifeMs).
+            setDelegationTokenExpiryTimeMs(delegationTokenExpiryTimeMs).
+            setDelegationTokenExpiryCheckIntervalMs(delegationTokenExpiryCheckIntervalMs).
             build();
         this.aclControlManager = new AclControlManager.Builder().
             setLogContext(logContext).

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -212,7 +212,7 @@ public final class QuorumController implements Controller {
         private int maxRecordsPerBatch = MAX_RECORDS_PER_BATCH;
         private boolean zkMigrationEnabled = false;
         private DelegationTokenCache tokenCache;
-        private String tokenKeyString;
+        private String tokenSecretKeyString;
         private long delegationTokenMaxLifeMs;
         private long delegationTokenExpiryTimeMs;
         private long delegationTokenExpiryCheckIntervalMs;
@@ -341,8 +341,8 @@ public final class QuorumController implements Controller {
             return this;
         }
 
-        public Builder setDelegationTokenSecretKeyString(String tokenKeyString) {
-            this.tokenKeyString = tokenKeyString;
+        public Builder setDelegationTokenSecretKey(String tokenSecretKeyString) {
+            this.tokenSecretKeyString = tokenSecretKeyString;
             return this;
         }
 
@@ -414,7 +414,7 @@ public final class QuorumController implements Controller {
                     maxRecordsPerBatch,
                     zkMigrationEnabled,
                     tokenCache,
-                    tokenKeyString,
+                    tokenSecretKeyString,
                     delegationTokenMaxLifeMs,
                     delegationTokenExpiryTimeMs,
                     delegationTokenExpiryCheckIntervalMs
@@ -1791,7 +1791,7 @@ public final class QuorumController implements Controller {
         int maxRecordsPerBatch,
         boolean zkMigrationEnabled,
         DelegationTokenCache tokenCache,
-        String tokenKeyString,
+        String tokenSecretKeyString,
         long delegationTokenMaxLifeMs,
         long delegationTokenExpiryTimeMs,
         long delegationTokenExpiryCheckIntervalMs
@@ -1874,7 +1874,7 @@ public final class QuorumController implements Controller {
         this.delegationTokenControlManager = new DelegationTokenControlManager.Builder().
             setLogContext(logContext).
             setTokenCache(tokenCache).
-            setTokenKeyString(tokenKeyString).
+            setDelegationTokenSecretKey(tokenSecretKeyString).
             setDelegationTokenMaxLifeMs(delegationTokenMaxLifeMs).
             setDelegationTokenExpiryTimeMs(delegationTokenExpiryTimeMs).
             build();

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -209,6 +209,7 @@ public final class QuorumController implements Controller {
         private int maxRecordsPerBatch = MAX_RECORDS_PER_BATCH;
         private boolean zkMigrationEnabled = false;
         private DelegationTokenCache tokenCache;
+        private String tokenKeyString;
 
         public Builder(int nodeId, String clusterId) {
             this.nodeId = nodeId;
@@ -334,6 +335,11 @@ public final class QuorumController implements Controller {
             return this;
         }
 
+        public Builder setDelegationTokenSecretKeyString(String tokenKeyString) {
+            this.tokenKeyString = tokenKeyString;
+            return this;
+        }
+
         @SuppressWarnings("unchecked")
         public QuorumController build() throws Exception {
             if (raftClient == null) {
@@ -386,7 +392,8 @@ public final class QuorumController implements Controller {
                     bootstrapMetadata,
                     maxRecordsPerBatch,
                     zkMigrationEnabled,
-                    tokenCache
+                    tokenCache,
+                    tokenKeyString
                 );
             } catch (Exception e) {
                 Utils.closeQuietly(queue, "event queue");
@@ -1730,7 +1737,8 @@ public final class QuorumController implements Controller {
         BootstrapMetadata bootstrapMetadata,
         int maxRecordsPerBatch,
         boolean zkMigrationEnabled,
-        DelegationTokenCache tokenCache
+        DelegationTokenCache tokenCache,
+        String tokenKeyString
     ) {
         this.nonFatalFaultHandler = nonFatalFaultHandler;
         this.fatalFaultHandler = fatalFaultHandler;
@@ -1810,6 +1818,7 @@ public final class QuorumController implements Controller {
             setLogContext(logContext).
             setSnapshotRegistry(snapshotRegistry).
             setTokenCache(tokenCache).
+            setTokenKeyString(tokenKeyString).
             build();
         this.aclControlManager = new AclControlManager.Builder().
             setLogContext(logContext).

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1447,6 +1447,11 @@ public final class QuorumController implements Controller {
         if (featureControl.metadataVersion().isDelegationTokenSupported() &&
             delegationTokenControlManager.isEnabled()) {
 
+            log.debug(
+                "Scheduling write event for {} because DelegationTokens are enabled.", 
+                SWEEP_EXPIRED_DELEGATION_TOKENS
+            );
+
             ControllerWriteEvent<Void> event = new ControllerWriteEvent<>(
                 SWEEP_EXPIRED_DELEGATION_TOKENS,
                 () -> {

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -49,6 +49,8 @@ import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
+import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
+import org.apache.kafka.common.message.RenewDelegationTokenResponseData;
 import org.apache.kafka.common.message.UpdateFeaturesRequestData;
 import org.apache.kafka.common.message.UpdateFeaturesResponseData;
 import org.apache.kafka.common.metadata.AbortTransactionRecord;
@@ -1863,6 +1865,16 @@ public final class QuorumController implements Controller {
         System.out.println("QuorumController createDelegationToken: start");
         return appendWriteEvent("createDelegationToken", context.deadlineNs(),
             () -> delegationTokenControlManager.createDelegationToken(context, request, featureControl.metadataVersion()));
+    }
+
+    @Override
+    public CompletableFuture<RenewDelegationTokenResponseData> renewDelegationToken(
+        ControllerRequestContext context,
+        RenewDelegationTokenRequestData request
+    ) {
+        System.out.println("QuorumController renewDelegationToken: start");
+        return appendWriteEvent("renewDelegationToken", context.deadlineNs(),
+            () -> delegationTokenControlManager.renewDelegationToken(context, request, featureControl.metadataVersion()));
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -70,6 +70,7 @@ import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.common.metadata.ProducerIdsRecord;
 import org.apache.kafka.common.metadata.RegisterBrokerRecord;
 import org.apache.kafka.common.metadata.RemoveAccessControlEntryRecord;
+import org.apache.kafka.common.metadata.RemoveDelegationTokenRecord;
 import org.apache.kafka.common.metadata.RemoveTopicRecord;
 import org.apache.kafka.common.metadata.UserScramCredentialRecord;
 import org.apache.kafka.common.metadata.RemoveUserScramCredentialRecord;
@@ -1503,6 +1504,9 @@ public final class QuorumController implements Controller {
                 break;
             case DELEGATION_TOKEN_RECORD:
                 delegationTokenControlManager.replay((DelegationTokenRecord) message);
+                break;
+            case REMOVE_DELEGATION_TOKEN_RECORD:
+                delegationTokenControlManager.replay((RemoveDelegationTokenRecord) message);
                 break;
             case NO_OP_RECORD:
                 // NoOpRecord is an empty record and doesn't need to be replayed

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1904,7 +1904,6 @@ public final class QuorumController implements Controller {
         ControllerRequestContext context,
         CreateDelegationTokenRequestData request
     ) {
-        System.out.println("QuorumController createDelegationToken: start");
         return appendWriteEvent("createDelegationToken", context.deadlineNs(),
             () -> delegationTokenControlManager.createDelegationToken(context, request, featureControl.metadataVersion()));
     }
@@ -1914,7 +1913,6 @@ public final class QuorumController implements Controller {
         ControllerRequestContext context,
         RenewDelegationTokenRequestData request
     ) {
-        System.out.println("QuorumController renewDelegationToken: start");
         return appendWriteEvent("renewDelegationToken", context.deadlineNs(),
             () -> delegationTokenControlManager.renewDelegationToken(context, request, featureControl.metadataVersion()));
     }
@@ -1924,7 +1922,6 @@ public final class QuorumController implements Controller {
         ControllerRequestContext context,
         ExpireDelegationTokenRequestData request
     ) {
-        System.out.println("QuorumController expireDelegationToken: start");
         return appendWriteEvent("expireDelegationToken", context.deadlineNs(),
             () -> delegationTokenControlManager.expireDelegationToken(context, request, featureControl.metadataVersion()));
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1873,12 +1873,10 @@ public final class QuorumController implements Controller {
         this.delegationTokenExpiryCheckIntervalMs = delegationTokenExpiryCheckIntervalMs;
         this.delegationTokenControlManager = new DelegationTokenControlManager.Builder().
             setLogContext(logContext).
-            setSnapshotRegistry(snapshotRegistry).
             setTokenCache(tokenCache).
             setTokenKeyString(tokenKeyString).
             setDelegationTokenMaxLifeMs(delegationTokenMaxLifeMs).
             setDelegationTokenExpiryTimeMs(delegationTokenExpiryTimeMs).
-            setDelegationTokenExpiryCheckIntervalMs(delegationTokenExpiryCheckIntervalMs).
             build();
         this.aclControlManager = new AclControlManager.Builder().
             setLogContext(logContext).

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -47,6 +47,8 @@ import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
+import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
+import org.apache.kafka.common.message.ExpireDelegationTokenResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
 import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
@@ -1888,6 +1890,16 @@ public final class QuorumController implements Controller {
         System.out.println("QuorumController renewDelegationToken: start");
         return appendWriteEvent("renewDelegationToken", context.deadlineNs(),
             () -> delegationTokenControlManager.renewDelegationToken(context, request, featureControl.metadataVersion()));
+    }
+
+    @Override
+    public CompletableFuture<ExpireDelegationTokenResponseData> expireDelegationToken(
+        ControllerRequestContext context,
+        ExpireDelegationTokenRequestData request
+    ) {
+        System.out.println("QuorumController expireDelegationToken: start");
+        return appendWriteEvent("expireDelegationToken", context.deadlineNs(),
+            () -> delegationTokenControlManager.expireDelegationToken(context, request, featureControl.metadataVersion()));
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/image/DelegationTokenDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/DelegationTokenDelta.java
@@ -33,6 +33,7 @@ import java.util.Map;
 public final class DelegationTokenDelta {
     private final DelegationTokenImage image;
 
+    // XXX This must use the same key value as the tokenCache
     private final Map<String, DelegationTokenData> changes = new HashMap<>();
 
     public DelegationTokenDelta(DelegationTokenImage image) {
@@ -47,7 +48,7 @@ public final class DelegationTokenDelta {
         return image;
     }
 
-    //XXX Map uuid to Data?
+    //XXX Map hash to Data?
     public Map<String, DelegationTokenData> changes() {
         return changes;
     }

--- a/metadata/src/main/java/org/apache/kafka/image/DelegationTokenDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/DelegationTokenDelta.java
@@ -84,7 +84,9 @@ public final class DelegationTokenDelta {
 
         for (Entry<String, Optional<DelegationTokenData>> entry : changes.entrySet()) {
             if (!newTokens.containsKey(entry.getKey())) {
-                newTokens.put(entry.getKey(), entry.getValue().get());
+                if (entry.getValue().isPresent()) {
+                    newTokens.put(entry.getKey(), entry.getValue().get());
+                }
             }
         }
         return new DelegationTokenImage(newTokens);

--- a/metadata/src/main/java/org/apache/kafka/image/DelegationTokenDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/DelegationTokenDelta.java
@@ -73,6 +73,10 @@ public final class DelegationTokenDelta {
 
     public DelegationTokenImage apply() {
         Map<String, DelegationTokenData> newTokens = new HashMap<>();
+
+        // Add image entries to newTokens if there isn't a change for that entry.
+        // A snapshot of the deltas will call finishSnapshot() first which will add a
+        // removal change for all entries in the base image which did not have a change record.
         for (Entry<String, DelegationTokenData> entry : image.tokens().entrySet()) {
             Optional<DelegationTokenData> change = changes.get(entry.getKey());
             if (change == null) {
@@ -82,6 +86,7 @@ public final class DelegationTokenDelta {
             }
         }
 
+        // Add changed entries to newTokens that aren't already in newTokens.
         for (Entry<String, Optional<DelegationTokenData>> entry : changes.entrySet()) {
             if (!newTokens.containsKey(entry.getKey())) {
                 if (entry.getValue().isPresent()) {

--- a/metadata/src/main/java/org/apache/kafka/image/DelegationTokenDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/DelegationTokenDelta.java
@@ -19,8 +19,8 @@ package org.apache.kafka.image;
 
 import org.apache.kafka.common.metadata.DelegationTokenRecord;
 import org.apache.kafka.common.metadata.RemoveDelegationTokenRecord;
-import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.metadata.DelegationTokenData;
+import org.apache.kafka.server.common.MetadataVersion;
 
 import java.util.HashMap;
 import java.util.Map.Entry;
@@ -70,7 +70,7 @@ public final class DelegationTokenDelta {
         for (Entry<String, Optional<DelegationTokenData>> tokenChange : changes.entrySet()) {
             if (tokenChange.getValue().isPresent()) {
                 newTokens.put(tokenChange.getKey(), tokenChange.getValue().get());
-            } else{
+            } else {
                 newTokens.remove(tokenChange.getKey());
             }
         }

--- a/metadata/src/main/java/org/apache/kafka/image/DelegationTokenDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/DelegationTokenDelta.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.metadata.DelegationTokenRecord;
+import org.apache.kafka.server.common.MetadataVersion;
+import org.apache.kafka.metadata.DelegationTokenData;
+
+import java.util.HashMap;
+import java.util.Map.Entry;
+import java.util.Map;
+// import java.util.Optional;
+
+
+/**
+ * Represents changes to delegation tokens in the metadata image.
+ */
+public final class DelegationTokenDelta {
+    private final DelegationTokenImage image;
+
+    private final Map<String, DelegationTokenData> changes = new HashMap<>();
+
+    public DelegationTokenDelta(DelegationTokenImage image) {
+        this.image = image;
+    }
+
+    public void finishSnapshot() {
+        // Not sure there is anything to do here
+    }
+
+    public DelegationTokenImage image() {
+        return image;
+    }
+
+    //XXX Map uuid to Data?
+    public Map<String, DelegationTokenData> changes() {
+        return changes;
+    }
+
+    public void replay(DelegationTokenRecord record) {
+        changes.put(record.tokenId(), DelegationTokenData.fromRecord(record));
+    }
+
+    public void handleMetadataVersionChange(MetadataVersion changedMetadataVersion) {
+        // nothing to do
+    }
+
+    public DelegationTokenImage apply() {
+        Map<String, DelegationTokenData> newTokens = new HashMap<>();
+        for (Entry<String, DelegationTokenData> tokenChange : changes.entrySet()) {
+            newTokens.put(tokenChange.getKey(), tokenChange.getValue());
+            /*
+            if (userNameEntry.getValue().isPresent()) {
+                userMap.put(userNameEntry.getKey(), userNameEntry.getValue().get());
+            } else {
+                userMap.remove(userNameEntry.getKey());
+                if (userMap.isEmpty()) {
+                    newMechanisms.remove(mechanismChangeEntry.getKey());
+                }
+            }
+            */
+        }
+        return new DelegationTokenImage(newTokens);
+    }
+
+    @Override
+    public String toString() {
+        return "DelegationTokenDelta(" +
+            "changes=" + changes +
+            ')';
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/DelegationTokenImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/DelegationTokenImage.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 
 /**
- * Represents the SCRAM credentials in the metadata image.
+ * Represents the DelegationToken credentials in the metadata image.
  *
  * This class is thread-safe.
  */
@@ -61,41 +61,6 @@ public final class DelegationTokenImage {
             } 
         }
     }
-
-//    private boolean filterOwners(RequestContext requestContext,
-//                                 List<KafkaPrincipal> owners,
-//                                 TokenInformation token) {
-//        for (KafkaPrincipal owner: owners) {
-//            if (token.ownerOrRenewer(owner)) {
-//                return true;
-//            }
-//        }
-//        return false;
-//    }
-
-    /*
-     * Return a list of TokenInformation for the requested owners or renewers.
-     * Return all if the list is null. Caller will authenticate for each TokenInformation
-     */
-//    public List<TokenInformation> describe(RequestContext requestContext, 
-//        DescribeDelegationTokenRequestData describeDelegationTokenRequestData) {
-//
-//        List<TokenInformation> infos = new ArrayList<TokenInformation>();
-//        List<KafkaPrincipal> owners = new ArrayList<KafkaPrincipal>();
-//        if (describeDelegationTokenRequestData.owners() != null) {
-//            for (DescribeDelegationTokenOwner owner: describeDelegationTokenRequestData.owners()) {
-//                owners.add(new KafkaPrincipal(owner.principalType(), owner.principalName()));
-//            }
-//        }
-//
-//        for (DelegationTokenData tokenData : tokens.values()) {
-//            if ((describeDelegationTokenRequestData.owners() == null) ||
-//                filterOwners(requestContext, owners, tokenData.tokenInformation())) {
-//                infos.add(tokenData.tokenInformation());
-//            }
-//        }
-//        return infos;
-//    }
 
     public Map<String, DelegationTokenData> tokens() {
         return tokens;

--- a/metadata/src/main/java/org/apache/kafka/image/DelegationTokenImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/DelegationTokenImage.java
@@ -18,11 +18,12 @@
 package org.apache.kafka.image;
 
 import org.apache.kafka.common.requests.RequestContext;
-import org.apache.kafka.common.requests.DescribeDelegationTokenRequest;
+// XXX import org.apache.kafka.common.requests.DescribeDelegationTokenRequest;
 import org.apache.kafka.common.message.DescribeDelegationTokenRequestData;
 import org.apache.kafka.common.message.DescribeDelegationTokenRequestData.DescribeDelegationTokenOwner;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.token.delegation.TokenInformation;
+import org.apache.kafka.image.node.DelegationTokenImageNode;
 import org.apache.kafka.image.writer.ImageWriter;
 import org.apache.kafka.image.writer.ImageWriterOptions;
 // import org.apache.kafka.common.protocol.Errors;
@@ -33,7 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.HashMap;
+// import java.util.HashMap;
 import java.util.Map.Entry;
 // import java.util.stream.Collectors;
 
@@ -119,7 +120,6 @@ public final class DelegationTokenImage {
 
     @Override
     public String toString() {
-// XXX        return new DelegationTokenImageNode(this).stringify();
-        return "";
+        return new DelegationTokenImageNode(this).stringify();
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/image/DelegationTokenImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/DelegationTokenImage.java
@@ -17,18 +17,10 @@
 
 package org.apache.kafka.image;
 
-import org.apache.kafka.common.requests.RequestContext;
-// XXX import org.apache.kafka.common.requests.DescribeDelegationTokenRequest;
-import org.apache.kafka.common.message.DescribeDelegationTokenRequestData;
-import org.apache.kafka.common.message.DescribeDelegationTokenRequestData.DescribeDelegationTokenOwner;
-import org.apache.kafka.common.security.auth.KafkaPrincipal;
-import org.apache.kafka.common.security.token.delegation.TokenInformation;
 import org.apache.kafka.image.node.DelegationTokenImageNode;
 import org.apache.kafka.image.writer.ImageWriter;
 import org.apache.kafka.image.writer.ImageWriterOptions;
-// import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.metadata.DelegationTokenData;
-
 
 import java.util.Collections;
 import java.util.List;
@@ -70,40 +62,40 @@ public final class DelegationTokenImage {
         }
     }
 
-    private boolean filterOwners(RequestContext requestContext,
-                                 List<KafkaPrincipal> owners,
-                                 TokenInformation token) {
-        for (KafkaPrincipal owner: owners) {
-            if (token.ownerOrRenewer(owner)) {
-                return true;
-            }
-        }
-        return false;
-    }
+//    private boolean filterOwners(RequestContext requestContext,
+//                                 List<KafkaPrincipal> owners,
+//                                 TokenInformation token) {
+//        for (KafkaPrincipal owner: owners) {
+//            if (token.ownerOrRenewer(owner)) {
+//                return true;
+//            }
+//        }
+//        return false;
+//    }
 
     /*
      * Return a list of TokenInformation for the requested owners or renewers.
-     * or all if the list s null. Caller will authenticate for each TokenInformation
+     * Return all if the list is null. Caller will authenticate for each TokenInformation
      */
-    public List<TokenInformation> describe(RequestContext requestContext, 
-        DescribeDelegationTokenRequestData describeDelegationTokenRequestData) {
-
-        List<TokenInformation> infos = new ArrayList<TokenInformation>();
-        List<KafkaPrincipal> owners = new ArrayList<KafkaPrincipal>();
-        if (describeDelegationTokenRequestData.owners() != null) {
-            for (DescribeDelegationTokenOwner owner: describeDelegationTokenRequestData.owners()) {
-                owners.add(new KafkaPrincipal(owner.principalType(), owner.principalName()));
-            }
-        }
-
-        for (DelegationTokenData tokenData : tokens.values()) {
-            if ((describeDelegationTokenRequestData.owners() == null) ||
-                filterOwners(requestContext, owners, tokenData.tokenInformation())) {
-                infos.add(tokenData.tokenInformation());
-            }
-        }
-        return infos;
-    }
+//    public List<TokenInformation> describe(RequestContext requestContext, 
+//        DescribeDelegationTokenRequestData describeDelegationTokenRequestData) {
+//
+//        List<TokenInformation> infos = new ArrayList<TokenInformation>();
+//        List<KafkaPrincipal> owners = new ArrayList<KafkaPrincipal>();
+//        if (describeDelegationTokenRequestData.owners() != null) {
+//            for (DescribeDelegationTokenOwner owner: describeDelegationTokenRequestData.owners()) {
+//                owners.add(new KafkaPrincipal(owner.principalType(), owner.principalName()));
+//            }
+//        }
+//
+//        for (DelegationTokenData tokenData : tokens.values()) {
+//            if ((describeDelegationTokenRequestData.owners() == null) ||
+//                filterOwners(requestContext, owners, tokenData.tokenInformation())) {
+//                infos.add(tokenData.tokenInformation());
+//            }
+//        }
+//        return infos;
+//    }
 
     public Map<String, DelegationTokenData> tokens() {
         return tokens;

--- a/metadata/src/main/java/org/apache/kafka/image/DelegationTokenImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/DelegationTokenImage.java
@@ -34,9 +34,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
-// import java.util.HashMap;
 import java.util.Map.Entry;
-// import java.util.stream.Collectors;
+import java.util.stream.Collectors;
 
 
 /**
@@ -56,9 +55,18 @@ public final class DelegationTokenImage {
     }
 
     public void write(ImageWriter writer, ImageWriterOptions options) {
-// XXX Must do this       if (options.metadataVersion().isDelegationTokenSupported()) 
-        for (Entry<String, DelegationTokenData> entry : tokens.entrySet()) {
-            writer.write(0, entry.getValue().toRecord());
+        if (options.metadataVersion().isDelegationTokenSupported()) {
+            for (Entry<String, DelegationTokenData> entry : tokens.entrySet()) {
+                writer.write(0, entry.getValue().toRecord());
+            }
+        } else {
+            if (!tokens.isEmpty()) {
+                List<String> tokenIds = new ArrayList<>(tokens.keySet());
+                StringBuffer delegationTokenImageString = new StringBuffer("DelegationTokenImage(");
+                delegationTokenImageString.append(tokenIds.stream().collect(Collectors.joining(", ")));
+                delegationTokenImageString.append(")");
+                options.handleLoss(delegationTokenImageString.toString());
+            } 
         }
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/DelegationTokenImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/DelegationTokenImage.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.requests.DescribeDelegationTokenRequest;
+import org.apache.kafka.common.message.DescribeDelegationTokenRequestData;
+import org.apache.kafka.common.message.DescribeDelegationTokenRequestData.DescribeDelegationTokenOwner;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.token.delegation.TokenInformation;
+import org.apache.kafka.image.writer.ImageWriter;
+import org.apache.kafka.image.writer.ImageWriterOptions;
+// import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.metadata.DelegationTokenData;
+
+
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Map.Entry;
+// import java.util.stream.Collectors;
+
+
+/**
+ * Represents the SCRAM credentials in the metadata image.
+ *
+ * This class is thread-safe.
+ */
+public final class DelegationTokenImage {
+    public static final DelegationTokenImage EMPTY = new DelegationTokenImage(Collections.emptyMap());
+
+    // Map TokenID to TokenInformation.
+    // The TokenID is also contained in the TokenInformation inside the DelegationTokenData
+    private final Map<String, DelegationTokenData> tokens;
+
+    public DelegationTokenImage(Map<String, DelegationTokenData> tokens) {
+        this.tokens = Collections.unmodifiableMap(tokens);
+    }
+
+    public void write(ImageWriter writer, ImageWriterOptions options) {
+// XXX Must do this       if (options.metadataVersion().isDelegationTokenSupported()) 
+        for (Entry<String, DelegationTokenData> entry : tokens.entrySet()) {
+            writer.write(0, entry.getValue().toRecord());
+        }
+    }
+
+    private boolean filterOwners(RequestContext requestContext,
+                                 List<KafkaPrincipal> owners,
+                                 TokenInformation token) {
+        for (KafkaPrincipal owner: owners) {
+            if (token.ownerOrRenewer(owner)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /*
+     * Return a list of TokenInformation for the requested owners or renewers.
+     * or all if the list s null. Caller will authenticate for each TokenInformation
+     */
+    public List<TokenInformation> describe(RequestContext requestContext, 
+        DescribeDelegationTokenRequestData describeDelegationTokenRequestData) {
+
+        List<TokenInformation> infos = new ArrayList<TokenInformation>();
+        List<KafkaPrincipal> owners = new ArrayList<KafkaPrincipal>();
+        if (describeDelegationTokenRequestData.owners() != null) {
+            for (DescribeDelegationTokenOwner owner: describeDelegationTokenRequestData.owners()) {
+                owners.add(new KafkaPrincipal(owner.principalType(), owner.principalName()));
+            }
+        }
+
+        for (DelegationTokenData tokenData : tokens.values()) {
+            if ((describeDelegationTokenRequestData.owners() == null) ||
+                filterOwners(requestContext, owners, tokenData.tokenInformation())) {
+                infos.add(tokenData.tokenInformation());
+            }
+        }
+        return infos;
+    }
+
+    public Map<String, DelegationTokenData> tokens() {
+        return tokens;
+    }
+
+    public boolean isEmpty() {
+        return tokens.isEmpty();
+    }
+
+    @Override
+    public int hashCode() {
+        return tokens.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        if (!o.getClass().equals(DelegationTokenImage.class)) return false;
+        DelegationTokenImage other = (DelegationTokenImage) o;
+        return tokens.equals(other.tokens);
+    }
+
+    @Override
+    public String toString() {
+// XXX        return new DelegationTokenImageNode(this).stringify();
+        return "";
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/MetadataDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/MetadataDelta.java
@@ -340,7 +340,6 @@ public final class MetadataDelta {
     public void replay(RemoveUserScramCredentialRecord record) {
         getOrCreateScramDelta().replay(record);
     }
-    // XXX Need a remove delegation Token
 
     public void replay(ZkMigrationStateRecord record) {
         getOrCreateFeaturesDelta().replay(record);

--- a/metadata/src/main/java/org/apache/kafka/image/MetadataDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/MetadataDelta.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.metadata.AccessControlEntryRecord;
 import org.apache.kafka.common.metadata.BrokerRegistrationChangeRecord;
 import org.apache.kafka.common.metadata.ClientQuotaRecord;
 import org.apache.kafka.common.metadata.ConfigRecord;
+import org.apache.kafka.common.metadata.DelegationTokenRecord;
 import org.apache.kafka.common.metadata.FeatureLevelRecord;
 import org.apache.kafka.common.metadata.FenceBrokerRecord;
 import org.apache.kafka.common.metadata.MetadataRecordType;
@@ -76,6 +77,8 @@ public final class MetadataDelta {
     private AclsDelta aclsDelta = null;
 
     private ScramDelta scramDelta = null;
+
+    private DelegationTokenDelta delegationTokenDelta = null;
 
     public MetadataDelta(MetadataImage image) {
         this.image = image;
@@ -159,6 +162,15 @@ public final class MetadataDelta {
         return scramDelta;
     }
 
+    public DelegationTokenDelta delegationTokenDelta() {
+        return delegationTokenDelta;
+    }
+
+    public DelegationTokenDelta getOrCreateDelegationTokenDelta() {
+        if (delegationTokenDelta == null) delegationTokenDelta = new DelegationTokenDelta(image.delegationTokens());
+        return delegationTokenDelta;
+    }
+
     public Optional<MetadataVersion> metadataVersionChanged() {
         if (featuresDelta == null) {
             return Optional.empty();
@@ -197,6 +209,9 @@ public final class MetadataDelta {
             case REMOVE_TOPIC_RECORD:
                 replay((RemoveTopicRecord) record);
                 break;
+            case DELEGATION_TOKEN_RECORD:
+                replay((DelegationTokenRecord) record);
+                break;
             case USER_SCRAM_CREDENTIAL_RECORD:
                 replay((UserScramCredentialRecord) record);
                 break;
@@ -221,6 +236,7 @@ public final class MetadataDelta {
             case REMOVE_USER_SCRAM_CREDENTIAL_RECORD:
                 replay((RemoveUserScramCredentialRecord) record);
                 break;
+            // XXX Need to create a REMOVE_DELEGATION_TOKEN_RECORD
             case NO_OP_RECORD:
                 /* NoOpRecord is an empty record and doesn't need to be replayed beyond
                  * updating the highest offset and epoch.
@@ -271,6 +287,10 @@ public final class MetadataDelta {
         getOrCreateConfigsDelta().replay(record, topicName);
     }
 
+    public void replay(DelegationTokenRecord record) {
+        getOrCreateDelegationTokenDelta().replay(record);
+    }
+
     public void replay(UserScramCredentialRecord record) {
         getOrCreateScramDelta().replay(record);
     }
@@ -286,6 +306,7 @@ public final class MetadataDelta {
             getOrCreateProducerIdsDelta().handleMetadataVersionChange(changedMetadataVersion);
             getOrCreateAclsDelta().handleMetadataVersionChange(changedMetadataVersion);
             getOrCreateScramDelta().handleMetadataVersionChange(changedMetadataVersion);
+            getOrCreateDelegationTokenDelta().handleMetadataVersionChange(changedMetadataVersion);
         });
     }
 
@@ -312,6 +333,7 @@ public final class MetadataDelta {
     public void replay(RemoveUserScramCredentialRecord record) {
         getOrCreateScramDelta().replay(record);
     }
+    // XXX Need a remove delegation Token
 
     public void replay(ZkMigrationStateRecord record) {
         getOrCreateFeaturesDelta().replay(record);
@@ -330,6 +352,7 @@ public final class MetadataDelta {
         getOrCreateProducerIdsDelta().finishSnapshot();
         getOrCreateAclsDelta().finishSnapshot();
         getOrCreateScramDelta().finishSnapshot();
+        getOrCreateDelegationTokenDelta().finishSnapshot();
     }
 
     public MetadataImage apply(MetadataProvenance provenance) {
@@ -381,6 +404,12 @@ public final class MetadataDelta {
         } else {
             newScram = scramDelta.apply();
         }
+        DelegationTokenImage newDelegationTokens;
+        if (delegationTokenDelta == null) {
+            newDelegationTokens = image.delegationTokens();
+        } else {
+            newDelegationTokens = delegationTokenDelta.apply();
+        }
         return new MetadataImage(
             provenance,
             newFeatures,
@@ -390,7 +419,8 @@ public final class MetadataDelta {
             newClientQuotas,
             newProducerIds,
             newAcls,
-            newScram
+            newScram,
+            newDelegationTokens
         );
     }
 
@@ -405,6 +435,7 @@ public final class MetadataDelta {
             ", producerIdsDelta=" + producerIdsDelta +
             ", aclsDelta=" + aclsDelta +
             ", scramDelta=" + scramDelta +
+            ", delegationTokenDelta=" + delegationTokenDelta +
             ')';
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/image/MetadataDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/MetadataDelta.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.common.metadata.ProducerIdsRecord;
 import org.apache.kafka.common.metadata.RegisterBrokerRecord;
 import org.apache.kafka.common.metadata.RemoveAccessControlEntryRecord;
+import org.apache.kafka.common.metadata.RemoveDelegationTokenRecord;
 import org.apache.kafka.common.metadata.RemoveTopicRecord;
 import org.apache.kafka.common.metadata.RemoveUserScramCredentialRecord;
 import org.apache.kafka.common.metadata.TopicRecord;
@@ -236,7 +237,9 @@ public final class MetadataDelta {
             case REMOVE_USER_SCRAM_CREDENTIAL_RECORD:
                 replay((RemoveUserScramCredentialRecord) record);
                 break;
-            // XXX Need to create a REMOVE_DELEGATION_TOKEN_RECORD
+            case REMOVE_DELEGATION_TOKEN_RECORD:
+                replay((RemoveDelegationTokenRecord) record);
+                break;
             case NO_OP_RECORD:
                 /* NoOpRecord is an empty record and doesn't need to be replayed beyond
                  * updating the highest offset and epoch.
@@ -288,6 +291,10 @@ public final class MetadataDelta {
     }
 
     public void replay(DelegationTokenRecord record) {
+        getOrCreateDelegationTokenDelta().replay(record);
+    }
+
+    public void replay(RemoveDelegationTokenRecord record) {
         getOrCreateDelegationTokenDelta().replay(record);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/MetadataImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/MetadataImage.java
@@ -40,7 +40,8 @@ public final class MetadataImage {
         ClientQuotasImage.EMPTY,
         ProducerIdsImage.EMPTY,
         AclsImage.EMPTY,
-        ScramImage.EMPTY);
+        ScramImage.EMPTY,
+        DelegationTokenImage.EMPTY);
 
     private final MetadataProvenance provenance;
 
@@ -60,6 +61,8 @@ public final class MetadataImage {
 
     private final ScramImage scram;
 
+    private final DelegationTokenImage delegationTokens;
+
     public MetadataImage(
         MetadataProvenance provenance,
         FeaturesImage features,
@@ -69,7 +72,8 @@ public final class MetadataImage {
         ClientQuotasImage clientQuotas,
         ProducerIdsImage producerIds,
         AclsImage acls,
-        ScramImage scram
+        ScramImage scram,
+        DelegationTokenImage delegationTokens
     ) {
         this.provenance = provenance;
         this.features = features;
@@ -80,6 +84,7 @@ public final class MetadataImage {
         this.producerIds = producerIds;
         this.acls = acls;
         this.scram = scram;
+        this.delegationTokens = delegationTokens;
     }
 
     public boolean isEmpty() {
@@ -90,7 +95,8 @@ public final class MetadataImage {
             clientQuotas.isEmpty() &&
             producerIds.isEmpty() &&
             acls.isEmpty() &&
-            scram.isEmpty();
+            scram.isEmpty() &&
+            delegationTokens.isEmpty();
     }
 
     public MetadataProvenance provenance() {
@@ -137,6 +143,10 @@ public final class MetadataImage {
         return scram;
     }
 
+    public DelegationTokenImage delegationTokens() {
+        return delegationTokens;
+    }
+
     public void write(ImageWriter writer, ImageWriterOptions options) {
         // Features should be written out first so we can include the metadata.version at the beginning of the
         // snapshot
@@ -148,6 +158,7 @@ public final class MetadataImage {
         producerIds.write(writer, options);
         acls.write(writer, options);
         scram.write(writer, options);
+        delegationTokens.write(writer, options);
         writer.close(true);
     }
 
@@ -163,7 +174,8 @@ public final class MetadataImage {
             clientQuotas.equals(other.clientQuotas) &&
             producerIds.equals(other.producerIds) &&
             acls.equals(other.acls) &&
-            scram.equals(other.scram);
+            scram.equals(other.scram) &&
+            delegationTokens.equals(other.delegationTokens);
     }
 
     @Override
@@ -177,7 +189,8 @@ public final class MetadataImage {
             clientQuotas,
             producerIds,
             acls,
-            scram);
+            scram,
+            delegationTokens);
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/image/node/DelegationTokenDataNode.java
+++ b/metadata/src/main/java/org/apache/kafka/image/node/DelegationTokenDataNode.java
@@ -39,24 +39,35 @@ public class DelegationTokenDataNode implements MetadataNode {
         TokenInformation tokenInformation = data.tokenInformation();
         StringBuilder bld = new StringBuilder();
         bld.append("DelegationTokenData");
+        bld.append("tokenId=");
+        if (printer.redactionCriteria().shouldRedactDelegationToken()) {
+            bld.append("[redacted]");
+        } else {
+            bld.append(tokenInformation.tokenId());
+        }
         bld.append("(owner=");
         if (printer.redactionCriteria().shouldRedactDelegationToken()) {
             bld.append("[redacted]");
         } else {
             bld.append(tokenInformation.ownerAsString());
         }
-        // XXX Need more fields
+        bld.append("(tokenRequester=");
+        if (printer.redactionCriteria().shouldRedactDelegationToken()) {
+            bld.append("[redacted]");
+        } else {
+            bld.append(tokenInformation.tokenRequesterAsString());
+        }
+        bld.append("(renewers=");
+        if (printer.redactionCriteria().shouldRedactDelegationToken()) {
+            bld.append("[redacted]");
+        } else {
+            bld.append(String.join(" ", tokenInformation.renewersAsString()));
+        }
         bld.append(", issueTimestamp=");
         if (printer.redactionCriteria().shouldRedactDelegationToken()) {
             bld.append("[redacted]");
         } else {
             bld.append(tokenInformation.issueTimestamp());
-        }
-        bld.append(", expiryTimestamp=");
-        if (printer.redactionCriteria().shouldRedactDelegationToken()) {
-            bld.append("[redacted]");
-        } else {
-            bld.append(tokenInformation.expiryTimestamp());
         }
         bld.append(", maxTimestamp=");
         if (printer.redactionCriteria().shouldRedactDelegationToken()) {
@@ -65,6 +76,12 @@ public class DelegationTokenDataNode implements MetadataNode {
             bld.append(tokenInformation.maxTimestamp());
         }
         bld.append(")");
+        bld.append(", expiryTimestamp=");
+        if (printer.redactionCriteria().shouldRedactDelegationToken()) {
+            bld.append("[redacted]");
+        } else {
+            bld.append(tokenInformation.expiryTimestamp());
+        }
         printer.output(bld.toString());
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/image/node/DelegationTokenDataNode.java
+++ b/metadata/src/main/java/org/apache/kafka/image/node/DelegationTokenDataNode.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image.node;
+
+import org.apache.kafka.common.security.token.delegation.TokenInformation;
+import org.apache.kafka.image.node.printer.MetadataNodePrinter;
+import org.apache.kafka.metadata.DelegationTokenData;
+
+
+public class DelegationTokenDataNode implements MetadataNode {
+    private final DelegationTokenData data;
+
+    public DelegationTokenDataNode(DelegationTokenData data) {
+        this.data = data;
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return false;
+    }
+
+    @Override
+    public void print(MetadataNodePrinter printer) {
+        TokenInformation tokenInformation = data.tokenInformation();
+        StringBuilder bld = new StringBuilder();
+        bld.append("DelegationTokenData");
+        bld.append("(owner=");
+        if (printer.redactionCriteria().shouldRedactDelegationToken()) {
+            bld.append("[redacted]");
+        } else {
+            bld.append(tokenInformation.ownerAsString());
+        }
+        // XXX Need more fields
+        bld.append(", issueTimestamp=");
+        if (printer.redactionCriteria().shouldRedactDelegationToken()) {
+            bld.append("[redacted]");
+        } else {
+            bld.append(tokenInformation.issueTimestamp());
+        }
+        bld.append(", expiryTimestamp=");
+        if (printer.redactionCriteria().shouldRedactDelegationToken()) {
+            bld.append("[redacted]");
+        } else {
+            bld.append(tokenInformation.expiryTimestamp());
+        }
+        bld.append(", maxTimestamp=");
+        if (printer.redactionCriteria().shouldRedactDelegationToken()) {
+            bld.append("[redacted]");
+        } else {
+            bld.append(tokenInformation.maxTimestamp());
+        }
+        bld.append(")");
+        printer.output(bld.toString());
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/node/DelegationTokenImageNode.java
+++ b/metadata/src/main/java/org/apache/kafka/image/node/DelegationTokenImageNode.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image.node;
+
+import org.apache.kafka.image.DelegationTokenImage;
+import org.apache.kafka.metadata.DelegationTokenData;
+
+import java.util.Collection;
+
+public class DelegationTokenImageNode implements MetadataNode {
+    /**
+     * The name of this node.
+     */
+    public final static String NAME = "delegationToken";
+
+    /**
+     * The DelegationToken image.
+     */
+    private final DelegationTokenImage image;
+
+    public DelegationTokenImageNode(DelegationTokenImage image) {
+        this.image = image;
+    }
+
+    @Override
+    public Collection<String> childNames() {
+        return image.tokens().keySet();
+    }
+
+    @Override
+    public MetadataNode child(String tokenId) {
+        DelegationTokenData data = image.tokens().get(tokenId);
+        if (data == null) return null;
+        return new DelegationTokenDataNode(data);
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/node/MetadataImageNode.java
+++ b/metadata/src/main/java/org/apache/kafka/image/node/MetadataImageNode.java
@@ -50,6 +50,7 @@ public class MetadataImageNode implements MetadataNode {
         children.put(ProducerIdsImageNode.NAME, image -> new ProducerIdsImageNode(image.producerIds()));
         children.put(AclsImageNode.NAME, image -> new AclsImageByIdNode(image.acls()));
         children.put(ScramImageNode.NAME, image -> new ScramImageNode(image.scram()));
+        children.put(DelegationTokenImageNode.NAME, image -> new DelegationTokenImageNode(image.delegationTokens()));
         CHILDREN = Collections.unmodifiableMap(children);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/node/printer/MetadataNodeRedactionCriteria.java
+++ b/metadata/src/main/java/org/apache/kafka/image/node/printer/MetadataNodeRedactionCriteria.java
@@ -28,6 +28,11 @@ public interface MetadataNodeRedactionCriteria {
     boolean shouldRedactScram();
 
     /**
+     * Returns true if DelegationToken data should be redacted.
+     */
+    boolean shouldRedactDelegationToken();
+
+    /**
      * Returns true if a configuration should be redacted.
      *
      * @param type      The configuration type.
@@ -42,6 +47,11 @@ public interface MetadataNodeRedactionCriteria {
 
         @Override
         public boolean shouldRedactScram() {
+            return true;
+        }
+
+        @Override
+        public boolean shouldRedactDelegationToken() {
             return true;
         }
 
@@ -64,6 +74,11 @@ public interface MetadataNodeRedactionCriteria {
         }
 
         @Override
+        public boolean shouldRedactDelegationToken() {
+            return true;
+        }
+
+        @Override
         public boolean shouldRedactConfig(ConfigResource.Type type, String key) {
             return configSchema.isSensitive(type, key);
         }
@@ -74,6 +89,11 @@ public interface MetadataNodeRedactionCriteria {
 
         @Override
         public boolean shouldRedactScram() {
+            return false;
+        }
+
+        @Override
+        public boolean shouldRedactDelegationToken() {
             return false;
         }
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/DelegationTokenData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/DelegationTokenData.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata;
+
+import org.apache.kafka.common.metadata.DelegationTokenRecord;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.token.delegation.TokenInformation;
+import org.apache.kafka.common.utils.SecurityUtils;
+
+import java.util.ArrayList;
+import java.util.Objects;
+
+/**
+ * Represents the Delegation Tokens in the metadata image.
+ *
+ * This class is thread-safe.
+ */
+public final class DelegationTokenData {
+
+    // XXX SHould this be the information in a record (as Strings) or a tokenInformation
+    private TokenInformation tokenInformation;
+
+    public static DelegationTokenData fromRecord(DelegationTokenRecord record) {
+        ArrayList<KafkaPrincipal> foo = new ArrayList<KafkaPrincipal>();
+        return new DelegationTokenData(TokenInformation.fromRecord(
+            record.tokenId(),
+            SecurityUtils.parseKafkaPrincipal(record.owner()),
+            SecurityUtils.parseKafkaPrincipal(record.requester()),
+            foo, // XXX record.renewers(),
+            record.issueTimestamp(),
+            record.maxTimestamp(),
+            record.expirationTimestamp()));
+    }
+
+    public DelegationTokenData(TokenInformation tokenInformation) {
+        this.tokenInformation = tokenInformation;
+    }
+
+    public TokenInformation tokenInformation() {
+        return tokenInformation;
+    }
+
+    public DelegationTokenRecord toRecord() {
+        // Collection<String> foo = tokenInformation.renewersAsString();
+        // String[] foos = foo.toArray(new String[foo.size()]);
+        //    .setRenewers(tokenInformation.renewersAsString())
+        return new DelegationTokenRecord()
+            .setOwner(tokenInformation.ownerAsString())
+            .setRequester(tokenInformation.tokenRequesterAsString())
+            .setRenewers(new ArrayList<String>(tokenInformation.renewersAsString()))
+            .setIssueTimestamp(tokenInformation.issueTimestamp())
+            .setMaxTimestamp(tokenInformation.maxTimestamp())
+            .setExpirationTimestamp(tokenInformation.expiryTimestamp())
+            .setTokenId(tokenInformation.tokenId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tokenInformation);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        if (!o.getClass().equals(DelegationTokenData.class)) return false;
+        DelegationTokenData other = (DelegationTokenData) o;
+        return tokenInformation.equals(other.tokenInformation);
+    }
+
+    @Override
+    public String toString() {
+        return "DelegationTokenData" +
+            "(tokenInformation=" + tokenInformation +
+            ")";
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/DelegationTokenData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/DelegationTokenData.java
@@ -82,10 +82,14 @@ public final class DelegationTokenData {
         return tokenInformation.equals(other.tokenInformation);
     }
 
+    /*
+     * We explicitly hide tokenInformation when converting DelegationTokenData to string
+     * For legacy reasons, we did not change TokenInformation to hide sensitive data.
+     */
     @Override
     public String toString() {
         return "DelegationTokenData" +
-            "(tokenInformation=" + tokenInformation +
+            "(tokenInformation=" + "[hidden]" +
             ")";
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/DelegationTokenData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/DelegationTokenData.java
@@ -37,7 +37,7 @@ public final class DelegationTokenData {
     private TokenInformation tokenInformation;
 
     public static DelegationTokenData fromRecord(DelegationTokenRecord record) {
-        List<KafkaPrincipal>renewers = new ArrayList<>();
+        List<KafkaPrincipal> renewers = new ArrayList<>();
         for (String renewerString : record.renewers()) {
             renewers.add(SecurityUtils.parseKafkaPrincipal(renewerString));
         }

--- a/metadata/src/main/java/org/apache/kafka/metadata/DelegationTokenData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/DelegationTokenData.java
@@ -33,7 +33,6 @@ import java.util.Objects;
  */
 public final class DelegationTokenData {
 
-    // XXX SHould this be the information in a record (as Strings) or a tokenInformation
     private TokenInformation tokenInformation;
 
     public static DelegationTokenData fromRecord(DelegationTokenRecord record) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/DelegationTokenData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/DelegationTokenData.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.security.token.delegation.TokenInformation;
 import org.apache.kafka.common.utils.SecurityUtils;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -36,12 +37,15 @@ public final class DelegationTokenData {
     private TokenInformation tokenInformation;
 
     public static DelegationTokenData fromRecord(DelegationTokenRecord record) {
-        ArrayList<KafkaPrincipal> foo = new ArrayList<KafkaPrincipal>();
+        List<KafkaPrincipal>renewers = new ArrayList<>();
+        for (String renewerString : record.renewers()) {
+            renewers.add(SecurityUtils.parseKafkaPrincipal(renewerString));
+        }
         return new DelegationTokenData(TokenInformation.fromRecord(
             record.tokenId(),
             SecurityUtils.parseKafkaPrincipal(record.owner()),
             SecurityUtils.parseKafkaPrincipal(record.requester()),
-            foo, // XXX record.renewers(),
+            renewers,
             record.issueTimestamp(),
             record.maxTimestamp(),
             record.expirationTimestamp()));
@@ -56,9 +60,6 @@ public final class DelegationTokenData {
     }
 
     public DelegationTokenRecord toRecord() {
-        // Collection<String> foo = tokenInformation.renewersAsString();
-        // String[] foos = foo.toArray(new String[foo.size()]);
-        //    .setRenewers(tokenInformation.renewersAsString())
         return new DelegationTokenRecord()
             .setOwner(tokenInformation.ownerAsString())
             .setRequester(tokenInformation.tokenRequesterAsString())

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/DelegationTokenMigrationClient.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/DelegationTokenMigrationClient.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.migration;
+
+import org.apache.kafka.common.security.token.delegation.TokenInformation;
+
+import java.util.List;
+
+public interface DelegationTokenMigrationClient {
+    List<String> getDelegationTokens();
+
+    ZkMigrationLeadershipState writeDelegationToken(
+        String tokenId,
+        TokenInformation tokenInformation,
+        ZkMigrationLeadershipState state
+    );
+
+    ZkMigrationLeadershipState deleteDelegationToken(
+        String tokenId,
+        ZkMigrationLeadershipState state
+    );
+
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
@@ -33,6 +33,8 @@ import org.apache.kafka.image.ClientQuotaImage;
 import org.apache.kafka.image.ClientQuotasImage;
 import org.apache.kafka.image.ConfigurationsDelta;
 import org.apache.kafka.image.ConfigurationsImage;
+import org.apache.kafka.image.DelegationTokenDelta;
+import org.apache.kafka.image.DelegationTokenImage;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.ProducerIdsDelta;
@@ -41,6 +43,7 @@ import org.apache.kafka.image.ScramImage;
 import org.apache.kafka.image.TopicImage;
 import org.apache.kafka.image.TopicsDelta;
 import org.apache.kafka.image.TopicsImage;
+import org.apache.kafka.metadata.DelegationTokenData;
 import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.metadata.ScramCredentialData;
 import org.apache.kafka.metadata.authorizer.StandardAcl;
@@ -91,6 +94,7 @@ public class KRaftMigrationZkWriter {
         handleClientQuotasSnapshot(image.clientQuotas(), image.scram(), operationConsumer);
         handleProducerIdSnapshot(image.producerIds(), operationConsumer);
         handleAclsSnapshot(image.acls(), operationConsumer);
+        handleDelegationTokenSnapshot(image.delegationTokens(), operationConsumer);
     }
 
     public boolean handleDelta(
@@ -118,6 +122,10 @@ public class KRaftMigrationZkWriter {
         }
         if (delta.aclsDelta() != null) {
             handleAclsDelta(image.acls(), delta.aclsDelta(), operationConsumer);
+            updated = true;
+        }
+        if (delta.delegationTokenDelta() != null) {
+            handleDelegationTokenDelta(image.delegationTokens(), delta.delegationTokenDelta(), operationConsumer);
             updated = true;
         }
         return updated;
@@ -631,6 +639,37 @@ public class KRaftMigrationZkWriter {
             String name = "Writing " + accessControlEntries.size() + " for resource " + resourcePattern;
             operationConsumer.accept(UPDATE_ACL, name, migrationState ->
                 migrationClient.aclClient().writeResourceAcls(resourcePattern, accessControlEntries, migrationState));
+        });
+    }
+
+    void handleDelegationTokenDelta(DelegationTokenImage image, DelegationTokenDelta delta, KRaftMigrationOperationConsumer operationConsumer) {
+        Set<String> updatedResources = delta.changes().keySet();
+        updatedResources.forEach(tokenId -> {
+            DelegationTokenData tokenData = image.tokens().get(tokenId);
+            if (tokenData == null) {
+                operationConsumer.accept("DeleteDelegationToken", "Delete DelegationToken for " + tokenId, migrationState ->
+                    migrationClient.delegationTokenClient().deleteDelegationToken(tokenId, migrationState));
+            } else {
+                operationConsumer.accept("UpdateDelegationToken", "Update DelegationToken for " + tokenId, migrationState ->
+                    migrationClient.delegationTokenClient().writeDelegationToken(tokenId, tokenData.tokenInformation(), migrationState));
+            }
+        });
+    }
+
+    void handleDelegationTokenSnapshot(DelegationTokenImage image, KRaftMigrationOperationConsumer operationConsumer) {
+        image.tokens().keySet().forEach(tokenId -> {
+            DelegationTokenData tokenData = image.tokens().get(tokenId);
+            operationConsumer.accept("UpdateDelegationToken", "Update DelegationToken for " + tokenId, migrationState ->
+                migrationClient.delegationTokenClient().writeDelegationToken(tokenId, tokenData.tokenInformation(), migrationState));
+        });
+
+        List<String> tokens = migrationClient.delegationTokenClient().getDelegationTokens();
+        tokens.forEach(tokenId -> {
+            if (!image.tokens().containsKey(tokenId)) {
+                operationConsumer.accept("DeleteDelegationToken", "Delete DelegationToken for " + tokenId, migrationState ->
+                    migrationClient.delegationTokenClient().deleteDelegationToken(tokenId, migrationState));
+
+            }
         });
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriter.java
@@ -643,8 +643,8 @@ public class KRaftMigrationZkWriter {
     }
 
     void handleDelegationTokenDelta(DelegationTokenImage image, DelegationTokenDelta delta, KRaftMigrationOperationConsumer operationConsumer) {
-        Set<String> updatedResources = delta.changes().keySet();
-        updatedResources.forEach(tokenId -> {
+        Set<String> updatedTokens = delta.changes().keySet();
+        updatedTokens.forEach(tokenId -> {
             DelegationTokenData tokenData = image.tokens().get(tokenId);
             if (tokenData == null) {
                 operationConsumer.accept("DeleteDelegationToken", "Delete DelegationToken for " + tokenId, migrationState ->
@@ -668,7 +668,6 @@ public class KRaftMigrationZkWriter {
             if (!image.tokens().containsKey(tokenId)) {
                 operationConsumer.accept("DeleteDelegationToken", "Delete DelegationToken for " + tokenId, migrationState ->
                     migrationClient.delegationTokenClient().deleteDelegationToken(tokenId, migrationState));
-
             }
         });
     }

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/MigrationClient.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/MigrationClient.java
@@ -76,6 +76,8 @@ public interface MigrationClient {
 
     AclMigrationClient aclClient();
 
+    DelegationTokenMigrationClient delegationTokenClient();
+
     Optional<ProducerIdsBlock> readProducerId();
 
     ZkMigrationLeadershipState writeProducerId(

--- a/metadata/src/main/resources/common/metadata/DelegationTokenRecord.json
+++ b/metadata/src/main/resources/common/metadata/DelegationTokenRecord.json
@@ -22,8 +22,10 @@
   "fields": [
     { "name": "Owner", "type": "string", "versions": "0+",
       "about": "The delegation token owner." },
+    { "name": "Requester", "type": "string", "versions": "0+",
+      "about": "The delegation token requester." },
     { "name": "Renewers", "type": "[]string", "versions": "0+",
-      "about": "The principals which have renewed this token." },
+      "about": "The principals which can renew this token." },
     { "name": "IssueTimestamp", "type": "int64", "versions": "0+",
       "about": "The time at which this timestamp was issued." },
     { "name": "MaxTimestamp", "type": "int64", "versions": "0+",

--- a/metadata/src/main/resources/common/metadata/RemoveDelegationTokenRecord.json
+++ b/metadata/src/main/resources/common/metadata/RemoveDelegationTokenRecord.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 23,
+  "type": "metadata",
+  "name": "RemoveDelegationTokenRecord",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "TokenId", "type": "string", "versions": "0+",
+      "about": "The tokenID to remove." }
+  ]
+}

--- a/metadata/src/main/resources/common/metadata/RemoveDelegationTokenRecord.json
+++ b/metadata/src/main/resources/common/metadata/RemoveDelegationTokenRecord.json
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 {
-  "apiKey": 23,
+  "apiKey": 26,
   "type": "metadata",
   "name": "RemoveDelegationTokenRecord",
   "validVersions": "0",

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisherTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisherTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.image.AclsImage;
 import org.apache.kafka.image.ClientQuotasImage;
 import org.apache.kafka.image.ClusterImage;
 import org.apache.kafka.image.ConfigurationsImage;
+import org.apache.kafka.image.DelegationTokenImage;
 import org.apache.kafka.image.FeaturesImage;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
@@ -86,7 +87,8 @@ public class ControllerMetadataMetricsPublisherTest {
             ClientQuotasImage.EMPTY,
             ProducerIdsImage.EMPTY,
             AclsImage.EMPTY,
-            ScramImage.EMPTY);
+            ScramImage.EMPTY,
+            DelegationTokenImage.EMPTY);
     }
 
     static final TopicsImage TOPICS_IMAGE1;

--- a/metadata/src/test/java/org/apache/kafka/image/DelegationTokenImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/DelegationTokenImageTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.image;
 
 import org.apache.kafka.common.metadata.DelegationTokenRecord;
+import org.apache.kafka.common.metadata.RemoveDelegationTokenRecord;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.token.delegation.TokenInformation;
 import org.apache.kafka.common.utils.SecurityUtils;
@@ -65,6 +66,7 @@ public class DelegationTokenImageTest {
         Map<String, DelegationTokenData> image1 = new HashMap<>();
         image1.put("somerandomuuid1", randomDelegationTokenData("somerandomuuid1", 100));
         image1.put("somerandomuuid2", randomDelegationTokenData("somerandomuuid2", 100));
+        image1.put("somerandomuuid3", randomDelegationTokenData("somerandomuuid3", 100));
         IMAGE1 = new DelegationTokenImage(image1);
 
         DELTA1_RECORDS = new ArrayList<>();
@@ -75,6 +77,8 @@ public class DelegationTokenImageTest {
             setMaxTimestamp(1000).
             setExpirationTimestamp(200).
             setTokenId("somerandomuuid1"), (short) 0));
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new RemoveDelegationTokenRecord().
+            setTokenId("somerandomuuid3"), (short) 0));
 
         DELTA1 = new DelegationTokenDelta(IMAGE1);
         RecordTestUtils.replayAll(DELTA1, DELTA1_RECORDS);

--- a/metadata/src/test/java/org/apache/kafka/image/DelegationTokenImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/DelegationTokenImageTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.token.delegation.TokenInformation;
+import org.apache.kafka.common.utils.SecurityUtils;
+import org.apache.kafka.image.writer.ImageWriterOptions;
+import org.apache.kafka.image.writer.RecordListWriter;
+import org.apache.kafka.metadata.RecordTestUtils;
+import org.apache.kafka.metadata.DelegationTokenData;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.MetadataVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+// import java.util.HashMap;
+import java.util.List;
+// import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+
+@Timeout(value = 40)
+public class DelegationTokenImageTest {
+    public final static DelegationTokenImage IMAGE1;
+
+    public final static List<ApiMessageAndVersion> DELTA1_RECORDS;
+
+    final static DelegationTokenDelta DELTA1;
+
+    final static DelegationTokenImage IMAGE2;
+
+    static DelegationTokenData randomDelegationTokenData() {
+        TokenInformation ti = new TokenInformation(
+            "somerandomuuid",
+            SecurityUtils.parseKafkaPrincipal("fred"),
+            SecurityUtils.parseKafkaPrincipal("fred"),
+            new ArrayList<KafkaPrincipal>(),
+            0,
+            0,
+            0);
+        return new DelegationTokenData(ti);
+    }
+
+    static {
+
+//        IMAGE1 = new ScramImage(image1mechanisms);
+        IMAGE1 = DelegationTokenImage.EMPTY;
+
+        DELTA1_RECORDS = new ArrayList<>();
+// Add records
+        DELTA1 = new DelegationTokenDelta(IMAGE1);
+        RecordTestUtils.replayAll(DELTA1, DELTA1_RECORDS);
+
+//        IMAGE2 = new ScramImage(image2mechanisms);
+        IMAGE2 = DelegationTokenImage.EMPTY;
+    }
+
+    @Test
+    public void testEmptyImageRoundTrip() throws Throwable {
+        testToImageAndBack(DelegationTokenImage.EMPTY);
+    }
+
+    @Test
+    public void testImage1RoundTrip() throws Throwable {
+        testToImageAndBack(IMAGE1);
+    }
+
+    @Test
+    public void testApplyDelta1() throws Throwable {
+        assertEquals(IMAGE2, DELTA1.apply());
+    }
+
+    @Test
+    public void testImage2RoundTrip() throws Throwable {
+        testToImageAndBack(IMAGE2);
+    }
+
+    private void testToImageAndBack(DelegationTokenImage image) throws Throwable {
+        RecordListWriter writer = new RecordListWriter();
+        image.write(writer, new ImageWriterOptions.Builder().build());
+        DelegationTokenDelta delta = new DelegationTokenDelta(DelegationTokenImage.EMPTY);
+        RecordTestUtils.replayAll(delta, writer.records());
+        DelegationTokenImage nextImage = delta.apply();
+        assertEquals(image, nextImage);
+    }
+
+    @Test
+    public void testEmptyWithInvalidIBP() throws Throwable {
+        ImageWriterOptions imageWriterOptions = new ImageWriterOptions.Builder().
+                setMetadataVersion(MetadataVersion.IBP_3_5_IV2).build();
+        RecordListWriter writer = new RecordListWriter();
+        DelegationTokenImage.EMPTY.write(writer, imageWriterOptions);
+    }
+
+    @Test
+    public void testImage1withInvalidIBP() throws Throwable {
+        ImageWriterOptions imageWriterOptions = new ImageWriterOptions.Builder().
+                setMetadataVersion(MetadataVersion.IBP_3_5_IV2).build();
+        RecordListWriter writer = new RecordListWriter();
+        try {
+            IMAGE1.write(writer, imageWriterOptions);
+            fail("expected exception writing IMAGE with Delegation Token records for MetadataVersion.IBP_3_5_IV2");
+        } catch (Exception expected) {
+            // ignore, expected
+        }
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/image/DelegationTokenImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/DelegationTokenImageTest.java
@@ -63,7 +63,8 @@ public class DelegationTokenImageTest {
 
     static {
         Map<String, DelegationTokenData> image1 = new HashMap<>();
-        image1.put("somerandomuuid", randomDelegationTokenData("somerandomuuid", 100));
+        image1.put("somerandomuuid1", randomDelegationTokenData("somerandomuuid1", 100));
+        image1.put("somerandomuuid2", randomDelegationTokenData("somerandomuuid2", 100));
         IMAGE1 = new DelegationTokenImage(image1);
 
         DELTA1_RECORDS = new ArrayList<>();
@@ -73,13 +74,14 @@ public class DelegationTokenImageTest {
             setIssueTimestamp(0).
             setMaxTimestamp(1000).
             setExpirationTimestamp(200).
-            setTokenId("somerandomuuid"), (short) 0));
+            setTokenId("somerandomuuid1"), (short) 0));
 
         DELTA1 = new DelegationTokenDelta(IMAGE1);
         RecordTestUtils.replayAll(DELTA1, DELTA1_RECORDS);
 
         Map<String, DelegationTokenData> image2 = new HashMap<>();
-        image2.put("somerandomuuid", randomDelegationTokenData("somerandomuuid", 200));
+        image2.put("somerandomuuid1", randomDelegationTokenData("somerandomuuid1", 200));
+        image2.put("somerandomuuid2", randomDelegationTokenData("somerandomuuid2", 100));
         IMAGE2 = new DelegationTokenImage(image2);
     }
 

--- a/metadata/src/test/java/org/apache/kafka/image/DelegationTokenImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/DelegationTokenImageTest.java
@@ -119,7 +119,7 @@ public class DelegationTokenImageTest {
     }
 
     @Test
-    public void testEmptyWithInvalidIBP() throws Throwable {
+    public void testEmptyWithInvalidIBP() {
         ImageWriterOptions imageWriterOptions = new ImageWriterOptions.Builder().
                 setMetadataVersion(MetadataVersion.IBP_3_5_IV2).build();
         RecordListWriter writer = new RecordListWriter();
@@ -127,7 +127,7 @@ public class DelegationTokenImageTest {
     }
 
     @Test
-    public void testImage1withInvalidIBP() throws Throwable {
+    public void testImage1withInvalidIBP() {
         ImageWriterOptions imageWriterOptions = new ImageWriterOptions.Builder().
                 setMetadataVersion(MetadataVersion.IBP_3_5_IV2).build();
         RecordListWriter writer = new RecordListWriter();

--- a/metadata/src/test/java/org/apache/kafka/image/MetadataImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/MetadataImageTest.java
@@ -103,6 +103,7 @@ public class MetadataImageTest {
         records.addAll(ProducerIdsImageTest.DELTA1_RECORDS);
         records.addAll(AclsImageTest.DELTA1_RECORDS);
         records.addAll(ScramImageTest.DELTA1_RECORDS);
+        records.addAll(DelegationTokenImageTest.DELTA1_RECORDS);
         testToImage(IMAGE2, records);
     }
 

--- a/metadata/src/test/java/org/apache/kafka/image/MetadataImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/MetadataImageTest.java
@@ -48,7 +48,8 @@ public class MetadataImageTest {
             ClientQuotasImageTest.IMAGE1,
             ProducerIdsImageTest.IMAGE1,
             AclsImageTest.IMAGE1,
-            ScramImageTest.IMAGE1);
+            ScramImageTest.IMAGE1,
+            DelegationTokenImageTest.IMAGE1);
 
         DELTA1 = new MetadataDelta.Builder().
                 setImage(IMAGE1).
@@ -61,6 +62,7 @@ public class MetadataImageTest {
         RecordTestUtils.replayAll(DELTA1, ProducerIdsImageTest.DELTA1_RECORDS);
         RecordTestUtils.replayAll(DELTA1, AclsImageTest.DELTA1_RECORDS);
         RecordTestUtils.replayAll(DELTA1, ScramImageTest.DELTA1_RECORDS);
+        RecordTestUtils.replayAll(DELTA1, DelegationTokenImageTest.DELTA1_RECORDS);
 
         IMAGE2 = new MetadataImage(
             new MetadataProvenance(200, 5, 4000),
@@ -71,7 +73,8 @@ public class MetadataImageTest {
             ClientQuotasImageTest.IMAGE2,
             ProducerIdsImageTest.IMAGE2,
             AclsImageTest.IMAGE2,
-            ScramImageTest.IMAGE2);
+            ScramImageTest.IMAGE2,
+            DelegationTokenImageTest.IMAGE2);
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/image/node/printer/MetadataNodeRedactionCriteriaTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/node/printer/MetadataNodeRedactionCriteriaTest.java
@@ -68,6 +68,21 @@ public class MetadataNodeRedactionCriteriaTest {
     }
 
     @Test
+    public void testStrictRedactsDelegationToken() {
+        assertTrue(STRICT.shouldRedactDelegationToken());
+    }
+
+    @Test
+    public void testNormalRedactsDelegationToken() {
+        assertTrue(NORMAL.shouldRedactDelegationToken());
+    }
+
+    @Test
+    public void testDisabledDoesNotRedactDelegationToken() {
+        assertFalse(DISABLED.shouldRedactDelegationToken());
+    }
+
+    @Test
     public void testStrictRedactsNonSensitiveConfig() {
         assertTrue(STRICT.shouldRedactConfig(BROKER, "non.secret"));
     }

--- a/metadata/src/test/java/org/apache/kafka/image/publisher/SnapshotEmitterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/publisher/SnapshotEmitterTest.java
@@ -150,7 +150,7 @@ public class SnapshotEmitterTest {
         assertEquals(0L, emitter.metrics().latestSnapshotGeneratedBytes());
         emitter.maybeEmit(MetadataImageTest.IMAGE1);
         assertEquals(0L, emitter.metrics().latestSnapshotGeneratedAgeMs());
-        assertEquals(1400L, emitter.metrics().latestSnapshotGeneratedBytes());
+        assertEquals(1500L, emitter.metrics().latestSnapshotGeneratedBytes());
         FakeSnapshotWriter writer = mockRaftClient.writers.get(
                 MetadataImageTest.IMAGE1.provenance().snapshotId());
         assertNotNull(writer);

--- a/metadata/src/test/java/org/apache/kafka/image/publisher/SnapshotEmitterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/publisher/SnapshotEmitterTest.java
@@ -150,7 +150,7 @@ public class SnapshotEmitterTest {
         assertEquals(0L, emitter.metrics().latestSnapshotGeneratedBytes());
         emitter.maybeEmit(MetadataImageTest.IMAGE1);
         assertEquals(0L, emitter.metrics().latestSnapshotGeneratedAgeMs());
-        assertEquals(1500L, emitter.metrics().latestSnapshotGeneratedBytes());
+        assertEquals(1600L, emitter.metrics().latestSnapshotGeneratedBytes());
         FakeSnapshotWriter writer = mockRaftClient.writers.get(
                 MetadataImageTest.IMAGE1.provenance().snapshotId());
         assertNotNull(writer);

--- a/metadata/src/test/java/org/apache/kafka/metadata/DelegationTokenDataTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/DelegationTokenDataTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata;
+
+import org.apache.kafka.common.metadata.DelegationTokenRecord;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.token.delegation.TokenInformation;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@Timeout(value = 40)
+public class DelegationTokenDataTest {
+
+    private static final List<String> UUID = Arrays.asList(
+        Uuid.randomUuid().toString(),
+        Uuid.randomUuid().toString(),
+        Uuid.randomUuid().toString());
+
+    private static final List<KafkaPrincipal> EMPTYRENEWERS = Arrays.asList();
+
+    private static final List<TokenInformation> TOKENINFORMATION = Arrays.asList(
+        new TokenInformation(
+            UUID.get(0),
+            new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "alice"),
+            new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "alice"),
+            EMPTYRENEWERS,
+            0,
+            100,
+            100),
+        new TokenInformation(
+            UUID.get(1),
+            new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "alice"),
+            new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "alice"),
+            EMPTYRENEWERS,
+            0,
+            100,
+            100),
+        new TokenInformation(
+            UUID.get(2),
+            new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "fred"),
+            new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "alice"),
+            EMPTYRENEWERS,
+            0,
+            100,
+            100));
+
+    private static final List<DelegationTokenData> DELEGATIONTOKENDATA = Arrays.asList(
+        new DelegationTokenData(TOKENINFORMATION.get(0)),
+        new DelegationTokenData(TOKENINFORMATION.get(1)),
+        new DelegationTokenData(TOKENINFORMATION.get(2)));
+
+    @Test
+    public void testValues() {
+        assertEquals(TOKENINFORMATION.get(0), DELEGATIONTOKENDATA.get(0).tokenInformation());
+        assertEquals(TOKENINFORMATION.get(1), DELEGATIONTOKENDATA.get(1).tokenInformation());
+        assertEquals(TOKENINFORMATION.get(2), DELEGATIONTOKENDATA.get(2).tokenInformation());
+    }
+
+    @Test
+    public void testEquals() {
+        assertNotEquals(DELEGATIONTOKENDATA.get(0), DELEGATIONTOKENDATA.get(1));
+        assertNotEquals(DELEGATIONTOKENDATA.get(1), DELEGATIONTOKENDATA.get(0));
+        assertNotEquals(DELEGATIONTOKENDATA.get(0), DELEGATIONTOKENDATA.get(2));
+        assertNotEquals(DELEGATIONTOKENDATA.get(2), DELEGATIONTOKENDATA.get(0));
+        assertEquals(DELEGATIONTOKENDATA.get(0), DELEGATIONTOKENDATA.get(0));
+        assertEquals(DELEGATIONTOKENDATA.get(1), DELEGATIONTOKENDATA.get(1));
+        assertEquals(DELEGATIONTOKENDATA.get(2), DELEGATIONTOKENDATA.get(2));
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("DelegationTokenData" +
+            "(tokenInformation=" + "[hidden]" +
+            ")", DELEGATIONTOKENDATA.get(0).toString());
+    }
+
+    @Test
+    public void testFromRecordAndToRecord() {
+        testRoundTrip(DELEGATIONTOKENDATA.get(0));
+        testRoundTrip(DELEGATIONTOKENDATA.get(1));
+        testRoundTrip(DELEGATIONTOKENDATA.get(2));
+    }
+
+    private void testRoundTrip(DelegationTokenData origDelegationTokenData) {
+        ApiMessageAndVersion messageAndVersion = new ApiMessageAndVersion(
+            origDelegationTokenData.toRecord(), (short) 0);
+        DelegationTokenData newDelegationTokenData = DelegationTokenData.fromRecord(
+            (DelegationTokenRecord) messageAndVersion.message());
+        assertEquals(origDelegationTokenData, newDelegationTokenData);
+        ApiMessageAndVersion messageAndVersion2 = new ApiMessageAndVersion(
+            newDelegationTokenData.toRecord(), (short) 0);
+        assertEquals(messageAndVersion, messageAndVersion2);
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/CapturingDelegationTokenMigrationClient.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/CapturingDelegationTokenMigrationClient.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.migration;
+
+import org.apache.kafka.common.security.token.delegation.TokenInformation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class CapturingDelegationTokenMigrationClient implements DelegationTokenMigrationClient {
+    
+    public List<String> deletedDelegationTokens = new ArrayList<>();
+    public HashMap<String, TokenInformation> updatedDelegationTokens = new HashMap<>();
+
+    public void reset() {
+        deletedDelegationTokens.clear();
+        updatedDelegationTokens.clear();
+    }
+
+
+    @Override
+    public List<String> getDelegationTokens() {
+        return new ArrayList<String>();
+    }
+
+    @Override
+    public ZkMigrationLeadershipState deleteDelegationToken(String tokenId, ZkMigrationLeadershipState state) {
+        deletedDelegationTokens.add(tokenId);
+        return state;
+    }
+
+    @Override
+    public ZkMigrationLeadershipState writeDelegationToken(String tokenId, TokenInformation tokenInformation, ZkMigrationLeadershipState state) {
+        updatedDelegationTokens.put(tokenId, tokenInformation);
+        return state;
+    }
+
+}

--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/CapturingMigrationClient.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/CapturingMigrationClient.java
@@ -39,6 +39,7 @@ class CapturingMigrationClient implements MigrationClient {
         TopicMigrationClient topicMigrationClient = new CapturingTopicMigrationClient();
         ConfigMigrationClient configMigrationClient = new CapturingConfigMigrationClient();
         AclMigrationClient aclMigrationClient = new CapturingAclMigrationClient();
+        DelegationTokenMigrationClient delegationTokenMigrationClient = new CapturingDelegationTokenMigrationClient();
 
         public Builder setBrokersInZk(int... brokerIds) {
             brokersInZk = IntStream.of(brokerIds).boxed().collect(Collectors.toSet());
@@ -60,12 +61,18 @@ class CapturingMigrationClient implements MigrationClient {
             return this;
         }
 
+        public Builder setDelegationTokenMigrationClient(DelegationTokenMigrationClient delegationTokenMigrationClient) {
+            this.delegationTokenMigrationClient = delegationTokenMigrationClient;
+            return this;
+        }
+
         public CapturingMigrationClient build() {
             return new CapturingMigrationClient(
                 brokersInZk,
                 topicMigrationClient,
                 configMigrationClient,
-                aclMigrationClient
+                aclMigrationClient,
+                delegationTokenMigrationClient
             );
         }
     }
@@ -74,6 +81,7 @@ class CapturingMigrationClient implements MigrationClient {
     private final TopicMigrationClient topicMigrationClient;
     private final ConfigMigrationClient configMigrationClient;
     private final AclMigrationClient aclMigrationClient;
+    private final DelegationTokenMigrationClient delegationTokenMigrationClient;
 
     private ZkMigrationLeadershipState state = null;
 
@@ -81,12 +89,14 @@ class CapturingMigrationClient implements MigrationClient {
         Set<Integer> brokerIdsInZk,
         TopicMigrationClient topicMigrationClient,
         ConfigMigrationClient configMigrationClient,
-        AclMigrationClient aclMigrationClient
+        AclMigrationClient aclMigrationClient,
+        DelegationTokenMigrationClient delegationTokenMigrationClient
     ) {
         this.brokerIds = brokerIdsInZk;
         this.topicMigrationClient = topicMigrationClient;
         this.configMigrationClient = configMigrationClient;
         this.aclMigrationClient = aclMigrationClient;
+        this.delegationTokenMigrationClient = delegationTokenMigrationClient;
     }
 
     @Override
@@ -129,6 +139,11 @@ class CapturingMigrationClient implements MigrationClient {
     @Override
     public AclMigrationClient aclClient() {
         return aclMigrationClient;
+    }
+
+    @Override
+    public DelegationTokenMigrationClient delegationTokenClient() {
+        return delegationTokenMigrationClient;
     }
 
     @Override

--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.image.AclsImage;
 import org.apache.kafka.image.ClientQuotasImage;
 import org.apache.kafka.image.ClusterImage;
 import org.apache.kafka.image.ConfigurationsImage;
+import org.apache.kafka.image.DelegationTokenImage;
 import org.apache.kafka.image.FeaturesImage;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
@@ -486,7 +487,8 @@ public class KRaftMigrationDriverTest {
                 ClientQuotasImage.EMPTY,
                 ProducerIdsImage.EMPTY,
                 AclsImage.EMPTY,
-                ScramImage.EMPTY);
+                ScramImage.EMPTY,
+                DelegationTokenImage.EMPTY);
             MetadataDelta delta = new MetadataDelta(image);
 
             driver.start();
@@ -538,7 +540,8 @@ public class KRaftMigrationDriverTest {
                 ClientQuotasImage.EMPTY,
                 ProducerIdsImage.EMPTY,
                 AclsImage.EMPTY,
-                ScramImage.EMPTY);
+                ScramImage.EMPTY,
+                DelegationTokenImage.EMPTY);
             MetadataDelta delta = new MetadataDelta(image);
 
             driver.start();
@@ -590,7 +593,8 @@ public class KRaftMigrationDriverTest {
                 ClientQuotasImage.EMPTY,
                 ProducerIdsImage.EMPTY,
                 AclsImage.EMPTY,
-                ScramImage.EMPTY);
+                ScramImage.EMPTY,
+                DelegationTokenImage.EMPTY);
             MetadataDelta delta = new MetadataDelta(image);
 
             driver.start();

--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
@@ -307,7 +307,10 @@ public class KRaftMigrationDriverTest {
         CountingMetadataPropagator metadataPropagator = new CountingMetadataPropagator();
         CountDownLatch claimLeaderAttempts = new CountDownLatch(3);
         CapturingMigrationClient migrationClient = new CapturingMigrationClient(new HashSet<>(Arrays.asList(1, 2, 3)),
-                new CapturingTopicMigrationClient(), new CapturingConfigMigrationClient(), new CapturingAclMigrationClient()) {
+                new CapturingTopicMigrationClient(),
+                new CapturingConfigMigrationClient(),
+                new CapturingAclMigrationClient(),
+                new CapturingDelegationTokenMigrationClient()) {
             @Override
             public ZkMigrationLeadershipState claimControllerLeadership(ZkMigrationLeadershipState state) {
                 if (claimLeaderAttempts.getCount() == 0) {
@@ -400,7 +403,10 @@ public class KRaftMigrationDriverTest {
     public void testSkipWaitForBrokersInDualWrite() throws Exception {
         CountingMetadataPropagator metadataPropagator = new CountingMetadataPropagator();
         CapturingMigrationClient migrationClient = new CapturingMigrationClient(Collections.emptySet(),
-            new CapturingTopicMigrationClient(), new CapturingConfigMigrationClient(), new CapturingAclMigrationClient());
+            new CapturingTopicMigrationClient(),
+            new CapturingConfigMigrationClient(),
+            new CapturingAclMigrationClient(),
+            new CapturingDelegationTokenMigrationClient());
         MockFaultHandler faultHandler = new MockFaultHandler("testMigrationClientExpiration");
         KRaftMigrationDriver.Builder builder = defaultTestBuilder()
             .setZkMigrationClient(migrationClient)

--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationZkWriterTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.image.ClientQuotasImage;
 import org.apache.kafka.image.ClusterImage;
 import org.apache.kafka.image.ConfigurationsImage;
 import org.apache.kafka.image.ConfigurationsImageTest;
+import org.apache.kafka.image.DelegationTokenImage;
 import org.apache.kafka.image.FeaturesImage;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.MetadataProvenance;
@@ -90,7 +91,8 @@ public class KRaftMigrationZkWriterTest {
             ClientQuotasImage.EMPTY,
             ProducerIdsImage.EMPTY,
             AclsImage.EMPTY,
-            ScramImage.EMPTY
+            ScramImage.EMPTY,
+            DelegationTokenImage.EMPTY
         );
 
         writer.handleSnapshot(image, (opType, opLog, operation) -> {
@@ -129,7 +131,8 @@ public class KRaftMigrationZkWriterTest {
             ClientQuotasImage.EMPTY,    // TODO KAFKA-15017
             ProducerIdsImageTest.IMAGE1,
             AclsImageTest.IMAGE1,
-            ScramImage.EMPTY            // TODO KAFKA-15017
+            ScramImage.EMPTY,            // TODO KAFKA-15017
+            DelegationTokenImage.EMPTY
         );
 
         Map<String, Integer> opCounts = new HashMap<>();
@@ -187,7 +190,8 @@ public class KRaftMigrationZkWriterTest {
             ClientQuotasImage.EMPTY,
             ProducerIdsImage.EMPTY,
             AclsImage.EMPTY,
-            ScramImage.EMPTY
+            ScramImage.EMPTY,
+            DelegationTokenImage.EMPTY
         );
 
         Map<String, Integer> opCounts = new HashMap<>();

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -275,7 +275,7 @@ public enum MetadataVersion {
     }
 
     public boolean isDelegationTokenSupported() {
-        return this.isAtLeast(IBP_3_6_IV0);
+        return this.isAtLeast(IBP_3_6_IV1);
     }
 
     public boolean isKRaftSupported() {

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -173,13 +173,13 @@ public enum MetadataVersion {
     // Adds replica epoch to Fetch request (KIP-903).
     IBP_3_5_IV1(10, "3.5", "IV1", false),
 
-    // Support for SCRAM
+    // KRaft support for SCRAM
     IBP_3_5_IV2(11, "3.5", "IV2", true),
 
     // Remove leader epoch bump when KRaft controller shrinks the ISR (KAFKA-15021)
     IBP_3_6_IV0(12, "3.6", "IV0", false),
 
-    // Add metadata transactions and support for Delegation Tokens
+    // Add metadata transactions and KRaft support for Delegation Tokens
     IBP_3_6_IV1(13, "3.6", "IV1", true);
 
     // NOTE: update the default version in @ClusterTest annotation to point to the latest version

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -179,7 +179,7 @@ public enum MetadataVersion {
     // Remove leader epoch bump when KRaft controller shrinks the ISR (KAFKA-15021)
     IBP_3_6_IV0(12, "3.6", "IV0", false),
 
-    // Add metadata transactions
+    // Add metadata transactions and support for Delegation Tokens
     IBP_3_6_IV1(13, "3.6", "IV1", true);
 
     // NOTE: update the default version in @ClusterTest annotation to point to the latest version
@@ -272,6 +272,10 @@ public enum MetadataVersion {
 
     public boolean isMetadataTransactionSupported() {
         return this.isAtLeast(IBP_3_6_IV1);
+    }
+
+    public boolean isDelegationTokenSupported() {
+        return this.isAtLeast(IBP_3_6_IV0);
     }
 
     public boolean isKRaftSupported() {

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -159,6 +159,10 @@ class MetadataVersionTest {
 
         assertEquals(IBP_3_5_IV0, MetadataVersion.fromVersionString("3.5-IV0"));
         assertEquals(IBP_3_5_IV1, MetadataVersion.fromVersionString("3.5-IV1"));
+        assertEquals(IBP_3_5_IV2, MetadataVersion.fromVersionString("3.5-IV2"));
+
+        assertEquals(IBP_3_6_IV0, MetadataVersion.fromVersionString("3.6-IV0"));
+        assertEquals(IBP_3_6_IV1, MetadataVersion.fromVersionString("3.6-IV1"));
     }
 
     @Test
@@ -209,6 +213,9 @@ class MetadataVersionTest {
         assertEquals("3.4", IBP_3_4_IV0.shortVersion());
         assertEquals("3.5", IBP_3_5_IV0.shortVersion());
         assertEquals("3.5", IBP_3_5_IV1.shortVersion());
+        assertEquals("3.5", IBP_3_5_IV2.shortVersion());
+        assertEquals("3.6", IBP_3_6_IV0.shortVersion());
+        assertEquals("3.6", IBP_3_6_IV1.shortVersion());
     }
 
     @Test
@@ -248,6 +255,9 @@ class MetadataVersionTest {
         assertEquals("3.4-IV0", IBP_3_4_IV0.version());
         assertEquals("3.5-IV0", IBP_3_5_IV0.version());
         assertEquals("3.5-IV1", IBP_3_5_IV1.version());
+        assertEquals("3.5-IV2", IBP_3_5_IV2.version());
+        assertEquals("3.6-IV0", IBP_3_6_IV0.version());
+        assertEquals("3.6-IV1", IBP_3_6_IV1.version());
     }
 
     @Test
@@ -297,6 +307,13 @@ class MetadataVersionTest {
     public void testIsInControlledShutdownStateSupported(MetadataVersion metadataVersion) {
         assertEquals(metadataVersion.isAtLeast(IBP_3_3_IV3),
             metadataVersion.isInControlledShutdownStateSupported());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MetadataVersion.class)
+    public void testIsDelegationTokenSupported(MetadataVersion metadataVersion) {
+        assertEquals(metadataVersion.isAtLeast(IBP_3_6_IV1),
+            metadataVersion.isDelegationTokenSupported());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
This PR includes KRaft Metadata support for DelelegationTokens, updated tests for DelegationTokens to run in Zk and KRaft mode, and a bump of the metadata version specifically for DelelegationTokens.
