### PR TITLE
KAFKA-15022: [4/N] use client tag assignor for rack aware standby task assignment

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -128,7 +128,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         private final ClientState state;
         private final SortedSet<String> consumers;
 
-        ClientMetadata(final String endPoint, final Map<String, String> clientTags) {
+        ClientMetadata(final UUID processId, final String endPoint, final Map<String, String> clientTags) {
 
             // get the host info, or null if no endpoint is configured (ie endPoint == null)
             hostInfo = HostInfo.buildFromEndpoint(endPoint);
@@ -137,7 +137,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             consumers = new TreeSet<>();
 
             // initialize the client state with client tags
-            state = new ClientState(clientTags);
+            state = new ClientState(processId, clientTags);
         }
 
         void addConsumer(final String consumerMemberId, final List<TopicPartition> ownedPartitions) {
@@ -340,7 +340,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 futureMetadataVersion = usedVersion;
                 processId = FUTURE_ID;
                 if (!clientMetadataMap.containsKey(FUTURE_ID)) {
-                    clientMetadataMap.put(FUTURE_ID, new ClientMetadata(null, Collections.emptyMap()));
+                    clientMetadataMap.put(FUTURE_ID, new ClientMetadata(FUTURE_ID, null, Collections.emptyMap()));
                 }
             } else {
                 processId = info.processId();
@@ -350,7 +350,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
             // create the new client metadata if necessary
             if (clientMetadata == null) {
-                clientMetadata = new ClientMetadata(info.userEndPoint(), info.clientTags());
+                clientMetadata = new ClientMetadata(info.processId(), info.userEndPoint(), info.clientTags());
                 clientMetadataMap.put(info.processId(), clientMetadata);
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -59,25 +59,31 @@ public class ClientState {
     private final ClientStateTask revokingActiveTasks = new ClientStateTask(null, new TreeMap<>());
 
     private int capacity;
+    private UUID processId;
 
     public ClientState() {
-        this(0);
+        this(null, 0);
     }
 
-    public ClientState(final Map<String, String> clientTags) {
-        this(0, clientTags);
+    public ClientState(final UUID processId, final Map<String, String> clientTags) {
+        this(processId, 0, clientTags);
     }
 
     ClientState(final int capacity) {
-        this(capacity, Collections.emptyMap());
+        this(null, capacity);
     }
 
-    ClientState(final int capacity, final Map<String, String> clientTags) {
+    ClientState(final UUID processId, final int capacity) {
+        this(processId, capacity, Collections.emptyMap());
+    }
+
+    ClientState(final UUID processId, final int capacity, final Map<String, String> clientTags) {
         previousStandbyTasks.taskIds(new TreeSet<>());
         previousActiveTasks.taskIds(new TreeSet<>());
         taskOffsetSums = new TreeMap<>();
         taskLagTotals = new TreeMap<>();
         this.capacity = capacity;
+        this.processId = processId;
         this.clientTags = unmodifiableMap(clientTags);
     }
 
@@ -97,6 +103,10 @@ public class ClientState {
 
     int capacity() {
         return capacity;
+    }
+
+    UUID processId() {
+        return processId;
     }
 
     public void incrementCapacity() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignor.java
@@ -16,8 +16,9 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
+import java.util.List;
+import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration.AssignmentConfigs;
 import org.slf4j.Logger;
@@ -44,17 +45,18 @@ import static org.apache.kafka.streams.processor.internals.assignment.StandbyTas
 class ClientTagAwareStandbyTaskAssignor implements StandbyTaskAssignor {
     private static final Logger log = LoggerFactory.getLogger(ClientTagAwareStandbyTaskAssignor.class);
 
-    private final Function<ClientState, Map<String, String>> clientTagFunction;
+    private final BiFunction<UUID, ClientState, Map<String, String>> clientTagFunction;
+    private final Function<AssignmentConfigs, List<String>> tagsFunction;
 
     public ClientTagAwareStandbyTaskAssignor() {
-        this(ClientState::clientTags);
+        this((uuid, clientState) -> clientState.clientTags(), assignmentConfigs -> assignmentConfigs.rackAwareAssignmentTags);
     }
 
-    public ClientTagAwareStandbyTaskAssignor(final Function<ClientState, Map<String, String>> clientTagFunction) {
+    public ClientTagAwareStandbyTaskAssignor(final BiFunction<UUID, ClientState, Map<String, String>> clientTagFunction,
+                                             final Function<AssignmentConfigs, List<String>> tagsFunction) {
         this.clientTagFunction = clientTagFunction;
+        this.tagsFunction = tagsFunction;
     }
-
-
 
     /**
      * The algorithm distributes standby tasks for the {@param statefulTaskIds} over different tag dimensions.
@@ -70,7 +72,7 @@ class ClientTagAwareStandbyTaskAssignor implements StandbyTaskAssignor {
                           final Set<TaskId> statefulTaskIds,
                           final AssignorConfiguration.AssignmentConfigs configs) {
         final int numStandbyReplicas = configs.numStandbyReplicas;
-        final Set<String> rackAwareAssignmentTags = new HashSet<>(configs.rackAwareAssignmentTags);
+        final Set<String> rackAwareAssignmentTags = new HashSet<>(tagsFunction.apply(configs));
 
         final Map<TaskId, Integer> tasksToRemainingStandbys = computeTasksToRemainingStandbys(
             numStandbyReplicas,
@@ -142,8 +144,8 @@ class ClientTagAwareStandbyTaskAssignor implements StandbyTaskAssignor {
 
     @Override
     public boolean isAllowedTaskMovement(final ClientState source, final ClientState destination) {
-        final Map<String, String> sourceClientTags = clientTagFunction.apply(source);
-        final Map<String, String> destinationClientTags = clientTagFunction.apply(destination);
+        final Map<String, String> sourceClientTags = clientTagFunction.apply(source.processId(), source);
+        final Map<String, String> destinationClientTags = clientTagFunction.apply(destination.processId(), destination);
 
         for (final Entry<String, String> sourceClientTagEntry : sourceClientTags.entrySet()) {
             if (!sourceClientTagEntry.getValue().equals(destinationClientTags.get(sourceClientTagEntry.getKey()))) {
@@ -162,7 +164,7 @@ class ClientTagAwareStandbyTaskAssignor implements StandbyTaskAssignor {
             final UUID clientId = clientStateEntry.getKey();
             final ClientState clientState = clientStateEntry.getValue();
 
-            clientTagFunction.apply(clientState).forEach((tagKey, tagValue) -> {
+            clientTagFunction.apply(clientId, clientState).forEach((tagKey, tagValue) -> {
                 tagKeyToValues.computeIfAbsent(tagKey, ignored -> new HashSet<>()).add(tagValue);
                 tagEntryToClients.computeIfAbsent(new TagEntry(tagKey, tagValue), ignored -> new HashSet<>()).add(clientId);
             });
@@ -213,9 +215,10 @@ class ClientTagAwareStandbyTaskAssignor implements StandbyTaskAssignor {
             numRemainingStandbys--;
 
             log.debug("Assigning {} out of {} standby tasks for an active task [{}] with client tags {}. " +
-                      "Standby task client tags are {}.",
-                      numberOfStandbyClients - numRemainingStandbys, numberOfStandbyClients, activeTaskId,
-                      clientTagFunction.apply(clientStates.get(activeTaskClient)), clientTagFunction.apply(clientStateOnUsedTagDimensions));
+                    "Standby task client tags are {}.",
+                    numberOfStandbyClients - numRemainingStandbys, numberOfStandbyClients, activeTaskId,
+                    clientTagFunction.apply(activeTaskClient, clientStates.get(activeTaskClient)),
+                    clientTagFunction.apply(clientStateOnUsedTagDimensions.processId(), clientStateOnUsedTagDimensions));
 
             clientStateOnUsedTagDimensions.assignStandby(activeTaskId);
             lastUsedClient = clientOnUnusedTagDimensions;
@@ -232,7 +235,7 @@ class ClientTagAwareStandbyTaskAssignor implements StandbyTaskAssignor {
                      "Standby task assignment will fall back to assigning standby tasks to the least loaded clients.",
                      numRemainingStandbys, numberOfStandbyClients,
                      activeTaskId, rackAwareAssignmentTags,
-                     clientTagFunction.apply(clientStates.get(activeTaskClient)));
+                     clientTagFunction.apply(activeTaskClient, clientStates.get(activeTaskClient)));
 
         } else {
             tasksToRemainingStandbys.remove(activeTaskId);
@@ -251,7 +254,7 @@ class ClientTagAwareStandbyTaskAssignor implements StandbyTaskAssignor {
                                                              final Map<TagEntry, Set<UUID>> tagEntryToClients,
                                                              final Map<String, Set<String>> tagKeyToValues,
                                                              final Map<TagEntry, Set<UUID>> tagEntryToUsedClients) {
-        final Map<String, String> usedClientTags = clientTagFunction.apply(clientStates.get(usedClient));
+        final Map<String, String> usedClientTags = clientTagFunction.apply(usedClient, clientStates.get(usedClient));
 
         for (final Entry<String, String> usedClientTagEntry : usedClientTags.entrySet()) {
             final String tagKey = usedClientTagEntry.getKey();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignor.java
@@ -158,8 +158,8 @@ class ClientTagAwareStandbyTaskAssignor implements StandbyTaskAssignor {
 
     // Visible for testing
     void fillClientsTagStatistics(final Map<UUID, ClientState> clientStates,
-                                         final Map<TagEntry, Set<UUID>> tagEntryToClients,
-                                         final Map<String, Set<String>> tagKeyToValues) {
+                                  final Map<TagEntry, Set<UUID>> tagEntryToClients,
+                                  final Map<String, Set<String>> tagKeyToValues) {
         for (final Entry<UUID, ClientState> clientStateEntry : clientStates.entrySet()) {
             final UUID clientId = clientStateEntry.getKey();
             final ClientState clientState = clientStateEntry.getValue();
@@ -173,15 +173,15 @@ class ClientTagAwareStandbyTaskAssignor implements StandbyTaskAssignor {
 
     // Visible for testing
     void assignStandbyTasksToClientsWithDifferentTags(final int numberOfStandbyClients,
-                                                             final ConstrainedPrioritySet standbyTaskClientsByTaskLoad,
-                                                             final TaskId activeTaskId,
-                                                             final UUID activeTaskClient,
-                                                             final Set<String> rackAwareAssignmentTags,
-                                                             final Map<UUID, ClientState> clientStates,
-                                                             final Map<TaskId, Integer> tasksToRemainingStandbys,
-                                                             final Map<String, Set<String>> tagKeyToValues,
-                                                             final Map<TagEntry, Set<UUID>> tagEntryToClients,
-                                                             final Map<TaskId, UUID> pendingStandbyTasksToClientId) {
+                                                      final ConstrainedPrioritySet standbyTaskClientsByTaskLoad,
+                                                      final TaskId activeTaskId,
+                                                      final UUID activeTaskClient,
+                                                      final Set<String> rackAwareAssignmentTags,
+                                                      final Map<UUID, ClientState> clientStates,
+                                                      final Map<TaskId, Integer> tasksToRemainingStandbys,
+                                                      final Map<String, Set<String>> tagKeyToValues,
+                                                      final Map<TagEntry, Set<UUID>> tagEntryToClients,
+                                                      final Map<TaskId, UUID> pendingStandbyTasksToClientId) {
         standbyTaskClientsByTaskLoad.offerAll(clientStates.keySet());
 
         // We set countOfUsedClients as 1 because client where active task is located has to be considered as used.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignor.java
@@ -134,7 +134,7 @@ public class HighAvailabilityTaskAssignor implements TaskAssignor {
             return;
         }
 
-        final StandbyTaskAssignor standbyTaskAssignor = StandbyTaskAssignorFactory.create(configs);
+        final StandbyTaskAssignor standbyTaskAssignor = StandbyTaskAssignorFactory.create(configs, null);
 
         standbyTaskAssignor.assign(clientStates, allTaskIds, statefulTasks, configs);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals.assignment;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -194,6 +195,10 @@ public class RackAwareTaskAssignor {
             racksForProcess.put(entry.getKey(), previousRackInfo.value);
         }
         return true;
+    }
+
+    public Map<UUID, String> racksForProcess() {
+        return Collections.unmodifiableMap(racksForProcess);
     }
 
     private int getCost(final TaskId taskId, final UUID processId, final boolean inCurrentAssignment, final int trafficCost, final int nonOverlapCost) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactory.java
@@ -30,7 +30,7 @@ class StandbyTaskAssignorFactory {
                                       final RackAwareTaskAssignor rackAwareTaskAssignor) {
         if (!configs.rackAwareAssignmentTags.isEmpty()) {
             return new ClientTagAwareStandbyTaskAssignor();
-        } else if (rackAwareTaskAssignor != null) {
+        } else if (rackAwareTaskAssignor != null && rackAwareTaskAssignor.validClientRack()) {
             // racksForProcess should be populated if rackAwareTaskAssignor isn't null
             final Map<UUID, String> racksForProcess = rackAwareTaskAssignor.racksForProcess();
             return new ClientTagAwareStandbyTaskAssignor(

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactory.java
@@ -16,12 +16,26 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
 class StandbyTaskAssignorFactory {
     private StandbyTaskAssignorFactory() {}
 
-    static StandbyTaskAssignor create(final AssignorConfiguration.AssignmentConfigs configs) {
+    static StandbyTaskAssignor create(final AssignorConfiguration.AssignmentConfigs configs,
+                                      final RackAwareTaskAssignor rackAwareTaskAssignor) {
         if (!configs.rackAwareAssignmentTags.isEmpty()) {
             return new ClientTagAwareStandbyTaskAssignor();
+        } else if (rackAwareTaskAssignor != null && rackAwareTaskAssignor.canEnableRackAwareAssignor()) {
+            final Map<UUID, String> racksForProcess = rackAwareTaskAssignor.racksForProcess();
+            return new ClientTagAwareStandbyTaskAssignor(
+                (processId, clientState) -> mkMap(mkEntry("rack", racksForProcess.get(processId))),
+                assignmentConfigs -> Collections.singletonList("rack")
+            );
         } else {
             return new DefaultStandbyTaskAssignor();
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactory.java
@@ -30,7 +30,8 @@ class StandbyTaskAssignorFactory {
                                       final RackAwareTaskAssignor rackAwareTaskAssignor) {
         if (!configs.rackAwareAssignmentTags.isEmpty()) {
             return new ClientTagAwareStandbyTaskAssignor();
-        } else if (rackAwareTaskAssignor != null && rackAwareTaskAssignor.canEnableRackAwareAssignor()) {
+        } else if (rackAwareTaskAssignor != null) {
+            // racksForProcess should be populated if rackAwareTaskAssignor isn't null
             final Map<UUID, String> racksForProcess = rackAwareTaskAssignor.racksForProcess();
             return new ClientTagAwareStandbyTaskAssignor(
                 (processId, clientState) -> mkMap(mkEntry("rack", racksForProcess.get(processId))),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -71,11 +71,11 @@ public final class AssignmentTestUtils {
     public static final UUID UUID_8 = uuidForInt(8);
     public static final UUID UUID_9 = uuidForInt(9);
 
-    public static final String RACK_0 = "rock0";
-    public static final String RACK_1 = "rock1";
-    public static final String RACK_2 = "rock2";
-    public static final String RACK_3 = "rock3";
-    public static final String RACK_4 = "rock4";
+    public static final String RACK_0 = "rack0";
+    public static final String RACK_1 = "rack1";
+    public static final String RACK_2 = "rack2";
+    public static final String RACK_3 = "rack3";
+    public static final String RACK_4 = "rack4";
 
     public static final Node NODE_0 = new Node(0, "node0", 1, RACK_0);
     public static final Node NODE_1 = new Node(1, "node1", 1, RACK_1);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -537,7 +537,7 @@ public class ClientStateTest {
     @Test
     public void shouldReturnClientTags() {
         final Map<String, String> clientTags = mkMap(mkEntry("k1", "v1"));
-        assertEquals(clientTags, new ClientState(0, clientTags).clientTags());
+        assertEquals(clientTags, new ClientState(null, 0, clientTags).clientTags());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -46,6 +46,9 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_3;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.hasActiveTasks;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.hasStandbyTasks;
 import static org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo.UNKNOWN_OFFSET_SUM;
@@ -55,6 +58,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -545,4 +549,11 @@ public class ClientStateTest {
         assertTrue(new ClientState().clientTags().isEmpty());
     }
 
+    @Test
+    public void shouldSetProcessId() {
+        assertEquals(UUID_1, new ClientState(UUID_1, 1).processId());
+        assertEquals(UUID_2, new ClientState(UUID_2, mkMap()).processId());
+        assertEquals(UUID_3, new ClientState(UUID_3, 1, mkMap()).processId());
+        assertNull(new ClientState().processId());
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignorTest.java
@@ -44,8 +44,6 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_2;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.uuidForInt;
-import static org.apache.kafka.streams.processor.internals.assignment.ClientTagAwareStandbyTaskAssignor.assignStandbyTasksToClientsWithDifferentTags;
-import static org.apache.kafka.streams.processor.internals.assignment.ClientTagAwareStandbyTaskAssignor.fillClientsTagStatistics;
 import static org.apache.kafka.streams.processor.internals.assignment.StandbyTaskAssignmentUtils.computeTasksToRemainingStandbys;
 import static org.apache.kafka.streams.processor.internals.assignment.StandbyTaskAssignmentUtils.createLeastLoadedPrioritySetConstrainedByAssignedTask;
 import static org.junit.Assert.assertEquals;
@@ -134,13 +132,13 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         final Map<String, Set<String>> tagKeyToValues = new HashMap<>();
         final Map<TagEntry, Set<UUID>> tagEntryToClients = new HashMap<>();
 
-        fillClientsTagStatistics(clientStates, tagEntryToClients, tagKeyToValues);
+        new ClientTagAwareStandbyTaskAssignor().fillClientsTagStatistics(clientStates, tagEntryToClients, tagKeyToValues);
 
         final Map<TaskId, UUID> pendingStandbyTasksToClientId = new HashMap<>();
         final Map<TaskId, Integer> tasksToRemainingStandbys = computeTasksToRemainingStandbys(numStandbyReplicas, allActiveTasks);
 
         for (final TaskId activeTaskId : allActiveTasks) {
-            assignStandbyTasksToClientsWithDifferentTags(
+            new ClientTagAwareStandbyTaskAssignor().assignStandbyTasksToClientsWithDifferentTags(
                 numStandbyReplicas,
                 constrainedPrioritySet,
                 activeTaskId,
@@ -177,13 +175,13 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         final Map<String, Set<String>> tagKeyToValues = new HashMap<>();
         final Map<TagEntry, Set<UUID>> tagEntryToClients = new HashMap<>();
 
-        fillClientsTagStatistics(clientStates, tagEntryToClients, tagKeyToValues);
+        new ClientTagAwareStandbyTaskAssignor().fillClientsTagStatistics(clientStates, tagEntryToClients, tagKeyToValues);
 
         final Map<TaskId, UUID> pendingStandbyTasksToClientId = new HashMap<>();
         final Map<TaskId, Integer> tasksToRemainingStandbys = computeTasksToRemainingStandbys(numStandbyReplicas, allActiveTasks);
 
         for (final TaskId activeTaskId : allActiveTasks) {
-            assignStandbyTasksToClientsWithDifferentTags(
+            new ClientTagAwareStandbyTaskAssignor().assignStandbyTasksToClientsWithDifferentTags(
                 numStandbyReplicas,
                 constrainedPrioritySet,
                 activeTaskId,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignorTest.java
@@ -49,6 +49,10 @@ import static org.apache.kafka.streams.processor.internals.assignment.StandbyTas
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ClientTagAwareStandbyTaskAssignorTest {
     private static final String ZONE_TAG = "zone";
@@ -88,17 +92,17 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         );
 
         final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
-            mkEntry(UUID_3, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
+            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
+            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
+            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
 
-            mkEntry(UUID_4, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1, TASK_1_1)),
-            mkEntry(UUID_5, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
-            mkEntry(UUID_6, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1, TASK_1_1)),
+            mkEntry(UUID_5, createClientStateWithCapacity(UUID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            mkEntry(UUID_6, createClientStateWithCapacity(UUID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
 
-            mkEntry(UUID_7, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2, TASK_1_2)),
-            mkEntry(UUID_8, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
-            mkEntry(UUID_9, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
+            mkEntry(UUID_7, createClientStateWithCapacity(UUID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2, TASK_1_2)),
+            mkEntry(UUID_8, createClientStateWithCapacity(UUID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
+            mkEntry(UUID_9, createClientStateWithCapacity(UUID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -118,9 +122,9 @@ public class ClientTagAwareStandbyTaskAssignorTest {
         final int numStandbyReplicas = 2;
         final Set<String> rackAwareAssignmentTags = mkSet(ZONE_TAG, CLUSTER_TAG);
         final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1)),
-            mkEntry(UUID_3, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2))
+            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
+            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1)),
+            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2))
         );
 
         final ConstrainedPrioritySet constrainedPrioritySet = createLeastLoadedPrioritySetConstrainedByAssignedTask(clientStates);
@@ -160,9 +164,9 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     public void shouldUpdateClientToRemainingStandbysAndPendingStandbyTasksToClientIdWhenNotAllStandbyTasksWereAssigned() {
         final Set<String> rackAwareAssignmentTags = mkSet(ZONE_TAG, CLUSTER_TAG);
         final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1)),
-            mkEntry(UUID_3, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2))
+            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
+            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1)),
+            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2))
         );
 
         final ConstrainedPrioritySet constrainedPrioritySet = createLeastLoadedPrioritySetConstrainedByAssignedTask(clientStates);
@@ -212,16 +216,16 @@ public class ClientTagAwareStandbyTaskAssignorTest {
 
     @Test
     public void shouldPermitTaskMovementWhenClientTagsMatch() {
-        final ClientState source = createClientStateWithCapacity(1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState destination = createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState source = createClientStateWithCapacity(UUID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState destination = createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
 
         assertTrue(standbyTaskAssignor.isAllowedTaskMovement(source, destination));
     }
 
     @Test
     public void shouldDeclineTaskMovementWhenClientTagsDoNotMatch() {
-        final ClientState source = createClientStateWithCapacity(1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
-        final ClientState destination = createClientStateWithCapacity(1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState source = createClientStateWithCapacity(UUID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)));
+        final ClientState destination = createClientStateWithCapacity(UUID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)));
 
         assertFalse(standbyTaskAssignor.isAllowedTaskMovement(source, destination));
     }
@@ -229,17 +233,17 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldDistributeStandbyTasksWhenActiveTasksAreLocatedOnSameZone() {
         final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
-            mkEntry(UUID_3, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
+            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
+            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
+            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)))),
 
-            mkEntry(UUID_4, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1, TASK_1_1)),
-            mkEntry(UUID_5, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
-            mkEntry(UUID_6, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)), TASK_0_1, TASK_1_1)),
+            mkEntry(UUID_5, createClientStateWithCapacity(UUID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            mkEntry(UUID_6, createClientStateWithCapacity(UUID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
 
-            mkEntry(UUID_7, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2, TASK_1_2)),
-            mkEntry(UUID_8, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
-            mkEntry(UUID_9, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
+            mkEntry(UUID_7, createClientStateWithCapacity(UUID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)), TASK_0_2, TASK_1_2)),
+            mkEntry(UUID_8, createClientStateWithCapacity(UUID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
+            mkEntry(UUID_9, createClientStateWithCapacity(UUID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -312,19 +316,144 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     }
 
     @Test
+    public void shouldDistributeStandbyTasksUsingFunctionAndSupplierTags() {
+        final RackAwareTaskAssignor rackAwareTaskAssignor = mock(RackAwareTaskAssignor.class);
+        when(rackAwareTaskAssignor.canEnableRackAwareAssignor()).thenReturn(true);
+        final Map<UUID, String> racksForProcess = mkMap(
+            mkEntry(UUID_1, "rack1"),
+            mkEntry(UUID_2, "rack2"),
+            mkEntry(UUID_3, "rack3"),
+            mkEntry(UUID_4, "rack1"),
+            mkEntry(UUID_5, "rack2"),
+            mkEntry(UUID_6, "rack3"),
+            mkEntry(UUID_7, "rack1"),
+            mkEntry(UUID_8, "rack2"),
+            mkEntry(UUID_9, "rack3")
+        );
+        when(rackAwareTaskAssignor.racksForProcess()).thenReturn(racksForProcess);
+        final AssignmentConfigs assignmentConfigs = newAssignmentConfigs(2);
+        standbyTaskAssignor = StandbyTaskAssignorFactory.create(assignmentConfigs, rackAwareTaskAssignor);
+        verify(rackAwareTaskAssignor, times(1)).racksForProcess();
+
+        final Map<UUID, ClientState> clientStates = mkMap(
+            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(), TASK_0_0, TASK_1_0)),
+            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(), TASK_0_1, TASK_1_1)),
+            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 2, mkMap(), TASK_0_2, TASK_1_2)),
+
+            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 2, mkMap())),
+            mkEntry(UUID_5, createClientStateWithCapacity(UUID_5, 2, mkMap())),
+            mkEntry(UUID_6, createClientStateWithCapacity(UUID_6, 2, mkMap())),
+
+            mkEntry(UUID_7, createClientStateWithCapacity(UUID_7, 2, mkMap())),
+            mkEntry(UUID_8, createClientStateWithCapacity(UUID_8, 2, mkMap())),
+            mkEntry(UUID_9, createClientStateWithCapacity(UUID_9, 2, mkMap()))
+        );
+
+        final Map<UUID, ClientState> clientStatesWithTags = mkMap(
+            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0, TASK_1_0)),
+            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2)), TASK_0_1, TASK_1_1)),
+            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3)), TASK_0_2, TASK_1_2)),
+
+            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1)))),
+            mkEntry(UUID_5, createClientStateWithCapacity(UUID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2)))),
+            mkEntry(UUID_6, createClientStateWithCapacity(UUID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3)))),
+
+            mkEntry(UUID_7, createClientStateWithCapacity(UUID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1)))),
+            mkEntry(UUID_8, createClientStateWithCapacity(UUID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2)))),
+            mkEntry(UUID_9, createClientStateWithCapacity(UUID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3))))
+        );
+
+        final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
+
+        standbyTaskAssignor.assign(clientStates, allActiveTasks, allActiveTasks, assignmentConfigs);
+
+        final AssignmentConfigs assignmentConfigsWithTags = newAssignmentConfigs(2, ZONE_TAG);
+        standbyTaskAssignor = new ClientTagAwareStandbyTaskAssignor();
+        standbyTaskAssignor.assign(clientStatesWithTags, allActiveTasks, allActiveTasks, assignmentConfigsWithTags);
+
+        Stream.of(clientStates, clientStatesWithTags).forEach(
+            cs -> {
+                assertTrue(cs.values().stream().allMatch(ClientState::reachedCapacity));
+                Stream.of(UUID_1, UUID_2, UUID_3)
+                    .forEach(client -> assertStandbyTaskCountForClientEqualsTo(cs, client, 0));
+                Stream.of(UUID_4, UUID_5, UUID_6, UUID_7, UUID_8, UUID_9)
+                    .forEach(client -> assertStandbyTaskCountForClientEqualsTo(cs, client, 2));
+                assertTotalNumberOfStandbyTasksEqualsTo(cs, 12);
+
+                assertTrue(
+                    standbyClientsHonorRackAwareness(
+                        TASK_0_0,
+                        cs,
+                        singletonList(
+                            mkSet(UUID_6, UUID_8)
+                        )
+                    )
+                );
+                assertTrue(
+                    standbyClientsHonorRackAwareness(
+                        TASK_1_0,
+                        cs,
+                        singletonList(
+                            mkSet(UUID_5, UUID_6)
+                        )
+                    )
+                );
+
+                assertTrue(
+                    standbyClientsHonorRackAwareness(
+                        TASK_0_1,
+                        cs,
+                        singletonList(
+                            mkSet(UUID_7, UUID_9)
+                        )
+                    )
+                );
+                assertTrue(
+                    standbyClientsHonorRackAwareness(
+                        TASK_1_1,
+                        cs,
+                        singletonList(
+                            mkSet(UUID_7, UUID_9)
+                        )
+                    )
+                );
+
+                assertTrue(
+                    standbyClientsHonorRackAwareness(
+                        TASK_0_2,
+                        cs,
+                        singletonList(
+                            mkSet(UUID_4, UUID_8)
+                        )
+                    )
+                );
+                assertTrue(
+                    standbyClientsHonorRackAwareness(
+                        TASK_1_2,
+                        cs,
+                        singletonList(
+                            mkSet(UUID_4, UUID_5)
+                        )
+                    )
+                );
+            }
+        );
+    }
+
+    @Test
     public void shouldDistributeStandbyTasksWhenActiveTasksAreLocatedOnSameCluster() {
         final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_1, TASK_1_1)),
-            mkEntry(UUID_3, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_2, TASK_1_2)),
+            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0, TASK_1_0)),
+            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_1, TASK_1_1)),
+            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_2, TASK_1_2)),
 
-            mkEntry(UUID_4, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
-            mkEntry(UUID_5, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
-            mkEntry(UUID_6, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            mkEntry(UUID_5, createClientStateWithCapacity(UUID_5, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
+            mkEntry(UUID_6, createClientStateWithCapacity(UUID_6, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_2)))),
 
-            mkEntry(UUID_7, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
-            mkEntry(UUID_8, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
-            mkEntry(UUID_9, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
+            mkEntry(UUID_7, createClientStateWithCapacity(UUID_7, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
+            mkEntry(UUID_8, createClientStateWithCapacity(UUID_8, 2, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_3)))),
+            mkEntry(UUID_9, createClientStateWithCapacity(UUID_9, 2, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_3))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -399,13 +528,13 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldDoThePartialRackAwareness() {
         final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_2)))),
-            mkEntry(UUID_3, createClientStateWithCapacity(1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_3)))),
+            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
+            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_2)))),
+            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_3)))),
 
-            mkEntry(UUID_4, createClientStateWithCapacity(1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_1)))),
-            mkEntry(UUID_5, createClientStateWithCapacity(1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_2)))),
-            mkEntry(UUID_6, createClientStateWithCapacity(1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_3)), TASK_1_0))
+            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_1)))),
+            mkEntry(UUID_5, createClientStateWithCapacity(UUID_5, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_2)))),
+            mkEntry(UUID_6, createClientStateWithCapacity(UUID_6, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_3)), TASK_1_0))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -464,12 +593,12 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldDistributeClientsOnDifferentZoneTagsEvenWhenClientsReachedCapacity() {
         final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_1)),
-            mkEntry(UUID_3, createClientStateWithCapacity(1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_2)),
-            mkEntry(UUID_4, createClientStateWithCapacity(1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_0)),
-            mkEntry(UUID_5, createClientStateWithCapacity(1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_1)),
-            mkEntry(UUID_6, createClientStateWithCapacity(1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_2))
+            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
+            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_1)),
+            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_2)),
+            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 1, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_0)),
+            mkEntry(UUID_5, createClientStateWithCapacity(UUID_5, 1, mkMap(mkEntry(ZONE_TAG, ZONE_2), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_1)),
+            mkEntry(UUID_6, createClientStateWithCapacity(UUID_6, 1, mkMap(mkEntry(ZONE_TAG, ZONE_3), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_1_2))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -541,10 +670,10 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldIgnoreTagsThatAreNotPresentInRackAwareness() {
         final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(2, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_2)))),
+            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
+            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_2)))),
 
-            mkEntry(UUID_3, createClientStateWithCapacity(1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_1))))
+            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 1, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_2), mkEntry(ZONE_TAG, ZONE_1))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -559,8 +688,8 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldHandleOverlappingTagValuesBetweenDifferentTagKeys() {
         final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(2, mkMap(mkEntry(ZONE_TAG, CLUSTER_1), mkEntry(CLUSTER_TAG, CLUSTER_3))))
+            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 2, mkMap(mkEntry(ZONE_TAG, ZONE_1), mkEntry(CLUSTER_TAG, CLUSTER_1)), TASK_0_0)),
+            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 2, mkMap(mkEntry(ZONE_TAG, CLUSTER_1), mkEntry(CLUSTER_TAG, CLUSTER_3))))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -583,10 +712,10 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldDistributeStandbyTasksOnLeastLoadedClientsWhenClientsAreNotOnDifferentTagDimensions() {
         final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
-            mkEntry(UUID_2, createClientStateWithCapacity(3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_1)),
-            mkEntry(UUID_3, createClientStateWithCapacity(3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_2)),
-            mkEntry(UUID_4, createClientStateWithCapacity(3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_1_0))
+            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0)),
+            mkEntry(UUID_2, createClientStateWithCapacity(UUID_2, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_1)),
+            mkEntry(UUID_3, createClientStateWithCapacity(UUID_3, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_2)),
+            mkEntry(UUID_4, createClientStateWithCapacity(UUID_4, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_1_0))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -604,7 +733,7 @@ public class ClientTagAwareStandbyTaskAssignorTest {
     @Test
     public void shouldNotAssignStandbyTasksIfThereAreNoEnoughClients() {
         final Map<UUID, ClientState> clientStates = mkMap(
-            mkEntry(UUID_1, createClientStateWithCapacity(3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0))
+            mkEntry(UUID_1, createClientStateWithCapacity(UUID_1, 3, mkMap(mkEntry(CLUSTER_TAG, CLUSTER_1), mkEntry(ZONE_TAG, ZONE_1)), TASK_0_0))
         );
 
         final Set<TaskId> allActiveTasks = findAllActiveTasks(clientStates);
@@ -658,10 +787,11 @@ public class ClientTagAwareStandbyTaskAssignorTest {
                                      asList(rackAwareAssignmentTags));
     }
 
-    private static ClientState createClientStateWithCapacity(final int capacity,
+    private static ClientState createClientStateWithCapacity(final UUID processId,
+                                                             final int capacity,
                                                              final Map<String, String> clientTags,
                                                              final TaskId... tasks) {
-        final ClientState clientState = new ClientState(capacity, clientTags);
+        final ClientState clientState = new ClientState(processId, capacity, clientTags);
 
         Optional.ofNullable(tasks).ifPresent(t -> clientState.assignActiveTasks(asList(t)));
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
@@ -591,7 +591,7 @@ public class RackAwareTaskAssignorTest {
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_1);
         final Exception exception = assertThrows(IllegalStateException.class,
             () -> assignor.optimizeActiveTasks(clientStateMap, taskIds, trafficCost, nonOverlapCost));
-        Assertions.assertEquals("TopicPartition topic0-0 has no rack information. Maybe forgot to call "
+        Assertions.assertEquals("Client 00000000-0000-0000-0000-000000000002 doesn't have rack configured. Maybe forgot to call "
             + "canEnableRackAwareAssignor first", exception.getMessage());
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
@@ -176,7 +176,7 @@ public class RackAwareTaskAssignorTest {
 
         // False since partitionWithoutInfo10 is missing in cluster metadata
         assertFalse(assignor.canEnableRackAwareAssignor());
-        assertFalse(assignor.populateTopicsToDiscribe(new HashSet<>()));
+        assertFalse(assignor.populateTopicsToDescribe(new HashSet<>()));
         assertTrue(assignor.validateClientRack());
     }
 
@@ -192,7 +192,7 @@ public class RackAwareTaskAssignorTest {
         );
 
         assertTrue(assignor.validateClientRack());
-        assertFalse(assignor.populateTopicsToDiscribe(new HashSet<>()));
+        assertFalse(assignor.populateTopicsToDescribe(new HashSet<>()));
         // False since nodeMissingRack has one node which doesn't have rack
         assertFalse(assignor.canEnableRackAwareAssignor());
     }
@@ -290,7 +290,7 @@ public class RackAwareTaskAssignorTest {
         );
 
         assertFalse(assignor.canEnableRackAwareAssignor());
-        assertTrue(assignor.populateTopicsToDiscribe(new HashSet<>()));
+        assertTrue(assignor.populateTopicsToDescribe(new HashSet<>()));
     }
 
     @Test
@@ -314,10 +314,10 @@ public class RackAwareTaskAssignorTest {
         final SortedSet<TaskId> taskIds = mkSortedSet();
 
         assertTrue(assignor.canEnableRackAwareAssignor());
-        final long originalCost = assignor.activeTasksCost(clientStateMap, taskIds, trafficCost, nonOverlapCost);
+        final long originalCost = assignor.activeTasksCost(taskIds, clientStateMap, trafficCost, nonOverlapCost);
         assertEquals(0, originalCost);
 
-        final long cost = assignor.optimizeActiveTasks(clientStateMap, taskIds, trafficCost, nonOverlapCost);
+        final long cost = assignor.optimizeActiveTasks(taskIds, clientStateMap, trafficCost, nonOverlapCost);
         assertEquals(0, cost);
 
         assertEquals(mkSet(TASK_0_1, TASK_1_1), clientState0.activeTasks());
@@ -356,11 +356,11 @@ public class RackAwareTaskAssignorTest {
 
         assertTrue(assignor.canEnableRackAwareAssignor());
         int expected = stateful ? 40 : 4;
-        final long originalCost = assignor.activeTasksCost(clientStateMap, taskIds, trafficCost, nonOverlapCost);
+        final long originalCost = assignor.activeTasksCost(taskIds, clientStateMap, trafficCost, nonOverlapCost);
         assertEquals(expected, originalCost);
 
         expected = stateful ? 4 : 0;
-        final long cost = assignor.optimizeActiveTasks(clientStateMap, taskIds, trafficCost, nonOverlapCost);
+        final long cost = assignor.optimizeActiveTasks(taskIds, clientStateMap, trafficCost, nonOverlapCost);
         assertEquals(expected, cost);
 
         assertEquals(mkSet(TASK_0_0, TASK_1_0), clientState0.activeTasks());
@@ -390,8 +390,8 @@ public class RackAwareTaskAssignorTest {
             .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().activeTasks().size()));
 
         assertTrue(assignor.canEnableRackAwareAssignor());
-        final long originalCost = assignor.activeTasksCost(clientStateMap, taskIds, trafficCost, nonOverlapCost);
-        final long cost = assignor.optimizeActiveTasks(clientStateMap, taskIds, trafficCost, nonOverlapCost);
+        final long originalCost = assignor.activeTasksCost(taskIds, clientStateMap, trafficCost, nonOverlapCost);
+        final long cost = assignor.optimizeActiveTasks(taskIds, clientStateMap, trafficCost, nonOverlapCost);
         assertThat(cost, lessThanOrEqualTo(originalCost));
 
         for (final Entry<UUID, ClientState> entry : clientStateMap.entrySet()) {
@@ -425,10 +425,10 @@ public class RackAwareTaskAssignorTest {
 
         // Because trafficCost is 0, original assignment should be maintained
         assertTrue(assignor.canEnableRackAwareAssignor());
-        final long originalCost = assignor.activeTasksCost(clientStateMap, taskIds, 0, 1);
+        final long originalCost = assignor.activeTasksCost(taskIds, clientStateMap, 0, 1);
         assertEquals(0, originalCost);
 
-        final long cost = assignor.optimizeActiveTasks(clientStateMap, taskIds, 0, 1);
+        final long cost = assignor.optimizeActiveTasks(taskIds, clientStateMap, 0, 1);
         assertEquals(0, cost);
 
         // Make sure assignment doesn't change
@@ -468,12 +468,12 @@ public class RackAwareTaskAssignorTest {
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_1_0);
 
         assertTrue(assignor.canEnableRackAwareAssignor());
-        final long originalCost = assignor.activeTasksCost(clientStateMap, taskIds, trafficCost, nonOverlapCost);
+        final long originalCost = assignor.activeTasksCost(taskIds, clientStateMap, trafficCost, nonOverlapCost);
         int expected = stateful ? 20 : 2;
         assertEquals(expected, originalCost);
 
         expected = stateful ? 2 : 0;
-        final long cost = assignor.optimizeActiveTasks(clientStateMap, taskIds, trafficCost, nonOverlapCost);
+        final long cost = assignor.optimizeActiveTasks(taskIds, clientStateMap, trafficCost, nonOverlapCost);
         assertEquals(expected, cost);
 
         // UUID_1 remains empty
@@ -512,12 +512,12 @@ public class RackAwareTaskAssignorTest {
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_0);
 
         assertTrue(assignor.canEnableRackAwareAssignor());
-        final long originalCost = assignor.activeTasksCost(clientStateMap, taskIds, trafficCost, nonOverlapCost);
+        final long originalCost = assignor.activeTasksCost(taskIds, clientStateMap, trafficCost, nonOverlapCost);
         int expected = stateful ? 20 : 2;
         assertEquals(expected, originalCost);
 
         expected = stateful ? 2 : 0;
-        final long cost = assignor.optimizeActiveTasks(clientStateMap, taskIds, trafficCost, nonOverlapCost);
+        final long cost = assignor.optimizeActiveTasks(taskIds, clientStateMap, trafficCost, nonOverlapCost);
         assertEquals(expected, cost);
 
         // Because original assignment is not balanced (3 tasks but client 0 has no task), we maintain it
@@ -555,10 +555,10 @@ public class RackAwareTaskAssignorTest {
 
         assertTrue(assignor.canEnableRackAwareAssignor());
         final int expectedCost = stateful ? 10 : 1;
-        final long originalCost = assignor.activeTasksCost(clientStateMap, taskIds, trafficCost, nonOverlapCost);
+        final long originalCost = assignor.activeTasksCost(taskIds, clientStateMap, trafficCost, nonOverlapCost);
         assertEquals(expectedCost, originalCost);
 
-        final long cost = assignor.optimizeActiveTasks(clientStateMap, taskIds, trafficCost, nonOverlapCost);
+        final long cost = assignor.optimizeActiveTasks(taskIds, clientStateMap, trafficCost, nonOverlapCost);
         assertEquals(expectedCost, cost);
 
         // Even though assigning all tasks to UUID_2 will result in min cost, but it's not balanced
@@ -590,7 +590,7 @@ public class RackAwareTaskAssignorTest {
         ));
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_1);
         final Exception exception = assertThrows(IllegalStateException.class,
-            () -> assignor.optimizeActiveTasks(clientStateMap, taskIds, trafficCost, nonOverlapCost));
+            () -> assignor.optimizeActiveTasks(taskIds, clientStateMap, trafficCost, nonOverlapCost));
         Assertions.assertEquals("Client 00000000-0000-0000-0000-000000000002 doesn't have rack configured. Maybe forgot to call "
             + "canEnableRackAwareAssignor first", exception.getMessage());
     }
@@ -619,7 +619,7 @@ public class RackAwareTaskAssignorTest {
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_1);
         assertTrue(assignor.canEnableRackAwareAssignor());
         final Exception exception = assertThrows(IllegalArgumentException.class,
-            () -> assignor.optimizeActiveTasks(clientStateMap, taskIds, trafficCost, nonOverlapCost));
+            () -> assignor.optimizeActiveTasks(taskIds, clientStateMap, trafficCost, nonOverlapCost));
         Assertions.assertEquals(
             "Task 1_1 assigned to multiple clients 00000000-0000-0000-0000-000000000005, "
                 + "00000000-0000-0000-0000-000000000002", exception.getMessage());
@@ -649,7 +649,7 @@ public class RackAwareTaskAssignorTest {
         final SortedSet<TaskId> taskIds = mkSortedSet(TASK_0_0, TASK_0_1, TASK_1_0, TASK_1_1);
         assertTrue(assignor.canEnableRackAwareAssignor());
         final Exception exception = assertThrows(IllegalArgumentException.class,
-            () -> assignor.optimizeActiveTasks(clientStateMap, taskIds, trafficCost, nonOverlapCost));
+            () -> assignor.optimizeActiveTasks(taskIds, clientStateMap, trafficCost, nonOverlapCost));
         Assertions.assertEquals(
             "Task 1_0 not assigned to any client", exception.getMessage());
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
@@ -224,6 +224,21 @@ public class RackAwareTaskAssignorTest {
     }
 
     @Test
+    public void shouldPopulateRacksForProcess() {
+        // Throws since process1 doesn't have rackId
+        final RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
+            getClusterForTopic0(),
+            getTaskTopicPartitionMapForTask0(),
+            getTopologyGroupTaskMap(),
+            getProcessRacksForProcess0(),
+            mockInternalTopicManager,
+            new AssignorConfiguration(streamsConfig.originals()).assignmentConfigs()
+        );
+        final Map<UUID, String> racksForProcess = assignor.racksForProcess();
+        assertEquals(mkMap(mkEntry(UUID_1, RACK_1)), racksForProcess);
+    }
+
+    @Test
     public void shouldThrowWhenRackDiffersInSameProcess() {
         final Map<UUID, Map<String, Optional<String>>> processRacks = new HashMap<>();
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactoryTest.java
@@ -16,30 +16,91 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@RunWith(Parameterized.class)
 public class StandbyTaskAssignorFactoryTest {
+    @org.junit.Rule
+    public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.LENIENT);
+
     private static final long ACCEPTABLE_RECOVERY_LAG = 0L;
     private static final int MAX_WARMUP_REPLICAS = 1;
     private static final int NUMBER_OF_STANDBY_REPLICAS = 1;
     private static final long PROBING_REBALANCE_INTERVAL_MS = 60000L;
 
+    enum State {
+        DISABLED,
+        ENABLED,
+        NULL
+    }
+
+    private RackAwareTaskAssignor rackAwareTaskAssignor;
+
+    @Parameter
+    public State state;
+
+    @Parameterized.Parameters(name = "RackAwareTaskAssignor={0}")
+    public static Collection<State> parameters() {
+        return Arrays.asList(State.DISABLED, State.ENABLED, State.NULL);
+    }
+
+    @Before
+    public void setUp() {
+        if (state == State.ENABLED) {
+            rackAwareTaskAssignor = mock(RackAwareTaskAssignor.class);
+            when(rackAwareTaskAssignor.canEnableRackAwareAssignor()).thenReturn(true);
+        } else if (state == State.DISABLED) {
+            rackAwareTaskAssignor = mock(RackAwareTaskAssignor.class);
+            when(rackAwareTaskAssignor.canEnableRackAwareAssignor()).thenReturn(false);
+        } else {
+            rackAwareTaskAssignor = null;
+        }
+    }
+
     @Test
     public void shouldReturnClientTagAwareStandbyTaskAssignorWhenRackAwareAssignmentTagsIsSet() {
-        final StandbyTaskAssignor standbyTaskAssignor = StandbyTaskAssignorFactory.create(newAssignmentConfigs(singletonList("az")));
+        final StandbyTaskAssignor standbyTaskAssignor = StandbyTaskAssignorFactory.create(newAssignmentConfigs(singletonList("az")), rackAwareTaskAssignor);
         assertTrue(standbyTaskAssignor instanceof ClientTagAwareStandbyTaskAssignor);
+        if (state != State.NULL) {
+            verify(rackAwareTaskAssignor, never()).canEnableRackAwareAssignor();
+            verify(rackAwareTaskAssignor, never()).racksForProcess();
+        }
     }
 
     @Test
     public void shouldReturnDefaultStandbyTaskAssignorWhenRackAwareAssignmentTagsIsEmpty() {
-        final StandbyTaskAssignor standbyTaskAssignor = StandbyTaskAssignorFactory.create(newAssignmentConfigs(Collections.emptyList()));
-        assertTrue(standbyTaskAssignor instanceof DefaultStandbyTaskAssignor);
+        final StandbyTaskAssignor standbyTaskAssignor = StandbyTaskAssignorFactory.create(newAssignmentConfigs(Collections.emptyList()), rackAwareTaskAssignor);
+        if (state == State.ENABLED) {
+            assertTrue(standbyTaskAssignor instanceof ClientTagAwareStandbyTaskAssignor);
+            verify(rackAwareTaskAssignor, times(1)).racksForProcess();
+            verify(rackAwareTaskAssignor, times(1)).canEnableRackAwareAssignor();
+        } else if (state == State.DISABLED) {
+            assertTrue(standbyTaskAssignor instanceof DefaultStandbyTaskAssignor);
+            verify(rackAwareTaskAssignor, never()).racksForProcess();
+            verify(rackAwareTaskAssignor, times(1)).canEnableRackAwareAssignor();
+        } else {
+            assertTrue(standbyTaskAssignor instanceof DefaultStandbyTaskAssignor);
+        }
     }
 
     private static AssignorConfiguration.AssignmentConfigs newAssignmentConfigs(final List<String> rackAwareAssignmentTags) {


### PR DESCRIPTION
## Description
Update `ClientTagAwareStandbyTaskAssignor` to take functional params so that we can pass custom tags from racks. The PR is on top of https://github.com/apache/kafka/pull/14030

## Testing
Unit test
