### PR TITLE
MINOR: Upgrade version of gradle-versions-plugin to 0.47.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.ben-manes.versions' version '0.46.0'
+  id 'com.github.ben-manes.versions' version '0.47.0'
   id 'idea'
   id 'java-library'
   id 'org.owasp.dependencycheck' version '8.2.1'


### PR DESCRIPTION
Upgrade the version of `Gradle` versions plugin, to version 0.47.0 is a too minor change that have no affect on the build process or design, nor documentation, but I can see it's very important to keep this plugin version up to date, because it's one of powerful tools that can give us a good insight about the already used versions, far from that it can suggest a newer available stable version 


The last stable version of plugin contains much dependency upgrades then bug fixing 
to read more about those changes please refer to the release notes : 

https://github.com/ben-manes/gradle-versions-plugin/releases

There is no change of the existing behaviour the command (related to the plugin ) : 

`./gradlew dependencyUpdates`

Works perfectly on local of course where it's more needed 


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
