### PR TITLE
Source task stop call was added to force stopping execution.

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
@@ -299,6 +299,7 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
     @Override
     public void stop() {
         super.stop();
+        task.stop();
         stopRequestedLatch.countDown();
     }
 


### PR DESCRIPTION
We face a problem with restarting of the tasks, sometimes it leads to resource leak. 

We used the jdbc source connector and noticed an increasing of count of opened sessions on Vertica side. But this problem is applicable for all databases and possibly for all source connectors.

Our case is the next: 
1) Run jdbc source connector (io.confluent.connect.jdbc.JdbcSourceConnector) and set poll.interval.ms (86400000) > task.shutdown.graceful.timeout.ms (it's the property on Kafka-connect side, we set 10000)
2) Send POST /connectors/<connector_name>/tasks/<task_number>/restart
ER: count of session is the same as before restart
AR: count of session increases

The main problem is when org.apache.kafka.connect.runtime.Worker#stopAndAwaitTasks(java.util.Collection<org.apache.kafka.connect.util.ConnectorTaskId>)  method is called it doesn't stop a source task itself. 
The source task stops only if polling process stops on source task side. But if polling is continuing for a long time it leads to  resource occupation as a result it can lead to the fail on DB side. We suggest to stop source task explicitly 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
