### PR TITLE
KAFKA-14585: 1st part : Java versions for metadata/broker and updated LogConfig

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/broker/BrokerMetadataCheckpoint.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/broker/BrokerMetadataCheckpoint.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.broker;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Utils;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+public class BrokerMetadataCheckpoint {
+    static LogContext logContext = new LogContext("[BrokerMetadataCheckpoint] ");
+    static Logger log = logContext.logger(BrokerMetadataCheckpoint.class);
+    private final File file;
+    private final Object lock = new Object();
+
+    public BrokerMetadataCheckpoint(File file) {
+        this.file = file;
+    }
+
+    public void write(Properties properties) throws IOException {
+        synchronized (lock) {
+            try {
+                File temp = new File(file.getAbsolutePath() + ".tmp");
+                FileOutputStream fileOutputStream = new FileOutputStream(temp);
+                try {
+                    properties.store(fileOutputStream, "");
+                    fileOutputStream.flush();
+                    fileOutputStream.getFD().sync();
+                } finally {
+                    Utils.closeQuietly(fileOutputStream, temp.getName());
+                }
+                Utils.atomicMoveWithFallback(temp.toPath(), file.toPath());
+            } catch (IOException e) {
+                log.error("Failed to write meta.properties due to", e);
+                throw e;
+            }
+        }
+    }
+
+    public Optional<Properties> read() throws IOException {
+        Files.deleteIfExists(new File(file.getPath() + ".tmp").toPath());
+
+        String absolutePath = file.getAbsolutePath();
+        synchronized (lock) {
+            try {
+                return Optional.of(Utils.loadProps(absolutePath));
+            } catch (NoSuchFileException e) {
+                log.warn("No meta.properties file under dir " + absolutePath);
+                return Optional.empty();
+            } catch (Exception e) {
+                log.error("Failed to read meta.properties file under dir " + absolutePath, e);
+                throw e;
+            }
+        }
+    }
+
+    public static Pair<RawMetaProperties, List<String>> getBrokerMetadataAndOfflineDirs(
+        List<String> logDirs,
+        boolean ignoreMissing,
+        boolean kraftMode
+    ) {
+        if (logDirs.isEmpty()) {
+            throw new IllegalArgumentException("Must have at least one log dir to read meta.properties");
+        }
+
+        Map<String, Properties> brokerMetadataMap = new HashMap<>();
+        List<String> offlineDirs = new ArrayList<>();
+
+        for (String logDir : logDirs) {
+            File brokerCheckpointFile = new File(logDir, "meta.properties");
+            BrokerMetadataCheckpoint brokerCheckpoint = new BrokerMetadataCheckpoint(brokerCheckpointFile);
+
+            try {
+                Optional<Properties> propertiesOptional = brokerCheckpoint.read();
+                if (propertiesOptional.isPresent()) {
+                    brokerMetadataMap.put(logDir, propertiesOptional.get());
+                } else {
+                    if (!ignoreMissing) {
+                        throw new KafkaException("No `meta.properties` found in " + logDir +
+                            " (have you run `kafka-storage.sh` to format the directory?)");
+                    }
+                }
+            } catch (IOException e) {
+                offlineDirs.add(logDir);
+                log.error("Failed to read " + brokerCheckpointFile, e);
+            }
+        }
+
+        if (brokerMetadataMap.isEmpty()) {
+            return new Pair<>(new RawMetaProperties(new Properties()), offlineDirs);
+        } else {
+            int numDistinctMetaProperties;
+            if (kraftMode) {
+                Set<MetaProperties> distinctMetaProperties = new HashSet<>();
+                for (Properties props : brokerMetadataMap.values()) {
+                    distinctMetaProperties.add(MetaProperties.parse(new RawMetaProperties(props)));
+                }
+
+                numDistinctMetaProperties = distinctMetaProperties.size();
+            } else {
+                numDistinctMetaProperties = brokerMetadataMap.values().size();
+            }
+
+            if (numDistinctMetaProperties > 1) {
+                StringBuilder builder = new StringBuilder();
+                for (Map.Entry<String, Properties> entry : brokerMetadataMap.entrySet()) {
+                    builder.append("- ").append(entry.getKey()).append(" -> ").append(entry.getValue()).append("\n");
+                }
+                throw new InconsistentBrokerMetadataException("BrokerMetadata is not consistent across log.dirs. " +
+                    "This could happen if multiple brokers shared a log directory (log.dirs) " +
+                    "or partial data was manually copied from another broker. Found:\n" + builder.toString());
+            }
+
+            RawMetaProperties rawProps = new RawMetaProperties(new ArrayList<>(brokerMetadataMap.values()).get(0));
+            return new Pair<>(rawProps, offlineDirs);
+        }
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/broker/InconsistentBrokerMetadataException.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/broker/InconsistentBrokerMetadataException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.broker;
+
+public class InconsistentBrokerMetadataException extends RuntimeException {
+    public InconsistentBrokerMetadataException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InconsistentBrokerMetadataException(String message) {
+        super(message);
+    }
+
+    public InconsistentBrokerMetadataException(Throwable cause) {
+        super(cause);
+    }
+
+    public InconsistentBrokerMetadataException() {
+        super();
+    }
+}
+

--- a/metadata/src/main/java/org/apache/kafka/metadata/broker/MetaProperties.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/broker/MetaProperties.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.broker;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.apache.kafka.metadata.broker.RawMetaProperties.BROKER_ID_KEY;
+import static org.apache.kafka.metadata.broker.RawMetaProperties.CLUSTER_ID_KEY;
+import static org.apache.kafka.metadata.broker.RawMetaProperties.NODE_ID_KEY;
+
+public class MetaProperties {
+    private String clusterId;
+    private int nodeId;
+
+    public MetaProperties(String clusterId, int nodeId) {
+        this.clusterId = clusterId;
+        this.nodeId = nodeId;
+    }
+
+    public String getClusterId() {
+        return clusterId;
+    }
+
+    public void setClusterId(String clusterId) {
+        this.clusterId = clusterId;
+    }
+
+    public int getNodeId() {
+        return nodeId;
+    }
+
+    public void setNodeId(int nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    public Properties toProperties() {
+        Properties props = new Properties();
+        RawMetaProperties properties = new RawMetaProperties(props);
+        properties.setVersion(1);
+        properties.setClusterId(clusterId);
+        properties.setNodeId(nodeId);
+        return properties.getProps();
+    }
+
+    public static MetaProperties parse(RawMetaProperties properties) {
+        String clusterId = require(CLUSTER_ID_KEY, properties.getClusterId());
+
+        if (properties.getVersion() == 1) {
+            Integer nodeId = require(NODE_ID_KEY, properties.getNodeId());
+            return new MetaProperties(clusterId, nodeId);
+        } else if (properties.getVersion() == 0) {
+            Integer brokerId = require(BROKER_ID_KEY, properties.getBrokerId());
+            return new MetaProperties(clusterId, brokerId);
+        } else {
+            throw new RuntimeException("Expected version 0 or 1, but got version " + properties.getVersion());
+        }
+    }
+
+    private static <T> T require(String key, Optional<T> value) {
+        return value.orElseThrow(() -> new RuntimeException("Failed to find required property " + key + "."));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MetaProperties that = (MetaProperties) o;
+        return nodeId == that.nodeId && Objects.equals(clusterId, that.clusterId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterId, nodeId);
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/broker/Pair.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/broker/Pair.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.broker;
+
+public class Pair<K, V> {
+    private K key;
+    private V value;
+
+    public Pair(K key, V value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public K getKey() {
+        return key;
+    }
+
+    public V getValue() {
+        return value;
+    }
+
+    public void setKey(K key) {
+        this.key = key;
+    }
+
+    public void setValue(V value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "Pair{" +
+            "key=" + key +
+            ", value=" + value +
+            '}';
+    }
+}
+

--- a/metadata/src/main/java/org/apache/kafka/metadata/broker/RawMetaProperties.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/broker/RawMetaProperties.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.broker;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+public class RawMetaProperties {
+    public static final String CLUSTER_ID_KEY = "cluster.id";
+    public static final String BROKER_ID_KEY = "broker.id";
+    public static final String NODE_ID_KEY = "node.id";
+    public static final String VERSION_KEY = "version";
+
+    private Properties props;
+
+    public RawMetaProperties(Properties props) {
+        this.props = props != null ? props : new Properties();
+    }
+
+    public Optional<String> getClusterId() {
+        return Optional.ofNullable(props.getProperty(CLUSTER_ID_KEY));
+    }
+
+    public void setClusterId(String id) {
+        props.setProperty(CLUSTER_ID_KEY, id);
+    }
+
+    public Optional<Integer> getBrokerId() {
+        return intValue(BROKER_ID_KEY);
+    }
+
+    public void setBrokerId(int id) {
+        props.setProperty(BROKER_ID_KEY, Integer.toString(id));
+    }
+
+    public Optional<Integer> getNodeId() {
+        return intValue(NODE_ID_KEY);
+    }
+
+    public void setNodeId(int id) {
+        props.setProperty(NODE_ID_KEY, Integer.toString(id));
+    }
+
+    public int getVersion() {
+        return intValue(VERSION_KEY).orElse(0);
+    }
+
+    public void setVersion(int ver) {
+        props.setProperty(VERSION_KEY, Integer.toString(ver));
+    }
+
+    public Properties getProps() {
+        return props;
+    }
+
+    public void requireVersion(int expectedVersion) {
+        if (getVersion() != expectedVersion) {
+            throw new RuntimeException("Expected version " + expectedVersion + ", but got version " + getVersion());
+        }
+    }
+
+    private Optional<Integer> intValue(String key) {
+        try {
+            return Optional.ofNullable(props.getProperty(key)).map(Integer::parseInt);
+        } catch (Throwable e) {
+            throw new RuntimeException("Failed to parse " + key + " property as an int: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof RawMetaProperties) {
+            RawMetaProperties other = (RawMetaProperties) obj;
+            return props.equals(other.props);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return props.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        List<String> keys = new ArrayList<>(props.stringPropertyNames());
+        Collections.sort(keys);
+
+        List<String> keyValuePairs = new ArrayList<>();
+        for (String key : keys) {
+            String value = props.getProperty(key);
+            keyValuePairs.add(key + "=" + value);
+        }
+
+        return "{" + String.join(", ", keyValuePairs) + "}";
+    }
+}
+
+

--- a/metadata/src/main/java/org/apache/kafka/metadata/broker/ZkMetaProperties.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/broker/ZkMetaProperties.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.broker;
+
+import java.util.Properties;
+
+public class ZkMetaProperties {
+    private String clusterId;
+    private int brokerId;
+
+    public ZkMetaProperties(String clusterId, int brokerId) {
+        this.clusterId = clusterId;
+        this.brokerId = brokerId;
+    }
+
+    public String getClusterId() {
+        return clusterId;
+    }
+
+    public void setClusterId(String clusterId) {
+        this.clusterId = clusterId;
+    }
+
+    public int getBrokerId() {
+        return brokerId;
+    }
+
+    public void setBrokerId(int brokerId) {
+        this.brokerId = brokerId;
+    }
+
+    public Properties toProperties() {
+        Properties props = new Properties();
+        RawMetaProperties properties = new RawMetaProperties(props);
+        properties.setVersion(0);
+        properties.setClusterId(clusterId);
+        properties.setBrokerId(brokerId);
+        return properties.getProps();
+    }
+
+    @Override
+    public String toString() {
+        return "ZkMetaProperties(brokerId=" + brokerId + ", clusterId=" + clusterId + ")";
+    }
+}
+

--- a/metadata/src/test/java/org/apache/kafka/metadata/broker/BrokerMetadataCheckpointTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/broker/BrokerMetadataCheckpointTest.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.broker;
+
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class BrokerMetadataCheckpointTest {
+    private final String clusterIdBase64 = "H3KKO4NTRPaCWtEmm3vW7A";
+
+    @Test
+    public void testReadWithNonExistentFile() throws IOException {
+        assertEquals(Optional.empty(), new BrokerMetadataCheckpoint(new File("path/that/does/not/exist")).read());
+    }
+
+    @Test
+    public void testCreateZkMetadataProperties() {
+        ZkMetaProperties meta = new ZkMetaProperties("7bc79ca1-9746-42a3-a35a-efb3cde44492", 3);
+        Properties properties = meta.toProperties();
+        RawMetaProperties parsed = new RawMetaProperties(properties);
+        assertEquals(0, parsed.getVersion());
+        assertEquals(meta.getClusterId(), parsed.getClusterId().get());
+        assertEquals(meta.getBrokerId(), parsed.getBrokerId().get());
+    }
+
+    @Test
+    public void testParseRawMetaPropertiesWithoutVersion() {
+        int brokerId = 1;
+        String clusterId = "7bc79ca1-9746-42a3-a35a-efb3cde44492";
+
+        Properties properties = new Properties();
+        properties.put(RawMetaProperties.BROKER_ID_KEY, Integer.toString(brokerId));
+        properties.put(RawMetaProperties.CLUSTER_ID_KEY, clusterId);
+
+        RawMetaProperties parsed = new RawMetaProperties(properties);
+        assertEquals(brokerId, (int) parsed.getBrokerId().get());
+        assertEquals(clusterId, parsed.getClusterId().get());
+        assertEquals(0, parsed.getVersion());
+    }
+
+    @Test
+    public void testRawPropertiesWithInvalidBrokerId() {
+        Properties properties = new Properties();
+        properties.put(RawMetaProperties.BROKER_ID_KEY, "oof");
+        RawMetaProperties parsed = new RawMetaProperties(properties);
+        assertThrows(RuntimeException.class, parsed::getBrokerId);
+    }
+
+    @Test
+    public void testCreateMetadataProperties() {
+        confirmValidForMetaProperties(clusterIdBase64);
+    }
+
+    @Test
+    public void testMetaPropertiesWithMissingVersion() {
+        Properties props = new Properties();
+        RawMetaProperties properties = new RawMetaProperties(props);
+        properties.setClusterId(clusterIdBase64);
+        properties.setNodeId(1);
+        assertThrows(RuntimeException.class, () -> MetaProperties.parse(properties));
+    }
+
+    @Test
+    public void testMetaPropertiesAllowsHexEncodedUUIDs() {
+        String clusterId = "7bc79ca1-9746-42a3-a35a-efb3cde44492";
+        confirmValidForMetaProperties(clusterId);
+    }
+
+    @Test
+    public void testMetaPropertiesWithNonUuidClusterId() {
+        String clusterId = "not a valid uuid";
+        confirmValidForMetaProperties(clusterId);
+    }
+
+    private void confirmValidForMetaProperties(String clusterId) {
+        MetaProperties meta = new MetaProperties(clusterId, 5);
+        MetaProperties meta2 = MetaProperties.parse(new RawMetaProperties(meta.toProperties()));
+        assertEquals(meta.toProperties(), meta2.toProperties());
+    }
+
+    @Test
+    public void testMetaPropertiesWithMissingBrokerId() {
+        Properties props = new Properties();
+        RawMetaProperties properties = new RawMetaProperties(props);
+        properties.setVersion(1);
+        properties.setClusterId(clusterIdBase64);
+        assertThrows(RuntimeException.class, () -> MetaProperties.parse(properties));
+    }
+
+    @Test
+    public void testMetaPropertiesWithMissingControllerId() {
+        Properties props = new Properties();
+        RawMetaProperties properties = new RawMetaProperties(props);
+        properties.setVersion(1);
+        properties.setClusterId(clusterIdBase64);
+        assertThrows(RuntimeException.class, () -> MetaProperties.parse(properties));
+    }
+
+    @Test
+    public void testMetaPropertiesWithVersionZero() {
+        Properties props = new Properties();
+        RawMetaProperties properties = new RawMetaProperties(props);
+        properties.setVersion(0);
+        properties.setClusterId(clusterIdBase64);
+        properties.setBrokerId(5);
+        MetaProperties metaProps = MetaProperties.parse(properties);
+        assertEquals(clusterIdBase64, metaProps.getClusterId());
+        assertEquals(5, metaProps.getNodeId());
+    }
+
+    @Test
+    public void testValidMetaPropertiesWithMultipleVersionsInLogDirs() {
+        // Let's create two directories with meta.properties one in v0 and v1.
+        Properties properties1 = new Properties();
+        RawMetaProperties props1 = new RawMetaProperties(properties1);
+        props1.setVersion(0);
+        props1.setClusterId(clusterIdBase64);
+        props1.setBrokerId(5);
+
+        Properties properties2 = new Properties();
+        RawMetaProperties props2 = new RawMetaProperties(properties2);
+        props2.setVersion(1);
+        props2.setClusterId(clusterIdBase64);
+        props2.setNodeId(5);
+
+        for (boolean ignoreMissing : new boolean[]{true, false}) {
+            Pair<RawMetaProperties, List<String>> result = getMetadataWithMultipleMetaPropLogDirs(
+                Arrays.asList(props1, props2), ignoreMissing, true
+            );
+
+            RawMetaProperties metaProps = result.getKey();
+            List<String> offlineDirs = result.getValue();
+
+            Assertions.assertEquals(MetaProperties.parse(props2), MetaProperties.parse(metaProps));
+            Assertions.assertEquals(new ArrayList<>(), offlineDirs);
+        }
+    }
+
+    @Test
+    public void testInvalidMetaPropertiesWithMultipleVersionsInLogDirs() {
+        // Let's create two directories with meta.properties one in v0 and v1.
+        Properties properties1 = new Properties();
+        RawMetaProperties props1 = new RawMetaProperties(properties1);
+        props1.setVersion(0);
+        props1.setBrokerId(5);
+
+        Properties properties2 = new Properties();
+        RawMetaProperties props2 = new RawMetaProperties(properties2);
+        props2.setVersion(1);
+        props2.setClusterId(clusterIdBase64);
+        props2.setNodeId(5);
+
+        for (boolean ignoreMissing : new boolean[]{true, false}) {
+            Assertions.assertThrows(RuntimeException.class, () -> {
+                getMetadataWithMultipleMetaPropLogDirs(Arrays.asList(props1, props2), ignoreMissing, true);
+            });
+        }
+    }
+
+    private Pair<RawMetaProperties, List<String>> getMetadataWithMultipleMetaPropLogDirs(
+        List<RawMetaProperties> metaProperties,
+        boolean ignoreMissing,
+        boolean kraftMode
+    ) {
+        List<File> logDirs = new ArrayList<>();
+        try {
+            for (RawMetaProperties mp : metaProperties) {
+                File logDir = TestUtils.tempDirectory();
+                logDirs.add(logDir);
+                File propFile = new File(logDir.getAbsolutePath(), "meta.properties");
+                FileOutputStream fs = new FileOutputStream(propFile);
+                try {
+                    mp.getProps().store(fs, "");
+                    fs.flush();
+                    fs.getFD().sync();
+                } finally {
+                    Utils.closeQuietly(fs, propFile.getName());
+                }
+            }
+            List<String> logDirPaths = new ArrayList<>();
+            for (File dir : logDirs) {
+                logDirPaths.add(dir.getAbsolutePath());
+            }
+            return BrokerMetadataCheckpoint.getBrokerMetadataAndOfflineDirs(logDirPaths, ignoreMissing, kraftMode);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            for (File logDir : logDirs) {
+                try {
+                    Utils.delete(logDir);
+                } catch (IOException e) {
+                    // swallow the error
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testGetBrokerMetadataAndOfflineDirsWithNonexistentDirectories() throws IOException {
+        // Use a regular file as an invalid log dir to trigger an IO error
+        File invalidDir = TestUtils.tempFile("blah");
+        try {
+            // The `ignoreMissing` and `kraftMode` flag has no effect if there is an IO error
+            testEmptyGetBrokerMetadataAndOfflineDirs(invalidDir,
+                Collections.singletonList(invalidDir), true, true);
+            testEmptyGetBrokerMetadataAndOfflineDirs(invalidDir,
+                Collections.singletonList(invalidDir), false, true);
+        } finally {
+            Utils.delete(invalidDir);
+        }
+    }
+
+    @Test
+    public void testGetBrokerMetadataAndOfflineDirsIgnoreMissing() throws IOException {
+        File tempDir = TestUtils.tempDirectory();
+        try {
+            testEmptyGetBrokerMetadataAndOfflineDirs(tempDir,
+                new ArrayList<>(), true, true);
+            testEmptyGetBrokerMetadataAndOfflineDirs(tempDir,
+                new ArrayList<>(), true, false);
+
+            Assertions.assertThrows(RuntimeException.class, () -> {
+                BrokerMetadataCheckpoint.getBrokerMetadataAndOfflineDirs(
+                    Collections.singletonList(tempDir.getAbsolutePath()), false, false);
+            });
+
+            Assertions.assertThrows(RuntimeException.class, () -> {
+                BrokerMetadataCheckpoint.getBrokerMetadataAndOfflineDirs(
+                    Collections.singletonList(tempDir.getAbsolutePath()), false, true);
+            });
+        } finally {
+            Utils.delete(tempDir);
+        }
+    }
+
+    private void testEmptyGetBrokerMetadataAndOfflineDirs(
+        File logDir,
+        List<File> expectedOfflineDirs,
+        boolean ignoreMissing,
+        boolean kraftMode
+    ) {
+        List<String> logDirPaths = new ArrayList<>();
+        logDirPaths.add(logDir.getAbsolutePath());
+
+        Pair<RawMetaProperties, List<String>> result = BrokerMetadataCheckpoint.getBrokerMetadataAndOfflineDirs(
+            logDirPaths,
+            ignoreMissing,
+            false
+        );
+
+        RawMetaProperties metaProperties = result.getKey();
+        List<String> offlineDirs = result.getValue();
+
+        List<String> expectedOfflineDirPaths = new ArrayList<>();
+        for (File dir : expectedOfflineDirs) {
+            expectedOfflineDirPaths.add(dir.getAbsolutePath());
+        }
+
+        Assertions.assertEquals(expectedOfflineDirPaths, offlineDirs);
+        Assertions.assertEquals(new Properties(), metaProperties.getProps());
+    }
+}
+


### PR DESCRIPTION
Description
This PR does the below.
- Create java version for core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
- Update LogConfig with new constructor to handle nodeId, brokerId, zookeeper connect properties

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
