### PR TITLE
KAFKA-15022: [5/N] compute rack aware assignment for standby tasks

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -93,12 +93,23 @@ public class ClientState {
                        final Map<TaskId, Long> taskLagTotals,
                        final Map<String, String> clientTags,
                        final int capacity) {
+        this(previousActiveTasks, previousStandbyTasks, taskLagTotals, clientTags, capacity, null);
+    }
+
+    // For testing only
+    public ClientState(final Set<TaskId> previousActiveTasks,
+                       final Set<TaskId> previousStandbyTasks,
+                       final Map<TaskId, Long> taskLagTotals,
+                       final Map<String, String> clientTags,
+                       final int capacity,
+                       final UUID processId) {
         this.previousStandbyTasks.taskIds(unmodifiableSet(new TreeSet<>(previousStandbyTasks)));
         this.previousActiveTasks.taskIds(unmodifiableSet(new TreeSet<>(previousActiveTasks)));
         taskOffsetSums = emptyMap();
         this.taskLagTotals = unmodifiableMap(taskLagTotals);
         this.capacity = capacity;
         this.clientTags = unmodifiableMap(clientTags);
+        this.processId = processId;
     }
 
     int capacity() {
@@ -131,6 +142,10 @@ public class ClientState {
 
     public void assignActiveTasks(final Collection<TaskId> tasks) {
         assignedActiveTasks.taskIds().addAll(tasks);
+    }
+
+    public void assignStandbyTasks(final Collection<TaskId> tasks) {
+        assignedStandbyTasks.taskIds().addAll(tasks);
     }
 
     public void assignActiveToConsumer(final TaskId task, final String consumer) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -206,6 +206,10 @@ public class ClientState {
         return assignedStandbyTasks.taskIds().contains(taskId);
     }
 
+    boolean hasActiveTask(final TaskId taskId) {
+        return assignedActiveTasks.taskIds().contains(taskId);
+    }
+
     int standbyTaskCount() {
         return assignedStandbyTasks.taskIds().size();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignor.java
@@ -150,10 +150,6 @@ class ClientTagAwareStandbyTaskAssignor implements StandbyTaskAssignor {
         final Map<String, String> sourceClientTags = clientTagFunction.apply(source.processId(), source);
         final Map<String, String> destinationClientTags = clientTagFunction.apply(destination.processId(), destination);
 
-        if (sourceClientTags.size() != destinationClientTags.size()) {
-            return false;
-        }
-
         for (final Entry<String, String> sourceClientTagEntry : sourceClientTags.entrySet()) {
             if (!sourceClientTagEntry.getValue().equals(destinationClientTags.get(sourceClientTagEntry.getKey()))) {
                 return false;
@@ -163,6 +159,16 @@ class ClientTagAwareStandbyTaskAssignor implements StandbyTaskAssignor {
         return true;
     }
 
+    /**
+     * Whether one task can be moved from source to destination. If the number of distinct tags including active
+     * and standby after the movement isn't decreased, then we can move the task. Otherwise, we can not move
+     * the task.
+     * @param source Source client
+     * @param destination Destination client
+     * @param sourceTask Task to move
+     * @param clientStateMap All client metadata
+     * @return If the task can be moved
+     */
     @Override
     public boolean isAllowedTaskMovement(final ClientState source,
                                          final ClientState destination,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignor.java
@@ -147,6 +147,10 @@ class ClientTagAwareStandbyTaskAssignor implements StandbyTaskAssignor {
         final Map<String, String> sourceClientTags = clientTagFunction.apply(source.processId(), source);
         final Map<String, String> destinationClientTags = clientTagFunction.apply(destination.processId(), destination);
 
+        if (sourceClientTags.size() != destinationClientTags.size()) {
+            return false;
+        }
+
         for (final Entry<String, String> sourceClientTagEntry : sourceClientTags.entrySet()) {
             if (!sourceClientTagEntry.getValue().equals(destinationClientTags.get(sourceClientTagEntry.getKey()))) {
                 return false;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
@@ -102,7 +102,6 @@ public class RackAwareTaskAssignor {
             return false;
         }
          */
-        // TODO: add changelog topic, standby task validation
         if (canEnable != null) {
             return canEnable;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
@@ -375,10 +375,18 @@ public class RackAwareTaskAssignor {
             for (int j = i + 1; j < clientList.size(); j++) {
                 final ClientState clientState2 = clientStates.get(clientList.get(j));
 
+                final String rack1 = racksForProcess.get(clientState1.processId());
+                final String rack2 = racksForProcess.get(clientState2.processId());
+                // Cross rack traffic can not be reduced if racks are the same
+                if (rack1.equals(rack2)) {
+                    continue;
+                }
+
                 final List<TaskId> movable1 = getMovableTasks.apply(clientState1, clientState2);
                 final List<TaskId> movable2 = getMovableTasks.apply(clientState2, clientState1);
 
-                // There's no needed to optimize if one is empty
+                // There's no needed to optimize if one is empty because the optimization
+                // can only swap tasks to keep the client's load balanced
                 if (movable1.isEmpty() || movable2.isEmpty()) {
                     continue;
                 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
@@ -337,7 +337,7 @@ public class RackAwareTaskAssignor {
                     Collectors.toList());
                 final Map<UUID, Integer> originalAssignedTaskNumber = new HashMap<>();
 
-                Graph<Integer> graph = constructTaskGraph(clients, taskIdList, clientStates, taskClientMap, originalAssignedTaskNumber,
+                final Graph<Integer> graph = constructTaskGraph(clients, taskIdList, clientStates, taskClientMap, originalAssignedTaskNumber,
                     ClientState::hasStandbyTask, trafficCost, nonOverlapCost);
                 graph.solveMinCostFlow();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
@@ -364,6 +364,7 @@ public class RackAwareTaskAssignor {
         final BiFunction<ClientState, ClientState, List<TaskId>> getMovableTasks = (source, destination) -> source.standbyTasks().stream()
             .filter(task -> !destination.hasAssignedTask(task))
             .filter(task -> moveStandbyTask.canMove(source, destination, task, clientStates))
+            .sorted()
             .collect(Collectors.toList());
 
         final List<UUID> clientList = new ArrayList<>(clientStates.keySet());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignor.java
@@ -16,8 +16,27 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
+import java.util.Map;
+import java.util.UUID;
+import org.apache.kafka.streams.processor.TaskId;
+
 interface StandbyTaskAssignor extends TaskAssignor {
     default boolean isAllowedTaskMovement(final ClientState source, final ClientState destination) {
+        return true;
+    }
+
+    /**
+     * If a specific task can be moved from source to destination
+     * @param source Source client
+     * @param destination Destination client
+     * @param sourceTask Task to move
+     * @param clientStateMap All client metadata
+     * @return True if task can be moved, false otherwise
+     */
+    default boolean isAllowedTaskMovement(final ClientState source,
+                                          final ClientState destination,
+                                          final TaskId sourceTask,
+                                          final Map<UUID, ClientState> clientStateMap) {
         return true;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -91,6 +91,10 @@ public final class AssignmentTestUtils {
     public static final String TP_0_NAME = "topic0";
     public static final String TP_1_NAME = "topic1";
 
+    public static final String CHANGELOG_TP_0_NAME = "store-0-changelog";
+
+    public static final TopicPartition CHANGELOG_TP_0_0 = new TopicPartition(CHANGELOG_TP_0_NAME, 0);
+
     public static final TopicPartition TP_0_0 = new TopicPartition(TP_0_NAME, 0);
     public static final TopicPartition TP_0_1 = new TopicPartition(TP_0_NAME, 1);
     public static final TopicPartition TP_0_2 = new TopicPartition(TP_0_NAME, 2);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -92,8 +92,14 @@ public final class AssignmentTestUtils {
     public static final String TP_1_NAME = "topic1";
 
     public static final String CHANGELOG_TP_0_NAME = "store-0-changelog";
+    public static final String CHANGELOG_TP_1_NAME = "store-1-changelog";
 
     public static final TopicPartition CHANGELOG_TP_0_0 = new TopicPartition(CHANGELOG_TP_0_NAME, 0);
+    public static final TopicPartition CHANGELOG_TP_0_1 = new TopicPartition(CHANGELOG_TP_0_NAME, 1);
+    public static final TopicPartition CHANGELOG_TP_0_2 = new TopicPartition(CHANGELOG_TP_0_NAME, 2);
+    public static final TopicPartition CHANGELOG_TP_1_0 = new TopicPartition(CHANGELOG_TP_1_NAME, 0);
+    public static final TopicPartition CHANGELOG_TP_1_1 = new TopicPartition(CHANGELOG_TP_1_NAME, 1);
+    public static final TopicPartition CHANGELOG_TP_1_2 = new TopicPartition(CHANGELOG_TP_1_NAME, 2);
 
     public static final TopicPartition TP_0_0 = new TopicPartition(TP_0_NAME, 0);
     public static final TopicPartition TP_0_1 = new TopicPartition(TP_0_NAME, 1);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -110,6 +110,7 @@ public final class AssignmentTestUtils {
 
     public static final PartitionInfo PI_0_0 = new PartitionInfo(TP_0_NAME, 0, NODE_0, REPLICA_0, REPLICA_0);
     public static final PartitionInfo PI_0_1 = new PartitionInfo(TP_0_NAME, 1, NODE_1, REPLICA_1, REPLICA_1);
+    public static final PartitionInfo PI_0_2 = new PartitionInfo(TP_0_NAME, 2, NODE_1, REPLICA_1, REPLICA_1);
     public static final PartitionInfo PI_1_0 = new PartitionInfo(TP_1_NAME, 0, NODE_2, REPLICA_2, REPLICA_2);
     public static final PartitionInfo PI_1_1 = new PartitionInfo(TP_1_NAME, 1, NODE_3, REPLICA_3, REPLICA_3);
     public static final PartitionInfo PI_1_2 = new PartitionInfo(TP_1_NAME, 2, NODE_0, REPLICA_0, REPLICA_0);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
@@ -1091,7 +1091,10 @@ public class RackAwareTaskAssignorTest {
         final SortedMap<TaskId, Set<TopicPartition>> taskTopicPartitionMap = new TreeMap<>();
         final String topicName = changelog ? CHANGELOG_TOPIC_PREFIX : TOPIC_PREFIX;
         for (int i = 0; i < tpSize; i++) {
-            taskTopicPartitionMap.put(new TaskId(i, 0), mkSet(new TopicPartition(topicName + i, 0)));
+            taskTopicPartitionMap.put(new TaskId(i, 0), mkSet(
+                new TopicPartition(topicName + i, 0),
+                new TopicPartition(topicName + (i + 1) % tpSize, 0)
+            ));
         }
         return taskTopicPartitionMap;
     }


### PR DESCRIPTION
## Description
Optimize cross rack traffic for standby tasks. This is a greedy algorithm to find optimal assignment between each pair of clients if standby tasks between them can be swapped. This PR is on top of https://github.com/apache/kafka/pull/14097

## Test
Unit tests
