### PR TITLE
KAFKA-15261: Do not block replica fetcher if RLMM is not initialized

### DIFF
--- a/checkstyle/import-control-core.xml
+++ b/checkstyle/import-control-core.xml
@@ -88,6 +88,7 @@
   <subpackage name="server">
     <allow pkg="kafka" />
     <allow pkg="org.apache.kafka" />
+    <allow pkg="org.mockito" />
   </subpackage>
 
   <subpackage name="test">

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -421,6 +421,16 @@ public class RemoteLogManager implements Closeable {
         return CompletableFuture.allOf(result.toArray(new CompletableFuture[0]));
     }
 
+    public boolean isInitialized(TopicPartition topicPartition) throws RemoteStorageException {
+        Uuid topicId = topicIdByPartitionMap.get(topicPartition);
+
+        if (topicId == null) {
+            throw new KafkaException("No topic id registered for topic partition: " + topicPartition);
+        }
+
+        return remoteLogMetadataManager.isInitialized(new TopicIdPartition(topicId, topicPartition));
+    }
+
     public Optional<RemoteLogSegmentMetadata> fetchRemoteLogSegmentMetadata(TopicPartition topicPartition,
                                                                             int epochForOffset,
                                                                             long offset) throws RemoteStorageException {

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataManager.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataManager.java
@@ -210,4 +210,14 @@ public interface RemoteLogMetadataManager extends Configurable, Closeable {
      * @return Total size of the log stored in remote storage in bytes.
      */
     long remoteLogSize(TopicIdPartition topicIdPartition, int leaderEpoch) throws RemoteStorageException;
+
+    /**
+     * Denotes whether the partition metadata is ready to serve.
+     *
+     * @param topicIdPartition topic partition
+     * @return True if the partition is initialized for remote storage operations.
+     */
+    default boolean isInitialized(TopicIdPartition topicIdPartition) throws RemoteStorageException {
+        return true;
+    }
 }

--- a/storage/api/src/test/java/org/apache/kafka/server/log/remote/storage/NoOpRemoteLogMetadataManager.java
+++ b/storage/api/src/test/java/org/apache/kafka/server/log/remote/storage/NoOpRemoteLogMetadataManager.java
@@ -80,6 +80,11 @@ public class NoOpRemoteLogMetadataManager implements RemoteLogMetadataManager {
     }
 
     @Override
+    public boolean isInitialized(TopicIdPartition topicIdPartition) {
+        return true;
+    }
+
+    @Override
     public void close() throws IOException {
     }
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ClassLoaderAwareRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ClassLoaderAwareRemoteLogMetadataManager.java
@@ -107,6 +107,11 @@ public class ClassLoaderAwareRemoteLogMetadataManager implements RemoteLogMetada
     }
 
     @Override
+    public boolean isInitialized(TopicIdPartition topicIdPartition) throws RemoteStorageException {
+        return withClassLoader(() -> delegate.isInitialized(topicIdPartition));
+    }
+
+    @Override
     public void configure(Map<String, ?> configs) {
         withClassLoader(() -> {
             delegate.configure(configs);


### PR DESCRIPTION
In this PR, I have added a check in the _buildRemoteLogAuxState_ method of `ReplicaFetcherTierStateMachine` to check if the RLMM is initialized for the given `TopicPartition` before fetching `RemoteLogSegmentMetadata`. If it is uninitialized, we throw an error which will make the `ReplicaFetcher` to retry after some time.

Without this check, the `fetchRemoteLogSegmentMetadata` method in RLMM will block until the `RemoteLogMetadataCache` initalizes and this will prevent other ReplicaFetchers from running as well, also block handling of `LeaderAndIsrRequest` (They all share a common lock)

Added unit tests for the changes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
