### PR TITLE
KAFKA-15263 Check KRaftMigrationDriver state in each event

### DIFF
--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -163,7 +163,10 @@ class ZkMigrationIntegrationTest {
       readyFuture.get(30, TimeUnit.SECONDS)
 
       val zkClient = zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying().zkClient
-      TestUtils.waitUntilTrue(() => zkClient.getControllerId.contains(3000), "Timed out waiting for KRaft controller to take over")
+      TestUtils.waitUntilTrue(
+        () => zkClient.getControllerId.contains(3000),
+        "Timed out waiting for KRaft controller to take over",
+        30_000)
 
       def inDualWrite(): Boolean = {
         val migrationState = kraftCluster.controllers().get(3000).migrationSupport.get.migrationDriver.migrationState().get(10, TimeUnit.SECONDS)
@@ -286,7 +289,10 @@ class ZkMigrationIntegrationTest {
 
       // Wait for migration to begin
       log.info("Waiting for ZK migration to begin")
-      TestUtils.waitUntilTrue(() => zkClient.getControllerId.contains(3000), "Timed out waiting for KRaft controller to take over")
+      TestUtils.waitUntilTrue(
+        () => zkClient.getControllerId.contains(3000),
+        "Timed out waiting for KRaft controller to take over",
+        30_000)
 
       // Alter the metadata
       log.info("Updating metadata with AdminClient")
@@ -358,7 +364,10 @@ class ZkMigrationIntegrationTest {
 
       // Wait for migration to begin
       log.info("Waiting for ZK migration to begin")
-      TestUtils.waitUntilTrue(() => zkClient.getControllerId.contains(3000), "Timed out waiting for KRaft controller to take over")
+      TestUtils.waitUntilTrue(
+        () => zkClient.getControllerId.contains(3000),
+        "Timed out waiting for KRaft controller to take over",
+        30_000)
 
       // Alter the metadata
       log.info("Updating metadata with AdminClient")
@@ -422,7 +431,10 @@ class ZkMigrationIntegrationTest {
 
       // Wait for migration to begin
       log.info("Waiting for ZK migration to begin")
-      TestUtils.waitUntilTrue(() => zkClient.getControllerId.contains(3000), "Timed out waiting for KRaft controller to take over")
+      TestUtils.waitUntilTrue(
+        () => zkClient.getControllerId.contains(3000),
+        "Timed out waiting for KRaft controller to take over",
+        30_000)
 
       // Alter the metadata
       log.info("Updating metadata with AdminClient")
@@ -481,7 +493,10 @@ class ZkMigrationIntegrationTest {
 
       // Wait for migration to begin
       log.info("Waiting for ZK migration to begin")
-      TestUtils.waitUntilTrue(() => zkClient.getControllerId.contains(3000), "Timed out waiting for KRaft controller to take over")
+      TestUtils.waitUntilTrue(
+        () => zkClient.getControllerId.contains(3000),
+        "Timed out waiting for KRaft controller to take over",
+        30_000)
 
       // Alter the metadata
       log.info("Create new topic with AdminClient")

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
@@ -297,6 +297,16 @@ public class KRaftMigrationDriver implements MetadataPublisher {
         }
     }
 
+    private boolean checkDriverState(MigrationDriverState expectedState) {
+        if (migrationState.equals(expectedState)) {
+            return true;
+        } else {
+            log.info("Expected driver state {} but found {}. Not running this event {}.",
+                expectedState, migrationState, this.getClass().getSimpleName());
+            return false;
+        }
+    }
+
     private void transitionTo(MigrationDriverState newState) {
         if (!isValidStateChange(newState)) {
             throw new IllegalStateException(
@@ -520,7 +530,7 @@ public class KRaftMigrationDriver implements MetadataPublisher {
 
         @Override
         public void run() throws Exception {
-            if (migrationState.equals(MigrationDriverState.WAIT_FOR_CONTROLLER_QUORUM)) {
+            if (checkDriverState(MigrationDriverState.WAIT_FOR_CONTROLLER_QUORUM)) {
                 if (!firstPublish) {
                     log.trace("Waiting until we have received metadata before proceeding with migration");
                     return;
@@ -564,16 +574,11 @@ public class KRaftMigrationDriver implements MetadataPublisher {
     class WaitForZkBrokersEvent extends MigrationEvent {
         @Override
         public void run() throws Exception {
-            switch (migrationState) {
-                case WAIT_FOR_BROKERS:
-                    if (areZkBrokersReadyForMigration()) {
-                        log.info("Zk brokers are registered and ready for migration");
-                        transitionTo(MigrationDriverState.BECOME_CONTROLLER);
-                    }
-                    break;
-                default:
-                    // Ignore the event as we're not in the appropriate state anymore.
-                    break;
+            if (checkDriverState(MigrationDriverState.WAIT_FOR_BROKERS)) {
+                if (areZkBrokersReadyForMigration()) {
+                    log.info("Zk brokers are registered and ready for migration");
+                    transitionTo(MigrationDriverState.BECOME_CONTROLLER);
+                }
             }
         }
     }
@@ -581,7 +586,7 @@ public class KRaftMigrationDriver implements MetadataPublisher {
     class BecomeZkControllerEvent extends MigrationEvent {
         @Override
         public void run() throws Exception {
-            if (migrationState == MigrationDriverState.BECOME_CONTROLLER) {
+            if (checkDriverState(MigrationDriverState.BECOME_CONTROLLER)) {
                 applyMigrationOperation("Claiming ZK controller leadership", zkMigrationClient::claimControllerLeadership);
                 if (migrationLeadershipState.zkControllerEpochZkVersion() == -1) {
                     log.info("Unable to claim leadership, will retry until we learn of a different KRaft leader");
@@ -599,6 +604,9 @@ public class KRaftMigrationDriver implements MetadataPublisher {
     class MigrateMetadataEvent extends MigrationEvent {
         @Override
         public void run() throws Exception {
+            if (!checkDriverState(MigrationDriverState.ZK_MIGRATION)) {
+                return;
+            }
             Set<Integer> brokersInMetadata = new HashSet<>();
             log.info("Starting ZK migration");
             MigrationManifest.Builder manifestBuilder = MigrationManifest.newBuilder(time);
@@ -655,7 +663,7 @@ public class KRaftMigrationDriver implements MetadataPublisher {
     class SyncKRaftMetadataEvent extends MigrationEvent {
         @Override
         public void run() throws Exception {
-            if (migrationState == MigrationDriverState.SYNC_KRAFT_TO_ZK) {
+            if (checkDriverState(MigrationDriverState.SYNC_KRAFT_TO_ZK)) {
                 log.info("Performing a full metadata sync from KRaft to ZK.");
                 Map<String, Integer> dualWriteCounts = new TreeMap<>();
                 zkMetadataWriter.handleSnapshot(image, countingOperationConsumer(
@@ -671,7 +679,7 @@ public class KRaftMigrationDriver implements MetadataPublisher {
         @Override
         public void run() throws Exception {
             // Ignore sending RPCs to the brokers since we're no longer in the state.
-            if (migrationState == MigrationDriverState.KRAFT_CONTROLLER_TO_BROKER_COMM) {
+            if (checkDriverState(MigrationDriverState.KRAFT_CONTROLLER_TO_BROKER_COMM)) {
                 if (image.highestOffsetAndEpoch().compareTo(migrationLeadershipState.offsetAndEpoch()) >= 0) {
                     log.trace("Sending RPCs to broker before moving to dual-write mode using " +
                             "at offset and epoch {}", image.highestOffsetAndEpoch());

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
@@ -480,8 +480,9 @@ public class KRaftMigrationDriver implements MetadataPublisher {
                 log.trace("Received metadata {}, but the controller is not in dual-write " +
                         "mode. Ignoring the change to be replicated to Zookeeper", metadataType);
                 completionHandler.accept(null);
+                // If the driver is active and dual-write is not yet enabled, then the migration has not yet begun.
+                // Only wake up the thread if the broker registrations have changed
                 if (delta.clusterDelta() != null) {
-                    // Only wake up the thread if we've possibly seen new brokers register
                     wakeup();
                 }
                 return;

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
@@ -470,11 +470,16 @@ public class KRaftMigrationDriver implements MetadataPublisher {
             KRaftMigrationDriver.this.image = image;
             String metadataType = isSnapshot ? "snapshot" : "delta";
 
+            if (migrationState.equals(MigrationDriverState.INACTIVE)) {
+                // No need to log anything if this node is not the active controller
+                completionHandler.accept(null);
+                return;
+            }
+
             if (!migrationState.allowDualWrite()) {
                 log.trace("Received metadata {}, but the controller is not in dual-write " +
                         "mode. Ignoring the change to be replicated to Zookeeper", metadataType);
                 completionHandler.accept(null);
-                wakeup();
                 return;
             }
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
@@ -480,6 +480,10 @@ public class KRaftMigrationDriver implements MetadataPublisher {
                 log.trace("Received metadata {}, but the controller is not in dual-write " +
                         "mode. Ignoring the change to be replicated to Zookeeper", metadataType);
                 completionHandler.accept(null);
+                if (delta.clusterDelta() != null) {
+                    // Only wake up the thread if we've possibly seen new brokers register
+                    wakeup();
+                }
                 return;
             }
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
@@ -301,7 +301,7 @@ public class KRaftMigrationDriver implements MetadataPublisher {
         if (migrationState.equals(expectedState)) {
             return true;
         } else {
-            log.debug("Expected driver state {} but found {}. Not running this event {}.",
+            log.info("Expected driver state {} but found {}. Not running this event {}.",
                 expectedState, migrationState, this.getClass().getSimpleName());
             return false;
         }

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
@@ -301,7 +301,7 @@ public class KRaftMigrationDriver implements MetadataPublisher {
         if (migrationState.equals(expectedState)) {
             return true;
         } else {
-            log.info("Expected driver state {} but found {}. Not running this event {}.",
+            log.debug("Expected driver state {} but found {}. Not running this event {}.",
                 expectedState, migrationState, this.getClass().getSimpleName());
             return false;
         }

--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
@@ -666,9 +666,12 @@ public class KRaftMigrationDriverTest {
             image = delta.apply(provenance);
 
             driver.onControllerChange(new LeaderAndEpoch(OptionalInt.of(3000), 1));
+            
+            // Call onMetadataUpdate twice. The first call will trigger the migration to begin (due to presence of brokers)
+            // Both calls will "wakeup" the driver and cause a PollEvent to be run. Calling these back-to-back effectively
+            // causes two MigrateMetadataEvents to be enqueued. Ensure only one is actually run.
             driver.onMetadataUpdate(delta, image, new LogDeltaManifest(provenance,
                 new LeaderAndEpoch(OptionalInt.of(3000), 1), 1, 100, 42));
-
             driver.onMetadataUpdate(delta, image, new LogDeltaManifest(provenance,
                 new LeaderAndEpoch(OptionalInt.of(3000), 1), 1, 100, 42));
 


### PR DESCRIPTION
To avoid processing events once we have transitioned to a new state, add a check at the beginning of the events created by PollEvent in KRaftMigrationDriver.