### PR TITLE
MINOR: Code cleanups in group-coordinator module

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -57,7 +57,7 @@ import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.coordinator.group.runtime.CoordinatorBuilderSupplier;
+import org.apache.kafka.coordinator.group.runtime.CoordinatorShardBuilderSupplier;
 import org.apache.kafka.coordinator.group.runtime.CoordinatorEventProcessor;
 import org.apache.kafka.coordinator.group.runtime.CoordinatorLoader;
 import org.apache.kafka.coordinator.group.runtime.CoordinatorRuntime;
@@ -133,7 +133,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
             String logPrefix = String.format("GroupCoordinator id=%d", nodeId);
             LogContext logContext = new LogContext(String.format("[%s] ", logPrefix));
 
-            CoordinatorBuilderSupplier<GroupCoordinatorShard, Record> supplier = () ->
+            CoordinatorShardBuilderSupplier<GroupCoordinatorShard, Record> supplier = () ->
                 new GroupCoordinatorShard.Builder(config);
 
             CoordinatorEventProcessor processor = new MultiThreadedEventProcessor(
@@ -151,7 +151,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     .withEventProcessor(processor)
                     .withPartitionWriter(writer)
                     .withLoader(loader)
-                    .withCoordinatorBuilderSupplier(supplier)
+                    .withCoordinatorShardBuilderSupplier(supplier)
                     .withTime(time)
                     .build();
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -133,8 +133,8 @@ public class GroupCoordinatorService implements GroupCoordinator {
             String logPrefix = String.format("GroupCoordinator id=%d", nodeId);
             LogContext logContext = new LogContext(String.format("[%s] ", logPrefix));
 
-            CoordinatorBuilderSupplier<ReplicatedGroupCoordinator, Record> supplier = () ->
-                new ReplicatedGroupCoordinator.Builder(config);
+            CoordinatorBuilderSupplier<GroupCoordinatorShard, Record> supplier = () ->
+                new GroupCoordinatorShard.Builder(config);
 
             CoordinatorEventProcessor processor = new MultiThreadedEventProcessor(
                 logContext,
@@ -142,8 +142,8 @@ public class GroupCoordinatorService implements GroupCoordinator {
                 config.numThreads
             );
 
-            CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime =
-                new CoordinatorRuntime.Builder<ReplicatedGroupCoordinator, Record>()
+            CoordinatorRuntime<GroupCoordinatorShard, Record> runtime =
+                new CoordinatorRuntime.Builder<GroupCoordinatorShard, Record>()
                     .withTime(time)
                     .withTimer(timer)
                     .withLogPrefix(logPrefix)
@@ -176,7 +176,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
     /**
      * The coordinator runtime.
      */
-    private final CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime;
+    private final CoordinatorRuntime<GroupCoordinatorShard, Record> runtime;
 
     /**
      * Boolean indicating whether the coordinator is active or not.
@@ -198,7 +198,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
     GroupCoordinatorService(
         LogContext logContext,
         GroupCoordinatorConfig config,
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime
     ) {
         this.log = logContext.logger(CoordinatorLoader.class);
         this.config = config;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.coordinator.group;
 
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.JoinGroupRequestData;
@@ -73,7 +72,6 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
         private final GroupCoordinatorConfig config;
         private LogContext logContext;
         private SnapshotRegistry snapshotRegistry;
-        private TopicPartition topicPartition;
         private Time time;
         private CoordinatorTimer<Void, Record> timer;
 
@@ -116,14 +114,6 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
         }
 
         @Override
-        public CoordinatorShardBuilder<GroupCoordinatorShard, Record> withTopicPartition(
-            TopicPartition topicPartition
-        ) {
-            this.topicPartition = topicPartition;
-            return this;
-        }
-
-        @Override
         public GroupCoordinatorShard build() {
             if (logContext == null) logContext = new LogContext();
             if (config == null)
@@ -134,15 +124,12 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
                 throw new IllegalArgumentException("Time must be set.");
             if (timer == null)
                 throw new IllegalArgumentException("Timer must be set.");
-            if (topicPartition == null)
-                throw new IllegalArgumentException("TopicPartition must be set.");
 
             GroupMetadataManager groupMetadataManager = new GroupMetadataManager.Builder()
                 .withLogContext(logContext)
                 .withSnapshotRegistry(snapshotRegistry)
                 .withTime(time)
                 .withTimer(timer)
-                .withTopicPartition(topicPartition)
                 .withAssignors(config.consumerGroupAssignors)
                 .withConsumerGroupMaxSize(config.consumerGroupMaxSize)
                 .withConsumerGroupHeartbeatInterval(config.consumerGroupHeartbeatIntervalMs)

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -130,7 +130,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
                 .withSnapshotRegistry(snapshotRegistry)
                 .withTime(time)
                 .withTimer(timer)
-                .withAssignors(config.consumerGroupAssignors)
+                .withConsumerGroupAssignors(config.consumerGroupAssignors)
                 .withConsumerGroupMaxSize(config.consumerGroupMaxSize)
                 .withConsumerGroupHeartbeatInterval(config.consumerGroupHeartbeatIntervalMs)
                 .withGenericGroupInitialRebalanceDelayMs(config.genericGroupInitialRebalanceDelayMs)

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -125,7 +125,7 @@ public class GroupMetadataManager {
         private SnapshotRegistry snapshotRegistry = null;
         private Time time = null;
         private CoordinatorTimer<Void, Record> timer = null;
-        private List<PartitionAssignor> assignors = null;
+        private List<PartitionAssignor> consumerGroupAssignors = null;
         private int consumerGroupMaxSize = Integer.MAX_VALUE;
         private int consumerGroupHeartbeatIntervalMs = 5000;
         private int consumerGroupMetadataRefreshIntervalMs = Integer.MAX_VALUE;
@@ -157,8 +157,8 @@ public class GroupMetadataManager {
             return this;
         }
 
-        Builder withAssignors(List<PartitionAssignor> assignors) {
-            this.assignors = assignors;
+        Builder withConsumerGroupAssignors(List<PartitionAssignor> consumerGroupAssignors) {
+            this.consumerGroupAssignors = consumerGroupAssignors;
             return this;
         }
 
@@ -220,7 +220,7 @@ public class GroupMetadataManager {
 
             if (timer == null)
                 throw new IllegalArgumentException("Timer must be set.");
-            if (assignors == null || assignors.isEmpty())
+            if (consumerGroupAssignors == null || consumerGroupAssignors.isEmpty())
                 throw new IllegalArgumentException("Assignors must be set before building.");
 
             return new GroupMetadataManager(
@@ -228,7 +228,7 @@ public class GroupMetadataManager {
                 logContext,
                 time,
                 timer,
-                assignors,
+                consumerGroupAssignors,
                 metadataImage,
                 consumerGroupMaxSize,
                 consumerGroupSessionTimeoutMs,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorBuilderSupplier.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorBuilderSupplier.java
@@ -17,14 +17,14 @@
 package org.apache.kafka.coordinator.group.runtime;
 
 /**
- * Supplies a {@link CoordinatorBuilder} to the {@link CoordinatorRuntime}.
+ * Supplies a {@link CoordinatorShardBuilder} to the {@link CoordinatorRuntime}.
  *
  * @param <S> The type of the coordinator.
  * @param <U> The record type.
  */
-public interface CoordinatorBuilderSupplier<S extends Coordinator<U>, U> {
+public interface CoordinatorBuilderSupplier<S extends CoordinatorShard<U>, U> {
     /**
-     * @return A {@link CoordinatorBuilder}.
+     * @return A {@link CoordinatorShardBuilder}.
      */
-    CoordinatorBuilder<S, U> get();
+    CoordinatorShardBuilder<S, U> get();
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -1008,14 +1008,14 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
     /**
      * Constructor.
      *
-     * @param logPrefix                     The log prefix.
-     * @param logContext                    The log context.
-     * @param processor                     The event processor.
-     * @param partitionWriter               The partition writer.
-     * @param loader                        The coordinator loader.
-     * @param coordinatorShardBuilderSupplier    The coordinator builder.
-     * @param time                          The system time.
-     * @param timer                         The system timer.
+     * @param logPrefix                         The log prefix.
+     * @param logContext                        The log context.
+     * @param processor                         The event processor.
+     * @param partitionWriter                   The partition writer.
+     * @param loader                            The coordinator loader.
+     * @param coordinatorShardBuilderSupplier   The coordinator builder.
+     * @param time                              The system time.
+     * @param timer                             The system timer.
      */
     private CoordinatorRuntime(
         String logPrefix,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -505,7 +505,6 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         .withSnapshotRegistry(snapshotRegistry)
                         .withTime(time)
                         .withTimer(timer)
-                        .withTopicPartition(tp)
                         .build();
                     break;
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -70,7 +70,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @param <S> The type of the state machine.
  * @param <U> The type of the record.
  */
-public class CoordinatorRuntime<S extends Coordinator<U>, U> implements AutoCloseable {
+public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements AutoCloseable {
 
     /**
      * Builder to create a CoordinatorRuntime.
@@ -78,7 +78,7 @@ public class CoordinatorRuntime<S extends Coordinator<U>, U> implements AutoClos
      * @param <S> The type of the state machine.
      * @param <U> The type of the record.
      */
-    public static class Builder<S extends Coordinator<U>, U> {
+    public static class Builder<S extends CoordinatorShard<U>, U> {
         private String logPrefix;
         private LogContext logContext;
         private CoordinatorEventProcessor eventProcessor;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -84,7 +84,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         private CoordinatorEventProcessor eventProcessor;
         private PartitionWriter<U> partitionWriter;
         private CoordinatorLoader<U> loader;
-        private CoordinatorBuilderSupplier<S, U> coordinatorBuilderSupplier;
+        private CoordinatorShardBuilderSupplier<S, U> coordinatorShardBuilderSupplier;
         private Time time = Time.SYSTEM;
         private Timer timer;
 
@@ -113,8 +113,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             return this;
         }
 
-        public Builder<S, U> withCoordinatorBuilderSupplier(CoordinatorBuilderSupplier<S, U> coordinatorBuilderSupplier) {
-            this.coordinatorBuilderSupplier = coordinatorBuilderSupplier;
+        public Builder<S, U> withCoordinatorShardBuilderSupplier(CoordinatorShardBuilderSupplier<S, U> coordinatorShardBuilderSupplier) {
+            this.coordinatorShardBuilderSupplier = coordinatorShardBuilderSupplier;
             return this;
         }
 
@@ -139,7 +139,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 throw new IllegalArgumentException("Partition write must be set.");
             if (loader == null)
                 throw new IllegalArgumentException("Loader must be set.");
-            if (coordinatorBuilderSupplier == null)
+            if (coordinatorShardBuilderSupplier == null)
                 throw new IllegalArgumentException("State machine supplier must be set.");
             if (time == null)
                 throw new IllegalArgumentException("Time must be set.");
@@ -152,7 +152,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 eventProcessor,
                 partitionWriter,
                 loader,
-                coordinatorBuilderSupplier,
+                coordinatorShardBuilderSupplier,
                 time,
                 timer
             );
@@ -499,7 +499,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             switch (newState) {
                 case LOADING:
                     state = CoordinatorState.LOADING;
-                    coordinator = coordinatorBuilderSupplier
+                    coordinator = coordinatorShardBuilderSupplier
                         .get()
                         .withLogContext(logContext)
                         .withSnapshotRegistry(snapshotRegistry)
@@ -980,7 +980,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      * The coordinator state machine builder used by the runtime
      * to instantiate a coordinator.
      */
-    private final CoordinatorBuilderSupplier<S, U> coordinatorBuilderSupplier;
+    private final CoordinatorShardBuilderSupplier<S, U> coordinatorShardBuilderSupplier;
 
     /**
      * Atomic boolean indicating whether the runtime is running.
@@ -1000,7 +1000,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      * @param processor                     The event processor.
      * @param partitionWriter               The partition writer.
      * @param loader                        The coordinator loader.
-     * @param coordinatorBuilderSupplier    The coordinator builder.
+     * @param coordinatorShardBuilderSupplier    The coordinator builder.
      * @param time                          The system time.
      * @param timer                         The system timer.
      */
@@ -1010,7 +1010,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         CoordinatorEventProcessor processor,
         PartitionWriter<U> partitionWriter,
         CoordinatorLoader<U> loader,
-        CoordinatorBuilderSupplier<S, U> coordinatorBuilderSupplier,
+        CoordinatorShardBuilderSupplier<S, U> coordinatorShardBuilderSupplier,
         Time time,
         Timer timer
     ) {
@@ -1024,7 +1024,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         this.partitionWriter = partitionWriter;
         this.highWatermarklistener = new HighWatermarkListener();
         this.loader = loader;
-        this.coordinatorBuilderSupplier = coordinatorBuilderSupplier;
+        this.coordinatorShardBuilderSupplier = coordinatorShardBuilderSupplier;
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorShard.java
@@ -20,10 +20,10 @@ import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 
 /**
- * Coordinator is basically a replicated state machine managed by the
+ * CoordinatorShard is basically a replicated state machine managed by the
  * {@link CoordinatorRuntime}.
  */
-public interface Coordinator<U> extends CoordinatorPlayback<U> {
+public interface CoordinatorShard<U> extends CoordinatorPlayback<U> {
 
     /**
      * The coordinator has been loaded. This is used to apply any
@@ -34,7 +34,7 @@ public interface Coordinator<U> extends CoordinatorPlayback<U> {
     default void onLoaded(MetadataImage newImage) {}
 
     /**
-     * A new metadata image is available. This is only called after {@link Coordinator#onLoaded(MetadataImage)}
+     * A new metadata image is available. This is only called after {@link CoordinatorShard#onLoaded(MetadataImage)}
      * is called to signal that the coordinator has been fully loaded.
      *
      * @param newImage  The new metadata image.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorShardBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorShardBuilder.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.coordinator.group.runtime;
 
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.timeline.SnapshotRegistry;
@@ -51,16 +50,6 @@ public interface CoordinatorShardBuilder<S extends CoordinatorShard<U>, U> {
      */
     CoordinatorShardBuilder<S, U> withLogContext(
         LogContext logContext
-    );
-
-    /**
-     * Sets the topic partition.
-     * @param topicPartition The topic partition.
-     *
-     * @return The builder.
-     */
-    CoordinatorShardBuilder<S, U> withTopicPartition(
-        TopicPartition topicPartition
     );
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorShardBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorShardBuilder.java
@@ -23,12 +23,12 @@ import org.apache.kafka.timeline.SnapshotRegistry;
 
 
 /**
- * A builder to build a {@link Coordinator} replicated state machine.
+ * A builder to build a {@link CoordinatorShard} replicated state machine.
  *
  * @param <S> The type of the coordinator.
  * @param <U> The record type.
  */
-public interface CoordinatorBuilder<S extends Coordinator<U>, U> {
+public interface CoordinatorShardBuilder<S extends CoordinatorShard<U>, U> {
 
     /**
      * Sets the snapshot registry used to back all the timeline
@@ -38,7 +38,7 @@ public interface CoordinatorBuilder<S extends Coordinator<U>, U> {
      *
      * @return The builder.
      */
-    CoordinatorBuilder<S, U> withSnapshotRegistry(
+    CoordinatorShardBuilder<S, U> withSnapshotRegistry(
         SnapshotRegistry snapshotRegistry
     );
 
@@ -49,7 +49,7 @@ public interface CoordinatorBuilder<S extends Coordinator<U>, U> {
      *
      * @return The builder.
      */
-    CoordinatorBuilder<S, U> withLogContext(
+    CoordinatorShardBuilder<S, U> withLogContext(
         LogContext logContext
     );
 
@@ -59,7 +59,7 @@ public interface CoordinatorBuilder<S extends Coordinator<U>, U> {
      *
      * @return The builder.
      */
-    CoordinatorBuilder<S, U> withTopicPartition(
+    CoordinatorShardBuilder<S, U> withTopicPartition(
         TopicPartition topicPartition
     );
 
@@ -70,7 +70,7 @@ public interface CoordinatorBuilder<S extends Coordinator<U>, U> {
      *
      * @return The builder.
      */
-    CoordinatorBuilder<S, U> withTime(
+    CoordinatorShardBuilder<S, U> withTime(
         Time time
     );
 
@@ -81,7 +81,7 @@ public interface CoordinatorBuilder<S extends Coordinator<U>, U> {
      *
      * @return The builder.
      */
-    CoordinatorBuilder<S, U> withTimer(
+    CoordinatorShardBuilder<S, U> withTimer(
         CoordinatorTimer<Void, U> timer
     );
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorShardBuilderSupplier.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorShardBuilderSupplier.java
@@ -22,7 +22,7 @@ package org.apache.kafka.coordinator.group.runtime;
  * @param <S> The type of the coordinator.
  * @param <U> The record type.
  */
-public interface CoordinatorBuilderSupplier<S extends CoordinatorShard<U>, U> {
+public interface CoordinatorShardBuilderSupplier<S extends CoordinatorShard<U>, U> {
     /**
      * @return A {@link CoordinatorShardBuilder}.
      */

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -79,8 +79,8 @@ import static org.mockito.Mockito.when;
 public class GroupCoordinatorServiceTest {
 
     @SuppressWarnings("unchecked")
-    private CoordinatorRuntime<ReplicatedGroupCoordinator, Record> mockRuntime() {
-        return (CoordinatorRuntime<ReplicatedGroupCoordinator, Record>) mock(CoordinatorRuntime.class);
+    private CoordinatorRuntime<GroupCoordinatorShard, Record> mockRuntime() {
+        return (CoordinatorRuntime<GroupCoordinatorShard, Record>) mock(CoordinatorRuntime.class);
     }
 
     private GroupCoordinatorConfig createConfig() {
@@ -102,7 +102,7 @@ public class GroupCoordinatorServiceTest {
 
     @Test
     public void testStartupShutdown() throws Exception {
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
         GroupCoordinatorService service = new GroupCoordinatorService(
             new LogContext(),
             createConfig(),
@@ -117,7 +117,7 @@ public class GroupCoordinatorServiceTest {
 
     @Test
     public void testConsumerGroupHeartbeatWhenNotStarted() {
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
         GroupCoordinatorService service = new GroupCoordinatorService(
             new LogContext(),
             createConfig(),
@@ -138,7 +138,7 @@ public class GroupCoordinatorServiceTest {
 
     @Test
     public void testConsumerGroupHeartbeat() throws ExecutionException, InterruptedException, TimeoutException {
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
         GroupCoordinatorService service = new GroupCoordinatorService(
             new LogContext(),
             createConfig(),
@@ -186,7 +186,7 @@ public class GroupCoordinatorServiceTest {
         short expectedErrorCode,
         String expectedErrorMessage
     ) throws ExecutionException, InterruptedException, TimeoutException {
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
         GroupCoordinatorService service = new GroupCoordinatorService(
             new LogContext(),
             createConfig(),
@@ -219,7 +219,7 @@ public class GroupCoordinatorServiceTest {
 
     @Test
     public void testPartitionFor() {
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
         GroupCoordinatorService service = new GroupCoordinatorService(
             new LogContext(),
             createConfig(),
@@ -236,7 +236,7 @@ public class GroupCoordinatorServiceTest {
 
     @Test
     public void testGroupMetadataTopicConfigs() {
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
         GroupCoordinatorService service = new GroupCoordinatorService(
             new LogContext(),
             createConfig(),
@@ -253,7 +253,7 @@ public class GroupCoordinatorServiceTest {
 
     @Test
     public void testOnElection() {
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
         GroupCoordinatorService service = new GroupCoordinatorService(
             new LogContext(),
             createConfig(),
@@ -274,7 +274,7 @@ public class GroupCoordinatorServiceTest {
 
     @Test
     public void testOnResignation() {
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
         GroupCoordinatorService service = new GroupCoordinatorService(
             new LogContext(),
             createConfig(),
@@ -295,7 +295,7 @@ public class GroupCoordinatorServiceTest {
 
     @Test
     public void testJoinGroup() {
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
         GroupCoordinatorService service = new GroupCoordinatorService(
             new LogContext(),
             createConfig(),
@@ -326,7 +326,7 @@ public class GroupCoordinatorServiceTest {
 
     @Test
     public void testJoinGroupWithException() throws Exception {
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
         GroupCoordinatorService service = new GroupCoordinatorService(
             new LogContext(),
             createConfig(),
@@ -359,7 +359,7 @@ public class GroupCoordinatorServiceTest {
 
     @Test
     public void testJoinGroupInvalidGroupId() throws Exception {
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
         GroupCoordinatorService service = new GroupCoordinatorService(
             new LogContext(),
             createConfig(),
@@ -404,7 +404,7 @@ public class GroupCoordinatorServiceTest {
 
     @Test
     public void testSyncGroup() {
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
         GroupCoordinatorService service = new GroupCoordinatorService(
             new LogContext(),
             createConfig(),
@@ -435,7 +435,7 @@ public class GroupCoordinatorServiceTest {
 
     @Test
     public void testSyncGroupWithException() throws Exception {
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
         GroupCoordinatorService service = new GroupCoordinatorService(
             new LogContext(),
             createConfig(),
@@ -469,7 +469,7 @@ public class GroupCoordinatorServiceTest {
 
     @Test
     public void testSyncGroupInvalidGroupId() throws Exception {
-        CoordinatorRuntime<ReplicatedGroupCoordinator, Record> runtime = mockRuntime();
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
         GroupCoordinatorService service = new GroupCoordinatorService(
             new LogContext(),
             createConfig(),

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -55,13 +55,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ReplicatedGroupCoordinatorTest {
+public class GroupCoordinatorShardTest {
 
     @Test
     public void testConsumerGroupHeartbeat() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -85,7 +85,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testCommitOffset() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -109,7 +109,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayOffsetCommit() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -134,7 +134,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayOffsetCommitWithNullValue() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -158,7 +158,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayConsumerGroupMetadata() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -178,7 +178,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayConsumerGroupMetadataWithNullValue() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -197,7 +197,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayConsumerGroupPartitionMetadata() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -217,7 +217,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayConsumerGroupPartitionMetadataWithNullValue() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -236,7 +236,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayConsumerGroupMemberMetadata() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -256,7 +256,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayConsumerGroupMemberMetadataWithNullValue() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -275,7 +275,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayConsumerGroupTargetAssignmentMetadata() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -295,7 +295,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayConsumerGroupTargetAssignmentMetadataWithNullValue() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -314,7 +314,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayConsumerGroupTargetAssignmentMember() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -334,7 +334,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayConsumerGroupTargetAssignmentMemberKeyWithNullValue() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -353,7 +353,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayConsumerGroupCurrentMemberAssignment() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -373,7 +373,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayConsumerGroupCurrentMemberAssignmentWithNullValue() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -392,7 +392,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayKeyCannotBeNull() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -404,7 +404,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayWithUnsupportedVersion() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -423,7 +423,7 @@ public class ReplicatedGroupCoordinatorTest {
         MetadataImage image = MetadataImage.EMPTY;
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -442,7 +442,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayGroupMetadata() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -462,7 +462,7 @@ public class ReplicatedGroupCoordinatorTest {
     public void testReplayGroupMetadataWithNullValue() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        ReplicatedGroupCoordinator coordinator = new ReplicatedGroupCoordinator(
+        GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             groupMetadataManager,
             offsetMetadataManager
         );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -275,7 +275,7 @@ public class GroupMetadataManagerTest {
             final private SnapshotRegistry snapshotRegistry = new SnapshotRegistry(logContext);
             final private TopicPartition groupMetadataTopicPartition = new TopicPartition("topic", 0);
             private MetadataImage metadataImage;
-            private List<PartitionAssignor> assignors = Collections.singletonList(new MockPartitionAssignor("range"));
+            private List<PartitionAssignor> consumerGroupAssignors = Collections.singletonList(new MockPartitionAssignor("range"));
             private List<ConsumerGroupBuilder> consumerGroupBuilders = new ArrayList<>();
             private int consumerGroupMaxSize = Integer.MAX_VALUE;
             private int consumerGroupMetadataRefreshIntervalMs = Integer.MAX_VALUE;
@@ -291,7 +291,7 @@ public class GroupMetadataManagerTest {
             }
 
             public Builder withAssignors(List<PartitionAssignor> assignors) {
-                this.assignors = assignors;
+                this.consumerGroupAssignors = assignors;
                 return this;
             }
 
@@ -332,7 +332,7 @@ public class GroupMetadataManagerTest {
 
             public GroupMetadataManagerTestContext build() {
                 if (metadataImage == null) metadataImage = MetadataImage.EMPTY;
-                if (assignors == null) assignors = Collections.emptyList();
+                if (consumerGroupAssignors == null) consumerGroupAssignors = Collections.emptyList();
 
                 GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext(
                     time,
@@ -347,7 +347,7 @@ public class GroupMetadataManagerTest {
                         .withConsumerGroupHeartbeatInterval(5000)
                         .withConsumerGroupSessionTimeout(45000)
                         .withConsumerGroupMaxSize(consumerGroupMaxSize)
-                        .withAssignors(assignors)
+                        .withConsumerGroupAssignors(consumerGroupAssignors)
                         .withConsumerGroupMetadataRefreshIntervalMs(consumerGroupMetadataRefreshIntervalMs)
                         .withGenericGroupMaxSize(genericGroupMaxSize)
                         .withGenericGroupMinSessionTimeoutMs(genericGroupMinSessionTimeoutMs)

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -339,7 +339,6 @@ public class GroupMetadataManagerTest {
                     timer,
                     snapshotRegistry,
                     new GroupMetadataManager.Builder()
-                        .withTopicPartition(groupMetadataTopicPartition)
                         .withSnapshotRegistry(snapshotRegistry)
                         .withLogContext(logContext)
                         .withTime(time)

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
@@ -92,7 +92,6 @@ public class OffsetMetadataManagerTest {
                     .withSnapshotRegistry(snapshotRegistry)
                     .withLogContext(logContext)
                     .withMetadataImage(metadataImage)
-                    .withTopicPartition(new TopicPartition("__consumer_offsets", 0))
                     .withAssignors(Collections.singletonList(new RangeAssignor()))
                     .build();
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
@@ -92,7 +92,7 @@ public class OffsetMetadataManagerTest {
                     .withSnapshotRegistry(snapshotRegistry)
                     .withLogContext(logContext)
                     .withMetadataImage(metadataImage)
-                    .withAssignors(Collections.singletonList(new RangeAssignor()))
+                    .withConsumerGroupAssignors(Collections.singletonList(new RangeAssignor()))
                     .build();
 
                 OffsetMetadataManager offsetMetadataManager = new OffsetMetadataManager.Builder()

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntimeTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntimeTest.java
@@ -247,7 +247,7 @@ public class CoordinatorRuntimeTest {
     /**
      * A CoordinatorBuilderSupplier that returns a MockCoordinatorBuilder.
      */
-    private static class MockCoordinatorBuilderSupplier implements CoordinatorBuilderSupplier<MockCoordinatorShard, String> {
+    private static class MockCoordinatorShardBuilderSupplier implements CoordinatorShardBuilderSupplier<MockCoordinatorShard, String> {
         @Override
         public CoordinatorShardBuilder<MockCoordinatorShard, String> get() {
             return new MockCoordinatorShardBuilder();
@@ -259,7 +259,7 @@ public class CoordinatorRuntimeTest {
         MockTimer timer = new MockTimer();
         MockCoordinatorLoader loader = mock(MockCoordinatorLoader.class);
         MockPartitionWriter writer = mock(MockPartitionWriter.class);
-        MockCoordinatorBuilderSupplier supplier = mock(MockCoordinatorBuilderSupplier.class);
+        MockCoordinatorShardBuilderSupplier supplier = mock(MockCoordinatorShardBuilderSupplier.class);
         MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
         MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
 
@@ -270,7 +270,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(loader)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
-                .withCoordinatorBuilderSupplier(supplier)
+                .withCoordinatorShardBuilderSupplier(supplier)
                 .build();
 
         when(builder.withSnapshotRegistry(any())).thenReturn(builder);
@@ -323,7 +323,7 @@ public class CoordinatorRuntimeTest {
         MockTimer timer = new MockTimer();
         MockPartitionWriter writer = mock(MockPartitionWriter.class);
         MockCoordinatorLoader loader = mock(MockCoordinatorLoader.class);
-        MockCoordinatorBuilderSupplier supplier = mock(MockCoordinatorBuilderSupplier.class);
+        MockCoordinatorShardBuilderSupplier supplier = mock(MockCoordinatorShardBuilderSupplier.class);
         MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
         MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
 
@@ -334,7 +334,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(loader)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
-                .withCoordinatorBuilderSupplier(supplier)
+                .withCoordinatorShardBuilderSupplier(supplier)
                 .build();
 
         when(builder.withSnapshotRegistry(any())).thenReturn(builder);
@@ -374,7 +374,7 @@ public class CoordinatorRuntimeTest {
     public void testScheduleLoadingWithStalePartitionEpoch() {
         MockTimer timer = new MockTimer();
         MockCoordinatorLoader loader = mock(MockCoordinatorLoader.class);
-        MockCoordinatorBuilderSupplier supplier = mock(MockCoordinatorBuilderSupplier.class);
+        MockCoordinatorShardBuilderSupplier supplier = mock(MockCoordinatorShardBuilderSupplier.class);
         MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
         MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
 
@@ -385,7 +385,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(loader)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
-                .withCoordinatorBuilderSupplier(supplier)
+                .withCoordinatorShardBuilderSupplier(supplier)
                 .build();
 
         when(builder.withSnapshotRegistry(any())).thenReturn(builder);
@@ -423,7 +423,7 @@ public class CoordinatorRuntimeTest {
     public void testScheduleLoadingAfterLoadingFailure() {
         MockTimer timer = new MockTimer();
         MockCoordinatorLoader loader = mock(MockCoordinatorLoader.class);
-        MockCoordinatorBuilderSupplier supplier = mock(MockCoordinatorBuilderSupplier.class);
+        MockCoordinatorShardBuilderSupplier supplier = mock(MockCoordinatorShardBuilderSupplier.class);
         MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
         MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
 
@@ -434,7 +434,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(loader)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
-                .withCoordinatorBuilderSupplier(supplier)
+                .withCoordinatorShardBuilderSupplier(supplier)
                 .build();
 
         when(builder.withSnapshotRegistry(any())).thenReturn(builder);
@@ -489,7 +489,7 @@ public class CoordinatorRuntimeTest {
     public void testScheduleUnloading() {
         MockTimer timer = new MockTimer();
         MockPartitionWriter writer = mock(MockPartitionWriter.class);
-        MockCoordinatorBuilderSupplier supplier = mock(MockCoordinatorBuilderSupplier.class);
+        MockCoordinatorShardBuilderSupplier supplier = mock(MockCoordinatorShardBuilderSupplier.class);
         MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
         MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
 
@@ -500,7 +500,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
-                .withCoordinatorBuilderSupplier(supplier)
+                .withCoordinatorShardBuilderSupplier(supplier)
                 .build();
 
         when(builder.withSnapshotRegistry(any())).thenReturn(builder);
@@ -537,7 +537,7 @@ public class CoordinatorRuntimeTest {
     @Test
     public void testScheduleUnloadingWithStalePartitionEpoch() {
         MockTimer timer = new MockTimer();
-        MockCoordinatorBuilderSupplier supplier = mock(MockCoordinatorBuilderSupplier.class);
+        MockCoordinatorShardBuilderSupplier supplier = mock(MockCoordinatorShardBuilderSupplier.class);
         MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
         MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
 
@@ -548,7 +548,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
-                .withCoordinatorBuilderSupplier(supplier)
+                .withCoordinatorShardBuilderSupplier(supplier)
                 .build();
 
         when(builder.withSnapshotRegistry(any())).thenReturn(builder);
@@ -586,7 +586,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
-                .withCoordinatorBuilderSupplier(new MockCoordinatorBuilderSupplier())
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
                 .build();
 
         // Schedule the loading.
@@ -694,7 +694,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
-                .withCoordinatorBuilderSupplier(new MockCoordinatorBuilderSupplier())
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
                 .build();
 
         // Scheduling a write fails with a NotCoordinatorException because the coordinator
@@ -714,7 +714,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
-                .withCoordinatorBuilderSupplier(new MockCoordinatorBuilderSupplier())
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
                 .build();
 
         // Loads the coordinator.
@@ -738,7 +738,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
-                .withCoordinatorBuilderSupplier(new MockCoordinatorBuilderSupplier())
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
                 .build();
 
         // Loads the coordinator.
@@ -783,7 +783,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
-                .withCoordinatorBuilderSupplier(new MockCoordinatorBuilderSupplier())
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
                 .build();
 
         // Loads the coordinator.
@@ -830,7 +830,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
-                .withCoordinatorBuilderSupplier(new MockCoordinatorBuilderSupplier())
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
                 .build();
 
         // Loads the coordinator.
@@ -884,7 +884,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
-                .withCoordinatorBuilderSupplier(new MockCoordinatorBuilderSupplier())
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
                 .build();
 
         // Schedule a read. It fails because the coordinator does not exist.
@@ -905,7 +905,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
-                .withCoordinatorBuilderSupplier(new MockCoordinatorBuilderSupplier())
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
                 .build();
 
         // Loads the coordinator.
@@ -946,7 +946,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(loader)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
-                .withCoordinatorBuilderSupplier(new MockCoordinatorBuilderSupplier())
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
                 .build();
 
         // Loads the coordinator.
@@ -1001,7 +1001,7 @@ public class CoordinatorRuntimeTest {
         MockTimer timer = new MockTimer();
         MockCoordinatorLoader loader = mock(MockCoordinatorLoader.class);
         MockPartitionWriter writer = mock(MockPartitionWriter.class);
-        MockCoordinatorBuilderSupplier supplier = mock(MockCoordinatorBuilderSupplier.class);
+        MockCoordinatorShardBuilderSupplier supplier = mock(MockCoordinatorShardBuilderSupplier.class);
         MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
 
         CoordinatorRuntime<MockCoordinatorShard, String> runtime =
@@ -1011,7 +1011,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(loader)
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(writer)
-                .withCoordinatorBuilderSupplier(supplier)
+                .withCoordinatorShardBuilderSupplier(supplier)
                 .build();
 
         MockCoordinatorShard coordinator0 = mock(MockCoordinatorShard.class);
@@ -1066,7 +1066,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
-                .withCoordinatorBuilderSupplier(new MockCoordinatorBuilderSupplier())
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
                 .build();
 
         // Loads the coordinator.
@@ -1117,7 +1117,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(processor)
                 .withPartitionWriter(new MockPartitionWriter())
-                .withCoordinatorBuilderSupplier(new MockCoordinatorBuilderSupplier())
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
                 .build();
 
         // Loads the coordinator.
@@ -1188,7 +1188,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(processor)
                 .withPartitionWriter(new MockPartitionWriter())
-                .withCoordinatorBuilderSupplier(new MockCoordinatorBuilderSupplier())
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
                 .build();
 
         // Loads the coordinator.
@@ -1256,7 +1256,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
-                .withCoordinatorBuilderSupplier(new MockCoordinatorBuilderSupplier())
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
                 .build();
 
         // Loads the coordinator.
@@ -1312,7 +1312,7 @@ public class CoordinatorRuntimeTest {
                 .withLoader(new MockCoordinatorLoader())
                 .withEventProcessor(new DirectEventProcessor())
                 .withPartitionWriter(new MockPartitionWriter())
-                .withCoordinatorBuilderSupplier(new MockCoordinatorBuilderSupplier())
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
                 .build();
 
         // Loads the coordinator.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntimeTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntimeTest.java
@@ -166,11 +166,11 @@ public class CoordinatorRuntimeTest {
     /**
      * A simple Coordinator implementation that stores the records into a set.
      */
-    private static class MockCoordinator implements Coordinator<String> {
+    private static class MockCoordinatorShard implements CoordinatorShard<String> {
         private final TimelineHashSet<String> records;
         private final CoordinatorTimer<Void, String> timer;
 
-        MockCoordinator(
+        MockCoordinatorShard(
             SnapshotRegistry snapshotRegistry,
             CoordinatorTimer<Void, String> timer
         ) {
@@ -195,12 +195,12 @@ public class CoordinatorRuntimeTest {
     /**
      * A CoordinatorBuilder that creates a MockCoordinator.
      */
-    private static class MockCoordinatorBuilder implements CoordinatorBuilder<MockCoordinator, String> {
+    private static class MockCoordinatorShardBuilder implements CoordinatorShardBuilder<MockCoordinatorShard, String> {
         private SnapshotRegistry snapshotRegistry;
         private CoordinatorTimer<Void, String> timer;
 
         @Override
-        public CoordinatorBuilder<MockCoordinator, String> withSnapshotRegistry(
+        public CoordinatorShardBuilder<MockCoordinatorShard, String> withSnapshotRegistry(
             SnapshotRegistry snapshotRegistry
         ) {
             this.snapshotRegistry = snapshotRegistry;
@@ -208,36 +208,36 @@ public class CoordinatorRuntimeTest {
         }
 
         @Override
-        public CoordinatorBuilder<MockCoordinator, String> withLogContext(
+        public CoordinatorShardBuilder<MockCoordinatorShard, String> withLogContext(
             LogContext logContext
         ) {
             return this;
         }
 
         @Override
-        public CoordinatorBuilder<MockCoordinator, String> withTime(
+        public CoordinatorShardBuilder<MockCoordinatorShard, String> withTime(
             Time time
         ) {
             return this;
         }
 
         @Override
-        public CoordinatorBuilder<MockCoordinator, String> withTimer(
+        public CoordinatorShardBuilder<MockCoordinatorShard, String> withTimer(
             CoordinatorTimer<Void, String> timer
         ) {
             this.timer = timer;
             return this;
         }
 
-        public CoordinatorBuilder<MockCoordinator, String> withTopicPartition(
+        public CoordinatorShardBuilder<MockCoordinatorShard, String> withTopicPartition(
             TopicPartition topicPartition
         ) {
             return this;
         }
 
         @Override
-        public MockCoordinator build() {
-            return new MockCoordinator(
+        public MockCoordinatorShard build() {
+            return new MockCoordinatorShard(
                 Objects.requireNonNull(this.snapshotRegistry),
                 Objects.requireNonNull(this.timer)
             );
@@ -247,10 +247,10 @@ public class CoordinatorRuntimeTest {
     /**
      * A CoordinatorBuilderSupplier that returns a MockCoordinatorBuilder.
      */
-    private static class MockCoordinatorBuilderSupplier implements CoordinatorBuilderSupplier<MockCoordinator, String> {
+    private static class MockCoordinatorBuilderSupplier implements CoordinatorBuilderSupplier<MockCoordinatorShard, String> {
         @Override
-        public CoordinatorBuilder<MockCoordinator, String> get() {
-            return new MockCoordinatorBuilder();
+        public CoordinatorShardBuilder<MockCoordinatorShard, String> get() {
+            return new MockCoordinatorShardBuilder();
         }
     }
 
@@ -260,11 +260,11 @@ public class CoordinatorRuntimeTest {
         MockCoordinatorLoader loader = mock(MockCoordinatorLoader.class);
         MockPartitionWriter writer = mock(MockPartitionWriter.class);
         MockCoordinatorBuilderSupplier supplier = mock(MockCoordinatorBuilderSupplier.class);
-        MockCoordinatorBuilder builder = mock(MockCoordinatorBuilder.class);
-        MockCoordinator coordinator = mock(MockCoordinator.class);
+        MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
+        MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
 
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(loader)
@@ -291,7 +291,7 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(TP, 0);
 
         // Getting the coordinator context succeeds now.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
 
         // The coordinator is loading.
         assertEquals(CoordinatorRuntime.CoordinatorState.LOADING, ctx.state);
@@ -324,11 +324,11 @@ public class CoordinatorRuntimeTest {
         MockPartitionWriter writer = mock(MockPartitionWriter.class);
         MockCoordinatorLoader loader = mock(MockCoordinatorLoader.class);
         MockCoordinatorBuilderSupplier supplier = mock(MockCoordinatorBuilderSupplier.class);
-        MockCoordinatorBuilder builder = mock(MockCoordinatorBuilder.class);
-        MockCoordinator coordinator = mock(MockCoordinator.class);
+        MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
+        MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
 
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(loader)
@@ -351,7 +351,7 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(TP, 0);
 
         // Getting the context succeeds and the coordinator should be in loading.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(CoordinatorRuntime.CoordinatorState.LOADING, ctx.state);
         assertEquals(0, ctx.epoch);
         assertEquals(coordinator, ctx.coordinator);
@@ -375,11 +375,11 @@ public class CoordinatorRuntimeTest {
         MockTimer timer = new MockTimer();
         MockCoordinatorLoader loader = mock(MockCoordinatorLoader.class);
         MockCoordinatorBuilderSupplier supplier = mock(MockCoordinatorBuilderSupplier.class);
-        MockCoordinatorBuilder builder = mock(MockCoordinatorBuilder.class);
-        MockCoordinator coordinator = mock(MockCoordinator.class);
+        MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
+        MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
 
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(loader)
@@ -402,7 +402,7 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(TP, 10);
 
         // Getting the context succeeds and the coordinator should be in loading.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(CoordinatorRuntime.CoordinatorState.LOADING, ctx.state);
         assertEquals(10, ctx.epoch);
         assertEquals(coordinator, ctx.coordinator);
@@ -424,11 +424,11 @@ public class CoordinatorRuntimeTest {
         MockTimer timer = new MockTimer();
         MockCoordinatorLoader loader = mock(MockCoordinatorLoader.class);
         MockCoordinatorBuilderSupplier supplier = mock(MockCoordinatorBuilderSupplier.class);
-        MockCoordinatorBuilder builder = mock(MockCoordinatorBuilder.class);
-        MockCoordinator coordinator = mock(MockCoordinator.class);
+        MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
+        MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
 
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(loader)
@@ -451,7 +451,7 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(TP, 10);
 
         // Getting the context succeeds and the coordinator should be in loading.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(CoordinatorRuntime.CoordinatorState.LOADING, ctx.state);
         assertEquals(10, ctx.epoch);
         assertEquals(coordinator, ctx.coordinator);
@@ -464,7 +464,7 @@ public class CoordinatorRuntimeTest {
         verify(coordinator, times(1)).onUnloaded();
 
         // Create a new coordinator.
-        coordinator = mock(MockCoordinator.class);
+        coordinator = mock(MockCoordinatorShard.class);
         when(builder.build()).thenReturn(coordinator);
 
         // Schedule the reloading.
@@ -490,11 +490,11 @@ public class CoordinatorRuntimeTest {
         MockTimer timer = new MockTimer();
         MockPartitionWriter writer = mock(MockPartitionWriter.class);
         MockCoordinatorBuilderSupplier supplier = mock(MockCoordinatorBuilderSupplier.class);
-        MockCoordinatorBuilder builder = mock(MockCoordinatorBuilder.class);
-        MockCoordinator coordinator = mock(MockCoordinator.class);
+        MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
+        MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
 
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -513,7 +513,7 @@ public class CoordinatorRuntimeTest {
 
         // Loads the coordinator. It directly transitions to active.
         runtime.scheduleLoadOperation(TP, 10);
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(CoordinatorRuntime.CoordinatorState.ACTIVE, ctx.state);
         assertEquals(10, ctx.epoch);
 
@@ -538,11 +538,11 @@ public class CoordinatorRuntimeTest {
     public void testScheduleUnloadingWithStalePartitionEpoch() {
         MockTimer timer = new MockTimer();
         MockCoordinatorBuilderSupplier supplier = mock(MockCoordinatorBuilderSupplier.class);
-        MockCoordinatorBuilder builder = mock(MockCoordinatorBuilder.class);
-        MockCoordinator coordinator = mock(MockCoordinator.class);
+        MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
+        MockCoordinatorShard coordinator = mock(MockCoordinatorShard.class);
 
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -563,7 +563,7 @@ public class CoordinatorRuntimeTest {
 
         // Loads the coordinator. It directly transitions to active.
         runtime.scheduleLoadOperation(TP, 10);
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(CoordinatorRuntime.CoordinatorState.ACTIVE, ctx.state);
         assertEquals(10, ctx.epoch);
 
@@ -579,8 +579,8 @@ public class CoordinatorRuntimeTest {
         MockTimer timer = new MockTimer();
         MockPartitionWriter writer = new MockPartitionWriter();
 
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -593,7 +593,7 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(TP, 10);
 
         // Verify the initial state.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(0L, ctx.lastWrittenOffset);
         assertEquals(0L, ctx.lastCommittedOffset);
         assertEquals(Collections.singletonList(0L), ctx.snapshotRegistry.epochsList());
@@ -687,8 +687,8 @@ public class CoordinatorRuntimeTest {
     @Test
     public void testScheduleWriteOpWhenInactive() {
         MockTimer timer = new MockTimer();
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -707,8 +707,8 @@ public class CoordinatorRuntimeTest {
     @Test
     public void testScheduleWriteOpWhenOpFails() {
         MockTimer timer = new MockTimer();
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -731,8 +731,8 @@ public class CoordinatorRuntimeTest {
     @Test
     public void testScheduleWriteOpWhenReplayFails() {
         MockTimer timer = new MockTimer();
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -745,14 +745,14 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(TP, 10);
 
         // Verify the initial state.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(0L, ctx.lastWrittenOffset);
         assertEquals(0L, ctx.lastCommittedOffset);
         assertEquals(Collections.singletonList(0L), ctx.snapshotRegistry.epochsList());
 
         // Override the coordinator with a coordinator that throws
         // an exception when replay is called.
-        ctx.coordinator = new MockCoordinator(ctx.snapshotRegistry, ctx.timer) {
+        ctx.coordinator = new MockCoordinatorShard(ctx.snapshotRegistry, ctx.timer) {
             @Override
             public void replay(String record) throws RuntimeException {
                 throw new IllegalArgumentException("error");
@@ -776,8 +776,8 @@ public class CoordinatorRuntimeTest {
         // The partition writer only accept on write.
         MockPartitionWriter writer = new MockPartitionWriter(2);
 
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -790,7 +790,7 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(TP, 10);
 
         // Verify the initial state.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(0, ctx.lastWrittenOffset);
         assertEquals(0, ctx.lastCommittedOffset);
         assertEquals(Collections.singletonList(0L), ctx.snapshotRegistry.epochsList());
@@ -823,8 +823,8 @@ public class CoordinatorRuntimeTest {
         MockTimer timer = new MockTimer();
         MockPartitionWriter writer = new MockPartitionWriter();
 
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -837,7 +837,7 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(TP, 10);
 
         // Verify the initial state.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(0, ctx.lastWrittenOffset);
         assertEquals(0, ctx.lastCommittedOffset);
 
@@ -877,8 +877,8 @@ public class CoordinatorRuntimeTest {
     @Test
     public void testScheduleReadOpWhenPartitionInactive() {
         MockTimer timer = new MockTimer();
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -898,8 +898,8 @@ public class CoordinatorRuntimeTest {
         MockTimer timer = new MockTimer();
         MockPartitionWriter writer = new MockPartitionWriter();
 
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -912,7 +912,7 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(TP, 10);
 
         // Verify the initial state.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(0, ctx.lastWrittenOffset);
         assertEquals(0, ctx.lastCommittedOffset);
 
@@ -939,8 +939,8 @@ public class CoordinatorRuntimeTest {
     public void testClose() throws Exception {
         MockCoordinatorLoader loader = spy(new MockCoordinatorLoader());
         MockTimer timer = new MockTimer();
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(loader)
@@ -953,7 +953,7 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(TP, 10);
 
         // Check initial state.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(0, ctx.lastWrittenOffset);
         assertEquals(0, ctx.lastCommittedOffset);
 
@@ -1002,10 +1002,10 @@ public class CoordinatorRuntimeTest {
         MockCoordinatorLoader loader = mock(MockCoordinatorLoader.class);
         MockPartitionWriter writer = mock(MockPartitionWriter.class);
         MockCoordinatorBuilderSupplier supplier = mock(MockCoordinatorBuilderSupplier.class);
-        MockCoordinatorBuilder builder = mock(MockCoordinatorBuilder.class);
+        MockCoordinatorShardBuilder builder = mock(MockCoordinatorShardBuilder.class);
 
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(loader)
@@ -1014,8 +1014,8 @@ public class CoordinatorRuntimeTest {
                 .withCoordinatorBuilderSupplier(supplier)
                 .build();
 
-        MockCoordinator coordinator0 = mock(MockCoordinator.class);
-        MockCoordinator coordinator1 = mock(MockCoordinator.class);
+        MockCoordinatorShard coordinator0 = mock(MockCoordinatorShard.class);
+        MockCoordinatorShard coordinator1 = mock(MockCoordinatorShard.class);
 
         when(supplier.get()).thenReturn(builder);
         when(builder.withSnapshotRegistry(any())).thenReturn(builder);
@@ -1059,8 +1059,8 @@ public class CoordinatorRuntimeTest {
     @Test
     public void testScheduleTimer() throws InterruptedException {
         MockTimer timer = new MockTimer();
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -1073,7 +1073,7 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(TP, 10);
 
         // Check initial state.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(0, ctx.lastWrittenOffset);
         assertEquals(0, ctx.lastCommittedOffset);
 
@@ -1110,8 +1110,8 @@ public class CoordinatorRuntimeTest {
     public void testRescheduleTimer() throws InterruptedException {
         MockTimer timer = new MockTimer();
         ManualEventProcessor processor = new ManualEventProcessor();
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -1128,7 +1128,7 @@ public class CoordinatorRuntimeTest {
         processor.poll();
 
         // Check initial state.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(0, ctx.timer.size());
 
         // The processor should be empty.
@@ -1181,8 +1181,8 @@ public class CoordinatorRuntimeTest {
     public void testCancelTimer() throws InterruptedException {
         MockTimer timer = new MockTimer();
         ManualEventProcessor processor = new ManualEventProcessor();
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -1199,7 +1199,7 @@ public class CoordinatorRuntimeTest {
         processor.poll();
 
         // Check initial state.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(0, ctx.timer.size());
 
         // The processor should be empty.
@@ -1249,8 +1249,8 @@ public class CoordinatorRuntimeTest {
     @Test
     public void testRetryableTimer() throws InterruptedException {
         MockTimer timer = new MockTimer();
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -1263,7 +1263,7 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(TP, 10);
 
         // Check initial state.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(0, ctx.timer.size());
 
         // Timer #1.
@@ -1305,8 +1305,8 @@ public class CoordinatorRuntimeTest {
     @Test
     public void testNonRetryableTimer() throws InterruptedException {
         MockTimer timer = new MockTimer();
-        CoordinatorRuntime<MockCoordinator, String> runtime =
-            new CoordinatorRuntime.Builder<MockCoordinator, String>()
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
                 .withTime(timer.time())
                 .withTimer(timer)
                 .withLoader(new MockCoordinatorLoader())
@@ -1319,7 +1319,7 @@ public class CoordinatorRuntimeTest {
         runtime.scheduleLoadOperation(TP, 10);
 
         // Check initial state.
-        CoordinatorRuntime<MockCoordinator, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
         assertEquals(0, ctx.timer.size());
 
         // Timer #1.


### PR DESCRIPTION
This patch does a few code cleanups in the group-coordinator module.
- It renames `Coordinator` to `CoordinatorShard`;
- It renames `ReplicatedGroupCoordinator` to `GroupCoordinatorShard`. I was never really happy with this name. The new name makes more sense to me;
- It removes `TopicPartition` from the `GroupMetadataManager`. It was only used in log messages. The log context already includes it so we don't have to log it again.
- It renames `assignors` to `consumerGroupAssignors`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
