### PR TITLE
KAFKA-14875: Implement wakeup

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
+import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -96,9 +97,11 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     private final Metrics metrics;
     private final long defaultApiTimeoutMs;
 
-    public PrototypeAsyncConsumer(final Properties properties,
-                                  final Deserializer<K> keyDeserializer,
-                                  final Deserializer<V> valueDeserializer) {
+
+    private WakeupTrigger wakeupTrigger = new WakeupTrigger();
+    public PrototypeAsyncConsumer(Properties properties,
+                         Deserializer<K> keyDeserializer,
+                         Deserializer<V> valueDeserializer) {
         this(Utils.propsToMap(properties), keyDeserializer, valueDeserializer);
     }
 
@@ -316,6 +319,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         }
 
         final OffsetFetchApplicationEvent event = new OffsetFetchApplicationEvent(partitions);
+        wakeupTrigger.setActiveTask(event.future());
         eventHandler.add(event);
         try {
             return event.future().get(timeout.toMillis(), TimeUnit.MILLISECONDS);
@@ -324,10 +328,9 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         } catch (TimeoutException e) {
             throw new org.apache.kafka.common.errors.TimeoutException(e);
         } catch (ExecutionException e) {
-            // Execution exception is thrown here
+            if (e.getCause() instanceof WakeupException)
+                throw new WakeupException();
             throw new KafkaException(e);
-        } catch (Exception e) {
-            throw e;
         }
     }
 
@@ -449,6 +452,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void wakeup() {
+        wakeupTrigger.wakeup();
     }
 
     /**
@@ -469,7 +473,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
-        CompletableFuture<Void> commitFuture = commit(offsets);
+        CompletableFuture<Void> commitFuture = wakeupTrigger.setActiveTask(commit(offsets));
         try {
             commitFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (final TimeoutException e) {
@@ -477,9 +481,9 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         } catch (final InterruptedException e) {
             throw new InterruptException(e);
         } catch (final ExecutionException e) {
+            if (e.getCause() instanceof WakeupException)
+                throw new WakeupException();
             throw new KafkaException(e);
-        } catch (final Exception e) {
-            throw e;
         }
     }
 
@@ -558,6 +562,11 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     @Deprecated
     public ConsumerRecords<K, V> poll(long timeout) {
         throw new KafkaException("method not implemented");
+    }
+
+    // Visible for testing
+    WakeupTrigger wakeupTrigger() {
+        return wakeupTrigger;
     }
 
     private static <K, V> ClusterResourceListeners configureClusterResourceListeners(

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -103,7 +103,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     public PrototypeAsyncConsumer(Properties properties,
                          Deserializer<K> keyDeserializer,
                          Deserializer<V> valueDeserializer) {
-            this(propsToMap(properties), keyDeserializer, valueDeserializer);
+        this(propsToMap(properties), keyDeserializer, valueDeserializer);
     }
 
     public PrototypeAsyncConsumer(final Map<String, Object> configs,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -42,6 +42,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
+import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -70,10 +71,10 @@ import java.util.regex.Pattern;
 
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredConsumerInterceptors;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createLogContext;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createMetrics;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createSubscriptionState;
-import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredConsumerInterceptors;
 import static org.apache.kafka.common.utils.Utils.closeQuietly;
 import static org.apache.kafka.common.utils.Utils.isBlank;
 import static org.apache.kafka.common.utils.Utils.join;
@@ -98,10 +99,11 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     private final Metrics metrics;
     private final long defaultApiTimeoutMs;
 
-    public PrototypeAsyncConsumer(final Properties properties,
-                                  final Deserializer<K> keyDeserializer,
-                                  final Deserializer<V> valueDeserializer) {
-        this(propsToMap(properties), keyDeserializer, valueDeserializer);
+    private WakeupTrigger wakeupTrigger = new WakeupTrigger();
+    public PrototypeAsyncConsumer(Properties properties,
+                         Deserializer<K> keyDeserializer,
+                         Deserializer<V> valueDeserializer) {
+            this(propsToMap(properties), keyDeserializer, valueDeserializer);
     }
 
     public PrototypeAsyncConsumer(final Map<String, Object> configs,
@@ -317,6 +319,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         }
 
         final OffsetFetchApplicationEvent event = new OffsetFetchApplicationEvent(partitions);
+        wakeupTrigger.setActiveTask(event.future());
         eventHandler.add(event);
         try {
             return event.future().get(timeout.toMillis(), TimeUnit.MILLISECONDS);
@@ -325,10 +328,9 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         } catch (TimeoutException e) {
             throw new org.apache.kafka.common.errors.TimeoutException(e);
         } catch (ExecutionException e) {
-            // Execution exception is thrown here
+            if (e.getCause() instanceof WakeupException)
+                throw new WakeupException();
             throw new KafkaException(e);
-        } catch (Exception e) {
-            throw e;
         }
     }
 
@@ -450,6 +452,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void wakeup() {
+        wakeupTrigger.wakeup();
     }
 
     /**
@@ -470,7 +473,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
-        CompletableFuture<Void> commitFuture = commit(offsets);
+        CompletableFuture<Void> commitFuture = wakeupTrigger.setActiveTask(commit(offsets));
         try {
             commitFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (final TimeoutException e) {
@@ -478,9 +481,9 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         } catch (final InterruptedException e) {
             throw new InterruptException(e);
         } catch (final ExecutionException e) {
+            if (e.getCause() instanceof WakeupException)
+                throw new WakeupException();
             throw new KafkaException(e);
-        } catch (final Exception e) {
-            throw e;
         }
     }
 
@@ -559,6 +562,24 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     @Deprecated
     public ConsumerRecords<K, V> poll(long timeout) {
         throw new KafkaException("method not implemented");
+    }
+
+    // Visible for testing
+    WakeupTrigger wakeupTrigger() {
+        return wakeupTrigger;
+    }
+
+    private static <K, V> ClusterResourceListeners configureClusterResourceListeners(
+            final Deserializer<K> keyDeserializer,
+            final Deserializer<V> valueDeserializer,
+            final List<?>... candidateLists) {
+        ClusterResourceListeners clusterResourceListeners = new ClusterResourceListeners();
+        for (List<?> candidateList: candidateLists)
+            clusterResourceListeners.maybeAddAll(candidateList);
+
+        clusterResourceListeners.maybeAdd(keyDeserializer);
+        clusterResourceListeners.maybeAdd(valueDeserializer);
+        return clusterResourceListeners;
     }
 
     // This is here temporary as we don't have public access to the ConsumerConfig in this module.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -199,6 +199,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         } catch (final Exception e) {
             throw new RuntimeException(e);
         }
+        // TODO: Once we implement poll(), clear wakeupTrigger in a finally block: wakeupTrigger.clearActiveTask();
 
         return ConsumerRecords.empty();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/WakeupTrigger.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/WakeupTrigger.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.errors.WakeupException;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Ensures blocking APIs can be woken up by the consumer.wakeup().
+ */
+public class WakeupTrigger {
+    private AtomicReference<Wakeupable> pendingTask = new AtomicReference<>(null);
+
+    /*
+    Wakeup a pending task.  If there isn't any pending task, return a WakedupFuture, so that the subsequent call
+    would know wakeup was previously called.
+
+    If there are active taks, complete it with WakeupException, then unset pending task (return null here.
+    If the current task has already been wakedup, do nothing.
+     */
+    public void wakeup() {
+        pendingTask.getAndUpdate(task -> {
+            if (task == null) {
+                return new WakedupFuture();
+            } else if (task instanceof ActiveFuture) {
+                ActiveFuture active = (ActiveFuture) task;
+                active.future().completeExceptionally(new WakeupException());
+                return null;
+            } else {
+                return task;
+            }
+        });
+    }
+
+    /*
+    If there is no pending task, set the pending task active.
+    If wakeup was called before setting an active task, the current task will complete exceptionally with
+    WakeupException right
+    away.
+    if there is an active task, throw exception.
+     */
+    public <T> CompletableFuture<T> setActiveTask(final CompletableFuture<T> currentTask) {
+        Objects.requireNonNull(currentTask, "currentTask cannot be null");
+        pendingTask.getAndUpdate(task -> {
+            if (task == null) {
+                return new ActiveFuture(currentTask);
+            } else if (task instanceof WakedupFuture) {
+                currentTask.completeExceptionally(new WakeupException());
+                return null;
+            }
+            // last active state is still active
+            throw new KafkaException("Last active task is still active");
+        });
+        return currentTask;
+    }
+
+    public void unsetActiveTask() {
+        pendingTask.getAndUpdate(task -> {
+            if (task == null) {
+                return null;
+            } else if (task instanceof ActiveFuture) {
+                return null;
+            }
+            return task;
+        });
+    }
+
+    Wakeupable getPendingTask() {
+        return pendingTask.get();
+    }
+
+    interface Wakeupable { }
+
+    static class ActiveFuture implements Wakeupable {
+        private final CompletableFuture<?> future;
+
+        public ActiveFuture(final CompletableFuture<?> future) {
+            this.future = future;
+        }
+
+        public CompletableFuture<?> future() {
+            return future;
+        }
+    }
+
+    static class WakedupFuture implements Wakeupable { }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/WakeupTrigger.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/WakeupTrigger.java
@@ -30,7 +30,7 @@ public class WakeupTrigger {
     private AtomicReference<Wakeupable> pendingTask = new AtomicReference<>(null);
 
     /*
-      Wakeup a pending task.  If there isn't any pending task, return a WakedupFuture, so that the subsequent call
+      Wakeup a pending task.  If there isn't any pending task, return a WakeupFuture, so that the subsequent call
       would know wakeup was previously called.
 
       If there are active tasks, complete it with WakeupException, then unset pending task (return null here.
@@ -39,7 +39,7 @@ public class WakeupTrigger {
     public void wakeup() {
         pendingTask.getAndUpdate(task -> {
             if (task == null) {
-                return new WakedupFuture();
+                return new WakeupFuture();
             } else if (task instanceof ActiveFuture) {
                 ActiveFuture active = (ActiveFuture) task;
                 active.future().completeExceptionally(new WakeupException());
@@ -62,7 +62,7 @@ public class WakeupTrigger {
         pendingTask.getAndUpdate(task -> {
             if (task == null) {
                 return new ActiveFuture(currentTask);
-            } else if (task instanceof WakedupFuture) {
+            } else if (task instanceof WakeupFuture) {
                 currentTask.completeExceptionally(new WakeupException());
                 return null;
             }
@@ -101,5 +101,5 @@ public class WakeupTrigger {
         }
     }
 
-    static class WakedupFuture implements Wakeupable { }
+    static class WakeupFuture implements Wakeupable { }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/WakeupTrigger.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/WakeupTrigger.java
@@ -30,11 +30,11 @@ public class WakeupTrigger {
     private AtomicReference<Wakeupable> pendingTask = new AtomicReference<>(null);
 
     /*
-    Wakeup a pending task.  If there isn't any pending task, return a WakedupFuture, so that the subsequent call
-    would know wakeup was previously called.
+      Wakeup a pending task.  If there isn't any pending task, return a WakedupFuture, so that the subsequent call
+      would know wakeup was previously called.
 
-    If there are active taks, complete it with WakeupException, then unset pending task (return null here.
-    If the current task has already been wakedup, do nothing.
+      If there are active tasks, complete it with WakeupException, then unset pending task (return null here.
+      If the current task has already been woken-up, do nothing.
      */
     public void wakeup() {
         pendingTask.getAndUpdate(task -> {
@@ -72,7 +72,7 @@ public class WakeupTrigger {
         return currentTask;
     }
 
-    public void unsetActiveTask() {
+    public void clearActiveTask() {
         pendingTask.getAndUpdate(task -> {
             if (task == null) {
                 return null;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -110,7 +110,7 @@ public class ApplicationEventProcessor {
         Optional<RequestManager> commitRequestManger = registry.get(RequestManager.Type.COMMIT);
         CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> future = event.future();
         if (!commitRequestManger.isPresent()) {
-            future.completeExceptionally(new KafkaException("Unable to fetch committed offset because the " +
+            event.future().completeExceptionally(new KafkaException("Unable to fetch committed offset because the " +
                     "CommittedRequestManager is not available. Check if group.id was set correctly"));
             return false;
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -110,7 +110,7 @@ public class ApplicationEventProcessor {
         Optional<RequestManager> commitRequestManger = registry.get(RequestManager.Type.COMMIT);
         CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> future = event.future();
         if (!commitRequestManger.isPresent()) {
-            event.future().completeExceptionally(new KafkaException("Unable to fetch committed offset because the " +
+            future.completeExceptionally(new KafkaException("Unable to fetch committed offset because the " +
                     "CommittedRequestManager is not available. Check if group.id was set correctly"));
             return false;
         }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.consumer.internals.events.OffsetFetchApplication
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
+import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -216,6 +217,35 @@ public class PrototypeAsyncConsumerTest {
     public void testAssignOnEmptyTopicInPartition() {
         consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(IllegalArgumentException.class, () -> consumer.assign(singleton(new TopicPartition("  ", 0))));
+    }
+
+    @Test
+    public void testWakeup_commitSync() {
+        consumer = newConsumer(time, new StringDeserializer(),
+            new StringDeserializer());
+        consumer.wakeup();
+        assertThrows(WakeupException.class, () -> consumer.commitSync());
+        assertNoPendingWakeup(consumer.wakeupTrigger());
+    }
+
+    @Test
+    public void testWakeup_committed() {
+        consumer = newConsumer(time, new StringDeserializer(),
+            new StringDeserializer());
+        consumer.wakeup();
+        assertThrows(WakeupException.class, () -> consumer.committed(mockTopicPartitionOffset().keySet()));
+        assertNoPendingWakeup(consumer.wakeupTrigger());
+    }
+
+    @Test
+    public void testClosed() {
+        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        consumer.close();
+        assertDoesNotThrow(() -> consumer.committed(new HashSet<>()));
+    }
+
+    private void assertNoPendingWakeup(final WakeupTrigger wakeupTrigger) {
+        assertTrue(wakeupTrigger.getPendingTask() == null);
     }
 
     private HashMap<TopicPartition, OffsetAndMetadata> mockTopicPartitionOffset() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -123,7 +123,7 @@ public class PrototypeAsyncConsumerTest {
         offsets.put(new TopicPartition("my-topic", 1), new OffsetAndMetadata(200L));
 
         PrototypeAsyncConsumer<?, ?> mockedConsumer = spy(newConsumer(time, new StringDeserializer(), new StringDeserializer()));
-        doReturn(future).when(mockedConsumer).commit(offsets);
+        doReturn(future).when(mockedConsumer).commit(offsets, false);
         mockedConsumer.commitAsync(offsets, null);
         future.complete(null);
         TestUtils.waitForCondition(() -> future.isDone(),
@@ -144,7 +144,7 @@ public class PrototypeAsyncConsumerTest {
 
         PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         PrototypeAsyncConsumer<?, ?> mockedConsumer = spy(consumer);
-        doReturn(future).when(mockedConsumer).commit(offsets);
+        doReturn(future).when(mockedConsumer).commit(offsets, false);
         OffsetCommitCallback customCallback = mock(OffsetCommitCallback.class);
         mockedConsumer.commitAsync(offsets, customCallback);
         future.complete(null);
@@ -235,13 +235,6 @@ public class PrototypeAsyncConsumerTest {
         consumer.wakeup();
         assertThrows(WakeupException.class, () -> consumer.committed(mockTopicPartitionOffset().keySet()));
         assertNoPendingWakeup(consumer.wakeupTrigger());
-    }
-
-    @Test
-    public void testClosed() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
-        consumer.close();
-        assertDoesNotThrow(() -> consumer.committed(new HashSet<>()));
     }
 
     private void assertNoPendingWakeup(final WakeupTrigger wakeupTrigger) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.common.errors.WakeupException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class WakeupTriggerTest {
+    private static long defaultTimeoutMs = 1000;
+    private WakeupTrigger wakeupTrigger;
+
+    @BeforeEach
+    public void setup() {
+        this.wakeupTrigger = new WakeupTrigger();
+    }
+    @Test
+    public void testEnsureActiveFutureCanBeWakeUp() {
+        CompletableFuture<Void> task = new CompletableFuture<>();
+        wakeupTrigger.setActiveTask(task);
+        wakeupTrigger.wakeup();
+        assertWakeupExceptionIsThrown(task);
+        assertNull(wakeupTrigger.getPendingTask());
+    }
+
+    @Test
+    public void testSettingActiveFutureAfterWakeupShouldThrow() {
+        wakeupTrigger.wakeup();
+        CompletableFuture<Void> task = new CompletableFuture<>();
+        wakeupTrigger.setActiveTask(task);
+        assertWakeupExceptionIsThrown(task);
+        assertNull(wakeupTrigger.getPendingTask());
+    }
+
+    @Test
+    public void testUnsetActiveFuture() {
+        CompletableFuture<Void> task = new CompletableFuture<>();
+        wakeupTrigger.setActiveTask(task);
+        wakeupTrigger.unsetActiveTask();
+        assertNull(wakeupTrigger.getPendingTask());
+    }
+
+    private void assertWakeupExceptionIsThrown(final CompletableFuture<?> future) {
+        assertTrue(future.isCompletedExceptionally());
+        try {
+            future.get(defaultTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof WakeupException);
+            return;
+        } catch (Exception e) {
+            fail("The task should throw an ExecutionException but got:" + e);
+        }
+        fail("The task should throw an ExecutionException");
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
@@ -36,6 +36,7 @@ public class WakeupTriggerTest {
     public void setup() {
         this.wakeupTrigger = new WakeupTrigger();
     }
+    
     @Test
     public void testEnsureActiveFutureCanBeWakeUp() {
         CompletableFuture<Void> task = new CompletableFuture<>();
@@ -58,7 +59,7 @@ public class WakeupTriggerTest {
     public void testUnsetActiveFuture() {
         CompletableFuture<Void> task = new CompletableFuture<>();
         wakeupTrigger.setActiveTask(task);
-        wakeupTrigger.unsetActiveTask();
+        wakeupTrigger.clearActiveTask();
         assertNull(wakeupTrigger.getPendingTask());
     }
 


### PR DESCRIPTION
Continuation of https://github.com/apache/kafka/pull/13490.  I closed the original one due to rebase difficulties.

**Summary**
Implemented wakeup() mechanism using a WakeupTrigger class to store the pending wakeup item, and when wakeup() is invoked, it checks whether there's an active task or a wakeup task.  
- If there's an active task: the task will be completed exceptionally and the atomic reference will be freed up.
- If there an wakedup task, which means wakeup() was invoked before a blocking call was issued.  Therefore, the current task will be completed exceptionally immediately.

This PR also addressed minor issues such as:
1. Throwing WakeupException at the right place: As wakeups are thrown by completing an active future exceptionally.  The WakeupException is wrapped inside of the ExecutionException.
2. mockConstruction is a thread-lock mock; therefore, we need to free up the reference before completing the test. Otherwise, other tests will continue using the thread-lock mock.