### PR TITLE
KAFKA-15266: Static configs set for non primary synonyms are ignored for Log configs

### DIFF
--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -252,7 +252,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     val expectedProps = new Properties
     expectedProps.setProperty(KafkaConfig.LogRetentionTimeMillisProp, "1680000000")
     expectedProps.setProperty(KafkaConfig.LogRetentionTimeHoursProp, "168")
-    expectedProps.setProperty(KafkaConfig.LogRollTimeHoursProp, "168")
+    expectedProps.setProperty(KafkaConfig.LogRollTimeHoursProp, "24")
     expectedProps.setProperty(KafkaConfig.LogCleanerThreadsProp, "1")
     val logRetentionMs = configEntry(configDesc, KafkaConfig.LogRetentionTimeMillisProp)
     verifyConfig(KafkaConfig.LogRetentionTimeMillisProp, logRetentionMs,
@@ -276,7 +276,8 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     assertEquals(List((KafkaConfig.LogRetentionTimeHoursProp, ConfigSource.STATIC_BROKER_CONFIG),
       (KafkaConfig.LogRetentionTimeHoursProp, ConfigSource.DEFAULT_CONFIG)),
       synonymsList(logRetentionHours))
-    assertEquals(List((KafkaConfig.LogRollTimeHoursProp, ConfigSource.DEFAULT_CONFIG)), synonymsList(logRollHours))
+    assertEquals(List((KafkaConfig.LogRollTimeHoursProp, ConfigSource.STATIC_BROKER_CONFIG),
+      (KafkaConfig.LogRollTimeHoursProp, ConfigSource.DEFAULT_CONFIG)), synonymsList(logRollHours))
     assertEquals(List((KafkaConfig.LogCleanerThreadsProp, ConfigSource.DEFAULT_CONFIG)), synonymsList(logCleanerThreads))
   }
 


### PR DESCRIPTION
This change ensures that values stored in "non-primary" synonyms is respected when altering configs. Currently if "non-primary" synonyms have a static config set up then it gets deleted from the default log config during reconfiguration. We want to ensure that we retain the correct order of using broker level synonyms(log.retention.ms > log.retention.minutes > log.retention.hours)

I have added unit test cases for this scenario.
1. During setup we configure log.roll.hours=24
2. We then run a few alter configs and ensure that LogConfig for segment.ms is still set to 24 hours
3. We then run alter-config to set log.roll.ms=50000 and we verify that segment.ms also changes to 50000
4. We then delete the dynamic config for log.roll.ms and then verify that we again pick up the statically configured 24 hour value

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
