### PR TITLE
MINOR: Fix committed API in the PrototypeAsyncConsumer timeout

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -333,7 +333,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         final OffsetFetchApplicationEvent event = new OffsetFetchApplicationEvent(partitions);
         eventHandler.add(event);
         try {
-            return event.complete(timeout);
+            return event.future().get(timeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             throw new InterruptException(e);
         } catch (TimeoutException e) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -16,16 +16,19 @@
  */
 package org.apache.kafka.clients.consumer.internals.events;
 
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.internals.CommitRequestManager;
 import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
 import org.apache.kafka.clients.consumer.internals.NoopBackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.RequestManager;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
 
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 
 public class ApplicationEventProcessor {
 
@@ -105,18 +108,19 @@ public class ApplicationEventProcessor {
 
     private boolean process(final OffsetFetchApplicationEvent event) {
         Optional<RequestManager> commitRequestManger = registry.get(RequestManager.Type.COMMIT);
+        CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> future = event.future();
         if (!commitRequestManger.isPresent()) {
-            event.future().completeExceptionally(new KafkaException("Unable to fetch committed offset because the " +
+            future.completeExceptionally(new KafkaException("Unable to fetch committed offset because the " +
                     "CommittedRequestManager is not available. Check if group.id was set correctly"));
             return false;
         }
         CommitRequestManager manager = (CommitRequestManager) commitRequestManger.get();
         manager.addOffsetFetchRequest(event.partitions()).whenComplete((r, e) -> {
             if (e != null) {
-                event.future().completeExceptionally(e);
+                future.completeExceptionally(e);
                 return;
             }
-            event.future().complete(r);
+            future.complete(r);
         });
         return true;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/OffsetFetchApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/OffsetFetchApplicationEvent.java
@@ -19,17 +19,13 @@ package org.apache.kafka.clients.consumer.internals.events;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 
-import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class OffsetFetchApplicationEvent extends ApplicationEvent {
-    final public CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> future;
-    public final Set<TopicPartition> partitions;
+    private final CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> future;
+    private final Set<TopicPartition> partitions;
 
     public OffsetFetchApplicationEvent(final Set<TopicPartition> partitions) {
         super(Type.FETCH_COMMITTED_OFFSET);
@@ -37,7 +33,19 @@ public class OffsetFetchApplicationEvent extends ApplicationEvent {
         this.future = new CompletableFuture<>();
     }
 
-    public Map<TopicPartition, OffsetAndMetadata> complete(final Duration duration) throws ExecutionException, InterruptedException, TimeoutException {
-        return future.get(duration.toMillis(), TimeUnit.MILLISECONDS);
+    public CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> future() {
+        return this.future;
+    }
+
+    public Set<TopicPartition> partitions() {
+        return partitions;
+    }
+
+    @Override
+    public String toString() {
+        return "OffsetFetchApplicationEvent{" +
+            "future=" + future +
+            ", partitions=" + partitions +
+            '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/OffsetFetchApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/OffsetFetchApplicationEvent.java
@@ -34,7 +34,7 @@ public class OffsetFetchApplicationEvent extends ApplicationEvent {
     }
 
     public CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> future() {
-        return this.future;
+        return future;
     }
 
     public Set<TopicPartition> partitions() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -151,7 +151,6 @@ public class PrototypeAsyncConsumerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testCommitted() {
         Set<TopicPartition> mockTopicPartitions = mockTopicPartitionOffset().keySet();
         CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> committedFuture = new CompletableFuture<>();
@@ -167,7 +166,6 @@ public class PrototypeAsyncConsumerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testCommitted_ExceptionThrown() {
         Set<TopicPartition> mockTopicPartitions = mockTopicPartitionOffset().keySet();
         CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> committedFuture = new CompletableFuture<>();

--- a/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
@@ -17,7 +17,7 @@
 package kafka.api
 
 import kafka.utils.TestUtils.waitUntilTrue
-import org.junit.jupiter.api.Assertions.{assertNotNull, assertNull}
+import org.junit.jupiter.api.Assertions.{assertNotNull, assertNull, assertTrue}
 import org.junit.jupiter.api.Test
 
 import java.time.Duration
@@ -35,11 +35,14 @@ class BaseAsyncConsumerTest extends AbstractConsumerTest {
     val startingTimestamp = System.currentTimeMillis()
     val cb = new CountConsumerCommitCallback
     sendRecords(producer, numRecords, tp, startingTimestamp = startingTimestamp)
+    consumer.assign(List(tp).asJava)
     consumer.commitAsync(cb)
     waitUntilTrue(() => {
       cb.successCount == 1
     }, "wait until commit is completed successfully", defaultBlockingAPITimeoutMs)
     val committedOffset = consumer.committed(Set(tp).asJava, Duration.ofMillis(defaultBlockingAPITimeoutMs))
+
+    assertTrue(consumer.assignment.contains(tp))
     assertNotNull(committedOffset)
     assertNull(committedOffset.get(tp))
   }
@@ -51,9 +54,11 @@ class BaseAsyncConsumerTest extends AbstractConsumerTest {
     val numRecords = 10000
     val startingTimestamp = System.currentTimeMillis()
     sendRecords(producer, numRecords, tp, startingTimestamp = startingTimestamp)
+    consumer.assign(List(tp).asJava)
     consumer.commitSync()
     val committedOffset = consumer.committed(Set(tp).asJava, Duration.ofMillis(defaultBlockingAPITimeoutMs))
     assertNotNull(committedOffset)
     assertNull(committedOffset.get(tp))
+    assertTrue(consumer.assignment.contains(tp))
   }
 }

--- a/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
@@ -40,10 +40,11 @@ class BaseAsyncConsumerTest extends AbstractConsumerTest {
       cb.successCount == 1
     }, "wait until commit is completed successfully", defaultBlockingAPITimeoutMs)
     val committedOffset = consumer.committed(Set(tp).asJava, Duration.ofMillis(defaultBlockingAPITimeoutMs))
-
-    assertTrue(consumer.assignment.contains(tp))
     assertNotNull(committedOffset)
+    // No valid fetch position due to the absence of consumer.poll; and therefore no offset was committed to
+    // tp. The committed offset should be null. This is intentional.
     assertNull(committedOffset.get(tp))
+    assertTrue(consumer.assignment.contains(tp))
   }
 
   @Test
@@ -57,6 +58,8 @@ class BaseAsyncConsumerTest extends AbstractConsumerTest {
     consumer.commitSync()
     val committedOffset = consumer.committed(Set(tp).asJava, Duration.ofMillis(defaultBlockingAPITimeoutMs))
     assertNotNull(committedOffset)
+    // No valid fetch position due to the absence of consumer.poll; and therefore no offset was committed to
+    // tp. The committed offset should be null. This is intentional.
     assertNull(committedOffset.get(tp))
     assertTrue(consumer.assignment.contains(tp))
   }

--- a/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test
 import java.time.Duration
 import scala.jdk.CollectionConverters._
 
-
 class BaseAsyncConsumerTest extends AbstractConsumerTest {
   val defaultBlockingAPITimeoutMs = 1000
 

--- a/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAsyncConsumerTest.scala
@@ -17,12 +17,16 @@
 package kafka.api
 
 import kafka.utils.TestUtils.waitUntilTrue
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.{assertNotNull, assertNull}
 import org.junit.jupiter.api.Test
 
+import java.time.Duration
 import scala.jdk.CollectionConverters._
 
+
 class BaseAsyncConsumerTest extends AbstractConsumerTest {
+  val defaultBlockingAPITimeoutMs = 1000
+
   @Test
   def testCommitAsync(): Unit = {
     val consumer = createAsyncConsumer()
@@ -31,12 +35,13 @@ class BaseAsyncConsumerTest extends AbstractConsumerTest {
     val startingTimestamp = System.currentTimeMillis()
     val cb = new CountConsumerCommitCallback
     sendRecords(producer, numRecords, tp, startingTimestamp = startingTimestamp)
-    consumer.assign(List(tp).asJava)
     consumer.commitAsync(cb)
     waitUntilTrue(() => {
       cb.successCount == 1
-    }, "wait until commit is completed successfully", 5000)
-    assertTrue(consumer.assignment.contains(tp))
+    }, "wait until commit is completed successfully", defaultBlockingAPITimeoutMs)
+    val committedOffset = consumer.committed(Set(tp).asJava, Duration.ofMillis(defaultBlockingAPITimeoutMs))
+    assertNotNull(committedOffset)
+    assertNull(committedOffset.get(tp))
   }
 
   @Test
@@ -46,9 +51,9 @@ class BaseAsyncConsumerTest extends AbstractConsumerTest {
     val numRecords = 10000
     val startingTimestamp = System.currentTimeMillis()
     sendRecords(producer, numRecords, tp, startingTimestamp = startingTimestamp)
-    consumer.assign(List(tp).asJava)
-    consumer.commitSync();
-
-    assertTrue(consumer.assignment.contains(tp))
+    consumer.commitSync()
+    val committedOffset = consumer.committed(Set(tp).asJava, Duration.ofMillis(defaultBlockingAPITimeoutMs))
+    assertNotNull(committedOffset)
+    assertNull(committedOffset.get(tp))
   }
 }


### PR DESCRIPTION
**Summary**
I discovered the committed() API timeout during the integration test.  After investigation, this is because the future was not completed in the ApplicationEventProcessor. I also added `toString` methods to the event class for debug purposes.