### PR TITLE
KAFKA-14509; [1/2] Define ConsumerGroupDescribe API request and response schemas and classes.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -111,7 +111,8 @@ public enum ApiKeys {
     DESCRIBE_TRANSACTIONS(ApiMessageType.DESCRIBE_TRANSACTIONS),
     LIST_TRANSACTIONS(ApiMessageType.LIST_TRANSACTIONS),
     ALLOCATE_PRODUCER_IDS(ApiMessageType.ALLOCATE_PRODUCER_IDS, true, true),
-    CONSUMER_GROUP_HEARTBEAT(ApiMessageType.CONSUMER_GROUP_HEARTBEAT);
+    CONSUMER_GROUP_HEARTBEAT(ApiMessageType.CONSUMER_GROUP_HEARTBEAT),
+    CONSUMER_GROUP_DESCRIBE(ApiMessageType.CONSUMER_GROUP_DESCRIBE);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -312,6 +312,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return AllocateProducerIdsRequest.parse(buffer, apiVersion);
             case CONSUMER_GROUP_HEARTBEAT:
                 return ConsumerGroupHeartbeatRequest.parse(buffer, apiVersion);
+            case CONSUMER_GROUP_DESCRIBE:
+                return ConsumerGroupDescribeRequest.parse(buffer, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -249,6 +249,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return AllocateProducerIdsResponse.parse(responseBuffer, version);
             case CONSUMER_GROUP_HEARTBEAT:
                 return ConsumerGroupHeartbeatResponse.parse(responseBuffer, version);
+            case CONSUMER_GROUP_DESCRIBE:
+                return ConsumerGroupDescribeResponse.parse(responseBuffer, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequest.java
@@ -61,7 +61,7 @@ public class ConsumerGroupDescribeRequest extends AbstractRequest {
     public ConsumerGroupDescribeResponse getErrorResponse(int throttleTimeMs, Throwable e) {
         ConsumerGroupDescribeResponseData data = new ConsumerGroupDescribeResponseData()
             .setThrottleTimeMs(throttleTimeMs);
-        // Set error for each group based on e
+        // Set error for each group
         this.data.groupIds().forEach(
             groupId -> data.groups().add(
                 new ConsumerGroupDescribeResponseData.DescribedGroup()

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ConsumerGroupDescribeRequestData;
+import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Possible error codes:
+ *
+ * GROUP_ID_NOT_FOUND (69)
+ */
+public class ConsumerGroupDescribeRequest extends AbstractRequest {
+
+    public static class Builder extends AbstractRequest.Builder<ConsumerGroupDescribeRequest> {
+
+        private final ConsumerGroupDescribeRequestData data;
+
+        public Builder(ConsumerGroupDescribeRequestData data) {
+            super(ApiKeys.CONSUMER_GROUP_DESCRIBE);
+            this.data = data;
+        }
+
+        @Override
+        public ConsumerGroupDescribeRequest build(short version) {
+            return new ConsumerGroupDescribeRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final ConsumerGroupDescribeRequestData data;
+
+    public ConsumerGroupDescribeRequest(ConsumerGroupDescribeRequestData data, short version) {
+        super(ApiKeys.CONSUMER_GROUP_DESCRIBE, version);
+        this.data = data;
+    }
+
+    @Override
+    public ConsumerGroupDescribeResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        return new ConsumerGroupDescribeResponse(
+            new ConsumerGroupDescribeResponseData()
+                .setThrottleTimeMs(throttleTimeMs)
+        );
+    }
+
+    @Override
+    public ConsumerGroupDescribeRequestData data() {
+        return data;
+    }
+
+    public static ConsumerGroupDescribeRequest parse(ByteBuffer buffer, short version) {
+        return new ConsumerGroupDescribeRequest(
+            new ConsumerGroupDescribeRequestData(new ByteBufferAccessor(buffer), version),
+            version
+        );
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequest.java
@@ -57,7 +57,7 @@ public class ConsumerGroupDescribeRequest extends AbstractRequest {
     public ConsumerGroupDescribeResponse getErrorResponse(int throttleTimeMs, Throwable e) {
         ConsumerGroupDescribeResponseData data = new ConsumerGroupDescribeResponseData()
             .setThrottleTimeMs(throttleTimeMs);
-        // Set error based on e for each group present in the request
+        // Set error for each group based on e
         this.data.groupIds().forEach(
             groupId -> data.groups().add(
                 new ConsumerGroupDescribeResponseData.DescribedGroup()

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequest.java
@@ -31,7 +31,11 @@ public class ConsumerGroupDescribeRequest extends AbstractRequest {
         private final ConsumerGroupDescribeRequestData data;
 
         public Builder(ConsumerGroupDescribeRequestData data) {
-            super(ApiKeys.CONSUMER_GROUP_DESCRIBE);
+            this(data, false);
+        }
+
+        public Builder(ConsumerGroupDescribeRequestData data, boolean enableUnstableLastVersion) {
+            super(ApiKeys.CONSUMER_GROUP_DESCRIBE, enableUnstableLastVersion);
             this.data = data;
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponse.java
@@ -39,7 +39,8 @@ import java.util.Map;
 public class ConsumerGroupDescribeResponse extends AbstractResponse {
 
     private final ConsumerGroupDescribeResponseData data;
-    protected ConsumerGroupDescribeResponse(ConsumerGroupDescribeResponseData data) {
+
+    public ConsumerGroupDescribeResponse(ConsumerGroupDescribeResponseData data) {
         super(ApiKeys.CONSUMER_GROUP_DESCRIBE);
         this.data = data;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponse.java
@@ -51,11 +51,11 @@ public class ConsumerGroupDescribeResponse extends AbstractResponse {
 
     @Override
     public Map<Errors, Integer> errorCounts() {
-        Map<Errors, Integer> errors = new HashMap<>();
+        HashMap<Errors, Integer> counts = new HashMap<>();
         data.groups().forEach(
-            group -> errors.merge(Errors.forCode(group.errorCode()), 1, Integer::sum)
+            group -> updateErrorCounts(counts, Errors.forCode(group.errorCode()))
         );
-        return errors;
+        return counts;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponse.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Possible error codes.
+ *
+ * - {@link Errors#GROUP_AUTHORIZATION_FAILED}
+ * - {@link Errors#NOT_COORDINATOR}
+ * - {@link Errors#COORDINATOR_NOT_AVAILABLE}
+ * - {@link Errors#COORDINATOR_LOAD_IN_PROGRESS}
+ * - {@link Errors#INVALID_REQUEST}
+ * - {@link Errors#INVALID_GROUP_ID}
+ * - {@link Errors#GROUP_ID_NOT_FOUND}
+ */
+public class ConsumerGroupDescribeResponse extends AbstractResponse {
+
+    private final ConsumerGroupDescribeResponseData data;
+    protected ConsumerGroupDescribeResponse(ConsumerGroupDescribeResponseData data) {
+        super(ApiKeys.CONSUMER_GROUP_DESCRIBE);
+        this.data = data;
+    }
+
+    @Override
+    public ConsumerGroupDescribeResponseData data() {
+        return data;
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        Map<Errors, Integer> errors = new HashMap<>();
+        data.groups().forEach(
+            group -> errors.merge(Errors.forCode(group.errorCode()), 1, Integer::sum)
+        );
+        return errors;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        data.setThrottleTimeMs(throttleTimeMs);
+    }
+
+    public static ConsumerGroupDescribeResponse parse(ByteBuffer buffer, short version) {
+        return new ConsumerGroupDescribeResponse(
+            new ConsumerGroupDescribeResponseData(new ByteBufferAccessor(buffer), version)
+        );
+    }
+}

--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 71,
+  "type": "request",
+  "listeners": ["zkBroker", "broker"],
+  "name": "ConsumerGroupDescribeRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "GroupIds", "type": "[]string", "versions": "0+", "entityType": "groupId",
+      "about": "The names of the groups to describe" },
+    { "name": "IncludeAuthorizedOperations", "type": "bool", "versions": "0+",
+      "about": "Whether to include authorized operations." }
+  ]
+}

--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
@@ -26,7 +26,7 @@
   "flexibleVersions": "0+",
   "fields": [
     { "name": "GroupIds", "type": "[]string", "versions": "0+", "entityType": "groupId",
-      "about": "The names of the groups to describe" },
+      "about": "The ids of the groups to describe" },
     { "name": "IncludeAuthorizedOperations", "type": "bool", "versions": "0+",
       "about": "Whether to include authorized operations." }
   ]

--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
@@ -19,6 +19,10 @@
   "listeners": ["zkBroker", "broker"],
   "name": "ConsumerGroupDescribeRequest",
   "validVersions": "0",
+  // The ConsumerGroupDescribeRequest API is added as part of KIP-848 and is still
+  // under development. Hence, the API is not exposed by default by brokers
+  // unless explicitly enabled.
+  "latestVersionUnstable": true,
   "flexibleVersions": "0+",
   "fields": [
     { "name": "GroupIds", "type": "[]string", "versions": "0+", "entityType": "groupId",

--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 {
-  "apiKey": 71,
+  "apiKey": 69,
   "type": "request",
   "listeners": ["zkBroker", "broker"],
   "name": "ConsumerGroupDescribeRequest",

--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
@@ -19,7 +19,7 @@
   "listeners": ["zkBroker", "broker"],
   "name": "ConsumerGroupDescribeRequest",
   "validVersions": "0",
-  // The ConsumerGroupDescribeRequest API is added as part of KIP-848 and is still
+  // The ConsumerGroupDescribe API is added as part of KIP-848 and is still
   // under development. Hence, the API is not exposed by default by brokers
   // unless explicitly enabled.
   "latestVersionUnstable": true,

--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
@@ -70,23 +70,24 @@
               "about": "The current assignment." },
             { "name": "TargetAssignment", "type": "Assignment", "versions": "0+",
               "about": "The target assignment." }
-            ]},
+          ]},
         { "name": "AuthorizedOperations", "type": "int32", "versions": "3+", "default": "-2147483648",
           "about": "32-bit bitfield to represent authorized operations for this group." }
-        ]}
+      ]
+    }
   ],
   "commonStructs": [
     { "name": "TopicPartitions", "versions": "0+", "fields": [
       { "name": "TopicId", "type": "uuid", "versions": "0+",
         "about": "The topic ID." },
-      { "name": "TopicName", "type":  "string", "versions": "0+",
-        "about":  "The topic name."},
+      { "name": "TopicName", "type": "string", "versions": "0+",
+        "about": "The topic name." },
       { "name": "Partitions", "type": "[]int32", "versions": "0+",
         "about": "The partitions." }
     ]},
     { "name": "Assignment", "versions": "0+", "fields": [
       { "name": "TopicPartitions", "type": "[]TopicPartitions", "versions": "0+",
-        "about":  "The assigned topic-partitions to the member." },
+        "about": "The assigned topic-partitions to the member." },
       { "name": "Error", "type": "int8", "versions": "0+",
         "about": "The assigned error." },
       { "name": "MetadataVersion", "type": "int32", "versions": "0+",

--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 {
-  "apiKey": 71,
+  "apiKey": 69,
   "type": "response",
   "name": "ConsumerGroupDescribeResponse",
   "validVersions": "0",

--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
@@ -85,8 +85,8 @@
         "about": "The partitions." }
     ]},
     { "name": "Assignment", "versions": "0+", "fields": [
-      { "name": "Partitions", "type": "[]TopicPartitions", "versions": "0+",
-        "about":  "The assigned topic-partitions to the member."},
+      { "name": "TopicPartitions", "type": "[]TopicPartitions", "versions": "0+",
+        "about":  "The assigned topic-partitions to the member." },
       { "name": "Error", "type": "int8", "versions": "0+",
         "about": "The assigned error." },
       { "name": "MetadataVersion", "type": "int32", "versions": "0+",

--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 71,
+  "type": "response",
+  "name": "ConsumerGroupDescribeResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  // Supported errors:
+  // - GROUP_AUTHORIZATION_FAILED¬
+  // - NOT_COORDINATOR
+  // - COORDINATOR_NOT_AVAILABLE
+  // - COORDINATOR_LOAD_IN_PROGRESS
+  // - INVALID_REQUEST
+  // - INVALID_GROUP_ID
+  // - GROUP_ID_NOT_FOUND
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "Groups", "type": "[]DescribedGroup", "versions": "0+",
+      "about": "Each described group.",
+      "fields": [
+        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+          "about": "The describe error, or 0 if there was no error." },
+        { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+          "about": "The top-level error message, or null if there was no error." },
+        { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
+          "about": "The group ID string." },
+        { "name": "GroupState", "type": "string", "versions": "0+",
+          "about": "The group state string, or the empty string." },
+        { "name": "GroupEpoch", "type": "int32", "versions": "0+",
+          "about": "The group epoch." },
+        { "name": "AssignmentEpoch", "type": "int32", "versions": "0+",
+          "about": "The assignment epoch." },
+        { "name": "AssignorName", "type": "string", "versions": "0+",
+          "about": "The selected assignor." },
+        { "name": "Members", "type": "[]Member", "versions": "0+",
+          "about": "The members.",
+          "fields": [
+            { "name": "MemberId", "type": "uuid", "versions": "0+",
+              "about": "The member ID." },
+            { "name": "InstanceId", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+              "about": "The member instance ID." },
+            { "name": "RackId", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+              "about": "The member rack ID." },
+            { "name": "MemberEpoch", "type": "int32", "versions": "0+",
+              "about": "The current member epoch." },
+            { "name": "ClientId", "type": "string", "versions": "0+",
+              "about": "The client ID." },
+            { "name": "ClientHost", "type": "string", "versions": "0+",
+              "about": "The client host." },
+            { "name": "SubscribedTopicNames", "type": "[]string", "versions": "0+",
+              "about": "The subscribed topic names." },
+            { "name": "SubscribedTopicRegex", "type": "string", "versions": "0+", "nullableVersions": "0+", "default": "null",
+              "about": "the subscribed topic regex otherwise or null of not provided." },
+            { "name": "Assignment", "type": "Assignment", "versions": "0+",
+              "about": "The current assignment." },
+            { "name": "TargetAssignment", "type": "Assignment", "versions": "0+",
+              "about": "The target assignment." },
+            { "name": "AuthorizedOperations", "type": "int32", "versions": "3+", "default": "-2147483648",
+              "about": "32-bit bitfield to represent authorized operations for this group." }
+          ]}
+        ]}
+  ],
+  "commonStructs": [
+    { "name": "TopicPartitions", "versions": "0+", "fields": [
+      { "name": "TopicId", "type": "uuid", "versions": "0+",
+        "about": "The topic ID." },
+      { "name": "Partitions", "type": "[]int32", "versions": "0+",
+        "about": "The partitions." }
+    ]},
+    { "name": "Assignment", "versions": "0+", "fields": [
+      { "name": "Partitions", "type": "[]TopicPartitions", "versions": "0+",
+        "about": "The assigned topic-partitions to the member.", "fields": [
+        { "name": "TopicId", "type": "uuid", "versions": "0+",
+          "about": "The topic ID." },
+        { "name": "TopicName", "type": "string", "versions": "0+",
+          "about": "The topic name." },
+        { "name": "Partitions", "type": "[]int32", "versions": "0+",
+          "about": "The partitions." }
+      ]},
+      { "name": "Error", "type": "int8", "versions": "0+",
+        "about": "The assigned error." },
+      { "name": "MetadataVersion", "type": "int32", "versions": "0+",
+        "about": "The assignor metadata version." },
+      { "name": "MetadataBytes", "type": "bytes", "versions": "0+",
+        "about": "The assignor metadata bytes." }
+    ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
@@ -20,13 +20,13 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   // Supported errors:
-  // - GROUP_AUTHORIZATION_FAILED¬
-  // - NOT_COORDINATOR
-  // - COORDINATOR_NOT_AVAILABLE
-  // - COORDINATOR_LOAD_IN_PROGRESS
-  // - INVALID_REQUEST
-  // - INVALID_GROUP_ID
-  // - GROUP_ID_NOT_FOUND
+  // - GROUP_AUTHORIZATION_FAILED (version 0+)
+  // - NOT_COORDINATOR (version 0+)
+  // - COORDINATOR_NOT_AVAILABLE (version 0+)
+  // - COORDINATOR_LOAD_IN_PROGRESS (version 0+)
+  // - INVALID_REQUEST (version 0+)
+  // - INVALID_GROUP_ID (version 0+)
+  // - GROUP_ID_NOT_FOUND (version 0+)
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
@@ -69,29 +69,24 @@
             { "name": "Assignment", "type": "Assignment", "versions": "0+",
               "about": "The current assignment." },
             { "name": "TargetAssignment", "type": "Assignment", "versions": "0+",
-              "about": "The target assignment." },
-            { "name": "AuthorizedOperations", "type": "int32", "versions": "3+", "default": "-2147483648",
-              "about": "32-bit bitfield to represent authorized operations for this group." }
-          ]}
+              "about": "The target assignment." }
+            ]},
+        { "name": "AuthorizedOperations", "type": "int32", "versions": "3+", "default": "-2147483648",
+          "about": "32-bit bitfield to represent authorized operations for this group." }
         ]}
   ],
   "commonStructs": [
     { "name": "TopicPartitions", "versions": "0+", "fields": [
       { "name": "TopicId", "type": "uuid", "versions": "0+",
         "about": "The topic ID." },
+      { "name": "TopicName", "type":  "string", "versions": "0+",
+        "about":  "The topic name."},
       { "name": "Partitions", "type": "[]int32", "versions": "0+",
         "about": "The partitions." }
     ]},
     { "name": "Assignment", "versions": "0+", "fields": [
       { "name": "Partitions", "type": "[]TopicPartitions", "versions": "0+",
-        "about": "The assigned topic-partitions to the member.", "fields": [
-        { "name": "TopicId", "type": "uuid", "versions": "0+",
-          "about": "The topic ID." },
-        { "name": "TopicName", "type": "string", "versions": "0+",
-          "about": "The topic name." },
-        { "name": "Partitions", "type": "[]int32", "versions": "0+",
-          "about": "The partitions." }
-      ]},
+        "about":  "The assigned topic-partitions to the member."},
       { "name": "Error", "type": "int8", "versions": "0+",
         "about": "The assigned error." },
       { "name": "MetadataVersion", "type": "int32", "versions": "0+",

--- a/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupDescribeRequestTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ConsumerGroupDescribeRequestData;
+import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConsumerGroupDescribeRequestTest {
+
+    @Test
+    void testGetErrorResponse() {
+        // Arrange
+        String groupId = "group0";
+        ConsumerGroupDescribeRequestData data = new ConsumerGroupDescribeRequestData();
+        data.groupIds().add(groupId);
+        ConsumerGroupDescribeRequest request = new ConsumerGroupDescribeRequest.Builder(data, true)
+            .build();
+        Throwable e = Errors.GROUP_AUTHORIZATION_FAILED.exception();
+
+        // Act
+        ConsumerGroupDescribeResponse response = request.getErrorResponse(1000, e);
+
+        // Assert
+        for (ConsumerGroupDescribeResponseData.DescribedGroup group: response.data().groups()) {
+            assertEquals(groupId, group.groupId());
+            assertEquals(Errors.forException(e).code(), group.errorCode());
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponseTest.java
@@ -23,12 +23,12 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ConsumerGroupDescribeResponseTest {
 
     @Test
     void testErrorCounts() {
-        // Arrange
         Errors e = Errors.INVALID_GROUP_ID;
         int errorCount = 2;
         ConsumerGroupDescribeResponseData data = new ConsumerGroupDescribeResponseData();
@@ -40,11 +40,9 @@ public class ConsumerGroupDescribeResponseTest {
         }
         ConsumerGroupDescribeResponse response = new ConsumerGroupDescribeResponse(data);
 
-        // Act
         Map<Errors, Integer> counts = response.errorCounts();
 
-        // Assert
         assertEquals(errorCount, counts.get(e));
-        assertEquals(null, counts.get(Errors.COORDINATOR_NOT_AVAILABLE));
+        assertNull(counts.get(Errors.COORDINATOR_NOT_AVAILABLE));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponseTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConsumerGroupDescribeResponseTest {
+
+    @Test
+    void testErrorCounts() {
+        // Arrange
+        Errors e = Errors.INVALID_GROUP_ID;
+        int errorCount = 2;
+        ConsumerGroupDescribeResponseData data = new ConsumerGroupDescribeResponseData();
+        for (int i = 0; i < errorCount; i++) {
+            data.groups().add(
+                new ConsumerGroupDescribeResponseData.DescribedGroup()
+                    .setErrorCode(e.code())
+            );
+        }
+        ConsumerGroupDescribeResponse response = new ConsumerGroupDescribeResponse(data);
+
+        // Act
+        Map<Errors, Integer> counts = response.errorCounts();
+
+        // Assert
+        assertEquals(errorCount, counts.get(e));
+        assertEquals(null, counts.get(Errors.COORDINATOR_NOT_AVAILABLE));
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1142,14 +1142,14 @@ public class RequestResponseTest {
 
     private ConsumerGroupDescribeRequest createConsumerGroupDescribeRequest(short version) {
         ConsumerGroupDescribeRequestData data = new ConsumerGroupDescribeRequestData()
-            .setGroupIds(Arrays.asList("group"))
+            .setGroupIds(Collections.singletonList("group"))
             .setIncludeAuthorizedOperations(false);
         return new ConsumerGroupDescribeRequest.Builder(data).build(version);
     }
 
     private ConsumerGroupDescribeResponse createConsumerGroupDescribeResponse() {
         ConsumerGroupDescribeResponseData data = new ConsumerGroupDescribeResponseData()
-            .setGroups(Arrays.asList(
+            .setGroups(Collections.singletonList(
                 new ConsumerGroupDescribeResponseData.DescribedGroup()
                     .setGroupId("group")
                     .setErrorCode((short) 0)

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1149,6 +1149,17 @@ public class RequestResponseTest {
 
     private ConsumerGroupDescribeResponse createConsumerGroupDescribeResponse() {
         ConsumerGroupDescribeResponseData data = new ConsumerGroupDescribeResponseData()
+            .setGroups(Arrays.asList(
+                new ConsumerGroupDescribeResponseData.DescribedGroup()
+                    .setGroupId("group")
+                    .setErrorCode((short) 0)
+                    .setErrorMessage(Errors.forCode((short) 0).message())
+                    .setGroupState(ConsumerGroupState.EMPTY.toString())
+                    .setGroupEpoch(0)
+                    .setAssignmentEpoch(0)
+                    .setAssignorName("range")
+                    .setMembers(new ArrayList<ConsumerGroupDescribeResponseData.Member>(0))
+            ))
             .setThrottleTimeMs(1000);
         return new ConsumerGroupDescribeResponse(data);
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -67,6 +67,8 @@ import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerHeartbeatResponseData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationResponseData;
+import org.apache.kafka.common.message.ConsumerGroupDescribeRequestData;
+import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.ControlledShutdownRequestData;
@@ -1057,6 +1059,7 @@ public class RequestResponseTest {
             case LIST_TRANSACTIONS: return createListTransactionsRequest(version);
             case ALLOCATE_PRODUCER_IDS: return createAllocateProducerIdsRequest(version);
             case CONSUMER_GROUP_HEARTBEAT: return createConsumerGroupHeartbeatRequest(version);
+            case CONSUMER_GROUP_DESCRIBE: return createConsumerGroupDescribeRequest(version);
             default: throw new IllegalArgumentException("Unknown API key " + apikey);
         }
     }
@@ -1132,8 +1135,22 @@ public class RequestResponseTest {
             case LIST_TRANSACTIONS: return createListTransactionsResponse();
             case ALLOCATE_PRODUCER_IDS: return createAllocateProducerIdsResponse();
             case CONSUMER_GROUP_HEARTBEAT: return createConsumerGroupHeartbeatResponse();
+            case CONSUMER_GROUP_DESCRIBE: return createConsumerGroupDescribeResponse();
             default: throw new IllegalArgumentException("Unknown API key " + apikey);
         }
+    }
+
+    private ConsumerGroupDescribeRequest createConsumerGroupDescribeRequest(short version) {
+        ConsumerGroupDescribeRequestData data = new ConsumerGroupDescribeRequestData()
+            .setGroupIds(Arrays.asList("group"))
+            .setIncludeAuthorizedOperations(false);
+        return new ConsumerGroupDescribeRequest.Builder(data).build(version);
+    }
+
+    private ConsumerGroupDescribeResponse createConsumerGroupDescribeResponse() {
+        ConsumerGroupDescribeResponseData data = new ConsumerGroupDescribeResponseData()
+            .setThrottleTimeMs(1000);
+        return new ConsumerGroupDescribeResponse(data);
     }
 
     private ConsumerGroupHeartbeatRequest createConsumerGroupHeartbeatRequest(short version) {

--- a/core/src/main/scala/kafka/network/RequestConvertToJson.scala
+++ b/core/src/main/scala/kafka/network/RequestConvertToJson.scala
@@ -96,6 +96,7 @@ object RequestConvertToJson {
       case req: DescribeTransactionsRequest => DescribeTransactionsRequestDataJsonConverter.write(req.data, request.version)
       case req: ListTransactionsRequest => ListTransactionsRequestDataJsonConverter.write(req.data, request.version)
       case req: ConsumerGroupHeartbeatRequest => ConsumerGroupHeartbeatRequestDataJsonConverter.write(req.data, request.version)
+      case req: ConsumerGroupDescribeRequest => ConsumerGroupDescribeRequestDataJsonConverter.write(req.data, request.version)
       case _ => throw new IllegalStateException(s"ApiKey ${request.apiKey} is not currently handled in `request`, the " +
         "code should be updated to do so.");
     }
@@ -172,6 +173,7 @@ object RequestConvertToJson {
       case res: DescribeTransactionsResponse => DescribeTransactionsResponseDataJsonConverter.write(res.data, version)
       case res: ListTransactionsResponse => ListTransactionsResponseDataJsonConverter.write(res.data, version)
       case res: ConsumerGroupHeartbeatResponse => ConsumerGroupHeartbeatResponseDataJsonConverter.write(res.data, version)
+      case res: ConsumerGroupDescribeResponse => ConsumerGroupDescribeResponseDataJsonConverter.write(res.data, version)
       case _ => throw new IllegalStateException(s"ApiKey ${response.apiKey} is not currently handled in `response`, the " +
         "code should be updated to do so.");
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3663,8 +3663,6 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleConsumerGroupDescribe(request: RequestChannel.Request): CompletableFuture[Unit] = {
-    // TODO: This method is Work-In-Progress
-    // It will be finished in the second PR of KAFKA-14509
     requestHelper.sendMaybeThrottle(request, request.body[ConsumerGroupDescribeRequest].getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
     CompletableFuture.completedFuture[Unit](())
   }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3665,32 +3665,8 @@ class KafkaApis(val requestChannel: RequestChannel,
   def handleConsumerGroupDescribe(request: RequestChannel.Request): CompletableFuture[Unit] = {
     // TODO: This method is Work-In-Progress
     // It will be finished in the second PR of KAFKA-14509
-    val consumerGroupDescribeRequest = request.body[ConsumerGroupDescribeRequest]
-
-    if (!config.isNewGroupCoordinatorEnabled) {
-      // The API is not supported by the "old" group coordinator (the default). If the
-      // new one is not enabled, we fail directly here.
-      requestHelper.sendMaybeThrottle(request, consumerGroupDescribeRequest.getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
-      CompletableFuture.completedFuture[Unit](())
-    } else {
-
-//      val response = new ConsumerGroupDescribeResponseData()
-      consumerGroupDescribeRequest.data().groupIds().forEach { groupId =>
-        val describedGroup = new ConsumerGroupDescribeResponseData.DescribedGroup()
-          .setGroupId(groupId)
-
-        // TODO: Check if group id exists
-
-        if (!authHelper.authorize(request.context, READ, GROUP, groupId)) {
-          describedGroup.setErrorMessage(new ApiError(Errors.GROUP_AUTHORIZATION_FAILED).message())
-          describedGroup.setErrorCode(Errors.GROUP_AUTHORIZATION_FAILED.code())
-        }
-      }
-
-//      This must be changed to handle all groups together instead of foreach
-//      groupCoordinator.describeGroups(request.context, )
-      CompletableFuture.completedFuture[Unit](())
-    }
+    requestHelper.sendMaybeThrottle(request, request.body[ConsumerGroupDescribeRequest].getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
+    CompletableFuture.completedFuture[Unit](())
   }
 
   private def updateRecordConversionStats(request: RequestChannel.Request,

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -6191,4 +6191,19 @@ class KafkaApisTest {
     val response = verifyNoThrottling[ConsumerGroupHeartbeatResponse](requestChannelRequest)
     assertEquals(Errors.GROUP_AUTHORIZATION_FAILED.code, response.data.errorCode)
   }
+
+  @Test
+  def testConsumerGroupDescribeReturnsUnsupportedVersion(): Unit = {
+    // Arrange
+    val consumerGroupDescribeRequestData = new ConsumerGroupDescribeRequestData()
+    consumerGroupDescribeRequestData.groupIds.add("group0")
+    val requestChannelRequest = buildRequest(new ConsumerGroupDescribeRequest.Builder(consumerGroupDescribeRequestData, true).build())
+
+    // Act
+    createKafkaApis().handle(requestChannelRequest, RequestLocal.NoCaching)
+    val response = verifyNoThrottling[ConsumerGroupDescribeResponse](requestChannelRequest)
+
+    // Assert
+    assertEquals(Errors.UNSUPPORTED_VERSION.code, response.data.groups.get(0).errorCode)
+  }
 }

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -648,6 +648,9 @@ class RequestQuotaTest extends BaseRequestTest {
         case ApiKeys.CONSUMER_GROUP_HEARTBEAT =>
           new ConsumerGroupHeartbeatRequest.Builder(new ConsumerGroupHeartbeatRequestData(), true)
 
+        case ApiKeys.CONSUMER_GROUP_DESCRIBE =>
+          new ConsumerGroupDescribeRequest.Builder(new ConsumerGroupDescribeRequestData(), true)
+
         case _ =>
           throw new IllegalArgumentException("Unsupported API key " + apiKey)
     }


### PR DESCRIPTION
First PR for KAFKA-14509.
This PR defines json request and response schemas for the new ConsumerGroupDescribe API and implements the corresponding java classes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
