### PR TITLE
MINOR Fix a Scala 2.12 compile issue

### DIFF
--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -166,7 +166,7 @@ class ZkMigrationIntegrationTest {
       TestUtils.waitUntilTrue(
         () => zkClient.getControllerId.contains(3000),
         "Timed out waiting for KRaft controller to take over",
-        30_000)
+        30000)
 
       def inDualWrite(): Boolean = {
         val migrationState = kraftCluster.controllers().get(3000).migrationSupport.get.migrationDriver.migrationState().get(10, TimeUnit.SECONDS)
@@ -292,7 +292,7 @@ class ZkMigrationIntegrationTest {
       TestUtils.waitUntilTrue(
         () => zkClient.getControllerId.contains(3000),
         "Timed out waiting for KRaft controller to take over",
-        30_000)
+        30000)
 
       // Alter the metadata
       log.info("Updating metadata with AdminClient")
@@ -367,7 +367,7 @@ class ZkMigrationIntegrationTest {
       TestUtils.waitUntilTrue(
         () => zkClient.getControllerId.contains(3000),
         "Timed out waiting for KRaft controller to take over",
-        30_000)
+        30000)
 
       // Alter the metadata
       log.info("Updating metadata with AdminClient")
@@ -434,7 +434,7 @@ class ZkMigrationIntegrationTest {
       TestUtils.waitUntilTrue(
         () => zkClient.getControllerId.contains(3000),
         "Timed out waiting for KRaft controller to take over",
-        30_000)
+        30000)
 
       // Alter the metadata
       log.info("Updating metadata with AdminClient")
@@ -496,7 +496,7 @@ class ZkMigrationIntegrationTest {
       TestUtils.waitUntilTrue(
         () => zkClient.getControllerId.contains(3000),
         "Timed out waiting for KRaft controller to take over",
-        30_000)
+        30000)
 
       // Alter the metadata
       log.info("Create new topic with AdminClient")


### PR DESCRIPTION
This was introduced in #14115. I added some timeouts to a test after the last Jenkins job. I ran `./gradlew check -x test` before committing, but apparently the issue was only present in Scala 2.12.