### PR TITLE
KAFKA-15272: Fix the logic which finds candidate log segments to upload it to tiered storage

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1023,6 +1023,14 @@ public class RemoteLogManager implements Closeable {
         public int hashCode() {
             return Objects.hash(logSegment, nextSegmentOffset);
         }
+
+        @Override
+        public String toString() {
+            return "EnrichedLogSegment{" +
+                    "logSegment=" + logSegment +
+                    ", nextSegmentOffset=" + nextSegmentOffset +
+                    '}';
+        }
     }
 
 }

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -568,7 +568,7 @@ public class RemoteLogManager implements Closeable {
                     //    committed/acked messages
                     List<EnrichedLogSegment> candidateSegments = enrichedLogSegments(log, fromOffset, lso)
                             .stream()
-                            .filter(enriched ->  enriched.segment.readNextOffset() <= lso)
+                            .filter(enrichedSegment ->  enrichedSegment.readNextOffset <= lso)
                             .collect(Collectors.toList());
                     logger.debug("Checking for segments to copy, copiedOffset: {} and lso: {}, candidateSegments: {}",
                             copiedOffset, lso, candidateSegments);

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -563,18 +563,16 @@ public class RemoteLogManager implements Closeable {
                 if (lso < 0) {
                     logger.warn("lastStableOffset for partition {} is {}, which should not be negative.", topicIdPartition, lso);
                 } else if (lso > 0 && copiedOffset < lso) {
-                    // log-start-offset can be ahead of the read-offset, when:
+                    // log-start-offset can be ahead of the copied-offset, when:
                     // 1) log-start-offset gets incremented via delete-records API (or)
                     // 2) enabling the remote log for the first time
                     long fromOffset = Math.max(copiedOffset + 1, log.logStartOffset());
-                    long activeSegmentBaseOffset = log.activeSegment().baseOffset();
-
                     List<CandidateLogSegment> candidateSegments = candidateLogSegments(log, fromOffset, lso);
-                    logger.debug("Checking for segments to copy, copiedOffset: {} and lso: {}, candidateSegments: {}",
-                            copiedOffset, lso, candidateSegments);
+                    logger.debug("Candidate log segments, logStartOffset: {}, copiedOffset: {}, fromOffset: {}, lso: {} " +
+                            "and candidateSegments: {}", log.logStartOffset(), copiedOffset, fromOffset, lso, candidateSegments);
                     if (candidateSegments.isEmpty()) {
                         logger.debug("No segments found to be copied for partition {} with copiedOffset: {} and active segment's base-offset: {}",
-                                topicIdPartition, copiedOffset, activeSegmentBaseOffset);
+                                topicIdPartition, copiedOffset, log.activeSegment().baseOffset());
                     } else {
                         for (CandidateLogSegment candidateLogSegment : candidateSegments) {
                             if (isCancelled() || !isLeader()) {

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -867,7 +867,7 @@ public class RemoteLogManagerTest {
                         new RemoteLogManager.CandidateLogSegment(segment1, 10L),
                         new RemoteLogManager.CandidateLogSegment(segment2, 15L)
                 );
-        List<RemoteLogManager.CandidateLogSegment> actual = task.candidateLogSegments(log, 5L, 15L);
+        List<RemoteLogManager.CandidateLogSegment> actual = task.candidateLogSegments(log, 5L, 20L);
         assertEquals(expected, actual);
     }
 

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -309,9 +309,7 @@ public class RemoteLogManagerTest {
         LogSegment activeSegment = mock(LogSegment.class);
 
         when(oldSegment.baseOffset()).thenReturn(oldSegmentStartOffset);
-        when(oldSegment.readNextOffset()).thenReturn(nextSegmentStartOffset);
         when(activeSegment.baseOffset()).thenReturn(nextSegmentStartOffset);
-        when(activeSegment.readNextOffset()).thenReturn(logEndOffset);
 
         FileRecords fileRecords = mock(FileRecords.class);
         when(oldSegment.log()).thenReturn(fileRecords);
@@ -872,7 +870,7 @@ public class RemoteLogManagerTest {
     }
 
     @Test
-    public void testCandidateLogSegmentsSkipsSegmentsBelowLastStableOffset() {
+    public void testCandidateLogSegmentsSkipsSegmentsAfterLastStableOffset() {
         UnifiedLog log = mock(UnifiedLog.class);
         LogSegment segment1 = mock(LogSegment.class);
         LogSegment segment2 = mock(LogSegment.class);

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -310,6 +310,8 @@ public class RemoteLogManagerTest {
 
         when(oldSegment.baseOffset()).thenReturn(oldSegmentStartOffset);
         when(activeSegment.baseOffset()).thenReturn(nextSegmentStartOffset);
+        verify(oldSegment, times(0)).readNextOffset();
+        verify(activeSegment, times(0)).readNextOffset();
 
         FileRecords fileRecords = mock(FileRecords.class);
         when(oldSegment.log()).thenReturn(fileRecords);
@@ -325,6 +327,7 @@ public class RemoteLogManagerTest {
         when(mockLog.producerStateManager()).thenReturn(mockStateManager);
         when(mockStateManager.fetchSnapshot(anyLong())).thenReturn(Optional.of(mockProducerSnapshotIndex));
         when(mockLog.lastStableOffset()).thenReturn(lastStableOffset);
+        when(mockLog.logEndOffset()).thenReturn(logEndOffset);
 
         LazyIndex idx = LazyIndex.forOffset(UnifiedLog.offsetIndexFile(tempDir, oldSegmentStartOffset, ""), oldSegmentStartOffset, 1000);
         LazyIndex timeIdx = LazyIndex.forTime(UnifiedLog.timeIndexFile(tempDir, oldSegmentStartOffset, ""), oldSegmentStartOffset, 1500);

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -275,9 +275,8 @@ public class RemoteLogManagerTest {
     }
 
     /**
-     * The following values will be equal when the active segment gets rotated to passive when there are no new messages:
-     * last-stable-offset = high-water-mark = log-end-offset = base-offset-of-active-segment
-     *
+     * The following values will be equal when the active segment gets rotated to passive and there are no new messages:
+     * last-stable-offset = high-water-mark = log-end-offset = base-offset-of-active-segment.
      * This test asserts that the active log segment that was rotated after log.roll.ms are copied to remote storage.
      */
     @Test

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -862,12 +862,12 @@ public class RemoteLogManagerTest {
                 .thenReturn(JavaConverters.collectionAsScalaIterable(Arrays.asList(segment1, segment2, activeSegment)));
 
         RemoteLogManager.RLMTask task = remoteLogManager.new RLMTask(leaderTopicIdPartition);
-        List<RemoteLogManager.CandidateLogSegment> expected =
+        List<RemoteLogManager.EnrichedLogSegment> expected =
                 Arrays.asList(
-                        new RemoteLogManager.CandidateLogSegment(segment1, 10L),
-                        new RemoteLogManager.CandidateLogSegment(segment2, 15L)
+                        new RemoteLogManager.EnrichedLogSegment(segment1, 10L),
+                        new RemoteLogManager.EnrichedLogSegment(segment2, 15L)
                 );
-        List<RemoteLogManager.CandidateLogSegment> actual = task.candidateLogSegments(log, 5L, 20L);
+        List<RemoteLogManager.EnrichedLogSegment> actual = task.candidateLogSegments(log, 5L, 20L);
         assertEquals(expected, actual);
     }
 
@@ -888,12 +888,12 @@ public class RemoteLogManagerTest {
                 .thenReturn(JavaConverters.collectionAsScalaIterable(Arrays.asList(segment1, segment2, segment3, activeSegment)));
 
         RemoteLogManager.RLMTask task = remoteLogManager.new RLMTask(leaderTopicIdPartition);
-        List<RemoteLogManager.CandidateLogSegment> expected =
+        List<RemoteLogManager.EnrichedLogSegment> expected =
                 Arrays.asList(
-                        new RemoteLogManager.CandidateLogSegment(segment1, 10L),
-                        new RemoteLogManager.CandidateLogSegment(segment2, 15L)
+                        new RemoteLogManager.EnrichedLogSegment(segment1, 10L),
+                        new RemoteLogManager.EnrichedLogSegment(segment2, 15L)
                 );
-        List<RemoteLogManager.CandidateLogSegment> actual = task.candidateLogSegments(log, 5L, 15L);
+        List<RemoteLogManager.EnrichedLogSegment> actual = task.candidateLogSegments(log, 5L, 15L);
         assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
In tiered storage, a segment is eligible for deletion from local disk when it gets uploaded to the remote storage.

If the topic active segment contains some messages and there are no new incoming messages, then the active segment gets rotated to passive segment after the configured log.roll.ms timeout.

The [logic](https://github.com/apache/kafka/blob/trunk/core/src/main/java/kafka/log/remote/RemoteLogManager.java#L553) to find the candidate segment in RemoteLogManager does not include the recently rotated passive segment as eligible to upload it to remote storage so the passive segment won't be removed even after if it breaches by retention time/size. (ie) Topic won't be empty after it becomes stale.

Added unit test to cover the scenario which will fail without this patch.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
