### PR TITLE
Kafka-15126: fix merge issue and range queries to accept null lower and upper bounds 

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/query/RangeQuery.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/RangeQuery.java
@@ -54,11 +54,12 @@ public final class RangeQuery<K, V> implements Query<KeyValueIterator<K, V>> {
      * @param <V> The value type
      */
     public static <K, V> RangeQuery<K, V> withRange(final K lower, final K upper) {
-        return new RangeQuery<>(Optional.of(lower), Optional.of(upper));
+        return new RangeQuery<>(Optional.ofNullable(lower), Optional.ofNullable(upper));
     }
 
     /**
      * Interactive range query using an upper bound to filter the keys returned.
+     * If both <K,V> are null, RangQuery returns a full range scan.
      * @param upper The key that specifies the upper bound of the range
      * @param <K> The key type
      * @param <V> The value type

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -1089,15 +1089,8 @@ public class IQv2StoreIntegrationTest {
         final Set<Integer> expectedValue) {
 
         final RangeQuery<Integer, V> query;
-        if (lower.isPresent() && upper.isPresent()) {
-            query = RangeQuery.withRange(lower.get(), upper.get());
-        } else if (lower.isPresent()) {
-            query = RangeQuery.withLowerBound(lower.get());
-        } else if (upper.isPresent()) {
-            query = RangeQuery.withUpperBound(upper.get());
-        } else {
-            query = RangeQuery.withNoBounds();
-        }
+        
+        query = RangeQuery.withRange(lower.orElse(null), upper.orElse(null));
 
         final StateQueryRequest<KeyValueIterator<Integer, V>> request =
             inStore(STORE_NAME)


### PR DESCRIPTION
Change in response to [KIP-941](https://cwiki.apache.org/confluence/display/KAFKA/KIP-941%3A+Range+queries+to+accept+null+lower+and+upper+bounds). 

New PR due to merge issue. 

Changes line 57 in the RangeQuery class file from:

```
public static <K, V> RangeQuery<K, V> withRange(final K lower, final K upper) {
    return new RangeQuery<>(Optional.of(lower), Optional.of(upper));
}
```
to
```
public static <K, V> RangeQuery<K, V> withRange(final K lower, final K upper) {
     return new RangeQuery<>(Optional.ofNullable(lower), Optional.ofNullable(upper));
 }
```

Testing strategy: 

Since null values can now be entered in `RangeQuery`s in order to receive full scans, I changed the logic defining `query` starting at [line 1085](https://github.com/apache/kafka/blob/trunk/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java#L1085) in `IQv2StoreIntegrationTest.java` from:

```
        final RangeQuery<Integer, V> query;
        if (lower.isPresent() && upper.isPresent()) {
            query = RangeQuery.withRange(lower.get(), upper.get());
        } else if (lower.isPresent()) {
            query = RangeQuery.withLowerBound(lower.get());
        } else if (upper.isPresent()) {
            query = RangeQuery.withUpperBound(upper.get());
        } else {
            query = RangeQuery.withNoBounds();
        }
```
to
```
query = RangeQuery.withRange(lower.orElse(null), upper.orElse(null));
```
because different combinations of `isPresent()` in the bounds is no longer necessary.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

