### PR TITLE
KAFKA-7438: Replace PowerMockRunner with MockitoJUnitRunner in RetryUtilTest

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/RetryUtil.java
@@ -80,7 +80,7 @@ public class RetryUtil {
 
         final long end = time.milliseconds() + timeoutMs;
         int attempt = 0;
-        Throwable lastError = null;
+        Throwable lastError;
         do {
             attempt++;
             try {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/RetryUtilTest.java
@@ -16,10 +16,6 @@
  */
 package org.apache.kafka.connect.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.utils.MockTime;
@@ -29,13 +25,17 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
-@RunWith(PowerMockRunner.class)
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class RetryUtilTest {
 
     private final Time mockTime = new MockTime(10);


### PR DESCRIPTION
- We've been replacing the usage of `EasyMock` and `PowerMock` with `Mockito` across the project over the last few years (see https://issues.apache.org/jira/browse/KAFKA-7438)
- `RetryUtilTest` already uses `Mockito` for method stubbing and verifications but was unnecessarily using the [PowerMockRunner](https://www.javadoc.io/doc/org.powermock/powermock-module-junit4/latest/org/powermock/modules/junit4/PowerMockRunner.html). This patch replaces it with the [MockitoJUnitRunner](https://www.javadoc.io/doc/org.mockito/mockito-core/4.11.0/org/mockito/junit/MockitoJUnitRunner.html) (with strict stubbing enabled) that is being used in the other tests that have been migrated to `Mockito`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
