### PR TITLE
KAFKA-14502; Implement LeaveGroup protocol in new GroupCoordinator

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -330,7 +330,7 @@
     <suppress checks="ParameterNumber"
               files="(ConsumerGroupMember|GroupMetadataManager).java"/>
     <suppress checks="ClassDataAbstractionCouplingCheck"
-              files="(RecordHelpersTest|GroupMetadataManagerTest|GroupCoordinatorServiceTest).java"/>
+              files="(RecordHelpersTest|GroupMetadataManager|GroupMetadataManagerTest|GroupCoordinatorServiceTest).java"/>
     <suppress checks="JavaNCSS"
               files="GroupMetadataManagerTest.java"/>
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -304,7 +304,8 @@ public class GroupCoordinatorService implements GroupCoordinator {
             return responseFuture;
         }
 
-        runtime.scheduleWriteOperation("generic-group-join",
+        runtime.scheduleWriteOperation(
+            "generic-group-join",
             topicPartitionFor(request.groupId()),
             coordinator -> coordinator.genericGroupJoin(context, request, responseFuture)
         ).exceptionally(exception -> {
@@ -343,7 +344,8 @@ public class GroupCoordinatorService implements GroupCoordinator {
 
         CompletableFuture<SyncGroupResponseData> responseFuture = new CompletableFuture<>();
 
-        runtime.scheduleWriteOperation("generic-group-sync",
+        runtime.scheduleWriteOperation(
+            "generic-group-sync",
             topicPartitionFor(request.groupId()),
             coordinator -> coordinator.genericGroupSync(context, request, responseFuture)
         ).exceptionally(exception -> {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -418,8 +418,8 @@ public class GroupCoordinatorService implements GroupCoordinator {
                 .setErrorCode(Errors.INVALID_GROUP_ID.code()));
         }
 
-
-        return runtime.scheduleWriteOperation("generic-group-leave",
+        return runtime.scheduleWriteOperation(
+            "generic-group-leave",
             topicPartitionFor(request.groupId()),
             coordinator -> coordinator.genericGroupLeave(context, request)
         ).exceptionally(exception -> {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.errors.NotEnoughReplicasException;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
 import org.apache.kafka.common.errors.RecordBatchTooLargeException;
 import org.apache.kafka.common.errors.RecordTooLargeException;
+import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
@@ -79,6 +80,7 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntSupplier;
+import java.util.stream.Collectors;
 
 /**
  * The group coordinator service.
@@ -411,9 +413,37 @@ public class GroupCoordinatorService implements GroupCoordinator {
             return FutureUtils.failedFuture(Errors.COORDINATOR_NOT_AVAILABLE.exception());
         }
 
-        return FutureUtils.failedFuture(Errors.UNSUPPORTED_VERSION.exception(
-            "This API is not implemented yet."
-        ));
+        if (!isGroupIdNotEmpty(request.groupId())) {
+            return CompletableFuture.completedFuture(new LeaveGroupResponseData()
+                .setErrorCode(Errors.INVALID_GROUP_ID.code()));
+        }
+
+
+        return runtime.scheduleWriteOperation("generic-group-leave",
+            topicPartitionFor(request.groupId()),
+            coordinator -> coordinator.genericGroupLeave(context, request)
+        ).exceptionally(exception -> {
+            if (!(exception instanceof KafkaException)) {
+                log.error("LeaveGroup request {} hit an unexpected exception: {}",
+                    request, exception.getMessage());
+            }
+
+            if (exception instanceof UnknownMemberIdException) {
+                // Group was not found.
+                List<LeaveGroupResponseData.MemberResponse> memberResponses = request.members().stream()
+                    .map(member -> new LeaveGroupResponseData.MemberResponse()
+                        .setMemberId(member.memberId())
+                        .setGroupInstanceId(member.groupInstanceId())
+                        .setErrorCode(Errors.UNKNOWN_MEMBER_ID.code()))
+                    .collect(Collectors.toList());
+
+                return new LeaveGroupResponseData()
+                    .setMembers(memberResponses);
+            }
+
+            return new LeaveGroupResponseData()
+                .setErrorCode(Errors.forException(exception).code());
+        });
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -309,12 +309,12 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
     }
 
     /**
-     * Handles a OffsetCommit request.
+     * Handles a LeaveGroup request.
      *
      * @param context The request context.
-     * @param request The actual OffsetCommit request.
+     * @param request The actual LeaveGroup request.
      *
-     * @return A Result containing the OffsetCommitResponse response and
+     * @return A Result containing the LeaveGroup response and
      *         a list of records to update the state machine.
      */
     public CoordinatorResult<LeaveGroupResponseData, Record> genericGroupLeave(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -22,6 +22,8 @@ import org.apache.kafka.common.message.HeartbeatRequestData;
 import org.apache.kafka.common.message.HeartbeatResponseData;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.message.JoinGroupResponseData;
+import org.apache.kafka.common.message.LeaveGroupRequestData;
+import org.apache.kafka.common.message.LeaveGroupResponseData;
 import org.apache.kafka.common.message.OffsetCommitRequestData;
 import org.apache.kafka.common.message.OffsetCommitResponseData;
 import org.apache.kafka.common.message.OffsetFetchRequestData;
@@ -304,6 +306,22 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
         OffsetCommitRequestData request
     ) throws ApiException {
         return offsetMetadataManager.commitOffset(context, request);
+    }
+
+    /**
+     * Handles a OffsetCommit request.
+     *
+     * @param context The request context.
+     * @param request The actual OffsetCommit request.
+     *
+     * @return A Result containing the OffsetCommitResponse response and
+     *         a list of records to update the state machine.
+     */
+    public CoordinatorResult<LeaveGroupResponseData, Record> genericGroupLeave(
+        RequestContext context,
+        LeaveGroupRequestData request
+    ) throws ApiException {
+        return groupMetadataManager.genericGroupLeave(context, request);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2959,7 +2959,7 @@ public class GroupMetadataManager {
             } else if (group.isPendingMember(member.memberId())) {
                 group.remove(member.memberId());
                 timer.cancel(genericGroupHeartbeatKey(group.groupId(), member.memberId()));
-                log.info("[Group {}] Pending member {} has left group through explicit `LeaveGroup` request; client  reason: {}",
+                log.info("[Group {}] Pending member {} has left group through explicit `LeaveGroup` request; client reason: {}",
                     group.groupId(), member.memberId(), reason);
 
                 memberResponses.add(
@@ -2992,7 +2992,7 @@ public class GroupMetadataManager {
         }
 
         List<String> validLeaveGroupMembers = memberResponses.stream()
-            .filter(response -> response.errorCode() == 0)
+            .filter(response -> response.errorCode() == Errors.NONE.code())
             .map(MemberResponse::memberId)
             .collect(Collectors.toList());
 
@@ -3007,6 +3007,8 @@ public class GroupMetadataManager {
                     break;
                 case PREPARING_REBALANCE:
                     coordinatorResult = maybeCompleteJoinPhase(group);
+                    break;
+                default:
             }
         }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
@@ -692,10 +692,10 @@ public class GenericGroup implements Group {
     }
 
     /**
-     * @return all static members in the group.
+     * @return the ids of all static members in the group.
      */
     public Set<String> allStaticMemberIds() {
-        return staticMembers.keySet();
+        return new HashSet<>(staticMembers.values());
     }
 
     // For testing only.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorResult.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorResult.java
@@ -41,7 +41,7 @@ public class CoordinatorResult<T, U> {
     /**
      * The future to complete once the records are committed.
      */
-    private final CompletableFuture<T> appendFuture;
+    private final CompletableFuture<Void> appendFuture;
 
     /**
      * Constructs a Result with records and a response.
@@ -64,7 +64,7 @@ public class CoordinatorResult<T, U> {
      */
     public CoordinatorResult(
         List<U> records,
-        CompletableFuture<T> appendFuture
+        CompletableFuture<Void> appendFuture
     ) {
         this(records, null, appendFuture);
     }
@@ -79,7 +79,7 @@ public class CoordinatorResult<T, U> {
     public CoordinatorResult(
         List<U> records,
         T response,
-        CompletableFuture<T> appendFuture
+        CompletableFuture<Void> appendFuture
     ) {
         this.records = Objects.requireNonNull(records);
         this.response = response;
@@ -114,7 +114,7 @@ public class CoordinatorResult<T, U> {
     /**
      * @return The append-future.
      */
-    public CompletableFuture<T> appendFuture() {
+    public CompletableFuture<Void> appendFuture() {
         return appendFuture;
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -698,10 +698,10 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
          */
         @Override
         public void complete(Throwable exception) {
-            CompletableFuture<T> appendFuture = result != null ? result.appendFuture() : null;
+            CompletableFuture<Void> appendFuture = result != null ? result.appendFuture() : null;
 
             if (exception == null) {
-                if (appendFuture != null) result.appendFuture().complete(result.response());
+                if (appendFuture != null) result.appendFuture().complete(null);
                 future.complete(result.response());
             } else {
                 if (appendFuture != null) result.appendFuture().completeExceptionally(exception);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -8899,30 +8899,19 @@ public class GroupMetadataManagerTest {
     public void testLeaveGroupUnknownGroup() {
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .build();
-        context.createGenericGroup("group-id");
 
-        CoordinatorResult<LeaveGroupResponseData, Record> leaveResult = context.sendGenericGroupLeave(
+        assertThrows(UnknownMemberIdException.class, () -> context.sendGenericGroupLeave(
             new LeaveGroupRequestData()
-                .setGroupId("group-id")
+                .setGroupId("unknown-group-id")
                 .setMembers(Collections.singletonList(
                     new MemberIdentity()
                         .setMemberId("member-id")
                 ))
-        );
-
-        LeaveGroupResponseData expectedResponse = new LeaveGroupResponseData()
-            .setMembers(Collections.singletonList(
-                new LeaveGroupResponseData.MemberResponse()
-                    .setGroupInstanceId(null)
-                    .setMemberId("member-id")
-                    .setErrorCode(Errors.UNKNOWN_MEMBER_ID.code())));
-
-        assertEquals(expectedResponse, leaveResult.response());
-        assertTrue(leaveResult.records().isEmpty());
+        ));
     }
 
     @Test
-    public void testLeaveGroupUnknownConsumerExistingGroup() throws Exception {
+    public void testLeaveGroupUnknownMemberIdExistingGroup() throws Exception {
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .build();
         context.createGenericGroup("group-id");
@@ -8940,7 +8929,7 @@ public class GroupMetadataManagerTest {
                 .setGroupId("group-id")
                 .setMembers(Collections.singletonList(
                     new MemberIdentity()
-                        .setMemberId("other-member-id")
+                        .setMemberId("unknown-member-id")
                 ))
         );
 
@@ -8948,7 +8937,7 @@ public class GroupMetadataManagerTest {
             .setMembers(Collections.singletonList(
                 new LeaveGroupResponseData.MemberResponse()
                     .setGroupInstanceId(null)
-                    .setMemberId("other-member-id")
+                    .setMemberId("unknown-member-id")
                     .setErrorCode(Errors.UNKNOWN_MEMBER_ID.code())));
 
         assertEquals(expectedResponse, leaveResult.response());


### PR DESCRIPTION
Built on top of https://github.com/apache/kafka/pull/14122, this patch implements the existing
LeaveGroup API in the new group coordinator.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
