### PR TITLE
KAFKA-14132: Replace Easymock & Powermock with Mockito in KafkaBasedLogTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -417,7 +417,7 @@ subprojects {
       // connect tests
       "**/DistributedHerderTest.*",
       "**/KafkaConfigBackingStoreTest.*",
-      "**/KafkaBasedLogTest.*", "**/StandaloneHerderTest.*",
+      "**/StandaloneHerderTest.*",
       "**/WorkerSinkTaskTest.*", "**/WorkerSinkTaskThreadedTest.*"
     ])
   }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -103,7 +103,7 @@ public class KafkaBasedLog<K, V> {
     private Optional<Producer<K, V>> producer;
     private TopicAdmin admin;
 
-    private Thread thread;
+    Thread thread;
     private boolean stopRequested;
     private final Queue<Callback<Void>> readLogEndOffsetCallbacks;
     private final java.util.function.Consumer<TopicAdmin> initializer;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -102,7 +102,7 @@ public class KafkaBasedLog<K, V> {
     private Consumer<K, V> consumer;
     private Optional<Producer<K, V>> producer;
     private TopicAdmin admin;
-
+    // Visible for testing
     Thread thread;
     private boolean stopRequested;
     private final Queue<Callback<Void>> readLogEndOffsetCallbacks;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -62,6 +62,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -309,6 +310,7 @@ public class KafkaBasedLogTest {
         // Cleanup
         store.stop();
 
+        // Producer flushes when read to log end is called
         verify(producer).flush();
         verifyStartAndStop();
     }
@@ -501,5 +503,6 @@ public class KafkaBasedLogTest {
         verify(initializer).accept(any());
         verify(producer).close();
         assertTrue(consumer.closed());
+        assertFalse(store.thread.isAlive());
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -36,8 +36,8 @@ import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.TimestampType;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,13 +66,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class KafkaBasedLogTest {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -451,6 +451,8 @@ public class KafkaBasedLogTest {
 
         store.start();
         assertEquals(endOffsets, store.readEndOffsets(tps, false));
+        verify(admin).retryEndOffsets(eq(tps), any(), anyLong());
+        verify(admin).endOffsets(eq(tps));
     }
 
     @Test
@@ -468,6 +470,7 @@ public class KafkaBasedLogTest {
 
         store.start();
         assertEquals(endOffsets, store.readEndOffsets(tps, false));
+        verify(admin).retryEndOffsets(eq(tps), any(), anyLong());
     }
 
     @Test
@@ -484,6 +487,8 @@ public class KafkaBasedLogTest {
 
         store.start();
         assertThrows(LeaderNotAvailableException.class, () -> store.readEndOffsets(tps, false));
+        verify(admin).retryEndOffsets(eq(tps), any(), anyLong());
+        verify(admin).endOffsets(eq(tps));
     }
 
     private void verifyStartAndStop() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -70,6 +70,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -116,11 +117,10 @@ public class KafkaBasedLogTest {
     private MockedKafkaBasedLog store;
 
     @Mock
-    private TopicAdmin admin = null;
-    @Mock
     private Consumer<TopicAdmin> initializer;
     @Mock
     private KafkaProducer<String, String> producer;
+    private TopicAdmin admin;
     private final Supplier<TopicAdmin> topicAdminSupplier = () -> admin;
     private MockConsumer<String, String> consumer;
 
@@ -445,6 +445,7 @@ public class KafkaBasedLogTest {
         Map<TopicPartition, Long> endOffsets = new HashMap<>();
         endOffsets.put(TP0, 0L);
         endOffsets.put(TP1, 0L);
+        admin = mock(TopicAdmin.class);
         when(admin.retryEndOffsets(eq(tps), any(), anyLong())).thenReturn(endOffsets);
         when(admin.endOffsets(eq(tps))).thenReturn(endOffsets);
 
@@ -455,6 +456,7 @@ public class KafkaBasedLogTest {
     @Test
     public void testReadEndOffsetsUsingAdminThatFailsWithUnsupported() {
         Set<TopicPartition> tps = new HashSet<>(Arrays.asList(TP0, TP1));
+        admin = mock(TopicAdmin.class);
         // Getting end offsets using the admin client should fail with unsupported version
         when(admin.retryEndOffsets(eq(tps), any(), anyLong())).thenThrow(new UnsupportedVersionException("too old"));
 
@@ -474,6 +476,7 @@ public class KafkaBasedLogTest {
         Map<TopicPartition, Long> endOffsets = new HashMap<>();
         endOffsets.put(TP0, 0L);
         endOffsets.put(TP1, 0L);
+        admin = mock(TopicAdmin.class);
         // Getting end offsets upon startup should work fine
         when(admin.retryEndOffsets(eq(tps), any(), anyLong())).thenReturn(endOffsets);
         // Getting end offsets using the admin client should fail with leader not available

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -74,7 +74,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class KafkaBasedLogTest {
 
     private static final String TOPIC = "connect-log";
@@ -154,7 +154,6 @@ public class KafkaBasedLogTest {
         assertEquals(CONSUMER_ASSIGNMENT, consumer.assignment());
 
         store.stop();
-        assertTrue(consumer.closed());
         verifyStartAndStop();
     }
 
@@ -195,8 +194,6 @@ public class KafkaBasedLogTest {
         assertEquals(TP1_VALUE, consumedRecords.get(TP1).get(0).value());
 
         store.stop();
-        //assertFalse(Whitebox.<Thread>getInternalState(store, "thread").isAlive());
-        assertTrue(consumer.closed());
         verifyStartAndStop();
     }
 
@@ -226,8 +223,6 @@ public class KafkaBasedLogTest {
 
         store.stop();
 
-        //assertFalse(Whitebox.<Thread>getInternalState(store, "thread").isAlive());
-        assertTrue(consumer.closed());
         verifyStartAndStop();
     }
 
@@ -312,8 +307,6 @@ public class KafkaBasedLogTest {
         // Cleanup
         store.stop();
 
-        //assertFalse(Whitebox.<Thread>getInternalState(store, "thread").isAlive());
-        assertTrue(consumer.closed());
         verify(producer).flush();
         verifyStartAndStop();
     }
@@ -351,8 +344,6 @@ public class KafkaBasedLogTest {
 
         store.stop();
 
-        //assertFalse(Whitebox.<Thread>getInternalState(store, "thread").isAlive());
-        assertTrue(consumer.closed());
         verifyStartAndStop();
     }
 
@@ -401,8 +392,6 @@ public class KafkaBasedLogTest {
 
         store.stop();
 
-        //assertFalse(Whitebox.<Thread>getInternalState(store, "thread").isAlive());
-        assertTrue(consumer.closed());
         verify(producer).flush();
         verifyStartAndStop();
     }
@@ -436,8 +425,6 @@ public class KafkaBasedLogTest {
 
         store.stop();
 
-        //assertFalse(Whitebox.<Thread>getInternalState(store, "thread").isAlive());
-        assertTrue(consumer.closed());
         verifyStartAndStop();
     }
 
@@ -511,6 +498,7 @@ public class KafkaBasedLogTest {
     private void verifyStartAndStop() {
         verify(initializer).run();
         verify(producer).close();
+        assertTrue(consumer.closed());
     }
 
     private static ByteBuffer buffer(String v) {


### PR DESCRIPTION
Replaced Easymock & Powermock with Mockito in KafkaBasedLogTest.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
