### PR TITLE
MINOR: update Kafka Streams state.dir doc

### DIFF
--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -415,7 +415,7 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
           <tr class="row-odd"><td>state.dir</td>
             <td>High</td>
             <td colspan="2">Directory location for state stores.</td>
-            <td><code class="docutils literal"><span class="pre">/tmp/kafka-streams</span></code></td>
+            <td><code class="docutils literal"><span class="pre">/${java.io.tmpdir}/kafka-streams</span></code></td>
           </tr>
           <tr class="row-odd"><td>task.timeout.ms</td>
             <td>Medium</td>


### PR DESCRIPTION
Default state directory was changes in 2.8.0 release (cf KAFKA-10604)