### PR TITLE
KAFKA-15296: Allow offsets to be committed for filtered records when Exactly Once support is disabled

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -125,6 +125,10 @@ class WorkerSourceTask extends AbstractWorkerSourceTask {
     @Override
     protected void recordDropped(SourceRecord record) {
         commitTaskRecord(record, null);
+        // We explicitly submit the record for committing offsets and ack it so that
+        // the offsets for it get committed.
+        SubmittedRecords.SubmittedRecord submittedRecord = submittedRecords.submit(record);
+        submittedRecord.ack();
     }
 
     @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -708,11 +708,11 @@ public class WorkerSourceTaskTest {
         expectTopicCreation(TOPIC);
 
         //Using different partitions and offsets for each record, so we can verify all were committed
-        final Map<String, Object> offset2 = Collections.singletonMap("other_key", 13);
-        final Map<String, Object> partition2 = Collections.singletonMap("other_key", "other_partition".getBytes());
+        Map<String, Object> otherOffset = Collections.singletonMap("other_key", 13);
+        Map<String, Object> otherPartition = Collections.singletonMap("other_key", "other_partition".getBytes());
 
         // Send 2 records. The first one gets filtered while the second one goes through.
-        SourceRecord record1 = new SourceRecord(partition2, offset2, TOPIC, 1, KEY_SCHEMA, KEY + 1, RECORD_SCHEMA, RECORD);
+        SourceRecord record1 = new SourceRecord(otherPartition, otherOffset, TOPIC, 1, KEY_SCHEMA, KEY + 1, RECORD_SCHEMA, RECORD);
         SourceRecord record2 = new SourceRecord(PARTITION, OFFSET, TOPIC, 2, KEY_SCHEMA, KEY, RECORD_SCHEMA, RECORD);
 
         expectOffsetFlush();
@@ -732,7 +732,7 @@ public class WorkerSourceTaskTest {
         workerTask.commitOffsets();
 
         //All offsets should be committed, even for filtered records.
-        verify(offsetWriter).offset(partition2, offset2);
+        verify(offsetWriter).offset(otherPartition, otherOffset);
         verify(offsetWriter).offset(PARTITION, OFFSET);
         verify(sourceTask).commitRecord(any(SourceRecord.class), isNull());
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -702,6 +702,46 @@ public class WorkerSourceTaskTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    public void testFilteredRecordOffsetsShouldGetCommitted(boolean enableTopicCreation) throws Exception {
+        setup(enableTopicCreation);
+        createWorkerTaskWithErrorToleration();
+        expectTopicCreation(TOPIC);
+
+        //Using different partitions and offsets for each record, so we can verify all were committed
+        final Map<String, Object> offset2 = Collections.singletonMap("other_key", 13);
+        final Map<String, Object> partition2 = Collections.singletonMap("other_key", "other_partition".getBytes());
+
+        // Send 2 records. The first one gets filtered while the second one goes through.
+        SourceRecord record1 = new SourceRecord(partition2, offset2, TOPIC, 1, KEY_SCHEMA, KEY + 1, RECORD_SCHEMA, RECORD);
+        SourceRecord record2 = new SourceRecord(PARTITION, OFFSET, TOPIC, 2, KEY_SCHEMA, KEY, RECORD_SCHEMA, RECORD);
+
+        expectOffsetFlush();
+
+        expectConvertHeadersAndKeyValue(TOPIC, emptyHeaders());
+        // First record gets filtered while the second one goes through
+        when(transformationChain.apply(any(), any())).thenReturn(null).thenReturn(record2);
+
+        // Second record gets sent successfully.
+        when(producer.send(any(ProducerRecord.class), any(Callback.class)))
+                .thenAnswer(producerSendAnswer(true));
+
+        //Send records and then commit offsets and verify both were committed
+        workerTask.toSend = Arrays.asList(record1, record2);
+        workerTask.sendRecords();
+        workerTask.updateCommittableOffsets();
+        workerTask.commitOffsets();
+
+        //All offsets should be committed, even for filtered records.
+        verify(offsetWriter).offset(partition2, offset2);
+        verify(offsetWriter).offset(PARTITION, OFFSET);
+        verify(sourceTask).commitRecord(any(SourceRecord.class), isNull());
+
+        //Double check to make sure all submitted records were cleared
+        assertEquals(0, workerTask.submittedRecords.records.size());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     public void testSlowTaskStart(boolean enableTopicCreation) throws Exception {
         setup(enableTopicCreation);
         final CountDownLatch startupLatch = new CountDownLatch(1);


### PR DESCRIPTION
Currently when Exactly Once support is disabled and if a record is filtered or dropped due to a transformation or the transformation fails, then the record is marked as dropped but it's offsets are never committed. This can be a problem in certain cases if the connector implementation depends upon offsets from the partition of the dropped record.

This PR addresses the above gap. Note that for cases when Exactly once Support is enabled and a record is filtered out then if the connector chooses to abort the batch containing the record, then its offset is still committed. This PR focusses for the case when Exactly-Once support is disabled only.