### PR TITLE
KAFKA-15312; Force channel before atomic file move

### DIFF
--- a/raft/src/main/java/org/apache/kafka/snapshot/FileRawSnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/FileRawSnapshotWriter.java
@@ -112,6 +112,9 @@ public final class FileRawSnapshotWriter implements RawSnapshotWriter {
             checkIfFrozen("Freeze");
 
             frozenSize = channel.size();
+            // force the channel to write to the file system before closing, this guarantees that the file has the data
+            // on disk before preforming the atomic file move
+            channel.force(true);
             channel.close();
 
             if (!tempSnapshotPath.toFile().setReadOnly()) {

--- a/raft/src/main/java/org/apache/kafka/snapshot/FileRawSnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/FileRawSnapshotWriter.java
@@ -112,8 +112,8 @@ public final class FileRawSnapshotWriter implements RawSnapshotWriter {
             checkIfFrozen("Freeze");
 
             frozenSize = channel.size();
-            // force the channel to write to the file system before closing, this guarantees that the file has the data
-            // on disk before preforming the atomic file move
+            // force the channel to write to the file system before closing, to make sure that the file has the data
+            // on disk before performing the atomic file move
             channel.force(true);
             channel.close();
 


### PR DESCRIPTION
On ext4 file systems we have seen snapshots with zero-length files. This is possible if the file is closed and moved before forcing the channel to write to disk.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
