### PR TITLE
KAFKA-15314: test(quotas): add unit test for default client ids

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
@@ -177,6 +177,50 @@ class ClientQuotaManagerTest extends BaseClientQuotaManagerTest {
   }
 
   @Test
+  def testSetAndRemoveDefaultClientIdQuota(): Unit = {
+    // quotaTypesEnabled will be QuotaTypes.NoQuotas initially
+    val clientQuotaManager = new ClientQuotaManager(ClientQuotaManagerConfig(),
+      metrics, Produce, time, "")
+
+    try {
+      // no quota set yet, should not throttle
+      checkQuota(clientQuotaManager, "userA", "client1", Long.MaxValue, 1000, false)
+
+      // Set default <client-id> quota config
+      clientQuotaManager.updateQuota(None, Some(ConfigEntityName.Default), Some(ConfigEntityName.Default), Some(new Quota(10, true)))
+      checkQuota(clientQuotaManager, "userA", "client1", 10, 1000, true)
+
+      // Remove default <user> quota config, back to no quotas
+      clientQuotaManager.updateQuota(None, Some(ConfigEntityName.Default), Some(ConfigEntityName.Default), None)
+      checkQuota(clientQuotaManager, "userA", "client1", Long.MaxValue, 1000, false)
+    } finally {
+      clientQuotaManager.shutdown()
+    }
+  }
+
+  @Test
+  def testSetAndRemoveDefaultClientIdQuotaWithNullClientId(): Unit = {
+    // quotaTypesEnabled will be QuotaTypes.NoQuotas initially
+    val clientQuotaManager = new ClientQuotaManager(ClientQuotaManagerConfig(),
+      metrics, Produce, time, "")
+
+    try {
+      // no quota set yet, should not throttle
+      checkQuota(clientQuotaManager, "userA", null, Long.MaxValue, 1000, false)
+
+      // Set default <client-id> quota config
+      clientQuotaManager.updateQuota(None, Some(ConfigEntityName.Default), Some(ConfigEntityName.Default), Some(new Quota(10, true)))
+      checkQuota(clientQuotaManager, "userA", null, 10, 1000, true)
+
+      // Remove default <user> quota config, back to no quotas
+      clientQuotaManager.updateQuota(None, Some(ConfigEntityName.Default), Some(ConfigEntityName.Default), None)
+      checkQuota(clientQuotaManager, "userA", null, Long.MaxValue, 1000, false)
+    } finally {
+      clientQuotaManager.shutdown()
+    }
+  }
+
+  @Test
   def testSetAndRemoveDefaultUserQuota(): Unit = {
     // quotaTypesEnabled will be QuotaTypes.NoQuotas initially
     val clientQuotaManager = new ClientQuotaManager(ClientQuotaManagerConfig(),

--- a/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
@@ -199,6 +199,28 @@ class ClientQuotaManagerTest extends BaseClientQuotaManagerTest {
   }
 
   @Test
+  def testSetAndRemoveDefaultClientIdQuotaWithEmptyClientId(): Unit = {
+    // quotaTypesEnabled will be QuotaTypes.NoQuotas initially
+    val clientQuotaManager = new ClientQuotaManager(ClientQuotaManagerConfig(),
+      metrics, Produce, time, "")
+
+    try {
+      // no quota set yet, should not throttle
+      checkQuota(clientQuotaManager, "userA", "", Long.MaxValue, 1000, false)
+
+      // Set default <client-id> quota config
+      clientQuotaManager.updateQuota(None, Some(ConfigEntityName.Default), Some(ConfigEntityName.Default), Some(new Quota(10, true)))
+      checkQuota(clientQuotaManager, "userA", "", 10, 1000, true)
+
+      // Remove default <user> quota config, back to no quotas
+      clientQuotaManager.updateQuota(None, Some(ConfigEntityName.Default), Some(ConfigEntityName.Default), None)
+      checkQuota(clientQuotaManager, "userA", "", Long.MaxValue, 1000, false)
+    } finally {
+      clientQuotaManager.shutdown()
+    }
+  }
+
+  @Test
   def testSetAndRemoveDefaultClientIdQuotaWithNullClientId(): Unit = {
     // quotaTypesEnabled will be QuotaTypes.NoQuotas initially
     val clientQuotaManager = new ClientQuotaManager(ClientQuotaManagerConfig(),


### PR DESCRIPTION
Include test for client-id = null. This is supposed to use default client id quota, but seems to not be the case. The failing unit test proves this.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
