### PR TITLE
KAFKA-15324 Do not bump leader epoch when changing the replica set

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -289,11 +289,7 @@ public class PartitionChangeBuilder {
     void triggerLeaderEpochBumpIfNeeded(PartitionChangeRecord record) {
         if (record.leader() == NO_LEADER_CHANGE) {
             boolean bumpLeaderEpochOnIsrShrink = metadataVersion.isLeaderEpochBumpRequiredOnIsrShrink() || zkMigrationEnabled;
-
-            if (!Replicas.contains(targetReplicas, partition.replicas)) {
-                // Reassignment
-                record.setLeader(partition.leader);
-            } else if (bumpLeaderEpochOnIsrShrink && !Replicas.contains(targetIsr, partition.isr)) {
+            if (bumpLeaderEpochOnIsrShrink && !Replicas.contains(targetIsr, partition.isr)) {
                 // ISR shrink
                 record.setLeader(partition.leader);
             }


### PR DESCRIPTION
The KRaft controller increases the leader epoch when a partition replica set shrink. This is not strictly required and should be removed.
Related changes: https://github.com/apache/kafka/pull/13765/files

To be discussed: should we add test case for this?