### PR TITLE
KAFKA-15326: [6/N] Processing thread task timeouts

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutionMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutionMetadata.java
@@ -97,7 +97,7 @@ public class TaskExecutionMetadata {
         return successfullyProcessed;
     }
 
-    void addToSuccessfullyProcessed(final Task task) {
+    public void addToSuccessfullyProcessed(final Task task) {
         successfullyProcessed.add(task);
     }
 


### PR DESCRIPTION
Implement setting and clearing task timeouts, as well as changing the output on exceptions to make 
it similar to the existing code path. This is a stacked PR, only the last commit needs to be reviewed.