### PR TITLE
KAFKA-15042: Improve TAGGED_FIELDS protocol documentation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -52,7 +52,7 @@ public class Protocol {
                     subTypes.put(field.def.name, type.arrayElementType().get());
                 }
             } else if (type instanceof TaggedFields) {
-                b.append("TAG_BUFFER ");
+                b.append("TAGGED_FIELDS ");
             } else {
                 b.append(field.def.name);
                 b.append(" ");

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -103,6 +103,9 @@ public class Protocol {
         b.append("<th>Description</th>\n");
         b.append("</tr>");
         for (BoundField field : fields) {
+            if (field.def.type instanceof TaggedFields) {
+                continue; // TaggedFields is a terminal symbol. Exclude from table.
+            }
             b.append("<tr>\n");
             b.append("<td>");
             b.append(field.def.name);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/TaggedFields.java
@@ -176,7 +176,10 @@ public class TaggedFields extends DocumentedType {
 
     @Override
     public String documentation() {
-        return "Represents a series of tagged fields.";
+        return "Represents a sequence of tagged fields. First the length N + 1 is given as an UNSIGNED_VARINT. " +
+            "Then N tag field instances follow. A tag field is a triplet of a tag, a length, and data. " +
+            "The tag is an UNSIGNED_VARINT. The length F + 1 is given as an UNSIGNED_VARINT. " +
+            "Null data is represented as a length of 0, otherwise F bytes of data follow.";
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.common.utils.Utils;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.Optional;
 
 /**
@@ -1116,7 +1117,8 @@ public abstract class Type {
             UNSIGNED_INT32, VARINT, VARLONG, UUID, FLOAT64,
             STRING, COMPACT_STRING, NULLABLE_STRING, COMPACT_NULLABLE_STRING,
             BYTES, COMPACT_BYTES, NULLABLE_BYTES, COMPACT_NULLABLE_BYTES,
-            RECORDS, new ArrayOf(STRING), new CompactArrayOf(COMPACT_STRING)};
+            RECORDS, new ArrayOf(STRING), new CompactArrayOf(COMPACT_STRING),
+            new TaggedFields(Collections.emptyMap())};
         final StringBuilder b = new StringBuilder();
         b.append("<table class=\"data-table\"><tbody>\n");
         b.append("<tr>");


### PR DESCRIPTION
- Rename TAG_BUFFER -> TAGGED_FIELDS (for better consistency with KIP-482 and the implementation)
- Add TAGGED_FIELDS into "protocol primitive types" section, and improve description
- Exclude "_tagged_fields" from individual API message field descriptions

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
