### PR TITLE
KAFKA-15288: Change BrokerApiVersionsCommandTest to support kraft mode

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NodeApiVersions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NodeApiVersions.java
@@ -68,7 +68,7 @@ public class NodeApiVersions {
      */
     public static NodeApiVersions create(Collection<ApiVersion> overrides) {
         List<ApiVersion> apiVersions = new LinkedList<>(overrides);
-        for (ApiKeys apiKey : ApiKeys.zkBrokerApis()) {
+        for (ApiKeys apiKey : ApiKeys.clientApis()) {
             boolean exists = false;
             for (ApiVersion apiVersion : apiVersions) {
                 if (apiVersion.apiKey() == apiKey.id) {
@@ -172,7 +172,7 @@ public class NodeApiVersions {
 
         // Also handle the case where some apiKey types are not specified at all in the given ApiVersions,
         // which may happen when the remote is too old.
-        for (ApiKeys apiKey : ApiKeys.zkBrokerApis()) {
+        for (ApiKeys apiKey : ApiKeys.clientApis()) {
             if (!apiKeysText.containsKey(apiKey.id)) {
                 StringBuilder bld = new StringBuilder();
                 bld.append(apiKey.name).append("(").

--- a/clients/src/main/java/org/apache/kafka/clients/NodeApiVersions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NodeApiVersions.java
@@ -68,7 +68,7 @@ public class NodeApiVersions {
      */
     public static NodeApiVersions create(Collection<ApiVersion> overrides) {
         List<ApiVersion> apiVersions = new LinkedList<>(overrides);
-        for (ApiKeys apiKey : ApiKeys.clientApis()) {
+        for (ApiKeys apiKey : ApiKeys.zkBrokerApis()) {
             boolean exists = false;
             for (ApiVersion apiVersion : apiVersions) {
                 if (apiVersion.apiKey() == apiKey.id) {

--- a/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
@@ -43,7 +43,7 @@ public class NodeApiVersionsTest {
         NodeApiVersions versions = new NodeApiVersions(new ApiVersionCollection(), Collections.emptyList(), false);
         StringBuilder bld = new StringBuilder();
         String prefix = "(";
-        for (ApiKeys apiKey : ApiKeys.zkBrokerApis()) {
+        for (ApiKeys apiKey : ApiKeys.clientApis()) {
             bld.append(prefix).append(apiKey.name).
                     append("(").append(apiKey.id).append("): UNSUPPORTED");
             prefix = ", ";

--- a/core/src/test/scala/integration/kafka/admin/BrokerApiVersionsCommandTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/BrokerApiVersionsCommandTest.scala
@@ -23,6 +23,7 @@ import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.NodeApiVersions
 import org.apache.kafka.common.message.ApiMessageType
 import org.apache.kafka.common.protocol.ApiKeys
+import org.apache.kafka.common.requests.ApiVersionsResponse
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull, assertTrue}
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.params.ParameterizedTest
@@ -30,6 +31,7 @@ import org.junit.jupiter.params.provider.ValueSource
 
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.nio.charset.StandardCharsets
+import java.util.Collections
 import scala.collection.Seq
 import scala.jdk.CollectionConverters._
 
@@ -38,6 +40,8 @@ class BrokerApiVersionsCommandTest extends KafkaServerTestHarness {
   def generateConfigs: Seq[KafkaConfig] =
     if (isKRaftTest()) {
       TestUtils.createBrokerConfigs(1, null).map(props => {
+        // Enable unstable api versions to be compatible with the new APIs under development,
+        // maybe we can remove this after the new APIs is complete.
         props.setProperty(KafkaConfig.UnstableApiVersionsEnableProp, "true")
         props
       }).map(KafkaConfig.fromProps)
@@ -65,16 +69,15 @@ class BrokerApiVersionsCommandTest extends KafkaServerTestHarness {
     val lineIter = content.split("\n").iterator
     assertTrue(lineIter.hasNext)
     assertEquals(s"${bootstrapServers()} (id: 0 rack: null) -> (", lineIter.next())
-    val nodeApiVersions = NodeApiVersions.create
     val listenerType = if (isKRaftTest()) {
       ApiMessageType.ListenerType.BROKER
     } else {
       ApiMessageType.ListenerType.ZK_BROKER
     }
     val clientApis = ApiKeys.clientApis().asScala
+    val nodeApiVersions = new NodeApiVersions(clientApis.map(ApiVersionsResponse.toApiVersion).asJava, Collections.emptyList(), false)
     for (apiKey <- clientApis) {
-      assertTrue(lineIter.hasNext)
-      val actual = lineIter.next()
+      val terminator = if (apiKey == clientApis.last) "" else ","
       if (apiKey.inScope(listenerType)) {
         val apiVersion = nodeApiVersions.apiVersion(apiKey)
         assertNotNull(apiVersion)
@@ -84,11 +87,13 @@ class BrokerApiVersionsCommandTest extends KafkaServerTestHarness {
           else s"${apiVersion.minVersion} to ${apiVersion.maxVersion}"
         val usableVersion = nodeApiVersions.latestUsableVersion(apiKey)
 
-        val terminator = if (apiKey == clientApis.last) "" else ","
-
         val line = s"\t${apiKey.name}(${apiKey.id}): $versionRangeStr [usable: $usableVersion]$terminator"
         assertTrue(lineIter.hasNext)
-        assertEquals(line, actual)
+        assertEquals(line, lineIter.next())
+      } else {
+        val line = s"\t${apiKey.name}(${apiKey.id}): UNSUPPORTED$terminator"
+        assertTrue(lineIter.hasNext)
+        assertEquals(line, lineIter.next())
       }
     }
     assertTrue(lineIter.hasNext)


### PR DESCRIPTION
Change BrokerApiVersionsCommandTest to support kraft mode.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
