### PR TITLE
MINOR: Fix SynchronizationTest Classloaders sometimes not being parallel capable

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/SynchronizationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/SynchronizationTest.java
@@ -162,7 +162,7 @@ public class SynchronizationTest {
         public DelegatingClassLoader newDelegatingClassLoader(ClassLoader parent) {
             return AccessController.doPrivileged(
                     (PrivilegedAction<DelegatingClassLoader>) () ->
-                            new SynchronizedDelegatingClassLoader(parent)
+                            new SynchronizedDelegatingClassLoader(parent, dclBreakpoint)
             );
         }
 
@@ -174,18 +174,21 @@ public class SynchronizationTest {
         ) {
             return AccessController.doPrivileged(
                     (PrivilegedAction<PluginClassLoader>) () ->
-                            new SynchronizedPluginClassLoader(pluginLocation, urls, parent)
+                            new SynchronizedPluginClassLoader(pluginLocation, urls, parent, pclBreakpoint)
             );
         }
     }
 
-    private class SynchronizedDelegatingClassLoader extends DelegatingClassLoader {
-        {
+    private static class SynchronizedDelegatingClassLoader extends DelegatingClassLoader {
+        static {
             ClassLoader.registerAsParallelCapable();
         }
 
-        public SynchronizedDelegatingClassLoader(ClassLoader parent) {
+        private final Breakpoint<String> dclBreakpoint;
+
+        public SynchronizedDelegatingClassLoader(ClassLoader parent, Breakpoint<String> dclBreakpoint) {
             super(parent);
+            this.dclBreakpoint = dclBreakpoint;
         }
 
         @Override
@@ -196,14 +199,19 @@ public class SynchronizationTest {
         }
     }
 
-    private class SynchronizedPluginClassLoader extends PluginClassLoader {
-        {
+    private static class SynchronizedPluginClassLoader extends PluginClassLoader {
+        static {
             ClassLoader.registerAsParallelCapable();
         }
 
+        private final Breakpoint<String> pclBreakpoint;
 
-        public SynchronizedPluginClassLoader(URL pluginLocation, URL[] urls, ClassLoader parent) {
+
+        public SynchronizedPluginClassLoader(
+                URL pluginLocation, URL[] urls, ClassLoader parent, Breakpoint<String> pclBreakpoint
+        ) {
             super(pluginLocation, urls, parent);
+            this.pclBreakpoint = pclBreakpoint;
         }
 
         @Override


### PR DESCRIPTION
The `Classloader.registerAsParallelCapable()` call is intended to be called during static initialization. It must be called prior to the `Classloader` superconstructor, because there it is evaluated to decide whether the classloader instance created will be parallel capable.

For the entire lifetime of this test, the `Classloader.registerAsParallelCapable()` call has been in an instance initializer, which is executed after the superconstructor is finished. This has meant that the first `SynchronizedDelegatingClassLoader`, and the first `SynchronizedPluginClassLoader` created have erroneously been non-parallel-capable.

However, this test did not flaky-fail until #14089 was merged, because the `SamplingConverter` was never located in the first `SynchronizedPluginClassLoader`. With that PR, the `TestPlugins.pluginPath(TestPlugins.TestPlugin...)` function was changed to return a Set instead of a List. This meant that the `SamplingConverter` then _could_ appear in the first `SynchronizedPluginClassLoader`, and whenever that happened, the test would reproduce a deadlock and fail.

Since there was only one `SynchronizedDelegatingClassLoader` created in this test, it was always non-parallel-capable. The test would only deadlock if _both_ classloaders were non-parallel-capable, which was not possible until recently.

Importantly, this is only a bug in the test, as the real PluginClassLoader and DelegatingClassLoader have been parallel-capable since they were fixed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
