### PR TITLE
MINOR: CommitRequestManager should only poll when the coordinator node is known

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -92,6 +92,11 @@ public class CommitRequestManager implements RequestManager {
      */
     @Override
     public NetworkClientDelegate.PollResult poll(final long currentTimeMs) {
+        // poll only when the coordinator node is known.
+        if (!coordinatorRequestManager.coordinator().isPresent()) {
+            return new NetworkClientDelegate.PollResult(Long.MAX_VALUE, Collections.emptyList());
+        }
+
         maybeAutoCommit(this.subscriptionState.allConsumed());
         if (!pendingRequests.hasUnsentRequests()) {
             return new NetworkClientDelegate.PollResult(Long.MAX_VALUE, Collections.emptyList());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
@@ -67,6 +68,7 @@ public class CommitRequestManagerTest {
     private MockTime time;
     private CoordinatorRequestManager coordinatorRequestManager;
     private Properties props;
+    private Node mockedNode = new Node(1, "host1", 9092);
 
     @BeforeEach
     public void setup() {
@@ -80,6 +82,18 @@ public class CommitRequestManagerTest {
         this.props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 100);
         this.props.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         this.props.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    }
+
+    @Test
+    public void testPoll_SkipIfCoordinatorUnknown() {
+        CommitRequestManager commitRequestManger = create(false, 0);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.empty());
+        assertPoll(false, 0, commitRequestManger);
+
+        Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+        offsets.put(new TopicPartition("t1", 0), new OffsetAndMetadata(0));
+        commitRequestManger.addOffsetCommitRequest(offsets);
+        assertPoll(false, 0, commitRequestManger);
     }
 
     @Test
@@ -110,6 +124,7 @@ public class CommitRequestManagerTest {
     @Test
     public void testPoll_EnsureCorrectInflightRequestBufferSize() {
         CommitRequestManager commitManager = create(false, 100);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
 
         // Create some offset commit requests
         Map<TopicPartition, OffsetAndMetadata> offsets1 = new HashMap<>();
@@ -146,6 +161,7 @@ public class CommitRequestManagerTest {
     @Test
     public void testPoll_EnsureEmptyPendingRequestAfterPoll() {
         CommitRequestManager commitRequestManger = create(true, 100);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
         commitRequestManger.addOffsetCommitRequest(new HashMap<>());
         assertEquals(1, commitRequestManger.unsentOffsetCommitRequests().size());
         commitRequestManger.poll(time.milliseconds());
@@ -192,6 +208,7 @@ public class CommitRequestManagerTest {
     @Test
     public void testOffsetFetchRequest_EnsureDuplicatedRequestSucceed() {
         CommitRequestManager commitRequestManger = create(true, 100);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
         Set<TopicPartition> partitions = new HashSet<>();
         partitions.add(new TopicPartition("t1", 0));
         List<CompletableFuture<Map<TopicPartition, OffsetAndMetadata>>> futures = sendAndVerifyDuplicatedRequests(
@@ -212,6 +229,8 @@ public class CommitRequestManagerTest {
     @MethodSource("exceptionSupplier")
     public void testOffsetFetchRequest_ErroredRequests(final Errors error, final boolean isRetriable) {
         CommitRequestManager commitRequestManger = create(true, 100);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
+
         Set<TopicPartition> partitions = new HashSet<>();
         partitions.add(new TopicPartition("t1", 0));
         List<CompletableFuture<Map<TopicPartition, OffsetAndMetadata>>> futures = sendAndVerifyDuplicatedRequests(
@@ -255,6 +274,7 @@ public class CommitRequestManagerTest {
     @MethodSource("partitionDataErrorSupplier")
     public void testOffsetFetchRequest_PartitionDataError(final Errors error, final boolean isRetriable) {
         CommitRequestManager commitRequestManger = create(true, 100);
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
         Set<TopicPartition> partitions = new HashSet<>();
         TopicPartition tp1 = new TopicPartition("t1", 2);
         TopicPartition tp2 = new TopicPartition("t2", 3);
@@ -316,8 +336,20 @@ public class CommitRequestManagerTest {
     }
 
     private List<CompletableFuture<ClientResponse>> assertPoll(
-            final int numRes,
-            final CommitRequestManager manager) {
+        final int numRes,
+        final CommitRequestManager manager) {
+        return assertPoll(true, numRes, manager);
+    }
+
+    private List<CompletableFuture<ClientResponse>> assertPoll(
+        final boolean coordinatorDiscovered,
+        final int numRes,
+        final CommitRequestManager manager) {
+        if (coordinatorDiscovered) {
+            when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));
+        } else {
+            when(coordinatorRequestManager.coordinator()).thenReturn(Optional.empty());
+        }
         NetworkClientDelegate.PollResult res = manager.poll(time.milliseconds());
         assertEquals(numRes, res.unsentRequests.size());
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -87,7 +87,6 @@ public class CommitRequestManagerTest {
     @Test
     public void testPoll_SkipIfCoordinatorUnknown() {
         CommitRequestManager commitRequestManger = create(false, 0);
-        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.empty());
         assertPoll(false, 0, commitRequestManger);
 
         Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();


### PR DESCRIPTION
As title, we discovered a flaky bug during testing that the commit request manager would seldomly throw a NOT_COORDINATOR exception, which means the request was routed to a non-coordinator node.  We discovered that if we don't check the coordinator node in the commitRequestManager, the request manager will pass on an empty node to the NetworkClientDelegate, which implies the request can be sent to any node in the cluster.  This behavior is incorrect as the commit requests need to be routed to a coordinator node.

Because the timing coordinator's discovery during integration testing isn't entirely deterministic; therefore, the test became extremely flaky. After fixing this: The coordinator node is mandatory before attempt to enqueue these commit request to the NetworkClient.