### PR TITLE
KAFKA-14682: Report Mockito unused stubbings during Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ def isChangeRequest(env) {
   env.CHANGE_ID != null && !env.CHANGE_ID.isEmpty()
 }
 
-def doTest(env, target = "unitTest integrationTest") {
+def doTest(env, target = "test") {
   sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
       --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
       -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/InternalRequestSignatureTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/InternalRequestSignatureTest.java
@@ -121,6 +121,8 @@ public class InternalRequestSignatureTest {
                 signatureAlgorithmCapture.capture()
             )).thenReturn(request);
 
+        when(request.getAgent()).thenThrow(new RuntimeException());
+
         InternalRequestSignature.addToRequest(crypto, KEY, REQUEST_BODY, SIGNATURE_ALGORITHM, request);
 
         assertEquals(

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/InternalRequestSignatureTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/InternalRequestSignatureTest.java
@@ -121,8 +121,6 @@ public class InternalRequestSignatureTest {
                 signatureAlgorithmCapture.capture()
             )).thenReturn(request);
 
-        when(request.getAgent()).thenThrow(new RuntimeException());
-
         InternalRequestSignature.addToRequest(crypto, KEY, REQUEST_BODY, SIGNATURE_ALGORITHM, request);
 
         assertEquals(


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-14682)

Our Jenkinsfile is currently configured to do testing with the `unitTest` and `integrationTest` tasks, instead of the `test` task. These tasks use JUnit test category filters to distinguish between integration and non-integration tests. Because of https://github.com/mockito/mockito/issues/3077, if a JUnit test category filter is used, Mockito does not report unused stubbings. As a result, our CI builds currently don't catch unused stubbings.

Although an upstream fix has been implemented with https://github.com/mockito/mockito/pull/3078, a release has not yet been published with that fix. Even when a new release is published, it will take place on the 5.x.y line, which requires JDK 11+ (see the [5.0.0 release notes](https://github.com/mockito/mockito/releases/tag/v5.0.0)).

As a workaround, we can switch to using the `test` task instead of the `unitTest` and `integrationTest` tasks. If there are benefits to the two-task approach, we can revert to that approach once we begin work on Kafka 4.0 (which drops support for Java 8) and upgrade to a version of Mockito with the fix.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
