### PR TITLE
KAFKA-13197: fix GlobalKTable join/left-join semantics documentation.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -2805,7 +2805,7 @@ public interface KStream<K, V> {
      * For each {@code KStream} record that finds a corresponding record in {@link GlobalKTable} the provided
      * {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as the key of this {@code KStream}.
-     * If a {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * If a {@code KStream} input value is {@code null} the record will not be included in the join
      * operation and thus no output record will be added to the resulting {@code KStream}.
      * If {@code keyValueMapper} returns {@code null} implying no match exists, no output record will be added to the
      * resulting {@code KStream}.
@@ -2839,7 +2839,7 @@ public interface KStream<K, V> {
      * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as the key of this {@code KStream}.
      * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * If a {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * If a {@code KStream} input value is {@code null} the record will not be included in the join
      * operation and thus no output record will be added to the resulting {@code KStream}.
      * If {@code keyValueMapper} returns {@code null} implying no match exists, no output record will be added to the
      * resulting {@code KStream}.
@@ -2872,7 +2872,7 @@ public interface KStream<K, V> {
      * For each {@code KStream} record that finds a corresponding record in {@link GlobalKTable} the provided
      * {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as the key of this {@code KStream}.
-     * If a {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * If a {@code KStream} input value is {@code null} the record will not be included in the join
      * operation and thus no output record will be added to the resulting {@code KStream}.
      * If {@code keyValueMapper} returns {@code null} implying no match exists, no output record will be added to the
      * resulting {@code KStream}.
@@ -2908,7 +2908,7 @@ public interface KStream<K, V> {
      * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as the key of this {@code KStream}.
      * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * If a {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * If a {@code KStream} input value is {@code null} the record will not be included in the join
      * operation and thus no output record will be added to the resulting {@code KStream}.
      * If {@code keyValueMapper} returns {@code null} implying no match exists, no output record will be added to the
      * resulting {@code KStream}.
@@ -2945,7 +2945,7 @@ public interface KStream<K, V> {
      * For each {@code KStream} record whether or not it finds a corresponding record in {@link GlobalKTable} the
      * provided {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as this {@code KStream}.
-     * If a {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * If a {@code KStream} input value is {@code null} the record will not be included in the join
      * operation and thus no output record will be added to the resulting {@code KStream}.
      * If {@code keyValueMapper} returns {@code null} implying no match exists, a {@code null} value will be
      * provided to {@link ValueJoiner}.
@@ -2983,7 +2983,7 @@ public interface KStream<K, V> {
      * provided {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as this {@code KStream}.
      * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * If a {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * If a {@code KStream} input value is {@code null} the record will not be included in the join
      * operation and thus no output record will be added to the resulting {@code KStream}.
      * If {@code keyValueMapper} returns {@code null} implying no match exists, a {@code null} value will be
      * provided to {@link ValueJoinerWithKey}.
@@ -3020,7 +3020,7 @@ public interface KStream<K, V> {
      * For each {@code KStream} record whether or not it finds a corresponding record in {@link GlobalKTable} the
      * provided {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as this {@code KStream}.
-     * If a {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * If a {@code KStream} input value is {@code null} the record will not be included in the join
      * operation and thus no output record will be added to the resulting {@code KStream}.
      * If {@code keyValueMapper} returns {@code null} implying no match exists, a {@code null} value will be
      * provided to {@link ValueJoiner}.
@@ -3059,7 +3059,7 @@ public interface KStream<K, V> {
      * For each {@code KStream} record whether or not it finds a corresponding record in {@link GlobalKTable} the
      * provided {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as this {@code KStream}.
-     * If a {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * If a {@code KStream} input value is {@code null} the record will not be included in the join
      * operation and thus no output record will be added to the resulting {@code KStream}.
      * If {@code keyValueMapper} returns {@code null} implying no match exists, a {@code null} value will be
      * provided to {@link ValueJoinerWithKey}.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -2805,10 +2805,8 @@ public interface KStream<K, V> {
      * For each {@code KStream} record that finds a corresponding record in {@link GlobalKTable} the provided
      * {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as the key of this {@code KStream}.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
-     * If {@code keyValueMapper} returns {@code null} implying no match exists, no output record will be added to the
-     * resulting {@code KStream}.
+     * If a {@code KStream} input value is {@code null} or if {@code keyValueMapper} returns {@code null} the record
+     * will not be included in the join operation and thus no output record will be added to the resulting {@code KStream}.
      *
      * @param globalTable    the {@link GlobalKTable} to be joined with this stream
      * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
@@ -2839,10 +2837,8 @@ public interface KStream<K, V> {
      * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as the key of this {@code KStream}.
      * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
-     * If {@code keyValueMapper} returns {@code null} implying no match exists, no output record will be added to the
-     * resulting {@code KStream}.
+     * If a {@code KStream} input value is {@code null} or if {@code keyValueMapper} returns {@code null} the record
+     * will not be included in the join operation and thus no output record will be added to the resulting {@code KStream}.
      *
      * @param globalTable    the {@link GlobalKTable} to be joined with this stream
      * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
@@ -2872,10 +2868,8 @@ public interface KStream<K, V> {
      * For each {@code KStream} record that finds a corresponding record in {@link GlobalKTable} the provided
      * {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as the key of this {@code KStream}.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
-     * If {@code keyValueMapper} returns {@code null} implying no match exists, no output record will be added to the
-     * resulting {@code KStream}.
+     * If a {@code KStream} input value is {@code null} or if {@code keyValueMapper} returns {@code null} the record
+     * will not be included in the join operation and thus no output record will be added to the resulting {@code KStream}.
      *
      * @param globalTable    the {@link GlobalKTable} to be joined with this stream
      * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
@@ -2908,10 +2902,8 @@ public interface KStream<K, V> {
      * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as the key of this {@code KStream}.
      * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
-     * If {@code keyValueMapper} returns {@code null} implying no match exists, no output record will be added to the
-     * resulting {@code KStream}.
+     * If a {@code KStream} input value is {@code null} or if {@code keyValueMapper} returns {@code null} the record
+     * will not be included in the join operation and thus no output record will be added to the resulting {@code KStream}.
      *
      * @param globalTable    the {@link GlobalKTable} to be joined with this stream
      * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -2937,10 +2937,8 @@ public interface KStream<K, V> {
      * For each {@code KStream} record whether or not it finds a corresponding record in {@link GlobalKTable} the
      * provided {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as this {@code KStream}.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
-     * If {@code keyValueMapper} returns {@code null} implying no match exists, a {@code null} value will be
-     * provided to {@link ValueJoiner}.
+     * If a {@code KStream} input value is {@code null} or if {@code keyValueMapper} returns {@code null} the record
+     * will not be included in the join operation and thus no output record will be added to the resulting {@code KStream}.
      * If no {@link GlobalKTable} record was found during lookup, a {@code null} value will be provided to
      * {@link ValueJoiner}.
      *
@@ -2975,10 +2973,8 @@ public interface KStream<K, V> {
      * provided {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as this {@code KStream}.
      * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
-     * If {@code keyValueMapper} returns {@code null} implying no match exists, a {@code null} value will be
-     * provided to {@link ValueJoinerWithKey}.
+     * If a {@code KStream} input value is {@code null} or if {@code keyValueMapper} returns {@code null} the record
+     * will not be included in the join operation and thus no output record will be added to the resulting {@code KStream}.
      * If no {@link GlobalKTable} record was found during lookup, a {@code null} value will be provided to
      * {@link ValueJoiner}.
      *
@@ -3012,10 +3008,8 @@ public interface KStream<K, V> {
      * For each {@code KStream} record whether or not it finds a corresponding record in {@link GlobalKTable} the
      * provided {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as this {@code KStream}.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
-     * If {@code keyValueMapper} returns {@code null} implying no match exists, a {@code null} value will be
-     * provided to {@link ValueJoiner}.
+     * If a {@code KStream} input value is {@code null} or if {@code keyValueMapper} returns {@code null} the record
+     * will not be included in the join operation and thus no output record will be added to the resulting {@code KStream}.
      * If no {@link GlobalKTable} record was found during lookup, a {@code null} value will be provided to
      * {@link ValueJoiner}.
      *
@@ -3051,10 +3045,8 @@ public interface KStream<K, V> {
      * For each {@code KStream} record whether or not it finds a corresponding record in {@link GlobalKTable} the
      * provided {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as this {@code KStream}.
-     * If a {@code KStream} input value is {@code null} the record will not be included in the join
-     * operation and thus no output record will be added to the resulting {@code KStream}.
-     * If {@code keyValueMapper} returns {@code null} implying no match exists, a {@code null} value will be
-     * provided to {@link ValueJoinerWithKey}.
+     * If a {@code KStream} input value is {@code null} or if {@code keyValueMapper} returns {@code null} the record
+     * will not be included in the join operation and thus no output record will be added to the resulting {@code KStream}.
      * If no {@link GlobalKTable} record was found during lookup, a {@code null} value will be provided to
      * {@link ValueJoinerWithKey}.
      *


### PR DESCRIPTION
The documentation for join/left-join Kstream-GlobalKtable is out dated: The left hand side key may be null.

Note: The constraint that KeyValueMapper cannot return null for left joins or else the record gets dropped will be relaxed as part of https://cwiki.apache.org/confluence/display/KAFKA/KIP-962%3A+Relax+non-null+key+requirement+in+Kafka+Streams

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
