### PR TITLE
Disable Tests causing exit issues during the builds

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/IdentityReplicationIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/IdentityReplicationIntegrationTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.connect.mirror.IdentityReplicationPolicy;
 
 import java.util.HashMap;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
  * migrated from the primary cluster to the backup cluster. Tests validate that consumer offsets
  * are translated and replicated from the primary cluster to the backup cluster during this failover.
  */
+@Disabled
 @Tag("integration")
 public class IdentityReplicationIntegrationTest extends MirrorConnectorsIntegrationBaseTest {
     @BeforeEach

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -71,7 +71,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -71,6 +71,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,9 +82,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Tests MM2 replication and failover/failback logic.
@@ -93,6 +91,7 @@ import org.junit.jupiter.api.BeforeEach;
  * one cluster to the other and back. Tests validate that consumer offsets are translated and replicated
  * between clusters during this failover and failback.
  */
+@Disabled
 @Tag("integration")
 public class MirrorConnectorsIntegrationBaseTest {
     private static final Logger log = LoggerFactory.getLogger(MirrorConnectorsIntegrationBaseTest.class);

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationExactlyOnceTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationExactlyOnceTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.mirror.integration;
 
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 import java.util.Arrays;
@@ -26,6 +27,7 @@ import java.util.Properties;
 /**
  * Tests MM2 replication with exactly-once support enabled on the Connect clusters.
  */
+@Disabled
 @Tag("integration")
 public class MirrorConnectorsIntegrationExactlyOnceTest extends MirrorConnectorsIntegrationBaseTest {
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationSSLTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationSSLTest.java
@@ -29,11 +29,13 @@ import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 /**
  * Tests MM2 replication with SSL enabled at backup kafka cluster
  */
+@Disabled
 @Tag("integration")
 public class MirrorConnectorsIntegrationSSLTest extends MirrorConnectorsIntegrationBaseTest {
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationTransactionsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationTransactionsTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 
 import java.util.HashMap;
 import java.util.List;
@@ -31,6 +32,7 @@ import java.util.Map;
  * Integration test for MirrorMaker2 in which source records are emitted with a transactional producer,
  * which interleaves transaction commit messages into the source topic which are not propagated downstream.
  */
+@Disabled
 public class MirrorConnectorsIntegrationTransactionsTest extends MirrorConnectorsIntegrationBaseTest {
 
     @BeforeEach

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsWithCustomForwardingAdminIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsWithCustomForwardingAdminIntegrationTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.connect.mirror.clients.admin.FakeLocalMetadataStore;
 import org.apache.kafka.connect.util.clusters.EmbeddedKafkaCluster;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -59,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests MM2 is using provided ForwardingAdmin to create/alter topics, partitions and ACLs.
  */
+@Disabled
 @Tag("integration")
 public class MirrorConnectorsWithCustomForwardingAdminIntegrationTest extends MirrorConnectorsIntegrationBaseTest {
     private static final int FAKE_LOCAL_METADATA_STORE_SYNC_DURATION_MS = 60_000;

--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -45,7 +45,7 @@ import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
 import org.apache.kafka.raft.RaftConfig
 import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion, ProducerIdsBlock}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull, assertTrue}
-import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.{Disabled, Timeout}
 import org.junit.jupiter.api.extension.ExtendWith
 import org.slf4j.LoggerFactory
 
@@ -56,6 +56,7 @@ import scala.collection.Seq
 import scala.jdk.CollectionConverters._
 
 
+@Disabled
 @ExtendWith(value = Array(classOf[ClusterTestExtensions]))
 @Timeout(300)
 class ZkMigrationIntegrationTest {

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandTest.java
@@ -25,6 +25,7 @@ import kafka.test.junit.ClusterTestExtensions;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -57,6 +58,7 @@ class MetadataQuorumCommandTest {
      * 2. More brokers than controllers
      * 3. Fewer brokers than controllers
      */
+    @Disabled
     @ClusterTests({
         @ClusterTest(clusterType = Type.CO_KRAFT, brokers = 2, controllers = 2),
         @ClusterTest(clusterType = Type.KRAFT, brokers = 2, controllers = 2),
@@ -98,6 +100,7 @@ class MetadataQuorumCommandTest {
      * 2. More brokers than controllers
      * 3. Fewer brokers than controllers
      */
+    @Disabled
     @ClusterTests({
         @ClusterTest(clusterType = Type.CO_KRAFT, brokers = 2, controllers = 2),
         @ClusterTest(clusterType = Type.KRAFT, brokers = 2, controllers = 2),
@@ -129,6 +132,7 @@ class MetadataQuorumCommandTest {
             assertTrue(outputs[7].matches("CurrentObservers:\\s+\\[\\d+(,\\d+)*]"));
     }
 
+    @Disabled
     @ClusterTests({
         @ClusterTest(clusterType = Type.CO_KRAFT, brokers = 1, controllers = 1),
         @ClusterTest(clusterType = Type.KRAFT, brokers = 1, controllers = 1)
@@ -156,6 +160,7 @@ class MetadataQuorumCommandTest {
                         "--command-config", tmpfile.getAbsolutePath(), "describe", "--status"));
     }
 
+    @Disabled
     @ClusterTest(clusterType = Type.ZK, brokers = 1)
     public void testDescribeQuorumInZkMode() {
         assertTrue(
@@ -174,6 +179,7 @@ class MetadataQuorumCommandTest {
 
     }
 
+    @Disabled
     @ClusterTest(clusterType = Type.CO_KRAFT, brokers = 1, controllers = 1)
     public void testHumanReadableOutput() {
         assertEquals(1, MetadataQuorumCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe", "--human-readable"));


### PR DESCRIPTION
AK Builds are exiting while running the tests. After going through various builds here is what I found - 

- Clients which ever aren't closed while running the tests are trying to connect to the broker even when broker got shutdown. And when a gradle worker starts running on the same port which is a system assigned port as gradle by default bind a worker to port:0 and if broker was running previously it starts accepting the connection from the hanging clients and result in MessageIOException and eventually gradle worker starts shutting down with a ConnectException. All the tests expect MetadataQuorumCommandTest may be the reason for this. 
 
- Whenever the build initiates the shutdown process it starts removing the shutdown hooks and these shutdown hooks can only be removed when all the executing threads were able to gracefully shutdown. But few tests in MetadataQuorumCommandTest aren't able to catch the InterruptSignal and resulting in failure of removing shutdown hooks.

These two issues are mainly contributing for the build failures. 

