### PR TITLE
MINOR: improve info log for memberIDRequired exception

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -497,8 +497,10 @@ public abstract class AbstractCoordinator implements Closeable {
                 resetJoinGroupFuture();
                 synchronized (AbstractCoordinator.this) {
                     final String simpleName = exception.getClass().getSimpleName();
-                    final String shortReason = String.format("rebalance failed due to %s", simpleName);
-                    final String fullReason = String.format("rebalance failed due to '%s' (%s)",
+                    final String shortReason = MemberIdRequiredException.class.getSimpleName().equals(simpleName) ?
+                            exception.getMessage() : String.format("rebalance failed due to %s", simpleName);
+                    final String fullReason = MemberIdRequiredException.class.getSimpleName().equals(simpleName) ?
+                            exception.getMessage() : String.format("rebalance failed due to '%s' (%s)",
                         exception.getMessage(),
                         simpleName);
                     requestRejoin(shortReason, fullReason);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -502,7 +502,7 @@ public abstract class AbstractCoordinator implements Closeable {
                         exception.getMessage(),
                         simpleName);
                     // Don't need to request rejoin again for MemberIdRequiredException since we've done that in JoinGroupResponseHandler
-                    if (!MemberIdRequiredException.class.getSimpleName().equals(simpleName)) {
+                    if (!(exception instanceof MemberIdRequiredException)) {
                         requestRejoin(shortReason, fullReason);
                     }
                 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -501,11 +501,9 @@ public abstract class AbstractCoordinator implements Closeable {
                     final String fullReason = String.format("rebalance failed due to '%s' (%s)",
                         exception.getMessage(),
                         simpleName);
-                    // Don't log error info to avoid confusing users
-                    if (MemberIdRequiredException.class.getSimpleName().equals(simpleName)) {
-                        requestRejoin(shortReason, fullReason, false);
-                    } else {
-                        requestRejoin(shortReason, fullReason, true);
+                    // Don't need to request rejoin again for MemberIdRequiredException since we've done that in JoinGroupResponseHandler
+                    if (!MemberIdRequiredException.class.getSimpleName().equals(simpleName)) {
+                        requestRejoin(shortReason, fullReason);
                     }
                 }
 
@@ -1062,12 +1060,7 @@ public abstract class AbstractCoordinator implements Closeable {
     }
 
     public synchronized void requestRejoin(final String shortReason) {
-        requestRejoin(shortReason, shortReason, true);
-    }
-
-    public synchronized void requestRejoin(final String shortReason,
-                                           final String fullReason) {
-        requestRejoin(shortReason, fullReason, true);
+        requestRejoin(shortReason, shortReason);
     }
 
     /**
@@ -1076,14 +1069,10 @@ public abstract class AbstractCoordinator implements Closeable {
      * @param shortReason This is the reason passed up to the group coordinator. It must be
      *                    reasonably small.
      * @param fullReason This is the reason logged locally.
-     * @param shouldLog Should log the reason why requesting joining group
      */
     public synchronized void requestRejoin(final String shortReason,
-                                           final String fullReason,
-                                           final boolean shouldLog) {
-        if (shouldLog) {
-            log.info("Request joining group due to: {}", fullReason);
-        }
+                                           final String fullReason) {
+        log.info("Request joining group due to: {}", fullReason);
         this.rejoinReason = shortReason;
         this.rejoinNeeded = true;
     }


### PR DESCRIPTION
Currently, when consumer startup, there will be a log message said:
```
[2023-08-11 15:47:17,713] INFO [Consumer clientId=console-consumer, groupId=console-consumer-28605] Request joining group due to: rebalance failed due to 'The group member needs to have a valid member id before actually entering a consumer group.' (MemberIdRequiredException) (org.apache.kafka.clients.consumer.internals.ConsumerCoordinator)
```
It confused users and make them think there's something wrong in the consumer application. Since we already log `need to re-join with the given member-id` logs in the joinGroupResponseHandler and already `requestRejoined`:
https://github.com/apache/kafka/blob/cdbc9a8d88c1ddc9dd088a33d047783a5b13c282/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java#L692-L701

So, we can skip this confusion logs. 

After change:

```
[2023-08-11 15:42:11,821] INFO [Consumer clientId=console-consumer, groupId=console-consumer-96226] Request joining group due to: need to re-join with the given member-id: console-consumer-f9528f56-2874-4947-bb71-14e4846835a4 (org.apache.kafka.clients.consumer.internals.ConsumerCoordinator)
[2023-08-11 15:42:11,821] INFO [Consumer clientId=console-consumer, groupId=console-consumer-96226] (Re-)joining group (org.apache.kafka.clients.consumer.internals.ConsumerCoordinator)

```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
