### PR TITLE
KAFKA-15336: Add ServiceLoader Javadocs for Connect plugins

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/provider/ConfigProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/provider/ConfigProvider.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * <p>Implementations are required to safely support concurrent calls to any of the methods in this interface.
  * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
- * {@code META-INF/service/org.apache.kafka.common.config.provider.ConfigProvider}.
+ * {@code META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider}.
  */
 public interface ConfigProvider extends Configurable, Closeable {
 

--- a/clients/src/main/java/org/apache/kafka/common/config/provider/ConfigProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/provider/ConfigProvider.java
@@ -25,9 +25,10 @@ import java.util.Set;
 
 /**
  * A provider of configuration data, which may optionally support subscriptions to configuration changes.
- * Implementations are required to safely support concurrent calls to any of the methods in this interface.
- * Kafka Connect discovers configuration providers using Java's Service Provider mechanism (see {@code java.util.ServiceLoader}).
- * To support this, implementations of this interface should also contain a service provider configuration file in {@code  META-INF/service/org.apache.kafka.common.config.provider.ConfigProvider}.
+ * <p>Implementations are required to safely support concurrent calls to any of the methods in this interface.
+ * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
+ * To support this, implementations of this interface should also contain a service provider configuration file in
+ * {@code META-INF/service/org.apache.kafka.common.config.provider.ConfigProvider}.
  */
 public interface ConfigProvider extends Configurable, Closeable {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/ConnectorClientConfigOverridePolicy.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/ConnectorClientConfigOverridePolicy.java
@@ -27,6 +27,9 @@ import java.util.List;
  * <p>
  * Common use cases are ability to provide principal per connector, <code>sasl.jaas.config</code>
  * and/or enforcing that the producer/consumer configurations for optimizations are within acceptable ranges.
+ * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
+ * To support this, implementations of this interface should also contain a service provider configuration file in
+ * {@code META-INF/service/org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy}.
  */
 public interface ConnectorClientConfigOverridePolicy extends Configurable, AutoCloseable {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/ConnectorClientConfigOverridePolicy.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/policy/ConnectorClientConfigOverridePolicy.java
@@ -29,7 +29,7 @@ import java.util.List;
  * and/or enforcing that the producer/consumer configurations for optimizations are within acceptable ranges.
  * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
- * {@code META-INF/service/org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy}.
+ * {@code META-INF/services/org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy}.
  */
 public interface ConnectorClientConfigOverridePolicy extends Configurable, AutoCloseable {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/rest/ConnectRestExtension.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/rest/ConnectRestExtension.java
@@ -28,9 +28,10 @@ import java.util.Map;
  * A plugin interface to allow registration of new JAX-RS resources like Filters, REST endpoints, providers, etc. The implementations will
  * be discovered using the standard Java {@link java.util.ServiceLoader} mechanism by  Connect's plugin class loading mechanism.
  *
- * <p>The extension class(es) must be packaged as a plugin, with one JAR containing the implementation classes and a {@code
- * META-INF/services/org.apache.kafka.connect.rest.extension.ConnectRestExtension} file that contains the fully qualified name of the
- * class(es) that implement the ConnectRestExtension interface. The plugin should also include the JARs of all dependencies except those
+ * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
+ * To support this, implementations of this interface should also contain a service provider configuration file in
+ * {@code META-INF/service/org.apache.kafka.connect.rest.ConnectRestExtension}.
+ * <p>The extension class(es) must be packaged as a plugin, including the JARs of all dependencies except those
  * already provided by the Connect framework.
  *
  * <p>To install into a Connect installation, add a directory named for the plugin and containing the plugin's JARs into a directory that is

--- a/connect/api/src/main/java/org/apache/kafka/connect/rest/ConnectRestExtension.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/rest/ConnectRestExtension.java
@@ -30,7 +30,7 @@ import java.util.Map;
  *
  * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
- * {@code META-INF/service/org.apache.kafka.connect.rest.ConnectRestExtension}.
+ * {@code META-INF/services/org.apache.kafka.connect.rest.ConnectRestExtension}.
  * <p>The extension class(es) must be packaged as a plugin, including the JARs of all dependencies except those
  * already provided by the Connect framework.
  *

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkConnector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkConnector.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * SinkConnectors implement the Connector interface to send Kafka data to another system.
  * <p>Kafka Connect discovers extensions of this class using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
- * {@code META-INF/service/org.apache.kafka.connect.sink.SinkConnector}.
+ * {@code META-INF/services/org.apache.kafka.connect.sink.SinkConnector}.
  */
 public abstract class SinkConnector extends Connector {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkConnector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkConnector.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 /**
  * SinkConnectors implement the Connector interface to send Kafka data to another system.
- * <p>Kafka Connect discovers extensions of this class using the Java {@link java.util.ServiceLoader} mechanism.
+ * <p>Kafka Connect may discover implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
  * {@code META-INF/services/org.apache.kafka.connect.sink.SinkConnector}.
  */

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkConnector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkConnector.java
@@ -23,6 +23,9 @@ import java.util.Map;
 
 /**
  * SinkConnectors implement the Connector interface to send Kafka data to another system.
+ * <p>Kafka Connect discovers extensions of this class using the Java {@link java.util.ServiceLoader} mechanism.
+ * To support this, implementations of this interface should also contain a service provider configuration file in
+ * {@code META-INF/service/org.apache.kafka.connect.sink.SinkConnector}.
  */
 public abstract class SinkConnector extends Connector {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceConnector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceConnector.java
@@ -23,7 +23,7 @@ import java.util.Map;
 /**
  * SourceConnectors implement the connector interface to pull data from another system and send
  * it to Kafka.
- * <p>Kafka Connect discovers extensions of this class using the Java {@link java.util.ServiceLoader} mechanism.
+ * <p>Kafka Connect may discover implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
  * {@code META-INF/services/org.apache.kafka.connect.source.SourceConnector}.
  */

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceConnector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceConnector.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * it to Kafka.
  * <p>Kafka Connect discovers extensions of this class using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
- * {@code META-INF/service/org.apache.kafka.connect.source.SourceConnector}.
+ * {@code META-INF/services/org.apache.kafka.connect.source.SourceConnector}.
  */
 public abstract class SourceConnector extends Connector {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceConnector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceConnector.java
@@ -23,6 +23,9 @@ import java.util.Map;
 /**
  * SourceConnectors implement the connector interface to pull data from another system and send
  * it to Kafka.
+ * <p>Kafka Connect discovers extensions of this class using the Java {@link java.util.ServiceLoader} mechanism.
+ * To support this, implementations of this interface should also contain a service provider configuration file in
+ * {@code META-INF/service/org.apache.kafka.connect.source.SourceConnector}.
  */
 public abstract class SourceConnector extends Connector {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/Converter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/Converter.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * The Converter interface provides support for translating between Kafka Connect's runtime data format
  * and byte[]. Internally, this likely includes an intermediate step to the format used by the serialization
  * layer (e.g. JsonNode, GenericRecord, Message).
- * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
+ * <p>Kafka Connect may discover implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
  * {@code META-INF/services/org.apache.kafka.connect.storage.Converter}.
  */

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/Converter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/Converter.java
@@ -27,6 +27,9 @@ import java.util.Map;
  * The Converter interface provides support for translating between Kafka Connect's runtime data format
  * and byte[]. Internally, this likely includes an intermediate step to the format used by the serialization
  * layer (e.g. JsonNode, GenericRecord, Message).
+ * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
+ * To support this, implementations of this interface should also contain a service provider configuration file in
+ * {@code META-INF/service/org.apache.kafka.connect.storage.Converter}.
  */
 public interface Converter {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/Converter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/Converter.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * layer (e.g. JsonNode, GenericRecord, Message).
  * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
- * {@code META-INF/service/org.apache.kafka.connect.storage.Converter}.
+ * {@code META-INF/services/org.apache.kafka.connect.storage.Converter}.
  */
 public interface Converter {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/HeaderConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/HeaderConverter.java
@@ -30,7 +30,7 @@ import java.io.Closeable;
  * {@link org.apache.kafka.connect.header.Headers Headers}.
  * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
- * {@code META-INF/service/org.apache.kafka.connect.storage.HeaderConverter}.
+ * {@code META-INF/services/org.apache.kafka.connect.storage.HeaderConverter}.
  */
 public interface HeaderConverter extends Configurable, Closeable {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/HeaderConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/HeaderConverter.java
@@ -28,6 +28,9 @@ import java.io.Closeable;
  * The HeaderConverter interface provides support for translating between Kafka Connect's runtime data format
  * and byte[]. This is similar to the {@link Converter} interface, but specifically for
  * {@link org.apache.kafka.connect.header.Headers Headers}.
+ * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
+ * To support this, implementations of this interface should also contain a service provider configuration file in
+ * {@code META-INF/service/org.apache.kafka.connect.storage.HeaderConverter}.
  */
 public interface HeaderConverter extends Configurable, Closeable {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/HeaderConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/HeaderConverter.java
@@ -28,7 +28,7 @@ import java.io.Closeable;
  * The HeaderConverter interface provides support for translating between Kafka Connect's runtime data format
  * and byte[]. This is similar to the {@link Converter} interface, but specifically for
  * {@link org.apache.kafka.connect.header.Headers Headers}.
- * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
+ * <p>Kafka Connect may discover implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
  * {@code META-INF/services/org.apache.kafka.connect.storage.HeaderConverter}.
  */

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
@@ -26,6 +26,9 @@ import java.io.Closeable;
  * Single message transformation for Kafka Connect record types.
  * <p>
  * Connectors can be configured with transformations to make lightweight message-at-a-time modifications.
+ * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
+ * To support this, implementations of this interface should also contain a service provider configuration file in
+ * {@code META-INF/service/org.apache.kafka.connect.transforms.Transformation}.
  *
  * @param <R> The type of record (must be an implementation of {@link ConnectRecord})
  */

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
@@ -26,7 +26,7 @@ import java.io.Closeable;
  * Single message transformation for Kafka Connect record types.
  * <p>
  * Connectors can be configured with transformations to make lightweight message-at-a-time modifications.
- * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
+ * <p>Kafka Connect may discover implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
  * {@code META-INF/services/org.apache.kafka.connect.transforms.Transformation}.
  *

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
@@ -28,7 +28,7 @@ import java.io.Closeable;
  * Connectors can be configured with transformations to make lightweight message-at-a-time modifications.
  * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
- * {@code META-INF/service/org.apache.kafka.connect.transforms.Transformation}.
+ * {@code META-INF/services/org.apache.kafka.connect.transforms.Transformation}.
  *
  * @param <R> The type of record (must be an implementation of {@link ConnectRecord})
  */

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/Predicate.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/Predicate.java
@@ -29,7 +29,7 @@ import org.apache.kafka.connect.connector.ConnectRecord;
  *
  * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
- * {@code META-INF/service/org.apache.kafka.connect.transforms.predicates.Predicate}.
+ * {@code META-INF/services/org.apache.kafka.connect.transforms.predicates.Predicate}.
  *
  * @param <R> The type of record.
  */

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/Predicate.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/Predicate.java
@@ -27,7 +27,9 @@ import org.apache.kafka.connect.connector.ConnectRecord;
  * In particular, the {@code Filter} transformation can be conditionally applied in order to filter
  * certain records from further processing.
  *
- * <p>Implementations of this interface must be public and have a public constructor with no parameters.
+ * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
+ * To support this, implementations of this interface should also contain a service provider configuration file in
+ * {@code META-INF/service/org.apache.kafka.connect.transforms.predicates.Predicate}.
  *
  * @param <R> The type of record.
  */

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/Predicate.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/predicates/Predicate.java
@@ -27,7 +27,7 @@ import org.apache.kafka.connect.connector.ConnectRecord;
  * In particular, the {@code Filter} transformation can be conditionally applied in order to filter
  * certain records from further processing.
  *
- * <p>Kafka Connect discovers implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
+ * <p>Kafka Connect may discover implementations of this interface using the Java {@link java.util.ServiceLoader} mechanism.
  * To support this, implementations of this interface should also contain a service provider configuration file in
  * {@code META-INF/services/org.apache.kafka.connect.transforms.predicates.Predicate}.
  *


### PR DESCRIPTION
In the past, the DirectoryConfigProvider was added without a corresponding manifest, which was finally noticed when Connect was unable to discover it. When this was being fixed, a notice was added to the ConfigProvider Javadoc mentioning that ServiceLoader manifests were relevant. Now that the ServiceLoader manifests are used to load all of the other Connect plugins, those classes should have a similar notice.

Some of the implementations already had similar notices, so this is also an effort to standardize the message across plugin types.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
