### PR TITLE
MINOR: fix rack aware test

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
@@ -1292,7 +1292,7 @@ public class HighAvailabilityTaskAssignorTest {
         final Set<TaskId> statefulTasks = statefulAndStatelessTasks.get(0);
         final Set<TaskId> statelessTasks = statefulAndStatelessTasks.get(1);
         final SortedMap<UUID, ClientState> clientStateMap = getRandomClientState(clientSize,
-            tpSize, maxCapacity, partitionSize, false, statefulTasks);
+            tpSize, partitionSize, maxCapacity, false, statefulTasks);
 
 
         new HighAvailabilityTaskAssignor().assign(
@@ -1358,7 +1358,7 @@ public class HighAvailabilityTaskAssignorTest {
         final List<Set<TaskId>> statefulAndStatelessTasks = getRandomSubset(taskIds, 2);
         final Set<TaskId> statefulTasks = statefulAndStatelessTasks.get(0);
         final SortedMap<UUID, ClientState> clientStateMap = getRandomClientState(clientSize,
-            tpSize, maxCapacity, partitionSize, false, statefulTasks);
+            tpSize, partitionSize, maxCapacity, false, statefulTasks);
         final SortedMap<UUID, ClientState> clientStateMapCopy = copyClientStateMap(clientStateMap);
 
         new HighAvailabilityTaskAssignor().assign(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
@@ -915,7 +915,7 @@ public class StickyTaskAssignorTest {
         final Set<TaskId> statefulTasks = statefulAndStatelessTasks.get(0);
         final Set<TaskId> statelessTasks = statefulAndStatelessTasks.get(1);
         final SortedMap<UUID, ClientState> clientStateMap = getRandomClientState(clientSize,
-            tpSize, maxCapacity, partitionSize, false, statefulTasks);
+            tpSize, partitionSize, maxCapacity, false, statefulTasks);
 
 
         final boolean probing = new StickyTaskAssignor().assign(
@@ -981,7 +981,7 @@ public class StickyTaskAssignorTest {
         final List<Set<TaskId>> statefulAndStatelessTasks = getRandomSubset(taskIds, 2);
         final Set<TaskId> statefulTasks = statefulAndStatelessTasks.get(0);
         final SortedMap<UUID, ClientState> clientStateMap = getRandomClientState(clientSize,
-            tpSize, maxCapacity, partitionSize, false, statefulTasks);
+            tpSize, partitionSize, maxCapacity, false, statefulTasks);
         final SortedMap<UUID, ClientState> clientStateMapCopy = copyClientStateMap(clientStateMap);
 
         new StickyTaskAssignor().assign(


### PR DESCRIPTION
Fix test. They were passing previously because `maxCapacity` and `partitionSize` have same value

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
