### PR TITLE
KAFKA-15022: Only relax edge when path exist

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/Graph.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/Graph.java
@@ -349,7 +349,7 @@ public class Graph<V extends Comparable<V>> {
     }
 
     /**
-     * Detect negative cycle using Bellman-ford shortest path algorithm.
+     * Detect negative cycle using Bellman-ford's shortest path algorithm.
      * @param source Source node
      * @param parentNodes Parent nodes to store negative cycle nodes
      * @param parentEdges Parent edges to store negative cycle edges
@@ -362,29 +362,29 @@ public class Graph<V extends Comparable<V>> {
         distance.put(source, 0L);
         final int nodeCount = nodes.size();
 
-        // Iterate nodeCount iterations since Bellaman-Ford will find shortest path in nodeCount - 1
+        // Iterate nodeCount iterations since Bellaman-Ford will find the shortest path in nodeCount - 1
         // iterations. If the distance can still be relaxed in nodeCount iteration, there's a negative
         // cycle
         for (int i = 0; i < nodeCount; i++) {
             // Iterate through all edges
             for (final Entry<V, SortedMap<V, Edge>> nodeEdges : adjList.entrySet()) {
-                final V u = nodeEdges.getKey();
+                final V start = nodeEdges.getKey();
                 for (final Entry<V, Edge> nodeEdge : nodeEdges.getValue().entrySet()) {
                     final Edge edge = nodeEdge.getValue();
                     if (edge.residualFlow == 0) {
                         continue;
                     }
-                    final V v = edge.destination;
-                    final Long distanceU = distance.get(u);
-                    final Long distanceV = distance.get(v);
+                    final V end = edge.destination;
+                    final Long distanceStart = distance.get(start);
+                    final Long distanceEnd = distance.get(end);
                     // There's a path to u and either we haven't computed V or distance to V is shorter
-                    if (distanceU != null && (distanceV == null || distanceV > distanceU + edge.cost)) {
+                    if (distanceStart != null && (distanceEnd == null || distanceEnd > distanceStart + edge.cost)) {
                         if (i == nodeCount - 1) {
-                            return v;
+                            return end;
                         }
-                        distance.put(v, distanceU + edge.cost);
-                        parentNodes.put(v, u);
-                        parentEdges.put(v, edge);
+                        distance.put(end, distanceStart + edge.cost);
+                        parentNodes.put(end, start);
+                        parentEdges.put(end, edge);
                     }
                 }
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/Graph.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/Graph.java
@@ -26,7 +26,6 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 public class Graph<V extends Comparable<V>> {
     public class Edge {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/Graph.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/Graph.java
@@ -359,7 +359,7 @@ public class Graph<V extends Comparable<V>> {
      */
     V detectNegativeCycles(final V source, final Map<V, V> parentNodes, final Map<V, Edge> parentEdges) {
         // Use long to account for any overflow
-        final Map<V, Long> distance = nodes.stream().collect(Collectors.toMap(node -> node, node -> (long) Integer.MAX_VALUE));
+        final Map<V, Long> distance = new HashMap<>();
         distance.put(source, 0L);
         final int nodeCount = nodes.size();
 
@@ -376,11 +376,14 @@ public class Graph<V extends Comparable<V>> {
                         continue;
                     }
                     final V v = edge.destination;
-                    if (distance.get(v) > distance.get(u) + edge.cost) {
+                    final Long distanceU = distance.get(u);
+                    final Long distanceV = distance.get(v);
+                    // There's a path to u and either we haven't computed V or distance to V is shorter
+                    if (distanceU != null && (distanceV == null || distanceV > distanceU + edge.cost)) {
                         if (i == nodeCount - 1) {
                             return v;
                         }
-                        distance.put(v, distance.get(u) + edge.cost);
+                        distance.put(v, distanceU + edge.cost);
                         parentNodes.put(v, u);
                         parentEdges.put(v, edge);
                     }


### PR DESCRIPTION
If we use `Integer.MAX_VALUE`, even there's no path from source to u and v, it can be still relaxed. Even though it computes negative correctly somehow, semantically it doesn't make sense to relax the distance if there's path to the node yet.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
