### PR TITLE
MINOR Fix the ZkMigrationState metric in KafkaController

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -175,7 +175,7 @@ class KafkaController(val config: KafkaConfig,
   /* single-thread scheduler to clean expired tokens */
   private val tokenCleanScheduler = new KafkaScheduler(1, true, "delegation-token-cleaner")
 
-  metricsGroup.newGauge(ZkMigrationStateMetricName, () => ZkMigrationState.ZK)
+  metricsGroup.newGauge(ZkMigrationStateMetricName, () => ZkMigrationState.ZK.value().intValue())
   metricsGroup.newGauge(ActiveControllerCountMetricName, () => if (isActive) 1 else 0)
   metricsGroup.newGauge(OfflinePartitionsCountMetricName, () => offlinePartitionCount)
   metricsGroup.newGauge(PreferredReplicaImbalanceCountMetricName, () => preferredReplicaImbalanceCount)


### PR DESCRIPTION
This patch fixes an issue for ZK controllers where we were emitting the ZkMigrationState enum rather than a value. This can lead to downstream failures with JMX metrics since the RMI protocol will marshal the ZkMigrationState object returned by the gauge. Any downstream consumer of this metric (like jconsole or a metrics exporter) will not be able to unmarshal the value since the ZkMigrationState class will not be present. 

The fix is simply to emit the byte value of this enum.