### PR TITLE
KAFKA-14133: Move mocks from KStreamTransformValuesTest, KTableImplTest and KTableTransformValuesTest to Mockito

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValuesTest.java
@@ -34,11 +34,10 @@ import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.NoOpValueTransformerWithKeySupplier;
 import org.apache.kafka.test.StreamsTestUtils;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
-import org.easymock.MockType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Properties;
 
@@ -46,12 +45,12 @@ import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 
-@RunWith(EasyMockRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class KStreamTransformValuesTest {
     private final String topicName = "topic";
     private final MockProcessorSupplier<Integer, Integer> supplier = new MockProcessorSupplier<>();
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.Integer());
-    @Mock(MockType.NICE)
+    @Mock
     private InternalProcessorContext context;
 
     @SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
@@ -54,21 +54,24 @@ import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Properties;
 
 import static java.util.Arrays.asList;
-import static org.easymock.EasyMock.mock;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
 
 @SuppressWarnings("unchecked")
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class KTableImplTest {
     private final Consumed<String, String> stringConsumed = Consumed.with(Serdes.String(), Serdes.String());
     private final Consumed<String, String> consumed = Consumed.with(Serdes.String(), Serdes.String());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
@@ -48,24 +48,18 @@ import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockReducer;
 import org.apache.kafka.test.NoOpValueTransformerWithKeySupplier;
 import org.apache.kafka.test.TestUtils;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
-import org.easymock.MockType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
-import static org.easymock.EasyMock.anyBoolean;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
@@ -73,8 +67,10 @@ import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 
-@RunWith(EasyMockRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 @SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
 public class KTableTransformValuesTest {
     private static final String QUERYABLE_NAME = "queryable-store";
@@ -87,19 +83,19 @@ public class KTableTransformValuesTest {
     private TopologyTestDriver driver;
     private MockProcessorSupplier<String, String> capture;
     private StreamsBuilder builder;
-    @Mock(MockType.NICE)
+    @Mock
     private KTableImpl<String, String, String> parent;
-    @Mock(MockType.NICE)
+    @Mock
     private InternalProcessorContext<String, Change<String>> context;
-    @Mock(MockType.NICE)
+    @Mock
     private KTableValueGetterSupplier<String, String> parentGetterSupplier;
-    @Mock(MockType.NICE)
+    @Mock
     private KTableValueGetter<String, String> parentGetter;
-    @Mock(MockType.NICE)
+    @Mock
     private TimestampedKeyValueStore<String, String> stateStore;
-    @Mock(MockType.NICE)
+    @Mock
     private ValueTransformerWithKeySupplier<String, String, String> mockSupplier;
-    @Mock(MockType.NICE)
+    @Mock
     private ValueTransformerWithKey<String, String, String> transformer;
 
     @After
@@ -163,13 +159,9 @@ public class KTableTransformValuesTest {
         final Processor<String, Change<String>, String, Change<String>> processor = transformValues.get();
         processor.init(context);
 
-        context.forward(new Record<>("Key", new Change<>("Key->newValue!", null), 0));
-        expectLastCall();
-        replay(context);
+        doNothing().when(context).forward(new Record<>("Key", new Change<>("Key->newValue!", null), 0));
 
         processor.process(new Record<>("Key", new Change<>("newValue", "oldValue"), 0));
-
-        verify(context);
     }
 
     @Test
@@ -177,43 +169,22 @@ public class KTableTransformValuesTest {
         final KTableTransformValues<String, String, String> transformValues =
             new KTableTransformValues<>(parent, new ExclamationValueTransformerSupplier(), null);
 
-        expect(parent.enableSendingOldValues(true)).andReturn(true);
-        replay(parent);
+        when(parent.enableSendingOldValues(true)).thenReturn(true);
 
         transformValues.enableSendingOldValues(true);
         final Processor<String, Change<String>, String, Change<String>> processor = transformValues.get();
         processor.init(context);
 
-        context.forward(new Record<>("Key", new Change<>("Key->newValue!", "Key->oldValue!"), 0));
-        expectLastCall();
-        replay(context);
+        doNothing().when(context).forward(new Record<>("Key", new Change<>("Key->newValue!", "Key->oldValue!"), 0));
 
         processor.process(new Record<>("Key", new Change<>("newValue", "oldValue"), 0));
-
-        verify(context);
-    }
-
-    @Test
-    public void shouldNotSetSendOldValuesOnParentIfMaterialized() {
-        expect(parent.enableSendingOldValues(anyBoolean()))
-            .andThrow(new AssertionError("Should not call enableSendingOldValues"))
-            .anyTimes();
-
-        replay(parent);
-
-        new KTableTransformValues<>(parent, new NoOpValueTransformerWithKeySupplier<>(), QUERYABLE_NAME).enableSendingOldValues(true);
-
-        verify(parent);
     }
 
     @Test
     public void shouldSetSendOldValuesOnParentIfNotMaterialized() {
-        expect(parent.enableSendingOldValues(true)).andReturn(true);
-        replay(parent);
+        when(parent.enableSendingOldValues(true)).thenReturn(true);
 
         new KTableTransformValues<>(parent, new NoOpValueTransformerWithKeySupplier<>(), null).enableSendingOldValues(true);
-
-        verify(parent);
     }
 
     @Test
@@ -221,9 +192,9 @@ public class KTableTransformValuesTest {
         final KTableTransformValues<String, String, String> transformValues =
             new KTableTransformValues<>(parent, new ExclamationValueTransformerSupplier(), null);
 
-        expect(parent.valueGetterSupplier()).andReturn(parentGetterSupplier);
-        expect(parentGetterSupplier.get()).andReturn(parentGetter);
-        expect(parentGetter.get("Key")).andReturn(ValueAndTimestamp.make("Value", 73L));
+        when(parent.valueGetterSupplier()).thenReturn(parentGetterSupplier);
+        when(parentGetterSupplier.get()).thenReturn(parentGetter);
+        when(parentGetter.get("Key")).thenReturn(ValueAndTimestamp.make("Value", 73L));
         final ProcessorRecordContext recordContext = new ProcessorRecordContext(
             42L,
             23L,
@@ -231,18 +202,15 @@ public class KTableTransformValuesTest {
             "foo",
             new RecordHeaders()
         );
-        expect(context.recordContext()).andReturn(recordContext);
-        context.setRecordContext(new ProcessorRecordContext(
+        when(context.recordContext()).thenReturn(recordContext);
+        doNothing().when(context).setRecordContext(new ProcessorRecordContext(
             73L,
             -1L,
             -1,
             null,
             new RecordHeaders()
         ));
-        expectLastCall();
-        context.setRecordContext(recordContext);
-        expectLastCall();
-        replay(parent, parentGetterSupplier, parentGetter, context);
+        doNothing().when(context).setRecordContext(recordContext);
 
         final KTableValueGetter<String, String> getter = transformValues.view().get();
         getter.init(context);
@@ -250,7 +218,6 @@ public class KTableTransformValuesTest {
         final String result = getter.get("Key").value();
 
         assertThat(result, is("Key->Value!"));
-        verify(context);
     }
 
     @Test
@@ -258,9 +225,8 @@ public class KTableTransformValuesTest {
         final KTableTransformValues<String, String, String> transformValues =
             new KTableTransformValues<>(parent, new ExclamationValueTransformerSupplier(), QUERYABLE_NAME);
 
-        expect(context.getStateStore(QUERYABLE_NAME)).andReturn(stateStore);
-        expect(stateStore.get("Key")).andReturn(ValueAndTimestamp.make("something", 0L));
-        replay(context, stateStore);
+        when(context.getStateStore(QUERYABLE_NAME)).thenReturn(stateStore);
+        when(stateStore.get("Key")).thenReturn(ValueAndTimestamp.make("something", 0L));
 
         final KTableValueGetter<String, String> getter = transformValues.view().get();
         getter.init(context);
@@ -275,9 +241,8 @@ public class KTableTransformValuesTest {
         final KTableTransformValues<String, String, String> transformValues =
             new KTableTransformValues<>(parent, new ExclamationValueTransformerSupplier(), null);
 
-        expect(parent.valueGetterSupplier()).andReturn(parentGetterSupplier);
-        expect(parentGetterSupplier.storeNames()).andReturn(new String[]{"store1", "store2"});
-        replay(parent, parentGetterSupplier);
+        when(parent.valueGetterSupplier()).thenReturn(parentGetterSupplier);
+        when(parentGetterSupplier.storeNames()).thenReturn(new String[]{"store1", "store2"});
 
         final String[] storeNames = transformValues.view().storeNames();
 
@@ -299,15 +264,11 @@ public class KTableTransformValuesTest {
         final KTableTransformValues<String, String, String> transformValues =
             new KTableTransformValues<>(parent, mockSupplier, null);
 
-        expect(mockSupplier.get()).andReturn(transformer);
-        transformer.close();
-        expectLastCall();
-        replay(mockSupplier, transformer);
+        when(mockSupplier.get()).thenReturn(transformer);
+        doNothing().when(transformer).close();
 
         final Processor<String, Change<String>, String, Change<String>> processor = transformValues.get();
         processor.close();
-
-        verify(transformer);
     }
 
     @Test
@@ -315,19 +276,14 @@ public class KTableTransformValuesTest {
         final KTableTransformValues<String, String, String> transformValues =
             new KTableTransformValues<>(parent, mockSupplier, null);
 
-        expect(mockSupplier.get()).andReturn(transformer);
-        expect(parentGetterSupplier.get()).andReturn(parentGetter);
-        expect(parent.valueGetterSupplier()).andReturn(parentGetterSupplier);
+        when(mockSupplier.get()).thenReturn(transformer);
+        when(parentGetterSupplier.get()).thenReturn(parentGetter);
+        when(parent.valueGetterSupplier()).thenReturn(parentGetterSupplier);
 
-        transformer.close();
-        expectLastCall();
-
-        replay(mockSupplier, transformer, parent, parentGetterSupplier);
+        doNothing().when(transformer).close();
 
         final KTableValueGetter<String, String> getter = transformValues.view().get();
         getter.close();
-
-        verify(transformer);
     }
 
     @Test
@@ -335,19 +291,13 @@ public class KTableTransformValuesTest {
         final KTableTransformValues<String, String, String> transformValues =
             new KTableTransformValues<>(parent, mockSupplier, null);
 
-        expect(parent.valueGetterSupplier()).andReturn(parentGetterSupplier);
-        expect(mockSupplier.get()).andReturn(transformer);
-        expect(parentGetterSupplier.get()).andReturn(parentGetter);
-
-        parentGetter.close();
-        expectLastCall();
-
-        replay(mockSupplier, parent, parentGetterSupplier, parentGetter);
+        when(parent.valueGetterSupplier()).thenReturn(parentGetterSupplier);
+        when(mockSupplier.get()).thenReturn(transformer);
+        when(parentGetterSupplier.get()).thenReturn(parentGetter);
+        doNothing().when(parentGetter).close();
 
         final KTableValueGetter<String, String> getter = transformValues.view().get();
         getter.close();
-
-        verify(parentGetter);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
@@ -67,8 +67,11 @@ import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
 @SuppressWarnings("deprecation") // Old PAPI. Needs to be migrated.
@@ -178,6 +181,13 @@ public class KTableTransformValuesTest {
         doNothing().when(context).forward(new Record<>("Key", new Change<>("Key->newValue!", "Key->oldValue!"), 0));
 
         processor.process(new Record<>("Key", new Change<>("newValue", "oldValue"), 0));
+    }
+
+    @Test
+    public void shouldNotSetSendOldValuesOnParentIfMaterialized() {
+        new KTableTransformValues<>(parent, new NoOpValueTransformerWithKeySupplier<>(), QUERYABLE_NAME).enableSendingOldValues(true);
+
+        verify(parent, never()).enableSendingOldValues(anyBoolean());
     }
 
     @Test


### PR DESCRIPTION
This pull requests migrates mocks from KStreamTransformValuesTest, KTableImplTest and KTableTransformValuesTest to Mockito.
