### PR TITLE
KAFKA-14133: Move RecordCollectorTest, StateRestoreCallbackAdapterTest and StoreToProcessorContextAdapterTest to Mockito

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -59,6 +59,8 @@ import org.apache.kafka.test.MockClientSupplier;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -81,11 +83,6 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.producerRecordSizeInBytes;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOPIC_LEVEL_GROUP;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -93,7 +90,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class RecordCollectorTest {
 
     private final LogContext logContext = new LogContext("test ");
@@ -741,13 +742,11 @@ public class RecordCollectorTest {
     @Test
     public void shouldForwardFlushToStreamsProducer() {
         final StreamsProducer streamsProducer = mock(StreamsProducer.class);
-        expect(streamsProducer.eosEnabled()).andReturn(false);
-        streamsProducer.flush();
-        expectLastCall();
+        when(streamsProducer.eosEnabled()).thenReturn(false);
+        doNothing().when(streamsProducer).flush();
 
         final ProcessorTopology topology = mock(ProcessorTopology.class);
-        expect(topology.sinkTopics()).andStubReturn(Collections.emptySet());
-        replay(streamsProducer, topology);
+        when(topology.sinkTopics()).thenReturn(Collections.emptySet());
 
         final RecordCollector collector = new RecordCollectorImpl(
             logContext,
@@ -759,19 +758,14 @@ public class RecordCollectorTest {
         );
 
         collector.flush();
-
-        verify(streamsProducer);
     }
 
     @Test
     public void shouldForwardFlushToStreamsProducerEosEnabled() {
         final StreamsProducer streamsProducer = mock(StreamsProducer.class);
-        expect(streamsProducer.eosEnabled()).andReturn(true);
-        streamsProducer.flush();
-        expectLastCall();
+        when(streamsProducer.eosEnabled()).thenReturn(true);
+        doNothing().when(streamsProducer).flush();
         final ProcessorTopology topology = mock(ProcessorTopology.class);
-        expect(topology.sinkTopics()).andStubReturn(Collections.emptySet());
-        replay(streamsProducer, topology);
         
         final RecordCollector collector = new RecordCollectorImpl(
             logContext,
@@ -783,18 +777,14 @@ public class RecordCollectorTest {
         );
 
         collector.flush();
-
-        verify(streamsProducer);
     }
 
     @Test
     public void shouldNotAbortTxOnCloseCleanIfEosEnabled() {
         final StreamsProducer streamsProducer = mock(StreamsProducer.class);
-        expect(streamsProducer.eosEnabled()).andReturn(true);
+        when(streamsProducer.eosEnabled()).thenReturn(true);
         
         final ProcessorTopology topology = mock(ProcessorTopology.class);
-        expect(topology.sinkTopics()).andStubReturn(Collections.emptySet());
-        replay(streamsProducer, topology);
         
         final RecordCollector collector = new RecordCollectorImpl(
             logContext,
@@ -806,19 +796,15 @@ public class RecordCollectorTest {
         );
        
         collector.closeClean();
-
-        verify(streamsProducer);
     }
 
     @Test
     public void shouldAbortTxOnCloseDirtyIfEosEnabled() {
         final StreamsProducer streamsProducer = mock(StreamsProducer.class);
-        expect(streamsProducer.eosEnabled()).andReturn(true);
-        streamsProducer.abortTransaction();
+        when(streamsProducer.eosEnabled()).thenReturn(true);
+        doNothing().when(streamsProducer).abortTransaction();
         
         final ProcessorTopology topology = mock(ProcessorTopology.class);
-        expect(topology.sinkTopics()).andStubReturn(Collections.emptySet());
-        replay(streamsProducer, topology);
         
         final RecordCollector collector = new RecordCollectorImpl(
             logContext,
@@ -830,8 +816,6 @@ public class RecordCollectorTest {
         );
 
         collector.closeDirty();
-
-        verify(streamsProducer);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateRestoreCallbackAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateRestoreCallbackAdapterTest.java
@@ -23,6 +23,8 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.BatchingStateRestoreCallback;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,11 +32,12 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.streams.processor.internals.StateRestoreCallbackAdapter.adapt;
-import static org.easymock.EasyMock.mock;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class StateRestoreCallbackAdapterTest {
     @Test
     public void shouldThrowOnRestoreAll() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreToProcessorContextAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreToProcessorContextAdapterTest.java
@@ -21,21 +21,20 @@ import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.To;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
-import org.easymock.MockType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.Duration;
 
-@RunWith(EasyMockRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class StoreToProcessorContextAdapterTest {
-    @Mock(MockType.NICE)
+    @Mock
     private StateStoreContext delegate;
     private ProcessorContext context;
-    @Mock(MockType.NICE)
+    @Mock
     private Punctuator punctuator;
 
     @Before


### PR DESCRIPTION
This pull requests migrates mocks from RecordCollectorTest, StateRestoreCallbackAdapterTest and StoreToProcessorContextAdapterTest to Mockito.