### PR TITLE
KAFKA-15319: Upgrade rocksdb to fix CVE-2022-37434

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -253,7 +253,7 @@ netty-transport-native-unix-common-4.1.94.Final
 plexus-utils-3.3.0
 reflections-0.10.2
 reload4j-1.2.25
-rocksdbjni-7.1.2
+rocksdbjni-7.9.2
 scala-collection-compat_2.13-2.10.0
 scala-library-2.13.11
 scala-logging_2.13-3.9.4

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -133,7 +133,7 @@ versions += [
   powermock: "2.0.9",
   reflections: "0.10.2",
   reload4j: "1.2.25",
-  rocksDB: "7.1.2",
+  rocksDB: "7.9.2",
   scalaCollectionCompat: "2.10.0",
   // When updating the scalafmt version please also update the version field in checkstyle/.scalafmt.conf. scalafmt now
   // has the version field as mandatory in its configuration, see

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
@@ -40,6 +40,7 @@ import org.rocksdb.InfoLogLevel;
 import org.rocksdb.MemTableConfig;
 import org.rocksdb.MergeOperator;
 import org.rocksdb.Options;
+import org.rocksdb.PrepopulateBlobCache;
 import org.rocksdb.RateLimiter;
 import org.rocksdb.SstFileManager;
 import org.rocksdb.SstPartitionerFactory;
@@ -1728,6 +1729,17 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
     public boolean memtableWholeKeyFiltering() {
         return columnFamilyOptions.memtableWholeKeyFiltering();
     }
+    
+    @Override
+    public Options setExperimentalMempurgeThreshold(final double experimentalMempurgeThreshold) {
+        columnFamilyOptions.setExperimentalMempurgeThreshold(experimentalMempurgeThreshold);
+        return this;
+    }
+
+    @Override
+    public double experimentalMempurgeThreshold() {
+        return columnFamilyOptions.experimentalMempurgeThreshold();
+    }
 
     //
     // BEGIN options for blobs (integrated BlobDB)
@@ -1808,6 +1820,29 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
     @Override
     public double blobGarbageCollectionForceThreshold() {
         return columnFamilyOptions.blobGarbageCollectionForceThreshold();
+    }
+
+
+    @Override
+    public Options setPrepopulateBlobCache(final PrepopulateBlobCache prepopulateBlobCache) {
+        columnFamilyOptions.setPrepopulateBlobCache(prepopulateBlobCache);
+        return this;
+    }
+
+    @Override
+    public PrepopulateBlobCache prepopulateBlobCache() {
+        return columnFamilyOptions.prepopulateBlobCache();
+    }
+
+    @Override
+    public Options setBlobFileStartingLevel(final int blobFileStartingLevel) {
+        columnFamilyOptions.setBlobFileStartingLevel(blobFileStartingLevel);
+        return this;
+    }
+
+    @Override
+    public int blobFileStartingLevel() {
+        return columnFamilyOptions.blobFileStartingLevel();
     }
 
     //

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape<0.9", "requests==2.31.0"],
+      install_requires=["ducktape==0.8.14", "requests==2.24.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       zip_safe=False


### PR DESCRIPTION
Rocksdbjni<7.9.2 is vulnerable to CVE-2022-37434 due to zlib 1.2.12
