### PR TITLE
KAFKA-15102: Add release notes about the replication.policy.internal.topic.separator.enabled property for MirrorMaker 2

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -43,6 +43,10 @@
             See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-925%3A+Rack+aware+task+assignment+in+Kafka+Streams">KIP-925</a>
             and <a href="/{{version}}/documentation/streams/developer-guide/config-streams.html#rack-aware-assignment-strategy"><b>Kafka Streams Developer Guide</b></a> for more details.
         </li>
+        <li>To account for a break in compatibility introduced in version 3.1.0, MirrorMaker 2 has added a new
+            <a href="#mirror_connector_replication.policy.internal.topic.separator.enabled">replication.policy.internal.topic.separator.enabled</a>
+            property. If upgrading from 3.0.x or earlier, it may be necessary to set this property to <code>false</code>; see the property's
+            <a href="#mirror_connector_replication.policy.internal.topic.separator.enabled">documentation</a> for more details.</li>
     </ul>
 
 <h4><a id="upgrade_3_5_0" href="#upgrade_3_5_0">Upgrading to 3.5.0 from any version 0.8.x through 3.4.x</a></h4>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -44,7 +44,7 @@
             and <a href="/{{version}}/documentation/streams/developer-guide/config-streams.html#rack-aware-assignment-strategy"><b>Kafka Streams Developer Guide</b></a> for more details.
         </li>
         <li>To account for a break in compatibility introduced in version 3.1.0, MirrorMaker 2 has added a new
-            <a href="#mirror_connector_replication.policy.internal.topic.separator.enabled">replication.policy.internal.topic.separator.enabled</a>
+            <code>replication.policy.internal.topic.separator.enabled</code>
             property. If upgrading from 3.0.x or earlier, it may be necessary to set this property to <code>false</code>; see the property's
             <a href="#mirror_connector_replication.policy.internal.topic.separator.enabled">documentation</a> for more details.</li>
     </ul>


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-15102)

This is a docs-only follow-up for https://github.com/apache/kafka/pull/14082 that calls out the necessity for this property in our release notes so that users upgrading MM2 from older versions can do so safely.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
