### PR TITLE
MINOR: fix currentLag javadoc

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -2209,7 +2209,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * for example if there is no position yet, or if the end offset is not known yet.
      *
      * <p>
-     * This method uses locally cached metadata and never makes a remote call.
+     * This method uses locally cached metadata. If the log end offset is not known yet, it triggers a request to fetch
+     * the log end offset, but returns immediately.
      *
      * @param topicPartition The partition to get the lag for.
      *


### PR DESCRIPTION
The documentation for `currentLag` seems incorrect or at least misleading.
