### PR TITLE
MINOR: Do not reuse admin client across tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
@@ -42,7 +42,6 @@ import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -83,14 +82,6 @@ public abstract class AbstractResetIntegrationTest {
 
     @Rule
     public final TestName testName = new TestName();
-
-    @AfterClass
-    public static void afterClassCleanup() {
-        if (adminClient != null) {
-            adminClient.close(Duration.ofSeconds(10));
-            adminClient = null;
-        }
-    }
 
     protected Properties commonClientConfig;
     protected Properties streamsConfig;
@@ -190,6 +181,10 @@ public abstract class AbstractResetIntegrationTest {
             streams.close(Duration.ofSeconds(30));
         }
         IntegrationTestUtils.purgeLocalStreamsState(streamsConfig);
+        if (adminClient != null) {
+            adminClient.close(Duration.ofSeconds(10));
+            adminClient = null;
+        }
     }
 
     private void add10InputElements() {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.integration;
 
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.tools.StreamsResetter;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
@@ -53,7 +54,6 @@ import org.junit.rules.Timeout;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -177,12 +177,10 @@ public abstract class AbstractResetIntegrationTest {
     }
 
     void cleanupTest() throws Exception {
-        if (streams != null) {
-            streams.close(Duration.ofSeconds(30));
-        }
+        Utils.closeQuietly(streams, "kafka streams");
         IntegrationTestUtils.purgeLocalStreamsState(streamsConfig);
         if (adminClient != null) {
-            adminClient.close(Duration.ofSeconds(10));
+            Utils.closeQuietly(adminClient, "admin client");
             adminClient = null;
         }
     }


### PR DESCRIPTION
Reusing an admin client across tests can cause false
positives in leak checkers, so don't do it.
