### PR TITLE
KAFKA-15326: [8/N] Move consumer interaction out of processing methods 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -429,7 +429,7 @@ subprojects {
     ignoreFailures = userIgnoreFailures
 
     maxHeapSize = defaultMaxHeapSize
-    jvmArgs = defaultJvmArgs
+    jvmArgs '-XX:ActiveProcessorCount=1'
 
     testLogging {
       events = userTestLoggingEvents ?: testLoggingEvents

--- a/build.gradle
+++ b/build.gradle
@@ -429,7 +429,7 @@ subprojects {
     ignoreFailures = userIgnoreFailures
 
     maxHeapSize = defaultMaxHeapSize
-    jvmArgs '-XX:ActiveProcessorCount=1'
+    jvmArgs = defaultJvmArgs
 
     testLogging {
       events = userTestLoggingEvents ?: testLoggingEvents

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGroup.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGroup.java
@@ -70,6 +70,7 @@ public class PartitionGroup {
     private int totalBuffered;
     private boolean allBuffered;
     private final Map<TopicPartition, Long> idlePartitionDeadlines = new HashMap<>();
+    private final Map<TopicPartition, Long> fetchedLags = new HashMap<>();
 
     static class RecordInfo {
         RecordQueue queue;
@@ -140,20 +141,22 @@ public class PartitionGroup {
                 idlePartitionDeadlines.remove(partition);
                 queued.add(partition);
             } else {
-                final OptionalLong fetchedLag = lagProvider.apply(partition);
+                final Long fetchedLag = fetchedLags.getOrDefault(partition, -1L);
 
-                if (!fetchedLag.isPresent()) {
+                logger.trace("Fetched lag for {} is {}", partition, fetchedLag);
+
+                if (fetchedLag == -1L) {
                     // must wait to fetch metadata for the partition
                     idlePartitionDeadlines.remove(partition);
                     logger.trace("Waiting to fetch data for {}", partition);
                     return false;
-                } else if (fetchedLag.getAsLong() > 0L) {
+                } else if (fetchedLag > 0L) {
                     // must wait to poll the data we know to be on the broker
                     idlePartitionDeadlines.remove(partition);
                     logger.trace(
                             "Lag for {} is currently {}, but no data is buffered locally. Waiting to buffer some records.",
                             partition,
-                            fetchedLag.getAsLong()
+                            fetchedLag
                     );
                     return false;
                 } else {
@@ -359,6 +362,7 @@ public class PartitionGroup {
         return totalBuffered;
     }
 
+    // for testing only
     boolean allPartitionsBufferedLocally() {
         return allBuffered;
     }
@@ -370,6 +374,7 @@ public class PartitionGroup {
         nonEmptyQueuesByTime.clear();
         totalBuffered = 0;
         streamTime = RecordQueue.UNKNOWN;
+        fetchedLags.clear();
     }
 
     void close() {
@@ -377,4 +382,22 @@ public class PartitionGroup {
             queue.close();
         }
     }
+
+    void updateLags() {
+        for (final TopicPartition tp : partitionQueues.keySet()) {
+            final OptionalLong l = lagProvider.apply(tp);
+            if (l.isPresent()) {
+                fetchedLags.put(tp, l.getAsLong());
+                logger.trace("Updated lag for {} to {}", tp, l.getAsLong());
+            } else {
+                fetchedLags.remove(tp);
+            }
+        }
+    }
+
+    // for testing only
+    Map<TopicPartition, Long> fetchedLags() {
+        return fetchedLags;
+    }
+
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGroup.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGroup.java
@@ -384,20 +384,17 @@ public class PartitionGroup {
     }
 
     void updateLags() {
-        for (final TopicPartition tp : partitionQueues.keySet()) {
-            final OptionalLong l = lagProvider.apply(tp);
-            if (l.isPresent()) {
-                fetchedLags.put(tp, l.getAsLong());
-                logger.trace("Updated lag for {} to {}", tp, l.getAsLong());
-            } else {
-                fetchedLags.remove(tp);
+        if (maxTaskIdleMs != StreamsConfig.MAX_TASK_IDLE_MS_DISABLED) {
+            for (final TopicPartition tp : partitionQueues.keySet()) {
+                final OptionalLong l = lagProvider.apply(tp);
+                if (l.isPresent()) {
+                    fetchedLags.put(tp, l.getAsLong());
+                    logger.trace("Updated lag for {} to {}", tp, l.getAsLong());
+                } else {
+                    fetchedLags.remove(tp);
+                }
             }
         }
-    }
-
-    // for testing only
-    Map<TopicPartition, Long> fetchedLags() {
-        return fetchedLags;
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ReadOnlyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ReadOnlyTask.java
@@ -135,6 +135,16 @@ public class ReadOnlyTask implements Task {
     }
 
     @Override
+    public void preparePoll() {
+        throw new UnsupportedOperationException("This task is read-only");
+    }
+
+    @Override
+    public void postPoll() {
+        throw new UnsupportedOperationException("This task is read-only");
+    }
+
+    @Override
     public void addRecords(final TopicPartition partition, final Iterable<ConsumerRecord<byte[], byte[]>> records) {
         throw new UnsupportedOperationException("This task is read-only");
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ReadOnlyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ReadOnlyTask.java
@@ -135,12 +135,12 @@ public class ReadOnlyTask implements Task {
     }
 
     @Override
-    public void preparePoll() {
+    public void resumePollingForPartitionsWithAvailableSpace() {
         throw new UnsupportedOperationException("This task is read-only");
     }
 
     @Override
-    public void postPoll() {
+    public void updateLags() {
         throw new UnsupportedOperationException("This task is read-only");
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -254,6 +254,15 @@ public class StandbyTask extends AbstractTask implements Task {
         log.info("Closed and recycled state");
     }
 
+    @Override
+    public void preparePoll() {
+        // noop
+    }
+    @Override
+    public void postPoll() {
+        // noop
+    }
+
     private void close(final boolean clean) {
         switch (state()) {
             case SUSPENDED:

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -255,11 +255,12 @@ public class StandbyTask extends AbstractTask implements Task {
     }
 
     @Override
-    public void preparePoll() {
+    public void resumePollingForPartitionsWithAvailableSpace() {
         // noop
     }
+
     @Override
-    public void postPoll() {
+    public void updateLags() {
         // noop
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -765,11 +765,11 @@ public class StreamThread extends Thread {
         now = startMs;
 
         final long pollLatency;
-        taskManager.preparePoll();
+        taskManager.resumePollingForPartitionsWithAvailableSpace();
         try {
             pollLatency = pollPhase();
         } finally {
-            taskManager.postPoll();
+            taskManager.updateLags();
         }
 
         // Shutdown hook could potentially be triggered and transit the thread state to PENDING_SHUTDOWN during #pollRequests().
@@ -1002,7 +1002,6 @@ public class StreamThread extends Thread {
         while (!nonFatalExceptionsToHandle.isEmpty()) {
             streamsUncaughtExceptionHandler.accept(nonFatalExceptionsToHandle.poll(), true);
         }
-
         return pollLatency;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -764,7 +764,13 @@ public class StreamThread extends Thread {
         final long startMs = time.milliseconds();
         now = startMs;
 
-        final long pollLatency = pollPhase();
+        final long pollLatency;
+        taskManager.preparePoll();
+        try {
+            pollLatency = pollPhase();
+        } finally {
+            taskManager.postPoll();
+        }
 
         // Shutdown hook could potentially be triggered and transit the thread state to PENDING_SHUTDOWN during #pollRequests().
         // The task manager internal states could be uninitialized if the state transition happens during #onPartitionsAssigned().
@@ -996,6 +1002,7 @@ public class StreamThread extends Thread {
         while (!nonFatalExceptionsToHandle.isEmpty()) {
             streamsUncaughtExceptionHandler.accept(nonFatalExceptionsToHandle.poll(), true);
         }
+
         return pollLatency;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -162,6 +162,12 @@ public interface Task {
      */
     void prepareRecycle();
 
+    /** Prepares the consumer for the next polling phase for this task */
+    void preparePoll();
+
+    /** Wraps up after a polling phase for this task */
+    void postPoll();
+
     // runtime methods (using in RUNNING state)
 
     void addRecords(TopicPartition partition, Iterable<ConsumerRecord<byte[], byte[]>> records);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -162,11 +162,16 @@ public interface Task {
      */
     void prepareRecycle();
 
-    /** Prepares the consumer for the next polling phase for this task */
-    void preparePoll();
+    /**
+     * Resumes polling in the main consumer for all partitions for which
+     * the corresponding record queues have capacity (again).
+     */
+    void resumePollingForPartitionsWithAvailableSpace();
 
-    /** Wraps up after a polling phase for this task */
-    void postPoll();
+    /**
+     * Fetches up-to-date lag information from the consumer.
+     */
+    void updateLags();
 
     // runtime methods (using in RUNNING state)
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1635,6 +1635,20 @@ public class TaskManager {
         return commit(tasks.allTasks());
     }
 
+    /** Prepare a poll-call on the main consumer */
+    public void preparePoll() {
+        for (final Task t: tasks.activeTasks()) {
+            t.preparePoll();
+        }
+    }
+
+    /** Wrap-up a poll-call on the main consumer */
+    public void postPoll() {
+        for (final Task t: tasks.activeTasks()) {
+            t.postPoll();
+        }
+    }
+
     /**
      * Take records and add them to each respective task
      *
@@ -1901,9 +1915,5 @@ public class TaskManager {
     // for testing only
     void addTask(final Task task) {
         tasks.addTask(task);
-    }
-
-    TasksRegistry tasks() {
-        return tasks;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1635,17 +1635,22 @@ public class TaskManager {
         return commit(tasks.allTasks());
     }
 
-    /** Prepare a poll-call on the main consumer */
-    public void preparePoll() {
+    /**
+     * Resumes polling in the main consumer for all partitions for which
+     * the corresponding record queues have capacity (again).
+     */
+    public void resumePollingForPartitionsWithAvailableSpace() {
         for (final Task t: tasks.activeTasks()) {
-            t.preparePoll();
+            t.resumePollingForPartitionsWithAvailableSpace();
         }
     }
 
-    /** Wrap-up a poll-call on the main consumer */
-    public void postPoll() {
+    /**
+     * Fetches up-to-date lag information from the consumer.
+     */
+    public void updateLags() {
         for (final Task t: tasks.activeTasks()) {
-            t.postPoll();
+            t.updateLags();
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/PauseResumeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/PauseResumeIntegrationTest.java
@@ -373,8 +373,8 @@ public class PauseResumeIntegrationTest {
 
     private void assertStreamsLocalStoreLagStaysConstant(final KafkaStreams streams) throws InterruptedException {
         waitForCondition(
-            () -> !streams.allLocalStorePartitionLags().isEmpty(),
-            "Lags for local store partitions were not found within the timeout!");
+            () -> streams.allLocalStorePartitionLags().containsKey("test-store"),
+            "Lags for test-store partitions were not found within the timeout!");
         waitUntilStreamsHasPolled(streams, 2);
         final long stateStoreLag1 = streams.allLocalStorePartitionLags().get("test-store").get(0).offsetLag();
         waitUntilStreamsHasPolled(streams, 2);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -1452,7 +1452,7 @@ public class IntegrationTestUtils {
     public static void waitUntilStreamsHasPolled(final KafkaStreams kafkaStreams, final int pollNumber)
         throws InterruptedException {
         final Double initialCount = getStreamsPollNumber(kafkaStreams);
-        retryOnExceptionWithTimeout(1000, () -> {
+        retryOnExceptionWithTimeout(10000, () -> {
             assertThat(getStreamsPollNumber(kafkaStreams), is(greaterThanOrEqualTo(initialCount + pollNumber)));
         });
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
@@ -782,7 +782,7 @@ public class PartitionGroupTest {
 
     private void hasNoFetchedLag(final PartitionGroup group, final TopicPartition partition) {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(PartitionGroup.class)) {
-            LogCaptureAppender.setClassLoggerToTrace(PartitionGroup.class);
+            appender.setClassLoggerToTrace(PartitionGroup.class);
             assertFalse(group.readyToProcess(0L));
             assertThat(appender.getEvents(), hasItem(Matchers.hasProperty("message",
                 equalTo(String.format("[test] Waiting to fetch data for %s", partition)))));
@@ -791,7 +791,7 @@ public class PartitionGroupTest {
 
     private void hasZeroFetchedLag(final PartitionGroup group, final TopicPartition partition) {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(PartitionGroup.class)) {
-            LogCaptureAppender.setClassLoggerToTrace(PartitionGroup.class);
+            appender.setClassLoggerToTrace(PartitionGroup.class);
             assertFalse(group.readyToProcess(0L));
             assertThat(appender.getEvents(), hasItem(Matchers.hasProperty("message",
                 startsWith(String.format("[test] Lag for %s is currently 0 and current time is %d. "
@@ -802,7 +802,7 @@ public class PartitionGroupTest {
     @SuppressWarnings("SameParameterValue")
     private void hasNonZeroFetchedLag(final PartitionGroup group, final TopicPartition partition, final long lag) {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(PartitionGroup.class)) {
-            LogCaptureAppender.setClassLoggerToTrace(PartitionGroup.class);
+            appender.setClassLoggerToTrace(PartitionGroup.class);
             assertFalse(group.readyToProcess(0L));
             assertThat(appender.getEvents(), hasItem(Matchers.hasProperty("message",
                 equalTo(String.format("[test] Lag for %s is currently %d, but no data is buffered locally. "

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -521,6 +521,10 @@ public class StreamTaskTest {
     @Test
     public void shouldProcessInOrder() {
         task = createStatelessTask(createConfig());
+        task.initializeIfNeeded();
+        task.completeRestoration(noOpResetter -> { });
+
+        task.preparePoll();
 
         task.addRecords(partition1, asList(
             getConsumerRecordWithOffsetAsTimestamp(partition1, 10, 101),
@@ -533,6 +537,8 @@ public class StreamTaskTest {
             getConsumerRecordWithOffsetAsTimestamp(partition2, 35, 202),
             getConsumerRecordWithOffsetAsTimestamp(partition2, 45, 203)
         ));
+
+        task.postPoll();
 
         assertTrue(task.process(0L));
         assertEquals(5, task.numBuffered());
@@ -958,6 +964,8 @@ public class StreamTaskTest {
     @Test
     public void shouldPauseAndResumeBasedOnBufferedRecords() {
         task = createStatelessTask(createConfig("100"));
+        task.initializeIfNeeded();
+        task.completeRestoration(noOpResetter -> { });
 
         task.addRecords(partition1, asList(
             getConsumerRecordWithOffsetAsTimestamp(partition1, 10),
@@ -992,6 +1000,13 @@ public class StreamTaskTest {
         assertEquals(2, source1.numReceived);
         assertEquals(0, source2.numReceived);
 
+        assertEquals(2, consumer.paused().size());
+        assertTrue(consumer.paused().contains(partition1));
+        assertTrue(consumer.paused().contains(partition2));
+
+        // resume once we do a preparePoll
+        task.preparePoll();
+
         assertEquals(1, consumer.paused().size());
         assertTrue(consumer.paused().contains(partition2));
 
@@ -1006,6 +1021,12 @@ public class StreamTaskTest {
         assertEquals(3, source1.numReceived);
         assertEquals(1, source2.numReceived);
 
+        assertEquals(1, consumer.paused().size());
+        assertTrue(consumer.paused().contains(partition2));
+
+        // resume once we do a preparePoll
+        task.preparePoll();
+
         assertEquals(0, consumer.paused().size());
     }
 
@@ -1014,6 +1035,8 @@ public class StreamTaskTest {
         task = createStatelessTask(createConfig());
         task.initializeIfNeeded();
         task.completeRestoration(noOpResetter -> { });
+
+        task.preparePoll();
 
         task.addRecords(partition1, asList(
             getConsumerRecordWithOffsetAsTimestamp(partition1, 20),
@@ -1028,6 +1051,8 @@ public class StreamTaskTest {
             getConsumerRecordWithOffsetAsTimestamp(partition2, 159),
             getConsumerRecordWithOffsetAsTimestamp(partition2, 161)
         ));
+
+        task.postPoll();
 
         // st: -1
         assertFalse(task.canPunctuateStreamTime());
@@ -1263,7 +1288,9 @@ public class StreamTaskTest {
         // the task should still be committed since the processed records have not reached the consumer position
         assertTrue(task.commitNeeded());
 
+        task.preparePoll();
         consumer.poll(Duration.ZERO);
+        task.postPoll();
         task.process(0L);
 
         assertTrue(task.commitNeeded());
@@ -1284,6 +1311,8 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         task.completeRestoration(noOpResetter -> { });
 
+        task.preparePoll();
+
         consumer.addRecord(getConsumerRecordWithOffsetAsTimestamp(partition1, 0L));
         consumer.addRecord(getConsumerRecordWithOffsetAsTimestamp(partition1, 1L));
         consumer.addRecord(getConsumerRecordWithOffsetAsTimestamp(partition2, 0L));
@@ -1292,6 +1321,8 @@ public class StreamTaskTest {
 
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 0L)));
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 1L)));
+
+        task.postPoll();
 
         task.process(0L);
         processorStreamTime.mockProcessor.addProcessorMetadata("key1", 100L);
@@ -1819,6 +1850,9 @@ public class StreamTaskTest {
 
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 5L)));
         task.addRecords(repartition, singletonList(getConsumerRecordWithOffsetAsTimestamp(repartition, 10L)));
+
+        task.preparePoll();
+        task.postPoll();
 
         assertTrue(task.process(0L));
         assertTrue(task.process(0L));
@@ -2508,8 +2542,10 @@ public class StreamTaskTest {
             getCorruptedConsumerRecordWithOffsetAsTimestamp(++offset));
         consumer.addRecord(records.get(0));
         consumer.addRecord(records.get(1));
+        task.preparePoll();
         consumer.poll(Duration.ZERO);
         task.addRecords(partition1, records);
+        task.postPoll();
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
@@ -2538,8 +2574,10 @@ public class StreamTaskTest {
             getConsumerRecordWithOffsetAsTimestamp(partition1, ++offset));
         consumer.addRecord(records.get(0));
         consumer.addRecord(records.get(1));
+        task.preparePoll();
         consumer.poll(Duration.ZERO);
         task.addRecords(partition1, records);
+        task.postPoll();
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
@@ -2565,8 +2603,10 @@ public class StreamTaskTest {
             getCorruptedConsumerRecordWithOffsetAsTimestamp(++offset));
         consumer.addRecord(records.get(0));
         consumer.addRecord(records.get(1));
+        task.preparePoll();
         consumer.poll(Duration.ZERO);
         task.addRecords(partition1, records);
+        task.postPoll();
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -3055,6 +3055,19 @@ public class StreamThreadTest {
     }
 
     @Test
+    public void shouldCallPreparePollAndPostPollOnTaskManager() {
+        final Properties streamsConfigProps = StreamsTestUtils.getStreamsConfig();
+        final StreamThread streamThread = setUpThread(streamsConfigProps);
+        streamThread.setState(State.STARTING);
+        streamThread.setState(State.PARTITIONS_ASSIGNED);
+
+        streamThread.runOnce();
+
+        Mockito.verify(streamThread.taskManager()).preparePoll();
+        Mockito.verify(streamThread.taskManager()).postPoll();
+    }
+
+    @Test
     public void shouldRespectPollTimeInPartitionsAssignedStateWithStateUpdater() {
         final Properties streamsConfigProps = StreamsTestUtils.getStreamsConfig();
         streamsConfigProps.put(InternalConfig.STATE_UPDATER_ENABLED, true);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -287,7 +287,7 @@ public class TaskManagerTest {
     }
 
     @Test
-    public void shouldPreparePollForAllActiveTasks() {
+    public void shouldResumePollingForPartitionsWithAvailableSpaceForAllActiveTasks() {
         final StreamTask activeTask1 = statefulTask(taskId00, taskId00ChangelogPartitions)
             .inState(State.RUNNING)
             .withInputPartitions(taskId00Partitions).build();
@@ -296,16 +296,16 @@ public class TaskManagerTest {
             .withInputPartitions(taskId01Partitions).build();
         final TasksRegistry tasks = Mockito.mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
-        when(tasks.allTasks()).thenReturn(mkSet(activeTask1, activeTask2));
+        when(tasks.activeTasks()).thenReturn(mkSet(activeTask1, activeTask2));
 
-        taskManager.preparePoll();
+        taskManager.resumePollingForPartitionsWithAvailableSpace();
 
-        Mockito.verify(activeTask1).preparePoll();
-        Mockito.verify(activeTask2).preparePoll();
+        Mockito.verify(activeTask1).resumePollingForPartitionsWithAvailableSpace();
+        Mockito.verify(activeTask2).resumePollingForPartitionsWithAvailableSpace();
     }
 
     @Test
-    public void shouldPostPollForAllActiveTasks() {
+    public void shouldUpdateLagForAllActiveTasks() {
         final StreamTask activeTask1 = statefulTask(taskId00, taskId00ChangelogPartitions)
             .inState(State.RUNNING)
             .withInputPartitions(taskId00Partitions).build();
@@ -314,12 +314,12 @@ public class TaskManagerTest {
             .withInputPartitions(taskId01Partitions).build();
         final TasksRegistry tasks = Mockito.mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
-        when(tasks.allTasks()).thenReturn(mkSet(activeTask1, activeTask2));
+        when(tasks.activeTasks()).thenReturn(mkSet(activeTask1, activeTask2));
 
-        taskManager.postPoll();
+        taskManager.updateLags();
 
-        Mockito.verify(activeTask1).postPoll();
-        Mockito.verify(activeTask2).postPoll();
+        Mockito.verify(activeTask1).updateLags();
+        Mockito.verify(activeTask2).updateLags();
     }
 
     @Test
@@ -4872,12 +4872,12 @@ public class TaskManagerTest {
         }
 
         @Override
-        public void preparePoll() {
+        public void resumePollingForPartitionsWithAvailableSpace() {
             // noop
         }
 
         @Override
-        public void postPoll() {
+        public void updateLags() {
             // noop
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -287,6 +287,42 @@ public class TaskManagerTest {
     }
 
     @Test
+    public void shouldPreparePollForAllActiveTasks() {
+        final StreamTask activeTask1 = statefulTask(taskId00, taskId00ChangelogPartitions)
+            .inState(State.RUNNING)
+            .withInputPartitions(taskId00Partitions).build();
+        final StreamTask activeTask2 = statefulTask(taskId01, taskId01ChangelogPartitions)
+            .inState(State.RUNNING)
+            .withInputPartitions(taskId01Partitions).build();
+        final TasksRegistry tasks = Mockito.mock(TasksRegistry.class);
+        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
+        when(tasks.allTasks()).thenReturn(mkSet(activeTask1, activeTask2));
+
+        taskManager.preparePoll();
+
+        Mockito.verify(activeTask1).preparePoll();
+        Mockito.verify(activeTask2).preparePoll();
+    }
+
+    @Test
+    public void shouldPostPollForAllActiveTasks() {
+        final StreamTask activeTask1 = statefulTask(taskId00, taskId00ChangelogPartitions)
+            .inState(State.RUNNING)
+            .withInputPartitions(taskId00Partitions).build();
+        final StreamTask activeTask2 = statefulTask(taskId01, taskId01ChangelogPartitions)
+            .inState(State.RUNNING)
+            .withInputPartitions(taskId01Partitions).build();
+        final TasksRegistry tasks = Mockito.mock(TasksRegistry.class);
+        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
+        when(tasks.allTasks()).thenReturn(mkSet(activeTask1, activeTask2));
+
+        taskManager.postPoll();
+
+        Mockito.verify(activeTask1).postPoll();
+        Mockito.verify(activeTask2).postPoll();
+    }
+
+    @Test
     public void shouldPrepareActiveTaskInStateUpdaterToBeRecycled() {
         final StreamTask activeTaskToRecycle = statefulTask(taskId03, taskId03ChangelogPartitions)
             .inState(State.RESTORING)
@@ -4833,6 +4869,16 @@ public class TaskManagerTest {
         @Override
         public void prepareRecycle() {
             transitionTo(State.CLOSED);
+        }
+
+        @Override
+        public void preparePoll() {
+            // noop
+        }
+
+        @Override
+        public void postPoll() {
+            // noop
         }
 
         @Override

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -596,6 +596,8 @@ public class TopologyTestDriver implements Closeable {
         // If the topology only has global tasks, then `task` would be null.
         // For this method, it just means there's nothing to do.
         if (task != null) {
+            task.preparePoll();
+            task.postPoll();
             while (task.hasRecordsQueued() && task.isProcessable(mockWallClockTime.milliseconds())) {
                 // Process the record ...
                 task.process(mockWallClockTime.milliseconds());

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -596,8 +596,8 @@ public class TopologyTestDriver implements Closeable {
         // If the topology only has global tasks, then `task` would be null.
         // For this method, it just means there's nothing to do.
         if (task != null) {
-            task.preparePoll();
-            task.postPoll();
+            task.resumePollingForPartitionsWithAvailableSpace();
+            task.updateLags();
             while (task.hasRecordsQueued() && task.isProcessable(mockWallClockTime.milliseconds())) {
                 // Process the record ...
                 task.process(mockWallClockTime.milliseconds());


### PR DESCRIPTION
The process method inside the tasks needs to be called from within
the processing threads. However, it currently interacts with the
consumer in two ways:

 - It resumes processing when the PartitionGroup buffers are empty
 - It fetches the lag from the consumer

We introduce preparePoll() and wrapUpPoll() methods that call into
the task from the polling thread, in order to set up the consumer
correctly for the next poll, and extract metadata from the consumer
after the poll.
