### PR TITLE
MINOR: Fix docs for ReplicationBytes(Out|In)PerSec metrics

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1453,7 +1453,7 @@ $ bin/kafka-acls.sh \
       </tr>
       <tr>
         <td>Byte in rate from other brokers</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesInPerSec)</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesInPerSec</td>
         <td>Byte in (from the other brokers) rate across all topics.</td>
       </tr>
       <tr>
@@ -1537,7 +1537,7 @@ $ bin/kafka-acls.sh \
       </tr>
       <tr>
         <td>Byte out rate to other brokers</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesOutPerSec)</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesOutPerSec</td>
         <td>Byte out (to the other brokers) rate across all topics</td>
       </tr>
       <tr>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1453,8 +1453,8 @@ $ bin/kafka-acls.sh \
       </tr>
       <tr>
         <td>Byte in rate from other brokers</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesInPerSec,topic=([-.\w]+)</td>
-        <td>Byte in (from the other brokers) rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesInPerSec)</td>
+        <td>Byte in (from the other brokers) rate across all topics.</td>
       </tr>
       <tr>
         <td>Controller Request rate from Broker</td>
@@ -1537,8 +1537,8 @@ $ bin/kafka-acls.sh \
       </tr>
       <tr>
         <td>Byte out rate to other brokers</td>
-        <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesOutPerSec,topic=([-.\w]+)</td>
-        <td>Byte out (to the other brokers) rate per topic. Omitting 'topic=(...)' will yield the all-topic rate.</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesOutPerSec)</td>
+        <td>Byte out (to the other brokers) rate across all topics</td>
       </tr>
       <tr>
         <td>Rejected byte rate</td>


### PR DESCRIPTION
Based on the code shown below it looks like `ReplicationBytes(Out|In)PerSec` metrics are reported only across all topics and NOT for each individual topic.   https://github.com/apache/kafka/blob/a9efca0bf63110d68f84fc9841d8a31f245e10e0/core/src/main/scala/kafka/server/KafkaRequestHandler.scala#L405-L416
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
