### PR TITLE
KAFKA-15226: Add connect-plugin-path and plugin.discovery system test

### DIFF
--- a/tests/kafkatest/directory_layout/kafka_path.py
+++ b/tests/kafkatest/directory_layout/kafka_path.py
@@ -16,7 +16,7 @@
 import importlib
 import os
 
-from kafkatest.version import get_version, KafkaVersion, DEV_BRANCH, LATEST_0_9
+from kafkatest.version import get_version, KafkaVersion, DEV_BRANCH, LATEST_0_9, LATEST_3_5
 
 
 """This module serves a few purposes:
@@ -41,6 +41,7 @@ CORE_LIBS_JAR_NAME = "core-libs"
 CORE_DEPENDANT_TEST_LIBS_JAR_NAME = "core-dependant-testlibs"
 TOOLS_JAR_NAME = "tools"
 TOOLS_DEPENDANT_TEST_LIBS_JAR_NAME = "tools-dependant-libs"
+CONNECT_FILE_JAR = "connect-file"
 
 JARS = {
     "dev": {
@@ -48,7 +49,12 @@ JARS = {
         CORE_LIBS_JAR_NAME: "core/build/libs/*.jar",
         CORE_DEPENDANT_TEST_LIBS_JAR_NAME: "core/build/dependant-testlibs/*.jar",
         TOOLS_JAR_NAME: "tools/build/libs/kafka-tools*.jar",
-        TOOLS_DEPENDANT_TEST_LIBS_JAR_NAME: "tools/build/dependant-libs*/*.jar"
+        TOOLS_DEPENDANT_TEST_LIBS_JAR_NAME: "tools/build/dependant-libs*/*.jar",
+        CONNECT_FILE_JAR: "connect/file/build/libs/connect-file*.jar"
+    },
+    # This version of the file connectors do not contain ServiceLoader manifests
+    LATEST_3_5.__str__(): {
+        CONNECT_FILE_JAR: "libs/connect-file*.jar"
     },
     # TODO: This is only used in 0.8.2.x system tests, remove with KAFKA-14762
     LATEST_0_9.__str__(): {

--- a/tests/kafkatest/directory_layout/kafka_path.py
+++ b/tests/kafkatest/directory_layout/kafka_path.py
@@ -52,7 +52,7 @@ JARS = {
         TOOLS_DEPENDANT_TEST_LIBS_JAR_NAME: "tools/build/dependant-libs*/*.jar",
         CONNECT_FILE_JAR: "connect/file/build/libs/connect-file*.jar"
     },
-    # This version of the file connectors do not contain ServiceLoader manifests
+    # This version of the file connectors does not contain ServiceLoader manifests
     LATEST_3_5.__str__(): {
         CONNECT_FILE_JAR: "libs/connect-file*.jar"
     },

--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -89,7 +89,7 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
         except:
             return []
 
-    def set_configs(self, config_template_func, connector_config_templates=[]):
+    def set_configs(self, config_template_func, connector_config_templates=None):
         """
         Set configurations for the worker and the connector to run on
         it. These are not provided in the constructor because the worker
@@ -97,7 +97,7 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
         create the configuration.
         """
         self.config_template_func = config_template_func
-        self.connector_config_templates = connector_config_templates
+        self.connector_config_templates = connector_config_templates if connector_config_templates else []
 
     def set_external_configs(self, external_config_template_func):
         """

--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -53,8 +53,6 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
     """STARTUP_MODE_LISTEN: Start Connect worker and return after opening the REST port."""
     STARTUP_MODE_JOIN = 'JOIN'
     """STARTUP_MODE_JOIN: Start Connect worker and return after joining the group."""
-    STARTUP_MODE_CRASH = 'CRASH'
-    """STARTUP_MODE_CRASH: Start Connect worker and return after the process exits."""
 
     logs = {
         "connect_log": {
@@ -153,12 +151,6 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
             monitor.wait_until('Joined group', timeout_sec=self.startup_timeout_sec,
                                err_msg="Never saw message indicating Kafka Connect joined group on node: " +
                                        "%s in condition mode: %s" % (str(node.account), self.startup_mode))
-
-    def start_and_wait_to_stop(self, node, worker_type, remote_connector_configs):
-        self.start_and_return_immediately(node, worker_type, remote_connector_configs)
-        wait_until(lambda: not node.account.alive(self.pids(node)), timeout_sec=self.startup_timeout_sec,
-                   err_msg="Kafka Connect did not stop: %s in condition mode: %s" %
-                           (str(node.account), self.startup_mode))
 
     def stop_node(self, node, clean_shutdown=True, await_shutdown=None):
         if await_shutdown is None:
@@ -371,8 +363,6 @@ class ConnectStandaloneService(ConnectServiceBase):
             self.start_and_return_immediately(node, 'standalone', remote_connector_configs)
         elif self.startup_mode == self.STARTUP_MODE_JOIN:
             self.start_and_wait_to_join_group(node, 'standalone', remote_connector_configs)
-        elif self.startup_mode == self.STARTUP_MODE_CRASH:
-            self.start_and_wait_to_stop(node, 'standalone', remote_connector_configs)
         else:
             # The default mode is to wait until the complete startup of the worker
             self.start_and_wait_to_start_listening(node, 'standalone', remote_connector_configs)
@@ -427,8 +417,6 @@ class ConnectDistributedService(ConnectServiceBase):
             self.start_and_return_immediately(node, 'distributed', '')
         elif self.startup_mode == self.STARTUP_MODE_LISTEN:
             self.start_and_wait_to_start_listening(node, 'distributed', '')
-        elif self.startup_mode == self.STARTUP_MODE_CRASH:
-            self.start_and_wait_to_stop(node, 'distributed', '')
         else:
             # The default mode is to wait until the complete startup of the worker
             self.start_and_wait_to_join_group(node, 'distributed', '')

--- a/tests/kafkatest/tests/connect/connect_plugin_discovery_test.py
+++ b/tests/kafkatest/tests/connect/connect_plugin_discovery_test.py
@@ -67,7 +67,7 @@ class ConnectPluginDiscoveryTest(KafkaTest):
 
         if should_start:
             # plugins should be visible in the backwards-compatible modes, or if the migration finished.
-            expect_discovered = (plugin_discovery == 'only_scan' or plugin_discovery == 'hybrid_warn') or migrated
+            expect_discovered = plugin_discovery == 'only_scan' or plugin_discovery == 'hybrid_warn' or migrated
             actual_discovered = set([connector_plugin['class'] for connector_plugin in self.cc.list_connector_plugins()]).issuperset({self.FILE_SOURCE_CONNECTOR, self.FILE_SINK_CONNECTOR})
             assert expect_discovered == actual_discovered
         else:

--- a/tests/kafkatest/tests/connect/connect_plugin_discovery_test.py
+++ b/tests/kafkatest/tests/connect/connect_plugin_discovery_test.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+from kafkatest.tests.kafka_test import KafkaTest
+from kafkatest.directory_layout.kafka_path import CONNECT_FILE_JAR
+from kafkatest.version import LATEST_3_5
+from kafkatest.services.connect import ConnectStandaloneService, ConnectServiceBase
+from ducktape.mark import matrix
+from ducktape.mark.resource import cluster
+
+
+class ConnectPluginDiscoveryTest(KafkaTest):
+    """
+    Test for the `plugin.discovery` configuration and accompanying `connect-plugin-path` migration script.
+    """
+
+    FILE_SOURCE_CONNECTOR = 'org.apache.kafka.connect.file.FileStreamSourceConnector'
+    FILE_SINK_CONNECTOR = 'org.apache.kafka.connect.file.FileStreamSinkConnector'
+
+    OFFSETS_FILE = "/mnt/connect.offsets"
+    PLUGIN_PATH = "/mnt/connect-plugin-path"
+
+    def __init__(self, test_context):
+        super(ConnectPluginDiscoveryTest, self).__init__(test_context, num_zk=1, num_brokers=1)
+
+        self.cc = ConnectStandaloneService(test_context, self.kafka, [self.PLUGIN_PATH, self.OFFSETS_FILE])
+
+    @cluster(num_nodes=3)
+    @matrix(plugin_discovery=['only_scan', 'hybrid_warn', 'hybrid_fail', 'service_load'],
+            command=[('sync-manifests', '--dry-run'), ('sync-manifests',)])
+    def test_plugin_discovery_migration(self, plugin_discovery, command):
+        # Template parameters
+        self.PLUGIN_DISCOVERY = plugin_discovery
+
+        self.cc.set_configs(lambda node: self.render("connect-standalone.properties", node=node))
+        # Explicitly clean the plugin path now, because we won't clean it on start
+        self.cc.clean()
+
+        plugin_location = os.path.join(self.PLUGIN_PATH, "connect-file")
+        for node in self.cc.nodes:
+            # Copy a non-migrated plugin jar into the plugin path
+            node.account.ssh("mkdir -p %s" % plugin_location)
+            node.account.ssh("cp %s %s" % ((self.cc.path.jar(CONNECT_FILE_JAR, LATEST_3_5)), plugin_location))
+            # Execute a connect-plugin-path command on the non-migrated plugin path
+            node.account.ssh("%s %s %s %s" % (
+                self.cc.path.script("connect-plugin-path.sh"), " ".join(command),
+                '--plugin-path', self.PLUGIN_PATH))
+
+        migrated = command == ('sync-manifests',)
+        should_start = not (plugin_discovery == 'hybrid_fail' and not migrated)
+        # Do not clean the plugin path during startup
+        self.cc.start(mode=None if should_start else ConnectServiceBase.STARTUP_MODE_CRASH, clean=False)
+
+        if should_start:
+            # plugins should be visible in the backwards-compatible modes, or if the migration finished.
+            expect_discovered = (plugin_discovery == 'only_scan' or plugin_discovery == 'hybrid_warn') or migrated
+            actual_discovered = set([connector_plugin['class'] for connector_plugin in self.cc.list_connector_plugins()]).issuperset({self.FILE_SOURCE_CONNECTOR, self.FILE_SINK_CONNECTOR})
+            assert expect_discovered == actual_discovered

--- a/tests/kafkatest/tests/connect/templates/connect-distributed.properties
+++ b/tests/kafkatest/tests/connect/templates/connect-distributed.properties
@@ -65,3 +65,8 @@ request.timeout.ms=30000
 #
 config.providers=file
 config.providers.file.class=org.apache.kafka.common.config.provider.FileConfigProvider
+
+{% if PLUGIN_PATH is defined %}
+plugin.path={{ PLUGIN_PATH }}
+{% endif %}
+plugin.discovery={{ PLUGIN_DISCOVERY|default("service_load") }}

--- a/tests/kafkatest/tests/connect/templates/connect-standalone.properties
+++ b/tests/kafkatest/tests/connect/templates/connect-standalone.properties
@@ -37,3 +37,8 @@ request.timeout.ms=30000
 #
 config.providers=file
 config.providers.file.class=org.apache.kafka.common.config.provider.FileConfigProvider
+
+{% if PLUGIN_PATH is defined %}
+plugin.path={{ PLUGIN_PATH }}
+{% endif %}
+plugin.discovery={{ PLUGIN_DISCOVERY|default("service_load") }}


### PR DESCRIPTION
This test uses a standalone worker to verify the behavior of the plugin.discovery configuration values with non-migrated and migrated artifacts. 

For a source of non-migrated artifacts, I'm getting the latest 3.5.x File connectors, which will not receive manifests. When I originally planned this testing, I thought I would add non-migrated connectors to the `test-plugins` artifact, but that would make it difficult for downstream projects to import that jar and run in hybrid_fail.

The templates are changed to provide the default `service_load` to hopefully speed up execution of the other system tests.

This test verifies that:
1. Backwards-compatible modes (only_scan and hybrid_warn) start up successfully and the file connectors are visible.
2. The hybrid_fail mode crashes the worker if and only if non-migrated plugins are present.
3. The service_load mode starts up successfully, and file connectors are visible if and only if they are migrated.
4. The dry-run does not migrate connectors.
5. The sync-manifest writes well-formed jars that are readable during worker startup.

The test runtime is <5m on my machine. I considered adding no-command and `list` cases, but thought they duplicated the `--dry-run` case and increased the runtime for very little added value. I did change the distributed template and the ConnectDistributedService so that they could run this same test, but didn't set up a matrix for the deployment type for the same reason.

I did not include migrations for other plugin types (converters, transforms, etc) or packaging styles (class hierarchy, single-jar) because this is already covered in unit tests. I did not include assertions for the WARN log statements printed during hybrid modes for the same reason.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
