### PR TITLE
MINOR: Permit tombstone offsets with any partition for file source connector

### DIFF
--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
@@ -213,6 +213,21 @@ public class FileStreamSourceConnectorTest {
         assertThrows(ConnectException.class, () -> alterOffsets.apply(-10L));
         assertTrue(() -> alterOffsets.apply(10L));
     }
+    @Test
+    public void testAlterOffsetsOffsetTombstones() {
+        Function<Map<String, ?>, Boolean> alterOffsets = partition ->
+                connector.alterOffsets(sourceProperties, Collections.singletonMap(partition, null));
+
+        assertTrue(alterOffsets.apply(null));
+        assertTrue(alterOffsets.apply(Collections.emptyMap()));
+        Map<String, Object> partition = new HashMap<>();
+        partition.put("unused_partition_key", "unused_partition_value");
+        assertTrue(alterOffsets.apply(partition));
+        partition.put(FILENAME_FIELD, FILENAME);
+        assertTrue(alterOffsets.apply(partition));
+        partition.put("", "");
+        assertTrue(alterOffsets.apply(partition));
+    }
 
     @Test
     public void testSuccessfulAlterOffsets() {


### PR DESCRIPTION
This aligns the behavior of the file and MM2 source connectors with regards to tombstone offsets submitted via the REST API. Partition validation is intentionally disabled for tombstone offsets to allow users to clean up the offsets topic in case there's garbage in there, which may come from previous connectors with the same name but a different type, or newer versions of the connector that aren't compatible with the current version after an upgrade is reverted.

See https://github.com/apache/kafka/pull/14005 for the PR that introduced this logic to MM2.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
