### PR TITLE
MINOR: Allow writing tombstone offsets for arbitrary partitions in the FileStreamSourceConnector

### DIFF
--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
@@ -227,4 +227,18 @@ public class FileStreamSourceConnectorTest {
         assertTrue(connector.alterOffsets(sourceProperties, offsets));
         assertTrue(connector.alterOffsets(sourceProperties, new HashMap<>()));
     }
+
+    @Test
+    public void testAlterOffsetsTombstones() {
+        Function<Map<String, ?>, Boolean> alterOffsets = partition -> connector.alterOffsets(
+            sourceProperties,
+            Collections.singletonMap(partition, null)
+        );
+
+        assertTrue(alterOffsets.apply(null));
+        assertTrue(alterOffsets.apply(Collections.emptyMap()));
+        assertTrue(alterOffsets.apply(Collections.singletonMap(FILENAME_FIELD, FILENAME)));
+        assertTrue(alterOffsets.apply(Collections.singletonMap(FILENAME_FIELD, "/someotherfilename")));
+        assertTrue(alterOffsets.apply(Collections.singletonMap("garbage_partition_key", "garbage_partition_value")));
+    }
 }


### PR DESCRIPTION
- Background - https://cwiki.apache.org/confluence/display/KAFKA/KIP-875%3A+First-class+offsets+support+in+Kafka+Connect, https://github.com/apache/kafka/pull/13945#discussion_r1266867639, https://github.com/apache/kafka/pull/14005

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
