### PR TITLE
KAFKA-15102 (backport): Add release notes about the replication.policy.internal.topic.separator.enabled property for MirrorMaker 2

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -14,6 +14,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
+<script id="ops-template" type="text/x-handlebars-template">
 
   Here is some information on actually running Kafka as a production system based on usage and experience at LinkedIn. Please send us any additional tips you know of.
 
@@ -785,6 +786,9 @@ us-west->us-east.emit.heartbeats = false
     <li><code>sync.group.offsets.enabled</code>: whether to periodically write the translated offsets of replicated consumer groups (in the source cluster) to <code>__consumer_offsets</code> topic in target cluster, as long as no active consumers in that group are connected to the target cluster (default: false)
     <li><code>sync.group.offsets.interval.seconds</code>: frequency at which consumer group offsets are synced (default: 60, every minute)
     <li><code>offset-syncs.topic.replication.factor</code>: replication factor of MirrorMaker's internal offset-sync topics (default: 3)
+    <li id="georeplication-replication-policy"><code>replication.policy</code>: the <a href="/{{version}}/javadoc/org/apache/kafka/connect/mirror/ReplicationPolicy.html">ReplicationPolicy</a> class to use, which defaults to <a href="/{{version}}/javadoc/org/apache/kafka/connect/mirror/DefaultReplicationPolicy.html">DefaultReplicationPolicy</a>
+    <li><code>replication.policy.separator</code>: the delimiter to use between cluster aliases and topic names, if using the <a href="/{{version}}/javadoc/org/apache/kafka/connect/mirror/DefaultReplicationPolicy.html">DefaultReplicationPolicy</a> class
+    <li id="georeplication-replication-policy-internal-topic-separator-enabled"><code>replication.policy.internal.topic.separator.enabled</code>: whether to use <code>replication.policy.separator</code> to control the names of topics used for checkpoints and offset syncs, if using the <a href="/{{version}}/javadoc/org/apache/kafka/connect/mirror/DefaultReplicationPolicy.html">DefaultReplicationPolicy</a> class. By default, custom separators are used in these topic names; however, if upgrading MirrorMaker 2 from older versions that did not allow for these topic names to be customized, it may be necessary to set this property to <code>false</code> in order to continue using the same names for those topics
   </ul>
 
   <h5 class="anchor-heading"><a id="georeplication-flow-secure" class="anchor-link"></a><a href="#georeplication-flow-secure">Securing Replication Flows</a></h5>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -18,6 +18,15 @@
 <script><!--#include virtual="js/templateData.js" --></script>
 
 <script id="upgrade-template" type="text/x-handlebars-template">
+    <h4><a id="upgrade_3_5_2" href="#upgrade_3_5_2">Upgrading to 3.5.2 from any version 0.8.x through 3.4.x</a></h4>
+    All upgrade steps remain same as <a id="upgrade_3_5_1" href="#upgrade_3_5_1">upgrading to 3.5.1</a>, with one important addition:
+    <ul>
+        <li>To account for a break in compatibility introduced in version 3.1.0, MirrorMaker 2 has added a new
+            <a href="#georeplication-replication-policy-internal-topic-separator-enabled">replication.policy.internal.topic.separator.enabled</a> property.
+            If upgrading from 3.0.x or earlier, it may be necessary to set this property to <code>false</code>; see the <a href="#georeplication-replication-policy">documentation</a>
+            for that property and other replication policy properties for more details.</li>
+    </ul>
+
 
 <h4><a id="upgrade_3_5_1" href="#upgrade_3_5_1">Upgrading to 3.5.1 from any version 0.8.x through 3.4.x</a></h4>
     All upgrade steps remain same as <a id="upgrade_3_5_0" href="#upgrade_3_5_0">upgrading to 3.5.0</a>


### PR DESCRIPTION
Backports the changes from https://github.com/apache/kafka/pull/14220 onto 3.5. Since we do not have autogenerated configuration docs for MM2 on 3.5 and older branches, information on the property (and some related properties) is manually added to the existing section in those docs on MM2's configuration properties.

If this is approved, similar changes will be backported (without accompanying pull requests) to the 3.4 and 3.3 branches.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
