### PR TITLE
KAFKA-15374 Handle case of default broker in config migration

### DIFF
--- a/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
+++ b/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
@@ -197,7 +197,9 @@ class ZkMigrationClient(
     brokerIdConsumer: Consumer[Integer]
   ): Unit = wrapZkException {
     configClient.iterateBrokerConfigs((broker, props) => {
-      brokerIdConsumer.accept(Integer.valueOf(broker))
+      if (broker.nonEmpty) {
+        brokerIdConsumer.accept(Integer.valueOf(broker))
+      }
       val batch = new util.ArrayList[ApiMessageAndVersion]()
       props.forEach((key, value) => {
         batch.add(new ApiMessageAndVersion(new ConfigRecord()


### PR DESCRIPTION
Don't try to convert "" to a broker ID when collecting broker IDs during broker config migration.