### PR TITLE
Remove consumer rejoin to the group's synchronized lock

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -459,19 +459,14 @@ public abstract class AbstractCoordinator implements Closeable {
             }
 
             if (future.succeeded()) {
-                Generation generationSnapshot;
-                MemberState stateSnapshot;
-
                 // Generation data maybe concurrently cleared by Heartbeat thread.
                 // Can't use synchronized for {@code onJoinComplete}, because it can be long enough
                 // and shouldn't block heartbeat thread.
                 // See {@link PlaintextConsumerTest#testMaxPollIntervalMsDelayInAssignment}
-                synchronized (AbstractCoordinator.this) {
-                    generationSnapshot = this.generation;
-                    stateSnapshot = this.state;
-                }
+                Generation generationSnapshot;
+                MemberState stateSnapshot = null;
 
-                if (!hasGenerationReset(generationSnapshot) && stateSnapshot == MemberState.STABLE) {
+                if (!hasGenerationReset(generationSnapshot = this.generation) && (stateSnapshot = this.state) == MemberState.STABLE) {
                     // Duplicate the buffer in case `onJoinComplete` does not complete and needs to be retried.
                     ByteBuffer memberAssignment = future.value().duplicate();
 
@@ -486,7 +481,7 @@ public abstract class AbstractCoordinator implements Closeable {
                 } else {
                     final String reason = String.format("rebalance failed since the generation/state was " +
                             "modified by heartbeat thread to %s/%s before the rebalance callback triggered",
-                            generationSnapshot, stateSnapshot);
+                            generationSnapshot, stateSnapshot == null ? this.state : stateSnapshot);
 
                     resetStateAndRejoin(reason, true);
                     resetJoinGroupFuture();


### PR DESCRIPTION
- First, the purpose of the heart-beat thread's `maybeLeave` is to help "fail-fast", so we do our bust not to block it. And if the consumer thread release lock, and heart-beat thread modifies `generation` may make it rejoin again, so I think don't nessary to add the synchronized.

- Secondly, compare `state` can help rejoin "fail-fast", delaying take it to get the newly value is better.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
