### PR TITLE
KAFKA-15372: Add MirrorMaker2 connector config forwarding on startup

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -492,6 +492,8 @@
       <allow pkg="org.apache.kafka.connect.converters" />
       <allow pkg="org.apache.kafka.connect.json" />
       <allow pkg="net.sourceforge.argparse4j" />
+      <allow pkg="javax.ws.rs.core" />
+      <allow pkg="com.fasterxml.jackson.core.type" />
       <!-- for tests -->
       <allow pkg="org.apache.kafka.connect.integration" />
       <allow pkg="org.apache.kafka.connect.mirror" />

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -497,6 +497,7 @@
       <allow pkg="org.apache.kafka.connect.mirror" />
       <allow pkg="kafka.server" />
       <subpackage name="rest">
+        <allow pkg="io.swagger.v3.oas.annotations"/>
         <allow pkg="javax.ws.rs" />
       </subpackage>
     </subpackage>

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -492,7 +492,6 @@
       <allow pkg="org.apache.kafka.connect.converters" />
       <allow pkg="org.apache.kafka.connect.json" />
       <allow pkg="net.sourceforge.argparse4j" />
-      <allow pkg="javax.ws.rs.core" />
       <allow pkg="com.fasterxml.jackson.core.type" />
       <!-- for tests -->
       <allow pkg="org.apache.kafka.connect.integration" />

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -28,7 +28,6 @@ import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.WorkerConfigTransformer;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedHerder;
-import org.apache.kafka.connect.runtime.distributed.NotLeaderException;
 import org.apache.kafka.connect.runtime.rest.HerderRequestHandler;
 import org.apache.kafka.connect.runtime.rest.RestClient;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
@@ -54,8 +53,6 @@ import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.ArgumentParsers;
 
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.UriBuilder;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -241,13 +241,8 @@ public class MirrorMaker {
 
         DistributedHerder herder = (DistributedHerder) herders.get(sourceAndTarget);
         herder.putConnectorConfig(connectorName, connectorProps, true, cb);
-        String connectorReconfigUrl = herder.namespacedUrl(herder.leaderUrl())
-                .path("connectors")
-                .path(connectorName)
-                .path("config")
-                .build()
-                .toString();
         try {
+            String connectorReconfigUrl = sourceAndTarget.source()  + "/" + sourceAndTarget.target() + "/connectors/" + connectorName + "/config";
             requestHandler.completeOrForwardRequest(cb, connectorReconfigUrl, "PUT", null, connectorProps, false);
             log.info("{} connector configured for {}.", connectorName, sourceAndTarget);
         } catch (Throwable e) {

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/rest/resources/InternalMirrorResource.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/rest/resources/InternalMirrorResource.java
@@ -16,17 +16,13 @@
  */
 package org.apache.kafka.connect.mirror.rest.resources;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.apache.kafka.connect.mirror.SourceAndTarget;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.rest.RestClient;
-import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
-import org.apache.kafka.connect.runtime.rest.resources.ConnectResource;
 import org.apache.kafka.connect.runtime.rest.resources.ConnectorsResource;
 import org.apache.kafka.connect.runtime.rest.resources.InternalClusterResource;
-import org.apache.kafka.connect.util.FutureCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,9 +34,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-import java.net.URI;
 import java.util.Map;
 
 @Path("/{source}/{target}/connectors")

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/rest/resources/InternalMirrorResource.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/rest/resources/InternalMirrorResource.java
@@ -16,17 +16,31 @@
  */
 package org.apache.kafka.connect.mirror.rest.resources;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.apache.kafka.connect.mirror.SourceAndTarget;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.rest.RestClient;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+import org.apache.kafka.connect.runtime.rest.resources.ConnectResource;
+import org.apache.kafka.connect.runtime.rest.resources.ConnectorsResource;
 import org.apache.kafka.connect.runtime.rest.resources.InternalClusterResource;
+import org.apache.kafka.connect.util.FutureCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
+import java.net.URI;
 import java.util.Map;
 
 @Path("/{source}/{target}/connectors")
@@ -43,6 +57,17 @@ public class InternalMirrorResource extends InternalClusterResource {
         super(restClient);
         this.herders = herders;
     }
+
+    @PUT
+    @Path("/{connector}/config")
+    @Operation(hidden = true, summary = "Create or reconfigure the specified connector")
+    public Response putConnectorConfig(final @PathParam("connector") String connector,
+                                       final @Context HttpHeaders headers,
+                                       final @Parameter(hidden = true) @QueryParam("forward") Boolean forward,
+                                       final Map<String, String> connectorConfig) throws Throwable {
+        return ConnectorsResource.putConnectorConfig(herderForRequest(), requestHandler, connector, headers, forward, connectorConfig);
+    }
+
 
     @Override
     protected Herder herderForRequest() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -2629,8 +2629,11 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         return false;
     }
 
-    public UriBuilder namespacedUrl(String workerUrl) {
-        UriBuilder result = UriBuilder.fromUri(workerUrl);
+    private UriBuilder namespacedUrl(String workerUrl) {
+        return namespacedUrl(UriBuilder.fromUri(workerUrl));
+    }
+
+    public UriBuilder namespacedUrl(UriBuilder result) {
         for (String namespacePath : restNamespace) {
             result = result.path(namespacePath);
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1605,7 +1605,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     /**
      * Get the URL for the leader's REST interface, or null if we do not have the leader's URL yet.
      */
-    public String leaderUrl() {
+    private String leaderUrl() {
         if (assignment == null)
             return null;
         return assignment.leaderUrl();
@@ -2630,14 +2630,15 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     }
 
     private UriBuilder namespacedUrl(String workerUrl) {
-        return namespacedUrl(UriBuilder.fromUri(workerUrl));
-    }
-
-    public UriBuilder namespacedUrl(UriBuilder result) {
+        UriBuilder result = UriBuilder.fromUri(workerUrl);
         for (String namespacePath : restNamespace) {
             result = result.path(namespacePath);
         }
         return result;
+    }
+
+    public List<String> namespace() {
+        return Collections.unmodifiableList(restNamespace);
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1605,7 +1605,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     /**
      * Get the URL for the leader's REST interface, or null if we do not have the leader's URL yet.
      */
-    private String leaderUrl() {
+    public String leaderUrl() {
         if (assignment == null)
             return null;
         return assignment.leaderUrl();
@@ -2629,7 +2629,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         return false;
     }
 
-    private UriBuilder namespacedUrl(String workerUrl) {
+    public UriBuilder namespacedUrl(String workerUrl) {
         UriBuilder result = UriBuilder.fromUri(workerUrl);
         for (String namespacePath : restNamespace) {
             result = result.path(namespacePath);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/HerderRequestHandler.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/HerderRequestHandler.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 
 public class HerderRequestHandler {
 
@@ -73,15 +74,33 @@ public class HerderRequestHandler {
         }
     }
 
-    /**
-     * Wait for a {@link FutureCallback} to complete. If it succeeds, return the parsed response. If it fails, try to forward the
-     * request to the indicated target.
-     */
     public <T, U> T completeOrForwardRequest(FutureCallback<T> cb,
                                              String path,
                                              String method,
                                              HttpHeaders headers,
                                              Map<String, String> queryParameters,
+                                             Object body,
+                                             TypeReference<U> resultType,
+                                             Translator<T, U> translator,
+                                             Boolean forward) throws Throwable {
+        Function<UriBuilder, UriBuilder> uriBuilder = builder -> {
+            builder = builder.path(path);
+            if (queryParameters != null) {
+                queryParameters.forEach(builder::queryParam);
+            }
+            return builder;
+        };
+        return completeOrForwardRequest(cb, uriBuilder, method, headers, body, resultType, translator, forward);
+    }
+
+    /**
+     * Wait for a {@link FutureCallback} to complete. If it succeeds, return the parsed response. If it fails, try to forward the
+     * request to the indicated target.
+     */
+    public <T, U> T completeOrForwardRequest(FutureCallback<T> cb,
+                                             Function<UriBuilder, UriBuilder> requestUri,
+                                             String method,
+                                             HttpHeaders headers,
                                              Object body,
                                              TypeReference<U> resultType,
                                              Translator<T, U> translator,
@@ -101,18 +120,14 @@ public class HerderRequestHandler {
                             "Cannot complete request momentarily due to no known leader URL, "
                                     + "likely because a rebalance was underway.");
                 }
-                UriBuilder uriBuilder = UriBuilder.fromUri(forwardedUrl)
-                        .path(path)
+                UriBuilder uriBuilder = requestUri.apply(UriBuilder.fromUri(forwardedUrl))
                         .queryParam("forward", recursiveForward);
-                if (queryParameters != null) {
-                    queryParameters.forEach(uriBuilder::queryParam);
-                }
                 String forwardUrl = uriBuilder.build().toString();
                 log.debug("Forwarding request {} {} {}", forwardUrl, method, body);
                 return translator.translate(restClient.httpRequest(forwardUrl, method, headers, body, resultType));
             } else {
                 log.error("Request '{} {}' failed because it couldn't find the target Connect worker within two hops (between workers).",
-                        method, path);
+                        method, requestUri);
                 // we should find the right target for the query within two hops, so if
                 // we don't, it probably means that a rebalance has taken place.
                 throw new ConnectRestException(Response.Status.CONFLICT.getStatusCode(),

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -223,6 +223,15 @@ public class ConnectorsResource implements ConnectResource {
                                        final @Context HttpHeaders headers,
                                        final @Parameter(hidden = true) @QueryParam("forward") Boolean forward,
                                        final Map<String, String> connectorConfig) throws Throwable {
+        return putConnectorConfig(herder, requestHandler, connector, headers, forward, connectorConfig);
+    }
+
+    public static Response putConnectorConfig(Herder herder,
+                                       HerderRequestHandler requestHandler,
+                                       String connector,
+                                       HttpHeaders headers,
+                                       Boolean forward,
+                                       Map<String, String> connectorConfig) throws Throwable {
         FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>();
         checkAndPutConnectorConfigName(connector, connectorConfig);
 
@@ -381,7 +390,7 @@ public class ConnectorsResource implements ConnectResource {
 
     // Check whether the connector name from the url matches the one (if there is one) provided in the connectorConfig
     // object. Throw BadRequestException on mismatch, otherwise put connectorName in config
-    private void checkAndPutConnectorConfigName(String connectorName, Map<String, String> connectorConfig) {
+    public static void checkAndPutConnectorConfigName(String connectorName, Map<String, String> connectorConfig) {
         String includedName = connectorConfig.get(ConnectorConfig.NAME_CONFIG);
         if (includedName != null) {
             if (!includedName.equals(connectorName))
@@ -391,7 +400,7 @@ public class ConnectorsResource implements ConnectResource {
         }
     }
 
-    private static class CreatedConnectorInfoTranslator implements Translator<Herder.Created<ConnectorInfo>, ConnectorInfo> {
+    public static class CreatedConnectorInfoTranslator implements Translator<Herder.Created<ConnectorInfo>, ConnectorInfo> {
         @Override
         public Herder.Created<ConnectorInfo> translate(RestClient.HttpResponse<ConnectorInfo> response) {
             boolean created = response.status() == 201;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/InternalClusterResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/InternalClusterResource.java
@@ -19,13 +19,11 @@ package org.apache.kafka.connect.runtime.rest.resources;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.distributed.Crypto;
 import org.apache.kafka.connect.runtime.rest.HerderRequestHandler;
 import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
 import org.apache.kafka.connect.runtime.rest.RestClient;
-import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.util.FutureCallback;
 
 import javax.ws.rs.POST;
@@ -37,10 +35,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/InternalClusterResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/InternalClusterResource.java
@@ -19,11 +19,13 @@ package org.apache.kafka.connect.runtime.rest.resources;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.distributed.Crypto;
 import org.apache.kafka.connect.runtime.rest.HerderRequestHandler;
 import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
 import org.apache.kafka.connect.runtime.rest.RestClient;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.util.FutureCallback;
 
 import javax.ws.rs.POST;
@@ -35,7 +37,10 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
@@ -50,7 +55,7 @@ public abstract class InternalClusterResource implements ConnectResource {
     private static final TypeReference<List<Map<String, String>>> TASK_CONFIGS_TYPE =
             new TypeReference<List<Map<String, String>>>() { };
 
-    private final HerderRequestHandler requestHandler;
+    protected final HerderRequestHandler requestHandler;
 
     // Visible for testing
     @Context


### PR DESCRIPTION
### Context

MirrorMaker2 dedicated mode was changed in KIP-710 to forward task reconfiguration and zombie fence requests to the leader. It was not changed to perform the same forwarding for connector configurations.

In dedicated mode, the MirrorMaker driver class will start up it's local herders, and then reconfigure all of the connectors based on it's on-disk configuration. When performing a slow-paced rolling update, a MirrorMaker node will not join the group as the leader, and will then be unable to write new connector configurations. This leads to the running configurations not reflecting the on-disk configurations after the on-disk configurations are changed.

In order to perform forwarding of the connector configurations, use the HerderRequestHandler in the MirrorMaker to forward configurations to a new `/connectors/<connector>/config` endpoint to the `InternalMirrorResource`. This shares it's implementation with the original `ConnectorsResource`.

This is intended to be a minimal patch that could be merged in time for the upcoming release. I tried to clean it up to avoid increasing the visibility of certain methods, or to re-use the `namespacedUrl` function, but the refactors ended up ballooning the scope of the fix. I want to address those refactors in a follow-up PR.

### Behavior summary
The running connector configurations in dedicated mode are from the worker that:

Current:
*  First became the leader after a cold-start

Implemented in this PR:
*  Most recently started (either in a cold-start or rolling-restart)

Rejected alternative:
*  Most recently became the leader

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
