### PR TITLE
MINOR: Add libs.slf4jlog4j to dependencies in project(':core')

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -887,6 +887,7 @@ project(':core') {
     implementation libs.scalaReflect
     implementation libs.scalaLogging
     implementation libs.slf4jApi
+    implementation libs.slf4jlog4j
     implementation(libs.zookeeper) {
       // Dropwizard Metrics are required by ZooKeeper as of v3.6.0,
       // but the library should *not* be used in Kafka code


### PR DESCRIPTION
## Description
- When I use IntelliJ to debug `kafka.core.main` following the [wiki](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=145722808), I kept having error messages like these.
```
> Task :core:Kafka.main()
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
SLF4J: Failed to load class "org.slf4j.impl.StaticMDCBinder".
SLF4J: Defaulting to no-operation MDCAdapter implementation.
SLF4J: See http://www.slf4j.org/codes.html#no_static_mdc_binder for further details.
```
- My debug configuration is as:
```
-Xmx1G
-Xms1G
-server
-XX:+UseG1GC
-XX:MaxGCPauseMillis=20
-XX:InitiatingHeapOccupancyPercent=35
-XX:+ExplicitGCInvokesConcurrent
-Djava.awt.headless=true
-Dcom.sun.management.jmxremote
-Dcom.sun.management.jmxremote.ssl=false
-Dcom.sun.management.jmxremote.authenticate=false
-Dkafka.logs.dir="/Users/me/logs"
-Dlog4j.configuration=file:/path/to/kafka/config/log4j.properties
```

- Adding `implementation libs.slf4jlog4j` resolved my problem,
- This change will make life easier for who want to start contributing to kafka.


## Test
- Run locally and test by `quick-start`. Should have no impact on existing functions.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
