### PR TITLE
KAFKA-10199: Change to RUNNING if no pending task to init exist

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -302,7 +302,7 @@ public class TaskManager {
             }
             task.revive();
             if (stateUpdater != null) {
-                tasks.addPendingTaskToInit(Collections.singleton(task));
+                tasks.addPendingTasksToInit(Collections.singleton(task));
             }
         }
     }
@@ -403,14 +403,14 @@ public class TaskManager {
     private void createNewTasks(final Map<TaskId, Set<TopicPartition>> activeTasksToCreate,
                                 final Map<TaskId, Set<TopicPartition>> standbyTasksToCreate) {
         final Collection<Task> newActiveTasks = activeTaskCreator.createTasks(mainConsumer, activeTasksToCreate);
-        final Collection<Task> newStandbyTask = standbyTaskCreator.createTasks(standbyTasksToCreate);
+        final Collection<Task> newStandbyTasks = standbyTaskCreator.createTasks(standbyTasksToCreate);
 
         if (stateUpdater == null) {
             tasks.addActiveTasks(newActiveTasks);
-            tasks.addStandbyTasks(newStandbyTask);
+            tasks.addStandbyTasks(newStandbyTasks);
         } else {
-            tasks.addPendingTaskToInit(newActiveTasks);
-            tasks.addPendingTaskToInit(newStandbyTask);
+            tasks.addPendingTasksToInit(newActiveTasks);
+            tasks.addPendingTasksToInit(newStandbyTasks);
         }
     }
 
@@ -477,7 +477,7 @@ public class TaskManager {
 
     private void handleTasksPendingInitialization() {
         // All tasks pending initialization are not part of the usual bookkeeping
-        for (final Task task : tasks.drainPendingTaskToInit()) {
+        for (final Task task : tasks.drainPendingTasksToInit()) {
             task.suspend();
             task.closeClean();
         }
@@ -489,7 +489,8 @@ public class TaskManager {
                                                 final Set<Task> tasksToCloseClean) {
         for (final Task task : tasks.allTasks()) {
             if (!task.isActive()) {
-                throw new IllegalStateException("Standby tasks should only be managed by the state updater");
+                throw new IllegalStateException("Standby tasks should only be managed by the state updater, " +
+                    "but standby task " + task.id() + " is managed by the stream thread");
             }
             final TaskId taskId = task.id();
             if (activeTasksToCreate.containsKey(taskId)) {
@@ -763,7 +764,9 @@ public class TaskManager {
         if (stateUpdater.restoresActiveTasks()) {
             handleRestoredTasksFromStateUpdater(now, offsetResetter);
         }
-        return !stateUpdater.restoresActiveTasks() && !tasks.hasPendingTasksToRecycle();
+        return !stateUpdater.restoresActiveTasks()
+            && !tasks.hasPendingTasksToRecycle()
+            && !tasks.hasPendingTasksToInit();
     }
 
     private void recycleTaskFromStateUpdater(final Task task,
@@ -838,7 +841,7 @@ public class TaskManager {
 
     private void addTasksToStateUpdater() {
         final Map<TaskId, RuntimeException> taskExceptions = new LinkedHashMap<>();
-        for (final Task task : tasks.drainPendingTaskToInit()) {
+        for (final Task task : tasks.drainPendingTasksToInit()) {
             try {
                 task.initializeIfNeeded();
                 stateUpdater.add(task);
@@ -846,7 +849,7 @@ public class TaskManager {
                 // The state directory may still be locked by another thread, when the rebalance just happened.
                 // Retry in the next iteration.
                 log.info("Encountered lock exception. Reattempting locking the state in the next iteration.", lockException);
-                tasks.addPendingTaskToInit(Collections.singleton(task));
+                tasks.addPendingTasksToInit(Collections.singleton(task));
             } catch (final RuntimeException e) {
                 // need to add task back to the bookkeeping to be handled by the stream thread
                 tasks.addTask(task);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
@@ -180,15 +180,20 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public Set<Task> drainPendingTaskToInit() {
+    public Set<Task> drainPendingTasksToInit() {
         final Set<Task> result = new HashSet<>(pendingTasksToInit);
         pendingTasksToInit.clear();
         return result;
     }
 
     @Override
-    public void addPendingTaskToInit(final Collection<Task> tasks) {
+    public void addPendingTasksToInit(final Collection<Task> tasks) {
         pendingTasksToInit.addAll(tasks);
+    }
+
+    @Override
+    public boolean hasPendingTasksToInit() {
+        return !pendingTasksToInit.isEmpty();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TasksRegistry.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TasksRegistry.java
@@ -53,9 +53,11 @@ public interface TasksRegistry {
 
     void addPendingTaskToCloseClean(final TaskId taskId);
 
-    Set<Task> drainPendingTaskToInit();
+    Set<Task> drainPendingTasksToInit();
 
-    void addPendingTaskToInit(final Collection<Task> tasks);
+    void addPendingTasksToInit(final Collection<Task> tasks);
+
+    boolean hasPendingTasksToInit();
 
     boolean removePendingActiveTaskToSuspend(final TaskId taskId);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -596,7 +596,8 @@ public class TaskManagerTest {
             )
         );
 
-        assertEquals(illegalStateException.getMessage(), "Standby tasks should only be managed by the state updater");
+        assertEquals(illegalStateException.getMessage(), "Standby tasks should only be managed by the state updater, " +
+            "but standby task " + taskId03 + " is managed by the stream thread");
         Mockito.verifyNoInteractions(activeTaskCreator);
     }
 
@@ -633,7 +634,8 @@ public class TaskManagerTest {
             () -> taskManager.handleAssignment(Collections.emptyMap(), Collections.emptyMap())
         );
 
-        assertEquals(illegalStateException.getMessage(), "Standby tasks should only be managed by the state updater");
+        assertEquals(illegalStateException.getMessage(), "Standby tasks should only be managed by the state updater, " +
+            "but standby task " + taskId03 + " is managed by the stream thread");
         Mockito.verifyNoInteractions(activeTaskCreator);
     }
 
@@ -715,7 +717,8 @@ public class TaskManagerTest {
             )
         );
 
-        assertEquals(illegalStateException.getMessage(), "Standby tasks should only be managed by the state updater");
+        assertEquals(illegalStateException.getMessage(), "Standby tasks should only be managed by the state updater, " +
+            "but standby task " + taskId02 + " is managed by the stream thread");
         Mockito.verifyNoInteractions(activeTaskCreator);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -528,7 +528,7 @@ public class TaskManagerTest {
 
         taskManager.handleAssignment(tasksToBeCreated, Collections.emptyMap());
 
-        Mockito.verify(tasks).addPendingTaskToInit(createdTasks);
+        Mockito.verify(tasks).addPendingTasksToInit(createdTasks);
         Mockito.verify(standbyTaskCreator).createTasks(Collections.emptyMap());
     }
 
@@ -550,7 +550,7 @@ public class TaskManagerTest {
         );
 
         Mockito.verify(activeTaskCreator).createTasks(consumer, Collections.emptyMap());
-        Mockito.verify(tasks).addPendingTaskToInit(createdTasks);
+        Mockito.verify(tasks).addPendingTasksToInit(createdTasks);
     }
 
     @Test
@@ -753,7 +753,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId01Partitions)
             .inState(State.RUNNING).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.drainPendingTaskToInit()).thenReturn(mkSet(task00, task01));
+        when(tasks.drainPendingTasksToInit()).thenReturn(mkSet(task00, task01));
         taskManager = setUpTaskManager(StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE, tasks, true);
 
         taskManager.checkStateUpdater(time.milliseconds(), noOpResetter);
@@ -773,7 +773,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId01Partitions)
             .inState(State.RUNNING).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.drainPendingTaskToInit()).thenReturn(mkSet(task00, task01));
+        when(tasks.drainPendingTasksToInit()).thenReturn(mkSet(task00, task01));
         final LockException lockException = new LockException("Where are my keys??");
         doThrow(lockException)
             .when(task00).initializeIfNeeded();
@@ -783,7 +783,7 @@ public class TaskManagerTest {
 
         Mockito.verify(task00).initializeIfNeeded();
         Mockito.verify(task01).initializeIfNeeded();
-        Mockito.verify(tasks).addPendingTaskToInit(Collections.singleton(task00));
+        Mockito.verify(tasks).addPendingTasksToInit(Collections.singleton(task00));
         Mockito.verify(stateUpdater).add(task01);
     }
 
@@ -1482,7 +1482,7 @@ public class TaskManagerTest {
             .withInputPartitions(taskId02Partitions).build();
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.EXACTLY_ONCE_V2, tasks, true);
-        when(tasks.drainPendingTaskToInit()).thenReturn(mkSet(statefulTask0, statefulTask1, statefulTask2));
+        when(tasks.drainPendingTasksToInit()).thenReturn(mkSet(statefulTask0, statefulTask1, statefulTask2));
         doThrow(new TaskCorruptedException(Collections.singleton(statefulTask0.id))).when(statefulTask0).initializeIfNeeded();
         doThrow(new TaskCorruptedException(Collections.singleton(statefulTask1.id))).when(statefulTask1).initializeIfNeeded();
 
@@ -2038,8 +2038,8 @@ public class TaskManagerTest {
         standbyTaskOrder.verify(corruptedStandbyTask).revive();
         Mockito.verify(tasks).removeTask(corruptedActiveTask);
         Mockito.verify(tasks).removeTask(corruptedStandbyTask);
-        Mockito.verify(tasks).addPendingTaskToInit(mkSet(corruptedActiveTask));
-        Mockito.verify(tasks).addPendingTaskToInit(mkSet(corruptedStandbyTask));
+        Mockito.verify(tasks).addPendingTasksToInit(mkSet(corruptedActiveTask));
+        Mockito.verify(tasks).addPendingTasksToInit(mkSet(corruptedStandbyTask));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -961,8 +961,7 @@ public class TaskManagerTest {
     }
 
     @Test
-    public void shouldReturnFalseFromCheckStateUpdaterIfActiveTasksAreNotRestoringButPendingTasksToRecycle() {
-        when(stateUpdater.restoresActiveTasks()).thenReturn(false);
+    public void shouldReturnFalseFromCheckStateUpdaterIfActiveTasksAreNotRestoringAndNoPendingTaskToInitButPendingTasksToRecycle() {
         final TasksRegistry tasks = mock(TasksRegistry.class);
         when(tasks.hasPendingTasksToRecycle()).thenReturn(true);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
@@ -971,10 +970,17 @@ public class TaskManagerTest {
     }
 
     @Test
-    public void shouldReturnTrueFromCheckStateUpdaterIfActiveTasksAreNotRestoringAndNoPendingTasksToRecycle() {
-        when(stateUpdater.restoresActiveTasks()).thenReturn(false);
+    public void shouldReturnFalseFromCheckStateUpdaterIfActiveTasksAreNotRestoringAndNoPendingTaskToRecycleButPendingTasksToInit() {
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        when(tasks.hasPendingTasksToRecycle()).thenReturn(false);
+        when(tasks.hasPendingTasksToInit()).thenReturn(true);
+        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
+
+        assertFalse(taskManager.checkStateUpdater(time.milliseconds(), noOpResetter));
+    }
+
+    @Test
+    public void shouldReturnTrueFromCheckStateUpdaterIfActiveTasksAreNotRestoringAndNoPendingTasksToRecycleAndInit() {
+        final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
 
         assertTrue(taskManager.checkStateUpdater(time.milliseconds(), noOpResetter));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
@@ -148,6 +148,28 @@ public class TasksTest {
     }
 
     @Test
+    public void shouldVerifyIfPendingTaskToInitExist() {
+        assertFalse(tasks.hasPendingTasksToInit());
+
+        final StreamTask activeTask = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_B_0)).build();
+        tasks.addPendingTasksToInit(Collections.singleton(activeTask));
+        assertTrue(tasks.hasPendingTasksToInit());
+
+        final StandbyTask standbyTask = standbyTask(TASK_1_0, mkSet(TOPIC_PARTITION_A_1)).build();
+        tasks.addPendingTasksToInit(Collections.singleton(standbyTask));
+        assertTrue(tasks.hasPendingTasksToInit());
+
+        tasks.addPendingTaskToCloseClean(TASK_0_1);
+        tasks.addPendingTaskToCloseDirty(TASK_0_2);
+        tasks.addPendingTaskToUpdateInputPartitions(TASK_1_1, mkSet(TOPIC_PARTITION_B_0));
+        tasks.addPendingActiveTaskToSuspend(TASK_1_2);
+        assertTrue(tasks.hasPendingTasksToInit());
+
+        tasks.drainPendingTasksToInit();
+        assertFalse(tasks.hasPendingTasksToInit());
+    }
+
+    @Test
     public void shouldAddAndRemovePendingTaskToUpdateInputPartitions() {
         final Set<TopicPartition> expectedInputPartitions = mkSet(TOPIC_PARTITION_A_0);
         assertNull(tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0));


### PR DESCRIPTION
A stream thread should only change to RUNNING if there are no active tasks in restoration in the state updater and if there are no pending tasks to recycle and to init.

Usually all pending tasks to init are added to the state updater in the same poll iteration that handles the assignment. However, if during an initialization of a task a LockException the task is re-added to the tasks to init and initialization is retried in the next poll iteration.

A LockException might occur when a state directory is still locked by another thread, when the rebalance just happened.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
