### PR TITLE
KAFKA-15294: Publish remote storage configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1074,7 +1074,8 @@ project(':core') {
                                ':streams:genStreamsConfigDocs', 'genConsumerMetricsDocs', 'genProducerMetricsDocs',
                                ':connect:runtime:genConnectMetricsDocs', ':connect:runtime:genConnectOpenAPIDocs',
                                ':connect:mirror:genMirrorSourceConfigDocs', ':connect:mirror:genMirrorCheckpointConfigDocs',
-                               ':connect:mirror:genMirrorHeartbeatConfigDocs', ':connect:mirror:genMirrorConnectorConfigDocs'], type: Tar) {
+                               ':connect:mirror:genMirrorHeartbeatConfigDocs', ':connect:mirror:genMirrorConnectorConfigDocs',
+                               ':storage:genRemoteLogManagerConfigDoc', ':storage:genRemoteLogMetadataManagerConfigDoc'], type: Tar) {
     archiveClassifier = 'site-docs'
     compression = Compression.GZIP
     from project.file("$rootDir/docs")
@@ -1764,6 +1765,20 @@ project(':storage') {
         .withPathSensitivity(PathSensitivity.RELATIVE)
     outputs.cacheIf { true }
     outputs.dir("src/generated/java/org/apache/kafka/server/log/remote/metadata/storage/generated")
+  }
+
+  task genRemoteLogManagerConfigDoc(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig'
+    if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
+    standardOutput = new File(generatedDocsDir, "remote_log_manager_config.html").newOutputStream()
+  }
+
+  task genRemoteLogMetadataManagerConfigDoc(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig'
+    if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
+    standardOutput = new File(generatedDocsDir, "remote_log_metadata_manager_config.html").newOutputStream()
   }
 
   sourceSets {

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -286,7 +286,12 @@
   Below is the configuration of MirrorMaker 2 heartbeat connector for checking connectivity between connectors and clusters.
   <!--#include virtual="generated/mirror_heartbeat_config.html" -->
 
-  <h3 class="anchor-heading"><a id="systemproperties" class="anchor-link"></a><a href="#systemproperties">3.9 System Properties</a></h3>
+  <h3 class="anchor-heading"><a id="remotestorageconfigs" class="anchor-link"></a><a href="#remotestorageconfigs">3.9 Tier Storage Configs</a></h3>
+  Below is the configuration of Tier Storage.
+  <!--#include virtual="generated/remote_log_manager_config.html" -->
+  <!--#include virtual="generated/remote_log_metadata_manager_config.html" -->
+
+  <h3 class="anchor-heading"><a id="systemproperties" class="anchor-link"></a><a href="#systemproperties">3.10 System Properties</a></h3>
   Kafka supports some configuration that can be enabled through Java system properties. System properties are usually set by passing the -D flag to the Java virtual machine in which Kafka components are running.
   Below are the supported system properties.
   <ul class="config-list">

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -286,12 +286,7 @@
   Below is the configuration of MirrorMaker 2 heartbeat connector for checking connectivity between connectors and clusters.
   <!--#include virtual="generated/mirror_heartbeat_config.html" -->
 
-  <h3 class="anchor-heading"><a id="remotestorageconfigs" class="anchor-link"></a><a href="#remotestorageconfigs">3.9 Tier Storage Configs</a></h3>
-  Below is the configuration of Tier Storage.
-  <!--#include virtual="generated/remote_log_manager_config.html" -->
-  <!--#include virtual="generated/remote_log_metadata_manager_config.html" -->
-
-  <h3 class="anchor-heading"><a id="systemproperties" class="anchor-link"></a><a href="#systemproperties">3.10 System Properties</a></h3>
+  <h3 class="anchor-heading"><a id="systemproperties" class="anchor-link"></a><a href="#systemproperties">3.9 System Properties</a></h3>
   Kafka supports some configuration that can be enabled through Java system properties. System properties are usually set by passing the -D flag to the Java virtual machine in which Kafka components are running.
   Below are the supported system properties.
   <ul class="config-list">
@@ -308,6 +303,11 @@
       </tbody></table>
     </li>
   </ul>
+
+  <h3 class="anchor-heading"><a id="tieredstorageconfigs" class="anchor-link"></a><a href="#tieredstorageconfigs">3.10 Tiered Storage Configs</a></h3>
+  Below are the configuration properties for Tiered Storage.
+  <!--#include virtual="generated/remote_log_manager_config.html" -->
+  <!--#include virtual="generated/remote_log_metadata_manager_config.html" -->
 </script>
 
 <div class="p-configuration"></div>

--- a/docs/toc.html
+++ b/docs/toc.html
@@ -52,7 +52,8 @@
                 <li><a href="#streamsconfigs">3.6 Kafka Streams Configs</a>
                 <li><a href="#adminclientconfigs">3.7 AdminClient Configs</a>
                 <li><a href="#mirrormakerconfigs">3.8 MirrorMaker Configs</a>
-                <li><a href="#systemproperties">3.9 System Properties</a>
+                <li><a href="#remotestorageconfigs">3.9 Tier Storage Configs</a></li>
+                <li><a href="#systemproperties">3.10 System Properties</a>
             </ul>
         </li>
         <li><a href="#design">4. Design</a>

--- a/docs/toc.html
+++ b/docs/toc.html
@@ -52,8 +52,8 @@
                 <li><a href="#streamsconfigs">3.6 Kafka Streams Configs</a>
                 <li><a href="#adminclientconfigs">3.7 AdminClient Configs</a>
                 <li><a href="#mirrormakerconfigs">3.8 MirrorMaker Configs</a>
-                <li><a href="#remotestorageconfigs">3.9 Tier Storage Configs</a></li>
-                <li><a href="#systemproperties">3.10 System Properties</a>
+                <li><a href="#systemproperties">3.9 System Properties</a>
+                <li><a href="#tieredstorageconfigs">3.10 Tiered Storage Configs</a></li>
             </ul>
         </li>
         <li><a href="#design">4. Design</a>

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
@@ -49,26 +49,26 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
     public static final String REMOTE_LOG_METADATA_INITIALIZATION_RETRY_INTERVAL_MS_PROP = "remote.log.metadata.initialization.retry.interval.ms";
 
     public static final int DEFAULT_REMOTE_LOG_METADATA_TOPIC_PARTITIONS = 50;
-    public static final long DEFAULT_REMOTE_LOG_METADATA_TOPIC_RETENTION_MILLIS = -1L;
+    public static final long DEFAULT_REMOTE_LOG_METADATA_TOPIC_RETENTION_MS = -1L;
     public static final short DEFAULT_REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR = 3;
     public static final long DEFAULT_REMOTE_LOG_METADATA_CONSUME_WAIT_MS = 2 * 60 * 1000L;
     public static final long DEFAULT_REMOTE_LOG_METADATA_INITIALIZATION_RETRY_MAX_TIMEOUT_MS = 2 * 60 * 1000L;
     public static final long DEFAULT_REMOTE_LOG_METADATA_INITIALIZATION_RETRY_INTERVAL_MS = 5 * 1000L;
 
-    public static final String REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_DOC = "Replication factor of remote log metadata Topic.";
-    public static final String REMOTE_LOG_METADATA_TOPIC_PARTITIONS_DOC = "The number of partitions for remote log metadata Topic.";
-    public static final String REMOTE_LOG_METADATA_TOPIC_RETENTION_MS_DOC = "Remote log metadata topic log retention in milli seconds." +
+    public static final String REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_DOC = "Replication factor of remote log metadata topic.";
+    public static final String REMOTE_LOG_METADATA_TOPIC_PARTITIONS_DOC = "The number of partitions for remote log metadata topic.";
+    public static final String REMOTE_LOG_METADATA_TOPIC_RETENTION_MS_DOC = "Retention of remote log metadata topic in milliseconds. " +
             "Default: -1, that means unlimited. Users can configure this value based on their use cases. " +
             "To avoid any data loss, this value should be more than the maximum retention period of any topic enabled with " +
             "tiered storage in the cluster.";
-    public static final String REMOTE_LOG_METADATA_CONSUME_WAIT_MS_DOC = "The amount of time in milli seconds to wait for the local consumer to " +
+    public static final String REMOTE_LOG_METADATA_CONSUME_WAIT_MS_DOC = "The amount of time in milliseconds to wait for the local consumer to " +
             "receive the published event.";
-    public static final String REMOTE_LOG_METADATA_INITIALIZATION_RETRY_INTERVAL_MS_DOC = "The retry interval in milli seconds for " +
-            " retrying RemoteLogMetadataManager resources initialization again.";
+    public static final String REMOTE_LOG_METADATA_INITIALIZATION_RETRY_INTERVAL_MS_DOC = "The retry interval in milliseconds for " +
+            "retrying RemoteLogMetadataManager resources initialization again.";
 
-    public static final String REMOTE_LOG_METADATA_INITIALIZATION_RETRY_MAX_TIMEOUT_MS_DOC = "The maximum amount of time in milli seconds " +
-            " for retrying RemoteLogMetadataManager resources initialization. When total retry intervals reach this timeout, initialization" +
-            " is considered as failed and broker starts shutting down.";
+    public static final String REMOTE_LOG_METADATA_INITIALIZATION_RETRY_MAX_TIMEOUT_MS_DOC = "The maximum amount of time in milliseconds " +
+            "for retrying RemoteLogMetadataManager resources initialization. When total retry intervals reach this timeout, initialization " +
+            "is considered as failed and broker starts shutting down.";
 
     public static final String REMOTE_LOG_METADATA_COMMON_CLIENT_PREFIX = "remote.log.metadata.common.client.";
     public static final String REMOTE_LOG_METADATA_PRODUCER_PREFIX = "remote.log.metadata.producer.";
@@ -84,7 +84,7 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
                       REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_DOC)
               .define(REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP, INT, DEFAULT_REMOTE_LOG_METADATA_TOPIC_PARTITIONS, atLeast(1), LOW,
                       REMOTE_LOG_METADATA_TOPIC_PARTITIONS_DOC)
-              .define(REMOTE_LOG_METADATA_TOPIC_RETENTION_MS_PROP, LONG, DEFAULT_REMOTE_LOG_METADATA_TOPIC_RETENTION_MILLIS, LOW,
+              .define(REMOTE_LOG_METADATA_TOPIC_RETENTION_MS_PROP, LONG, DEFAULT_REMOTE_LOG_METADATA_TOPIC_RETENTION_MS, LOW,
                       REMOTE_LOG_METADATA_TOPIC_RETENTION_MS_DOC)
               .define(REMOTE_LOG_METADATA_CONSUME_WAIT_MS_PROP, LONG, DEFAULT_REMOTE_LOG_METADATA_CONSUME_WAIT_MS, atLeast(0), LOW,
                       REMOTE_LOG_METADATA_CONSUME_WAIT_MS_DOC)
@@ -243,5 +243,9 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
                 ", consumerProps=" + consumerProps +
                 ", producerProps=" + producerProps +
                 '}';
+    }
+
+    public static void main(String[] args) {
+        System.out.println(CONFIG.toHtml(4, config -> "remote_log_metadata_manager_" + config));
     }
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfig.java
@@ -56,8 +56,8 @@ public final class RemoteLogManagerConfig {
 
 
     public static final String REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP = "remote.log.storage.system.enable";
-    public static final String REMOTE_LOG_STORAGE_SYSTEM_ENABLE_DOC = "Whether to enable tier storage functionality in a broker or not. Valid values " +
-            "are `true` or `false` and the default value is false. When it is true broker starts all the services required for tiered storage functionality.";
+    public static final String REMOTE_LOG_STORAGE_SYSTEM_ENABLE_DOC = "Whether to enable tiered storage functionality in a broker or not. Valid values " +
+            "are `true` or `false` and the default value is false. When it is true broker starts all the services required for the tiered storage functionality.";
     public static final boolean DEFAULT_REMOTE_LOG_STORAGE_SYSTEM_ENABLE = false;
 
     public static final String REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP = "remote.log.storage.manager.class.name";
@@ -197,7 +197,7 @@ public final class RemoteLogManagerConfig {
                                   atLeast(0),
                                   LOW,
                                   REMOTE_LOG_METADATA_CUSTOM_METADATA_MAX_BYTES_DOC)
-                  .define(REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES_PROP,
+                  .defineInternal(REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES_PROP,
                                   LONG,
                                   DEFAULT_REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES,
                                   atLeast(1),
@@ -215,18 +215,18 @@ public final class RemoteLogManagerConfig {
                                   atLeast(1),
                                   LOW,
                                   REMOTE_LOG_MANAGER_TASK_INTERVAL_MS_DOC)
-                  .define(REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MS_PROP,
+                  .defineInternal(REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MS_PROP,
                                   LONG,
                                   DEFAULT_REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MS,
                                   atLeast(1),
                                   LOW,
                                   REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MS_DOC)
-                  .define(REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MAX_MS_PROP,
+                  .defineInternal(REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MAX_MS_PROP,
                                   LONG,
                                   DEFAULT_REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MAX_MS,
                                   atLeast(1), LOW,
                                   REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MAX_MS_DOC)
-                  .define(REMOTE_LOG_MANAGER_TASK_RETRY_JITTER_PROP,
+                  .defineInternal(REMOTE_LOG_MANAGER_TASK_RETRY_JITTER_PROP,
                                   DOUBLE,
                                   DEFAULT_REMOTE_LOG_MANAGER_TASK_RETRY_JITTER,
                                   between(0, 0.5),

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerConfig.java
@@ -64,20 +64,20 @@ public final class RemoteLogManagerConfig {
     public static final String REMOTE_STORAGE_MANAGER_CLASS_NAME_DOC = "Fully qualified class name of `RemoteLogStorageManager` implementation.";
 
     public static final String REMOTE_STORAGE_MANAGER_CLASS_PATH_PROP = "remote.log.storage.manager.class.path";
-    public static final String REMOTE_STORAGE_MANAGER_CLASS_PATH_DOC = "Class path of the `RemoteLogStorageManager` implementation." +
-            "If specified, the RemoteLogStorageManager implementation and its dependent libraries will be loaded by a dedicated" +
-            "classloader which searches this class path before the Kafka broker class path. The syntax of this parameter is same" +
-            "with the standard Java class path string.";
+    public static final String REMOTE_STORAGE_MANAGER_CLASS_PATH_DOC = "Class path of the `RemoteLogStorageManager` implementation. " +
+            "If specified, the RemoteLogStorageManager implementation and its dependent libraries will be loaded by a dedicated " +
+            "classloader which searches this class path before the Kafka broker class path. The syntax of this parameter is same " +
+            "as the standard Java class path string.";
 
     public static final String REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP = "remote.log.metadata.manager.class.name";
     public static final String REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_DOC = "Fully qualified class name of `RemoteLogMetadataManager` implementation.";
     public static final String DEFAULT_REMOTE_LOG_METADATA_MANAGER_CLASS_NAME = "org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager";
 
     public static final String REMOTE_LOG_METADATA_MANAGER_CLASS_PATH_PROP = "remote.log.metadata.manager.class.path";
-    public static final String REMOTE_LOG_METADATA_MANAGER_CLASS_PATH_DOC = "Class path of the `RemoteLogMetadataManager` implementation." +
-            "If specified, the RemoteLogMetadataManager implementation and its dependent libraries will be loaded by a dedicated" +
-            "classloader which searches this class path before the Kafka broker class path. The syntax of this parameter is same" +
-            "with the standard Java class path string.";
+    public static final String REMOTE_LOG_METADATA_MANAGER_CLASS_PATH_DOC = "Class path of the `RemoteLogMetadataManager` implementation. " +
+            "If specified, the RemoteLogMetadataManager implementation and its dependent libraries will be loaded by a dedicated " +
+            "classloader which searches this class path before the Kafka broker class path. The syntax of this parameter is same " +
+            "as the standard Java class path string.";
 
     public static final String REMOTE_LOG_METADATA_MANAGER_LISTENER_NAME_PROP = "remote.log.metadata.manager.listener.name";
     public static final String REMOTE_LOG_METADATA_MANAGER_LISTENER_NAME_DOC = "Listener name of the local broker to which it should get connected if " +
@@ -146,111 +146,111 @@ public final class RemoteLogManagerConfig {
     public static final ConfigDef CONFIG_DEF = new ConfigDef();
 
     static {
-        CONFIG_DEF.defineInternal(REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP,
+        CONFIG_DEF.define(REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP,
                                   BOOLEAN,
                                   DEFAULT_REMOTE_LOG_STORAGE_SYSTEM_ENABLE,
                                   null,
                                   MEDIUM,
                                   REMOTE_LOG_STORAGE_SYSTEM_ENABLE_DOC)
-                  .defineInternal(REMOTE_STORAGE_MANAGER_CONFIG_PREFIX_PROP,
+                  .define(REMOTE_STORAGE_MANAGER_CONFIG_PREFIX_PROP,
                                   STRING,
                                   DEFAULT_REMOTE_STORAGE_MANAGER_CONFIG_PREFIX,
                                   new ConfigDef.NonEmptyString(),
                                   MEDIUM,
                                   REMOTE_STORAGE_MANAGER_CONFIG_PREFIX_DOC)
-                  .defineInternal(REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP,
+                  .define(REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP,
                                   STRING,
                                   DEFAULT_REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX,
                                   new ConfigDef.NonEmptyString(),
                                   MEDIUM,
                                   REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_DOC)
-                  .defineInternal(REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, STRING,
+                  .define(REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, STRING,
                                   null,
                                   new ConfigDef.NonEmptyString(),
                                   MEDIUM,
                                   REMOTE_STORAGE_MANAGER_CLASS_NAME_DOC)
-                  .defineInternal(REMOTE_STORAGE_MANAGER_CLASS_PATH_PROP, STRING,
+                  .define(REMOTE_STORAGE_MANAGER_CLASS_PATH_PROP, STRING,
                                   null,
                                   new ConfigDef.NonEmptyString(),
                                   MEDIUM,
                                   REMOTE_STORAGE_MANAGER_CLASS_PATH_DOC)
-                  .defineInternal(REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP,
+                  .define(REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP,
                                   STRING,
                                   DEFAULT_REMOTE_LOG_METADATA_MANAGER_CLASS_NAME,
                                   new ConfigDef.NonEmptyString(),
                                   MEDIUM,
                                   REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_DOC)
-                  .defineInternal(REMOTE_LOG_METADATA_MANAGER_CLASS_PATH_PROP,
+                  .define(REMOTE_LOG_METADATA_MANAGER_CLASS_PATH_PROP,
                                   STRING,
                                   null,
                                   new ConfigDef.NonEmptyString(),
                                   MEDIUM,
                                   REMOTE_LOG_METADATA_MANAGER_CLASS_PATH_DOC)
-                  .defineInternal(REMOTE_LOG_METADATA_MANAGER_LISTENER_NAME_PROP, STRING,
+                  .define(REMOTE_LOG_METADATA_MANAGER_LISTENER_NAME_PROP, STRING,
                                   null,
                                   new ConfigDef.NonEmptyString(),
                                   MEDIUM,
                                   REMOTE_LOG_METADATA_MANAGER_LISTENER_NAME_DOC)
-                  .defineInternal(REMOTE_LOG_METADATA_CUSTOM_METADATA_MAX_BYTES_PROP,
+                  .define(REMOTE_LOG_METADATA_CUSTOM_METADATA_MAX_BYTES_PROP,
                                   INT,
                                   DEFAULT_REMOTE_LOG_METADATA_CUSTOM_METADATA_MAX_BYTES,
                                   atLeast(0),
                                   LOW,
                                   REMOTE_LOG_METADATA_CUSTOM_METADATA_MAX_BYTES_DOC)
-                  .defineInternal(REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES_PROP,
+                  .define(REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES_PROP,
                                   LONG,
                                   DEFAULT_REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES,
                                   atLeast(1),
                                   LOW,
                                   REMOTE_LOG_INDEX_FILE_CACHE_TOTAL_SIZE_BYTES_DOC)
-                  .defineInternal(REMOTE_LOG_MANAGER_THREAD_POOL_SIZE_PROP,
+                  .define(REMOTE_LOG_MANAGER_THREAD_POOL_SIZE_PROP,
                                   INT,
                                   DEFAULT_REMOTE_LOG_MANAGER_THREAD_POOL_SIZE,
                                   atLeast(1),
                                   MEDIUM,
                                   REMOTE_LOG_MANAGER_THREAD_POOL_SIZE_DOC)
-                  .defineInternal(REMOTE_LOG_MANAGER_TASK_INTERVAL_MS_PROP,
+                  .define(REMOTE_LOG_MANAGER_TASK_INTERVAL_MS_PROP,
                                   LONG,
                                   DEFAULT_REMOTE_LOG_MANAGER_TASK_INTERVAL_MS,
                                   atLeast(1),
                                   LOW,
                                   REMOTE_LOG_MANAGER_TASK_INTERVAL_MS_DOC)
-                  .defineInternal(REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MS_PROP,
+                  .define(REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MS_PROP,
                                   LONG,
                                   DEFAULT_REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MS,
                                   atLeast(1),
                                   LOW,
                                   REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MS_DOC)
-                  .defineInternal(REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MAX_MS_PROP,
+                  .define(REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MAX_MS_PROP,
                                   LONG,
                                   DEFAULT_REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MAX_MS,
                                   atLeast(1), LOW,
                                   REMOTE_LOG_MANAGER_TASK_RETRY_BACK_OFF_MAX_MS_DOC)
-                  .defineInternal(REMOTE_LOG_MANAGER_TASK_RETRY_JITTER_PROP,
+                  .define(REMOTE_LOG_MANAGER_TASK_RETRY_JITTER_PROP,
                                   DOUBLE,
                                   DEFAULT_REMOTE_LOG_MANAGER_TASK_RETRY_JITTER,
                                   between(0, 0.5),
                                   LOW,
                                   REMOTE_LOG_MANAGER_TASK_RETRY_JITTER_DOC)
-                  .defineInternal(REMOTE_LOG_READER_THREADS_PROP,
+                  .define(REMOTE_LOG_READER_THREADS_PROP,
                                   INT,
                                   DEFAULT_REMOTE_LOG_READER_THREADS,
                                   atLeast(1),
                                   MEDIUM,
                                   REMOTE_LOG_READER_THREADS_DOC)
-                  .defineInternal(REMOTE_LOG_READER_MAX_PENDING_TASKS_PROP,
+                  .define(REMOTE_LOG_READER_MAX_PENDING_TASKS_PROP,
                                   INT,
                                   DEFAULT_REMOTE_LOG_READER_MAX_PENDING_TASKS,
                                   atLeast(1),
                                   MEDIUM,
                                   REMOTE_LOG_READER_MAX_PENDING_TASKS_DOC)
-                  .defineInternal(LOG_LOCAL_RETENTION_MS_PROP,
+                  .define(LOG_LOCAL_RETENTION_MS_PROP,
                                   LONG,
                                   DEFAULT_LOG_LOCAL_RETENTION_MS,
                                   atLeast(DEFAULT_LOG_LOCAL_RETENTION_MS),
                                   MEDIUM,
                                   LOG_LOCAL_RETENTION_MS_DOC)
-                  .defineInternal(LOG_LOCAL_RETENTION_BYTES_PROP,
+                  .define(LOG_LOCAL_RETENTION_BYTES_PROP,
                                   LONG,
                                   DEFAULT_LOG_LOCAL_RETENTION_BYTES,
                                   atLeast(DEFAULT_LOG_LOCAL_RETENTION_BYTES),
@@ -456,5 +456,9 @@ public final class RemoteLogManagerConfig {
                             remoteLogManagerTaskRetryBackoffMs, remoteLogManagerTaskRetryBackoffMaxMs, remoteLogManagerTaskRetryJitter,
                             remoteLogReaderThreads, remoteLogReaderMaxPendingTasks, remoteStorageManagerProps, remoteLogMetadataManagerProps,
                             remoteStorageManagerPrefix, remoteLogMetadataManagerPrefix);
+    }
+
+    public static void main(String[] args) {
+        System.out.println(CONFIG_DEF.toHtml(4, config -> "remote_log_manager_" + config));
     }
 }


### PR DESCRIPTION
- Make RemoteLogManagerConfigs that are implemented public
- Add tasks to generate html docs for the configs
- Include config docs in the main site

![Screenshot 2023-08-25 at 11 08 28](https://github.com/apache/kafka/assets/39860586/e75722a3-8197-4345-b165-02fd68243190)
![Screenshot 2023-08-25 at 11 14 50](https://github.com/apache/kafka/assets/39860586/26527d9d-99cb-41b8-84f5-39432a6625cf)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
