### PR TITLE
KAFKA-14936: fix grace period partition issue

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoin.java
@@ -20,7 +20,6 @@ import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
-import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -32,24 +31,24 @@ class KStreamKTableJoin<K, V1, V2, VOut> implements ProcessorSupplier<K, V1, K, 
     private final ValueJoinerWithKey<? super K, ? super V1, ? super V2, VOut> joiner;
     private final boolean leftJoin;
     private final Optional<Duration> gracePeriod;
-    private final Optional<TimeOrderedKeyValueBuffer<K, V1, V1>> buffer;
+    private final Optional<String> storeName;
 
 
     KStreamKTableJoin(final KTableValueGetterSupplier<K, V2> valueGetterSupplier,
                       final ValueJoinerWithKey<? super K, ? super V1, ? super V2, VOut> joiner,
                       final boolean leftJoin,
                       final Optional<Duration> gracePeriod,
-                      final Optional<TimeOrderedKeyValueBuffer<K, V1, V1>> buffer) {
+                      final Optional<String> storeName) {
         this.valueGetterSupplier = valueGetterSupplier;
         this.joiner = joiner;
         this.leftJoin = leftJoin;
         this.gracePeriod = gracePeriod;
-        this.buffer = buffer;
+        this.storeName = storeName;
     }
 
     @Override
     public Processor<K, V1, K, VOut> get() {
-        return new KStreamKTableJoinProcessor<>(valueGetterSupplier.get(), keyValueMapper, joiner, leftJoin, gracePeriod, buffer);
+        return new KStreamKTableJoinProcessor<>(valueGetterSupplier.get(), keyValueMapper, joiner, leftJoin, gracePeriod, storeName);
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
@@ -86,7 +86,7 @@ class KStreamKTableJoinProcessor<K1, K2, V1, V2, VOut> extends ContextualProcess
             buffer = new RocksDBTimeOrderedKeyValueBuffer<>(
                 requireNonNull(context.getStateStore(storeName)),
                 gracePeriod.orElse(Duration.ZERO),
-                ((org.apache.kafka.streams.processor.ProcessorContext) context).topic(),
+                internalProcessorContext.topic(),
                 true);
             buffer.setSerdesIfNull(new SerdeGetter(context));
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
@@ -29,6 +29,7 @@ import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.internals.RocksDBTimeOrderedKeyValueBuffer;
 import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.Optional;
 
+import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
@@ -49,27 +51,25 @@ class KStreamKTableJoinProcessor<K1, K2, V1, V2, VOut> extends ContextualProcess
     private final boolean leftJoin;
     private Sensor droppedRecordsSensor;
     private final Optional<Duration> gracePeriod;
-    private final Optional<TimeOrderedKeyValueBuffer<K1, V1, V1>> buffer;
+    private TimeOrderedKeyValueBuffer<K1, V1, V1> buffer;
     protected long observedStreamTime = ConsumerRecord.NO_TIMESTAMP;
     private InternalProcessorContext internalProcessorContext;
     private final boolean useBuffer;
+    private final String storeName;
 
     KStreamKTableJoinProcessor(final KTableValueGetter<K2, V2> valueGetter,
                                final KeyValueMapper<? super K1, ? super V1, ? extends K2> keyMapper,
                                final ValueJoinerWithKey<? super K1, ? super V1, ? super V2, ? extends VOut> joiner,
                                final boolean leftJoin,
                                final Optional<Duration> gracePeriod,
-                               final Optional<TimeOrderedKeyValueBuffer<K1, V1, V1>> buffer) {
+                               final Optional<String> storeName) {
         this.valueGetter = valueGetter;
         this.keyMapper = keyMapper;
         this.joiner = joiner;
         this.leftJoin = leftJoin;
-        this.useBuffer = buffer.isPresent();
-        if (gracePeriod.isPresent() ^ buffer.isPresent()) {
-            throw new IllegalArgumentException("Grace Period requires a buffer");
-        }
+        this.useBuffer = gracePeriod.isPresent();
         this.gracePeriod = gracePeriod;
-        this.buffer = buffer;
+        this.storeName = storeName.orElse("");
     }
 
     @Override
@@ -83,9 +83,12 @@ class KStreamKTableJoinProcessor<K1, K2, V1, V2, VOut> extends ContextualProcess
             if (!valueGetter.isVersioned() && gracePeriod.isPresent()) {
                 throw new IllegalArgumentException("KTable must be versioned to use a grace period in a stream table join.");
             }
-
-            buffer.get().setSerdesIfNull(new SerdeGetter(context));
-            buffer.get().init((org.apache.kafka.streams.processor.StateStoreContext) context(), null);
+            buffer = new RocksDBTimeOrderedKeyValueBuffer<>(
+                requireNonNull(context.getStateStore(storeName)),
+                gracePeriod.orElse(Duration.ZERO),
+                ((org.apache.kafka.streams.processor.ProcessorContext) context).topic(),
+                true);
+            buffer.setSerdesIfNull(new SerdeGetter(context));
         }
     }
 
@@ -100,10 +103,10 @@ class KStreamKTableJoinProcessor<K1, K2, V1, V2, VOut> extends ContextualProcess
         if (!useBuffer) {
             doJoin(record);
         } else {
-            if (!buffer.get().put(observedStreamTime, record, internalProcessorContext.recordContext())) {
+            if (!buffer.put(observedStreamTime, record, internalProcessorContext.recordContext())) {
                 doJoin(record);
             } else {
-                buffer.get().evictWhile(() -> true, this::emit);
+                buffer.evictWhile(() -> true, this::emit);
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
@@ -29,7 +29,6 @@ import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
-import org.apache.kafka.streams.state.internals.RocksDBTimeOrderedKeyValueBuffer;
 import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,11 +82,7 @@ class KStreamKTableJoinProcessor<K1, K2, V1, V2, VOut> extends ContextualProcess
             if (!valueGetter.isVersioned() && gracePeriod.isPresent()) {
                 throw new IllegalArgumentException("KTable must be versioned to use a grace period in a stream table join.");
             }
-            buffer = new RocksDBTimeOrderedKeyValueBuffer<>(
-                requireNonNull(context.getStateStore(storeName)),
-                gracePeriod.orElse(Duration.ZERO),
-                internalProcessorContext.topic(),
-                true);
+            buffer = requireNonNull(context.getStateStore(storeName));
             buffer.setSerdesIfNull(new SerdeGetter(context));
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamTableJoinNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamTableJoinNode.java
@@ -22,6 +22,7 @@ import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * Represents a join between a KStream and a KTable or GlobalKTable
@@ -33,13 +34,15 @@ public class StreamTableJoinNode<K, V> extends GraphNode {
     private final ProcessorParameters<K, V, ?, ?> processorParameters;
     private final String otherJoinSideNodeName;
     private final Duration gracePeriod;
+    private final Optional<String> bufferName;
 
 
     public StreamTableJoinNode(final String nodeName,
                                final ProcessorParameters<K, V, ?, ?> processorParameters,
                                final String[] storeNames,
                                final String otherJoinSideNodeName,
-                               final Duration gracePeriod) {
+                               final Duration gracePeriod,
+                               final Optional<String> bufferName) {
         super(nodeName);
 
         // in the case of Stream-Table join the state stores associated with the KTable
@@ -47,6 +50,7 @@ public class StreamTableJoinNode<K, V> extends GraphNode {
         this.processorParameters = processorParameters;
         this.otherJoinSideNodeName = otherJoinSideNodeName;
         this.gracePeriod = gracePeriod;
+        this.bufferName = bufferName;
     }
 
     @Override
@@ -69,6 +73,7 @@ public class StreamTableJoinNode<K, V> extends GraphNode {
         // Steam - KTable join only
         if (otherJoinSideNodeName != null) {
             topologyBuilder.connectProcessorAndStateStores(processorName, storeNames);
+            bufferName.ifPresent(s -> topologyBuilder.connectProcessorAndStateStores(processorName, s));
             if (gracePeriod != null) {
                 for (final String storeName : storeNames) {
                     if (!topologyBuilder.isStoreVersioned(storeName)) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
@@ -44,10 +44,11 @@ import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
-public class RocksDBTimeOrderedKeyValueBuffer<K, V> extends WrappedStateStore<RocksDBTimeOrderedKeyValueBytesStore, Object, Object> implements TimeOrderedKeyValueBuffer<K, V, V> {
+public class RocksDBTimeOrderedKeyValueBuffer<K, V> implements TimeOrderedKeyValueBuffer<K, V, V> {
     private static final BytesSerializer KEY_SERIALIZER = new BytesSerializer();
     private static final ByteArraySerializer VALUE_SERIALIZER = new ByteArraySerializer();
     private final long gracePeriod;
+    private final RocksDBTimeOrderedKeyValueBytesStore store;
     private long bufferSize;
     private long minTimestamp;
     private int numRecords;
@@ -141,7 +142,7 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V> extends WrappedStateStore<Ro
                                             final Duration gracePeriod,
                                             final String topic,
                                             final boolean loggingEnabled) {
-        super(store);
+        this.store = store;
         this.gracePeriod = gracePeriod.toMillis();
         minTimestamp = store.minTimestamp();
         minValid = false;
@@ -157,27 +158,57 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V> extends WrappedStateStore<Ro
     public void setSerdesIfNull(final SerdeGetter getter) {
         keySerde = keySerde == null ? (Serde<K>) getter.keySerde() : keySerde;
         valueSerde = valueSerde == null ? getter.valueSerde() : valueSerde;
-        this.context = ProcessorContextUtils.asInternalProcessorContext(wrapped().context);
-        partition = context.taskId().partition();
-        if (loggingEnabled) {
-            changelogTopic = ProcessorContextUtils.changelogFor((ProcessorContext) context, name(), Boolean.TRUE);
-        }
+    }
+
+    /**
+     * The name of this store.
+     *
+     * @return the storage name
+     */
+    @Override
+    public String name() {
+        return store.name();
     }
 
     @Deprecated
     @Override
     public void init(final ProcessorContext context, final StateStore root) {
-        wrapped().init(context, wrapped());
-    }
-
-    @Override
-    public void init(final StateStoreContext context, final StateStore root) {
-        wrapped().init(context, wrapped());
+        store.init(context, root);
         this.context = ProcessorContextUtils.asInternalProcessorContext(context);
         partition = context.taskId().partition();
         if (loggingEnabled) {
             changelogTopic = ProcessorContextUtils.changelogFor(context, name(), Boolean.TRUE);
         }
+    }
+
+    @Override
+    public void init(final StateStoreContext context, final StateStore root) {
+        store.init(context, root);
+        this.context = ProcessorContextUtils.asInternalProcessorContext(context);
+        partition = context.taskId().partition();
+        if (loggingEnabled) {
+            changelogTopic = ProcessorContextUtils.changelogFor(context, name(), Boolean.TRUE);
+        }
+    }
+
+    @Override
+    public void flush() {
+        store.flush();
+    }
+
+    @Override
+    public void close() {
+        store.close();
+    }
+
+    @Override
+    public boolean persistent() {
+        return store.persistent();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return store.isOpen();
     }
 
     @Override
@@ -189,8 +220,8 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V> extends WrappedStateStore<Ro
             if (minValid) {
                 start = minTimestamp();
             }
-            try (final KeyValueIterator<Bytes, byte[]> iterator = wrapped()
-                .fetchAll(start, wrapped().observedStreamTime - gracePeriod)) {
+            try (final KeyValueIterator<Bytes, byte[]> iterator = store
+                .fetchAll(start, store.observedStreamTime - gracePeriod)) {
                 while (iterator.hasNext() && predicate.get()) {
                     keyValue = iterator.next();
 
@@ -211,7 +242,7 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V> extends WrappedStateStore<Ro
 
                     callback.accept(new Eviction<>(key, value, bufferValue.context()));
 
-                    wrapped().remove(keyValue.key);
+                    store.remove(keyValue.key);
 
                     if (loggingEnabled) {
                         logTombstone(keyValue.key);
@@ -223,7 +254,7 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V> extends WrappedStateStore<Ro
                 if (numRecords == 0) {
                     minTimestamp = Long.MAX_VALUE;
                 } else {
-                    minTimestamp = wrapped().observedStreamTime - gracePeriod + 1;
+                    minTimestamp = store.observedStreamTime - gracePeriod + 1;
                 }
             }
         }
@@ -240,7 +271,7 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V> extends WrappedStateStore<Ro
         requireNonNull(record.value(), "value cannot be null");
         requireNonNull(record.key(), "key cannot be null");
         requireNonNull(recordContext, "recordContext cannot be null");
-        if (wrapped().observedStreamTime - gracePeriod > record.timestamp()) {
+        if (store.observedStreamTime - gracePeriod > record.timestamp()) {
             return false;
         }
         maybeUpdateSeqnumForDups();
@@ -250,7 +281,7 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V> extends WrappedStateStore<Ro
                 seqnum).get());
         final byte[] valueBytes = valueSerde.serializer().serialize(topic, record.value());
         final BufferValue buffered = new BufferValue(null, null, valueBytes, recordContext);
-        wrapped().put(serializedKey, buffered.serialize(0).array());
+        store.put(serializedKey, buffered.serialize(0).array());
 
         if (loggingEnabled) {
             final BufferKey key = new BufferKey(0L, serializedKey);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
@@ -310,7 +310,6 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V> extends WrappedStateStore<Ro
     }
 
     private void logTombstone(final Bytes key) {
-        this.context = ProcessorContextUtils.asInternalProcessorContext(wrapped().context);
         ((RecordCollector.Supplier) context).recordCollector().send(
             changelogTopic,
             key,

--- a/streams/src/test/java/org/apache/kafka/streams/integration/JoinGracePeriodDurabilityIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/JoinGracePeriodDurabilityIntegrationTest.java
@@ -125,10 +125,9 @@ public class JoinGracePeriodDurabilityIntegrationTest {
         final String storeName = "grace";
         final String output = "output" + testId;
 
-        // change this once task bug fixed.
         // create multiple partitions as a trap, in case the buffer doesn't properly set the
         // partition on the records, but instead relies on the default key partitioner
-        cleanStateBeforeTest(CLUSTER, 1, streamInput, tableInput, output);
+        cleanStateBeforeTest(CLUSTER, 2, streamInput, tableInput, output);
 
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<String, String> stream = builder.stream(streamInput, Consumed.with(STRING_SERDE, STRING_SERDE));
@@ -165,7 +164,8 @@ public class JoinGracePeriodDurabilityIntegrationTest {
                     new KeyValueTimestamp<>("k2", "v2", scaledTime(0L)),
                     new KeyValueTimestamp<>("k3", "v3", scaledTime(0L)),
                     new KeyValueTimestamp<>("k4", "v4", scaledTime(0L)),
-                    new KeyValueTimestamp<>("k5", "v5", scaledTime(0L))
+                    new KeyValueTimestamp<>("k5", "v5", scaledTime(0L)),
+                    new KeyValueTimestamp<>("k6", "v6", scaledTime(0L))
                 )
             );
             produceSynchronouslyToPartitionZero(
@@ -213,10 +213,11 @@ public class JoinGracePeriodDurabilityIntegrationTest {
                 output,
                 asList(
                     new KeyValueTimestamp<>("k4", "v4+v4", scaledTime(4L)),
-                    new KeyValueTimestamp<>("k5", "v5+v5", scaledTime(5L))
-                )
+                    new KeyValueTimestamp<>("k5", "v5+v5", scaledTime(5L)),
+                    new KeyValueTimestamp<>("k3", "v3+v3", scaledTime(7L))
+                    )
             );
-            assertThat("There should only be 4 output events.", eventCount.get(), is(4));
+            assertThat("There should only be 5 output events.", eventCount.get(), is(5));
 
         } finally {
             driver.close();


### PR DESCRIPTION
Move the store creation to builder pattern and recover mintimestamp.

Also fix a flaky test for this feature.

The test was flaky because the mintimestamp wasn't being recovered from store properly.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
