### PR TITLE
MINOR: Move delegation token support to Metadata Version 3.6-IV2

### DIFF
--- a/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
+++ b/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
@@ -117,6 +117,6 @@ public class ClusterTestExtensionsTest {
 
     @ClusterTest
     public void testDefaults(ClusterConfig config) {
-        Assertions.assertEquals(MetadataVersion.IBP_3_6_IV1, config.metadataVersion());
+        Assertions.assertEquals(MetadataVersion.IBP_3_6_IV2, config.metadataVersion());
     }
 }

--- a/core/src/test/java/kafka/test/annotation/ClusterTest.java
+++ b/core/src/test/java/kafka/test/annotation/ClusterTest.java
@@ -41,6 +41,6 @@ public @interface ClusterTest {
     String name() default "";
     SecurityProtocol securityProtocol() default SecurityProtocol.PLAINTEXT;
     String listener() default "";
-    MetadataVersion metadataVersion() default MetadataVersion.IBP_3_6_IV1;
+    MetadataVersion metadataVersion() default MetadataVersion.IBP_3_6_IV2;
     ClusterConfigProperty[] serverProperties() default {};
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -158,7 +158,7 @@ public class QuorumControllerTest {
         ) {
             controlEnv.activeController().registerBroker(ANONYMOUS_CONTEXT,
                 new BrokerRegistrationRequestData().
-                setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_6_IV1)).
+                setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_6_IV2)).
                 setBrokerId(0).
                 setClusterId(logEnv.clusterId())).get();
             testConfigurationOperations(controlEnv.activeController());
@@ -199,7 +199,7 @@ public class QuorumControllerTest {
         ) {
             controlEnv.activeController().registerBroker(ANONYMOUS_CONTEXT,
                 new BrokerRegistrationRequestData().
-                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_6_IV1)).
+                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_6_IV2)).
                     setBrokerId(0).
                     setClusterId(logEnv.clusterId())).get();
             testDelayedConfigurationOperations(logEnv, controlEnv.activeController());
@@ -536,7 +536,7 @@ public class QuorumControllerTest {
                     setBrokerId(0).
                     setClusterId(active.clusterId()).
                     setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwBA")).
-                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_6_IV1)).
+                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_6_IV2)).
                     setListeners(listeners));
             assertEquals(3L, reply.get().epoch());
             CreateTopicsRequestData createTopicsRequestData =

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -179,8 +179,11 @@ public enum MetadataVersion {
     // Remove leader epoch bump when KRaft controller shrinks the ISR (KAFKA-15021)
     IBP_3_6_IV0(12, "3.6", "IV0", false),
 
-    // Add metadata transactions and KRaft support for Delegation Tokens
-    IBP_3_6_IV1(13, "3.6", "IV1", true);
+    // Add metadata transactions
+    IBP_3_6_IV1(13, "3.6", "IV1", true),
+
+    // Add KRaft support for Delegation Tokens
+    IBP_3_6_IV2(14, "3.6", "IV2", true);
 
     // NOTE: update the default version in @ClusterTest annotation to point to the latest version
     public static final String FEATURE_NAME = "metadata.version";
@@ -275,7 +278,7 @@ public enum MetadataVersion {
     }
 
     public boolean isDelegationTokenSupported() {
-        return this.isAtLeast(IBP_3_6_IV1);
+        return this.isAtLeast(IBP_3_6_IV2);
     }
 
     public boolean isKRaftSupported() {

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -185,7 +185,9 @@ public enum MetadataVersion {
     // Add KRaft support for Delegation Tokens
     IBP_3_6_IV2(14, "3.6", "IV2", true);
 
-    // NOTE: update the default version in @ClusterTest annotation to point to the latest version
+    // NOTES when adding a new version:
+    //   Update the default version in @ClusterTest annotation to point to the latest version
+    //   Change expected message in org.apache.kafka.tools.FeatureCommandTest in multiple places (search for "Change expected message")
     public static final String FEATURE_NAME = "metadata.version";
 
     /**

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -163,6 +163,7 @@ class MetadataVersionTest {
 
         assertEquals(IBP_3_6_IV0, MetadataVersion.fromVersionString("3.6-IV0"));
         assertEquals(IBP_3_6_IV1, MetadataVersion.fromVersionString("3.6-IV1"));
+        assertEquals(IBP_3_6_IV2, MetadataVersion.fromVersionString("3.6-IV2"));
     }
 
     @Test
@@ -216,6 +217,7 @@ class MetadataVersionTest {
         assertEquals("3.5", IBP_3_5_IV2.shortVersion());
         assertEquals("3.6", IBP_3_6_IV0.shortVersion());
         assertEquals("3.6", IBP_3_6_IV1.shortVersion());
+        assertEquals("3.6", IBP_3_6_IV2.shortVersion());
     }
 
     @Test
@@ -258,6 +260,7 @@ class MetadataVersionTest {
         assertEquals("3.5-IV2", IBP_3_5_IV2.version());
         assertEquals("3.6-IV0", IBP_3_6_IV0.version());
         assertEquals("3.6-IV1", IBP_3_6_IV1.version());
+        assertEquals("3.6-IV2", IBP_3_6_IV2.version());
     }
 
     @Test
@@ -312,7 +315,7 @@ class MetadataVersionTest {
     @ParameterizedTest
     @EnumSource(value = MetadataVersion.class)
     public void testIsDelegationTokenSupported(MetadataVersion metadataVersion) {
-        assertEquals(metadataVersion.isAtLeast(IBP_3_6_IV1),
+        assertEquals(metadataVersion.isAtLeast(IBP_3_6_IV2),
             metadataVersion.isDelegationTokenSupported());
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -66,8 +66,9 @@ public class FeatureCommandTest {
         String commandOutput = ToolsTestUtils.captureStandardOut(() ->
                 assertEquals(0, FeatureCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(), "describe"))
         );
+        // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 3.6-IV1\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(commandOutput));
+                "SupportedMaxVersion: 3.6-IV2\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(commandOutput));
     }
 
     @ClusterTest(clusterType = Type.ZK, metadataVersion = MetadataVersion.IBP_3_3_IV1)
@@ -124,8 +125,9 @@ public class FeatureCommandTest {
                 assertEquals(1, FeatureCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(),
                         "disable", "--feature", "metadata.version"))
         );
+        // Change expected message to reflect possible MetadataVersion range 1-N (N increases when adding a new version)
         assertEquals("Could not disable metadata.version. Invalid update version 0 for feature " +
-                "metadata.version. Local controller 3000 only supports versions 1-13", commandOutput);
+                "metadata.version. Local controller 3000 only supports versions 1-14", commandOutput);
 
         commandOutput = ToolsTestUtils.captureStandardOut(() ->
                 assertEquals(1, FeatureCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(),


### PR DESCRIPTION
https://github.com/apache/kafka/pull/14083 added support for delegation tokens in KRaft and attached that support to the existing MetadataVersion `3.6-IV1`.  This patch moves that support into a separate MetadataVersion `3.6-IV2`.

This must be merged to `3.6` as well as `trunk`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
