### PR TITLE
MINOR: Missing space in ProducerStateManager LogContext

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -141,7 +141,7 @@ public class ProducerStateManager {
         this.maxTransactionTimeoutMs = maxTransactionTimeoutMs;
         this.producerStateManagerConfig = producerStateManagerConfig;
         this.time = time;
-        log = new LogContext("[ProducerStateManager partition=" + topicPartition + "]").logger(ProducerStateManager.class);
+        log = new LogContext("[ProducerStateManager partition=" + topicPartition + "] ").logger(ProducerStateManager.class);
         snapshots = loadSnapshots();
     }
 


### PR DESCRIPTION
Currently this produces log lines like:
```
INFO [ProducerStateManager partition=connect-status-1]Wrote producer snapshot at offset 2 with 0 producer ids in 19 ms. (org.apache.kafka.storage.internals.log.ProducerStateManager)
```

Ideally LogContext should add a space to separate the context from the message instead of having to put a trailing space in each context string. But we have trailing spaces in all the codebase, so just adding the missing space here.

I spotted a few other missing spaces but only in tests. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
