### PR TITLE
KAFKA-15392: Prevent shadowing RestServer shutdown exceptions

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -348,11 +348,13 @@ public abstract class RestServer {
         log.info("Stopping REST server");
 
         try {
-            for (Handler handler : handlers.getHandlers()) {
-                try {
-                    handler.stop();
-                } catch (Exception e) {
-                    log.warn("Error while stopping " + handler, e);
+            if (handlers.isRunning()) {
+                for (Handler handler : handlers.getHandlers()) {
+                    try {
+                        handler.stop();
+                    } catch (Exception e) {
+                        log.warn("Error while stopping " + handler, e);
+                    }
                 }
             }
             for (ConnectRestExtension connectRestExtension : connectRestExtensions) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -350,10 +350,8 @@ public abstract class RestServer {
         try {
             if (handlers.isRunning()) {
                 for (Handler handler : handlers.getHandlers()) {
-                    try {
-                        handler.stop();
-                    } catch (Exception e) {
-                        log.warn("Error while stopping " + handler, e);
+                    if (handler != null) {
+                        Utils.closeQuietly(handler::stop, handler.toString());
                     }
                 }
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -348,6 +348,13 @@ public abstract class RestServer {
         log.info("Stopping REST server");
 
         try {
+            for (Handler handler : handlers.getHandlers()) {
+                try {
+                    handler.stop();
+                } catch (Exception e) {
+                    log.warn("Error while stopping " + handler, e);
+                }
+            }
             for (ConnectRestExtension connectRestExtension : connectRestExtensions) {
                 try {
                     connectRestExtension.close();
@@ -358,8 +365,13 @@ public abstract class RestServer {
             jettyServer.stop();
             jettyServer.join();
         } catch (Exception e) {
-            jettyServer.destroy();
             throw new ConnectException("Unable to stop REST server", e);
+        } finally {
+            try {
+                jettyServer.destroy();
+            } catch (Exception e) {
+                log.error("Unable to destroy REST server", e);
+            }
         }
 
         log.info("REST server stopped");


### PR DESCRIPTION
The ServletContextHandlers which are initialized and started in `initializeResources()` are never stopped, causing Jetty's Server#destroy() call to always throw an exception. When another exception is thrown, that exception is always shadowed by the exception from the destroy() call, making it harder to diagnose failures.

Additionally, destroy() should be called on the happy-path, in order to perform cleanup of the jetty resources.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
