### PR TITLE
KAFKA-15393: Improve shutdown behavior in MM2 integration tests

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -262,8 +262,6 @@ public class MirrorConnectorsIntegrationBaseTest {
             for (String x : backup.connectors()) {
                 backup.deleteConnector(x);
             }
-            deleteAllTopics(primary.kafka());
-            deleteAllTopics(backup.kafka());
         } finally {
             shuttingDown = true;
             try {
@@ -1049,17 +1047,6 @@ public class MirrorConnectorsIntegrationBaseTest {
         }
     }
 
-    /*
-     * delete all topics of the input kafka cluster
-     */
-    private static void deleteAllTopics(EmbeddedKafkaCluster cluster) throws Exception {
-        try (final Admin adminClient = cluster.createAdminClient()) {
-            Set<String> topicsToBeDeleted = adminClient.listTopics().names().get();
-            log.debug("Deleting topics: {} ", topicsToBeDeleted);
-            adminClient.deleteTopics(topicsToBeDeleted).all().get();
-        }
-    }
-    
     /*
      * retrieve the config value based on the input cluster, topic and config name
      */


### PR DESCRIPTION
The MirrorConnectorsIntegrationBaseTest and derived tests delete all of the topics after the test is complete, but before the EmbeddedConnectCluster (and EmbeddedKafkaCluster) are stopped. If a topic is deleted before the source task can stop (usually the MirrorHeartbeatTask), the task will get stuck and eventually be cancelled. The worker itself also appears to get stuck on accesses to the internal topics, which must time out before the worker will stop.

This has the effect of making the test runtime inconsistent, and sometimes extremely slow. With this patch applied and a very small sample size, I saw speedups of up to 8x for individual test methods, and ~2x for the suite overall. On my machine a single suite is now <5 minutes and `connect:mirror:test` completes in <10 minutes.

Because the EmbeddedConnectCluster is created fresh in the startClusters command, deleting the topics has no effect on the behavior of the tests, only the time it takes to clean them up. We can just eliminate the deletion step completely, and discard the contents of the topics by discarding the whole EmbeddedKafkaCluster instance.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
