### PR TITLE
KAFKA-15179: Add integration tests for the file sink and source connectors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2900,6 +2900,10 @@ project(':connect:file') {
 
     testRuntimeOnly libs.slf4jlog4j
     testImplementation project(':clients').sourceSets.test.output
+    testImplementation project(':connect:runtime')
+    testImplementation project(':connect:runtime').sourceSets.test.output
+    testImplementation project(':core')
+    testImplementation project(':core').sourceSets.test.output
   }
 
   javadoc {

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSinkConnectorIntegrationTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSinkConnectorIntegrationTest.java
@@ -49,7 +49,7 @@ public class FileStreamSinkConnectorIntegrationTest {
 
     private static final String CONNECTOR_NAME = "test-connector";
     private static final String TOPIC = "test-topic";
-    private static final String MESSAGE_FORMAT = "Message %d";
+    private static final String MESSAGE_PREFIX = "Message ";
     private static final int NUM_MESSAGES = 5;
     private static final String FILE_NAME = "test-file";
     private final EmbeddedConnectCluster connect = new EmbeddedConnectCluster.Builder().build();
@@ -155,7 +155,7 @@ public class FileStreamSinkConnectorIntegrationTest {
 
     private void produceMessagesToTopic(String topic, int numMessages) {
         for (int i = 0; i < numMessages; i++) {
-            connect.kafka().produce(topic, String.format(MESSAGE_FORMAT, i));
+            connect.kafka().produce(topic, MESSAGE_PREFIX + i);
         }
     }
 
@@ -168,9 +168,11 @@ public class FileStreamSinkConnectorIntegrationTest {
     }
 
     /**
-     * Verify that the number of lines in the file at {@code filePath} is equal to {@code numLines}.
-     * If {@code verifyLinearity} is true, this method will also verify that the lines match {@link #MESSAGE_FORMAT}
-     * with a linearly increasing message number (beginning with 0).
+     * Verify that the number of lines in the file at {@code filePath} is equal to {@code numLines} and that they all begin with the
+     * prefix {@link #MESSAGE_PREFIX}.
+     * <p>
+     * If {@code verifyLinearity} is true, this method will also verify that the lines also have a linearly increasing message number
+     * (beginning with 0) after the prefix.
      *
      * @param filePath the file path
      * @param numLines the expected number of lines in the file
@@ -185,9 +187,9 @@ public class FileStreamSinkConnectorIntegrationTest {
                         return false;
                     }
                     if (verifyLinearity) {
-                        assertEquals(String.format(MESSAGE_FORMAT, i), line);
+                        assertEquals(MESSAGE_PREFIX + i, line);
                     } else {
-                        assertTrue(line.startsWith(MESSAGE_FORMAT));
+                        assertTrue(line.startsWith(MESSAGE_PREFIX));
                     }
                 }
                 return true;

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSinkConnectorIntegrationTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSinkConnectorIntegrationTest.java
@@ -16,10 +16,8 @@
  */
 package org.apache.kafka.connect.file.integration;
 
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.file.FileStreamSinkConnector;
-import org.apache.kafka.connect.runtime.rest.entities.ConnectorOffset;
-import org.apache.kafka.connect.runtime.rest.entities.ConnectorOffsets;
-import org.apache.kafka.connect.util.SinkUtils;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -32,9 +30,7 @@ import java.io.File;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.apache.kafka.connect.file.FileStreamSinkConnector.FILE_CONFIG;
@@ -93,13 +89,7 @@ public class FileStreamSinkConnectorIntegrationTest {
         connect.assertions().assertConnectorIsStopped(CONNECTOR_NAME, "Connector did not stop in time");
 
         // Alter the offsets to cause the last message in the topic to be re-processed
-        Map<String, Object> partition = new HashMap<>();
-        partition.put(SinkUtils.KAFKA_TOPIC_KEY, TOPIC);
-        partition.put(SinkUtils.KAFKA_PARTITION_KEY, 0);
-        Map<String, Object> offset = Collections.singletonMap(SinkUtils.KAFKA_OFFSET_KEY, NUM_MESSAGES - 1);
-        List<ConnectorOffset> offsetsToAlter = Collections.singletonList(new ConnectorOffset(partition, offset));
-
-        connect.alterConnectorOffsets(CONNECTOR_NAME, new ConnectorOffsets(offsetsToAlter));
+        connect.alterSinkConnectorOffset(CONNECTOR_NAME, new TopicPartition(TOPIC, 0), (long) (NUM_MESSAGES - 1));
 
         connect.resumeConnector(CONNECTOR_NAME);
         connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 1,

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSinkConnectorIntegrationTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSinkConnectorIntegrationTest.java
@@ -162,7 +162,7 @@ public class FileStreamSinkConnectorIntegrationTest {
      * Verify that the number of lines in the file at {@code filePath} is equal to {@code numLines} and that they all begin with the
      * prefix {@link #MESSAGE_PREFIX}.
      * <p>
-     * If {@code verifyLinearity} is true, this method will also verify that the lines also have a linearly increasing message number
+     * If {@code verifyLinearity} is true, this method will also verify that the lines have a linearly increasing message number
      * (beginning with 0) after the prefix.
      *
      * @param filePath the file path

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSinkConnectorIntegrationTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSinkConnectorIntegrationTest.java
@@ -185,5 +185,8 @@ public class FileStreamSinkConnectorIntegrationTest {
                 return true;
             }
         }, "Expected to read " + numLines + " lines from the file");
+
+        // Ensure that there are exactly the expected number of lines present
+        assertEquals(numLines, Files.readAllLines(filePath).size());
     }
 }

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSinkConnectorIntegrationTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSinkConnectorIntegrationTest.java
@@ -42,6 +42,7 @@ import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_C
 import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
 import static org.apache.kafka.connect.sink.SinkConnector.TOPICS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("integration")
 public class FileStreamSinkConnectorIntegrationTest {
@@ -71,7 +72,7 @@ public class FileStreamSinkConnectorIntegrationTest {
         Path tempFilePath = tempDir.toPath().resolve(FILE_NAME);
         Map<String, String> connectorConfigs = baseConnectorConfigs(TOPIC, tempFilePath.toString());
         connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
-        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 1,
             "Connector and task did not start in time");
 
         verifyLinesInFile(tempFilePath, NUM_MESSAGES, true);
@@ -83,7 +84,7 @@ public class FileStreamSinkConnectorIntegrationTest {
         Path tempFilePath = tempDir.toPath().resolve(FILE_NAME);
         Map<String, String> connectorConfigs = baseConnectorConfigs(TOPIC, tempFilePath.toString());
         connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
-        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 1,
             "Connector and task did not start in time");
 
         verifyLinesInFile(tempFilePath, NUM_MESSAGES, true);
@@ -95,7 +96,7 @@ public class FileStreamSinkConnectorIntegrationTest {
         Map<String, Object> partition = new HashMap<>();
         partition.put(SinkUtils.KAFKA_TOPIC_KEY, TOPIC);
         partition.put(SinkUtils.KAFKA_PARTITION_KEY, 0);
-        Map<String, Object> offset = Collections.singletonMap(SinkUtils.KAFKA_OFFSET_KEY, 4);
+        Map<String, Object> offset = Collections.singletonMap(SinkUtils.KAFKA_OFFSET_KEY, NUM_MESSAGES - 1);
         List<ConnectorOffset> offsetsToAlter = Collections.singletonList(new ConnectorOffset(partition, offset));
 
         connect.alterConnectorOffsets(CONNECTOR_NAME, new ConnectorOffsets(offsetsToAlter));
@@ -114,7 +115,7 @@ public class FileStreamSinkConnectorIntegrationTest {
         Path tempFilePath = tempDir.toPath().resolve(FILE_NAME);
         Map<String, String> connectorConfigs = baseConnectorConfigs(TOPIC, tempFilePath.toString());
         connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
-        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 1,
             "Connector and task did not start in time");
 
         verifyLinesInFile(tempFilePath, NUM_MESSAGES, true);
@@ -145,7 +146,7 @@ public class FileStreamSinkConnectorIntegrationTest {
         connectorConfigs.put(TASKS_MAX_CONFIG, "2");
 
         connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
-        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 2,
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 2,
             "Connector and task did not start in time");
 
         // Only verify the number of lines since the messages can be consumed in any order across the two topics
@@ -185,6 +186,8 @@ public class FileStreamSinkConnectorIntegrationTest {
                     }
                     if (verifyLinearity) {
                         assertEquals(String.format(MESSAGE_FORMAT, i), line);
+                    } else {
+                        assertTrue(line.startsWith(MESSAGE_FORMAT));
                     }
                 }
                 return true;

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSinkConnectorIntegrationTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSinkConnectorIntegrationTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.file.integration;
+
+import org.apache.kafka.connect.file.FileStreamSinkConnector;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorOffset;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorOffsets;
+import org.apache.kafka.connect.util.SinkUtils;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.connect.file.FileStreamSinkConnector.FILE_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.connect.sink.SinkConnector.TOPICS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("integration")
+public class FileStreamSinkConnectorIntegrationTest {
+
+    private static final String CONNECTOR_NAME = "test-connector";
+    private static final String TOPIC = "test-topic";
+    private static final String MESSAGE_FORMAT = "Message %d";
+    private static final int NUM_MESSAGES = 5;
+    private static final String FILE_NAME = "test-file";
+    private final EmbeddedConnectCluster connect = new EmbeddedConnectCluster.Builder().build();
+
+    @BeforeEach
+    public void setup() {
+        connect.start();
+        connect.kafka().createTopic(TOPIC);
+        produceMessagesToTopic(TOPIC, NUM_MESSAGES);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        connect.stop();
+    }
+
+    @Test
+    public void testSimpleSink() throws Exception {
+        File tempDir = TestUtils.tempDirectory();
+        Path tempFilePath = tempDir.toPath().resolve(FILE_NAME);
+        Map<String, String> connectorConfigs = baseConnectorConfigs(TOPIC, tempFilePath.toString());
+        connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+            "Connector and task did not start in time");
+
+        verifyLinesInFile(tempFilePath, NUM_MESSAGES, true);
+    }
+
+    @Test
+    public void testAlterOffsets() throws Exception {
+        File tempDir = TestUtils.tempDirectory();
+        Path tempFilePath = tempDir.toPath().resolve(FILE_NAME);
+        Map<String, String> connectorConfigs = baseConnectorConfigs(TOPIC, tempFilePath.toString());
+        connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+            "Connector and task did not start in time");
+
+        verifyLinesInFile(tempFilePath, NUM_MESSAGES, true);
+
+        connect.stopConnector(CONNECTOR_NAME);
+        connect.assertions().assertConnectorIsStopped(CONNECTOR_NAME, "Connector did not stop in time");
+
+        // Alter the offsets to cause the last message in the topic to be re-processed
+        Map<String, Object> partition = new HashMap<>();
+        partition.put(SinkUtils.KAFKA_TOPIC_KEY, TOPIC);
+        partition.put(SinkUtils.KAFKA_PARTITION_KEY, 0);
+        Map<String, Object> offset = Collections.singletonMap(SinkUtils.KAFKA_OFFSET_KEY, 4);
+        List<ConnectorOffset> offsetsToAlter = Collections.singletonList(new ConnectorOffset(partition, offset));
+
+        connect.alterConnectorOffsets(CONNECTOR_NAME, new ConnectorOffsets(offsetsToAlter));
+
+        connect.resumeConnector(CONNECTOR_NAME);
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 1,
+            "Connector and task did not resume in time");
+
+        // The last message should be re-processed when the connector is resumed after the offsets are altered
+        verifyLinesInFile(tempFilePath, NUM_MESSAGES + 1, false);
+    }
+
+    @Test
+    public void testResetOffsets() throws Exception {
+        File tempDir = TestUtils.tempDirectory();
+        Path tempFilePath = tempDir.toPath().resolve(FILE_NAME);
+        Map<String, String> connectorConfigs = baseConnectorConfigs(TOPIC, tempFilePath.toString());
+        connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+            "Connector and task did not start in time");
+
+        verifyLinesInFile(tempFilePath, NUM_MESSAGES, true);
+
+        connect.stopConnector(CONNECTOR_NAME);
+        connect.assertions().assertConnectorIsStopped(CONNECTOR_NAME, "Connector did not stop in time");
+
+        // Reset the offsets to cause all the message in the topic to be re-processed
+        connect.resetConnectorOffsets(CONNECTOR_NAME);
+
+        connect.resumeConnector(CONNECTOR_NAME);
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 1,
+            "Connector and task did not resume in time");
+
+        // All the messages should be re-processed when the connector is resumed after the offsets are reset
+        verifyLinesInFile(tempFilePath, 2 * NUM_MESSAGES, false);
+    }
+
+    @Test
+    public void testSinkMultipleTopicsWithMultipleTasks() throws Exception {
+        String topic2 = "test-topic-2";
+        connect.kafka().createTopic(topic2);
+        produceMessagesToTopic(topic2, NUM_MESSAGES);
+
+        File tempDir = TestUtils.tempDirectory();
+        Path tempFilePath = tempDir.toPath().resolve(FILE_NAME);
+        Map<String, String> connectorConfigs = baseConnectorConfigs(TOPIC + "," + topic2, tempFilePath.toString());
+        connectorConfigs.put(TASKS_MAX_CONFIG, "2");
+
+        connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 2,
+            "Connector and task did not start in time");
+
+        // Only verify the number of lines since the messages can be consumed in any order across the two topics
+        verifyLinesInFile(tempFilePath, 2 * NUM_MESSAGES, false);
+    }
+
+    private void produceMessagesToTopic(String topic, int numMessages) {
+        for (int i = 0; i < numMessages; i++) {
+            connect.kafka().produce(topic, String.format(MESSAGE_FORMAT, i));
+        }
+    }
+
+    private Map<String, String> baseConnectorConfigs(String topics, String filePath) {
+        Map<String, String> connectorConfigs = new HashMap<>();
+        connectorConfigs.put(CONNECTOR_CLASS_CONFIG, FileStreamSinkConnector.class.getName());
+        connectorConfigs.put(TOPICS_CONFIG, topics);
+        connectorConfigs.put(FILE_CONFIG, filePath);
+        return connectorConfigs;
+    }
+
+    /**
+     * Verify that the number of lines in the file at {@code filePath} is equal to {@code numLines}.
+     * If {@code verifyLinearity} is true, this method will also verify that the lines match {@link #MESSAGE_FORMAT}
+     * with a linearly increasing message number (beginning with 0).
+     *
+     * @param filePath the file path
+     * @param numLines the expected number of lines in the file
+     * @param verifyLinearity true if the line contents are to be verified
+     */
+    private void verifyLinesInFile(Path filePath, int numLines, boolean verifyLinearity) throws Exception {
+        TestUtils.waitForCondition(() -> {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(Files.newInputStream(filePath)))) {
+                for (int i = 0; i < numLines; i++) {
+                    String line = reader.readLine();
+                    if (line == null) {
+                        return false;
+                    }
+                    if (verifyLinearity) {
+                        assertEquals(String.format(MESSAGE_FORMAT, i), line);
+                    }
+                }
+                return true;
+            }
+        }, "Expected to read " + numLines + " lines from the file");
+    }
+}

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSourceConnectorIntegrationTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSourceConnectorIntegrationTest.java
@@ -18,8 +18,6 @@ package org.apache.kafka.connect.file.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.connect.file.FileStreamSourceConnector;
-import org.apache.kafka.connect.runtime.rest.entities.ConnectorOffset;
-import org.apache.kafka.connect.runtime.rest.entities.ConnectorOffsets;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -129,9 +127,11 @@ public class FileStreamSourceConnectorIntegrationTest {
         connect.assertions().assertConnectorIsStopped(CONNECTOR_NAME, "Connector did not stop in time");
 
         // Alter the offsets to make the connector re-process the last line in the file
-        Map<String, Object> partition = Collections.singletonMap(FILENAME_FIELD, sourceFile.getAbsolutePath());
-        Map<String, Object> offset = Collections.singletonMap(POSITION_FIELD, 28L);
-        connect.alterConnectorOffsets(CONNECTOR_NAME, new ConnectorOffsets(Collections.singletonList(new ConnectorOffset(partition, offset))));
+        connect.alterSourceConnectorOffset(
+            CONNECTOR_NAME,
+            Collections.singletonMap(FILENAME_FIELD, sourceFile.getAbsolutePath()),
+            Collections.singletonMap(POSITION_FIELD, 28L)
+        );
 
         connect.resumeConnector(CONNECTOR_NAME);
         connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 1,

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSourceConnectorIntegrationTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSourceConnectorIntegrationTest.java
@@ -195,7 +195,7 @@ public class FileStreamSourceConnectorIntegrationTest {
     private File createTempFile(int numLines) throws Exception {
         File sourceFile = TestUtils.tempFile();
 
-        try (PrintStream printStream = new PrintStream(Files.newOutputStream(sourceFile.toPath(), StandardOpenOption.APPEND))) {
+        try (PrintStream printStream = new PrintStream(Files.newOutputStream(sourceFile.toPath()))) {
             for (int i = 0; i < numLines; i++) {
                 printStream.println(String.format(LINE_FORMAT, i));
             }

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSourceConnectorIntegrationTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSourceConnectorIntegrationTest.java
@@ -73,7 +73,7 @@ public class FileStreamSourceConnectorIntegrationTest {
     public void testSimpleSource() throws Exception {
         Map<String, String> connectorConfigs = baseConnectorConfigs(sourceFile.getAbsolutePath());
         connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
-        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 1,
             "Connector and task did not start in time");
 
         int i = 0;
@@ -86,7 +86,7 @@ public class FileStreamSourceConnectorIntegrationTest {
     public void testStopResumeSavedOffset() throws Exception {
         Map<String, String> connectorConfigs = baseConnectorConfigs(sourceFile.getAbsolutePath());
         connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
-        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 1,
             "Connector and task did not start in time");
 
         // Wait for the initially written records to be sourced by the connector and produced to the configured Kafka topic
@@ -119,7 +119,7 @@ public class FileStreamSourceConnectorIntegrationTest {
     public void testAlterOffsets() throws Exception {
         Map<String, String> connectorConfigs = baseConnectorConfigs(sourceFile.getAbsolutePath());
         connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
-        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 1,
             "Connector and task did not start in time");
 
         // Wait for the initially written records to be sourced by the connector and produced to the configured Kafka topic
@@ -134,14 +134,13 @@ public class FileStreamSourceConnectorIntegrationTest {
         connect.alterConnectorOffsets(CONNECTOR_NAME, new ConnectorOffsets(Collections.singletonList(new ConnectorOffset(partition, offset))));
 
         connect.resumeConnector(CONNECTOR_NAME);
-        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 1,
             "Connector and task did not resume in time");
 
         Iterator<ConsumerRecord<byte[], byte[]>> recordIterator = connect.kafka().consume(NUM_LINES + 1, TIMEOUT_MS, TOPIC).iterator();
 
-        int i = 0;
-        while (i < NUM_LINES) {
-            assertEquals(String.format(LINE_FORMAT, i++), new String(recordIterator.next().value()));
+        for (int i = 0; i < NUM_LINES; i++) {
+            assertEquals(String.format(LINE_FORMAT, i), new String(recordIterator.next().value()));
         }
 
         // Verify that the last line has been sourced again after the alter offsets request
@@ -152,7 +151,7 @@ public class FileStreamSourceConnectorIntegrationTest {
     public void testResetOffsets() throws Exception {
         Map<String, String> connectorConfigs = baseConnectorConfigs(sourceFile.getAbsolutePath());
         connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
-        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 1,
             "Connector and task did not start in time");
 
         // Wait for the initially written records to be sourced by the connector and produced to the configured Kafka topic
@@ -165,7 +164,7 @@ public class FileStreamSourceConnectorIntegrationTest {
         connect.resetConnectorOffsets(CONNECTOR_NAME);
 
         connect.resumeConnector(CONNECTOR_NAME);
-        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 1,
             "Connector and task did not resume in time");
 
         // We expect 2 * NUM_LINES messages to be produced

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSourceConnectorIntegrationTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/integration/FileStreamSourceConnectorIntegrationTest.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.file.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.connect.file.FileStreamSourceConnector;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorOffset;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorOffsets;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.connect.util.clusters.EmbeddedKafkaCluster;
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.kafka.connect.file.FileStreamSourceConnector.FILE_CONFIG;
+import static org.apache.kafka.connect.file.FileStreamSourceConnector.TOPIC_CONFIG;
+import static org.apache.kafka.connect.file.FileStreamSourceTask.FILENAME_FIELD;
+import static org.apache.kafka.connect.file.FileStreamSourceTask.POSITION_FIELD;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag("integration")
+public class FileStreamSourceConnectorIntegrationTest {
+
+    private static final String CONNECTOR_NAME = "test-connector";
+    private static final String TOPIC = "test-topic";
+    private static final String LINE_FORMAT = "Line %d";
+    private static final int NUM_LINES = 5;
+    private static final long TIMEOUT_MS = TimeUnit.SECONDS.toMillis(15);
+    private final EmbeddedConnectCluster connect = new EmbeddedConnectCluster.Builder().build();
+    private File sourceFile;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        connect.start();
+        sourceFile = createTempFile(NUM_LINES);
+        connect.kafka().createTopic(TOPIC);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        connect.stop();
+    }
+
+    @Test
+    public void testSimpleSource() throws Exception {
+        Map<String, String> connectorConfigs = baseConnectorConfigs(sourceFile.getAbsolutePath());
+        connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+            "Connector and task did not start in time");
+
+        int i = 0;
+        for (ConsumerRecord<byte[], byte[]> record : connect.kafka().consume(NUM_LINES, TIMEOUT_MS, TOPIC)) {
+            assertEquals(String.format(LINE_FORMAT, i++), new String(record.value()));
+        }
+    }
+
+    @Test
+    public void testStopResumeSavedOffset() throws Exception {
+        Map<String, String> connectorConfigs = baseConnectorConfigs(sourceFile.getAbsolutePath());
+        connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+            "Connector and task did not start in time");
+
+        // Wait for the initially written records to be sourced by the connector and produced to the configured Kafka topic
+        connect.kafka().consume(NUM_LINES, TIMEOUT_MS, TOPIC);
+
+        connect.stopConnector(CONNECTOR_NAME);
+        connect.assertions().assertConnectorIsStopped(CONNECTOR_NAME, "Connector did not stop in time");
+
+        // Append NUM_LINES more lines to the file
+        try (PrintStream printStream = new PrintStream(Files.newOutputStream(sourceFile.toPath(), StandardOpenOption.APPEND))) {
+            for (int i = NUM_LINES; i < 2 * NUM_LINES; i++) {
+                printStream.println(String.format(LINE_FORMAT, i));
+            }
+        }
+
+        connect.resumeConnector(CONNECTOR_NAME);
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(CONNECTOR_NAME, 1,
+            "Connector and task did not resume in time");
+
+        // We expect only 2 * NUM_LINES messages to be produced since the connector should continue from where it left off on being resumed
+        assertThrows(EmbeddedKafkaCluster.NotEnoughRecordsException.class, () -> connect.kafka().consume(2 * NUM_LINES + 1, TIMEOUT_MS, TOPIC));
+
+        int i = 0;
+        for (ConsumerRecord<byte[], byte[]> record : connect.kafka().consume(2 * NUM_LINES, TIMEOUT_MS, TOPIC)) {
+            assertEquals(String.format(LINE_FORMAT, i++), new String(record.value()));
+        }
+    }
+
+    @Test
+    public void testAlterOffsets() throws Exception {
+        Map<String, String> connectorConfigs = baseConnectorConfigs(sourceFile.getAbsolutePath());
+        connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+            "Connector and task did not start in time");
+
+        // Wait for the initially written records to be sourced by the connector and produced to the configured Kafka topic
+        connect.kafka().consume(NUM_LINES, TIMEOUT_MS, TOPIC);
+
+        connect.stopConnector(CONNECTOR_NAME);
+        connect.assertions().assertConnectorIsStopped(CONNECTOR_NAME, "Connector did not stop in time");
+
+        // Alter the offsets to make the connector re-process the last line in the file
+        Map<String, Object> partition = Collections.singletonMap(FILENAME_FIELD, sourceFile.getAbsolutePath());
+        Map<String, Object> offset = Collections.singletonMap(POSITION_FIELD, 28L);
+        connect.alterConnectorOffsets(CONNECTOR_NAME, new ConnectorOffsets(Collections.singletonList(new ConnectorOffset(partition, offset))));
+
+        connect.resumeConnector(CONNECTOR_NAME);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+            "Connector and task did not resume in time");
+
+        Iterator<ConsumerRecord<byte[], byte[]>> recordIterator = connect.kafka().consume(NUM_LINES + 1, TIMEOUT_MS, TOPIC).iterator();
+
+        int i = 0;
+        while (i < NUM_LINES) {
+            assertEquals(String.format(LINE_FORMAT, i++), new String(recordIterator.next().value()));
+        }
+
+        // Verify that the last line has been sourced again after the alter offsets request
+        assertEquals(String.format(LINE_FORMAT, NUM_LINES - 1), new String(recordIterator.next().value()));
+    }
+
+    @Test
+    public void testResetOffsets() throws Exception {
+        Map<String, String> connectorConfigs = baseConnectorConfigs(sourceFile.getAbsolutePath());
+        connect.configureConnector(CONNECTOR_NAME, connectorConfigs);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+            "Connector and task did not start in time");
+
+        // Wait for the initially written records to be sourced by the connector and produced to the configured Kafka topic
+        connect.kafka().consume(NUM_LINES, TIMEOUT_MS, TOPIC);
+
+        connect.stopConnector(CONNECTOR_NAME);
+        connect.assertions().assertConnectorIsStopped(CONNECTOR_NAME, "Connector did not stop in time");
+
+        // Reset the offsets to make the connector re-read all the previously written lines
+        connect.resetConnectorOffsets(CONNECTOR_NAME);
+
+        connect.resumeConnector(CONNECTOR_NAME);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+            "Connector and task did not resume in time");
+
+        // We expect 2 * NUM_LINES messages to be produced
+        assertThrows(EmbeddedKafkaCluster.NotEnoughRecordsException.class, () -> connect.kafka().consume(2 * NUM_LINES + 1, TIMEOUT_MS, TOPIC));
+
+        Iterator<ConsumerRecord<byte[], byte[]>> recordIterator = connect.kafka().consume(2 * NUM_LINES, TIMEOUT_MS, TOPIC).iterator();
+
+        int i = 0;
+        while (i < NUM_LINES) {
+            assertEquals(String.format(LINE_FORMAT, i++), new String(recordIterator.next().value()));
+        }
+
+        // Verify that the same lines have been sourced again after the reset offsets request
+        while (i < 2 * NUM_LINES) {
+            assertEquals(String.format(LINE_FORMAT, i - NUM_LINES), new String(recordIterator.next().value()));
+            i++;
+        }
+    }
+
+    /**
+     * Create a temporary file and append {@code numLines} to it
+     *
+     * @param numLines the number of lines to be appended to the created file
+     * @return the created file
+     */
+    private File createTempFile(int numLines) throws Exception {
+        File sourceFile = TestUtils.tempFile();
+
+        try (PrintStream printStream = new PrintStream(Files.newOutputStream(sourceFile.toPath(), StandardOpenOption.APPEND))) {
+            for (int i = 0; i < numLines; i++) {
+                printStream.println(String.format(LINE_FORMAT, i));
+            }
+        }
+
+        return sourceFile;
+    }
+
+    private Map<String, String> baseConnectorConfigs(String filePath) {
+        Map<String, String> connectorConfigs = new HashMap<>();
+        connectorConfigs.put(CONNECTOR_CLASS_CONFIG, FileStreamSourceConnector.class.getName());
+        connectorConfigs.put(TOPIC_CONFIG, TOPIC);
+        connectorConfigs.put(FILE_CONFIG, filePath);
+        return connectorConfigs;
+    }
+}

--- a/connect/file/src/test/resources/log4j.properties
+++ b/connect/file/src/test/resources/log4j.properties
@@ -1,0 +1,28 @@
+##
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+#
+# The `%X{connector.context}` parameter in the layout includes connector-specific and task-specific information
+# in the log message, where appropriate. This makes it easier to identify those log messages that apply to a
+# specific connector. Simply add this parameter to the log layout configuration below to include the contextual information.
+#
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (%c:%L)%n
+
+log4j.logger.kafka=WARN

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
@@ -809,13 +809,7 @@ public class ExactlyOnceSourceIntegrationTest {
             );
 
             // also consume from the cluster's global offsets topic
-            offsetRecords = connect.kafka()
-                    .consumeAll(
-                            TimeUnit.MINUTES.toMillis(1),
-                            null,
-                            null,
-                            globalOffsetsTopic
-                    );
+            offsetRecords = connect.kafka().consumeAll(TimeUnit.MINUTES.toMillis(1), globalOffsetsTopic);
             seqnos = parseAndAssertOffsetsForSingleTask(offsetRecords);
             seqnos.forEach(seqno ->
                 assertEquals("Offset commits should occur on connector-defined poll boundaries, which happen every " + MINIMUM_MESSAGES + " records",

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -522,7 +522,7 @@ public class EmbeddedKafkaCluster {
             }
         }
 
-        throw new RuntimeException("Could not find enough records. found " + consumedRecords + ", expected " + n);
+        throw new NotEnoughRecordsException(n, consumedRecords);
     }
 
     /**
@@ -684,6 +684,12 @@ public class EmbeddedKafkaCluster {
     private static void putIfAbsent(final Map<String, Object> props, final String propertyKey, final Object propertyValue) {
         if (!props.containsKey(propertyKey)) {
             props.put(propertyKey, propertyValue);
+        }
+    }
+
+    public static class NotEnoughRecordsException extends ConnectException {
+        public NotEnoughRecordsException(int expected, int actual) {
+            super("Could not find enough records. Found: " + actual + ", Expected: " + expected);
         }
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -522,7 +522,20 @@ public class EmbeddedKafkaCluster {
             }
         }
 
-        throw new NotEnoughRecordsException(n, consumedRecords);
+        throw new RuntimeException("Could not find enough records. found " + consumedRecords + ", expected " + n);
+    }
+
+    /**
+     * Consume all currently-available records for the specified topics in a given duration, or throw an exception.
+     * @param maxDurationMs the max duration to wait for these records (in milliseconds).
+     * @param topics the topics to consume from
+     * @return a {@link ConsumerRecords} collection containing the records for all partitions of the given topics
+     */
+    public ConsumerRecords<byte[], byte[]> consumeAll(
+        long maxDurationMs,
+        String... topics
+    ) throws TimeoutException, InterruptedException, ExecutionException {
+        return consumeAll(maxDurationMs, null, null, topics);
     }
 
     /**
@@ -684,12 +697,6 @@ public class EmbeddedKafkaCluster {
     private static void putIfAbsent(final Map<String, Object> props, final String propertyKey, final Object propertyValue) {
         if (!props.containsKey(propertyKey)) {
             props.put(propertyKey, propertyValue);
-        }
-    }
-
-    public static class NotEnoughRecordsException extends ConnectException {
-        public NotEnoughRecordsException(int expected, int actual) {
-            super("Could not find enough records. Found: " + actual + ", Expected: " + expected);
         }
     }
 }


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/KAFKA-15179
- In https://github.com/apache/kafka/pull/13945 we realized that it would be nice to have an integration test suite for the `FileStreamSinkConnector` and `FileStreamSourceConnector` to test some complex interactions between the Connect runtime and the connector / task implementations.
- This patch adds some basic integration tests to validate some common scenarios for both the connectors.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
