### PR TITLE
KAFKA-15391: Handle concurrent dir rename which makes log-dir to be offline unexpectedly

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -1008,6 +1008,19 @@ public final class Utils {
     }
 
     /**
+     * Flushes dirty directories to guarantee crash consistency with swallowing {@link NoSuchFileException}
+     *
+     * @throws IOException if flushing the directory fails.
+     */
+    public static void flushDirIfExists(Path path) throws IOException {
+        try {
+            flushDir(path);
+        } catch (NoSuchFileException e) {
+            log.warn("Failed to flush directory {}", path);
+        }
+    }
+
+    /**
      * Closes all the provided closeables.
      * @throws IOException if any of the close methods throws an IOException.
      *         The first IOException is thrown with subsequent exceptions

--- a/core/src/main/scala/kafka/log/LocalLog.scala
+++ b/core/src/main/scala/kafka/log/LocalLog.scala
@@ -173,8 +173,11 @@ class LocalLog(@volatile private var _dir: File,
       val segmentsToFlush = segments.values(currentRecoveryPoint, offset)
       segmentsToFlush.foreach(_.flush())
       // If there are any new segments, we need to flush the parent directory for crash consistency.
-      if (segmentsToFlush.exists(_.baseOffset >= currentRecoveryPoint))
-        Utils.flushDir(dir.toPath)
+      if (segmentsToFlush.exists(_.baseOffset >= currentRecoveryPoint)) {
+        // The directory might be renamed concurrently for topic deletion, which may cause NoSuchFileException here.
+        // Since the directory is to be deleted anyways, we just swallow NoSuchFileException and let it go.
+        Utils.flushDirIfExists(dir.toPath)
+      }
     }
   }
 

--- a/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
@@ -713,7 +713,7 @@ class LocalLogTest {
     val newSegment = log.roll()
 
     // simulate the directory is renamed concurrently
-    doReturn(new File("__NON_EXISTENT__")).when(spyLog).dir
+    doReturn(new File("__NON_EXISTENT__"), Nil: _*).when(spyLog).dir
     assertDoesNotThrow((() => spyLog.flush(newSegment.baseOffset)): Executable)
   }
 

--- a/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
@@ -31,7 +31,9 @@ import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.server.util.{MockTime, Scheduler}
 import org.apache.kafka.storage.internals.log.{FetchDataInfo, LogConfig, LogDirFailureChannel, LogFileUtils, LogOffsetMetadata}
 import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.mockito.Mockito.{doReturn, spy}
 
 import scala.jdk.CollectionConverters._
 
@@ -699,6 +701,20 @@ class LocalLogTest {
     // expect an error because of attempt to roll to a new offset (1L) that's lower than the
     // base offset (3L) of the active segment
     assertThrows(classOf[KafkaException], () => log.roll())
+  }
+
+  @Test
+  def testFlushingNonExistentDir(): Unit = {
+    val spyLog = spy(log)
+
+    val record = new SimpleRecord(mockTime.milliseconds, "a".getBytes)
+    appendRecords(List(record))
+    mockTime.sleep(1)
+    val newSegment = log.roll()
+
+    // simulate the directory is renamed concurrently
+    doReturn(new File("__NON_EXISTENT__")).when(spyLog).dir
+    assertDoesNotThrow((() => spyLog.flush(newSegment.baseOffset)): Executable)
   }
 
   private def createLocalLogWithActiveSegment(dir: File = logDir,


### PR DESCRIPTION
JIRA ticket: https://issues.apache.org/jira/browse/KAFKA-15391

- As described in the ticket, local log directory might be renamed (with adding `-delete`) by topic deletion concurrently with async log-flush tasks for log-rolling, which may cause `NoSuchFileException` on flush timing and mark the log-dir offline unexpectedly
- This PR adds a handling for `NoSuchFileException` on flush timing

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
