### PR TITLE
KAFKA-15326: [9/N] Start and stop executors and cornercases

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -235,7 +235,7 @@
               files="(EosV2UpgradeIntegrationTest|KStreamKStreamJoinTest|KTableKTableForeignKeyJoinIntegrationTest|KTableKTableForeignKeyVersionedJoinIntegrationTest|RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest|RelationalSmokeTest|MockProcessorContextStateStoreTest).java"/>
 
     <suppress checks="JavaNCSS"
-              files="(EosV2UpgradeIntegrationTest|KStreamKStreamJoinTest|StreamThreadTest|TaskManagerTest).java"/>
+              files="(EosV2UpgradeIntegrationTest|KStreamKStreamJoinTest|StreamThreadTest|TaskManagerTest|StreamTaskTest).java"/>
 
     <suppress checks="NPathComplexity"
               files="(EosV2UpgradeIntegrationTest|EosTestDriver|KStreamKStreamJoinTest|KTableKTableForeignKeyJoinIntegrationTest|KTableKTableForeignKeyVersionedJoinIntegrationTest|RelationalSmokeTest|MockProcessorContextStateStoreTest|TopologyTestDriverTest).java"/>

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -394,6 +394,12 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         timeCurrentIdlingStarted = Optional.empty();
     }
 
+
+    public void flush() {
+        stateMgr.flushCache();
+        recordCollector.flush();
+    }
+
     /**
      * @throws StreamsException fatal error that should cause the thread to die
      * @throws TaskMigratedException recoverable error that would cause the task to be removed
@@ -414,8 +420,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                     // cached records to be processed and hence generate more records to be sent out
                     //
                     // TODO: this should be removed after we decouple caching with emitting
-                    stateMgr.flushCache();
-                    recordCollector.flush();
+                    flush();
                     hasPendingTxCommit = eosEnabled;
 
                     log.debug("Prepared {} task for committing", state());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.processor.internals.tasks;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.concurrent.locks.Condition;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.internals.KafkaFutureImpl;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
@@ -362,7 +362,7 @@ public class DefaultTaskManager implements TaskManager {
                 taskExecutionMetadata.canPunctuateTask(task) && (task.canPunctuateStreamTime() || task.canPunctuateSystemTime());
     }
 
-    public void start() {
+    public void startTaskExecutors() {
         for (final TaskExecutor t: taskExecutors) {
             t.start();
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
@@ -16,12 +16,13 @@
  */
 package org.apache.kafka.streams.processor.internals.tasks;
 
+import java.time.Duration;
+import java.util.Collection;
 import java.util.concurrent.locks.Condition;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.ReadOnlyTask;
@@ -65,7 +66,7 @@ public class DefaultTaskManager implements TaskManager {
 
     private final List<TaskExecutor> taskExecutors;
 
-    static class DefaultTaskExecutorCreator implements TaskExecutorCreator {
+    public static class DefaultTaskExecutorCreator implements TaskExecutorCreator {
         @Override
         public TaskExecutor create(final TaskManager taskManager, final String name, final Time time, final TaskExecutionMetadata taskExecutionMetadata) {
             return new DefaultTaskExecutor(taskManager, name, time, taskExecutionMetadata);
@@ -76,9 +77,9 @@ public class DefaultTaskManager implements TaskManager {
     public DefaultTaskManager(final Time time,
                               final String clientId,
                               final TasksRegistry tasks,
-                              final StreamsConfig config,
                               final TaskExecutorCreator executorCreator,
-                              final TaskExecutionMetadata taskExecutionMetadata
+                              final TaskExecutionMetadata taskExecutionMetadata,
+                              final int numExecutors
                               ) {
         final String logPrefix = String.format("%s ", clientId);
         final LogContext logContext = new LogContext(logPrefix);
@@ -87,7 +88,6 @@ public class DefaultTaskManager implements TaskManager {
         this.tasks = tasks;
         this.taskExecutionMetadata = taskExecutionMetadata;
 
-        final int numExecutors = config.getInt(StreamsConfig.NUM_STREAM_THREADS_CONFIG);
         this.taskExecutors = new ArrayList<>(numExecutors);
         for (int i = 1; i <= numExecutors; i++) {
             final String name = clientId + "-TaskExecutor-" + i;
@@ -106,7 +106,8 @@ public class DefaultTaskManager implements TaskManager {
             for (final Task task : tasks.activeTasks()) {
                 if (!assignedTasks.containsKey(task.id()) &&
                     !lockedTasks.contains(task.id()) &&
-                    canProgress((StreamTask) task, time.milliseconds())
+                    canProgress((StreamTask) task, time.milliseconds()) &&
+                    !hasUncaughtException(task.id())
                 ) {
 
                     assignedTasks.put(task.id(), executor);
@@ -116,6 +117,8 @@ public class DefaultTaskManager implements TaskManager {
                     return (StreamTask) task;
                 }
             }
+
+            log.debug("Found no assignable task for executor {}", executor.name());
 
             return null;
         });
@@ -127,7 +130,8 @@ public class DefaultTaskManager implements TaskManager {
             for (final Task task : tasks.activeTasks()) {
                 if (!assignedTasks.containsKey(task.id()) &&
                     !lockedTasks.contains(task.id()) &&
-                    canProgress((StreamTask) task, time.milliseconds())
+                    canProgress((StreamTask) task, time.milliseconds()) &&
+                    !hasUncaughtException(task.id())
                 ) {
                     log.debug("Await unblocked: returning early from await since a processable task {} was found", task.id());
                     return false;
@@ -151,7 +155,7 @@ public class DefaultTaskManager implements TaskManager {
         }
     }
 
-    public void signalProcessableTasks() {
+    public void signalTaskExecutors() {
         log.debug("Waking up task executors");
         executeWithTasksLocked(tasksCondition::signalAll);
     }
@@ -176,11 +180,17 @@ public class DefaultTaskManager implements TaskManager {
     }
 
     @Override
-    public KafkaFuture<Void> lockTasks(final Set<TaskId> taskIds) {
+    public KafkaFuture<Void> lockTasks(final Collection<TaskId> taskIds) {
+        final KafkaFutureImpl<Void> result = new KafkaFutureImpl<>();
+
+        if (taskIds.isEmpty()) {
+            result.complete(null);
+            return result;
+        }
+
         return returnWithTasksLocked(() -> {
             lockedTasks.addAll(taskIds);
 
-            final KafkaFutureImpl<Void> result = new KafkaFutureImpl<>();
             final Set<TaskId> remainingTaskIds = new ConcurrentSkipListSet<>(taskIds);
 
             for (final TaskId taskId : taskIds) {
@@ -195,12 +205,18 @@ public class DefaultTaskManager implements TaskManager {
                 }
 
                 if (assignedTasks.containsKey(taskId)) {
-                    final KafkaFuture<StreamTask> future = assignedTasks.get(taskId).unassign();
+                    final TaskExecutor executor = assignedTasks.get(taskId);
+                    log.debug("Requesting release of task {} from {}", taskId, executor.name());
+                    final KafkaFuture<StreamTask> future = executor.unassign();
                     future.whenComplete((streamTask, throwable) -> {
                         if (throwable != null) {
                             result.completeExceptionally(throwable);
                         } else {
-                            remainingTaskIds.remove(streamTask.id());
+                            assert !assignedTasks.containsKey(taskId);
+                            // It can happen that the executor handed back the task before we asked it to
+                            // in which case `streamTask` will be null here.
+                            assert streamTask == null || streamTask.id() == taskId;
+                            remainingTaskIds.remove(taskId);
                             if (remainingTaskIds.isEmpty()) {
                                 result.complete(null);
                             }
@@ -226,7 +242,12 @@ public class DefaultTaskManager implements TaskManager {
     }
 
     @Override
-    public void unlockTasks(final Set<TaskId> taskIds) {
+    public void unlockTasks(final Collection<TaskId> taskIds) {
+
+        if (taskIds.isEmpty()) {
+            return;
+        }
+
         executeWithTasksLocked(() -> {
             lockedTasks.removeAll(taskIds);
             log.debug("Waking up task executors");
@@ -306,9 +327,15 @@ public class DefaultTaskManager implements TaskManager {
             return result;
         });
 
-        log.debug("Drained {} uncaught exceptions", returnValue.size());
+        if (!returnValue.isEmpty()) {
+            log.debug("Drained {} uncaught exceptions", returnValue.size());
+        }
 
         return returnValue;
+    }
+
+    public boolean hasUncaughtException(final TaskId taskId) {
+        return returnWithTasksLocked(() -> uncaughtExceptions.containsKey(taskId));
     }
 
     private void executeWithTasksLocked(final Runnable action) {
@@ -333,6 +360,22 @@ public class DefaultTaskManager implements TaskManager {
         return
             taskExecutionMetadata.canProcessTask(task, nowMs) && task.isProcessable(nowMs) ||
                 taskExecutionMetadata.canPunctuateTask(task) && (task.canPunctuateStreamTime() || task.canPunctuateSystemTime());
+    }
+
+    public void start() {
+        for (final TaskExecutor t: taskExecutors) {
+            t.start();
+        }
+    }
+
+    public void shutdown(final Duration duration) {
+        for (final TaskExecutor t: taskExecutors) {
+            t.requestShutdown();
+        }
+        signalTaskExecutors();
+        for (final TaskExecutor t: taskExecutors) {
+            t.awaitShutdown(duration);
+        }
     }
 }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
@@ -180,7 +180,7 @@ public class DefaultTaskManager implements TaskManager {
     }
 
     @Override
-    public KafkaFuture<Void> lockTasks(final Collection<TaskId> taskIds) {
+    public KafkaFuture<Void> lockTasks(final Set<TaskId> taskIds) {
         final KafkaFutureImpl<Void> result = new KafkaFutureImpl<>();
 
         if (taskIds.isEmpty()) {
@@ -242,7 +242,7 @@ public class DefaultTaskManager implements TaskManager {
     }
 
     @Override
-    public void unlockTasks(final Collection<TaskId> taskIds) {
+    public void unlockTasks(final Set<TaskId> taskIds) {
 
         if (taskIds.isEmpty()) {
             return;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskExecutor.java
@@ -31,18 +31,35 @@ public interface TaskExecutor {
 
     /**
      * Starts the task executor.
+     * Idempotent operation - will have no effect if thread is already started.
      */
     void start();
 
     /**
-     * Shuts down the task processor updater.
-     *
-     * @param timeout duration how long to wait until the state updater is shut down
+     * Returns true if the task executor thread is running.
+     */
+    boolean isRunning();
+
+    /**
+     * Asks the task executor to shut down.
+     * Idempotent operation - will have no effect if thread was already asked to shut down
      *
      * @throws
      *     org.apache.kafka.streams.errors.StreamsException if the state updater thread cannot shutdown within the timeout
      */
-    void shutdown(final Duration timeout);
+    void requestShutdown();
+
+    /**
+     * Shuts down the task processor updater.
+     * Idempotent operation - will have no effect if thread is already shut down.
+     * Must call `requestShutdown` first.
+     *
+     * @param timeout duration how long to wait until the state updater is shut down
+     *
+     * @throws
+     *     org.apache.kafka.streams.errors.StreamsException if the state updater thread does not shutdown within the timeout
+     */
+    void awaitShutdown(final Duration timeout);
 
     /**
      * Get the current assigned processing task. The task returned is read-only and cannot be modified.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskManager.java
@@ -141,7 +141,7 @@ public interface TaskManager {
     /**
      * Starts all threads associated with this task manager.
      */
-    void start();
+    void startTaskExecutors();
 
     /**
      * Shuts down all threads associated with this task manager.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskManager.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.streams.processor.internals.tasks;
 
+import java.time.Duration;
+import java.util.Collection;
 import java.util.Map;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -56,10 +58,10 @@ public interface TaskManager {
      *
      * This method does not block, instead a future is returned.
      */
-    KafkaFuture<Void> lockTasks(final Set<TaskId> taskIds);
+    KafkaFuture<Void> lockTasks(final Collection<TaskId> taskIds);
 
     /**
-     * Lock all of the managed active tasks from the task manager. Similar to {@link #lockTasks(Set)}.
+     * Lock all the managed active tasks from the task manager. Similar to {@link #lockTasks(Collection)}.
      *
      * This method does not block, instead a future is returned.
      */
@@ -68,10 +70,10 @@ public interface TaskManager {
     /**
      * Unlock the tasks so that they can be assigned to executors
      */
-    void unlockTasks(final Set<TaskId> taskIds);
+    void unlockTasks(final Collection<TaskId> taskIds);
 
     /**
-     * Unlock all of the managed active tasks from the task manager. Similar to {@link #unlockTasks(Set)}.
+     * Unlock all the managed active tasks from the task manager. Similar to {@link #unlockTasks(Collection)}.
      */
     void unlockAllTasks();
 
@@ -120,13 +122,33 @@ public interface TaskManager {
     Map<TaskId, StreamsException> drainUncaughtExceptions();
 
     /**
+     * Can be used to check if a specific task has an uncaught exception.
+     *
+     * @param taskId the task ID to check for
+     */
+    boolean hasUncaughtException(final TaskId taskId);
+
+    /**
      * Signals that at least one task has become processable, e.g. because it was resumed or new records may be available.
      */
-    void signalProcessableTasks();
+    void signalTaskExecutors();
 
     /**
      * Blocks until unassigned processable tasks may be available.
      */
     void awaitProcessableTasks() throws InterruptedException;
+
+    /**
+     * Starts all threads associated with this task manager.
+     */
+    void start();
+
+    /**
+     * Shuts down all threads associated with this task manager.
+     * All tasks will be unlocked and unassigned by the end of this.
+     *
+     * @param duration Time to wait for each thread to shut down.
+     */
+    void shutdown(final Duration duration);
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskManager.java
@@ -58,10 +58,10 @@ public interface TaskManager {
      *
      * This method does not block, instead a future is returned.
      */
-    KafkaFuture<Void> lockTasks(final Collection<TaskId> taskIds);
+    KafkaFuture<Void> lockTasks(final Set<TaskId> taskIds);
 
     /**
-     * Lock all the managed active tasks from the task manager. Similar to {@link #lockTasks(Collection)}.
+     * Lock all the managed active tasks from the task manager. Similar to {@link #lockTasks(Set)}.
      *
      * This method does not block, instead a future is returned.
      */
@@ -70,10 +70,10 @@ public interface TaskManager {
     /**
      * Unlock the tasks so that they can be assigned to executors
      */
-    void unlockTasks(final Collection<TaskId> taskIds);
+    void unlockTasks(final Set<TaskId> taskIds);
 
     /**
-     * Unlock all the managed active tasks from the task manager. Similar to {@link #unlockTasks(Collection)}.
+     * Unlock all the managed active tasks from the task manager. Similar to {@link #unlockTasks(Set)}.
      */
     void unlockAllTasks();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/TaskManager.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.processor.internals.tasks;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Map;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.streams.errors.StreamsException;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -2324,6 +2324,19 @@ public class StreamTaskTest {
     }
 
     @Test
+    public void shouldFlushStateManagerAndRecordCollector() {
+        stateManager.flush();
+        EasyMock.expectLastCall().once();
+        recordCollector.flush();
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(stateManager, recordCollector);
+
+        task = createStatefulTask(createConfig("100"), false);
+
+        task.flush();
+    }
+
+    @Test
     public void shouldClearCommitStatusesInCloseDirty() {
         task = createSingleSourceStateless(createConfig(AT_LEAST_ONCE, "0"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutorTest.java
@@ -108,7 +108,6 @@ public class DefaultTaskExecutorTest {
         taskExecutor.awaitShutdown(Duration.ofMinutes(1));
 
         waitForCondition(future::isDone, "Await for unassign future to complete");
-        assertTrue(future.isDone());
         assertNull(taskExecutor.currentTask(), "Have task assigned after shutdown");
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutorTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.TaskExecutionMetadata;
 import org.junit.jupiter.api.AfterEach;
@@ -31,6 +32,7 @@ import java.time.Duration;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,6 +44,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import static org.apache.kafka.test.TestUtils.waitForCondition;
 
 public class DefaultTaskExecutorTest {
 
@@ -60,28 +64,51 @@ public class DefaultTaskExecutorTest {
         when(taskManager.assignNextTask(taskExecutor)).thenReturn(task).thenReturn(null);
         when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
         when(task.isProcessable(anyLong())).thenReturn(true);
+        when(task.id()).thenReturn(new TaskId(0, 0, "A"));
         when(task.process(anyLong())).thenReturn(true);
         when(task.prepareCommit()).thenReturn(Collections.emptyMap());
     }
 
     @AfterEach
     public void tearDown() {
-        taskExecutor.shutdown(Duration.ofMinutes(1));
+        taskExecutor.requestShutdown();
+        taskExecutor.awaitShutdown(Duration.ofMinutes(1));
     }
 
     @Test
     public void shouldShutdownTaskExecutor() {
+        assertNull(taskExecutor.currentTask(), "Have task assigned before startup");
+        assertFalse(taskExecutor.isRunning());
+
+        taskExecutor.start();
+
+        assertTrue(taskExecutor.isRunning());
+        verify(taskManager, timeout(VERIFICATION_TIMEOUT)).assignNextTask(taskExecutor);
+
+        taskExecutor.requestShutdown();
+        taskExecutor.awaitShutdown(Duration.ofMinutes(1));
+
+        verify(task).flush();
+        verify(taskManager).unassignTask(task, taskExecutor);
+
+        assertNull(taskExecutor.currentTask(), "Have task assigned after shutdown");
+        assertFalse(taskExecutor.isRunning());
+    }
+
+    @Test
+    public void shouldClearTaskReleaseFutureOnShutdown() throws InterruptedException {
         assertNull(taskExecutor.currentTask(), "Have task assigned before startup");
 
         taskExecutor.start();
 
         verify(taskManager, timeout(VERIFICATION_TIMEOUT)).assignNextTask(taskExecutor);
 
-        taskExecutor.shutdown(Duration.ofMinutes(1));
+        final KafkaFuture<StreamTask> future = taskExecutor.unassign();
+        taskExecutor.requestShutdown();
+        taskExecutor.awaitShutdown(Duration.ofMinutes(1));
 
-        verify(task).prepareCommit();
-        verify(taskManager).unassignTask(task, taskExecutor);
-
+        waitForCondition(future::isDone, "Await for unassign future to complete");
+        assertTrue(future.isDone());
         assertNull(taskExecutor.currentTask(), "Have task assigned after shutdown");
     }
 
@@ -104,7 +131,7 @@ public class DefaultTaskExecutorTest {
         taskExecutor.start();
 
         verify(taskManager, timeout(VERIFICATION_TIMEOUT)).unassignTask(task, taskExecutor);
-        verify(task).prepareCommit();
+        verify(task).flush();
         assertNull(taskExecutor.currentTask());
     }
 
@@ -209,7 +236,7 @@ public class DefaultTaskExecutorTest {
         final KafkaFuture<StreamTask> future = taskExecutor.unassign();
 
         verify(taskManager, timeout(VERIFICATION_TIMEOUT)).unassignTask(task, taskExecutor);
-        verify(task).prepareCommit();
+        verify(task).flush();
         assertNull(taskExecutor.currentTask());
 
         assertTrue(future.isDone(), "Unassign is not completed");
@@ -223,10 +250,22 @@ public class DefaultTaskExecutorTest {
 
         taskExecutor.start();
 
-        verify(taskManager, timeout(VERIFICATION_TIMEOUT)).assignNextTask(taskExecutor);
         verify(taskManager, timeout(VERIFICATION_TIMEOUT)).setUncaughtException(exception, task.id());
         verify(taskManager, timeout(VERIFICATION_TIMEOUT)).unassignTask(task, taskExecutor);
         assertNull(taskExecutor.currentTask());
+        assertTrue(taskExecutor.isRunning(), "should not shut down upon exception");
+    }
+
+    @Test
+    public void shouldNotFlushOnException() {
+        final StreamsException exception = mock(StreamsException.class);
+        when(task.process(anyLong())).thenThrow(exception);
+        when(taskManager.hasUncaughtException(task.id())).thenReturn(true);
+
+        taskExecutor.start();
+
+        verify(taskManager, timeout(VERIFICATION_TIMEOUT)).unassignTask(task, taskExecutor);
+        verify(task, never()).flush();
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManagerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals.tasks;
 
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -23,9 +24,9 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.ReadOnlyTask;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.TaskExecutionMetadata;
 import org.apache.kafka.streams.processor.internals.TasksRegistry;
@@ -34,11 +35,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
-import java.util.Properties;
-
-import static org.apache.kafka.common.utils.Utils.mkEntry;
-import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -65,23 +61,30 @@ public class DefaultTaskManagerTest {
     private final StreamsException exception = mock(StreamsException.class);
     private final TaskExecutionMetadata taskExecutionMetadata = mock(TaskExecutionMetadata.class);
 
-    private final StreamsConfig config = new StreamsConfig(configProps());
-    private final TaskManager taskManager = new DefaultTaskManager(time, "TaskManager", tasks, config,
-        (taskManager, name, time, taskExecutionMetadata) -> taskExecutor, taskExecutionMetadata);
-
-    private Properties configProps() {
-        return mkObjectProperties(mkMap(
-            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
-            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
-            mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2)
-        ));
-    }
+    private final TaskManager taskManager = new DefaultTaskManager(time, "TaskManager", tasks,
+        (taskManager, name, time, taskExecutionMetadata) -> taskExecutor, taskExecutionMetadata, 1);
 
     @BeforeEach
     public void setUp() {
         when(task.isProcessable(anyLong())).thenReturn(true);
         when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
         when(tasks.task(taskId)).thenReturn(task);
+    }
+
+    @Test
+    public void shouldShutdownTaskExecutors() {
+        final Duration duration = mock(Duration.class);
+        taskManager.shutdown(duration);
+
+        verify(taskExecutor).requestShutdown();
+        verify(taskExecutor).awaitShutdown(duration);
+    }
+
+    @Test
+    public void shouldStartTaskExecutors() {
+        taskManager.start();
+
+        verify(taskExecutor).start();
     }
 
     @Test
@@ -119,7 +122,7 @@ public class DefaultTaskManagerTest {
 
         public void shutdown() {
             shutdownRequested.set(true);
-            taskManager.signalProcessableTasks();
+            taskManager.signalTaskExecutors();
         }
     }
 
@@ -155,7 +158,7 @@ public class DefaultTaskManagerTest {
         awaitingThread.start();
         verify(tasks, timeout(VERIFICATION_TIMEOUT).atLeastOnce()).activeTasks();
 
-        taskManager.signalProcessableTasks();
+        taskManager.signalTaskExecutors();
 
         assertTrue(awaitingRunnable.awaitDone.await(VERIFICATION_TIMEOUT, TimeUnit.MILLISECONDS));
 
@@ -230,6 +233,19 @@ public class DefaultTaskManagerTest {
         when(task.canPunctuateStreamTime()).thenReturn(true);
 
         assertEquals(task, taskManager.assignNextTask(taskExecutor));
+        assertNull(taskManager.assignNextTask(taskExecutor));
+    }
+
+    @Test
+    public void shouldNotAssignTasksIfUncaughtExceptionPresent() {
+        taskManager.add(Collections.singleton(task));
+        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(taskExecutionMetadata.canPunctuateTask(eq(task))).thenReturn(true);
+        when(task.canPunctuateStreamTime()).thenReturn(true);
+        taskManager.assignNextTask(taskExecutor);
+        taskManager.setUncaughtException(mock(StreamsException.class), taskId);
+        taskManager.unassignTask(task, taskExecutor);
+
         assertNull(taskManager.assignNextTask(taskExecutor));
     }
 
@@ -314,6 +330,7 @@ public class DefaultTaskManagerTest {
     public void shouldNotAssignLockedTask() {
         taskManager.add(Collections.singleton(task));
         when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
         when(tasks.task(task.id())).thenReturn(task);
         when(tasks.contains(task.id())).thenReturn(true);
 
@@ -323,9 +340,47 @@ public class DefaultTaskManagerTest {
     }
 
     @Test
+    public void shouldLockAnEmptySetOfTasks() {
+        taskManager.add(Collections.singleton(task));
+        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
+        when(tasks.task(task.id())).thenReturn(task);
+        when(tasks.contains(task.id())).thenReturn(true);
+
+        assertTrue(taskManager.lockTasks(Collections.emptySet()).isDone());
+
+        assertEquals(task, taskManager.assignNextTask(taskExecutor));
+    }
+
+
+    @Test
+    public void shouldLockATaskThatWasVoluntarilyReleased() {
+        final KafkaFutureImpl<StreamTask> future = new KafkaFutureImpl<>();
+
+        taskManager.add(Collections.singleton(task));
+        when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
+        when(tasks.task(task.id())).thenReturn(task);
+        when(tasks.contains(task.id())).thenReturn(true);
+        when(taskExecutor.unassign()).thenReturn(future);
+
+        assertEquals(task, taskManager.assignNextTask(taskExecutor));
+
+        final KafkaFuture<Void> lockingFuture = taskManager.lockTasks(Collections.singleton(task.id()));
+        assertFalse(lockingFuture.isDone());
+
+        taskManager.unassignTask(task, taskExecutor);
+        future.complete(null);
+
+        assertTrue(lockingFuture.isDone());
+        assertNull(taskManager.assignNextTask(taskExecutor));
+    }
+
+    @Test
     public void shouldNotAssignAnyLockedTask() {
         taskManager.add(Collections.singleton(task));
         when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
+        when(taskExecutionMetadata.canProcessTask(eq(task), anyLong())).thenReturn(true);
         when(tasks.task(task.id())).thenReturn(task);
         when(tasks.contains(task.id())).thenReturn(true);
 
@@ -379,12 +434,15 @@ public class DefaultTaskManagerTest {
 
         assertEquals(task, taskManager.assignNextTask(taskExecutor));
 
+        when(taskExecutor.currentTask()).thenReturn(new ReadOnlyTask(task));
         final KafkaFuture<Void> lockFuture = taskManager.lockAllTasks();
         assertFalse(lockFuture.isDone());
 
         verify(taskExecutor).unassign();
 
+        taskManager.unassignTask(task, taskExecutor);
         future.complete(task);
+
         assertTrue(lockFuture.isDone());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManagerTest.java
@@ -82,7 +82,7 @@ public class DefaultTaskManagerTest {
 
     @Test
     public void shouldStartTaskExecutors() {
-        taskManager.start();
+        taskManager.startTaskExecutors();
 
         verify(taskExecutor).start();
     }
@@ -240,8 +240,7 @@ public class DefaultTaskManagerTest {
     public void shouldNotAssignTasksIfUncaughtExceptionPresent() {
         taskManager.add(Collections.singleton(task));
         when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
-        when(taskExecutionMetadata.canPunctuateTask(eq(task))).thenReturn(true);
-        when(task.canPunctuateStreamTime()).thenReturn(true);
+        ensureTaskMakesProgress();
         taskManager.assignNextTask(taskExecutor);
         taskManager.setUncaughtException(mock(StreamsException.class), taskId);
         taskManager.unassignTask(task, taskExecutor);
@@ -445,4 +444,10 @@ public class DefaultTaskManagerTest {
 
         assertTrue(lockFuture.isDone());
     }
+
+    private void ensureTaskMakesProgress() {
+        when(taskExecutionMetadata.canPunctuateTask(eq(task))).thenReturn(true);
+        when(task.canPunctuateStreamTime()).thenReturn(true);
+    }
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManagerTest.java
@@ -242,7 +242,7 @@ public class DefaultTaskManagerTest {
         when(tasks.activeTasks()).thenReturn(Collections.singleton(task));
         ensureTaskMakesProgress();
         taskManager.assignNextTask(taskExecutor);
-        taskManager.setUncaughtException(mock(StreamsException.class), taskId);
+        taskManager.setUncaughtException(new StreamsException("Exception"), taskId);
         taskManager.unassignTask(task, taskExecutor);
 
         assertNull(taskManager.assignNextTask(taskExecutor));


### PR DESCRIPTION
 - Implements start and stop of task executors
 - Introduce flush operation to keep consumer operations out of the processing threads
 - Fixes corner case: handle requested unassignment during shutdown
 - Fixes corner case: handle race between voluntary unassignment and requested unassigment
 - Fixes corner case: task locking future completes for the empty set
 - Fixes corner case: we should not reassign a task with an uncaught exception to a task executor
 - Improved logging
 - Number of threads controlled from outside, of the TaskManager
