### PR TITLE
KAFKA-15389 Don't publish until we have replayed at least one record

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataBatchLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataBatchLoader.java
@@ -67,6 +67,7 @@ public class MetadataBatchLoader {
     private int numBatches;
     private long totalBatchElapsedNs;
     private TransactionState transactionState;
+    private boolean empty;
 
     public MetadataBatchLoader(
         LogContext logContext,
@@ -78,6 +79,15 @@ public class MetadataBatchLoader {
         this.time = time;
         this.faultHandler = faultHandler;
         this.callback = callback;
+        this.resetToImage(MetadataImage.EMPTY);
+        this.empty = true;
+    }
+
+    /**
+     * @return True if this batch loader has seen at least one record.
+     */
+    public boolean isEmpty() {
+        return empty;
     }
 
     /**
@@ -88,6 +98,7 @@ public class MetadataBatchLoader {
      */
     public void resetToImage(MetadataImage image) {
         this.image = image;
+        this.empty = false;
         this.delta = new MetadataDelta.Builder().setImage(image).build();
         this.transactionState = TransactionState.NO_TRANSACTION;
         this.lastOffset = image.provenance().lastContainedOffset();
@@ -241,6 +252,7 @@ public class MetadataBatchLoader {
                     default:
                         break;
                 }
+                empty = false;
                 delta.replay(record.message());
         }
     }

--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -240,7 +240,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
                     offset + ", but the high water mark is {}", where, highWaterMark.getAsLong());
             return true;
         }
-        if (batchLoader.isEmpty()) {
+        if (!batchLoader.hasSeenRecord()) {
             log.info("{}: The loader is still catching up because we have not loaded a controller record as of offset " +
                     offset + " and high water mark is {}", where, highWaterMark.getAsLong());
             return true;

--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -212,7 +212,6 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
             time,
             faultHandler,
             this::maybePublishMetadata);
-        this.batchLoader.resetToImage(this.image);
         this.eventQueue = new KafkaEventQueue(
             Time.SYSTEM,
             logContext,
@@ -239,6 +238,11 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
         if (highWaterMark.getAsLong() - 1 > offset) {
             log.info("{}: The loader is still catching up because we have loaded up to offset " +
                     offset + ", but the high water mark is {}", where, highWaterMark.getAsLong());
+            return true;
+        }
+        if (batchLoader.isEmpty()) {
+            log.info("{}: The loader is still catching up because we have not loaded a controller record as of offset " +
+                    offset + " and high water mark is {}", where, highWaterMark.getAsLong());
             return true;
         }
         log.info("{}: The loader finished catching up to the current high water mark of {}",
@@ -387,8 +391,8 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
                         image.provenance().lastContainedOffset(),
                         NANOSECONDS.toMicros(manifest.elapsedNs()));
                 MetadataImage image = delta.apply(manifest.provenance());
-                maybePublishMetadata(delta, image, manifest);
                 batchLoader.resetToImage(image);
+                maybePublishMetadata(delta, image, manifest);
             } catch (Throwable e) {
                 // This is a general catch-all block where we don't expect to end up;
                 // failure-prone operations should have individual try/catch blocks around them.


### PR DESCRIPTION
When starting up a controller for the first time (i.e., with an empty log), it is possible for MetadataLoader to publish an empty MetadataImage before the activation records of the controller have been written. This patch closes that gap by waiting for at least one controller record to be committed before the MetadataLoader starts publishing images.