### PR TITLE
MINOR: Check the existence of AppInfo for the given ID before creating a new mbean of the same name

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
@@ -60,8 +60,13 @@ public class AppInfoParser {
     public static synchronized void registerAppInfo(String prefix, String id, Metrics metrics, long nowMs) {
         try {
             ObjectName name = new ObjectName(prefix + ":type=app-info,id=" + Sanitizer.jmxSanitize(id));
+            MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+            if (server.isRegistered(name)) {
+                log.info("App info {} for {} already exists, so skipping  a new mbean creation", prefix, id);
+                return;
+            }
             AppInfo mBean = new AppInfo(nowMs);
-            ManagementFactory.getPlatformMBeanServer().registerMBean(mBean, name);
+            server.registerMBean(mBean, name);
 
             registerMetrics(metrics, mBean); // prefix will be added later by JmxReporter
         } catch (JMException e) {

--- a/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
@@ -62,7 +62,7 @@ public class AppInfoParser {
             ObjectName name = new ObjectName(prefix + ":type=app-info,id=" + Sanitizer.jmxSanitize(id));
             MBeanServer server = ManagementFactory.getPlatformMBeanServer();
             if (server.isRegistered(name)) {
-                log.info("App info {} for {} already exists, so skipping  a new mbean creation", prefix, id);
+                log.info("The mbean of App info: [{}], id: [{}] already exists, so skipping a new mbean creation.", prefix, id);
                 return;
             }
             AppInfo mBean = new AppInfo(nowMs);

--- a/clients/src/test/java/org/apache/kafka/common/utils/AppInfoParserTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/AppInfoParserTest.java
@@ -57,6 +57,7 @@ public class AppInfoParserTest {
     @Test
     public void testRegisterAppInfoRegistersMetrics() throws JMException {
         registerAppInfo();
+        registerAppInfoMultipleTimes();
     }
 
     @Test
@@ -75,6 +76,19 @@ public class AppInfoParserTest {
         assertEquals(EXPECTED_VERSION, AppInfoParser.getVersion());
 
         AppInfoParser.registerAppInfo(METRICS_PREFIX, METRICS_ID, metrics, EXPECTED_START_MS);
+
+        assertTrue(mBeanServer.isRegistered(expectedAppObjectName()));
+        assertEquals(EXPECTED_COMMIT_VERSION, metrics.metric(metrics.metricName("commit-id", "app-info")).metricValue());
+        assertEquals(EXPECTED_VERSION, metrics.metric(metrics.metricName("version", "app-info")).metricValue());
+        assertEquals(EXPECTED_START_MS, metrics.metric(metrics.metricName("start-time-ms", "app-info")).metricValue());
+    }
+
+    private void registerAppInfoMultipleTimes() throws JMException {
+        assertEquals(EXPECTED_COMMIT_VERSION, AppInfoParser.getCommitId());
+        assertEquals(EXPECTED_VERSION, AppInfoParser.getVersion());
+
+        AppInfoParser.registerAppInfo(METRICS_PREFIX, METRICS_ID, metrics, EXPECTED_START_MS);
+        AppInfoParser.registerAppInfo(METRICS_PREFIX, METRICS_ID, metrics, EXPECTED_START_MS); // We register it again
 
         assertTrue(mBeanServer.isRegistered(expectedAppObjectName()));
         assertEquals(EXPECTED_COMMIT_VERSION, metrics.metric(metrics.metricName("commit-id", "app-info")).metricValue());


### PR DESCRIPTION
When using kafka consumer in apache pinot , we did see couple of WARN as we are trying to create kafka consumer class with the same name . We currently have to use a added suffix to create a new mBean as each new kafka consumer in same process creates a mBean . Adding support here to skip creation of mBean if its already existing

```
javax.management.InstanceAlreadyExistsException: kafka.consumer:type=app-info,id=transcript2_REALTIME-transcript-topic-0
at com.sun.jmx.mbeanserver.Repository.addMBean(Repository.java:436) ~[?:?]
at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerWithRepository(DefaultMBeanServerInterceptor.java:1855) ~[?:?]
at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerDynamicMBean(DefaultMBeanServerInterceptor.java:955) ~[?:?]
at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerObject(DefaultMBeanServerInterceptor.java:890) ~[?:?]
at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerMBean(DefaultMBeanServerInterceptor.java:320) ~[?:?]
at com.sun.jmx.mbeanserver.JmxMBeanServer.registerMBean(JmxMBeanServer.java:522) ~[?:?]
at org.apache.pinot.shaded.org.apache.kafka.common.utils.AppInfoParser.registerAppInfo(AppInfoParser.java:64) [pinot-protobuf-0.13.0-SNAPSHOT-shaded.jar:0.13.0-SNAPSHOT-02fe2f1f864627b4a0e80c1291422b75cd173879]
at org.apache.pinot.shaded.org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:814) [pinot-protobuf-0.13.0-SNAPSHOT-shaded.jar:0.13.0-SNAPSHOT-02fe2f1f864627b4a0e80c1291422b75cd173879]
at org.apache.pinot.shaded.org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:665) [pinot-protobuf-0.13.0-SNAPSHOT-shaded.jar:0.13.0-SNAPSHOT-02fe2f1f864627b4a0e80c1291422b75cd173879]
at org.apache.pinot.shaded.org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:646) [pinot-protobuf-0.13.0-SNAPSHOT-shaded.jar:0.13.0-SNAPSHOT-02fe2f1f864627b4a0e80c1291422b75cd173879]
at org.apache.pinot.shaded.org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:626) [pinot-protobuf-0.13.0-SNAPSHOT-shaded.jar:0.13.0-SNAPSHOT-02fe2f1f864627b4a0e80c1291422b75cd173879]
at org.apache.pinot.plugin.stream.kafka20.KafkaPartitionLevelConnectionHandler.createConsumer(KafkaPartitionLevelConnectionHandler.java:84) [pinot-kafka-2.0-0.13.0-SNAPSHOT-shaded.jar:0.13.0-SNAPSHOT-02fe2f1f864627b4a0e80c1291422b75cd173879]
```