### PR TITLE
KAFKA-15256: Adding reviewer as part of release announcement email template

### DIFF
--- a/release.py
+++ b/release.py
@@ -332,8 +332,8 @@ def command_release_announcement_email():
         validate_release_num(previous_release_version_num)
     if release_version_num < previous_release_version_num :
         fail("Current release version number can't be less than previous release version number")
-    number_of_contributors = int(subprocess.check_output('git shortlog -sn --group=author --group=trailer:co-authored-by --no-merges %s..%s | uniq | wc -l' % (previous_release_version_num, release_version_num) , shell=True).decode('utf-8'))
-    contributors = subprocess.check_output("git shortlog -sn --group=author --group=trailer:co-authored-by --no-merges %s..%s | cut -f2 | sort --ignore-case | uniq" % (previous_release_version_num, release_version_num), shell=True).decode('utf-8')
+    number_of_contributors = int(subprocess.check_output('git shortlog -sn --group=author --group=trailer:co-authored-by --group=trailer:Reviewers --no-merges %s..%s | uniq | wc -l' % (previous_release_version_num, release_version_num) , shell=True).decode('utf-8'))
+    contributors = subprocess.check_output("git shortlog -sn --group=author --group=trailer:co-authored-by --group=trailer:Reviewers  --no-merges %s..%s | cut -f2 | sort --ignore-case | uniq" % (previous_release_version_num, release_version_num), shell=True).decode('utf-8')
     release_announcement_data = {
         'number_of_contributors': number_of_contributors,
         'contributors': ', '.join(str(x) for x in filter(None, contributors.split('\n'))),


### PR DESCRIPTION
This change adds reviewers (as captured from commit message) to the list of contributors for a release. I will change https://cwiki.apache.org/confluence/display/KAFKA/Release+Process to reflect the same once this PR is merged.

**Testing**
I tried parsing **reviewed-by** label from commit message but it did not worked because commit message includes reviewer list field as "Reviewers".
<img width="880" alt="Screenshot 2023-08-24 at 6 21 24 PM" src="https://github.com/apache/kafka/assets/59436466/f42b1d5f-6f6b-402f-9391-d2de71c1f41f">

python release.py release-email 
Execute for  (3.5.0..3.5.1)
Before reviewer parsing the count was 22
<img width="1769" alt="Screenshot 2023-08-25 at 12 54 18 AM" src="https://github.com/apache/kafka/assets/59436466/63345f28-8941-4bba-8a59-16fc0a35cf95">

After Added Reviewer parsing 
<img width="1774" alt="Screenshot 2023-08-25 at 12 56 46 AM" src="https://github.com/apache/kafka/assets/59436466/e3008789-2b1a-4e4f-8a54-fba37bfb67cc">


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
