### PR TITLE
MINOR: Fix the incorrect comment in the TopicDeletionManager.isTopicEligibleForDeletion method.

### DIFF
--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -214,7 +214,7 @@ class TopicDeletionManager(config: KafkaConfig,
    * Topic deletion can be retried if -
    * 1. Topic deletion is not already complete
    * 2. Topic deletion is currently not in progress for that topic
-   * 3. Topic is currently marked ineligible for deletion
+   * 3. Topic is currently not marked ineligible for deletion
    * @param topic Topic
    * @return Whether or not deletion can be retried for the topic
    */


### PR DESCRIPTION
This commit updates the comment in the `isTopicEligibleForDeletion()` method
to accurately reflect the logic in the code. 
The third condition in the comment
has been modified to match the actual third condition in the code.

Before:
"3. Topic is currently marked ineligible for deletion"

After:
"3. Topic is currently not marked ineligible for deletion"