### PR TITLE
MINOR: StoreChangelogReaderTest fails with log-level DEBUG

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -520,7 +520,11 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
     public void shouldRestoreFromBeginningAndCheckCompletion() {
         final TaskId taskId = new TaskId(0, 0);
 
-        EasyMock.expect(storeMetadata.offset()).andReturn(null).andReturn(9L).anyTimes();
+        if (type == STANDBY && logContext.logger(StoreChangelogReader.class).isDebugEnabled()) {
+            EasyMock.expect(storeMetadata.offset()).andReturn(null).andReturn(null).andReturn(9L).anyTimes();
+        } else {
+            EasyMock.expect(storeMetadata.offset()).andReturn(null).andReturn(9L).anyTimes();
+        }
         EasyMock.expect(stateManager.changelogOffsets()).andReturn(singletonMap(tp, 5L));
         EasyMock.expect(stateManager.taskId()).andReturn(taskId).anyTimes();
         EasyMock.replay(stateManager, storeMetadata, store);


### PR DESCRIPTION
A mocked method is executed unexpectedly when we enable DEBUG log level, leading to confusing test failures during debugging. Since the log message itself seems useful, we adapt the test to take the additional mocked method call into account.
