### PR TITLE
KAFKA-15351: Ensure log-start-offset not updated to local-log-start-offset when remote storage enabled

### DIFF
--- a/core/src/main/scala/kafka/log/LogLoader.scala
+++ b/core/src/main/scala/kafka/log/LogLoader.scala
@@ -78,7 +78,8 @@ class LogLoader(
   recoveryPointCheckpoint: Long,
   leaderEpochCache: Option[LeaderEpochFileCache],
   producerStateManager: ProducerStateManager,
-  numRemainingSegments: ConcurrentMap[String, Int] = new ConcurrentHashMap[String, Int]
+  numRemainingSegments: ConcurrentMap[String, Int] = new ConcurrentHashMap[String, Int],
+  isRemoteLogEnabled: Boolean = false,
 ) extends Logging {
   logIdent = s"[LogLoader partition=$topicPartition, dir=${dir.getParent}] "
 
@@ -180,7 +181,11 @@ class LogLoader(
     }
 
     leaderEpochCache.foreach(_.truncateFromEnd(nextOffset))
-    val newLogStartOffset = math.max(logStartOffsetCheckpoint, segments.firstSegment.get.baseOffset)
+    val newLogStartOffset = if (isRemoteLogEnabled) {
+      logStartOffsetCheckpoint
+    } else {
+      math.max(logStartOffsetCheckpoint, segments.firstSegment.get.baseOffset)
+    }
     // The earliest leader epoch may not be flushed during a hard failure. Recover it here.
     leaderEpochCache.foreach(_.truncateFromStart(logStartOffsetCheckpoint))
 

--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -166,9 +166,9 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
                            configOverrides: Properties = new Properties): KafkaProducer[K, V] = {
     val props = new Properties
     props ++= producerConfig
-    props ++= configOverrides
     // rediscover the new bootstrap-server port incase of broker restarts
     props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
+    props ++= configOverrides
     val producer = new KafkaProducer[K, V](props, keySerializer, valueSerializer)
     producers += producer
     producer
@@ -180,10 +180,10 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
                                 configsToRemove: List[String] = List()): PrototypeAsyncConsumer[K, V] = {
     val props = new Properties
     props ++= consumerConfig
-    props ++= configOverrides
-    configsToRemove.foreach(props.remove(_))
     // rediscover the new bootstrap-server port incase of broker restarts
     props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
+    props ++= configOverrides
+    configsToRemove.foreach(props.remove(_))
     val consumer = new PrototypeAsyncConsumer[K, V](props, keyDeserializer, valueDeserializer)
     consumers += consumer
     consumer
@@ -195,10 +195,10 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
                            configsToRemove: List[String] = List()): Consumer[K, V] = {
     val props = new Properties
     props ++= consumerConfig
-    props ++= configOverrides
-    configsToRemove.foreach(props.remove(_))
     // rediscover the new bootstrap-server port incase of broker restarts
     props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
+    props ++= configOverrides
+    configsToRemove.foreach(props.remove(_))
     val consumer = new KafkaConsumer[K, V](props, keyDeserializer, valueDeserializer)
     consumers += consumer
     consumer
@@ -210,9 +210,9 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
   ): Admin = {
     val props = new Properties
     props ++= adminClientConfig
-    props ++= configOverrides
     // rediscover the new bootstrap-server port incase of broker restarts
     props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
+    props ++= configOverrides
     val admin = TestUtils.createAdminClient(brokers, listenerName, props)
     adminClients += admin
     admin
@@ -224,6 +224,8 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
   ): Admin = {
     val props = new Properties
     props ++= superuserClientConfig
+    // rediscover the new bootstrap-server port incase of broker restarts
+    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
     props ++= configOverrides
     val admin = TestUtils.createAdminClient(brokers, listenerName, props)
     adminClients += admin

--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -26,6 +26,7 @@ import java.util.Properties
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig}
 import kafka.server.KafkaConfig
 import kafka.integration.KafkaServerTestHarness
+import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
 import org.apache.kafka.clients.consumer.internals.PrototypeAsyncConsumer
 import org.apache.kafka.common.network.{ListenerName, Mode}
@@ -166,6 +167,8 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
     val props = new Properties
     props ++= producerConfig
     props ++= configOverrides
+    // rediscover the new bootstrap-server port incase of broker restarts
+    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
     val producer = new KafkaProducer[K, V](props, keySerializer, valueSerializer)
     producers += producer
     producer
@@ -179,6 +182,8 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
     props ++= consumerConfig
     props ++= configOverrides
     configsToRemove.foreach(props.remove(_))
+    // rediscover the new bootstrap-server port incase of broker restarts
+    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
     val consumer = new PrototypeAsyncConsumer[K, V](props, keyDeserializer, valueDeserializer)
     consumers += consumer
     consumer
@@ -192,6 +197,8 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
     props ++= consumerConfig
     props ++= configOverrides
     configsToRemove.foreach(props.remove(_))
+    // rediscover the new bootstrap-server port incase of broker restarts
+    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
     val consumer = new KafkaConsumer[K, V](props, keyDeserializer, valueDeserializer)
     consumers += consumer
     consumer
@@ -204,6 +211,8 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
     val props = new Properties
     props ++= adminClientConfig
     props ++= configOverrides
+    // rediscover the new bootstrap-server port incase of broker restarts
+    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
     val admin = TestUtils.createAdminClient(brokers, listenerName, props)
     adminClients += admin
     admin

--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -26,7 +26,6 @@ import java.util.Properties
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig}
 import kafka.server.KafkaConfig
 import kafka.integration.KafkaServerTestHarness
-import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
 import org.apache.kafka.clients.consumer.internals.PrototypeAsyncConsumer
 import org.apache.kafka.common.network.{ListenerName, Mode}
@@ -166,8 +165,6 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
                            configOverrides: Properties = new Properties): KafkaProducer[K, V] = {
     val props = new Properties
     props ++= producerConfig
-    // rediscover the new bootstrap-server port incase of broker restarts
-    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
     props ++= configOverrides
     val producer = new KafkaProducer[K, V](props, keySerializer, valueSerializer)
     producers += producer
@@ -180,8 +177,6 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
                                 configsToRemove: List[String] = List()): PrototypeAsyncConsumer[K, V] = {
     val props = new Properties
     props ++= consumerConfig
-    // rediscover the new bootstrap-server port incase of broker restarts
-    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
     props ++= configOverrides
     configsToRemove.foreach(props.remove(_))
     val consumer = new PrototypeAsyncConsumer[K, V](props, keyDeserializer, valueDeserializer)
@@ -195,8 +190,6 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
                            configsToRemove: List[String] = List()): Consumer[K, V] = {
     val props = new Properties
     props ++= consumerConfig
-    // rediscover the new bootstrap-server port incase of broker restarts
-    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
     props ++= configOverrides
     configsToRemove.foreach(props.remove(_))
     val consumer = new KafkaConsumer[K, V](props, keyDeserializer, valueDeserializer)
@@ -210,8 +203,6 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
   ): Admin = {
     val props = new Properties
     props ++= adminClientConfig
-    // rediscover the new bootstrap-server port incase of broker restarts
-    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
     props ++= configOverrides
     val admin = TestUtils.createAdminClient(brokers, listenerName, props)
     adminClients += admin
@@ -224,8 +215,6 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
   ): Admin = {
     val props = new Properties
     props ++= superuserClientConfig
-    // rediscover the new bootstrap-server port incase of broker restarts
-    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers())
     props ++= configOverrides
     val admin = TestUtils.createAdminClient(brokers, listenerName, props)
     adminClients += admin

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestContext.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestContext.java
@@ -228,8 +228,11 @@ public final class TieredStorageTestContext implements AutoCloseable {
 
     public void bounce(int brokerId) {
         harness.killBroker(brokerId);
+        boolean allBrokersDead = harness.aliveBrokers().isEmpty();
         harness.startBroker(brokerId);
-        reinitClients();
+        if (allBrokersDead) {
+            reinitClients();
+        }
         initContext();
     }
 
@@ -239,8 +242,11 @@ public final class TieredStorageTestContext implements AutoCloseable {
     }
 
     public void start(int brokerId) {
+        boolean allBrokersDead = harness.aliveBrokers().isEmpty();
         harness.startBroker(brokerId);
-        reinitClients();
+        if (allBrokersDead) {
+            reinitClients();
+        }
         initContext();
     }
 
@@ -318,7 +324,7 @@ public final class TieredStorageTestContext implements AutoCloseable {
     private void reinitClients() {
         // Broker uses a random port (TestUtils.RandomPort) for the listener. If the initial bootstrap-server config
         // becomes invalid, then the clients won't be able to reconnect to the cluster.
-        // To avoid this, we reinitialize the clients after a broker is bounced.
+        // To avoid this, we reinitialize the clients after all the brokers are bounced.
         Utils.closeQuietly(producer, "Producer client");
         Utils.closeQuietly(consumer, "Consumer client");
         Utils.closeQuietly(admin, "Admin client");

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestContext.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestContext.java
@@ -229,6 +229,7 @@ public final class TieredStorageTestContext implements AutoCloseable {
     public void bounce(int brokerId) {
         harness.killBroker(brokerId);
         harness.startBroker(brokerId);
+        reinitClients();
         initContext();
     }
 
@@ -239,6 +240,7 @@ public final class TieredStorageTestContext implements AutoCloseable {
 
     public void start(int brokerId) {
         harness.startBroker(brokerId);
+        reinitClients();
         initContext();
     }
 
@@ -310,5 +312,16 @@ public final class TieredStorageTestContext implements AutoCloseable {
 
     @Override
     public void close() throws IOException {
+        // IntegrationTestHarness closes the clients on tearDown, no need to close them explicitly.
+    }
+
+    private void reinitClients() {
+        // Broker uses a random port (TestUtils.RandomPort) for the listener. If the initial bootstrap-server config
+        // becomes invalid, then the clients won't be able to reconnect to the cluster.
+        // To avoid this, we reinitialize the clients after a broker is bounced.
+        Utils.closeQuietly(producer, "Producer client");
+        Utils.closeQuietly(consumer, "Consumer client");
+        Utils.closeQuietly(admin, "Admin client");
+        initClients();
     }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndConsumeFromLeaderTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndConsumeFromLeaderTest.java
@@ -46,10 +46,10 @@ public final class OffloadAndConsumeFromLeaderTest extends TieredStorageTestHarn
         final Integer p0 = 0;
         final Integer partitionCount = 1;
         final Integer replicationFactor = 1;
-        final Integer maxBatchCountPerSegment = 1;
+        final Integer oneBatchPerSegment = 1;
+        final Integer twoBatchPerSegment = 2;
         final Map<Integer, List<Integer>> replicaAssignment = null;
         final boolean enableRemoteLogStorage = true;
-        final Integer batchSize = 1;
 
         builder
                 /*
@@ -75,9 +75,8 @@ public final class OffloadAndConsumeFromLeaderTest extends TieredStorageTestHarn
                  *                                            |  (k1, v1)         |
                  *                                            *-------------------*
                  */
-                .createTopic(topicA, partitionCount, replicationFactor, maxBatchCountPerSegment, replicaAssignment,
+                .createTopic(topicA, partitionCount, replicationFactor, oneBatchPerSegment, replicaAssignment,
                         enableRemoteLogStorage)
-                .withBatchSize(topicA, p0, batchSize)
                 .expectSegmentToBeOffloaded(broker, topicA, p0, 0, new KeyValueSpec("k0", "v0"))
                 .expectSegmentToBeOffloaded(broker, topicA, p0, 1, new KeyValueSpec("k1", "v1"))
                 .expectEarliestLocalOffsetInLogDirectory(topicA, p0, 2L)
@@ -105,9 +104,8 @@ public final class OffloadAndConsumeFromLeaderTest extends TieredStorageTestHarn
                  *                                            |  (k3, v3)         |
                  *                                            *-------------------*
                  */
-                .createTopic(topicB, partitionCount, replicationFactor, 2, replicaAssignment,
+                .createTopic(topicB, partitionCount, replicationFactor, twoBatchPerSegment, replicaAssignment,
                         enableRemoteLogStorage)
-                .withBatchSize(topicB, p0, batchSize)
                 .expectEarliestLocalOffsetInLogDirectory(topicB, p0, 4L)
                 .expectSegmentToBeOffloaded(broker, topicB, p0, 0,
                         new KeyValueSpec("k0", "v0"), new KeyValueSpec("k1", "v1"))
@@ -125,7 +123,7 @@ public final class OffloadAndConsumeFromLeaderTest extends TieredStorageTestHarn
                  *       -----------
                  *       - For topic A, this offset is defined such that only the second segment is fetched from
                  *         the tiered storage.
-                 *       - For topic B, only one segment is present in the tiered storage, as asserted by the
+                 *       - For topic B, two segments are present in the tiered storage, as asserted by the
                  *         previous sub-test-case.
                  */
                 .bounce(broker)

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndConsumeFromLeaderTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndConsumeFromLeaderTest.java
@@ -127,7 +127,7 @@ public final class OffloadAndConsumeFromLeaderTest extends TieredStorageTestHarn
                  *       - For topic B, only one segment is present in the tiered storage, as asserted by the
                  *         previous sub-test-case.
                  */
-                // .bounce(broker)
+                .bounce(broker)
                 .expectFetchFromTieredStorage(broker, topicA, p0, 1)
                 .consume(topicA, p0, 1L, 2, 1)
                 .expectFetchFromTieredStorage(broker, topicB, p0, 2)

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndConsumeFromLeaderTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndConsumeFromLeaderTest.java
@@ -68,20 +68,21 @@ public final class OffloadAndConsumeFromLeaderTest extends TieredStorageTestHarn
                  *           Log tA-p0                         Log tA-p0
                  *          *-------------------*             *-------------------*
                  *          | base offset = 2   |             |  base offset = 0  |
-                 *          | (k3, v3)          |             |  (k1, v1)         |
+                 *          | (k2, v2)          |             |  (k0, v0)         |
                  *          *-------------------*             *-------------------*
                  *                                            *-------------------*
                  *                                            |  base offset = 1  |
-                 *                                            |  (k2, v2)         |
+                 *                                            |  (k1, v1)         |
                  *                                            *-------------------*
                  */
                 .createTopic(topicA, partitionCount, replicationFactor, maxBatchCountPerSegment, replicaAssignment,
                         enableRemoteLogStorage)
                 .withBatchSize(topicA, p0, batchSize)
-                .expectSegmentToBeOffloaded(broker, topicA, p0, 0, new KeyValueSpec("k1", "v1"))
-                .expectSegmentToBeOffloaded(broker, topicA, p0, 1, new KeyValueSpec("k2", "v2"))
-                .produce(topicA, p0, new KeyValueSpec("k1", "v1"), new KeyValueSpec("k2", "v2"),
-                        new KeyValueSpec("k3", "v3"))
+                .expectSegmentToBeOffloaded(broker, topicA, p0, 0, new KeyValueSpec("k0", "v0"))
+                .expectSegmentToBeOffloaded(broker, topicA, p0, 1, new KeyValueSpec("k1", "v1"))
+                .expectEarliestLocalOffsetInLogDirectory(topicA, p0, 2L)
+                .produce(topicA, p0, new KeyValueSpec("k0", "v0"), new KeyValueSpec("k1", "v1"),
+                        new KeyValueSpec("k2", "v2"))
 
                 /*
                  * (2) Similar scenario as above, but with segments of two records.
@@ -95,13 +96,13 @@ public final class OffloadAndConsumeFromLeaderTest extends TieredStorageTestHarn
                  *           Log tB-p0                         Log tB-p0
                  *          *-------------------*             *-------------------*
                  *          | base offset = 4   |             |  base offset = 0  |
-                 *          | (k5, v5)          |             |  (k1, v1)         |
-                 *          *-------------------*             |  (k2, v2)         |
+                 *          | (k4, v4)          |             |  (k0, v0)         |
+                 *          *-------------------*             |  (k1, v1)         |
                  *                                            *-------------------*
                  *                                            *-------------------*
                  *                                            |  base offset = 2  |
+                 *                                            |  (k2, v2)         |
                  *                                            |  (k3, v3)         |
-                 *                                            |  (k4, v4)         |
                  *                                            *-------------------*
                  */
                 .createTopic(topicB, partitionCount, replicationFactor, 2, replicaAssignment,
@@ -109,11 +110,11 @@ public final class OffloadAndConsumeFromLeaderTest extends TieredStorageTestHarn
                 .withBatchSize(topicB, p0, batchSize)
                 .expectEarliestLocalOffsetInLogDirectory(topicB, p0, 4L)
                 .expectSegmentToBeOffloaded(broker, topicB, p0, 0,
-                        new KeyValueSpec("k1", "v1"), new KeyValueSpec("k2", "v2"))
+                        new KeyValueSpec("k0", "v0"), new KeyValueSpec("k1", "v1"))
                 .expectSegmentToBeOffloaded(broker, topicB, p0, 2,
-                        new KeyValueSpec("k3", "v3"), new KeyValueSpec("k4", "v4"))
-                .produce(topicB, p0, new KeyValueSpec("k1", "v1"), new KeyValueSpec("k2", "v2"),
-                        new KeyValueSpec("k3", "v3"), new KeyValueSpec("k4", "v4"), new KeyValueSpec("k5", "v5"))
+                        new KeyValueSpec("k2", "v2"), new KeyValueSpec("k3", "v3"))
+                .produce(topicB, p0, new KeyValueSpec("k0", "v0"), new KeyValueSpec("k1", "v1"),
+                        new KeyValueSpec("k2", "v2"), new KeyValueSpec("k3", "v3"), new KeyValueSpec("k4", "v4"))
 
                 /*
                  * (3) Stops and restarts the broker. The purpose of this test is to a) exercise consumption

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndConsumeFromLeaderTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/OffloadAndConsumeFromLeaderTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Test Cases (A):
+ * Test Cases:
  *    Elementary offloads and fetches from tiered storage.
  */
 public final class OffloadAndConsumeFromLeaderTest extends TieredStorageTestHarness {
@@ -53,7 +53,7 @@ public final class OffloadAndConsumeFromLeaderTest extends TieredStorageTestHarn
 
         builder
                 /*
-                 * (A.1) Create a topic which segments contain only one batch and produce three records
+                 * (1) Create a topic which segments contain only one batch and produce three records
                  *       with a batch size of 1.
                  *
                  *       The topic and broker are configured so that the two rolled segments are picked from
@@ -84,7 +84,7 @@ public final class OffloadAndConsumeFromLeaderTest extends TieredStorageTestHarn
                         new KeyValueSpec("k3", "v3"))
 
                 /*
-                 * (A.2) Similar scenario as above, but with segments of two records.
+                 * (2) Similar scenario as above, but with segments of two records.
                  *
                  *       Acceptance:
                  *       -----------
@@ -116,7 +116,7 @@ public final class OffloadAndConsumeFromLeaderTest extends TieredStorageTestHarn
                         new KeyValueSpec("k3", "v3"), new KeyValueSpec("k4", "v4"), new KeyValueSpec("k5", "v5"))
 
                 /*
-                 * (A.3) Stops and restarts the broker. The purpose of this test is to a) exercise consumption
+                 * (3) Stops and restarts the broker. The purpose of this test is to a) exercise consumption
                  *       from a given offset and b) verify that upon broker start, existing remote log segments
                  *       metadata are loaded by Kafka and these log segments available.
                  *


### PR DESCRIPTION
Part-1: When tiered storage is enabled on the topic, and the last-standing-replica is restarted, then the log-start-offset should not reset its offset to first-local-log-segment-base-offset.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
