### PR TITLE
KAFKA-13327: Gracefully report connector validation errors instead of returning 500 responses

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -371,7 +371,9 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
     }
 
     protected Map<String, ConfigValue> validateSinkConnectorConfig(SinkConnector connector, ConfigDef configDef, Map<String, String> config) {
-        return configDef.validateAll(config);
+        Map<String, ConfigValue> result = configDef.validateAll(config);
+        SinkConnectorConfig.validate(config, result);
+        return result;
     }
 
     protected Map<String, ConfigValue> validateSourceConnectorConfig(SourceConnector connector, ConfigDef configDef, Map<String, String> config) {
@@ -478,7 +480,6 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                 enrichedConfigDef = ConnectorConfig.enrich(plugins(), SourceConnectorConfig.configDef(), connectorProps, false);
                 validatedConnectorConfig = validateSourceConnectorConfig((SourceConnector) connector, enrichedConfigDef, connectorProps);
             } else {
-                SinkConnectorConfig.validate(connectorProps);
                 connectorType = org.apache.kafka.connect.health.ConnectorType.SINK;
                 enrichedConfigDef = ConnectorConfig.enrich(plugins(), SinkConnectorConfig.configDef(), connectorProps, false);
                 validatedConnectorConfig = validateSinkConnectorConfig((SinkConnector) connector, enrichedConfigDef, connectorProps);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -429,7 +429,9 @@ public class ConnectorConfig extends AbstractConfig {
                 final ConfigDef.Validator typeValidator = ConfigDef.LambdaValidator.with(
                     (String name, Object value) -> {
                         validateProps(prefix);
-                        getConfigDefFromConfigProvidingClass(typeConfig, (Class<?>) value);
+                        if (value != null) {
+                            getConfigDefFromConfigProvidingClass(typeConfig, (Class<?>) value);
+                        }
                     },
                     () -> "valid configs for " + alias + " " + aliasKind.toLowerCase(Locale.ENGLISH));
                 newDef.define(typeConfig, Type.CLASS, ConfigDef.NO_DEFAULT_VALUE, typeValidator, Importance.HIGH,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -429,6 +429,7 @@ public class ConnectorConfig extends AbstractConfig {
                 final ConfigDef.Validator typeValidator = ConfigDef.LambdaValidator.with(
                     (String name, Object value) -> {
                         validateProps(prefix);
+                        // The value will be null if the class couldn't be found; no point in performing follow-up validation
                         if (value != null) {
                             getConfigDefFromConfigProvidingClass(typeConfig, (Class<?>) value);
                         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SinkConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SinkConnectorConfig.java
@@ -19,15 +19,18 @@ package org.apache.kafka.connect.runtime;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.kafka.connect.transforms.util.RegexValidator;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -90,48 +93,95 @@ public class SinkConnectorConfig extends ConnectorConfig {
      * @param props sink configuration properties
      */
     public static void validate(Map<String, String> props) {
-        final boolean hasTopicsConfig = hasTopicsConfig(props);
-        final boolean hasTopicsRegexConfig = hasTopicsRegexConfig(props);
-        final boolean hasDlqTopicConfig = hasDlqTopicConfig(props);
+        validate(
+                props,
+                error -> {
+                    throw new ConfigException(error.property, error.value, error.errorMessage);
+                }
+        );
+    }
+
+    /**
+     * Perform preflight validation for the sink-specific properties for a connector.
+     *
+     * @param props           the configuration for the sink connector
+     * @param validatedConfig any already-known {@link ConfigValue validation results} for the configuration.
+     *                        May be empty, but may not be null. Any configuration errors discovered by this method will
+     *                        be {@link ConfigValue#addErrorMessage(String) added} to a value in this map, adding a new
+     *                        entry if one for the problematic property does not already exist.
+     */
+    public static void validate(Map<String, String> props, Map<String, ConfigValue> validatedConfig) {
+        validate(props, error -> addErrorMessage(validatedConfig, error));
+    }
+
+    private static void validate(Map<String, String> props, Consumer<ConfigError> onError) {
+        final String topicsList = props.get(TOPICS_CONFIG);
+        final String topicsRegex = props.get(TOPICS_REGEX_CONFIG);
+        final String dlqTopic = props.getOrDefault(DLQ_TOPIC_NAME_CONFIG, "").trim();
+        final boolean hasTopicsConfig = !Utils.isBlank(topicsList);
+        final boolean hasTopicsRegexConfig = !Utils.isBlank(topicsRegex);
+        final boolean hasDlqTopicConfig = !Utils.isBlank(dlqTopic);
 
         if (hasTopicsConfig && hasTopicsRegexConfig) {
-            throw new ConfigException(SinkTask.TOPICS_CONFIG + " and " + SinkTask.TOPICS_REGEX_CONFIG +
-                " are mutually exclusive options, but both are set.");
+            String errorMessage = TOPICS_CONFIG + " and " + TOPICS_REGEX_CONFIG + " are mutually exclusive options, but both are set.";
+            onError.accept(new ConfigError(TOPICS_CONFIG, topicsList, errorMessage));
+            onError.accept(new ConfigError(TOPICS_REGEX_CONFIG, topicsRegex, errorMessage));
         }
 
         if (!hasTopicsConfig && !hasTopicsRegexConfig) {
-            throw new ConfigException("Must configure one of " +
-                SinkTask.TOPICS_CONFIG + " or " + SinkTask.TOPICS_REGEX_CONFIG);
+            String errorMessage = "Must configure one of " + TOPICS_CONFIG + " or " + TOPICS_REGEX_CONFIG;
+            onError.accept(new ConfigError(TOPICS_CONFIG, topicsList, errorMessage));
+            onError.accept(new ConfigError(TOPICS_REGEX_CONFIG, topicsRegex, errorMessage));
         }
 
         if (hasDlqTopicConfig) {
-            String dlqTopic = props.get(DLQ_TOPIC_NAME_CONFIG).trim();
             if (hasTopicsConfig) {
                 List<String> topics = parseTopicsList(props);
                 if (topics.contains(dlqTopic)) {
-                    throw new ConfigException(String.format("The DLQ topic '%s' may not be included in the list of "
-                            + "topics ('%s=%s') consumed by the connector", dlqTopic, SinkTask.TOPICS_REGEX_CONFIG, topics));
+                    String errorMessage = String.format(
+                            "The DLQ topic '%s' may not be included in the list of topics ('%s=%s') consumed by the connector",
+                            dlqTopic, TOPICS_CONFIG, topics
+                    );
+                    onError.accept(new ConfigError(TOPICS_CONFIG, topicsList, errorMessage));
                 }
             }
             if (hasTopicsRegexConfig) {
-                String topicsRegexStr = props.get(SinkTask.TOPICS_REGEX_CONFIG);
-                Pattern pattern = Pattern.compile(topicsRegexStr);
+                Pattern pattern = Pattern.compile(topicsRegex);
                 if (pattern.matcher(dlqTopic).matches()) {
-                    throw new ConfigException(String.format("The DLQ topic '%s' may not be included in the regex matching the "
-                            + "topics ('%s=%s') consumed by the connector", dlqTopic, SinkTask.TOPICS_REGEX_CONFIG, topicsRegexStr));
+                    String errorMessage = String.format(
+                            "The DLQ topic '%s' may not be included in the regex matching the topics ('%s=%s') consumed by the connector",
+                            dlqTopic, TOPICS_REGEX_CONFIG, topicsRegex
+                    );
+                    onError.accept(new ConfigError(TOPICS_REGEX_CONFIG, topicsRegex, errorMessage));
                 }
             }
         }
+    }
+
+    private static class ConfigError {
+        public final String property;
+        public final Object value;
+        public final String errorMessage;
+
+        public ConfigError(String property, Object value, String errorMessage) {
+            this.property = property;
+            this.value = value;
+            this.errorMessage = errorMessage;
+        }
+    }
+
+    private static void addErrorMessage(Map<String, ConfigValue> validatedConfig, ConfigError error) {
+        validatedConfig.computeIfAbsent(
+                error.property,
+                p -> new ConfigValue(error.property, error.value, Collections.emptyList(), new ArrayList<>())
+        ).addErrorMessage(
+                error.errorMessage
+        );
     }
 
     public static boolean hasTopicsConfig(Map<String, String> props) {
         String topicsStr = props.get(TOPICS_CONFIG);
         return !Utils.isBlank(topicsStr);
-    }
-
-    public static boolean hasTopicsRegexConfig(Map<String, String> props) {
-        String topicsRegexStr = props.get(TOPICS_REGEX_CONFIG);
-        return !Utils.isBlank(topicsRegexStr);
     }
 
     public static boolean hasDlqTopicConfig(Map<String, String> props) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SinkConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SinkConnectorConfig.java
@@ -147,7 +147,7 @@ public class SinkConnectorConfig extends ConnectorConfig {
                 Pattern pattern = Pattern.compile(topicsRegex);
                 if (pattern.matcher(dlqTopic).matches()) {
                     String errorMessage = String.format(
-                            "The DLQ topic '%s' may not be included in the regex matching the topics ('%s=%s') consumed by the connector",
+                            "The DLQ topic '%s' may not be matched by the regex for the topics ('%s=%s') consumed by the connector",
                             dlqTopic, TOPICS_REGEX_CONFIG, topicsRegex
                     );
                     addErrorMessage(validatedConfig, TOPICS_REGEX_CONFIG, topicsRegex, errorMessage);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
@@ -1,0 +1,334 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.integration;
+
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.connect.transforms.Filter;
+import org.apache.kafka.connect.transforms.predicates.RecordIsTombstone;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+import static org.apache.kafka.connect.integration.MonitorableSourceConnector.TOPIC_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.NAME_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.PREDICATES_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TRANSFORMS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG;
+import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_CONFIG;
+import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_REGEX_CONFIG;
+import static org.apache.kafka.connect.runtime.SourceConnectorConfig.TOPIC_CREATION_GROUPS_CONFIG;
+
+/**
+ * Integration test for preflight connector config validation
+ */
+@Category(IntegrationTest.class)
+public class ConnectorValidationIntegrationTest {
+
+    private static final String WORKER_GROUP_ID = "connect-worker-group-id";
+
+    // Use a single embedded cluster for all test cases in order to cut down on runtime
+    private static EmbeddedConnectCluster connect;
+
+    @BeforeClass
+    public static void setup() {
+        Map<String, String> workerProps = new HashMap<>();
+        workerProps.put(GROUP_ID_CONFIG, WORKER_GROUP_ID);
+
+        // build a Connect cluster backed by Kafka and Zk
+        connect = new EmbeddedConnectCluster.Builder()
+                .name("connector-validation-connect-cluster")
+                .workerProps(workerProps)
+                .build();
+        connect.start();
+    }
+
+    @AfterClass
+    public static void close() {
+        if (connect != null) {
+            // stop all Connect, Kafka and Zk threads.
+            Utils.closeQuietly(connect::stop, "Embedded Connect cluster");
+        }
+    }
+
+    @Test
+    public void testSinkConnectorHasNeitherTopicsListNorTopicsRegex() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.remove(TOPICS_CONFIG);
+        config.remove(TOPICS_REGEX_CONFIG);
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                2, // One error each for topics list and topics regex
+                "Sink connector config should fail preflight validation when neither topics list nor topics regex are provided",
+                0
+        );
+    }
+
+    @Test
+    public void testSinkConnectorHasBothTopicsListAndTopicsRegex() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(TOPICS_CONFIG, "t1");
+        config.put(TOPICS_REGEX_CONFIG, "r.*");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                2, // One error each for topics list and topics regex
+                "Sink connector config should fail preflight validation when both topics list and topics regex are provided",
+                0
+        );
+    }
+
+    @Test
+    public void testSinkConnectorDeadLetterQueueTopicInTopicsList() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(TOPICS_CONFIG, "t1");
+        config.put(DLQ_TOPIC_NAME_CONFIG, "t1");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                1,
+                "Sink connector config should fail preflight validation when DLQ topic is included in topics list",
+                0
+        );
+    }
+
+    @Test
+    public void testSinkConnectorDeadLetterQueueTopicMatchesTopicsRegex() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(TOPICS_REGEX_CONFIG, "r.*");
+        config.put(DLQ_TOPIC_NAME_CONFIG, "ruh.roh");
+        config.remove(TOPICS_CONFIG);
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                1,
+                "Sink connector config should fail preflight validation when DLQ topic matches topics regex",
+                0
+        );
+    }
+
+    @Test
+    public void testSinkConnectorDefaultGroupIdConflictsWithWorkerGroupId() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        // Combined with the logic in SinkUtils::consumerGroupId, this should conflict with the worker group ID
+        config.put(NAME_CONFIG, "worker-group-id");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                1,
+                "Sink connector config should fail preflight validation when default consumer group ID conflicts with Connect worker group ID",
+                0
+        );
+    }
+
+    @Test
+    public void testSinkConnectorOverriddenGroupIdConflictsWithWorkerGroupId() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + GROUP_ID_CONFIG, WORKER_GROUP_ID);
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                1,
+                "Sink connector config should fail preflight validation when overridden consumer group ID conflicts with Connect worker group ID",
+                0
+        );
+    }
+
+    @Test
+    public void testSourceConnectorHasDuplicateTopicCreationGroups() throws InterruptedException {
+        Map<String, String> config = defaultSourceConnectorProps();
+        config.put(TOPIC_CREATION_GROUPS_CONFIG, "g1, g2, g1");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                1,
+                "Source connector config should fail preflight validation when the same topic creation group is specified multiple times",
+                0
+        );
+    }
+
+    @Test
+    public void testConnectorHasDuplicateTransformations() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        String transformName = "t";
+        config.put(TRANSFORMS_CONFIG, transformName + ", " + transformName);
+        config.put(TRANSFORMS_CONFIG + "." + transformName + ".type", Filter.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                1,
+                "Connector config should fail preflight validation when the same transformation is specified multiple times",
+                0
+        );
+    }
+
+    @Test
+    public void testConnectorHasMissingTransformClass() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        String transformName = "t";
+        config.put(TRANSFORMS_CONFIG, transformName);
+        config.put(TRANSFORMS_CONFIG + "." + transformName + ".type", "WheresTheFruit");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                1,
+                "Connector config should fail preflight validation when a transformation with a class not found on the worker is specified",
+                0
+        );
+    }
+
+    @Test
+    public void testConnectorHasInvalidTransformClass() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        String transformName = "t";
+        config.put(TRANSFORMS_CONFIG, transformName);
+        config.put(TRANSFORMS_CONFIG + "." + transformName + ".type", MonitorableSinkConnector.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                1,
+                "Connector config should fail preflight validation when a transformation with a class of the wrong type is specified",
+                0
+        );
+    }
+
+    @Test
+    public void testConnectorHasNegationForUndefinedPredicate() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        String transformName = "t";
+        config.put(TRANSFORMS_CONFIG, transformName);
+        config.put(TRANSFORMS_CONFIG + "." + transformName + ".type", Filter.class.getName());
+        config.put(TRANSFORMS_CONFIG + "." + transformName + ".negate", "true");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                1,
+                "Connector config should fail preflight validation when an undefined predicate is negated",
+                0
+        );
+    }
+
+    @Test
+    public void testConnectorHasDuplicatePredicates() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        String predicateName = "p";
+        config.put(PREDICATES_CONFIG, predicateName + ", " + predicateName);
+        config.put(PREDICATES_CONFIG + "." + predicateName + ".type", RecordIsTombstone.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                1,
+                "Connector config should fail preflight validation when the same predicate is specified multiple times",
+                0
+        );
+    }
+
+    @Test
+    public void testConnectorHasMissingPredicateClass() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        String predicateName = "p";
+        config.put(PREDICATES_CONFIG, predicateName);
+        config.put(PREDICATES_CONFIG + "." + predicateName + ".type", "WheresTheFruit");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                1,
+                "Connector config should fail preflight validation when a predicate with a class not found on the worker is specified",
+                0
+        );
+    }
+
+    @Test
+    public void testConnectorHasInvalidPredicateClass() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        String predicateName = "p";
+        config.put(PREDICATES_CONFIG, predicateName);
+        config.put(PREDICATES_CONFIG + "." + predicateName + ".type", MonitorableSinkConnector.class.getName());
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                1,
+                "Connector config should fail preflight validation when a predicate with a class of the wrong type is specified",
+                0
+        );
+    }
+
+    @Test
+    public void testConnectorHasMissingConverterClass() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(KEY_CONVERTER_CLASS_CONFIG, "WheresTheFruit");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                1,
+                "Connector config should fail preflight validation when a converter with a class not found on the worker is specified",
+                0
+        );
+    }
+
+    @Test
+    public void testConnectorHasMissingHeaderConverterClass() throws InterruptedException {
+        Map<String, String> config = defaultSinkConnectorProps();
+        config.put(HEADER_CONVERTER_CLASS_CONFIG, "WheresTheFruit");
+        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
+                config.get(CONNECTOR_CLASS_CONFIG),
+                config,
+                1,
+                "Connector config should fail preflight validation when a header converter with a class not found on the worker is specified",
+                0
+        );
+    }
+
+    private Map<String, String> defaultSourceConnectorProps() {
+        // setup up props for the source connector
+        Map<String, String> props = new HashMap<>();
+        props.put(NAME_CONFIG, "source-connector");
+        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName());
+        props.put(TASKS_MAX_CONFIG, "1");
+        props.put(TOPIC_CONFIG, "t1");
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        return props;
+    }
+
+    private Map<String, String> defaultSinkConnectorProps() {
+        // setup up props for the sink connector
+        Map<String, String> props = new HashMap<>();
+        props.put(NAME_CONFIG, "sink-connector");
+        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSinkConnector.class.getSimpleName());
+        props.put(TASKS_MAX_CONFIG, "1");
+        props.put(TOPICS_CONFIG, "t1");
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        return props;
+    }
+
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
@@ -66,6 +66,8 @@ public class ConnectorValidationIntegrationTest {
         connect = new EmbeddedConnectCluster.Builder()
                 .name("connector-validation-connect-cluster")
                 .workerProps(workerProps)
+                .numBrokers(1)
+                .numWorkers(1)
                 .build();
         connect.start();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.connect.runtime;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigTransformer;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.config.SaslConfigs;
@@ -517,7 +516,15 @@ public class AbstractHerderTest {
         config.put(SinkConnectorConfig.TOPICS_CONFIG, "topic1,topic2");
         config.put(SinkConnectorConfig.TOPICS_REGEX_CONFIG, "topic.*");
 
-        assertThrows(ConfigException.class, () -> herder.validateConnectorConfig(config, false));
+        ConfigInfos validation = herder.validateConnectorConfig(config, false);
+
+        ConfigInfo topicsListInfo = findInfo(validation, SinkConnectorConfig.TOPICS_CONFIG);
+        assertNotNull(topicsListInfo);
+        assertEquals(1, topicsListInfo.configValue().errors().size());
+
+        ConfigInfo topicsRegexInfo = findInfo(validation, SinkConnectorConfig.TOPICS_REGEX_CONFIG);
+        assertNotNull(topicsRegexInfo);
+        assertEquals(1, topicsRegexInfo.configValue().errors().size());
 
         verifyValidationIsolation();
     }
@@ -532,7 +539,11 @@ public class AbstractHerderTest {
         config.put(SinkConnectorConfig.TOPICS_CONFIG, "topic1");
         config.put(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, "topic1");
 
-        assertThrows(ConfigException.class, () -> herder.validateConnectorConfig(config, false));
+        ConfigInfos validation = herder.validateConnectorConfig(config, false);
+
+        ConfigInfo topicsListInfo = findInfo(validation, SinkConnectorConfig.TOPICS_CONFIG);
+        assertNotNull(topicsListInfo);
+        assertEquals(1, topicsListInfo.configValue().errors().size());
 
         verifyValidationIsolation();
     }
@@ -547,7 +558,11 @@ public class AbstractHerderTest {
         config.put(SinkConnectorConfig.TOPICS_REGEX_CONFIG, "topic.*");
         config.put(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, "topic1");
 
-        assertThrows(ConfigException.class, () -> herder.validateConnectorConfig(config, false));
+        ConfigInfos validation = herder.validateConnectorConfig(config, false);
+
+        ConfigInfo topicsRegexInfo = findInfo(validation, SinkConnectorConfig.TOPICS_REGEX_CONFIG);
+        assertNotNull(topicsRegexInfo);
+        assertEquals(1, topicsRegexInfo.configValue().errors().size());
 
         verifyValidationIsolation();
     }
@@ -587,7 +602,7 @@ public class AbstractHerderTest {
                 "Transforms: xformB"
         );
         assertEquals(expectedGroups, result.groups());
-        assertEquals(2, result.errorCount());
+        assertEquals(1, result.errorCount());
         Map<String, ConfigInfo> infos = result.values().stream()
                 .collect(Collectors.toMap(info -> info.configKey().name(), Function.identity()));
         assertEquals(26, infos.size());
@@ -644,7 +659,7 @@ public class AbstractHerderTest {
                 "Predicates: predY"
         );
         assertEquals(expectedGroups, result.groups());
-        assertEquals(2, result.errorCount());
+        assertEquals(1, result.errorCount());
         Map<String, ConfigInfo> infos = result.values().stream()
                 .collect(Collectors.toMap(info -> info.configKey().name(), Function.identity()));
         assertEquals(28, infos.size());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
@@ -237,6 +237,7 @@ public class EmbeddedConnectClusterAssertions {
      * @param connectorClass the class of the connector to validate
      * @param connConfig     the intended configuration
      * @param numErrors      the number of errors expected
+     * @param detailMessage  the assertion message
      */
     public void assertExactlyNumErrorsOnConnectorConfigValidation(String connectorClass, Map<String, String> connConfig,
                                                                   int numErrors, String detailMessage) throws InterruptedException {
@@ -249,6 +250,7 @@ public class EmbeddedConnectClusterAssertions {
      * @param connectorClass the class of the connector to validate
      * @param connConfig     the intended configuration
      * @param numErrors      the number of errors expected
+     * @param detailMessage  the assertion message
      * @param timeout        how long to retry for before throwing an exception
      *
      * @throws AssertionError if the exact number of errors is not produced during config

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
@@ -239,7 +239,23 @@ public class EmbeddedConnectClusterAssertions {
      * @param numErrors      the number of errors expected
      */
     public void assertExactlyNumErrorsOnConnectorConfigValidation(String connectorClass, Map<String, String> connConfig,
-        int numErrors, String detailMessage) throws InterruptedException {
+                                                                  int numErrors, String detailMessage) throws InterruptedException {
+        assertExactlyNumErrorsOnConnectorConfigValidation(connectorClass, connConfig, numErrors, detailMessage, VALIDATION_DURATION_MS);
+    }
+
+    /**
+     * Assert that the required number of errors are produced by a connector config validation.
+     *
+     * @param connectorClass the class of the connector to validate
+     * @param connConfig     the intended configuration
+     * @param numErrors      the number of errors expected
+     * @param timeout        how long to retry for before throwing an exception
+     *
+     * @throws AssertionError if the exact number of errors is not produced during config
+     * validation before the timeout expires
+     */
+    public void assertExactlyNumErrorsOnConnectorConfigValidation(String connectorClass, Map<String, String> connConfig,
+        int numErrors, String detailMessage, long timeout) throws InterruptedException {
         try {
             waitForCondition(
                 () -> checkValidationErrors(
@@ -248,7 +264,7 @@ public class EmbeddedConnectClusterAssertions {
                     numErrors,
                     (actual, expected) -> actual == expected
                 ).orElse(false),
-                VALIDATION_DURATION_MS,
+                timeout,
                 "Didn't meet the exact requested number of validation errors: " + numErrors);
         } catch (AssertionError e) {
             throw new AssertionError(detailMessage, e);


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-13327)

Background context: this is split off from https://github.com/apache/kafka/pull/11369, which addressed this issue and two others. Not only does this new PR fix the merge conflicts with its predecessor, it also simplifies the review process by addressing a single issue at a time.

This change addresses an issue where some types of validation errors are reported via HTTP 500 responses, which is incorrect (the issue is not the fault of the server, but rather of the connector configuration) and can cover up other validation errors. Instead, these types of errors are now reported as part of a well-formed response body.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
