### PR TITLE
KAFKA-14499: [5/N] Refactor GroupCoordinator.fetchOffsets and GroupCoordinator.fetchAllOffsets

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1452,17 +1452,17 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   private def fetchAllOffsetsForGroup(
     requestContext: RequestContext,
-    groupOffsetFetch: OffsetFetchRequestData.OffsetFetchRequestGroup,
+    offsetFetchRequest: OffsetFetchRequestData.OffsetFetchRequestGroup,
     requireStable: Boolean
   ): CompletableFuture[OffsetFetchResponseData.OffsetFetchResponseGroup] = {
     groupCoordinator.fetchAllOffsets(
       requestContext,
-      groupOffsetFetch.groupId,
+      offsetFetchRequest,
       requireStable
-    ).handle[OffsetFetchResponseData.OffsetFetchResponseGroup] { (offsets, exception) =>
+    ).handle[OffsetFetchResponseData.OffsetFetchResponseGroup] { (offsetFetchResponse, exception) =>
       if (exception != null) {
         new OffsetFetchResponseData.OffsetFetchResponseGroup()
-          .setGroupId(groupOffsetFetch.groupId)
+          .setGroupId(offsetFetchRequest.groupId)
           .setErrorCode(Errors.forException(exception).code)
       } else {
         // Clients are not allowed to see offsets for topics that are not authorized for Describe.
@@ -1470,11 +1470,11 @@ class KafkaApis(val requestChannel: RequestChannel,
           requestContext,
           DESCRIBE,
           TOPIC,
-          offsets.asScala
+          offsetFetchResponse.topics.asScala
         )(_.name)
 
         new OffsetFetchResponseData.OffsetFetchResponseGroup()
-          .setGroupId(groupOffsetFetch.groupId)
+          .setGroupId(offsetFetchRequest.groupId)
           .setTopics(authorizedOffsets.asJava)
       }
     }
@@ -1482,7 +1482,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   private def fetchOffsetsForGroup(
     requestContext: RequestContext,
-    groupOffsetFetch: OffsetFetchRequestData.OffsetFetchRequestGroup,
+    offsetFetchRequest: OffsetFetchRequestData.OffsetFetchRequestGroup,
     requireStable: Boolean
   ): CompletableFuture[OffsetFetchResponseData.OffsetFetchResponseGroup] = {
     // Clients are not allowed to see offsets for topics that are not authorized for Describe.
@@ -1490,24 +1490,25 @@ class KafkaApis(val requestChannel: RequestChannel,
       requestContext,
       DESCRIBE,
       TOPIC,
-      groupOffsetFetch.topics.asScala
+      offsetFetchRequest.topics.asScala
     )(_.name)
 
     groupCoordinator.fetchOffsets(
       requestContext,
-      groupOffsetFetch.groupId,
-      authorizedTopics.asJava,
+      new OffsetFetchRequestData.OffsetFetchRequestGroup()
+        .setGroupId(offsetFetchRequest.groupId)
+        .setTopics(authorizedTopics.asJava),
       requireStable
-    ).handle[OffsetFetchResponseData.OffsetFetchResponseGroup] { (topicOffsets, exception) =>
+    ).handle[OffsetFetchResponseData.OffsetFetchResponseGroup] { (offsetFetchResponse, exception) =>
       if (exception != null) {
         new OffsetFetchResponseData.OffsetFetchResponseGroup()
-          .setGroupId(groupOffsetFetch.groupId)
+          .setGroupId(offsetFetchRequest.groupId)
           .setErrorCode(Errors.forException(exception).code)
       } else {
         val response = new OffsetFetchResponseData.OffsetFetchResponseGroup()
-          .setGroupId(groupOffsetFetch.groupId)
+          .setGroupId(offsetFetchRequest.groupId)
 
-        response.topics.addAll(topicOffsets)
+        response.topics.addAll(offsetFetchResponse.topics)
 
         unauthorizedTopics.foreach { topic =>
           val topicResponse = new OffsetFetchResponseData.OffsetFetchResponseTopics().setName(topic.name)
@@ -1525,9 +1526,12 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
   }
 
-  private def partitionByAuthorized(seq: Seq[TopicPartition], context: RequestContext):
-  (Seq[TopicPartition], Seq[TopicPartition]) =
+  private def partitionByAuthorized(
+    seq: Seq[TopicPartition],
+    context: RequestContext
+  ): (Seq[TopicPartition], Seq[TopicPartition]) = {
     authHelper.partitionSeqByAuthorized(context, DESCRIBE, TOPIC, seq)(_.topic)
+  }
 
   def handleFindCoordinatorRequest(request: RequestChannel.Request): Unit = {
     val version = request.header.apiVersion

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
@@ -502,7 +502,7 @@ class GroupCoordinatorAdapterTest {
     val ctx = makeContext(ApiKeys.OFFSET_FETCH, ApiKeys.OFFSET_FETCH.latestVersion)
     val future = adapter.fetchAllOffsets(
       ctx,
-      "group",
+      new OffsetFetchRequestData.OffsetFetchRequestGroup().setGroupId("group"),
       true
     )
 
@@ -537,9 +537,10 @@ class GroupCoordinatorAdapterTest {
         ).asJava)
     )
 
+    assertEquals("group", future.get().groupId)
     assertEquals(
       expectedResponse.sortWith(_.name > _.name),
-      future.get().asScala.toList.sortWith(_.name > _.name)
+      future.get().topics.asScala.toList.sortWith(_.name > _.name)
     )
   }
 
@@ -583,15 +584,15 @@ class GroupCoordinatorAdapterTest {
     val ctx = makeContext(ApiKeys.OFFSET_FETCH, ApiKeys.OFFSET_FETCH.latestVersion)
     val future = adapter.fetchOffsets(
       ctx,
-      "group",
-      List(
-        new OffsetFetchRequestData.OffsetFetchRequestTopics()
-          .setName(foo0.topic)
-          .setPartitionIndexes(List[Integer](foo0.partition, foo1.partition).asJava),
-        new OffsetFetchRequestData.OffsetFetchRequestTopics()
-          .setName(bar1.topic)
-          .setPartitionIndexes(List[Integer](bar1.partition).asJava),
-      ).asJava,
+      new OffsetFetchRequestData.OffsetFetchRequestGroup()
+        .setGroupId("group")
+        .setTopics(List(
+          new OffsetFetchRequestData.OffsetFetchRequestTopics()
+            .setName(foo0.topic)
+            .setPartitionIndexes(List[Integer](foo0.partition, foo1.partition).asJava),
+          new OffsetFetchRequestData.OffsetFetchRequestTopics()
+            .setName(bar1.topic)
+            .setPartitionIndexes(List[Integer](bar1.partition).asJava)).asJava),
       true
     )
 
@@ -626,9 +627,10 @@ class GroupCoordinatorAdapterTest {
         ).asJava)
     )
 
+    assertEquals("group", future.get().groupId)
     assertEquals(
       expectedResponse.sortWith(_.name > _.name),
-      future.get().asScala.toList.sortWith(_.name > _.name)
+      future.get().topics.asScala.toList.sortWith(_.name > _.name)
     )
   }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
@@ -170,15 +170,13 @@ public interface GroupCoordinator {
      * Fetch offsets for a given Group.
      *
      * @param context           The request context.
-     * @param groupId           The group id.
-     * @param topics            The topics to fetch the offsets for.
+     * @param request           The OffsetFetchRequestGroup request.
      *
      * @return A future yielding the results or an exception.
      */
-    CompletableFuture<List<OffsetFetchResponseData.OffsetFetchResponseTopics>> fetchOffsets(
+    CompletableFuture<OffsetFetchResponseData.OffsetFetchResponseGroup> fetchOffsets(
         RequestContext context,
-        String groupId,
-        List<OffsetFetchRequestData.OffsetFetchRequestTopics> topics,
+        OffsetFetchRequestData.OffsetFetchRequestGroup request,
         boolean requireStable
     );
 
@@ -186,13 +184,13 @@ public interface GroupCoordinator {
      * Fetch all offsets for a given Group.
      *
      * @param context           The request context.
-     * @param groupId           The group id.
+     * @param request           The OffsetFetchRequestGroup request.
      *
      * @return A future yielding the results or an exception.
      */
-    CompletableFuture<List<OffsetFetchResponseData.OffsetFetchResponseTopics>> fetchAllOffsets(
+    CompletableFuture<OffsetFetchResponseData.OffsetFetchResponseGroup> fetchAllOffsets(
         RequestContext context,
-        String groupId,
+        OffsetFetchRequestData.OffsetFetchRequestGroup request,
         boolean requireStable
     );
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -469,13 +469,12 @@ public class GroupCoordinatorService implements GroupCoordinator {
     }
 
     /**
-     * See {@link GroupCoordinator#fetchOffsets(RequestContext, String, List, boolean)}.
+     * See {@link GroupCoordinator#fetchOffsets(RequestContext, OffsetFetchRequestData.OffsetFetchRequestGroup, boolean)}.
      */
     @Override
-    public CompletableFuture<List<OffsetFetchResponseData.OffsetFetchResponseTopics>> fetchOffsets(
+    public CompletableFuture<OffsetFetchResponseData.OffsetFetchResponseGroup> fetchOffsets(
         RequestContext context,
-        String groupId,
-        List<OffsetFetchRequestData.OffsetFetchRequestTopics> topics,
+        OffsetFetchRequestData.OffsetFetchRequestGroup request,
         boolean requireStable
     ) {
         if (!isActive.get()) {
@@ -483,7 +482,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
         }
 
         // For backwards compatibility, we support fetch commits for the empty group id.
-        if (groupId == null) {
+        if (request.groupId() == null) {
             return FutureUtils.failedFuture(Errors.INVALID_GROUP_ID.exception());
         }
 
@@ -498,28 +497,28 @@ public class GroupCoordinatorService implements GroupCoordinator {
         if (requireStable) {
             return runtime.scheduleWriteOperation(
                 "fetch-offsets",
-                topicPartitionFor(groupId),
+                topicPartitionFor(request.groupId()),
                 coordinator -> new CoordinatorResult<>(
                     Collections.emptyList(),
-                    coordinator.fetchOffsets(groupId, topics, Long.MAX_VALUE)
+                    coordinator.fetchOffsets(request, Long.MAX_VALUE)
                 )
             );
         } else {
             return runtime.scheduleReadOperation(
                 "fetch-offsets",
-                topicPartitionFor(groupId),
-                (coordinator, offset) -> coordinator.fetchOffsets(groupId, topics, offset)
+                topicPartitionFor(request.groupId()),
+                (coordinator, offset) -> coordinator.fetchOffsets(request, offset)
             );
         }
     }
 
     /**
-     * See {@link GroupCoordinator#fetchAllOffsets(RequestContext, String, boolean)}.
+     * See {@link GroupCoordinator#fetchAllOffsets(RequestContext, OffsetFetchRequestData.OffsetFetchRequestGroup, boolean)}.
      */
     @Override
-    public CompletableFuture<List<OffsetFetchResponseData.OffsetFetchResponseTopics>> fetchAllOffsets(
+    public CompletableFuture<OffsetFetchResponseData.OffsetFetchResponseGroup> fetchAllOffsets(
         RequestContext context,
-        String groupId,
+        OffsetFetchRequestData.OffsetFetchRequestGroup request,
         boolean requireStable
     ) {
         if (!isActive.get()) {
@@ -527,7 +526,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
         }
 
         // For backwards compatibility, we support fetch commits for the empty group id.
-        if (groupId == null) {
+        if (request.groupId() == null) {
             return FutureUtils.failedFuture(Errors.INVALID_GROUP_ID.exception());
         }
 
@@ -542,17 +541,17 @@ public class GroupCoordinatorService implements GroupCoordinator {
         if (requireStable) {
             return runtime.scheduleWriteOperation(
                 "fetch-all-offsets",
-                topicPartitionFor(groupId),
+                topicPartitionFor(request.groupId()),
                 coordinator -> new CoordinatorResult<>(
                     Collections.emptyList(),
-                    coordinator.fetchAllOffsets(groupId, Long.MAX_VALUE)
+                    coordinator.fetchAllOffsets(request, Long.MAX_VALUE)
                 )
             );
         } else {
             return runtime.scheduleReadOperation(
                 "fetch-all-offsets",
-                topicPartitionFor(groupId),
-                (coordinator, offset) -> coordinator.fetchAllOffsets(groupId, offset)
+                topicPartitionFor(request.groupId()),
+                (coordinator, offset) -> coordinator.fetchAllOffsets(request, offset)
             );
         }
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -58,7 +58,6 @@ import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -262,35 +261,33 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
     /**
      * Fetch offsets for a given set of partitions and a given group.
      *
-     * @param groupId   The group id.
-     * @param topics    The topics to fetch the offsets for.
+     * @param request   The OffsetFetchRequestGroup request.
      * @param epoch     The epoch (or offset) used to read from the
      *                  timeline data structure.
      *
      * @return A List of OffsetFetchResponseTopics response.
      */
-    public List<OffsetFetchResponseData.OffsetFetchResponseTopics> fetchOffsets(
-        String groupId,
-        List<OffsetFetchRequestData.OffsetFetchRequestTopics> topics,
+    public OffsetFetchResponseData.OffsetFetchResponseGroup fetchOffsets(
+        OffsetFetchRequestData.OffsetFetchRequestGroup request,
         long epoch
     ) throws ApiException {
-        return offsetMetadataManager.fetchOffsets(groupId, topics, epoch);
+        return offsetMetadataManager.fetchOffsets(request, epoch);
     }
 
     /**
      * Fetch all offsets for a given group.
      *
-     * @param groupId   The group id.
+     * @param request   The OffsetFetchRequestGroup request.
      * @param epoch     The epoch (or offset) used to read from the
      *                  timeline data structure.
      *
      * @return A List of OffsetFetchResponseTopics response.
      */
-    public List<OffsetFetchResponseData.OffsetFetchResponseTopics> fetchAllOffsets(
-        String groupId,
+    public OffsetFetchResponseData.OffsetFetchResponseGroup fetchAllOffsets(
+        OffsetFetchRequestData.OffsetFetchRequestGroup request,
         long epoch
     ) throws ApiException {
-        return offsetMetadataManager.fetchAllOffsets(groupId, epoch);
+        return offsetMetadataManager.fetchAllOffsets(request, epoch);
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -63,7 +63,6 @@ import org.mockito.ArgumentMatchers;
 
 import java.net.InetAddress;
 import java.util.Collections;
-import java.util.List;
 import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
@@ -614,40 +613,43 @@ public class GroupCoordinatorServiceTest {
 
         service.startup(() -> 1);
 
-        List<OffsetFetchRequestData.OffsetFetchRequestTopics> topicsRequest =
-            Collections.singletonList(new OffsetFetchRequestData.OffsetFetchRequestTopics()
-                .setName("foo")
-                .setPartitionIndexes(Collections.singletonList(0)));
+        OffsetFetchRequestData.OffsetFetchRequestGroup request =
+            new OffsetFetchRequestData.OffsetFetchRequestGroup()
+                .setGroupId("group")
+                .setTopics(Collections.singletonList(new OffsetFetchRequestData.OffsetFetchRequestTopics()
+                    .setName("foo")
+                    .setPartitionIndexes(Collections.singletonList(0))));
 
-        List<OffsetFetchResponseData.OffsetFetchResponseTopics> topicsResponse =
-            Collections.singletonList(new OffsetFetchResponseData.OffsetFetchResponseTopics()
-                .setName("foo")
-                .setPartitions(Collections.singletonList(new OffsetFetchResponseData.OffsetFetchResponsePartitions()
-                    .setPartitionIndex(0)
-                    .setCommittedOffset(100L))));
+        OffsetFetchResponseData.OffsetFetchResponseGroup response =
+            new OffsetFetchResponseData.OffsetFetchResponseGroup()
+                .setGroupId("group")
+                .setTopics(Collections.singletonList(new OffsetFetchResponseData.OffsetFetchResponseTopics()
+                    .setName("foo")
+                    .setPartitions(Collections.singletonList(new OffsetFetchResponseData.OffsetFetchResponsePartitions()
+                        .setPartitionIndex(0)
+                        .setCommittedOffset(100L)))));
 
         if (requireStable) {
             when(runtime.scheduleWriteOperation(
                 ArgumentMatchers.eq("fetch-offsets"),
                 ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
                 ArgumentMatchers.any()
-            )).thenReturn(CompletableFuture.completedFuture(topicsResponse));
+            )).thenReturn(CompletableFuture.completedFuture(response));
         } else {
             when(runtime.scheduleReadOperation(
                 ArgumentMatchers.eq("fetch-offsets"),
                 ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
                 ArgumentMatchers.any()
-            )).thenReturn(CompletableFuture.completedFuture(topicsResponse));
+            )).thenReturn(CompletableFuture.completedFuture(response));
         }
 
-        CompletableFuture<List<OffsetFetchResponseData.OffsetFetchResponseTopics>> future = service.fetchOffsets(
+        CompletableFuture<OffsetFetchResponseData.OffsetFetchResponseGroup> future = service.fetchOffsets(
             requestContext(ApiKeys.OFFSET_FETCH),
-            "group",
-            topicsRequest,
+            request,
             requireStable
         );
 
-        assertEquals(topicsResponse, future.get(5, TimeUnit.SECONDS));
+        assertEquals(response, future.get(5, TimeUnit.SECONDS));
     }
 
     @ParameterizedTest
@@ -664,33 +666,39 @@ public class GroupCoordinatorServiceTest {
 
         service.startup(() -> 1);
 
-        List<OffsetFetchResponseData.OffsetFetchResponseTopics> topicsResponse =
-            Collections.singletonList(new OffsetFetchResponseData.OffsetFetchResponseTopics()
-                .setName("foo")
-                .setPartitions(Collections.singletonList(new OffsetFetchResponseData.OffsetFetchResponsePartitions()
-                    .setPartitionIndex(0)
-                    .setCommittedOffset(100L))));
+        OffsetFetchRequestData.OffsetFetchRequestGroup request =
+            new OffsetFetchRequestData.OffsetFetchRequestGroup()
+                .setGroupId("group");
+
+        OffsetFetchResponseData.OffsetFetchResponseGroup response =
+            new OffsetFetchResponseData.OffsetFetchResponseGroup()
+                .setGroupId("group")
+                .setTopics(Collections.singletonList(new OffsetFetchResponseData.OffsetFetchResponseTopics()
+                    .setName("foo")
+                    .setPartitions(Collections.singletonList(new OffsetFetchResponseData.OffsetFetchResponsePartitions()
+                        .setPartitionIndex(0)
+                        .setCommittedOffset(100L)))));
 
         if (requireStable) {
             when(runtime.scheduleWriteOperation(
                 ArgumentMatchers.eq("fetch-all-offsets"),
                 ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
                 ArgumentMatchers.any()
-            )).thenReturn(CompletableFuture.completedFuture(topicsResponse));
+            )).thenReturn(CompletableFuture.completedFuture(response));
         } else {
             when(runtime.scheduleReadOperation(
                 ArgumentMatchers.eq("fetch-all-offsets"),
                 ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
                 ArgumentMatchers.any()
-            )).thenReturn(CompletableFuture.completedFuture(topicsResponse));
+            )).thenReturn(CompletableFuture.completedFuture(response));
         }
 
-        CompletableFuture<List<OffsetFetchResponseData.OffsetFetchResponseTopics>> future = service.fetchAllOffsets(
+        CompletableFuture<OffsetFetchResponseData.OffsetFetchResponseGroup> future = service.fetchAllOffsets(
             requestContext(ApiKeys.OFFSET_FETCH),
-            "group",
+            request,
             requireStable
         );
 
-        assertEquals(topicsResponse, future.get(5, TimeUnit.SECONDS));
+        assertEquals(response, future.get(5, TimeUnit.SECONDS));
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
@@ -182,22 +182,26 @@ public class OffsetMetadataManagerTest {
             List<OffsetFetchRequestData.OffsetFetchRequestTopics> topics,
             long committedOffset
         ) {
-            return offsetMetadataManager.fetchOffsets(
+            OffsetFetchResponseData.OffsetFetchResponseGroup response = offsetMetadataManager.fetchOffsets(
                 new OffsetFetchRequestData.OffsetFetchRequestGroup()
                     .setGroupId(groupId)
                     .setTopics(topics),
                 committedOffset
-            ).topics();
+            );
+            assertEquals(groupId, response.groupId());
+            return response.topics();
         }
 
         public List<OffsetFetchResponseData.OffsetFetchResponseTopics> fetchAllOffsets(
             String groupId,
             long committedOffset
         ) {
-            return offsetMetadataManager.fetchAllOffsets(
+            OffsetFetchResponseData.OffsetFetchResponseGroup response = offsetMetadataManager.fetchAllOffsets(
                 new OffsetFetchRequestData.OffsetFetchRequestGroup().setGroupId(groupId),
                 committedOffset
-            ).topics();
+            );
+            assertEquals(groupId, response.groupId());
+            return response.topics();
         }
 
         public List<MockCoordinatorTimer.ExpiredTimeout<Void, Record>> sleep(long ms) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
@@ -183,10 +183,11 @@ public class OffsetMetadataManagerTest {
             long committedOffset
         ) {
             return offsetMetadataManager.fetchOffsets(
-                groupId,
-                topics,
+                new OffsetFetchRequestData.OffsetFetchRequestGroup()
+                    .setGroupId(groupId)
+                    .setTopics(topics),
                 committedOffset
-            );
+            ).topics();
         }
 
         public List<OffsetFetchResponseData.OffsetFetchResponseTopics> fetchAllOffsets(
@@ -194,9 +195,9 @@ public class OffsetMetadataManagerTest {
             long committedOffset
         ) {
             return offsetMetadataManager.fetchAllOffsets(
-                groupId,
+                new OffsetFetchRequestData.OffsetFetchRequestGroup().setGroupId(groupId),
                 committedOffset
-            );
+            ).topics();
         }
 
         public List<MockCoordinatorTimer.ExpiredTimeout<Void, Record>> sleep(long ms) {


### PR DESCRIPTION
This patch refactors the GroupCoordinator.fetchOffsets and GroupCoordinator.fetchAllOffsets methods to take an OffsetFetchRequestGroup and to return an OffsetFetchResponseGroup. It prepares the ground for adding the member id and the member epoch to the OffsetFetchRequest. This change also makes those two methods more aligned with the others in the interface.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
