### PR TITLE
KAFKA-15416: Fix flaky TopicAdminTest::retryEndOffsetsShouldRetryWhenTopicNotFound test case

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.connect.mirror;
 
-import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.Producer;
@@ -75,7 +74,7 @@ class OffsetSyncStore implements AutoCloseable {
         try {
             consumer = MirrorUtils.newConsumer(config.offsetSyncsTopicConsumerConfig());
             admin = new TopicAdmin(
-                    config.offsetSyncsTopicAdminConfig().get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG),
+                    config.offsetSyncsTopicAdminConfig(),
                     config.forwardingAdmin(config.offsetSyncsTopicAdminConfig()));
             store = createBackingStore(config, consumer, admin);
         } catch (Throwable t) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -720,23 +720,23 @@ public class TopicAdmin implements AutoCloseable {
                 String topic = partition.topic();
                 if (cause instanceof AuthorizationException) {
                     String msg = String.format("Not authorized to get the end offsets for topic '%s' on brokers at %s", topic, bootstrapServers);
-                    throw new ConnectException(msg, e);
+                    throw new ConnectException(msg, cause);
                 } else if (cause instanceof UnsupportedVersionException) {
                     // Should theoretically never happen, because this method is the same as what the consumer uses and therefore
                     // should exist in the broker since before the admin client was added
                     String msg = String.format("API to get the get the end offsets for topic '%s' is unsupported on brokers at %s", topic, bootstrapServers);
-                    throw new UnsupportedVersionException(msg, e);
+                    throw new UnsupportedVersionException(msg, cause);
                 } else if (cause instanceof TimeoutException) {
                     String msg = String.format("Timed out while waiting to get end offsets for topic '%s' on brokers at %s", topic, bootstrapServers);
-                    throw new TimeoutException(msg, e);
+                    throw new TimeoutException(msg, cause);
                 } else if (cause instanceof LeaderNotAvailableException) {
                     String msg = String.format("Unable to get end offsets during leader election for topic '%s' on brokers at %s", topic, bootstrapServers);
-                    throw new LeaderNotAvailableException(msg, e);
+                    throw new LeaderNotAvailableException(msg, cause);
                 } else if (cause instanceof org.apache.kafka.common.errors.RetriableException) {
                     throw (org.apache.kafka.common.errors.RetriableException) cause;
                 } else {
                     String msg = String.format("Error while getting end offsets for topic '%s' on brokers at %s", topic, bootstrapServers);
-                    throw new ConnectException(msg, e);
+                    throw new ConnectException(msg, cause);
                 }
             } catch (InterruptedException e) {
                 Thread.interrupted();
@@ -774,7 +774,7 @@ public class TopicAdmin implements AutoCloseable {
             // Older brokers don't support this admin method, so rethrow it without wrapping it
             throw e;
         } catch (Exception e) {
-            throw new ConnectException("Failed to list offsets for topic partitions.", e);
+            throw ConnectUtils.maybeWrap(e, "Failed to list offsets for topic partitions");
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -286,18 +286,28 @@ public class TopicAdmin implements AutoCloseable {
      * @param adminConfig the configuration for the {@link Admin}
      */
     public TopicAdmin(Map<String, Object> adminConfig) {
-        this(adminConfig.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG), Admin.create(adminConfig));
+        this(adminConfig, Admin.create(adminConfig));
     }
 
-    public TopicAdmin(Object bootstrapServers, Admin adminClient) {
-        this(bootstrapServers, adminClient, true);
+    public TopicAdmin(Map<String, Object> adminConfig, Admin adminClient) {
+        this(bootstrapServers(adminConfig), adminClient, true);
     }
 
     // visible for testing
-    TopicAdmin(Object bootstrapServers, Admin adminClient, boolean logCreation) {
+    TopicAdmin(Admin adminClient) {
+        this(null, adminClient, true);
+    }
+
+    // visible for testing
+    TopicAdmin(String bootstrapServers, Admin adminClient, boolean logCreation) {
         this.admin = adminClient;
-        this.bootstrapServers = bootstrapServers != null ? bootstrapServers.toString() : "<unknown>";
+        this.bootstrapServers = bootstrapServers != null ? bootstrapServers : "<unknown>";
         this.logCreation = logCreation;
+    }
+
+    private static String bootstrapServers(Map<String, Object> adminConfig) {
+        Object result = adminConfig.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG);
+        return result != null ? result.toString() : null;
     }
 
    /**

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -91,7 +91,7 @@ public class TopicAdminTest {
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponse(createTopicResponseWithUnsupportedVersion(newTopic));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             assertTrue(admin.createOrFindTopics(newTopic).isEmpty());
         }
     }
@@ -108,7 +108,7 @@ public class TopicAdminTest {
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponse(describeTopicResponseWithUnsupportedVersion(newTopic));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             Exception e = assertThrows(ConnectException.class, () -> admin.describeTopics(newTopic.name()));
             assertTrue(e.getCause() instanceof UnsupportedVersionException);
         }
@@ -120,7 +120,7 @@ public class TopicAdminTest {
         Cluster cluster = createCluster(1);
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             env.kafkaClient().prepareResponse(createTopicResponseWithClusterAuthorizationException(newTopic));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             assertFalse(admin.createTopic(newTopic));
 
             env.kafkaClient().prepareResponse(createTopicResponseWithClusterAuthorizationException(newTopic));
@@ -134,7 +134,7 @@ public class TopicAdminTest {
         Cluster cluster = createCluster(1);
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             env.kafkaClient().prepareResponse(describeTopicResponseWithClusterAuthorizationException(newTopic));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             Exception e = assertThrows(ConnectException.class, () -> admin.describeTopics(newTopic.name()));
             assertTrue(e.getCause() instanceof ClusterAuthorizationException);
         }
@@ -146,7 +146,7 @@ public class TopicAdminTest {
         Cluster cluster = createCluster(1);
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             env.kafkaClient().prepareResponse(createTopicResponseWithTopicAuthorizationException(newTopic));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             assertFalse(admin.createTopic(newTopic));
 
             env.kafkaClient().prepareResponse(createTopicResponseWithTopicAuthorizationException(newTopic));
@@ -160,7 +160,7 @@ public class TopicAdminTest {
         Cluster cluster = createCluster(1);
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             env.kafkaClient().prepareResponse(describeTopicResponseWithTopicAuthorizationException(newTopic));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             Exception e = assertThrows(ConnectException.class, () -> admin.describeTopics(newTopic.name()));
             assertTrue(e.getCause() instanceof TopicAuthorizationException);
         }
@@ -173,7 +173,7 @@ public class TopicAdminTest {
         try (MockAdminClient mockAdminClient = new MockAdminClient(cluster.nodes(), cluster.nodeById(0))) {
             TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(0, cluster.nodeById(0), cluster.nodes(), Collections.emptyList());
             mockAdminClient.addTopic(false, "myTopic", Collections.singletonList(topicPartitionInfo), null);
-            TopicAdmin admin = new TopicAdmin(null, mockAdminClient);
+            TopicAdmin admin = new TopicAdmin(mockAdminClient);
             assertFalse(admin.createTopic(newTopic));
             assertTrue(admin.createTopics(newTopic).isEmpty());
             assertTrue(admin.createOrFindTopic(newTopic));
@@ -252,7 +252,7 @@ public class TopicAdminTest {
         NewTopic newTopic1 = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
         NewTopic newTopic2 = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
         Cluster cluster = createCluster(1);
-        try (TopicAdmin admin = new TopicAdmin(null, new MockAdminClient(cluster.nodes(), cluster.nodeById(0)))) {
+        try (TopicAdmin admin = new TopicAdmin(new MockAdminClient(cluster.nodes(), cluster.nodeById(0)))) {
             Set<String> newTopicNames = admin.createTopics(newTopic1, newTopic2);
             assertEquals(1, newTopicNames.size());
             assertEquals(newTopic2.name(), newTopicNames.iterator().next());
@@ -264,7 +264,7 @@ public class TopicAdminTest {
         Cluster cluster = createCluster(1);
         NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).replicationFactor((short) 2).compacted().build();
 
-        try (TopicAdmin admin = Mockito.spy(new TopicAdmin(null, new MockAdminClient(cluster.nodes(), cluster.nodeById(0))))) {
+        try (TopicAdmin admin = Mockito.spy(new TopicAdmin(new MockAdminClient(cluster.nodes(), cluster.nodeById(0))))) {
             try {
                 admin.createTopicsWithRetry(newTopic, 2, 1, new MockTime());
             } catch (Exception e) {
@@ -281,7 +281,7 @@ public class TopicAdminTest {
         NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).replicationFactor((short) 1).compacted().build();
 
         try (MockAdminClient mockAdminClient = new MockAdminClient(cluster.nodes(), cluster.nodeById(0));
-             TopicAdmin admin = Mockito.spy(new TopicAdmin(null, mockAdminClient))) {
+             TopicAdmin admin = Mockito.spy(new TopicAdmin(mockAdminClient))) {
             mockAdminClient.timeoutNextRequest(1);
             try {
                 admin.createTopicsWithRetry(newTopic, 2, 1, new MockTime());
@@ -296,7 +296,7 @@ public class TopicAdminTest {
     @Test
     public void createShouldReturnFalseWhenSuppliedNullTopicDescription() {
         Cluster cluster = createCluster(1);
-        try (TopicAdmin admin = new TopicAdmin(null, new MockAdminClient(cluster.nodes(), cluster.nodeById(0)))) {
+        try (TopicAdmin admin = new TopicAdmin(new MockAdminClient(cluster.nodes(), cluster.nodeById(0)))) {
             boolean created = admin.createTopic(null);
             assertFalse(created);
         }
@@ -306,7 +306,7 @@ public class TopicAdminTest {
     public void describeShouldReturnEmptyWhenTopicDoesNotExist() {
         NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
         Cluster cluster = createCluster(1);
-        try (TopicAdmin admin = new TopicAdmin(null, new MockAdminClient(cluster.nodes(), cluster.nodeById(0)))) {
+        try (TopicAdmin admin = new TopicAdmin(new MockAdminClient(cluster.nodes(), cluster.nodeById(0)))) {
             assertTrue(admin.describeTopics(newTopic.name()).isEmpty());
         }
     }
@@ -319,7 +319,7 @@ public class TopicAdminTest {
         try (MockAdminClient mockAdminClient = new MockAdminClient(cluster.nodes(), cluster.nodeById(0))) {
             TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(0, cluster.nodeById(0), cluster.nodes(), Collections.emptyList());
             mockAdminClient.addTopic(false, topicName, Collections.singletonList(topicPartitionInfo), null);
-            TopicAdmin admin = new TopicAdmin(null, mockAdminClient);
+            TopicAdmin admin = new TopicAdmin(mockAdminClient);
             Map<String, TopicDescription> desc = admin.describeTopics(newTopic.name());
             assertFalse(desc.isEmpty());
             TopicDescription topicDesc = new TopicDescription(topicName, false, Collections.singletonList(topicPartitionInfo));
@@ -333,7 +333,7 @@ public class TopicAdminTest {
         Cluster cluster = createCluster(1);
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             env.kafkaClient().prepareResponse(describeConfigsResponseWithUnsupportedVersion(newTopic));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             Map<String, Config> results = admin.describeTopicConfigs();
             assertTrue(results.isEmpty());
         }
@@ -345,7 +345,7 @@ public class TopicAdminTest {
         Cluster cluster = createCluster(1);
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             env.kafkaClient().prepareResponse(describeConfigsResponseWithUnsupportedVersion(newTopic));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             Map<String, Config> results = admin.describeTopicConfigs(newTopic.name());
             assertTrue(results.isEmpty());
         }
@@ -357,7 +357,7 @@ public class TopicAdminTest {
         Cluster cluster = createCluster(1);
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             env.kafkaClient().prepareResponse(describeConfigsResponseWithClusterAuthorizationException(newTopic));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             Map<String, Config> results = admin.describeTopicConfigs(newTopic.name());
             assertTrue(results.isEmpty());
         }
@@ -369,7 +369,7 @@ public class TopicAdminTest {
         Cluster cluster = createCluster(1);
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             env.kafkaClient().prepareResponse(describeConfigsResponseWithTopicAuthorizationException(newTopic));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             Map<String, Config> results = admin.describeTopicConfigs(newTopic.name());
             assertTrue(results.isEmpty());
         }
@@ -379,7 +379,7 @@ public class TopicAdminTest {
     public void describeTopicConfigShouldReturnMapWithNullValueWhenTopicDoesNotExist() {
         NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
         Cluster cluster = createCluster(1);
-        try (TopicAdmin admin = new TopicAdmin(null, new MockAdminClient(cluster.nodes(), cluster.nodeById(0)))) {
+        try (TopicAdmin admin = new TopicAdmin(new MockAdminClient(cluster.nodes(), cluster.nodeById(0)))) {
             Map<String, Config> results = admin.describeTopicConfigs(newTopic.name());
             assertFalse(results.isEmpty());
             assertEquals(1, results.size());
@@ -399,7 +399,7 @@ public class TopicAdminTest {
         try (MockAdminClient mockAdminClient = new MockAdminClient(cluster.nodes(), cluster.nodeById(0))) {
             TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(0, cluster.nodeById(0), cluster.nodes(), Collections.emptyList());
             mockAdminClient.addTopic(false, topicName, Collections.singletonList(topicPartitionInfo), null);
-            TopicAdmin admin = new TopicAdmin(null, mockAdminClient);
+            TopicAdmin admin = new TopicAdmin(mockAdminClient);
             Map<String, Config> result = admin.describeTopicConfigs(newTopic.name());
             assertFalse(result.isEmpty());
             assertEquals(1, result.size());
@@ -415,7 +415,7 @@ public class TopicAdminTest {
         Cluster cluster = createCluster(1);
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             env.kafkaClient().prepareResponse(describeConfigsResponseWithUnsupportedVersion(newTopic));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             boolean result = admin.verifyTopicCleanupPolicyOnlyCompact("myTopic", "worker.topic", "purpose");
             assertFalse(result);
         }
@@ -427,7 +427,7 @@ public class TopicAdminTest {
         Cluster cluster = createCluster(1);
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             env.kafkaClient().prepareResponse(describeConfigsResponseWithClusterAuthorizationException(newTopic));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             boolean result = admin.verifyTopicCleanupPolicyOnlyCompact("myTopic", "worker.topic", "purpose");
             assertFalse(result);
         }
@@ -439,7 +439,7 @@ public class TopicAdminTest {
         Cluster cluster = createCluster(1);
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             env.kafkaClient().prepareResponse(describeConfigsResponseWithTopicAuthorizationException(newTopic));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             boolean result = admin.verifyTopicCleanupPolicyOnlyCompact("myTopic", "worker.topic", "purpose");
             assertFalse(result);
         }
@@ -453,7 +453,7 @@ public class TopicAdminTest {
         try (MockAdminClient mockAdminClient = new MockAdminClient(cluster.nodes(), cluster.nodeById(0))) {
             TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(0, cluster.nodeById(0), cluster.nodes(), Collections.emptyList());
             mockAdminClient.addTopic(false, topicName, Collections.singletonList(topicPartitionInfo), topicConfigs);
-            TopicAdmin admin = new TopicAdmin(null, mockAdminClient);
+            TopicAdmin admin = new TopicAdmin(mockAdminClient);
             boolean result = admin.verifyTopicCleanupPolicyOnlyCompact("myTopic", "worker.topic", "purpose");
             assertTrue(result);
         }
@@ -467,7 +467,7 @@ public class TopicAdminTest {
         try (MockAdminClient mockAdminClient = new MockAdminClient(cluster.nodes(), cluster.nodeById(0))) {
             TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(0, cluster.nodeById(0), cluster.nodes(), Collections.emptyList());
             mockAdminClient.addTopic(false, topicName, Collections.singletonList(topicPartitionInfo), topicConfigs);
-            TopicAdmin admin = new TopicAdmin(null, mockAdminClient);
+            TopicAdmin admin = new TopicAdmin(mockAdminClient);
             ConfigException e = assertThrows(ConfigException.class, () -> admin.verifyTopicCleanupPolicyOnlyCompact("myTopic", "worker.topic", "purpose"));
             assertTrue(e.getMessage().contains("to guarantee consistency and durability"));
         }
@@ -481,7 +481,7 @@ public class TopicAdminTest {
         try (MockAdminClient mockAdminClient = new MockAdminClient(cluster.nodes(), cluster.nodeById(0))) {
             TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(0, cluster.nodeById(0), cluster.nodes(), Collections.emptyList());
             mockAdminClient.addTopic(false, topicName, Collections.singletonList(topicPartitionInfo), topicConfigs);
-            TopicAdmin admin = new TopicAdmin(null, mockAdminClient);
+            TopicAdmin admin = new TopicAdmin(mockAdminClient);
             ConfigException e = assertThrows(ConfigException.class, () -> admin.verifyTopicCleanupPolicyOnlyCompact("myTopic", "worker.topic", "purpose"));
             assertTrue(e.getMessage().contains("to guarantee consistency and durability"));
         }
@@ -495,7 +495,7 @@ public class TopicAdminTest {
         try (MockAdminClient mockAdminClient = new MockAdminClient(cluster.nodes(), cluster.nodeById(0))) {
             TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(0, cluster.nodeById(0), cluster.nodes(), Collections.emptyList());
             mockAdminClient.addTopic(false, topicName, Collections.singletonList(topicPartitionInfo), topicConfigs);
-            TopicAdmin admin = new TopicAdmin(null, mockAdminClient);
+            TopicAdmin admin = new TopicAdmin(mockAdminClient);
             Set<String> policies = admin.topicCleanupPolicy("myTopic");
             assertEquals(1, policies.size());
             assertEquals(TopicConfig.CLEANUP_POLICY_COMPACT, policies.iterator().next());
@@ -519,7 +519,7 @@ public class TopicAdminTest {
             env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
             // Expect the admin client list offsets will throw unsupported version, simulating older brokers
             env.kafkaClient().prepareResponse(listOffsetsResultWithUnsupportedVersion(tp1, offset));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             // The retryEndOffsets should catch and rethrow an unsupported version exception
             assertThrows(UnsupportedVersionException.class, () -> admin.retryEndOffsets(tps, Duration.ofMillis(100), 1));
         }
@@ -532,7 +532,6 @@ public class TopicAdminTest {
         Set<TopicPartition> tps = Collections.singleton(tp1);
         Long offset = 1000L;
         Cluster cluster = createCluster(1, "myTopic", 1);
-        String bootstrapServers = "localhost:8121";
 
         try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             Map<TopicPartition, Long> offsetMap = new HashMap<>();
@@ -546,7 +545,7 @@ public class TopicAdminTest {
             env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
             env.kafkaClient().prepareResponse(listOffsetsResult(tp1, offset));
 
-            TopicAdmin admin = new TopicAdmin(bootstrapServers, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             ConnectException exception = assertThrows(ConnectException.class, () ->
                 admin.retryEndOffsets(tps, Duration.ofMillis(100), 1)
             );
@@ -567,7 +566,6 @@ public class TopicAdminTest {
         Set<TopicPartition> tps = Collections.singleton(tp1);
         Long offset = 1000L;
         Cluster cluster = createCluster(1, "myTopic", 1);
-        String bootstrapServers = "localhost:8121";
 
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
             Map<TopicPartition, Long> offsetMap = new HashMap<>();
@@ -577,7 +575,7 @@ public class TopicAdminTest {
             env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
             env.kafkaClient().prepareResponse(listOffsetsResult(tp1, offset));
 
-            TopicAdmin admin = new TopicAdmin(bootstrapServers, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             Map<TopicPartition, Long> endoffsets = admin.retryEndOffsets(tps, Duration.ofMillis(100), 1);
             assertEquals(Collections.singletonMap(tp1, offset), endoffsets);
         }
@@ -594,7 +592,7 @@ public class TopicAdminTest {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
             env.kafkaClient().prepareResponse(listOffsetsResultWithClusterAuthorizationException(tp1, offset));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             ConnectException e = assertThrows(ConnectException.class, () -> admin.endOffsets(tps));
             assertTrue(e.getMessage().contains("Not authorized to get the end offsets"));
         }
@@ -611,7 +609,7 @@ public class TopicAdminTest {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
             env.kafkaClient().prepareResponse(listOffsetsResultWithUnsupportedVersion(tp1, offset));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             UnsupportedVersionException e = assertThrows(UnsupportedVersionException.class, () -> admin.endOffsets(tps));
         }
     }
@@ -629,7 +627,7 @@ public class TopicAdminTest {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
             env.kafkaClient().prepareResponse(listOffsetsResultWithTimeout(tp1, offset));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             TimeoutException e = assertThrows(TimeoutException.class, () -> admin.endOffsets(tps));
         }
     }
@@ -645,7 +643,7 @@ public class TopicAdminTest {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
             env.kafkaClient().prepareResponse(listOffsetsResultWithUnknownError(tp1, offset));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             ConnectException e = assertThrows(ConnectException.class, () -> admin.endOffsets(tps));
             assertTrue(e.getMessage().contains("Error while getting end offsets for topic"));
         }
@@ -656,7 +654,7 @@ public class TopicAdminTest {
         String topicName = "myTopic";
         Cluster cluster = createCluster(1, topicName, 1);
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             Map<TopicPartition, Long> offsets = admin.endOffsets(Collections.emptySet());
             assertTrue(offsets.isEmpty());
         }
@@ -673,7 +671,7 @@ public class TopicAdminTest {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
             env.kafkaClient().prepareResponse(listOffsetsResult(tp1, offset));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             Map<TopicPartition, Long> offsets = admin.endOffsets(tps);
             assertEquals(1, offsets.size());
             assertEquals(Long.valueOf(offset), offsets.get(tp1));
@@ -693,7 +691,7 @@ public class TopicAdminTest {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
             env.kafkaClient().prepareResponse(listOffsetsResult(tp1, offset1, tp2, offset2));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             Map<TopicPartition, Long> offsets = admin.endOffsets(tps);
             assertEquals(2, offsets.size());
             assertEquals(Long.valueOf(offset1), offsets.get(tp1));
@@ -712,7 +710,7 @@ public class TopicAdminTest {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponse(prepareMetadataResponse(cluster, Errors.NONE));
             env.kafkaClient().prepareResponse(listOffsetsResultWithClusterAuthorizationException(tp1, null));
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicAdmin admin = new TopicAdmin(env.adminClient());
             ConnectException e = assertThrows(ConnectException.class, () -> admin.endOffsets(tps));
             assertTrue(e.getMessage().contains("Not authorized to get the end offsets"));
         }


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-15416)

There's some fairly subtle behavior involved here, so apologies in advance for the wall of text.

# Problem

In the `retryEndOffsetsShouldRetryWhenTopicNotFound` test case, we currently use a `MockTime` object that has an auto-tick of 10ms with our [AdminClientUnitTestEnv](https://github.com/apache/kafka/blob/703e1d9faafbf07795261b3233ab985583f17fcb/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientUnitTestEnv.java), which ends up also being utilized by the [admin client](https://github.com/apache/kafka/blob/703e1d9faafbf07795261b3233ab985583f17fcb/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientUnitTestEnv.java#L107-L109) that it provides.

By default, admin clients perform periodic metadata refresh every five minutes (see the [metadata.max.age.ms property](https://github.com/apache/kafka/blob/703e1d9faafbf07795261b3233ab985583f17fcb/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java#L137)). With a `MockTime` instance that has an auto-tick of 10ms, periodic metadata refresh will be triggered every 30,000 times that `MockTime::milliseconds` (or `MockTime::nanoseconds`, but that's not relevant to these tests) is called.

Because of how the testing admin is set up by the `AdminClientUnitTestEnv` class, [checks for periodic metadata refresh](https://github.com/apache/kafka/blob/703e1d9faafbf07795261b3233ab985583f17fcb/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java#L1359-L1368) take place in a tight loop with no time spent sleeping during each iteration. As a result, it's not unreasonable for 30,000 iterations to take place fairly quickly.

When a periodic metadata refresh is triggered, it can sometimes "swallow" the responses that we [prepare for the admin client](https://github.com/apache/kafka/blob/703e1d9faafbf07795261b3233ab985583f17fcb/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java#L563-L565), causing these responses to be delivered to the periodic metadata refresh request instead of requests that the admin client issues in service of application logic (e.g., an invocation of `Admin::listOffsets`).

As a brief refresher on admin client behavior, when servicing a call to `Admin::listOffsets`, on the happy path, two broker requests are made: the first is a metadata request for the specified topic partitions, and the second is a request for the actual offset info of the requested topic partitions.

With the current `TopicAdminTest::retryEndOffsetsShouldRetryWhenTopicNotFound` case, this can lead to a variety of timing-dependent failures:

- If every prepared response is swallowed, a spurious timeout is caused by repeated attempts to contact a node that never responds because all prepared responses have already been consumed, with every attempt causing the mocked time to move forward slowly but surely past the operation timeout
- If two prepared responses are swallowed before `Admin::listOffsets` is invoked, a `ClassCastException` is thrown because the metadata request issued in service of the call to `Admin::listOffsets` receives the response prepared for the list offsets request, and the admin (somewhat reasonably) [expects the response for that metadata request to be a `MetadataResponse` instance](https://github.com/apache/kafka/blob/703e1d9faafbf07795261b3233ab985583f17fcb/clients/src/main/java/org/apache/kafka/clients/admin/internals/PartitionLeaderStrategy.java#L144)
- If a single response is swallowed, the test passes, but the test is rendered ineffective since the retry logic it intends to verify is never actually covered

# Solutions

There are a few options for a fix:

1. Disable periodic metadata refresh in the admin client
1. Disable auto-tick in our `MockTime` instance
1. Switch to a fully-deterministic mocking method for the admin client (e.g., use Mockito to construct a mock `Admin` instance)

In this PR I've opted for the second option, as this appears to be (implicitly or explicitly) the strategy used in all other tests that use the `AdminClientUnitTestEnv` class, and I'd prefer not to introduce inconsistency in the strategies we use in the `TopicAdminTest` suite to mock out admin client behavior.


# Other changes

## Test retryEndOffsetsShouldWrapNonRetriableExceptionsWithConnectException

This PR also tweaks the `retryEndOffsetsShouldWrapNonRetriableExceptionsWithConnectException` test case to prevent false negatives. Currently, because of a resurfacing of [KAFKA-12879](https://issues.apache.org/jira/browse/KAFKA-12879), admin clients will retry attempts to list offsets on unknown topics. The test expects the opposite behavior, but because the next automatic retry is met with a spurious timeout, it fails anyways.

The test is modified here to 1) prepare a different failure (authorization error) that is less likely to be be treated as retriable by future changes, 2) prepare a valid response for the admin client in the event that it ever retries the operation (which should, conversely, cause the test to fail), and 3) make finer-grained assertions on the kind of exception thrown by `TopicAdmin::retryEndOffsets` to ensure that it fails for the reason that we expect it to.

## TopicAdmin::retryEndOffsets and TopicAdmin::endOffsets

A few tweaks are made to these methods to eliminate unnecessary chained elements in the stack trace of exceptions they throw. This not only facilitates the stronger testing assertions added to `TopicAdminTest::retryEndOffsetsShouldWrapNonRetriableExceptionsWithConnectException`, it also improves the readability of the stack traces shown to users.

This same improvement may be made to other parts of the `TopicAdmin` class. I've left that for follow-up work to try to keep this PR focused for now, but can add it if we agree it's warranted.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
