### PR TITLE
MINOR: Close topic RLMM correctly in test

### DIFF
--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
@@ -482,7 +482,7 @@ public class RemoteLogSegmentLifecycleTest {
 
         @Override
         public void close() throws IOException {
-            tearDown();
+            super.close();
         }
 
     }


### PR DESCRIPTION
The `TopicBasedRemoteLogMetadataManagerWrapper` extends `TopicBasedRemoteLogMetadataManagerHarness` to create a `TopicBasedRemoteLogMetadataManager`. But in the `close` method, we didn't close the `TopicBasedRemoteLogMetadataManager` instance via `TopicBasedRemoteLogMetadataManagerHarness#close`, which causes resource leak.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
