### PR TITLE
KAFKA-15427: Fix resource leak in integration tests for tiered storage

### DIFF
--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerWrapperWithHarness.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerWrapperWithHarness.java
@@ -93,7 +93,7 @@ public class TopicBasedRemoteLogMetadataManagerWrapperWithHarness implements Rem
 
     @Override
     public void close() throws IOException {
-        remoteLogMetadataManagerHarness.remoteLogMetadataManager().close();
+        remoteLogMetadataManagerHarness.close();
     }
 
     @Override


### PR DESCRIPTION
This pull request addresses a resource leak which caused integration tests related to Tiered Storage to fail.

The original problem could be reproduced by running
```
./gradlew --no-parallel --max-workers 1 -PmaxParallelForks=1 storage:test --tests org.apache.kafka.server.log.remote.storage.RemoteLogMetadataManagerTest --tests org.apache.kafka.tiered.storage.integration.OffloadAndConsumeFromLeaderTest --rerun
```
and would result in
```
> Task :storage:testGradle Test Run :storage:test > Gradle Test Executor 3 > RemoteLogMetadataManagerTest > testRemotePartitionDeletion(RemoteLogMetadataManager) > remoteLogMetadataManager = org.apache.kafka.server.log.remote.storage.InmemoryRemoteLogMetadataManager@4cc76301 PASSED

Gradle Test Run :storage:test > Gradle Test Executor 3 > RemoteLogMetadataManagerTest > testRemotePartitionDeletion(RemoteLogMetadataManager) > remoteLogMetadataManager = org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerWrapperWithHarness@2ca47471 PASSED

Gradle Test Run :storage:test > Gradle Test Executor 3 > RemoteLogMetadataManagerTest > testFetchSegments(RemoteLogMetadataManager) > remoteLogMetadataManager = org.apache.kafka.server.log.remote.storage.InmemoryRemoteLogMetadataManager@ce12fbb PASSED

Gradle Test Run :storage:test > Gradle Test Executor 3 > RemoteLogMetadataManagerTest > testFetchSegments(RemoteLogMetadataManager) > remoteLogMetadataManager = org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerWrapperWithHarness@69aabcb0 PASSED

org.apache.kafka.tiered.storage.integration.OffloadAndConsumeFromLeaderTest.initializationError failed, log available in /Users/lolovc/Documents/kafka/storage/build/reports/testOutput/org.apache.kafka.tiered.storage.integration.OffloadAndConsumeFromLeaderTest.initializationError.test.stdoutGradle Test Run :storage:test > Gradle Test Executor 3 > OffloadAndConsumeFromLeaderTest > initializationError FAILED
    org.opentest4j.AssertionFailedError: Found 2 unexpected threads during @BeforeAll: `controller-event-thread,Test worker-EventThread` ==> expected: <true> but was: <false>

... 
```

After this change the same command results in
```
> Task :storage:test

Gradle Test Run :storage:test > Gradle Test Executor 3 > RemoteLogMetadataManagerTest > testRemotePartitionDeletion(RemoteLogMetadataManager) > remoteLogMetadataManager = org.apache.kafka.server.log.remote.storage.InmemoryRemoteLogMetadataManager@3a3e4aff PASSED

Gradle Test Run :storage:test > Gradle Test Executor 3 > RemoteLogMetadataManagerTest > testRemotePartitionDeletion(RemoteLogMetadataManager) > remoteLogMetadataManager = org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerWrapperWithHarness@2dbe250d PASSED

Gradle Test Run :storage:test > Gradle Test Executor 3 > RemoteLogMetadataManagerTest > testFetchSegments(RemoteLogMetadataManager) > remoteLogMetadataManager = org.apache.kafka.server.log.remote.storage.InmemoryRemoteLogMetadataManager@412c5e8b PASSED

Gradle Test Run :storage:test > Gradle Test Executor 3 > RemoteLogMetadataManagerTest > testFetchSegments(RemoteLogMetadataManager) > remoteLogMetadataManager = org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerWrapperWithHarness@2574a9e3 PASSED

Gradle Test Run :storage:test > Gradle Test Executor 3 > OffloadAndConsumeFromLeaderTest > executeTieredStorageTest() PASSED
```