### PR TITLE
KAFKA-15418: update statement on decompression

### DIFF
--- a/docs/design.html
+++ b/docs/design.html
@@ -137,8 +137,7 @@
     the same type (e.g. field names in JSON or user agents in web logs or common string values). Efficient compression requires compressing multiple messages together rather than compressing each message individually.
     <p>
     Kafka supports this with an efficient batching format. A batch of messages can be grouped together, compressed, and sent to the server in this form. The broker decompresses the batch in order to validate it. For
-    example, it validates that the number of records in the batch is same as what batch header states. The broker may also potentially modify the batch (e.g., if the topic is compacted, the broker will filter out 
-    records eligible for compaction prior to writing to disk). This batch of messages is then written to disk in compressed form. The batch will remain compressed in the log and it will also be transmitted to the 
+    example, it validates that the number of records in the batch is same as what batch header states. This batch of messages is then written to disk in compressed form. The batch will remain compressed in the log and it will also be transmitted to the 
     consumer in compressed form. The consumer decompresses any compressed data that it receives.
     <p>
     Kafka supports GZIP, Snappy, LZ4 and ZStandard compression protocols. More details on compression can be found <a href="https://cwiki.apache.org/confluence/display/KAFKA/Compression">here</a>.

--- a/docs/design.html
+++ b/docs/design.html
@@ -136,8 +136,9 @@
     the user can always compress its messages one at a time without any support needed from Kafka, but this can lead to very poor compression ratios as much of the redundancy is due to repetition between messages of
     the same type (e.g. field names in JSON or user agents in web logs or common string values). Efficient compression requires compressing multiple messages together rather than compressing each message individually.
     <p>
-    Kafka supports this with an efficient batching format. A batch of messages can be clumped together compressed and sent to the server in this form. This batch of messages will be written in compressed form and will
-    remain compressed in the log and will only be decompressed by the consumer.
+    Kafka supports this with an efficient batching format. A batch of messages can be grouped together, compressed, and sent to the server in this form. The broker decompresses the batch in order to validate it and 
+    potentially modify it (e.g., if the topic is compacted, the broker will filter out records eligible for compaction prior to writing to disk). This batch of messages is then written to disk in compressed form. 
+    The batch will remain compressed in the log and it will also be transmitted to the consumer in compressed form. The consumer decompresses any compressed data that it receives.
     <p>
     Kafka supports GZIP, Snappy, LZ4 and ZStandard compression protocols. More details on compression can be found <a href="https://cwiki.apache.org/confluence/display/KAFKA/Compression">here</a>.
 

--- a/docs/design.html
+++ b/docs/design.html
@@ -136,9 +136,10 @@
     the user can always compress its messages one at a time without any support needed from Kafka, but this can lead to very poor compression ratios as much of the redundancy is due to repetition between messages of
     the same type (e.g. field names in JSON or user agents in web logs or common string values). Efficient compression requires compressing multiple messages together rather than compressing each message individually.
     <p>
-    Kafka supports this with an efficient batching format. A batch of messages can be grouped together, compressed, and sent to the server in this form. The broker decompresses the batch in order to validate it and 
-    potentially modify it (e.g., if the topic is compacted, the broker will filter out records eligible for compaction prior to writing to disk). This batch of messages is then written to disk in compressed form. 
-    The batch will remain compressed in the log and it will also be transmitted to the consumer in compressed form. The consumer decompresses any compressed data that it receives.
+    Kafka supports this with an efficient batching format. A batch of messages can be grouped together, compressed, and sent to the server in this form. The broker decompresses the batch in order to validate it. For
+    example, it validates that the number of records in the batch is same as what batch header states. The broker may also potentially modify the batch (e.g., if the topic is compacted, the broker will filter out 
+    records eligible for compaction prior to writing to disk). This batch of messages is then written to disk in compressed form. The batch will remain compressed in the log and it will also be transmitted to the 
+    consumer in compressed form. The consumer decompresses any compressed data that it receives.
     <p>
     Kafka supports GZIP, Snappy, LZ4 and ZStandard compression protocols. More details on compression can be found <a href="https://cwiki.apache.org/confluence/display/KAFKA/Compression">here</a>.
 


### PR DESCRIPTION
The docs state: 

-https://github.com/apache/kafka/blob/0912ca27e2a229d2ebe02f4d1dabc40ed5fab0bb/docs/design.html#L139-L140

However, brokers always perform some amount of batch decompression in order to validate data. Internally, the LogValidator class implements the validation logic, and message decompression ultimately happens in the relevant CompressionType's wrapForInput implementation. These lines need updating to reflect that, including the scenarios that require full payload decompression on the broker (compacted topic, or topic level compression codec different from producer's codec).

This PR proposes to update the copy to reflect this. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
