### PR TITLE
KAFKA-15429: catch+log errors from unsubscribe in streamthread shutdown

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1196,8 +1196,12 @@ public class StreamThread extends Thread {
         } catch (final Throwable e) {
             log.error("Failed to close changelog reader due to the following error:", e);
         }
-        if (leaveGroupRequested.get()) {
-            mainConsumer.unsubscribe();
+        try {
+            if (leaveGroupRequested.get()) {
+                mainConsumer.unsubscribe();
+            }
+        } catch (final Throwable e) {
+            log.error("Failed to unsubscribe due to the following error: ", e);
         }
         try {
             mainConsumer.close();


### PR DESCRIPTION
Preliminary fix for KAFKA-15429 which updates StreamThread.completeShutdown to catch-and-log errors from consumer.unsubscribe. Though this does not prevent the exception, it does preserve the original exception that caused the stream thread to exit.