### PR TITLE
KAFKA-15429: reset transactionInFlight on StreamsProducer close

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -371,6 +371,7 @@ public class StreamsProducer {
 
     void close() {
         producer.close();
+        transactionInFlight = false;
     }
 
     // for testing only

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -192,12 +192,11 @@ public class StreamsProducer {
 
         oldProducerTotalBlockedTime += totalBlockedTime(producer);
         final long start = time.nanoseconds();
-        producer.close();
+        close();
         final long closeTime = time.nanoseconds() - start;
         oldProducerTotalBlockedTime += closeTime;
 
         producer = clientSupplier.getProducer(eosV2ProducerConfigs);
-        transactionInitialized = false;
     }
 
     private double getMetricValue(final Map<MetricName, ? extends Metric> metrics,
@@ -372,6 +371,7 @@ public class StreamsProducer {
     void close() {
         producer.close();
         transactionInFlight = false;
+        transactionInitialized = false;
     }
 
     // for testing only

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -212,10 +212,24 @@ public class StreamsProducerTest {
         // given:
         eosBetaStreamsProducer.send(
             new ProducerRecord<>("topic", new byte[1]), (metadata, error) -> { });
-        assertThat(eosBetaStreamsProducer.eosEnabled(), is(true));
+        assertThat(eosBetaStreamsProducer.transactionInFlight(), is(true));
 
         // when:
         eosBetaStreamsProducer.close();
+
+        // then:
+        assertThat(eosBetaStreamsProducer.transactionInFlight(), is(false));
+    }
+
+    @Test
+    public void shouldResetTransactionInFlightOnReset() {
+        // given:
+        eosBetaStreamsProducer.send(
+            new ProducerRecord<>("topic", new byte[1]), (metadata, error) -> { });
+        assertThat(eosBetaStreamsProducer.transactionInFlight(), is(true));
+
+        // when:
+        eosBetaStreamsProducer.resetProducer();
 
         // then:
         assertThat(eosBetaStreamsProducer.transactionInFlight(), is(false));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -208,6 +208,20 @@ public class StreamsProducerTest {
     // functional tests
 
     @Test
+    public void shouldResetTransactionInFlightOnClose() {
+        // given:
+        eosBetaStreamsProducer.send(
+            new ProducerRecord<>("topic", new byte[1]), (metadata, error) -> { });
+        assertThat(eosBetaStreamsProducer.eosEnabled(), is(true));
+
+        // when:
+        eosBetaStreamsProducer.close();
+
+        // then:
+        assertThat(eosBetaStreamsProducer.transactionInFlight(), is(false));
+    }
+
+    @Test
     public void shouldCreateProducer() {
         assertThat(mockClientSupplier.producers.size(), is(1));
         assertThat(eosAlphaMockClientSupplier.producers.size(), is(1));


### PR DESCRIPTION
Resets the value of transactionInFlight to false when closing the StreamsProducer. This ensures we don't try to commit against a closed producer. Tested using a unit test of StreamsProducer.