### PR TITLE
KAFKA-15307: Removes non-existent configs

### DIFF
--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -85,8 +85,12 @@ settings.put(... , ...);</code></pre>
               <li><a class="reference internal" href="#processing-guarantee" id="id25">processing.guarantee</a></li>
               <li><a class="reference internal" href="#rack-aware-assignment-non-overlap-cost" id="id37">rack.aware.assignment.non_overlap_cost</a></li>
               <li><a class="reference internal" href="#rack-aware-assignment-strategy" id="id35">rack.aware.assignment.strategy</a></li>
+              <li><a class="reference internal" href="#rack-aware-assignment-tags" id="id34">rack.aware.assignment.tags</a></li>
               <li><a class="reference internal" href="#rack-aware-assignment-traffic-cost" id="id36">rack.aware.assignment.traffic_cost</a></li>
               <li><a class="reference internal" href="#replication-factor" id="id13">replication.factor</a></li>
+              <li><a class="reference internal" href="#rocksdb-config-setter" id="id20">rocksdb.config.setter</a></li>
+              <li><a class="reference internal" href="#state-dir" id="id14">state.dir</a></li>
+              <li><a class="reference internal" href="#topology-optimization" id="id31">topology.optimization</a></li>
             </ul>
           </li>
           <li><a class="reference internal" href="#kafka-consumers-and-producer-configuration-parameters" id="id16">Kafka consumers and producer configuration parameters</a>
@@ -131,6 +135,7 @@ settings.put(... , ...);</code></pre>
               <ul class="simple">
                 <li>As the default Kafka consumer and producer <code class="docutils literal"><span class="pre">client.id</span></code> prefix</li>
                 <li>As the Kafka consumer <code class="docutils literal"><span class="pre">group.id</span></code> for coordination</li>
+                <li>As the name of the subdirectory in the state directory (cf. <code class="docutils literal"><span class="pre">state.dir</span></code>)</li>
                 <li>As the prefix of internal Kafka topic names</li>
               </ul>
               <dl class="docutils">
@@ -376,6 +381,13 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
             <td colspan="2">The amount of time in milliseconds to block waiting for input.</td>
             <td>100 milliseconds</td>
           </tr>
+          <tr class="row-even"><td>rack.aware.assignment.tags</td>
+            <td>Medium</td>
+            <td colspan="2">List of tag keys used to distribute standby replicas across Kafka Streams
+              clients. When configured, Kafka Streams will make a best-effort to distribute the standby tasks over
+              clients with different tag values.</td>
+            <td>the empty list</td>
+          </tr>
           <tr class="row-even"><td>replication.factor</td>
             <td>Medium</td>
             <td colspan="2">The replication factor for changelog topics and repartition topics created by the application.
@@ -387,15 +399,30 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
               <td colspan="2">The amount of time in milliseconds, before a request is retried. This applies if the <code class="docutils literal"><span class="pre">retries</span></code> parameter is configured to be greater than 0. </td>
               <td>100 milliseconds</td>
           </tr>
+          <tr class="row-odd"><td>rocksdb.config.setter</td>
+            <td>Medium</td>
+            <td colspan="2">The RocksDB configuration.</td>
+            <td></td>
+          </tr>
           <tr class="row-even"><td>state.cleanup.delay.ms</td>
             <td>Low</td>
             <td colspan="2">The amount of time in milliseconds to wait before deleting state when a partition has migrated.</td>
             <td>600000 milliseconds (10 minutes)</td>
           </tr>
+          <tr class="row-odd"><td>state.dir</td>
+            <td>High</td>
+            <td colspan="2">Directory location for state stores.</td>
+            <td><code class="docutils literal"><span class="pre">/${java.io.tmpdir}/kafka-streams</span></code></td>
+          </tr>
           <tr class="row-odd"><td>task.timeout.ms</td>
             <td>Medium</td>
             <td colspan="2">The maximum amount of time in milliseconds a task might stall due to internal errors and retries until an error is raised. For a timeout of <code>0 ms</code>, a task would raise an error for the first internal error. For any timeout larger than <code>0 ms</code>, a task will retry at least once before an error is raised.</td>
             <td>300000 milliseconds (5 minutes)</td>
+          </tr>
+          <tr class="row-even"><td>topology.optimization</td>
+            <td>Medium</td>
+            <td colspan="2">A configuration telling Kafka Streams if it should optimize the topology and what optimizations to apply. Acceptable values are: <code>StreamsConfig.NO_OPTIMIZATION</code> (<code>none</code>), <code>StreamsConfig.OPTIMIZE</code> (<code>all</code>) or a comma separated list of specific optimizations: (<code>StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS</code> (<code>reuse.ktable.source.topics</code>), <code>StreamsConfig.MERGE_REPARTITION_TOPICS</code> (<code>merge.repartition.topics</code>)). </td>
+            <td><code> NO_OPTIMIZATION</code></td>
           </tr>
           <tr class="row-odd"><td>upgrade.from</td>
             <td>Medium</td>
@@ -694,6 +721,40 @@ streamsConfiguration.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
           </div>
         </blockquote>
       </div>
+      <div class="section" id="rack-aware-assignment-tags">
+        <h4><a class="toc-backref" href="#id34">rack.aware.assignment.tags</a><a class="headerlink" href="#rack-aware-assignment-tags" title="Permalink to this headline"></a>
+        </h4>
+        <blockquote>
+          <div>
+            <p>
+              This configuration sets a list of tag keys used to distribute standby replicas across Kafka Streams
+              clients. When configured, Kafka Streams will make a best-effort to distribute the standby tasks over
+              clients with different tag values.
+            </p>
+            <p>
+              Tags for the Kafka Streams clients can be set via <code class="docutils literal"><span class="pre">client.tag.</span></code>
+              prefix. Example:
+            </p>
+            <pre><code class="language-text">
+Client-1                                   | Client-2
+_______________________________________________________________________
+client.tag.zone: eu-central-1a             | client.tag.zone: eu-central-1b
+client.tag.cluster: k8s-cluster1           | client.tag.cluster: k8s-cluster1
+rack.aware.assignment.tags: zone,cluster   | rack.aware.assignment.tags: zone,cluster
+
+
+Client-3                                   | Client-4
+_______________________________________________________________________
+client.tag.zone: eu-central-1a             | client.tag.zone: eu-central-1b
+client.tag.cluster: k8s-cluster2           | client.tag.cluster: k8s-cluster2
+rack.aware.assignment.tags: zone,cluster   | rack.aware.assignment.tags: zone,cluster</code></pre>
+            <p>
+              In the above example, we have four Kafka Streams clients across two zones (<code class="docutils literal"><span class="pre">eu-central-1a</span></code>, <code class="docutils literal"><span class="pre">eu-central-1b</span></code>) and across two clusters (<code class="docutils literal"><span class="pre">k8s-cluster1</span></code>, <code class="docutils literal"><span class="pre">k8s-cluster2</span></code>).
+              For an active task located on <code class="docutils literal"><span class="pre">Client-1</span></code>, Kafka Streams will allocate a standby task on <code class="docutils literal"><span class="pre">Client-4</span></code>, since <code class="docutils literal"><span class="pre">Client-4</span></code> has a different <code class="docutils literal"><span class="pre">zone</span></code> and a different <code class="docutils literal"><span class="pre">cluster</span></code> than <code class="docutils literal"><span class="pre">Client-1</span></code>.
+            </p>
+          </div>
+        </blockquote>
+      </div>
       <div class="section" id="rack-aware-assignment-traffic-cost">
         <h4><a class="toc-backref" href="#id36">rack.aware.assignment.traffic_cost</a><a class="headerlink" href="#rack-aware-assignment-traffic-cost" title="Permalink to this headline"></a></h4>
         <blockquote>
@@ -816,17 +877,6 @@ streamsConfiguration.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
             <div>This specifies the number of stream threads in an instance of the Kafka Streams application. The stream processing code runs in these thread.
               For more information about Kafka Streams threading model, see <a class="reference internal" href="../architecture.html#streams_architecture_threads"><span class="std std-ref">Threading Model</span></a>.</div></blockquote>
         </div>
-        <div class="section" id="partition-grouper">
-          <span id="streams-developer-guide-partition-grouper"></span><h4><a class="toc-backref" href="#id12">partition.grouper</a><a class="headerlink" href="#partition-grouper" title="Permalink to this headline"></a></h4>
-          <blockquote>
-            <div>
-              <b>[DEPRECATED]</b> A partition grouper creates a list of stream tasks from the partitions of source topics, where each created task is assigned with a group of source topic partitions.
-              The default implementation provided by Kafka Streams is <a class="reference external" href="/{{version}}/javadoc/org/apache/kafka/streams/processor/DefaultPartitionGrouper.html">DefaultPartitionGrouper</a>.
-              It assigns each task with one partition for each of the source topic partitions. The generated number of tasks equals the largest
-              number of partitions among the input topics. Usually an application does not need to customize the partition grouper.
-            </div>
-          </blockquote>
-        </div>
         <div class="section" id="probing-rebalance-interval-ms">
           <h4><a class="toc-backref" href="#id30">probing.rebalance.interval.ms</a><a class="headerlink" href="#probing-rebalance-interval-ms" title="Permalink to this headline"></a></h4>
           <blockquote>
@@ -881,6 +931,85 @@ streamsConfiguration.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
               </dl>
             </div></blockquote>
         </div>
+        <div class="section" id="rocksdb-config-setter">
+          <span id="streams-developer-guide-rocksdb-config"></span><h4><a class="toc-backref" href="#id20">rocksdb.config.setter</a><a class="headerlink" href="#rocksdb-config-setter" title="Permalink to this headline"></a></h4>
+          <blockquote>
+            <div><p>The RocksDB configuration. Kafka Streams uses RocksDB as the default storage engine for persistent stores. To change the default
+              configuration for RocksDB, you can implement <code class="docutils literal"><span class="pre">RocksDBConfigSetter</span></code> and provide your custom class via <a class="reference external" href="/{{version}}/javadoc/org/apache/kafka/streams/state/RocksDBConfigSetter.html">rocksdb.config.setter</a>.</p>
+              <p>Here is an example that adjusts the memory size consumed by RocksDB.</p>
+              <pre class="line-numbers"><code class="language-java">public static class CustomRocksDBConfig implements RocksDBConfigSetter {
+    // This object should be a member variable so it can be closed in RocksDBConfigSetter#close.
+    private org.rocksdb.Cache cache = new org.rocksdb.LRUCache(16 * 1024L * 1024L);
+
+    @Override
+    public void setConfig(final String storeName, final Options options, final Map&lt;String, Object&gt; configs) {
+        // See #1 below.
+        BlockBasedTableConfig tableConfig = (BlockBasedTableConfig) options.tableFormatConfig();
+        tableConfig.setBlockCache(cache);
+        // See #2 below.
+        tableConfig.setBlockSize(16 * 1024L);
+        // See #3 below.
+        tableConfig.setCacheIndexAndFilterBlocks(true);
+        options.setTableFormatConfig(tableConfig);
+        // See #4 below.
+        options.setMaxWriteBufferNumber(2);
+    }
+
+    @Override
+    public void close(final String storeName, final Options options) {
+        // See #5 below.
+        cache.close();
+    }
+}
+
+Properties streamsSettings = new Properties();
+streamsConfig.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, CustomRocksDBConfig.class);</code></pre>
+              <dl class="docutils">
+                <dt>Notes for example:</dt>
+                <dd><ol class="first last arabic simple">
+                  <li><code class="docutils literal"><span class="pre">BlockBasedTableConfig tableConfig = (BlockBasedTableConfig) options.tableFormatConfig();</span></code> Get a reference to the existing table config rather than create a new one, so you don't accidentally overwrite defaults such as the <code class="docutils literal"><span class="pre">BloomFilter</span></code>, which is an important optimization.
+                  <li><code class="docutils literal"><span class="pre">tableConfig.setBlockSize(16</span> <span class="pre">*</span> <span class="pre">1024L);</span></code> Modify the default <a class="reference external" href="https://github.com/apache/kafka/blob/2.3/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java#L79">block size</a> per these instructions from the <a class="reference external" href="https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB#indexes-and-filter-blocks">RocksDB GitHub</a>.</li>
+                  <li><code class="docutils literal"><span class="pre">tableConfig.setCacheIndexAndFilterBlocks(true);</span></code> Do not let the index and filter blocks grow unbounded. For more information, see the <a class="reference external" href="https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-and-filter-blocks">RocksDB GitHub</a>.</li>
+                  <li><code class="docutils literal"><span class="pre">options.setMaxWriteBufferNumber(2);</span></code> See the advanced options in the <a class="reference external" href="https://github.com/facebook/rocksdb/blob/8dee8cad9ee6b70fd6e1a5989a8156650a70c04f/include/rocksdb/advanced_options.h#L103">RocksDB GitHub</a>.</li>
+                  <li><code class="docutils literal"><span class="pre">cache.close();</span></code> To avoid memory leaks, you must close any objects you constructed that extend org.rocksdb.RocksObject. See  <a class="reference external" href="https://github.com/facebook/rocksdb/wiki/RocksJava-Basics#memory-management">RocksJava docs</a> for more details.</li>
+                </ol>
+                </dd>
+              </dl>
+            </div>
+          </blockquote>
+        </div>
+      </div>
+      </blockquote>
+    </div>
+    <div class="section" id="state-dir">
+      <h4><a class="toc-backref" href="#id14">state.dir</a><a class="headerlink" href="#state-dir" title="Permalink to this headline"></a></h4>
+      <blockquote>
+        <div>The state directory. Kafka Streams persists local states under the state directory. Each application has a subdirectory on its hosting
+          machine that is located under the state directory. The name of the subdirectory is the application ID. The state stores associated
+          with the application are created under this subdirectory. When running multiple instances of the same application on a single machine,
+          this path must be unique for each such instance.</div>
+      </blockquote>
+    </div>
+    <div class="section" id="topology-optimization">
+      <h4><a class="toc-backref" href="#id31">topology.optimization</a><a class="headerlink" href="#topology-optimization" title="Permalink to this headline"></a></h4>
+      <blockquote>
+        <div>
+          <p>
+            A configuration telling Kafka Streams if it should optimize the topology and what optimizations to apply. Acceptable values are: <code>StreamsConfig.NO_OPTIMIZATION</code> (<code>none</code>), <code>StreamsConfig.OPTIMIZE</code> (<code>all</code>) or a comma separated list of specific optimizations: (<code>StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS</code> (<code>reuse.ktable.source.topics</code>), <code>StreamsConfig.MERGE_REPARTITION_TOPICS</code> (<code>merge.repartition.topics</code>)).
+          </p>
+          <p>
+            We recommend listing specific optimizations in the config for production code so that the structure of your topology will not change unexpectedly during upgrades of the Streams library.
+          </p>
+          <p>
+            These optimizations include moving/reducing repartition topics and reusing the source topic as the changelog for source KTables. These optimizations will save on network traffic and storage in Kafka without changing the semantics of your applications. Enabling them is recommended.
+          </p>
+          <p>
+            Note that as of 2.3, you need to do two things to enable optimizations. In addition to setting this config to <code>StreamsConfig.OPTIMIZE</code>, you'll need to pass in your
+            configuration properties when building your topology by using the overloaded <code>StreamsBuilder.build(Properties)</code> method.
+            For example <code>KafkaStreams myStream = new KafkaStreams(streamsBuilder.build(properties), properties)</code>.
+          </p>
+        </div></blockquote>
+    </div>
     <div class="section" id="upgrade-from">
       <span id="streams-developer-guide-upgrade-from"></span><h4><a class="toc-backref" href="#id14">upgrade.from</a><a class="headerlink" href="#upgrade-from" title="Permalink to this headline"></a></h4>
       <blockquote>

--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -81,17 +81,12 @@ settings.put(... , ...);</code></pre>
               <li><a class="reference internal" href="#max-warmup-replicas" id="id29">max.warmup.replicas</a></li>
               <li><a class="reference internal" href="#num-standby-replicas" id="id10">num.standby.replicas</a></li>
               <li><a class="reference internal" href="#num-stream-threads" id="id11">num.stream.threads</a></li>
-              <li><a class="reference internal" href="#partition-grouper" id="id12">partition.grouper</a></li>
               <li><a class="reference internal" href="#probing-rebalance-interval-ms" id="id30">probing.rebalance.interval.ms</a></li>
               <li><a class="reference internal" href="#processing-guarantee" id="id25">processing.guarantee</a></li>
               <li><a class="reference internal" href="#rack-aware-assignment-non-overlap-cost" id="id37">rack.aware.assignment.non_overlap_cost</a></li>
               <li><a class="reference internal" href="#rack-aware-assignment-strategy" id="id35">rack.aware.assignment.strategy</a></li>
-              <li><a class="reference internal" href="#rack-aware-assignment-tags" id="id34">rack.aware.assignment.tags</a></li>
               <li><a class="reference internal" href="#rack-aware-assignment-traffic-cost" id="id36">rack.aware.assignment.traffic_cost</a></li>
               <li><a class="reference internal" href="#replication-factor" id="id13">replication.factor</a></li>
-              <li><a class="reference internal" href="#rocksdb-config-setter" id="id20">rocksdb.config.setter</a></li>
-              <li><a class="reference internal" href="#state-dir" id="id14">state.dir</a></li>
-              <li><a class="reference internal" href="#topology-optimization" id="id31">topology.optimization</a></li>
             </ul>
           </li>
           <li><a class="reference internal" href="#kafka-consumers-and-producer-configuration-parameters" id="id16">Kafka consumers and producer configuration parameters</a>
@@ -136,7 +131,6 @@ settings.put(... , ...);</code></pre>
               <ul class="simple">
                 <li>As the default Kafka consumer and producer <code class="docutils literal"><span class="pre">client.id</span></code> prefix</li>
                 <li>As the Kafka consumer <code class="docutils literal"><span class="pre">group.id</span></code> for coordination</li>
-                <li>As the name of the subdirectory in the state directory (cf. <code class="docutils literal"><span class="pre">state.dir</span></code>)</li>
                 <li>As the prefix of internal Kafka topic names</li>
               </ul>
               <dl class="docutils">
@@ -365,11 +359,6 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
             <td colspan="2">The number of threads to execute stream processing.</td>
             <td>1</td>
           </tr>
-          <tr class="row-even"><td>partition.grouper</td>
-            <td>Low</td>
-            <td colspan="2">Partition grouper class that implements the <code class="docutils literal"><span class="pre">PartitionGrouper</span></code> interface.</td>
-            <td>See <a class="reference internal" href="#streams-developer-guide-partition-grouper"><span class="std std-ref">Partition Grouper</span></a></td>
-          </tr>
           <tr class="row-odd"><td>probing.rebalance.interval.ms</td>
             <td>Low</td>
             <td colspan="2">The maximum time in milliseconds to wait before triggering a rebalance to probe for warmup replicas that have sufficiently caught up.</td>
@@ -387,13 +376,6 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
             <td colspan="2">The amount of time in milliseconds to block waiting for input.</td>
             <td>100 milliseconds</td>
           </tr>
-          <tr class="row-even"><td>rack.aware.assignment.tags</td>
-            <td>Medium</td>
-            <td colspan="2">List of tag keys used to distribute standby replicas across Kafka Streams
-              clients. When configured, Kafka Streams will make a best-effort to distribute the standby tasks over
-              clients with different tag values.</td>
-            <td>the empty list</td>
-          </tr>
           <tr class="row-even"><td>replication.factor</td>
             <td>Medium</td>
             <td colspan="2">The replication factor for changelog topics and repartition topics created by the application.
@@ -405,30 +387,15 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
               <td colspan="2">The amount of time in milliseconds, before a request is retried. This applies if the <code class="docutils literal"><span class="pre">retries</span></code> parameter is configured to be greater than 0. </td>
               <td>100 milliseconds</td>
           </tr>
-          <tr class="row-odd"><td>rocksdb.config.setter</td>
-            <td>Medium</td>
-            <td colspan="2">The RocksDB configuration.</td>
-            <td></td>
-          </tr>
           <tr class="row-even"><td>state.cleanup.delay.ms</td>
             <td>Low</td>
             <td colspan="2">The amount of time in milliseconds to wait before deleting state when a partition has migrated.</td>
             <td>600000 milliseconds (10 minutes)</td>
           </tr>
-          <tr class="row-odd"><td>state.dir</td>
-            <td>High</td>
-            <td colspan="2">Directory location for state stores.</td>
-            <td><code class="docutils literal"><span class="pre">/${java.io.tmpdir}/kafka-streams</span></code></td>
-          </tr>
           <tr class="row-odd"><td>task.timeout.ms</td>
             <td>Medium</td>
             <td colspan="2">The maximum amount of time in milliseconds a task might stall due to internal errors and retries until an error is raised. For a timeout of <code>0 ms</code>, a task would raise an error for the first internal error. For any timeout larger than <code>0 ms</code>, a task will retry at least once before an error is raised.</td>
             <td>300000 milliseconds (5 minutes)</td>
-          </tr>
-          <tr class="row-even"><td>topology.optimization</td>
-            <td>Medium</td>
-            <td colspan="2">A configuration telling Kafka Streams if it should optimize the topology and what optimizations to apply. Acceptable values are: <code>StreamsConfig.NO_OPTIMIZATION</code> (<code>none</code>), <code>StreamsConfig.OPTIMIZE</code> (<code>all</code>) or a comma separated list of specific optimizations: (<code>StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS</code> (<code>reuse.ktable.source.topics</code>), <code>StreamsConfig.MERGE_REPARTITION_TOPICS</code> (<code>merge.repartition.topics</code>)). </td>
-            <td><code> NO_OPTIMIZATION</code></td>
           </tr>
           <tr class="row-odd"><td>upgrade.from</td>
             <td>Medium</td>
@@ -727,40 +694,6 @@ streamsConfiguration.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
           </div>
         </blockquote>
       </div>
-      <div class="section" id="rack-aware-assignment-tags">
-        <h4><a class="toc-backref" href="#id34">rack.aware.assignment.tags</a><a class="headerlink" href="#rack-aware-assignment-tags" title="Permalink to this headline"></a>
-        </h4>
-        <blockquote>
-          <div>
-            <p>
-              This configuration sets a list of tag keys used to distribute standby replicas across Kafka Streams
-              clients. When configured, Kafka Streams will make a best-effort to distribute the standby tasks over
-              clients with different tag values.
-            </p>
-            <p>
-              Tags for the Kafka Streams clients can be set via <code class="docutils literal"><span class="pre">client.tag.</span></code>
-              prefix. Example:
-            </p>
-            <pre><code class="language-text">
-Client-1                                   | Client-2
-_______________________________________________________________________
-client.tag.zone: eu-central-1a             | client.tag.zone: eu-central-1b
-client.tag.cluster: k8s-cluster1           | client.tag.cluster: k8s-cluster1
-rack.aware.assignment.tags: zone,cluster   | rack.aware.assignment.tags: zone,cluster
-
-
-Client-3                                   | Client-4
-_______________________________________________________________________
-client.tag.zone: eu-central-1a             | client.tag.zone: eu-central-1b
-client.tag.cluster: k8s-cluster2           | client.tag.cluster: k8s-cluster2
-rack.aware.assignment.tags: zone,cluster   | rack.aware.assignment.tags: zone,cluster</code></pre>
-            <p>
-              In the above example, we have four Kafka Streams clients across two zones (<code class="docutils literal"><span class="pre">eu-central-1a</span></code>, <code class="docutils literal"><span class="pre">eu-central-1b</span></code>) and across two clusters (<code class="docutils literal"><span class="pre">k8s-cluster1</span></code>, <code class="docutils literal"><span class="pre">k8s-cluster2</span></code>).
-              For an active task located on <code class="docutils literal"><span class="pre">Client-1</span></code>, Kafka Streams will allocate a standby task on <code class="docutils literal"><span class="pre">Client-4</span></code>, since <code class="docutils literal"><span class="pre">Client-4</span></code> has a different <code class="docutils literal"><span class="pre">zone</span></code> and a different <code class="docutils literal"><span class="pre">cluster</span></code> than <code class="docutils literal"><span class="pre">Client-1</span></code>.
-            </p>
-          </div>
-        </blockquote>
-      </div>
       <div class="section" id="rack-aware-assignment-traffic-cost">
         <h4><a class="toc-backref" href="#id36">rack.aware.assignment.traffic_cost</a><a class="headerlink" href="#rack-aware-assignment-traffic-cost" title="Permalink to this headline"></a></h4>
         <blockquote>
@@ -948,85 +881,6 @@ rack.aware.assignment.tags: zone,cluster   | rack.aware.assignment.tags: zone,cl
               </dl>
             </div></blockquote>
         </div>
-        <div class="section" id="rocksdb-config-setter">
-          <span id="streams-developer-guide-rocksdb-config"></span><h4><a class="toc-backref" href="#id20">rocksdb.config.setter</a><a class="headerlink" href="#rocksdb-config-setter" title="Permalink to this headline"></a></h4>
-          <blockquote>
-            <div><p>The RocksDB configuration. Kafka Streams uses RocksDB as the default storage engine for persistent stores. To change the default
-              configuration for RocksDB, you can implement <code class="docutils literal"><span class="pre">RocksDBConfigSetter</span></code> and provide your custom class via <a class="reference external" href="/{{version}}/javadoc/org/apache/kafka/streams/state/RocksDBConfigSetter.html">rocksdb.config.setter</a>.</p>
-              <p>Here is an example that adjusts the memory size consumed by RocksDB.</p>
-              <pre class="line-numbers"><code class="language-java">public static class CustomRocksDBConfig implements RocksDBConfigSetter {
-    // This object should be a member variable so it can be closed in RocksDBConfigSetter#close.
-    private org.rocksdb.Cache cache = new org.rocksdb.LRUCache(16 * 1024L * 1024L);
-
-    @Override
-    public void setConfig(final String storeName, final Options options, final Map&lt;String, Object&gt; configs) {
-        // See #1 below.
-        BlockBasedTableConfig tableConfig = (BlockBasedTableConfig) options.tableFormatConfig();
-        tableConfig.setBlockCache(cache);
-        // See #2 below.
-        tableConfig.setBlockSize(16 * 1024L);
-        // See #3 below.
-        tableConfig.setCacheIndexAndFilterBlocks(true);
-        options.setTableFormatConfig(tableConfig);
-        // See #4 below.
-        options.setMaxWriteBufferNumber(2);
-    }
-
-    @Override
-    public void close(final String storeName, final Options options) {
-        // See #5 below.
-        cache.close();
-    }
-}
-
-Properties streamsSettings = new Properties();
-streamsConfig.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, CustomRocksDBConfig.class);</code></pre>
-              <dl class="docutils">
-                <dt>Notes for example:</dt>
-                <dd><ol class="first last arabic simple">
-                  <li><code class="docutils literal"><span class="pre">BlockBasedTableConfig tableConfig = (BlockBasedTableConfig) options.tableFormatConfig();</span></code> Get a reference to the existing table config rather than create a new one, so you don't accidentally overwrite defaults such as the <code class="docutils literal"><span class="pre">BloomFilter</span></code>, which is an important optimization.
-                  <li><code class="docutils literal"><span class="pre">tableConfig.setBlockSize(16</span> <span class="pre">*</span> <span class="pre">1024L);</span></code> Modify the default <a class="reference external" href="https://github.com/apache/kafka/blob/2.3/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java#L79">block size</a> per these instructions from the <a class="reference external" href="https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB#indexes-and-filter-blocks">RocksDB GitHub</a>.</li>
-                  <li><code class="docutils literal"><span class="pre">tableConfig.setCacheIndexAndFilterBlocks(true);</span></code> Do not let the index and filter blocks grow unbounded. For more information, see the <a class="reference external" href="https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-and-filter-blocks">RocksDB GitHub</a>.</li>
-                  <li><code class="docutils literal"><span class="pre">options.setMaxWriteBufferNumber(2);</span></code> See the advanced options in the <a class="reference external" href="https://github.com/facebook/rocksdb/blob/8dee8cad9ee6b70fd6e1a5989a8156650a70c04f/include/rocksdb/advanced_options.h#L103">RocksDB GitHub</a>.</li>
-                  <li><code class="docutils literal"><span class="pre">cache.close();</span></code> To avoid memory leaks, you must close any objects you constructed that extend org.rocksdb.RocksObject. See  <a class="reference external" href="https://github.com/facebook/rocksdb/wiki/RocksJava-Basics#memory-management">RocksJava docs</a> for more details.</li>
-                </ol>
-                </dd>
-              </dl>
-            </div>
-          </blockquote>
-        </div>
-      </div>
-      </blockquote>
-    </div>
-    <div class="section" id="state-dir">
-      <h4><a class="toc-backref" href="#id14">state.dir</a><a class="headerlink" href="#state-dir" title="Permalink to this headline"></a></h4>
-      <blockquote>
-        <div>The state directory. Kafka Streams persists local states under the state directory. Each application has a subdirectory on its hosting
-          machine that is located under the state directory. The name of the subdirectory is the application ID. The state stores associated
-          with the application are created under this subdirectory. When running multiple instances of the same application on a single machine,
-          this path must be unique for each such instance.</div>
-      </blockquote>
-    </div>
-    <div class="section" id="topology-optimization">
-      <h4><a class="toc-backref" href="#id31">topology.optimization</a><a class="headerlink" href="#topology-optimization" title="Permalink to this headline"></a></h4>
-      <blockquote>
-        <div>
-          <p>
-            A configuration telling Kafka Streams if it should optimize the topology and what optimizations to apply. Acceptable values are: <code>StreamsConfig.NO_OPTIMIZATION</code> (<code>none</code>), <code>StreamsConfig.OPTIMIZE</code> (<code>all</code>) or a comma separated list of specific optimizations: (<code>StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS</code> (<code>reuse.ktable.source.topics</code>), <code>StreamsConfig.MERGE_REPARTITION_TOPICS</code> (<code>merge.repartition.topics</code>)).
-          </p>
-          <p>
-            We recommend listing specific optimizations in the config for production code so that the structure of your topology will not change unexpectedly during upgrades of the Streams library.
-          </p>
-          <p>
-            These optimizations include moving/reducing repartition topics and reusing the source topic as the changelog for source KTables. These optimizations will save on network traffic and storage in Kafka without changing the semantics of your applications. Enabling them is recommended.
-          </p>
-          <p>
-            Note that as of 2.3, you need to do two things to enable optimizations. In addition to setting this config to <code>StreamsConfig.OPTIMIZE</code>, you'll need to pass in your
-            configuration properties when building your topology by using the overloaded <code>StreamsBuilder.build(Properties)</code> method.
-            For example <code>KafkaStreams myStream = new KafkaStreams(streamsBuilder.build(properties), properties)</code>.
-          </p>
-        </div></blockquote>
-    </div>
     <div class="section" id="upgrade-from">
       <span id="streams-developer-guide-upgrade-from"></span><h4><a class="toc-backref" href="#id14">upgrade.from</a><a class="headerlink" href="#upgrade-from" title="Permalink to this headline"></a></h4>
       <blockquote>


### PR DESCRIPTION
addresses 1/3 of https://issues.apache.org/jira/browse/KAFKA-15307 

Removes pieces of configuration from the [developer guide to configuring streams.](https://kafka.apache.org/35/documentation/streams/developer-guide/config-streams.html). 

These were the pieces of configuration not found in [StreamsConfig.java](https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java). 

They include: 
 - `partition.grouper`
 - `rack.aware.assignment.tag`
 - `rocksdb.config.setter`
 - `state.dir`
 - `topology.optimization`

Note: `acks` and `replication.factor`, although not found in 'StreamsConfig.java', are listed in the developer guide to configuring streams. I am assuming they are defined somewhere else. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
