### PR TITLE
[MINOR] fix: Align LogContext setup for core components

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -562,7 +562,7 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     static LogContext createLogContext(String clientId) {
-        return LogContext.newBuilder("AdminClient").withTag("clientId", clientId).build();
+        return LogContext.forComponent("AdminClient").withTag("clientId", clientId).build();
     }
 
     private KafkaAdminClient(AdminClientConfig config,

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -562,7 +562,7 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     static LogContext createLogContext(String clientId) {
-        return new LogContext("[AdminClient clientId=" + clientId + "] ");
+        return LogContext.newBuilder("AdminClient").withTag("clientId", clientId).build();
     }
 
     private KafkaAdminClient(AdminClientConfig config,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
@@ -113,13 +113,13 @@ public final class ConsumerUtils {
 
         // If group.instance.id is set, we will append it to the log context.
         if (groupRebalanceConfig.groupInstanceId.isPresent()) {
-            return LogContext.newBuilder("Consumer")
+            return LogContext.forComponent("Consumer")
                 .withTag("instanceId", groupRebalanceConfig.groupInstanceId.get())
                 .withTag("clientId", clientId)
                 .withTag("groupId", groupId.orElse("null"))
                 .build();
         } else {
-            return LogContext.newBuilder("Consumer")
+            return LogContext.forComponent("Consumer")
                 .withTag("clientId", clientId)
                 .withTag("groupId", groupId.orElse("null"))
                 .build();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
@@ -113,10 +113,16 @@ public final class ConsumerUtils {
 
         // If group.instance.id is set, we will append it to the log context.
         if (groupRebalanceConfig.groupInstanceId.isPresent()) {
-            return new LogContext("[Consumer instanceId=" + groupRebalanceConfig.groupInstanceId.get() +
-                    ", clientId=" + clientId + ", groupId=" + groupId.orElse("null") + "] ");
+            return LogContext.newBuilder("Consumer")
+                .withTag("instanceId", groupRebalanceConfig.groupInstanceId.get())
+                .withTag("clientId", clientId)
+                .withTag("groupId", groupId.orElse("null"))
+                .build();
         } else {
-            return new LogContext("[Consumer clientId=" + clientId + ", groupId=" + groupId.orElse("null") + "] ");
+            return LogContext.newBuilder("Consumer")
+                .withTag("clientId", clientId)
+                .withTag("groupId", groupId.orElse("null"))
+                .build();
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Heartbeat.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Heartbeat.java
@@ -58,7 +58,7 @@ public final class Heartbeat {
                 CommonClientConfigs.RETRY_BACKOFF_JITTER);
 
         final LogContext logContext =
-            LogContext.newBuilder("Heartbeat")
+            LogContext.forComponent("Heartbeat")
                 .withTag("groupId", config.groupId)
                 .build();
         this.log = logContext.logger(getClass());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Heartbeat.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Heartbeat.java
@@ -57,7 +57,10 @@ public final class Heartbeat {
                 rebalanceConfig.retryBackoffMaxMs,
                 CommonClientConfigs.RETRY_BACKOFF_JITTER);
 
-        final LogContext logContext = new LogContext("[Heartbeat groupID=" + config.groupId + "] ");
+        final LogContext logContext =
+            LogContext.newBuilder("Heartbeat")
+                .withTag("groupId", config.groupId)
+                .build();
         this.log = logContext.logger(getClass());
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -355,7 +355,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
 
             this.clientId = config.getString(ProducerConfig.CLIENT_ID_CONFIG);
 
-            LogContext.Builder logContextBuilder = LogContext.newBuilder("Producer")
+            LogContext.Builder logContextBuilder = LogContext.forComponent("Producer")
                 .withTag("clientId", clientId);
             if (transactionalId != null)
                 logContextBuilder.withTag("transactionalId", transactionalId);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -355,11 +355,11 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
 
             this.clientId = config.getString(ProducerConfig.CLIENT_ID_CONFIG);
 
-            LogContext logContext;
-            if (transactionalId == null)
-                logContext = new LogContext(String.format("[Producer clientId=%s] ", clientId));
-            else
-                logContext = new LogContext(String.format("[Producer clientId=%s, transactionalId=%s] ", clientId, transactionalId));
+            LogContext.Builder logContextBuilder = LogContext.newBuilder("Producer")
+                .withTag("clientId", clientId);
+            if (transactionalId != null)
+                logContextBuilder.withTag("transactionalId", transactionalId);
+            LogContext logContext = logContextBuilder.build();
             log = logContext.logger(KafkaProducer.class);
             log.trace("Starting the Kafka producer");
 

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -105,7 +105,7 @@ public class SslTransportLayer implements TransportLayer {
         this.state = State.NOT_INITIALIZED;
         this.metadataRegistry = metadataRegistry;
 
-        final LogContext logContext = LogContext.newBuilder("SslTransportLayer")
+        final LogContext logContext = LogContext.forComponent("SslTransportLayer")
             .withTag("channelId", channelId)
             .withTag("key", key.toString())
             .build();

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -105,7 +105,10 @@ public class SslTransportLayer implements TransportLayer {
         this.state = State.NOT_INITIALIZED;
         this.metadataRegistry = metadataRegistry;
 
-        final LogContext logContext = new LogContext(String.format("[SslTransportLayer channelId=%s key=%s] ", channelId, key));
+        final LogContext logContext = LogContext.newBuilder("SslTransportLayer")
+            .withTag("channelId", channelId)
+            .withTag("key", key.toString())
+            .build();
         this.log = logContext.logger(getClass());
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/LogContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/LogContext.java
@@ -23,6 +23,11 @@ import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MessageFormatter;
 import org.slf4j.spi.LocationAwareLogger;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
 /**
  * This class provides a way to instrument loggers with a common context which can be used to
  * automatically enrich log messages. For example, in the KafkaConsumer, it is often useful to know
@@ -33,6 +38,10 @@ import org.slf4j.spi.LocationAwareLogger;
 public class LogContext {
 
     private final String logPrefix;
+
+    public static Builder newBuilder(String componentName) {
+        return new Builder(componentName);
+    }
 
     public LogContext(String logPrefix) {
         this.logPrefix = logPrefix == null ? "" : logPrefix;
@@ -53,6 +62,45 @@ public class LogContext {
 
     public String logPrefix() {
         return logPrefix;
+    }
+
+    public static class Builder {
+        private final String componentName;
+        private final List<String> tags = new ArrayList<>();
+
+        public Builder(String componentName) {
+            requireNonNullAndNonEmpty(componentName, "componentName");
+            this.componentName = componentName;
+        }
+
+        private void requireNonNullAndNonEmpty(String value, String name) {
+            Objects.requireNonNull(value, name + " cannot be null");
+            if (value.isEmpty()) {
+                throw new IllegalArgumentException(name + " cannot be empty");
+            }
+        }
+
+        public Builder withTag(String tag, Object value) {
+            return withTag(tag, value.toString());
+        }
+
+        public Builder withTag(String tag, String value) {
+            requireNonNullAndNonEmpty(tag, "tag");
+            requireNonNullAndNonEmpty(value, "tagValue");
+            this.tags.add(tag + "=" + value);
+            return this;
+        }
+
+        public LogContext build() {
+            String tagsAnnotation = Optional.of(this.tags)
+                .filter(t -> !t.isEmpty())
+                .map(t -> String.join(", ", t))
+                .orElse("");
+            tagsAnnotation = tagsAnnotation.isEmpty() ? "" : " " + tagsAnnotation;
+            // space is needed after brackets to separate context from log message
+            String logPrefix = "[" + componentName + tagsAnnotation + "] ";
+            return new LogContext(logPrefix);
+        }
     }
 
     private static abstract class AbstractKafkaLogger implements Logger {

--- a/clients/src/main/java/org/apache/kafka/common/utils/LogContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/LogContext.java
@@ -39,7 +39,7 @@ public class LogContext {
 
     private final String logPrefix;
 
-    public static Builder newBuilder(String componentName) {
+    public static Builder forComponent(String componentName) {
         return new Builder(componentName);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/FetchSessionHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/FetchSessionHandlerTest.java
@@ -60,7 +60,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @Timeout(120)
 public class FetchSessionHandlerTest {
-    private static final LogContext LOG_CONTEXT = LogContext.newBuilder("FetchSessionHandler").build();
+    private static final LogContext LOG_CONTEXT = LogContext.forComponent("FetchSessionHandler").build();
 
     /**
      * Create a set of TopicPartitions.  We use a TreeSet, in order to get a deterministic

--- a/clients/src/test/java/org/apache/kafka/clients/FetchSessionHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/FetchSessionHandlerTest.java
@@ -60,7 +60,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @Timeout(120)
 public class FetchSessionHandlerTest {
-    private static final LogContext LOG_CONTEXT = new LogContext("[FetchSessionHandler]=");
+    private static final LogContext LOG_CONTEXT = LogContext.newBuilder("FetchSessionHandler").build();
 
     /**
      * Create a set of TopicPartitions.  We use a TreeSet, in order to get a deterministic

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -2457,7 +2457,7 @@ public class KafkaProducerTest {
         }
 
         public KafkaProducer<T, T> newKafkaProducer() {
-            LogContext logContext = LogContext.newBuilder("Producer")
+            LogContext logContext = LogContext.forComponent("Producer")
                 .withTag("test", testInfo.getDisplayName())
                 .build();
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -2457,7 +2457,9 @@ public class KafkaProducerTest {
         }
 
         public KafkaProducer<T, T> newKafkaProducer() {
-            LogContext logContext = new LogContext("[Producer test=" + testInfo.getDisplayName() + "] ");
+            LogContext logContext = LogContext.newBuilder("Producer")
+                .withTag("test", testInfo.getDisplayName())
+                .build();
 
             ProducerConfig producerConfig = new ProducerConfig(
                 ProducerConfig.appendSerializerToConfig(configs, serializer, serializer));

--- a/clients/src/test/java/org/apache/kafka/common/utils/LogContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/LogContextTest.java
@@ -24,27 +24,27 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class LogContextTest {
     @Test
     void testBuilderCannotBuildWithoutComponent() {
-        assertThrows(NullPointerException.class, () -> LogContext.newBuilder(null));
-        assertThrows(IllegalArgumentException.class, () -> LogContext.newBuilder(""));
+        assertThrows(NullPointerException.class, () -> LogContext.forComponent(null));
+        assertThrows(IllegalArgumentException.class, () -> LogContext.forComponent(""));
     }
 
     @Test
     void testBuilderCannotAddEmptyTags() {
-        assertThrows(NullPointerException.class, () -> LogContext.newBuilder("test").withTag(null, "test"));
-        assertThrows(IllegalArgumentException.class, () -> LogContext.newBuilder("test").withTag("", "test"));
-        assertThrows(NullPointerException.class, () -> LogContext.newBuilder("test").withTag("test", null));
-        assertThrows(IllegalArgumentException.class, () -> LogContext.newBuilder("test").withTag("test", ""));
+        assertThrows(NullPointerException.class, () -> LogContext.forComponent("test").withTag(null, "test"));
+        assertThrows(IllegalArgumentException.class, () -> LogContext.forComponent("test").withTag("", "test"));
+        assertThrows(NullPointerException.class, () -> LogContext.forComponent("test").withTag("test", null));
+        assertThrows(IllegalArgumentException.class, () -> LogContext.forComponent("test").withTag("test", ""));
     }
 
     @Test
     void testBuilderWithoutComponent() {
-        LogContext context = LogContext.newBuilder("test").build();
+        LogContext context = LogContext.forComponent("test").build();
         assertEquals("[test] ", context.logPrefix());
     }
 
     @Test
     void testBuilderWithComponentAndTags() {
-        LogContext context = LogContext.newBuilder("test")
+        LogContext context = LogContext.forComponent("test")
             .withTag("client-id", "test-client")
             .withTag("group-id", "test-group")
             .build();

--- a/clients/src/test/java/org/apache/kafka/common/utils/LogContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/LogContextTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class LogContextTest {
+    @Test
+    void testBuilderCannotBuildWithoutComponent() {
+        assertThrows(NullPointerException.class, () -> LogContext.newBuilder(null));
+        assertThrows(IllegalArgumentException.class, () -> LogContext.newBuilder(""));
+    }
+
+    @Test
+    void testBuilderCannotAddEmptyTags() {
+        assertThrows(NullPointerException.class, () -> LogContext.newBuilder("test").withTag(null, "test"));
+        assertThrows(IllegalArgumentException.class, () -> LogContext.newBuilder("test").withTag("", "test"));
+        assertThrows(NullPointerException.class, () -> LogContext.newBuilder("test").withTag("test", null));
+        assertThrows(IllegalArgumentException.class, () -> LogContext.newBuilder("test").withTag("test", ""));
+    }
+
+    @Test
+    void testBuilderWithoutComponent() {
+        LogContext context = LogContext.newBuilder("test").build();
+        assertEquals("[test] ", context.logPrefix());
+    }
+
+    @Test
+    void testBuilderWithComponentAndTags() {
+        LogContext context = LogContext.newBuilder("test")
+            .withTag("client-id", "test-client")
+            .withTag("group-id", "test-group")
+            .build();
+        assertEquals("[test client-id=test-client, group-id=test-group] ", context.logPrefix());
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -303,7 +303,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         // Thread factory uses String.format and '%' is handled as a placeholder
         // need to escape if the client.id contains an actual % character
         String escapedClientIdForThreadNameFormat = clientId.replace("%", "%%");
-        LogContext logContext = new LogContext("[Worker clientId=" + clientId + ", groupId=" + this.workerGroupId + "] ");
+        LogContext logContext = LogContext.newBuilder("Worker")
+            .withTag("clientId", clientId)
+            .withTag("groupId", this.workerGroupId)
+            .build();
         log = logContext.logger(DistributedHerder.class);
 
         this.member = member != null

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -303,7 +303,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         // Thread factory uses String.format and '%' is handled as a placeholder
         // need to escape if the client.id contains an actual % character
         String escapedClientIdForThreadNameFormat = clientId.replace("%", "%%");
-        LogContext logContext = LogContext.newBuilder("Worker")
+        LogContext logContext = LogContext.forComponent("Worker")
             .withTag("clientId", clientId)
             .withTag("groupId", this.workerGroupId)
             .build();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMemberTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMemberTest.java
@@ -65,7 +65,7 @@ public class WorkerGroupMemberTest {
         DistributedConfig config = spy(new DistributedConfig(workerProps));
         doReturn("cluster-1").when(config).kafkaClusterId();
 
-        LogContext logContext = LogContext.newBuilder("Worker")
+        LogContext logContext = LogContext.forComponent("Worker")
             .withTag("clientId", "client-1")
             .withTag("groupId", "group-1")
             .build();
@@ -110,7 +110,7 @@ public class WorkerGroupMemberTest {
         DistributedConfig config = spy(new DistributedConfig(workerProps));
         doReturn("cluster-1").when(config).kafkaClusterId();
 
-        LogContext logContext = LogContext.newBuilder("Worker")
+        LogContext logContext = LogContext.forComponent("Worker")
             .withTag("clientId", "client-1")
             .withTag("groupId", "group-1")
             .build();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMemberTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMemberTest.java
@@ -65,7 +65,10 @@ public class WorkerGroupMemberTest {
         DistributedConfig config = spy(new DistributedConfig(workerProps));
         doReturn("cluster-1").when(config).kafkaClusterId();
 
-        LogContext logContext = new LogContext("[Worker clientId=client-1 + groupId= group-1]");
+        LogContext logContext = LogContext.newBuilder("Worker")
+            .withTag("clientId", "client-1")
+            .withTag("groupId", "group-1")
+            .build();
         member = new WorkerGroupMember(config, "", configBackingStore, null, Time.SYSTEM, "client-1", logContext);
 
         verify(config, atLeastOnce()).kafkaClusterId();
@@ -107,7 +110,10 @@ public class WorkerGroupMemberTest {
         DistributedConfig config = spy(new DistributedConfig(workerProps));
         doReturn("cluster-1").when(config).kafkaClusterId();
 
-        LogContext logContext = new LogContext("[Worker clientId=client-1 + groupId= group-1]");
+        LogContext logContext = LogContext.newBuilder("Worker")
+            .withTag("clientId", "client-1")
+            .withTag("groupId", "group-1")
+            .build();
         member = new WorkerGroupMember(config, "", configBackingStore, null, Time.SYSTEM, "client-1", logContext);
 
         verify(config, atLeastOnce()).kafkaClusterId();

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -586,7 +586,7 @@ public class RemoteLogManager implements Closeable {
         public RLMTask(TopicIdPartition topicIdPartition, int customMetadataSizeLimit) {
             this.topicIdPartition = topicIdPartition;
             this.customMetadataSizeLimit = customMetadataSizeLimit;
-            LogContext logContext = LogContext.newBuilder("RemoteLogManager")
+            LogContext logContext = LogContext.forComponent("RemoteLogManager")
                 .withTag("brokerId", String.valueOf(brokerId))
                 .withTag("topicIdPartition", topicIdPartition.toString())
                 .build();

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -586,7 +586,10 @@ public class RemoteLogManager implements Closeable {
         public RLMTask(TopicIdPartition topicIdPartition, int customMetadataSizeLimit) {
             this.topicIdPartition = topicIdPartition;
             this.customMetadataSizeLimit = customMetadataSizeLimit;
-            LogContext logContext = new LogContext("[RemoteLogManager=" + brokerId + " partition=" + topicIdPartition + "] ");
+            LogContext logContext = LogContext.newBuilder("RemoteLogManager")
+                .withTag("brokerId", String.valueOf(brokerId))
+                .withTag("topicIdPartition", topicIdPartition.toString())
+                .build();
             logger = logContext.logger(RLMTask.class);
         }
 

--- a/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
@@ -268,7 +268,9 @@ object BrokerApiVersionsCommand {
 
     def create(config: AdminConfig): AdminClient = {
       val clientId = "admin-" + AdminClientIdSequence.getAndIncrement()
-      val logContext = new LogContext(s"[LegacyAdminClient clientId=$clientId] ")
+      val logContext = LogContext.newBuilder("LegacyAdminClient")
+        .withTag("clientId", clientId)
+        .build()
       val time = Time.SYSTEM
       val metrics = new Metrics(time)
       val metadata = new Metadata(CommonClientConfigs.DEFAULT_RETRY_BACKOFF_MS,

--- a/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
@@ -268,7 +268,7 @@ object BrokerApiVersionsCommand {
 
     def create(config: AdminConfig): AdminClient = {
       val clientId = "admin-" + AdminClientIdSequence.getAndIncrement()
-      val logContext = LogContext.newBuilder("LegacyAdminClient")
+      val logContext = LogContext.forComponent("LegacyAdminClient")
         .withTag("clientId", clientId)
         .build()
       val time = Time.SYSTEM

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -41,7 +41,7 @@ import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
 import org.apache.kafka.common.record.{MemoryRecords, RecordBatch}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.{UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET}
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.storage.internals.log.{AppendOrigin, FetchDataInfo, FetchIsolation, FetchParams, LeaderHwChange, LogAppendInfo, LogOffsetMetadata, LogOffsetSnapshot, LogOffsetsListener, LogReadInfo, LogStartOffsetIncrementReason, VerificationGuard}
@@ -339,7 +339,11 @@ class Partition(val topicPartition: TopicPartition,
    * In addition to the leader, the controller can also send the epoch of the controller that elected the leader for
    * each partition. */
   private var controllerEpoch: Int = KafkaController.InitialControllerEpoch
-  this.logContext = s"[Partition $topicPartition broker=$localBrokerId] "
+  this.logIdent = LogContext.newBuilder("Partition")
+    .withTag("partition", topicPartition)
+    .withTag("broker", localBrokerId)
+    .build()
+    .logPrefix()
 
   private val tags = Map("topic" -> topic, "partition" -> partitionId.toString).asJava
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -339,7 +339,7 @@ class Partition(val topicPartition: TopicPartition,
    * In addition to the leader, the controller can also send the epoch of the controller that elected the leader for
    * each partition. */
   private var controllerEpoch: Int = KafkaController.InitialControllerEpoch
-  this.logIdent = s"[Partition $topicPartition broker=$localBrokerId] "
+  this.logContext = s"[Partition $topicPartition broker=$localBrokerId] "
 
   private val tags = Map("topic" -> topic, "partition" -> partitionId.toString).asJava
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -339,7 +339,7 @@ class Partition(val topicPartition: TopicPartition,
    * In addition to the leader, the controller can also send the epoch of the controller that elected the leader for
    * each partition. */
   private var controllerEpoch: Int = KafkaController.InitialControllerEpoch
-  this.logIdent = LogContext.newBuilder("Partition")
+  this.logIdent = LogContext.forComponent("Partition")
     .withTag("partition", topicPartition)
     .withTag("broker", localBrokerId)
     .build()

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -61,7 +61,7 @@ class ControllerChannelManager(controllerEpoch: () => Int,
 
   protected val brokerStateInfo = new mutable.HashMap[Int, ControllerBrokerStateInfo]
   private val brokerLock = new Object
-  this.logContext = LogContext.newBuilder("ChannelManagerOnController").withTag("id", config.brokerId).build()
+  this.logIdent = LogContext.newBuilder("ChannelManagerOnController").withTag("id", config.brokerId).build().logPrefix()
 
   metricsGroup.newGauge("TotalQueueSize",
     () => brokerLock synchronized {
@@ -232,10 +232,11 @@ class RequestSendThread(val controllerId: Int,
                         name: String)
   extends ShutdownableThread(name, true, LogContext.newBuilder("RequestSendThread")
     .withTag("controllerId", controllerId)
-    .build())
+    .build()
+    .logPrefix())
     with Logging {
 
-  logContext = logContext
+  logIdent = logPrefix
 
   private val socketTimeoutMs = config.controllerSocketTimeoutMs
 

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -61,7 +61,7 @@ class ControllerChannelManager(controllerEpoch: () => Int,
 
   protected val brokerStateInfo = new mutable.HashMap[Int, ControllerBrokerStateInfo]
   private val brokerLock = new Object
-  this.logIdent = "[Channel manager on controller " + config.brokerId + "]: "
+  this.logContext = LogContext.newBuilder("ChannelManagerOnController").withTag("id", config.brokerId).build()
 
   metricsGroup.newGauge("TotalQueueSize",
     () => brokerLock synchronized {
@@ -120,7 +120,10 @@ class ControllerChannelManager(controllerEpoch: () => Int,
     val controllerToBrokerListenerName = config.controlPlaneListenerName.getOrElse(config.interBrokerListenerName)
     val controllerToBrokerSecurityProtocol = config.controlPlaneSecurityProtocol.getOrElse(config.interBrokerSecurityProtocol)
     val brokerNode = broker.node(controllerToBrokerListenerName)
-    val logContext = new LogContext(s"[Controller id=${config.brokerId}, targetBrokerId=${brokerNode.idString}] ")
+    val logContext = LogContext.newBuilder("Controller")
+      .withTag("id", config.brokerId.toString)
+      .withTag("targetBrokerId", brokerNode.idString())
+      .build()
     val (networkClient, reconfigurableChannelBuilder) = {
       val channelBuilder = ChannelBuilders.clientChannelBuilder(
         controllerToBrokerSecurityProtocol,
@@ -227,10 +230,12 @@ class RequestSendThread(val controllerId: Int,
                         val requestRateAndQueueTimeMetrics: Timer,
                         val stateChangeLogger: StateChangeLogger,
                         name: String)
-  extends ShutdownableThread(name, true, s"[RequestSendThread controllerId=$controllerId] ")
+  extends ShutdownableThread(name, true, LogContext.newBuilder("RequestSendThread")
+    .withTag("controllerId", controllerId)
+    .build())
     with Logging {
 
-  logIdent = logPrefix
+  logContext = logContext
 
   private val socketTimeoutMs = config.controllerSocketTimeoutMs
 

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -61,7 +61,7 @@ class ControllerChannelManager(controllerEpoch: () => Int,
 
   protected val brokerStateInfo = new mutable.HashMap[Int, ControllerBrokerStateInfo]
   private val brokerLock = new Object
-  this.logIdent = LogContext.newBuilder("ChannelManagerOnController").withTag("id", config.brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("ChannelManagerOnController").withTag("id", config.brokerId).build().logPrefix()
 
   metricsGroup.newGauge("TotalQueueSize",
     () => brokerLock synchronized {
@@ -120,7 +120,7 @@ class ControllerChannelManager(controllerEpoch: () => Int,
     val controllerToBrokerListenerName = config.controlPlaneListenerName.getOrElse(config.interBrokerListenerName)
     val controllerToBrokerSecurityProtocol = config.controlPlaneSecurityProtocol.getOrElse(config.interBrokerSecurityProtocol)
     val brokerNode = broker.node(controllerToBrokerListenerName)
-    val logContext = LogContext.newBuilder("Controller")
+    val logContext = LogContext.forComponent("Controller")
       .withTag("id", config.brokerId.toString)
       .withTag("targetBrokerId", brokerNode.idString())
       .build()
@@ -230,7 +230,7 @@ class RequestSendThread(val controllerId: Int,
                         val requestRateAndQueueTimeMetrics: Timer,
                         val stateChangeLogger: StateChangeLogger,
                         name: String)
-  extends ShutdownableThread(name, true, LogContext.newBuilder("RequestSendThread")
+  extends ShutdownableThread(name, true, LogContext.forComponent("RequestSendThread")
     .withTag("controllerId", controllerId)
     .build()
     .logPrefix())

--- a/core/src/main/scala/kafka/controller/ControllerEventManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerEventManager.scala
@@ -123,7 +123,7 @@ class ControllerEventManager(controllerId: Int,
       name, false, s"[ControllerEventThread controllerId=$controllerId] ")
       with Logging {
 
-    logIdent = logPrefix
+    logContext = logPrefix
 
     override def doWork(): Unit = {
       val dequeued = pollFromEventQueue()

--- a/core/src/main/scala/kafka/controller/ControllerEventManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerEventManager.scala
@@ -119,7 +119,7 @@ class ControllerEventManager(controllerId: Int,
   def isEmpty: Boolean = queue.isEmpty
 
   class ControllerEventThread(name: String)
-    extends ShutdownableThread(name, false, LogContext.newBuilder("ControllerEventThread").withTag("controllerId", controllerId).build().logPrefix())
+    extends ShutdownableThread(name, false, LogContext.forComponent("ControllerEventThread").withTag("controllerId", controllerId).build().logPrefix())
       with Logging {
 
     logIdent = logPrefix

--- a/core/src/main/scala/kafka/controller/ControllerEventManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerEventManager.scala
@@ -25,7 +25,7 @@ import java.util.concurrent.{CountDownLatch, LinkedBlockingQueue, TimeUnit}
 import java.util.concurrent.locks.ReentrantLock
 import kafka.utils.CoreUtils.inLock
 import kafka.utils.Logging
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.ShutdownableThread
 
@@ -119,11 +119,10 @@ class ControllerEventManager(controllerId: Int,
   def isEmpty: Boolean = queue.isEmpty
 
   class ControllerEventThread(name: String)
-    extends ShutdownableThread(
-      name, false, s"[ControllerEventThread controllerId=$controllerId] ")
+    extends ShutdownableThread(name, false, LogContext.newBuilder("ControllerEventThread").withTag("controllerId", controllerId).build().logPrefix())
       with Logging {
 
-    logContext = logPrefix
+    logIdent = logPrefix
 
     override def doWork(): Unit = {
       val dequeued = pollFromEventQueue()

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -116,7 +116,7 @@ class KafkaController(val config: KafkaConfig,
 
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
 
-  this.logIdent = LogContext.newBuilder("Controller").withTag("id", config.brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("Controller").withTag("id", config.brokerId).build().logPrefix()
 
   @volatile private var brokerInfo = initialBrokerInfo
   @volatile private var _brokerEpoch = initialBrokerEpoch

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -116,7 +116,7 @@ class KafkaController(val config: KafkaConfig,
 
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
 
-  this.logIdent = s"[Controller id=${config.brokerId}] "
+  this.logContext = s"[Controller id=${config.brokerId}] "
 
   @volatile private var brokerInfo = initialBrokerInfo
   @volatile private var _brokerEpoch = initialBrokerEpoch

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -42,7 +42,7 @@ import org.apache.kafka.common.message.{AllocateProducerIdsRequestData, Allocate
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractControlRequest, ApiError, LeaderAndIsrResponse, UpdateFeaturesRequest, UpdateMetadataResponse}
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{LogContext, Time, Utils}
 import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.metadata.migration.ZkMigrationState
 import org.apache.kafka.server.common.{AdminOperationException, ProducerIdsBlock}
@@ -116,7 +116,7 @@ class KafkaController(val config: KafkaConfig,
 
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
 
-  this.logContext = s"[Controller id=${config.brokerId}] "
+  this.logIdent = LogContext.newBuilder("Controller").withTag("id", config.brokerId).build().logPrefix()
 
   @volatile private var brokerInfo = initialBrokerInfo
   @volatile private var _brokerEpoch = initialBrokerEpoch

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -27,6 +27,7 @@ import kafka.zk.KafkaZkClient.UpdateLeaderAndIsrResult
 import kafka.zk.TopicPartitionStateZNode
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.ControllerMovedException
+import org.apache.kafka.common.utils.LogContext
 import org.apache.kafka.server.common.MetadataVersion.IBP_3_2_IV0
 import org.apache.zookeeper.KeeperException
 import org.apache.zookeeper.KeeperException.Code
@@ -136,7 +137,7 @@ class ZkPartitionStateMachine(config: KafkaConfig,
   private val isLeaderRecoverySupported = config.interBrokerProtocolVersion.isAtLeast(IBP_3_2_IV0)
 
   private val controllerId = config.brokerId
-  this.logContext = s"[PartitionStateMachine controllerId=$controllerId] "
+  this.logIdent = LogContext.newBuilder("PartitionStateMachine").withTag("controllerId", controllerId).build().logPrefix()
 
   /**
    * Try to change the state of the given partitions to the given targetState, using the given

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -137,7 +137,7 @@ class ZkPartitionStateMachine(config: KafkaConfig,
   private val isLeaderRecoverySupported = config.interBrokerProtocolVersion.isAtLeast(IBP_3_2_IV0)
 
   private val controllerId = config.brokerId
-  this.logIdent = LogContext.newBuilder("PartitionStateMachine").withTag("controllerId", controllerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("PartitionStateMachine").withTag("controllerId", controllerId).build().logPrefix()
 
   /**
    * Try to change the state of the given partitions to the given targetState, using the given

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -136,7 +136,7 @@ class ZkPartitionStateMachine(config: KafkaConfig,
   private val isLeaderRecoverySupported = config.interBrokerProtocolVersion.isAtLeast(IBP_3_2_IV0)
 
   private val controllerId = config.brokerId
-  this.logIdent = s"[PartitionStateMachine controllerId=$controllerId] "
+  this.logContext = s"[PartitionStateMachine controllerId=$controllerId] "
 
   /**
    * Try to change the state of the given partitions to the given targetState, using the given

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -102,7 +102,7 @@ class ZkReplicaStateMachine(config: KafkaConfig,
   extends ReplicaStateMachine(controllerContext) with Logging {
 
   private val controllerId = config.brokerId
-  this.logIdent = s"[ReplicaStateMachine controllerId=$controllerId] "
+  this.logContext = s"[ReplicaStateMachine controllerId=$controllerId] "
 
   override def handleStateChanges(replicas: Seq[PartitionAndReplica], targetState: ReplicaState): Unit = {
     if (replicas.nonEmpty) {

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -26,7 +26,9 @@ import kafka.zk.KafkaZkClient.UpdateLeaderAndIsrResult
 import kafka.zk.TopicPartitionStateZNode
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.ControllerMovedException
+import org.apache.kafka.common.utils.LogContext
 import org.apache.zookeeper.KeeperException.Code
+
 import scala.collection.{Seq, mutable}
 
 abstract class ReplicaStateMachine(controllerContext: ControllerContext) extends Logging {
@@ -102,7 +104,7 @@ class ZkReplicaStateMachine(config: KafkaConfig,
   extends ReplicaStateMachine(controllerContext) with Logging {
 
   private val controllerId = config.brokerId
-  this.logContext = s"[ReplicaStateMachine controllerId=$controllerId] "
+  this.logIdent = LogContext.newBuilder("ReplicaStateMachine").withTag("controllerId", controllerId).build().logPrefix()
 
   override def handleStateChanges(replicas: Seq[PartitionAndReplica], targetState: ReplicaState): Unit = {
     if (replicas.nonEmpty) {

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -104,7 +104,7 @@ class ZkReplicaStateMachine(config: KafkaConfig,
   extends ReplicaStateMachine(controllerContext) with Logging {
 
   private val controllerId = config.brokerId
-  this.logIdent = LogContext.newBuilder("ReplicaStateMachine").withTag("controllerId", controllerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("ReplicaStateMachine").withTag("controllerId", controllerId).build().logPrefix()
 
   override def handleStateChanges(replicas: Seq[PartitionAndReplica], targetState: ReplicaState): Unit = {
     if (replicas.nonEmpty) {

--- a/core/src/main/scala/kafka/controller/StateChangeLogger.scala
+++ b/core/src/main/scala/kafka/controller/StateChangeLogger.scala
@@ -40,7 +40,7 @@ class StateChangeLogger(brokerId: Int, inControllerContext: Boolean, controllerE
   locally {
     val prefix = if (inControllerContext) "Controller" else "Broker"
     val epochEntry = controllerEpoch.fold("")(epoch => s" epoch=$epoch")
-    logIdent = LogContext.newBuilder(prefix).withTag("id", brokerId).withTag("epoch", epochEntry).build().logPrefix()
+    logIdent = LogContext.forComponent(prefix).withTag("id", brokerId).withTag("epoch", epochEntry).build().logPrefix()
   }
 
   def withControllerEpoch(controllerEpoch: Int): StateChangeLogger =

--- a/core/src/main/scala/kafka/controller/StateChangeLogger.scala
+++ b/core/src/main/scala/kafka/controller/StateChangeLogger.scala
@@ -39,7 +39,7 @@ class StateChangeLogger(brokerId: Int, inControllerContext: Boolean, controllerE
   locally {
     val prefix = if (inControllerContext) "Controller" else "Broker"
     val epochEntry = controllerEpoch.fold("")(epoch => s" epoch=$epoch")
-    logIdent = s"[$prefix id=$brokerId$epochEntry] "
+    logContext = s"[$prefix id=$brokerId$epochEntry] "
   }
 
   def withControllerEpoch(controllerEpoch: Int): StateChangeLogger =

--- a/core/src/main/scala/kafka/controller/StateChangeLogger.scala
+++ b/core/src/main/scala/kafka/controller/StateChangeLogger.scala
@@ -19,6 +19,7 @@ package kafka.controller
 
 import com.typesafe.scalalogging.Logger
 import kafka.utils.Logging
+import org.apache.kafka.common.utils.LogContext
 
 object StateChangeLogger {
   private val logger = Logger("state.change.logger")
@@ -39,7 +40,7 @@ class StateChangeLogger(brokerId: Int, inControllerContext: Boolean, controllerE
   locally {
     val prefix = if (inControllerContext) "Controller" else "Broker"
     val epochEntry = controllerEpoch.fold("")(epoch => s" epoch=$epoch")
-    logContext = s"[$prefix id=$brokerId$epochEntry] "
+    logIdent = LogContext.newBuilder(prefix).withTag("id", brokerId).withTag("epoch", epochEntry).build().logPrefix()
   }
 
   def withControllerEpoch(controllerEpoch: Int): StateChangeLogger =

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -89,7 +89,7 @@ class TopicDeletionManager(config: KafkaConfig,
                            replicaStateMachine: ReplicaStateMachine,
                            partitionStateMachine: PartitionStateMachine,
                            client: DeletionClient) extends Logging {
-  this.logIdent = s"[Topic Deletion Manager ${config.brokerId}] "
+  this.logContext = s"[Topic Deletion Manager ${config.brokerId}] "
   val isDeleteTopicEnabled: Boolean = config.deleteTopicEnable
 
   def init(initialTopicsToBeDeleted: Set[String], initialTopicsIneligibleForDeletion: Set[String]): Unit = {

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -20,6 +20,7 @@ import kafka.server.KafkaConfig
 import kafka.utils.Logging
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.utils.LogContext
 
 import scala.collection.Set
 import scala.collection.mutable
@@ -89,7 +90,7 @@ class TopicDeletionManager(config: KafkaConfig,
                            replicaStateMachine: ReplicaStateMachine,
                            partitionStateMachine: PartitionStateMachine,
                            client: DeletionClient) extends Logging {
-  this.logContext = s"[Topic Deletion Manager ${config.brokerId}] "
+  this.logIdent = LogContext.newBuilder("TopicDeletionManager").withTag("id", config.brokerId).build().logPrefix()
   val isDeleteTopicEnabled: Boolean = config.deleteTopicEnable
 
   def init(initialTopicsToBeDeleted: Set[String], initialTopicsIneligibleForDeletion: Set[String]): Unit = {

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -90,7 +90,7 @@ class TopicDeletionManager(config: KafkaConfig,
                            replicaStateMachine: ReplicaStateMachine,
                            partitionStateMachine: PartitionStateMachine,
                            client: DeletionClient) extends Logging {
-  this.logIdent = LogContext.newBuilder("TopicDeletionManager").withTag("id", config.brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("TopicDeletionManager").withTag("id", config.brokerId).build().logPrefix()
   val isDeleteTopicEnabled: Boolean = config.deleteTopicEnable
 
   def init(initialTopicsToBeDeleted: Set[String], initialTopicsIneligibleForDeletion: Set[String]): Unit = {

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.common.metrics.stats.Meter
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.requests._
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.server.record.BrokerCompressionType
 import org.apache.kafka.storage.internals.log.VerificationGuard
 
@@ -86,7 +86,7 @@ private[group] class GroupCoordinator(
       "group-coordinator-metrics",
       "The total number of completed rebalance")))
 
-  this.logContext = "[GroupCoordinator " + brokerId + "]: "
+  this.logIdent = LogContext.newBuilder("GroupCoordinator").withTag("id", brokerId).build().logPrefix()
 
   private val isActive = new AtomicBoolean(false)
 

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -86,7 +86,7 @@ private[group] class GroupCoordinator(
       "group-coordinator-metrics",
       "The total number of completed rebalance")))
 
-  this.logIdent = LogContext.newBuilder("GroupCoordinator").withTag("id", brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("GroupCoordinator").withTag("id", brokerId).build().logPrefix()
 
   private val isActive = new AtomicBoolean(false)
 

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -86,7 +86,7 @@ private[group] class GroupCoordinator(
       "group-coordinator-metrics",
       "The total number of completed rebalance")))
 
-  this.logIdent = "[GroupCoordinator " + brokerId + "]: "
+  this.logContext = "[GroupCoordinator " + brokerId + "]: "
 
   private val isActive = new AtomicBoolean(false)
 

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -123,7 +123,7 @@ class GroupMetadataManager(brokerId: Int,
       "group-coordinator-metrics",
       "The total number of expired offsets")))
 
-  this.logIdent = LogContext.newBuilder("GroupMetadataManager").withTag("brokerId", brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("GroupMetadataManager").withTag("brokerId", brokerId).build().logPrefix()
 
   private def recreateGauge[T](name: String, gauge: Gauge[T]): Gauge[T] = {
     metricsGroup.removeMetric(name)

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -123,7 +123,7 @@ class GroupMetadataManager(brokerId: Int,
       "group-coordinator-metrics",
       "The total number of expired offsets")))
 
-  this.logIdent = s"[GroupMetadataManager brokerId=$brokerId] "
+  this.logContext = s"[GroupMetadataManager brokerId=$brokerId] "
 
   private def recreateGauge[T](name: String, gauge: Gauge[T]): Gauge[T] = {
     metricsGroup.removeMetric(name)

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -41,7 +41,7 @@ import org.apache.kafka.common.record._
 import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.{OffsetCommitRequest, OffsetFetchResponse}
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{LogContext, Time, Utils}
 import org.apache.kafka.common.{KafkaException, MessageFormatter, TopicIdPartition, TopicPartition}
 import org.apache.kafka.coordinator.group.generated.{GroupMetadataValue, OffsetCommitKey, OffsetCommitValue, GroupMetadataKey => GroupMetadataKeyData}
 import org.apache.kafka.server.common.MetadataVersion
@@ -123,7 +123,7 @@ class GroupMetadataManager(brokerId: Int,
       "group-coordinator-metrics",
       "The total number of expired offsets")))
 
-  this.logContext = s"[GroupMetadataManager brokerId=$brokerId] "
+  this.logIdent = LogContext.newBuilder("GroupMetadataManager").withTag("brokerId", brokerId).build().logPrefix()
 
   private def recreateGauge[T](name: String, gauge: Gauge[T]): Gauge[T] = {
     metricsGroup.removeMetric(name)

--- a/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.message.AllocateProducerIdsRequestData
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AllocateProducerIdsRequest, AllocateProducerIdsResponse}
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.server.{ControllerRequestCompletionHandler, NodeToControllerChannelManager}
 import org.apache.kafka.server.common.ProducerIdsBlock
 
@@ -114,7 +114,7 @@ object ZkProducerIdManager {
 
 class ZkProducerIdManager(brokerId: Int, zkClient: KafkaZkClient) extends ProducerIdManager with Logging {
 
-  this.logContext = "[ZK ProducerId Manager " + brokerId + "]: "
+  this.logIdent = LogContext.newBuilder("ZKProducerIdManager").withTag("brokerId", brokerId).build().logPrefix()
 
   private var currentProducerIdBlock: ProducerIdsBlock = ProducerIdsBlock.EMPTY
   private var nextProducerId: Long = _
@@ -164,7 +164,7 @@ class RPCProducerIdManager(brokerId: Int,
                            brokerEpochSupplier: () => Long,
                            controllerChannel: NodeToControllerChannelManager) extends ProducerIdManager with Logging {
 
-  this.logContext = "[RPC ProducerId Manager " + brokerId + "]: "
+  this.logIdent = LogContext.newBuilder("RPCProducerIdManager").withTag("brokerId", brokerId).build().logPrefix()
 
   // Visible for testing
   private[transaction] var nextProducerIdBlock = new AtomicReference[ProducerIdsBlock](null)

--- a/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
@@ -114,7 +114,7 @@ object ZkProducerIdManager {
 
 class ZkProducerIdManager(brokerId: Int, zkClient: KafkaZkClient) extends ProducerIdManager with Logging {
 
-  this.logIdent = LogContext.newBuilder("ZKProducerIdManager").withTag("brokerId", brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("ZKProducerIdManager").withTag("brokerId", brokerId).build().logPrefix()
 
   private var currentProducerIdBlock: ProducerIdsBlock = ProducerIdsBlock.EMPTY
   private var nextProducerId: Long = _
@@ -164,7 +164,7 @@ class RPCProducerIdManager(brokerId: Int,
                            brokerEpochSupplier: () => Long,
                            controllerChannel: NodeToControllerChannelManager) extends ProducerIdManager with Logging {
 
-  this.logIdent = LogContext.newBuilder("RPCProducerIdManager").withTag("brokerId", brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("RPCProducerIdManager").withTag("brokerId", brokerId).build().logPrefix()
 
   // Visible for testing
   private[transaction] var nextProducerIdBlock = new AtomicReference[ProducerIdsBlock](null)

--- a/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
@@ -114,7 +114,7 @@ object ZkProducerIdManager {
 
 class ZkProducerIdManager(brokerId: Int, zkClient: KafkaZkClient) extends ProducerIdManager with Logging {
 
-  this.logIdent = "[ZK ProducerId Manager " + brokerId + "]: "
+  this.logContext = "[ZK ProducerId Manager " + brokerId + "]: "
 
   private var currentProducerIdBlock: ProducerIdsBlock = ProducerIdsBlock.EMPTY
   private var nextProducerId: Long = _
@@ -164,7 +164,7 @@ class RPCProducerIdManager(brokerId: Int,
                            brokerEpochSupplier: () => Long,
                            controllerChannel: NodeToControllerChannelManager) extends ProducerIdManager with Logging {
 
-  this.logIdent = "[RPC ProducerId Manager " + brokerId + "]: "
+  this.logContext = "[RPC ProducerId Manager " + brokerId + "]: "
 
   // Visible for testing
   private[transaction] var nextProducerIdBlock = new AtomicReference[ProducerIdsBlock](null)

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -58,7 +58,7 @@ object TransactionCoordinator {
     val txnStateManager = new TransactionStateManager(config.brokerId, scheduler, replicaManager, txnConfig,
       time, metrics)
 
-    val logContext = LogContext.newBuilder("TransactionCoordinator")
+    val logContext = LogContext.forComponent("TransactionCoordinator")
       .withTag("id", config.brokerId.toString)
       .build()
     val txnMarkerChannelManager = TransactionMarkerChannelManager(config, metrics, metadataCache, txnStateManager,

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -58,7 +58,9 @@ object TransactionCoordinator {
     val txnStateManager = new TransactionStateManager(config.brokerId, scheduler, replicaManager, txnConfig,
       time, metrics)
 
-    val logContext = new LogContext(s"[TransactionCoordinator id=${config.brokerId}] ")
+    val logContext = LogContext.newBuilder("TransactionCoordinator")
+      .withTag("id", config.brokerId.toString)
+      .build()
     val txnMarkerChannelManager = TransactionMarkerChannelManager(config, metrics, metadataCache, txnStateManager,
       time, logContext)
 
@@ -90,7 +92,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                              txnMarkerChannelManager: TransactionMarkerChannelManager,
                              time: Time,
                              logContext: LogContext) extends Logging {
-  this.logIdent = logContext.logPrefix
+  this.logContext = logContext.logPrefix
 
   import TransactionCoordinator._
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -92,7 +92,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                              txnMarkerChannelManager: TransactionMarkerChannelManager,
                              time: Time,
                              logContext: LogContext) extends Logging {
-  this.logContext = logContext.logPrefix
+  this.logIdent = logContext.logPrefix
 
   import TransactionCoordinator._
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -147,7 +147,7 @@ class TransactionMarkerChannelManager(
 
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
 
-  this.logContext = "[Transaction Marker Channel Manager " + config.brokerId + "]: "
+  this.logIdent = LogContext.newBuilder("TransactionMarkerChannelManager").withTag("brokerId", config.brokerId).build().logPrefix()
 
   private val interBrokerListenerName: ListenerName = config.interBrokerListenerName
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -147,7 +147,7 @@ class TransactionMarkerChannelManager(
 
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
 
-  this.logIdent = "[Transaction Marker Channel Manager " + config.brokerId + "]: "
+  this.logContext = "[Transaction Marker Channel Manager " + config.brokerId + "]: "
 
   private val interBrokerListenerName: ListenerName = config.interBrokerListenerName
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -147,7 +147,7 @@ class TransactionMarkerChannelManager(
 
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
 
-  this.logIdent = LogContext.newBuilder("TransactionMarkerChannelManager").withTag("brokerId", config.brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("TransactionMarkerChannelManager").withTag("brokerId", config.brokerId).build().logPrefix()
 
   private val interBrokerListenerName: ListenerName = config.interBrokerListenerName
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerRequestCompletionHandler.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerRequestCompletionHandler.scala
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.{ClientResponse, RequestCompletionHandler}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.WriteTxnMarkersResponse
+import org.apache.kafka.common.utils.LogContext
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
@@ -31,7 +32,7 @@ class TransactionMarkerRequestCompletionHandler(brokerId: Int,
                                                 txnMarkerChannelManager: TransactionMarkerChannelManager,
                                                 txnIdAndMarkerEntries: java.util.List[TxnIdAndMarkerEntry]) extends RequestCompletionHandler with Logging {
 
-  this.logContext = "[Transaction Marker Request Completion Handler " + brokerId + "]: "
+  this.logIdent = LogContext.newBuilder("TransactionMarkerRequestCompletionHandler").withTag("brokerId", brokerId).build().logPrefix()
 
   override def onComplete(response: ClientResponse): Unit = {
     val requestHeader = response.requestHeader

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerRequestCompletionHandler.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerRequestCompletionHandler.scala
@@ -31,7 +31,7 @@ class TransactionMarkerRequestCompletionHandler(brokerId: Int,
                                                 txnMarkerChannelManager: TransactionMarkerChannelManager,
                                                 txnIdAndMarkerEntries: java.util.List[TxnIdAndMarkerEntry]) extends RequestCompletionHandler with Logging {
 
-  this.logIdent = "[Transaction Marker Request Completion Handler " + brokerId + "]: "
+  this.logContext = "[Transaction Marker Request Completion Handler " + brokerId + "]: "
 
   override def onComplete(response: ClientResponse): Unit = {
     val requestHeader = response.requestHeader

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerRequestCompletionHandler.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerRequestCompletionHandler.scala
@@ -32,7 +32,7 @@ class TransactionMarkerRequestCompletionHandler(brokerId: Int,
                                                 txnMarkerChannelManager: TransactionMarkerChannelManager,
                                                 txnIdAndMarkerEntries: java.util.List[TxnIdAndMarkerEntry]) extends RequestCompletionHandler with Logging {
 
-  this.logIdent = LogContext.newBuilder("TransactionMarkerRequestCompletionHandler").withTag("brokerId", brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("TransactionMarkerRequestCompletionHandler").withTag("brokerId", brokerId).build().logPrefix()
 
   override def onComplete(response: ClientResponse): Unit = {
     val requestHeader = response.requestHeader

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -79,7 +79,7 @@ class TransactionStateManager(brokerId: Int,
                               time: Time,
                               metrics: Metrics) extends Logging {
 
-  this.logIdent = LogContext.newBuilder("TransactionStateManager").withTag("brokerId", brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("TransactionStateManager").withTag("brokerId", brokerId).build().logPrefix()
 
   type SendTxnMarkersCallback = (Int, TransactionResult, TransactionMetadata, TxnTransitMetadata) => Unit
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -79,7 +79,7 @@ class TransactionStateManager(brokerId: Int,
                               time: Time,
                               metrics: Metrics) extends Logging {
 
-  this.logIdent = "[Transaction State Manager " + brokerId + "]: "
+  this.logContext = "[Transaction State Manager " + brokerId + "]: "
 
   type SendTxnMarkersCallback = (Int, TransactionResult, TransactionMetadata, TxnTransitMetadata) => Unit
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -34,7 +34,7 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.{FileRecords, MemoryRecords, MemoryRecordsBuilder, Record, SimpleRecord, TimestampType}
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.TransactionResult
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{LogContext, Time, Utils}
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.server.record.BrokerCompressionType
 import org.apache.kafka.server.util.Scheduler
@@ -79,7 +79,7 @@ class TransactionStateManager(brokerId: Int,
                               time: Time,
                               metrics: Metrics) extends Logging {
 
-  this.logContext = "[Transaction State Manager " + brokerId + "]: "
+  this.logIdent = LogContext.newBuilder("TransactionStateManager").withTag("brokerId", brokerId).build().logPrefix()
 
   type SendTxnMarkersCallback = (Int, TransactionResult, TransactionMetadata, TxnTransitMetadata) => Unit
 

--- a/core/src/main/scala/kafka/log/LocalLog.scala
+++ b/core/src/main/scala/kafka/log/LocalLog.scala
@@ -74,7 +74,7 @@ class LocalLog(@volatile private var _dir: File,
 
   import kafka.log.LocalLog._
 
-  this.logIdent = LogContext.newBuilder("LocalLog").withTag("partition", topicPartition).withTag("dir", dir.getParent).build().logPrefix()
+  this.logIdent = LogContext.forComponent("LocalLog").withTag("partition", topicPartition).withTag("dir", dir.getParent).build().logPrefix()
 
   // The memory mapped buffer for index files of this log will be closed with either delete() or closeHandlers()
   // After memory mapped buffer is closed, no disk IO operation should be performed for this log.

--- a/core/src/main/scala/kafka/log/LocalLog.scala
+++ b/core/src/main/scala/kafka/log/LocalLog.scala
@@ -74,7 +74,7 @@ class LocalLog(@volatile private var _dir: File,
 
   import kafka.log.LocalLog._
 
-  this.logIdent = s"[LocalLog partition=$topicPartition, dir=${dir.getParent}] "
+  this.logContext = s"[LocalLog partition=$topicPartition, dir=${dir.getParent}] "
 
   // The memory mapped buffer for index files of this log will be closed with either delete() or closeHandlers()
   // After memory mapped buffer is closed, no disk IO operation should be performed for this log.
@@ -286,7 +286,7 @@ class LocalLog(@volatile private var _dir: File,
       toDelete.foreach { segment =>
         segments.remove(segment.baseOffset)
       }
-      LocalLog.deleteSegmentFiles(toDelete, asyncDelete, dir, topicPartition, config, scheduler, logDirFailureChannel, logIdent)
+      LocalLog.deleteSegmentFiles(toDelete, asyncDelete, dir, topicPartition, config, scheduler, logDirFailureChannel, logContext)
     }
   }
 
@@ -323,7 +323,7 @@ class LocalLog(@volatile private var _dir: File,
     reason.logReason(List(segmentToDelete))
     if (newOffset != segmentToDelete.baseOffset)
       segments.remove(segmentToDelete.baseOffset)
-    LocalLog.deleteSegmentFiles(List(segmentToDelete), asyncDelete, dir, topicPartition, config, scheduler, logDirFailureChannel, logIdent)
+    LocalLog.deleteSegmentFiles(List(segmentToDelete), asyncDelete, dir, topicPartition, config, scheduler, logDirFailureChannel, logContext)
 
     newSegment
   }

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -344,7 +344,7 @@ class LogCleaner(initialConfig: CleanerConfig,
     extends ShutdownableThread(s"kafka-log-cleaner-thread-$threadId", false) with Logging {
     protected override def loggerName: String = classOf[LogCleaner].getName
 
-    this.logIdent = logPrefix
+    this.logContext = logPrefix
 
     if (config.dedupeBufferSize / config.numThreads > Int.MaxValue)
       warn("Cannot use more than 2G of cleaner buffer space per cleaner thread, ignoring excess buffer space...")
@@ -556,7 +556,7 @@ private[log] class Cleaner(val id: Int,
 
   protected override def loggerName: String = classOf[LogCleaner].getName
 
-  this.logIdent = s"Cleaner $id: "
+  this.logContext = s"Cleaner $id: "
 
   /* buffer used for read i/o */
   private var readBuffer = ByteBuffer.allocate(ioBufferSize)

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -556,7 +556,7 @@ private[log] class Cleaner(val id: Int,
 
   protected override def loggerName: String = classOf[LogCleaner].getName
 
-  this.logIdent = LogContext.newBuilder("Cleaner").withTag("id", id).build().logPrefix()
+  this.logIdent = LogContext.forComponent("Cleaner").withTag("id", id).build().logPrefix()
 
   /* buffer used for read i/o */
   private var readBuffer = ByteBuffer.allocate(ioBufferSize)

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.common.errors.{CorruptRecordException, KafkaStorageExcep
 import org.apache.kafka.common.record.MemoryRecords.RecordFilter
 import org.apache.kafka.common.record.MemoryRecords.RecordFilter.BatchRetention
 import org.apache.kafka.common.record._
-import org.apache.kafka.common.utils.{BufferSupplier, Time}
+import org.apache.kafka.common.utils.{BufferSupplier, LogContext, Time}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.ShutdownableThread
 import org.apache.kafka.storage.internals.log.{AbortedTxn, CleanerConfig, LastRecord, LogDirFailureChannel, LogSegment, LogSegmentOffsetOverflowException, OffsetMap, SkimpyOffsetMap, TransactionIndex}
@@ -344,7 +344,7 @@ class LogCleaner(initialConfig: CleanerConfig,
     extends ShutdownableThread(s"kafka-log-cleaner-thread-$threadId", false) with Logging {
     protected override def loggerName: String = classOf[LogCleaner].getName
 
-    this.logContext = logPrefix
+    this.logIdent = logPrefix
 
     if (config.dedupeBufferSize / config.numThreads > Int.MaxValue)
       warn("Cannot use more than 2G of cleaner buffer space per cleaner thread, ignoring excess buffer space...")
@@ -556,7 +556,7 @@ private[log] class Cleaner(val id: Int,
 
   protected override def loggerName: String = classOf[LogCleaner].getName
 
-  this.logContext = s"Cleaner $id: "
+  this.logIdent = LogContext.newBuilder("Cleaner").withTag("id", id).build().logPrefix()
 
   /* buffer used for read i/o */
   private var readBuffer = ByteBuffer.allocate(ioBufferSize)

--- a/core/src/main/scala/kafka/log/LogLoader.scala
+++ b/core/src/main/scala/kafka/log/LogLoader.scala
@@ -69,7 +69,7 @@ class LogLoader(
   numRemainingSegments: ConcurrentMap[String, Int] = new ConcurrentHashMap[String, Int],
   isRemoteLogEnabled: Boolean = false,
 ) extends Logging {
-  logIdent = s"[LogLoader partition=$topicPartition, dir=${dir.getParent}] "
+  logContext = s"[LogLoader partition=$topicPartition, dir=${dir.getParent}] "
 
   /**
    * Load the log segments from the log files on disk, and returns the components of the loaded log.
@@ -198,7 +198,7 @@ class LogLoader(
       config.recordVersion,
       time,
       reloadFromCleanShutdown = hadCleanShutdown,
-      logIdent)
+      logContext)
     val activeSegment = segments.lastSegment.get
     new LoadedLogOffsets(
       newLogStartOffset,
@@ -281,7 +281,7 @@ class LogLoader(
             config,
             scheduler,
             logDirFailureChannel,
-            logIdent)
+            logContext)
           deleteProducerSnapshotsAsync(result.deletedSegments)
       }
     }
@@ -366,7 +366,7 @@ class LogLoader(
       config.recordVersion,
       time,
       reloadFromCleanShutdown = false,
-      logIdent)
+      logContext)
     val bytesTruncated = segment.recover(producerStateManager, leaderEpochCache)
     // once we have recovered the segment's data, take a snapshot to ensure that we won't
     // need to reload the same segment again while recovering another segment.
@@ -509,7 +509,7 @@ class LogLoader(
         config,
         scheduler,
         logDirFailureChannel,
-        logIdent)
+        logContext)
       deleteProducerSnapshotsAsync(segmentsToDelete)
     }
   }

--- a/core/src/main/scala/kafka/log/LogLoader.scala
+++ b/core/src/main/scala/kafka/log/LogLoader.scala
@@ -69,7 +69,7 @@ class LogLoader(
   numRemainingSegments: ConcurrentMap[String, Int] = new ConcurrentHashMap[String, Int],
   isRemoteLogEnabled: Boolean = false,
 ) extends Logging {
-  logIdent = LogContext.newBuilder("LogLoader").withTag("partition", topicPartition).withTag("dir", dir.getParent).build().logPrefix()
+  logIdent = LogContext.forComponent("LogLoader").withTag("partition", topicPartition).withTag("dir", dir.getParent).build().logPrefix()
 
   /**
    * Load the log segments from the log files on disk, and returns the components of the loaded log.

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -117,7 +117,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
     }
   }
 
-  this.logIdent = LogContext.newBuilder("UnifiedLog").withTag("partition", topicPartition).withTag("dir", parentDir).build().logPrefix()
+  this.logIdent = LogContext.forComponent("UnifiedLog").withTag("partition", topicPartition).withTag("dir", parentDir).build().logPrefix()
 
   /* A lock that guards all modifications to the log */
   private val lock = new Object

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -117,7 +117,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
     }
   }
 
-  this.logIdent = s"[UnifiedLog partition=$topicPartition, dir=$parentDir] "
+  this.logContext = s"[UnifiedLog partition=$topicPartition, dir=$parentDir] "
 
   /* A lock that guards all modifications to the log */
   private val lock = new Object
@@ -519,7 +519,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
   }
 
   private def initializeLeaderEpochCache(): Unit = lock synchronized {
-    leaderEpochCache = UnifiedLog.maybeCreateLeaderEpochCache(dir, topicPartition, logDirFailureChannel, recordVersion, logIdent)
+    leaderEpochCache = UnifiedLog.maybeCreateLeaderEpochCache(dir, topicPartition, logDirFailureChannel, recordVersion, logContext)
   }
 
   private def updateHighWatermarkWithLogEndOffset(): Unit = {
@@ -554,7 +554,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
                                    producerStateManager: ProducerStateManager): Unit = lock synchronized {
     localLog.checkIfMemoryMappedBufferClosed()
     UnifiedLog.rebuildProducerState(producerStateManager, localLog.segments, logStartOffset, lastOffset, recordVersion, time,
-      reloadFromCleanShutdown = false, logIdent)
+      reloadFromCleanShutdown = false, logContext)
   }
 
   @threadsafe
@@ -1872,7 +1872,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
     lock synchronized {
       localLog.checkIfMemoryMappedBufferClosed()
       val deletedSegments = UnifiedLog.replaceSegments(localLog.segments, newSegments, oldSegments, dir, topicPartition,
-        config, scheduler, logDirFailureChannel, logIdent)
+        config, scheduler, logDirFailureChannel, logContext)
       deleteProducerSnapshots(deletedSegments, asyncDelete = true)
     }
   }
@@ -1912,7 +1912,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
   }
 
   private[log] def splitOverflowedSegment(segment: LogSegment): List[LogSegment] = lock synchronized {
-    val result = UnifiedLog.splitOverflowedSegment(segment, localLog.segments, dir, topicPartition, config, scheduler, logDirFailureChannel, logIdent)
+    val result = UnifiedLog.splitOverflowedSegment(segment, localLog.segments, dir, topicPartition, config, scheduler, logDirFailureChannel, logContext)
     deleteProducerSnapshots(result.deletedSegments, asyncDelete = true)
     result.newSegments.toList
   }

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -86,7 +86,7 @@ class SocketServer(val config: KafkaConfig,
 
   protected val nodeId = config.brokerId
 
-  private val logContext = LogContext.newBuilder("SocketServer")
+  private val logContext = LogContext.forComponent("SocketServer")
     .withTag("listenerType", apiVersionManager.listenerType.toString)
     .withTag("nodeId", nodeId)
     .build()

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -86,9 +86,12 @@ class SocketServer(val config: KafkaConfig,
 
   protected val nodeId = config.brokerId
 
-  private val logContext = new LogContext(s"[SocketServer listenerType=${apiVersionManager.listenerType}, nodeId=$nodeId] ")
+  private val logContext = LogContext.newBuilder("SocketServer")
+    .withTag("listenerType", apiVersionManager.listenerType.toString)
+    .withTag("nodeId", nodeId)
+    .build()
 
-  this.logIdent = logContext.logPrefix
+  this.logContext = logContext.logPrefix
 
   private val memoryPoolSensor = metrics.sensor("MemoryPoolUtilization")
   private val memoryPoolDepletedPercentMetricName = metrics.metricName("MemoryPoolAvgDepletedPercent", MetricsGroup)

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -91,7 +91,7 @@ class SocketServer(val config: KafkaConfig,
     .withTag("nodeId", nodeId)
     .build()
 
-  this.logContext = logContext.logPrefix
+  this.logIdent = logContext.logPrefix
 
   private val memoryPoolSensor = metrics.sensor("MemoryPoolUtilization")
   private val memoryPoolDepletedPercentMetricName = metrics.metricName("MemoryPoolAvgDepletedPercent", MetricsGroup)

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -49,7 +49,7 @@ final class KafkaMetadataLog private (
   config: MetadataLogConfig
 ) extends ReplicatedLog with Logging {
 
-  this.logIdent = LogContext.newBuilder("MetadataLog").withTag("partition", topicPartition).withTag("nodeId", config.nodeId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("MetadataLog").withTag("partition", topicPartition).withTag("nodeId", config.nodeId).build().logPrefix()
 
   override def read(startOffset: Long, readIsolation: Isolation): LogFetchInfo = {
     val isolation = readIsolation match {

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -49,7 +49,7 @@ final class KafkaMetadataLog private (
   config: MetadataLogConfig
 ) extends ReplicatedLog with Logging {
 
-  this.logIdent = s"[MetadataLog partition=$topicPartition, nodeId=${config.nodeId}] "
+  this.logContext = s"[MetadataLog partition=$topicPartition, nodeId=${config.nodeId}] "
 
   override def read(startOffset: Long, readIsolation: Isolation): LogFetchInfo = {
     val isolation = readIsolation match {

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -23,7 +23,7 @@ import kafka.utils.{CoreUtils, Logging}
 import org.apache.kafka.common.config.{AbstractConfig, TopicConfig}
 import org.apache.kafka.common.errors.InvalidConfigurationException
 import org.apache.kafka.common.record.{MemoryRecords, Records}
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.common.{KafkaException, TopicPartition, Uuid}
 import org.apache.kafka.raft.{Isolation, KafkaRaftClient, LogAppendInfo, LogFetchInfo, LogOffsetMetadata, OffsetAndEpoch, OffsetMetadata, ReplicatedLog, ValidOffsetAndEpoch}
 import org.apache.kafka.server.util.Scheduler
@@ -49,7 +49,7 @@ final class KafkaMetadataLog private (
   config: MetadataLogConfig
 ) extends ReplicatedLog with Logging {
 
-  this.logContext = s"[MetadataLog partition=$topicPartition, nodeId=${config.nodeId}] "
+  this.logIdent = LogContext.newBuilder("MetadataLog").withTag("partition", topicPartition).withTag("nodeId", config.nodeId).build().logPrefix()
 
   override def read(startOffset: Long, readIsolation: Isolation): LogFetchInfo = {
     val isolation = readIsolation match {

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -57,7 +57,7 @@ object KafkaRaftManager {
     fatalFaultHandler: FaultHandler
   ) extends ShutdownableThread(threadNamePrefix + "-io-thread", false) with Logging {
 
-    this.logContext = logPrefix
+    this.logIdent = logPrefix
 
     override def doWork(): Unit = {
       try {
@@ -146,7 +146,7 @@ class KafkaRaftManager[T](
   private val logContext = LogContext.newBuilder("RaftManager")
     .withTag("id", config.nodeId.toString)
     .build()
-  this.logContext = logContext.logPrefix()
+  this.logIdent = logContext.logPrefix()
 
   private val scheduler = new KafkaScheduler(1, true, threadNamePrefix + "-scheduler")
   scheduler.startup()

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -57,7 +57,7 @@ object KafkaRaftManager {
     fatalFaultHandler: FaultHandler
   ) extends ShutdownableThread(threadNamePrefix + "-io-thread", false) with Logging {
 
-    this.logIdent = logPrefix
+    this.logContext = logPrefix
 
     override def doWork(): Unit = {
       try {
@@ -143,8 +143,10 @@ class KafkaRaftManager[T](
   val apiVersions = new ApiVersions()
   private val raftConfig = new RaftConfig(config)
   private val threadNamePrefix = threadNamePrefixOpt.getOrElse("kafka-raft")
-  private val logContext = new LogContext(s"[RaftManager id=${config.nodeId}] ")
-  this.logIdent = logContext.logPrefix()
+  private val logContext = LogContext.newBuilder("RaftManager")
+    .withTag("id", config.nodeId.toString)
+    .build()
+  this.logContext = logContext.logPrefix()
 
   private val scheduler = new KafkaScheduler(1, true, threadNamePrefix + "-scheduler")
   scheduler.startup()

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -143,7 +143,7 @@ class KafkaRaftManager[T](
   val apiVersions = new ApiVersions()
   private val raftConfig = new RaftConfig(config)
   private val threadNamePrefix = threadNamePrefixOpt.getOrElse("kafka-raft")
-  private val logContext = LogContext.newBuilder("RaftManager")
+  private val logContext = LogContext.forComponent("RaftManager")
     .withTag("id", config.nodeId.toString)
     .build()
   this.logIdent = logContext.logPrefix()

--- a/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
@@ -37,7 +37,7 @@ abstract class AbstractFetcherManager[T <: AbstractFetcherThread](val name: Stri
   private val lock = new Object
   private var numFetchersPerBroker = numFetchers
   val failedPartitions = new FailedPartitions
-  this.logIdent = LogContext.newBuilder(name).build().logPrefix()
+  this.logIdent = LogContext.forComponent(name).build().logPrefix()
 
   private val tags = Map("clientId" -> clientId).asJava
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
@@ -37,7 +37,7 @@ abstract class AbstractFetcherManager[T <: AbstractFetcherThread](val name: Stri
   private val lock = new Object
   private var numFetchersPerBroker = numFetchers
   val failedPartitions = new FailedPartitions
-  this.logIdent = "[" + name + "] "
+  this.logContext = "[" + name + "] "
 
   private val tags = Map("clientId" -> clientId).asJava
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
@@ -21,7 +21,7 @@ import kafka.cluster.BrokerEndPoint
 import kafka.utils.Implicits._
 import kafka.utils.Logging
 import org.apache.kafka.common.{TopicPartition, Uuid}
-import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.common.utils.{LogContext, Utils}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 
 import scala.collection.{Map, Set, mutable}
@@ -37,7 +37,7 @@ abstract class AbstractFetcherManager[T <: AbstractFetcherThread](val name: Stri
   private val lock = new Object
   private var numFetchersPerBroker = numFetchers
   val failedPartitions = new FailedPartitions
-  this.logContext = "[" + name + "] "
+  this.logIdent = LogContext.newBuilder(name).build().logPrefix()
 
   private val tags = Map("clientId" -> clientId).asJava
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -62,7 +62,7 @@ abstract class AbstractFetcherThread(name: String,
                                      val brokerTopicStats: BrokerTopicStats) //BrokerTopicStats's lifecycle managed by ReplicaManager
   extends ShutdownableThread(name, isInterruptible) with Logging {
 
-  this.logIdent = this.logPrefix
+  this.logContext = this.logPrefix
 
   type FetchData = FetchResponseData.PartitionData
   type EpochData = OffsetForLeaderEpochRequestData.OffsetForLeaderPartition

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -62,7 +62,7 @@ abstract class AbstractFetcherThread(name: String,
                                      val brokerTopicStats: BrokerTopicStats) //BrokerTopicStats's lifecycle managed by ReplicaManager
   extends ShutdownableThread(name, isInterruptible) with Logging {
 
-  this.logContext = this.logPrefix
+  this.logIdent = this.logPrefix
 
   type FetchData = FetchResponseData.PartitionData
   type EpochData = OffsetForLeaderEpochRequestData.OffsetForLeaderPartition

--- a/core/src/main/scala/kafka/server/AclApis.scala
+++ b/core/src/main/scala/kafka/server/AclApis.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
 import org.apache.kafka.common.resource.ResourceType
+import org.apache.kafka.common.utils.LogContext
 import org.apache.kafka.server.authorizer._
 
 import java.util
@@ -47,7 +48,7 @@ class AclApis(authHelper: AuthHelper,
               requestHelper: RequestHandlerHelper,
               name: String,
               config: KafkaConfig) extends Logging {
-  this.logContext = "[AclApis-%s-%s] ".format(name, config.nodeId)
+  this.logIdent = LogContext.newBuilder("AclApis").withTag("name", name).withTag("nodeId", config.nodeId).build().logPrefix()
   private val alterAclsPurgatory =
       new DelayedFuturePurgatory(purgatoryName = "AlterAcls", brokerId = config.nodeId)
 

--- a/core/src/main/scala/kafka/server/AclApis.scala
+++ b/core/src/main/scala/kafka/server/AclApis.scala
@@ -47,7 +47,7 @@ class AclApis(authHelper: AuthHelper,
               requestHelper: RequestHandlerHelper,
               name: String,
               config: KafkaConfig) extends Logging {
-  this.logIdent = "[AclApis-%s-%s] ".format(name, config.nodeId)
+  this.logContext = "[AclApis-%s-%s] ".format(name, config.nodeId)
   private val alterAclsPurgatory =
       new DelayedFuturePurgatory(purgatoryName = "AlterAcls", brokerId = config.nodeId)
 

--- a/core/src/main/scala/kafka/server/AclApis.scala
+++ b/core/src/main/scala/kafka/server/AclApis.scala
@@ -48,7 +48,7 @@ class AclApis(authHelper: AuthHelper,
               requestHelper: RequestHandlerHelper,
               name: String,
               config: KafkaConfig) extends Logging {
-  this.logIdent = LogContext.newBuilder("AclApis").withTag("name", name).withTag("nodeId", config.nodeId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("AclApis").withTag("name", name).withTag("nodeId", config.nodeId).build().logPrefix()
   private val alterAclsPurgatory =
       new DelayedFuturePurgatory(purgatoryName = "AlterAcls", brokerId = config.nodeId)
 

--- a/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
+++ b/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
@@ -64,7 +64,7 @@ class AddPartitionsToTxnManager(
   time
 ) with Logging {
 
-  this.logContext = logPrefix
+  this.logIdent = logPrefix
 
   private val inflightNodes = mutable.HashSet[Node]()
   private val nodesToTransactions = mutable.Map[Node, TransactionDataAndCallbacks]()

--- a/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
+++ b/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
@@ -64,7 +64,7 @@ class AddPartitionsToTxnManager(
   time
 ) with Logging {
 
-  this.logIdent = logPrefix
+  this.logContext = logPrefix
 
   private val inflightNodes = mutable.HashSet[Node]()
   private val nodesToTransactions = mutable.Map[Node, TransactionDataAndCallbacks]()

--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -72,7 +72,7 @@ class BrokerLifecycleManager(
 
   val logContext: LogContext = logContextBuilder().build()
 
-  this.logContext = logContext.logPrefix()
+  this.logIdent = logContext.logPrefix()
 
   /**
    * The broker id.

--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -61,19 +61,18 @@ class BrokerLifecycleManager(
   val logDirs: Set[Uuid]
 ) extends Logging {
 
-  private def logPrefix(): String = {
-    val builder = new StringBuilder("[BrokerLifecycleManager")
-    builder.append(" id=").append(config.nodeId)
+  private def logContextBuilder(): LogContext.Builder = {
+    val builder = LogContext.newBuilder("BrokerLifecycleManager")
+    builder.withTag("id", config.nodeId)
     if (isZkBroker) {
-      builder.append(" isZkBroker=true")
+      builder.withTag("isZkBroker", "true")
     }
-    builder.append("] ")
-    builder.toString()
+    builder
   }
 
-  val logContext = new LogContext(logPrefix())
+  val logContext: LogContext = logContextBuilder().build()
 
-  this.logIdent = logContext.logPrefix()
+  this.logContext = logContext.logPrefix()
 
   /**
    * The broker id.

--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -62,7 +62,7 @@ class BrokerLifecycleManager(
 ) extends Logging {
 
   private def logContextBuilder(): LogContext.Builder = {
-    val builder = LogContext.newBuilder("BrokerLifecycleManager")
+    val builder = LogContext.forComponent("BrokerLifecycleManager")
     builder.withTag("id", config.nodeId)
     if (isZkBroker) {
       builder.withTag("isZkBroker", "true")

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -81,7 +81,7 @@ class BrokerServer(
 
   import kafka.server.Server._
 
-  private val logContext: LogContext = LogContext.newBuilder("BrokerServer").withTag("id", config.nodeId.toString).build()
+  private val logContext: LogContext = LogContext.forComponent("BrokerServer").withTag("id", config.nodeId.toString).build()
 
   this.logIdent = logContext.logPrefix
 
@@ -271,7 +271,7 @@ class BrokerServer(
       )
       alterPartitionManager.start()
 
-      val addPartitionsLogContext = LogContext.newBuilder("AddPartitionsToTxnManager")
+      val addPartitionsLogContext = LogContext.forComponent("AddPartitionsToTxnManager")
         .withTag("brokerId", config.brokerId.toString)
         .build()
       val addPartitionsToTxnNetworkClient = NetworkUtils.buildNetworkClient("AddPartitionsManager", config, metrics, time, addPartitionsLogContext)

--- a/core/src/main/scala/kafka/server/ConfigAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ConfigAdminManager.scala
@@ -36,6 +36,7 @@ import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.{Alte
 import org.apache.kafka.common.protocol.Errors.{INVALID_REQUEST, UNKNOWN_SERVER_ERROR}
 import org.apache.kafka.common.requests.ApiError
 import org.apache.kafka.common.resource.{Resource, ResourceType}
+import org.apache.kafka.common.utils.LogContext
 import org.slf4j.LoggerFactory
 
 import scala.collection.{Map, Seq}
@@ -84,7 +85,7 @@ class ConfigAdminManager(nodeId: Int,
                          configRepository: ConfigRepository) extends Logging {
   import ConfigAdminManager._
 
-  this.logContext = "[ConfigAdminManager[nodeId=" + nodeId + "]: "
+  this.logIdent = LogContext.newBuilder("ConfigAdminManager").withTag("nodeId", nodeId).build().logPrefix()
 
   val runtimeLoggerManager = new RuntimeLoggerManager(nodeId, logger.underlying)
 

--- a/core/src/main/scala/kafka/server/ConfigAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ConfigAdminManager.scala
@@ -84,7 +84,7 @@ class ConfigAdminManager(nodeId: Int,
                          configRepository: ConfigRepository) extends Logging {
   import ConfigAdminManager._
 
-  this.logIdent = "[ConfigAdminManager[nodeId=" + nodeId + "]: "
+  this.logContext = "[ConfigAdminManager[nodeId=" + nodeId + "]: "
 
   val runtimeLoggerManager = new RuntimeLoggerManager(nodeId, logger.underlying)
 

--- a/core/src/main/scala/kafka/server/ConfigAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ConfigAdminManager.scala
@@ -85,7 +85,7 @@ class ConfigAdminManager(nodeId: Int,
                          configRepository: ConfigRepository) extends Logging {
   import ConfigAdminManager._
 
-  this.logIdent = LogContext.newBuilder("ConfigAdminManager").withTag("nodeId", nodeId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("ConfigAdminManager").withTag("nodeId", nodeId).build().logPrefix()
 
   val runtimeLoggerManager = new RuntimeLoggerManager(nodeId, logger.underlying)
 

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -79,7 +79,7 @@ class ControllerApis(
   val metadataCache: KRaftMetadataCache
 ) extends ApiRequestHandler with Logging {
 
-  this.logIdent = s"[ControllerApis nodeId=${config.nodeId}] "
+  this.logContext = s"[ControllerApis nodeId=${config.nodeId}] "
   val authHelper = new AuthHelper(authorizer)
   val configHelper = new ConfigHelper(metadataCache, config, metadataCache)
   val requestHelper = new RequestHandlerHelper(requestChannel, quotas, time)

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -79,7 +79,7 @@ class ControllerApis(
   val metadataCache: KRaftMetadataCache
 ) extends ApiRequestHandler with Logging {
 
-  this.logIdent = LogContext.newBuilder("ControllerApis").withTag("nodeId", config.nodeId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("ControllerApis").withTag("nodeId", config.nodeId).build().logPrefix()
   val authHelper = new AuthHelper(authorizer)
   val configHelper = new ConfigHelper(metadataCache, config, metadataCache)
   val requestHelper = new RequestHandlerHelper(requestChannel, quotas, time)

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -48,7 +48,7 @@ import org.apache.kafka.common.protocol.{ApiKeys, ApiMessage, Errors}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
 import org.apache.kafka.common.resource.ResourceType.{CLUSTER, TOPIC, USER}
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.controller.ControllerRequestContext.requestTimeoutMsToDeadlineNs
 import org.apache.kafka.controller.{Controller, ControllerRequestContext}
@@ -79,7 +79,7 @@ class ControllerApis(
   val metadataCache: KRaftMetadataCache
 ) extends ApiRequestHandler with Logging {
 
-  this.logContext = s"[ControllerApis nodeId=${config.nodeId}] "
+  this.logIdent = LogContext.newBuilder("ControllerApis").withTag("nodeId", config.nodeId).build().logPrefix()
   val authHelper = new AuthHelper(authorizer)
   val configHelper = new ConfigHelper(metadataCache, config, metadataCache)
   val requestHelper = new RequestHandlerHelper(requestChannel, quotas, time)

--- a/core/src/main/scala/kafka/server/ControllerRegistrationManager.scala
+++ b/core/src/main/scala/kafka/server/ControllerRegistrationManager.scala
@@ -57,17 +57,16 @@ class ControllerRegistrationManager(
 ) extends Logging with MetadataPublisher {
   override def name(): String = "ControllerRegistrationManager"
 
-  private def logPrefix(): String = {
-    val builder = new StringBuilder("[ControllerRegistrationManager")
-    builder.append(" id=").append(nodeId)
-    builder.append(" incarnation=").append(incarnationId)
-    builder.append("] ")
-    builder.toString()
+  private def logContextBuilder(): LogContext.Builder = {
+    val builder = LogContext.newBuilder("ControllerRegistrationManager")
+    builder.withTag("id", nodeId)
+    builder.withTag("incarnation", incarnationId)
+    builder
   }
 
-  val logContext = new LogContext(logPrefix())
+  val logContext: LogContext = logContextBuilder().build()
 
-  this.logIdent = logContext.logPrefix()
+  this.logContext = logContext.logPrefix()
 
   /**
    * True if there is a pending RPC. Only read or written from the event queue thread.

--- a/core/src/main/scala/kafka/server/ControllerRegistrationManager.scala
+++ b/core/src/main/scala/kafka/server/ControllerRegistrationManager.scala
@@ -66,7 +66,7 @@ class ControllerRegistrationManager(
 
   val logContext: LogContext = logContextBuilder().build()
 
-  this.logContext = logContext.logPrefix()
+  this.logIdent = logContext.logPrefix()
 
   /**
    * True if there is a pending RPC. Only read or written from the event queue thread.

--- a/core/src/main/scala/kafka/server/ControllerRegistrationManager.scala
+++ b/core/src/main/scala/kafka/server/ControllerRegistrationManager.scala
@@ -58,7 +58,7 @@ class ControllerRegistrationManager(
   override def name(): String = "ControllerRegistrationManager"
 
   private def logContextBuilder(): LogContext.Builder = {
-    val builder = LogContext.newBuilder("ControllerRegistrationManager")
+    val builder = LogContext.forComponent("ControllerRegistrationManager")
     builder.withTag("id", nodeId)
     builder.withTag("incarnation", incarnationId)
     builder

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -93,7 +93,7 @@ class ControllerServer(
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
 
   val config = sharedServer.controllerConfig
-  val logContext = LogContext.newBuilder("ControllerServer").withTag("id", config.nodeId).build()
+  val logContext = LogContext.forComponent("ControllerServer").withTag("id", config.nodeId).build()
   val time = sharedServer.time
   def metrics = sharedServer.metrics
   def raftManager: KafkaRaftManager[ApiMessageAndVersion] = sharedServer.raftManager

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -145,7 +145,7 @@ class ControllerServer(
     if (!maybeChangeStatus(SHUTDOWN, STARTING)) return
     val startupDeadline = Deadline.fromDelay(time, config.serverMaxStartupTimeMs, TimeUnit.MILLISECONDS)
     try {
-      this.logContext = logContext.logPrefix()
+      this.logIdent = logContext.logPrefix()
       info("Starting controller")
       config.dynamicConfig.initialize(zkClientOpt = None, clientMetricsReceiverPluginOpt = None)
 
@@ -211,7 +211,7 @@ class ControllerServer(
       alterConfigPolicy = Option(config.
         getConfiguredInstance(AlterConfigPolicyClassNameProp, classOf[AlterConfigPolicy]))
 
-      val voterConnections = FutureUtils.waitWithLogging(logger.underlying, logContext,
+      val voterConnections = FutureUtils.waitWithLogging(logger.underlying, logIdent,
         "controller quorum voters future",
         sharedServer.controllerQuorumVotersFuture,
         startupDeadline, time)
@@ -410,7 +410,7 @@ class ControllerServer(
       ))
 
       // Install all metadata publishers.
-      FutureUtils.waitWithLogging(logger.underlying, logContext,
+      FutureUtils.waitWithLogging(logger.underlying, logIdent,
         "the controller metadata publishers to be installed",
         sharedServer.loader.installPublishers(metadataPublishers), startupDeadline, time)
 
@@ -442,12 +442,12 @@ class ControllerServer(
       registrationManager.start(registrationChannelManager)
 
       // Block here until all the authorizer futures are complete
-      FutureUtils.waitWithLogging(logger.underlying, logContext,
+      FutureUtils.waitWithLogging(logger.underlying, logIdent,
         "all of the authorizer futures to be completed",
         CompletableFuture.allOf(authorizerFutures.values.toSeq: _*), startupDeadline, time)
 
       // Wait for all the SocketServer ports to be open, and the Acceptors to be started.
-      FutureUtils.waitWithLogging(logger.underlying, logContext,
+      FutureUtils.waitWithLogging(logger.underlying, logIdent,
         "all of the SocketServer Acceptors to be started",
         socketServerFuture, startupDeadline, time)
 

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -93,7 +93,7 @@ class ControllerServer(
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
 
   val config = sharedServer.controllerConfig
-  val logContext = new LogContext(s"[ControllerServer id=${config.nodeId}] ")
+  val logContext = LogContext.newBuilder("ControllerServer").withTag("id", config.nodeId).build()
   val time = sharedServer.time
   def metrics = sharedServer.metrics
   def raftManager: KafkaRaftManager[ApiMessageAndVersion] = sharedServer.raftManager
@@ -145,7 +145,7 @@ class ControllerServer(
     if (!maybeChangeStatus(SHUTDOWN, STARTING)) return
     val startupDeadline = Deadline.fromDelay(time, config.serverMaxStartupTimeMs, TimeUnit.MILLISECONDS)
     try {
-      this.logIdent = logContext.logPrefix()
+      this.logContext = logContext.logPrefix()
       info("Starting controller")
       config.dynamicConfig.initialize(zkClientOpt = None, clientMetricsReceiverPluginOpt = None)
 
@@ -211,7 +211,7 @@ class ControllerServer(
       alterConfigPolicy = Option(config.
         getConfiguredInstance(AlterConfigPolicyClassNameProp, classOf[AlterConfigPolicy]))
 
-      val voterConnections = FutureUtils.waitWithLogging(logger.underlying, logIdent,
+      val voterConnections = FutureUtils.waitWithLogging(logger.underlying, logContext,
         "controller quorum voters future",
         sharedServer.controllerQuorumVotersFuture,
         startupDeadline, time)
@@ -410,7 +410,7 @@ class ControllerServer(
       ))
 
       // Install all metadata publishers.
-      FutureUtils.waitWithLogging(logger.underlying, logIdent,
+      FutureUtils.waitWithLogging(logger.underlying, logContext,
         "the controller metadata publishers to be installed",
         sharedServer.loader.installPublishers(metadataPublishers), startupDeadline, time)
 
@@ -442,12 +442,12 @@ class ControllerServer(
       registrationManager.start(registrationChannelManager)
 
       // Block here until all the authorizer futures are complete
-      FutureUtils.waitWithLogging(logger.underlying, logIdent,
+      FutureUtils.waitWithLogging(logger.underlying, logContext,
         "all of the authorizer futures to be completed",
         CompletableFuture.allOf(authorizerFutures.values.toSeq: _*), startupDeadline, time)
 
       // Wait for all the SocketServer ports to be open, and the Acceptors to be started.
-      FutureUtils.waitWithLogging(logger.underlying, logIdent,
+      FutureUtils.waitWithLogging(logger.underlying, logContext,
         "all of the SocketServer Acceptors to be started",
         socketServerFuture, startupDeadline, time)
 

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -100,7 +100,7 @@ object DelegationTokenManager {
 class DelegationTokenManager(val config: KafkaConfig,
                              val tokenCache: DelegationTokenCache,
                              val time: Time) extends Logging {
-  this.logIdent = s"[Token Manager on Node ${config.brokerId}]: "
+  this.logContext = s"[Token Manager on Node ${config.brokerId}]: "
 
   protected val lock = new Object()
 

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -20,7 +20,6 @@ package kafka.server
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.security.InvalidKeyException
-
 import javax.crypto.spec.SecretKeySpec
 import javax.crypto.{Mac, SecretKey}
 import kafka.utils.Logging
@@ -30,7 +29,7 @@ import org.apache.kafka.common.security.scram.internals.{ScramFormatter, ScramMe
 import org.apache.kafka.common.security.scram.ScramCredential
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
 import org.apache.kafka.common.security.token.delegation.{DelegationToken, TokenInformation}
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{LogContext, Time}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
@@ -100,7 +99,7 @@ object DelegationTokenManager {
 class DelegationTokenManager(val config: KafkaConfig,
                              val tokenCache: DelegationTokenCache,
                              val time: Time) extends Logging {
-  this.logContext = s"[Token Manager on Node ${config.brokerId}]: "
+  this.logIdent = LogContext.newBuilder("TokenManager").withTag("nodeId", config.brokerId).build().logPrefix()
 
   protected val lock = new Object()
 

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -99,7 +99,7 @@ object DelegationTokenManager {
 class DelegationTokenManager(val config: KafkaConfig,
                              val tokenCache: DelegationTokenCache,
                              val time: Time) extends Logging {
-  this.logIdent = LogContext.newBuilder("TokenManager").withTag("nodeId", config.brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("TokenManager").withTag("nodeId", config.brokerId).build().logPrefix()
 
   protected val lock = new Object()
 

--- a/core/src/main/scala/kafka/server/FinalizedFeatureChangeListener.scala
+++ b/core/src/main/scala/kafka/server/FinalizedFeatureChangeListener.scala
@@ -147,7 +147,7 @@ class FinalizedFeatureChangeListener(private val finalizedFeatureCache: ZkMetada
    */
   private class ChangeNotificationProcessorThread(name: String) extends ShutdownableThread(name) with Logging {
 
-    this.logIdent = logPrefix
+    this.logContext = logPrefix
 
     override def doWork(): Unit = {
       try {

--- a/core/src/main/scala/kafka/server/FinalizedFeatureChangeListener.scala
+++ b/core/src/main/scala/kafka/server/FinalizedFeatureChangeListener.scala
@@ -147,7 +147,7 @@ class FinalizedFeatureChangeListener(private val finalizedFeatureCache: ZkMetada
    */
   private class ChangeNotificationProcessorThread(name: String) extends ShutdownableThread(name) with Logging {
 
-    this.logContext = logPrefix
+    this.logIdent = logPrefix
 
     override def doWork(): Unit = {
       try {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -114,7 +114,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 ) extends ApiRequestHandler with Logging {
 
   type FetchResponseStats = Map[TopicPartition, RecordValidationStats]
-  this.logIdent = LogContext.newBuilder("KafkaApi").withTag("brokerId", brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("KafkaApi").withTag("brokerId", brokerId).build().logPrefix()
   val configHelper = new ConfigHelper(metadataCache, config, configRepository)
   val authHelper = new AuthHelper(authorizer)
   val requestHelper = new RequestHandlerHelper(requestChannel, quotas, time)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -114,7 +114,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 ) extends ApiRequestHandler with Logging {
 
   type FetchResponseStats = Map[TopicPartition, RecordValidationStats]
-  this.logIdent = "[KafkaApi-%d] ".format(brokerId)
+  this.logContext = "[KafkaApi-%d] ".format(brokerId)
   val configHelper = new ConfigHelper(metadataCache, config, configRepository)
   val authHelper = new AuthHelper(authorizer)
   val requestHelper = new RequestHandlerHelper(requestChannel, quotas, time)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -65,7 +65,7 @@ import org.apache.kafka.common.resource.ResourceType._
 import org.apache.kafka.common.resource.{Resource, ResourceType}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.security.token.delegation.{DelegationToken, TokenInformation}
-import org.apache.kafka.common.utils.{ProducerIdAndEpoch, Time}
+import org.apache.kafka.common.utils.{LogContext, ProducerIdAndEpoch, Time}
 import org.apache.kafka.common.{Node, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.server.ClientMetricsManager
@@ -114,7 +114,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 ) extends ApiRequestHandler with Logging {
 
   type FetchResponseStats = Map[TopicPartition, RecordValidationStats]
-  this.logContext = "[KafkaApi-%d] ".format(brokerId)
+  this.logIdent = LogContext.newBuilder("KafkaApi").withTag("brokerId", brokerId).build().logPrefix()
   val configHelper = new ConfigHelper(metadataCache, config, configRepository)
   val authHelper = new AuthHelper(authorizer)
   val requestHelper = new RequestHandlerHelper(requestChannel, quotas, time)

--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -24,7 +24,7 @@ import kafka.server.KafkaRaftServer.{BrokerRole, ControllerRole}
 import kafka.utils.{CoreUtils, Logging, Mx4jLoader, VerifiableProperties}
 import org.apache.kafka.common.config.{ConfigDef, ConfigResource}
 import org.apache.kafka.common.internals.Topic
-import org.apache.kafka.common.utils.{AppInfoParser, Time}
+import org.apache.kafka.common.utils.{AppInfoParser, LogContext, Time}
 import org.apache.kafka.common.{KafkaException, Uuid}
 import org.apache.kafka.metadata.KafkaConfigSchema
 import org.apache.kafka.metadata.bootstrap.{BootstrapDirectory, BootstrapMetadata}
@@ -52,12 +52,12 @@ class KafkaRaftServer(
   time: Time,
 ) extends Server with Logging {
 
-  this.logContext = s"[KafkaRaftServer nodeId=${config.nodeId}] "
+  this.logIdent = LogContext.newBuilder("KafkaRaftServer").withTag("nodeId", config.nodeId).build().logPrefix()
   KafkaMetricsReporter.startReporters(VerifiableProperties(config.originals))
   KafkaYammerMetrics.INSTANCE.configure(config.originals)
 
   private val (metaPropsEnsemble, bootstrapMetadata) =
-    KafkaRaftServer.initializeLogDirs(config, this.logger.underlying, this.logContext)
+    KafkaRaftServer.initializeLogDirs(config, this.logger.underlying, this.logIdent)
 
   private val metrics = Server.initializeMetrics(
     config,

--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -52,12 +52,12 @@ class KafkaRaftServer(
   time: Time,
 ) extends Server with Logging {
 
-  this.logIdent = s"[KafkaRaftServer nodeId=${config.nodeId}] "
+  this.logContext = s"[KafkaRaftServer nodeId=${config.nodeId}] "
   KafkaMetricsReporter.startReporters(VerifiableProperties(config.originals))
   KafkaYammerMetrics.INSTANCE.configure(config.originals)
 
   private val (metaPropsEnsemble, bootstrapMetadata) =
-    KafkaRaftServer.initializeLogDirs(config, this.logger.underlying, this.logIdent)
+    KafkaRaftServer.initializeLogDirs(config, this.logger.underlying, this.logContext)
 
   private val metrics = Server.initializeMetrics(
     config,

--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -52,7 +52,7 @@ class KafkaRaftServer(
   time: Time,
 ) extends Server with Logging {
 
-  this.logIdent = LogContext.newBuilder("KafkaRaftServer").withTag("nodeId", config.nodeId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("KafkaRaftServer").withTag("nodeId", config.nodeId).build().logPrefix()
   KafkaMetricsReporter.startReporters(VerifiableProperties(config.originals))
   KafkaYammerMetrics.INSTANCE.configure(config.originals)
 

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -97,7 +97,7 @@ class KafkaRequestHandler(
   time: Time,
   nodeName: String = "broker"
 ) extends Runnable with Logging {
-  this.logIdent = LogContext.newBuilder("KafkaRequestHandler")
+  this.logIdent = LogContext.forComponent("KafkaRequestHandler")
     .withTag("id", id)
     .withTag("nodeName", nodeName.capitalize)
     .withTag("brokerId", brokerId)
@@ -215,7 +215,7 @@ class KafkaRequestHandlerPool(
   /* a meter to track the average free capacity of the request handlers */
   private val aggregateIdleMeter = metricsGroup.newMeter(requestHandlerAvgIdleMetricName, "percent", TimeUnit.NANOSECONDS)
 
-  this.logIdent = LogContext.newBuilder(logAndThreadNamePrefix + " KafkaRequestHandler").withTag("brokerId", brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent(logAndThreadNamePrefix + " KafkaRequestHandler").withTag("brokerId", brokerId).build().logPrefix()
   val runnables = new mutable.ArrayBuffer[KafkaRequestHandler](numThreads)
   for (i <- 0 until numThreads) {
     createHandler(i)

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -97,7 +97,7 @@ class KafkaRequestHandler(
   time: Time,
   nodeName: String = "broker"
 ) extends Runnable with Logging {
-  this.logIdent = s"[Kafka Request Handler $id on ${nodeName.capitalize} $brokerId], "
+  this.logContext = s"[Kafka Request Handler $id on ${nodeName.capitalize} $brokerId], "
   private val shutdownComplete = new CountDownLatch(1)
   private val requestLocal = RequestLocal.withThreadConfinedCaching
   @volatile private var stopped = false
@@ -210,7 +210,7 @@ class KafkaRequestHandlerPool(
   /* a meter to track the average free capacity of the request handlers */
   private val aggregateIdleMeter = metricsGroup.newMeter(requestHandlerAvgIdleMetricName, "percent", TimeUnit.NANOSECONDS)
 
-  this.logIdent = "[" + logAndThreadNamePrefix + " Kafka Request Handler on Broker " + brokerId + "], "
+  this.logContext = "[" + logAndThreadNamePrefix + " Kafka Request Handler on Broker " + brokerId + "], "
   val runnables = new mutable.ArrayBuffer[KafkaRequestHandler](numThreads)
   for (i <- 0 until numThreads) {
     createHandler(i)

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -25,7 +25,7 @@ import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 import com.yammer.metrics.core.{Gauge, Meter}
 import org.apache.kafka.common.internals.FatalExitError
-import org.apache.kafka.common.utils.{KafkaThread, Time}
+import org.apache.kafka.common.utils.{KafkaThread, LogContext, Time}
 import org.apache.kafka.server.log.remote.storage.RemoteStorageMetrics
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 
@@ -97,7 +97,12 @@ class KafkaRequestHandler(
   time: Time,
   nodeName: String = "broker"
 ) extends Runnable with Logging {
-  this.logContext = s"[Kafka Request Handler $id on ${nodeName.capitalize} $brokerId], "
+  this.logIdent = LogContext.newBuilder("KafkaRequestHandler")
+    .withTag("id", id)
+    .withTag("nodeName", nodeName.capitalize)
+    .withTag("brokerId", brokerId)
+    .build()
+    .logPrefix()
   private val shutdownComplete = new CountDownLatch(1)
   private val requestLocal = RequestLocal.withThreadConfinedCaching
   @volatile private var stopped = false
@@ -210,7 +215,7 @@ class KafkaRequestHandlerPool(
   /* a meter to track the average free capacity of the request handlers */
   private val aggregateIdleMeter = metricsGroup.newMeter(requestHandlerAvgIdleMetricName, "percent", TimeUnit.NANOSECONDS)
 
-  this.logContext = "[" + logAndThreadNamePrefix + " Kafka Request Handler on Broker " + brokerId + "], "
+  this.logIdent = LogContext.newBuilder(logAndThreadNamePrefix + " KafkaRequestHandler").withTag("brokerId", brokerId).build().logPrefix()
   val runnables = new mutable.ArrayBuffer[KafkaRequestHandler](numThreads)
   for (i <- 0 until numThreads) {
     createHandler(i)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -252,8 +252,8 @@ class KafkaServer(
 
         /* generate brokerId */
         config.brokerId = getOrGenerateBrokerId(initialMetaPropsEnsemble)
-        logContext = new LogContext(s"[KafkaServer id=${config.brokerId}] ")
-        this.logIdent = logContext.logPrefix
+        logContext = LogContext.newBuilder("KafkaServer").withTag("id", config.brokerId).build()
+        this.logContext = logContext.logPrefix
 
         // initialize dynamic broker configs from ZooKeeper. Any updates made after this will be
         // applied after ZkConfigManager starts.
@@ -681,7 +681,9 @@ class KafkaServer(
   }
 
   protected def createReplicaManager(isShuttingDown: AtomicBoolean): ReplicaManager = {
-    val addPartitionsLogContext = new LogContext(s"[AddPartitionsToTxnManager broker=${config.brokerId}]")
+    val addPartitionsLogContext = LogContext.newBuilder("AddPartitionsToTxnManager")
+      .withTag("brokerId", config.brokerId.toString)
+      .build()
     val addPartitionsToTxnNetworkClient = NetworkUtils.buildNetworkClient("AddPartitionsManager", config, metrics, time, addPartitionsLogContext)
     val addPartitionsToTxnManager = new AddPartitionsToTxnManager(
       config,

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -252,7 +252,7 @@ class KafkaServer(
 
         /* generate brokerId */
         config.brokerId = getOrGenerateBrokerId(initialMetaPropsEnsemble)
-        logContext = LogContext.newBuilder("KafkaServer").withTag("id", config.brokerId).build()
+        logContext = LogContext.forComponent("KafkaServer").withTag("id", config.brokerId).build()
         this.logIdent = logContext.logPrefix
 
         // initialize dynamic broker configs from ZooKeeper. Any updates made after this will be
@@ -681,7 +681,7 @@ class KafkaServer(
   }
 
   protected def createReplicaManager(isShuttingDown: AtomicBoolean): ReplicaManager = {
-    val addPartitionsLogContext = LogContext.newBuilder("AddPartitionsToTxnManager")
+    val addPartitionsLogContext = LogContext.forComponent("AddPartitionsToTxnManager")
       .withTag("brokerId", config.brokerId.toString)
       .build()
     val addPartitionsToTxnNetworkClient = NetworkUtils.buildNetworkClient("AddPartitionsManager", config, metrics, time, addPartitionsLogContext)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -69,9 +69,9 @@ import java.io.{File, IOException}
 import java.net.{InetAddress, SocketTimeoutException}
 import java.nio.file.{Files, Paths}
 import java.util
-import java.util.{Optional, OptionalInt, OptionalLong}
 import java.util.concurrent._
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.{Optional, OptionalInt, OptionalLong}
 import scala.collection.{Map, Seq}
 import scala.compat.java8.OptionConverters.RichOptionForJava8
 import scala.jdk.CollectionConverters._
@@ -253,7 +253,7 @@ class KafkaServer(
         /* generate brokerId */
         config.brokerId = getOrGenerateBrokerId(initialMetaPropsEnsemble)
         logContext = LogContext.newBuilder("KafkaServer").withTag("id", config.brokerId).build()
-        this.logContext = logContext.logPrefix
+        this.logIdent = logContext.logPrefix
 
         // initialize dynamic broker configs from ZooKeeper. Any updates made after this will be
         // applied after ZkConfigManager starts.

--- a/core/src/main/scala/kafka/server/NodeToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/NodeToControllerChannelManager.scala
@@ -148,7 +148,10 @@ class NodeToControllerChannelManagerImpl(
   threadNamePrefix: String,
   retryTimeoutMs: Long
 ) extends NodeToControllerChannelManager with Logging {
-  private val logContext = new LogContext(s"[NodeToControllerChannelManager id=${config.nodeId} name=${channelName}] ")
+  private val logContext = LogContext.newBuilder("NodeToControllerChannelManager")
+    .withTag("id", config.nodeId)
+    .withTag("name", channelName)
+    .build()
   private val manualMetadataUpdater = new ManualMetadataUpdater()
   private val apiVersions = new ApiVersions()
   private val requestThread = newRequestThread
@@ -271,7 +274,7 @@ class NodeToControllerRequestThread(
   false
 ) with Logging {
 
-  this.logIdent = logPrefix
+  this.logContext = logPrefix
 
   private def maybeResetNetworkClient(controllerInformation: ControllerInformation): Unit = {
     if (isNetworkClientForZkController != controllerInformation.isZkController) {

--- a/core/src/main/scala/kafka/server/NodeToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/NodeToControllerChannelManager.scala
@@ -148,7 +148,7 @@ class NodeToControllerChannelManagerImpl(
   threadNamePrefix: String,
   retryTimeoutMs: Long
 ) extends NodeToControllerChannelManager with Logging {
-  private val logContext = LogContext.newBuilder("NodeToControllerChannelManager")
+  private val logContext = LogContext.forComponent("NodeToControllerChannelManager")
     .withTag("id", config.nodeId)
     .withTag("name", channelName)
     .build()

--- a/core/src/main/scala/kafka/server/NodeToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/NodeToControllerChannelManager.scala
@@ -274,8 +274,6 @@ class NodeToControllerRequestThread(
   false
 ) with Logging {
 
-  this.logContext = logPrefix
-
   private def maybeResetNetworkClient(controllerInformation: ControllerInformation): Unit = {
     if (isNetworkClientForZkController != controllerInformation.isZkController) {
       debug("Controller changed to " + (if (isNetworkClientForZkController) "kraft" else "zk") + " mode. " +

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -59,7 +59,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
                            metadataVersionSupplier: () => MetadataVersion,
                            brokerEpochSupplier: () => Long) extends LeaderEndPoint with Logging {
 
-  this.logIdent = logPrefix
+  this.logContext = logPrefix
 
   private val maxWait = brokerConfig.replicaFetchWaitMaxMs
   private val minBytes = brokerConfig.replicaFetchMinBytes

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -18,25 +18,24 @@
 package kafka.server
 
 import kafka.cluster.BrokerEndPoint
-
-import java.util.{Collections, Optional}
 import kafka.server.AbstractFetcherThread.{ReplicaFetch, ResultWithPartitions}
 import kafka.utils.Implicits.MapExtensionMethods
 import kafka.utils.Logging
 import org.apache.kafka.clients.FetchSessionHandler
 import org.apache.kafka.common.errors.KafkaStorageException
-import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartition, ListOffsetsTopic}
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.{OffsetForLeaderTopic, OffsetForLeaderTopicCollection}
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, ListOffsetsRequest, ListOffsetsResponse, OffsetsForLeaderEpochRequest, OffsetsForLeaderEpochResponse}
-import org.apache.kafka.server.common.{OffsetAndEpoch, MetadataVersion}
+import org.apache.kafka.common.requests._
+import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.server.common.MetadataVersion.IBP_0_10_1_IV2
+import org.apache.kafka.server.common.{MetadataVersion, OffsetAndEpoch}
 
-import scala.jdk.CollectionConverters._
+import java.util.{Collections, Optional}
 import scala.collection.{Map, mutable}
 import scala.compat.java8.OptionConverters.RichOptionForJava8
+import scala.jdk.CollectionConverters._
 
 /**
  * Facilitates fetches from a remote replica leader.
@@ -59,7 +58,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
                            metadataVersionSupplier: () => MetadataVersion,
                            brokerEpochSupplier: () => Long) extends LeaderEndPoint with Logging {
 
-  this.logContext = logPrefix
+  this.logIdent = logPrefix
 
   private val maxWait = brokerConfig.replicaFetchWaitMaxMs
   private val minBytes = brokerConfig.replicaFetchMinBytes

--- a/core/src/main/scala/kafka/server/ReplicaFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherManager.scala
@@ -39,8 +39,11 @@ class ReplicaFetcherManager(brokerConfig: KafkaConfig,
   override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): ReplicaFetcherThread = {
     val prefix = threadNamePrefix.map(tp => s"$tp:").getOrElse("")
     val threadName = s"${prefix}ReplicaFetcherThread-$fetcherId-${sourceBroker.id}"
-    val logContext = new LogContext(s"[ReplicaFetcher replicaId=${brokerConfig.brokerId}, leaderId=${sourceBroker.id}, " +
-      s"fetcherId=$fetcherId] ")
+    val logContext = LogContext.newBuilder("ReplicaFetcher")
+      .withTag("replicaId", brokerConfig.brokerId)
+      .withTag("leaderId", sourceBroker.id)
+      .withTag("fetcherId", fetcherId)
+      .build()
     val endpoint = new BrokerBlockingSender(sourceBroker, brokerConfig, metrics, time, fetcherId,
       s"broker-${brokerConfig.brokerId}-fetcher-$fetcherId", logContext)
     val fetchSessionHandler = new FetchSessionHandler(logContext, sourceBroker.id)

--- a/core/src/main/scala/kafka/server/ReplicaFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherManager.scala
@@ -39,7 +39,7 @@ class ReplicaFetcherManager(brokerConfig: KafkaConfig,
   override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): ReplicaFetcherThread = {
     val prefix = threadNamePrefix.map(tp => s"$tp:").getOrElse("")
     val threadName = s"${prefix}ReplicaFetcherThread-$fetcherId-${sourceBroker.id}"
-    val logContext = LogContext.newBuilder("ReplicaFetcher")
+    val logContext = LogContext.forComponent("ReplicaFetcher")
       .withTag("replicaId", brokerConfig.brokerId)
       .withTag("leaderId", sourceBroker.id)
       .withTag("fetcherId", fetcherId)

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -42,7 +42,7 @@ class ReplicaFetcherThread(name: String,
                                 isInterruptible = false,
                                 replicaMgr.brokerTopicStats) {
 
-  this.logIdent = logPrefix
+  this.logContext = logPrefix
 
   // Visible for testing
   private[server] val partitionsWithNewHighWatermark = mutable.Buffer[TopicPartition]()

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -42,7 +42,7 @@ class ReplicaFetcherThread(name: String,
                                 isInterruptible = false,
                                 replicaMgr.brokerTopicStats) {
 
-  this.logContext = logPrefix
+  this.logIdent = logPrefix
 
   // Visible for testing
   private[server] val partitionsWithNewHighWatermark = mutable.Buffer[TopicPartition]()

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -50,7 +50,7 @@ import org.apache.kafka.common.replica._
 import org.apache.kafka.common.requests.FetchRequest.PartitionData
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests._
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.common.{ElectionType, IsolationLevel, Node, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.image.{LocalReplicaChanges, MetadataImage, TopicsDelta}
 import org.apache.kafka.metadata.LeaderConstants.NO_LEADER
@@ -309,7 +309,7 @@ class ReplicaManager(val config: KafkaConfig,
 
   @volatile private var isInControlledShutdown = false
 
-  this.logContext = s"[ReplicaManager broker=$localBrokerId] "
+  this.logIdent = LogContext.newBuilder("ReplicaManager").withTag("brokerId", localBrokerId).build().logPrefix()
   protected val stateChangeLogger = new StateChangeLogger(localBrokerId, inControllerContext = false, None)
 
   private var logDirFailureHandler: LogDirFailureHandler = _

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -309,7 +309,7 @@ class ReplicaManager(val config: KafkaConfig,
 
   @volatile private var isInControlledShutdown = false
 
-  this.logIdent = s"[ReplicaManager broker=$localBrokerId] "
+  this.logContext = s"[ReplicaManager broker=$localBrokerId] "
   protected val stateChangeLogger = new StateChangeLogger(localBrokerId, inControllerContext = false, None)
 
   private var logDirFailureHandler: LogDirFailureHandler = _

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -309,7 +309,7 @@ class ReplicaManager(val config: KafkaConfig,
 
   @volatile private var isInControlledShutdown = false
 
-  this.logIdent = LogContext.newBuilder("ReplicaManager").withTag("brokerId", localBrokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("ReplicaManager").withTag("brokerId", localBrokerId).build().logPrefix()
   protected val stateChangeLogger = new StateChangeLogger(localBrokerId, inControllerContext = false, None)
 
   private var logDirFailureHandler: LogDirFailureHandler = _

--- a/core/src/main/scala/kafka/server/SharedServer.scala
+++ b/core/src/main/scala/kafka/server/SharedServer.scala
@@ -98,7 +98,7 @@ class SharedServer(
   private val logContext: LogContext = LogContext.newBuilder("SharedServer")
     .withTag("id", sharedServerConfig.nodeId)
     .build()
-  this.logContext = logContext.logPrefix
+  this.logIdent = logContext.logPrefix
   private var started = false
   private var usedByBroker: Boolean = false
   private var usedByController: Boolean = false

--- a/core/src/main/scala/kafka/server/SharedServer.scala
+++ b/core/src/main/scala/kafka/server/SharedServer.scala
@@ -95,8 +95,10 @@ class SharedServer(
   val controllerQuorumVotersFuture: CompletableFuture[util.Map[Integer, AddressSpec]],
   val faultHandlerFactory: FaultHandlerFactory
 ) extends Logging {
-  private val logContext: LogContext = new LogContext(s"[SharedServer id=${sharedServerConfig.nodeId}] ")
-  this.logIdent = logContext.logPrefix
+  private val logContext: LogContext = LogContext.newBuilder("SharedServer")
+    .withTag("id", sharedServerConfig.nodeId)
+    .build()
+  this.logContext = logContext.logPrefix
   private var started = false
   private var usedByBroker: Boolean = false
   private var usedByController: Boolean = false

--- a/core/src/main/scala/kafka/server/SharedServer.scala
+++ b/core/src/main/scala/kafka/server/SharedServer.scala
@@ -95,7 +95,7 @@ class SharedServer(
   val controllerQuorumVotersFuture: CompletableFuture[util.Map[Integer, AddressSpec]],
   val faultHandlerFactory: FaultHandlerFactory
 ) extends Logging {
-  private val logContext: LogContext = LogContext.newBuilder("SharedServer")
+  private val logContext: LogContext = LogContext.forComponent("SharedServer")
     .withTag("id", sharedServerConfig.nodeId)
     .build()
   this.logIdent = logContext.logPrefix

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -72,7 +72,7 @@ class ZkAdminManager(val config: KafkaConfig,
                      val metadataCache: MetadataCache,
                      val zkClient: KafkaZkClient) extends Logging {
 
-  this.logIdent = LogContext.newBuilder("AdminManager").withTag("brokerId", config.brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("AdminManager").withTag("brokerId", config.brokerId).build().logPrefix()
 
   private val topicPurgatory = DelayedOperationPurgatory[DelayedOperation]("topic", config.brokerId)
   private val adminZkClient = new AdminZkClient(zkClient, Some(config))

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -46,7 +46,7 @@ import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity, 
 import org.apache.kafka.common.requests.CreateTopicsRequest._
 import org.apache.kafka.common.requests.{AlterConfigsRequest, ApiError}
 import org.apache.kafka.common.security.scram.internals.{ScramCredentialUtils, ScramFormatter}
-import org.apache.kafka.common.utils.Sanitizer
+import org.apache.kafka.common.utils.{LogContext, Sanitizer}
 import org.apache.kafka.server.common.AdminOperationException
 import org.apache.kafka.server.config.ConfigType
 import org.apache.kafka.storage.internals.log.LogConfig
@@ -72,7 +72,7 @@ class ZkAdminManager(val config: KafkaConfig,
                      val metadataCache: MetadataCache,
                      val zkClient: KafkaZkClient) extends Logging {
 
-  this.logContext = "[Admin Manager on Broker " + config.brokerId + "]: "
+  this.logIdent = LogContext.newBuilder("AdminManager").withTag("brokerId", config.brokerId).build().logPrefix()
 
   private val topicPurgatory = DelayedOperationPurgatory[DelayedOperation]("topic", config.brokerId)
   private val adminZkClient = new AdminZkClient(zkClient, Some(config))

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -72,7 +72,7 @@ class ZkAdminManager(val config: KafkaConfig,
                      val metadataCache: MetadataCache,
                      val zkClient: KafkaZkClient) extends Logging {
 
-  this.logIdent = "[Admin Manager on Broker " + config.brokerId + "]: "
+  this.logContext = "[Admin Manager on Broker " + config.brokerId + "]: "
 
   private val topicPurgatory = DelayedOperationPurgatory[DelayedOperation]("topic", config.brokerId)
   private val adminZkClient = new AdminZkClient(zkClient, Some(config))

--- a/core/src/main/scala/kafka/server/metadata/AclPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/AclPublisher.scala
@@ -34,7 +34,7 @@ class AclPublisher(
   nodeType: String,
   authorizer: Option[Authorizer],
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logIdent = LogContext.newBuilder(name()).build().logPrefix()
+  logIdent = LogContext.forComponent(name()).build().logPrefix()
 
   override def name(): String = s"AclPublisher $nodeType id=$nodeId"
 

--- a/core/src/main/scala/kafka/server/metadata/AclPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/AclPublisher.scala
@@ -18,6 +18,7 @@
 package kafka.server.metadata
 
 import kafka.utils.Logging
+import org.apache.kafka.common.utils.LogContext
 import org.apache.kafka.image.loader.{LoaderManifest, LoaderManifestType}
 import org.apache.kafka.image.{MetadataDelta, MetadataImage}
 import org.apache.kafka.metadata.authorizer.ClusterMetadataAuthorizer
@@ -33,7 +34,7 @@ class AclPublisher(
   nodeType: String,
   authorizer: Option[Authorizer],
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logContext = s"[${name()}] "
+  logIdent = LogContext.newBuilder(name()).build().logPrefix()
 
   override def name(): String = s"AclPublisher $nodeType id=$nodeId"
 

--- a/core/src/main/scala/kafka/server/metadata/AclPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/AclPublisher.scala
@@ -33,7 +33,7 @@ class AclPublisher(
   nodeType: String,
   authorizer: Option[Authorizer],
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logIdent = s"[${name()}] "
+  logContext = s"[${name()}] "
 
   override def name(): String = s"AclPublisher $nodeType id=$nodeId"
 

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -110,7 +110,7 @@ class BrokerMetadataPublisher(
   fatalFaultHandler: FaultHandler,
   metadataPublishingFaultHandler: FaultHandler
 ) extends MetadataPublisher with Logging {
-  logIdent = s"[BrokerMetadataPublisher id=${config.nodeId}] "
+  logContext = s"[BrokerMetadataPublisher id=${config.nodeId}] "
 
   import BrokerMetadataPublisher._
 

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -25,6 +25,7 @@ import kafka.utils.Logging
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.internals.Topic
+import org.apache.kafka.common.utils.LogContext
 import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.image.loader.LoaderManifest
 import org.apache.kafka.image.publisher.MetadataPublisher
@@ -110,7 +111,7 @@ class BrokerMetadataPublisher(
   fatalFaultHandler: FaultHandler,
   metadataPublishingFaultHandler: FaultHandler
 ) extends MetadataPublisher with Logging {
-  logContext = s"[BrokerMetadataPublisher id=${config.nodeId}] "
+  logIdent = LogContext.newBuilder("BrokerMetadataPublisher").withTag("id", config.nodeId).build().logPrefix()
 
   import BrokerMetadataPublisher._
 

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -111,7 +111,7 @@ class BrokerMetadataPublisher(
   fatalFaultHandler: FaultHandler,
   metadataPublishingFaultHandler: FaultHandler
 ) extends MetadataPublisher with Logging {
-  logIdent = LogContext.newBuilder("BrokerMetadataPublisher").withTag("id", config.nodeId).build().logPrefix()
+  logIdent = LogContext.forComponent("BrokerMetadataPublisher").withTag("id", config.nodeId).build().logPrefix()
 
   import BrokerMetadataPublisher._
 

--- a/core/src/main/scala/kafka/server/metadata/DelegationTokenPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DelegationTokenPublisher.scala
@@ -20,6 +20,7 @@ package kafka.server.metadata
 import kafka.server.DelegationTokenManager
 import kafka.server.KafkaConfig
 import kafka.utils.Logging
+import org.apache.kafka.common.utils.LogContext
 import org.apache.kafka.image.loader.LoaderManifest
 import org.apache.kafka.image.{MetadataDelta, MetadataImage}
 import org.apache.kafka.server.fault.FaultHandler
@@ -31,7 +32,7 @@ class DelegationTokenPublisher(
   nodeType: String,
   tokenManager: DelegationTokenManager,
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logContext = s"[${name()}] "
+  logIdent = LogContext.newBuilder(name()).build().logPrefix()
 
   var _firstPublish = true
 

--- a/core/src/main/scala/kafka/server/metadata/DelegationTokenPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DelegationTokenPublisher.scala
@@ -31,7 +31,7 @@ class DelegationTokenPublisher(
   nodeType: String,
   tokenManager: DelegationTokenManager,
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logIdent = s"[${name()}] "
+  logContext = s"[${name()}] "
 
   var _firstPublish = true
 

--- a/core/src/main/scala/kafka/server/metadata/DelegationTokenPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DelegationTokenPublisher.scala
@@ -32,7 +32,7 @@ class DelegationTokenPublisher(
   nodeType: String,
   tokenManager: DelegationTokenManager,
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logIdent = LogContext.newBuilder(name()).build().logPrefix()
+  logIdent = LogContext.forComponent(name()).build().logPrefix()
 
   var _firstPublish = true
 

--- a/core/src/main/scala/kafka/server/metadata/DynamicClientQuotaPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DynamicClientQuotaPublisher.scala
@@ -31,7 +31,7 @@ class DynamicClientQuotaPublisher(
   nodeType: String,
   clientQuotaMetadataManager: ClientQuotaMetadataManager,
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logIdent = LogContext.newBuilder(name()).build().logPrefix()
+  logIdent = LogContext.forComponent(name()).build().logPrefix()
 
   override def name(): String = s"DynamicClientQuotaPublisher $nodeType id=${conf.nodeId}"
 

--- a/core/src/main/scala/kafka/server/metadata/DynamicClientQuotaPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DynamicClientQuotaPublisher.scala
@@ -30,7 +30,7 @@ class DynamicClientQuotaPublisher(
   nodeType: String,
   clientQuotaMetadataManager: ClientQuotaMetadataManager,
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logIdent = s"[${name()}] "
+  logContext = s"[${name()}] "
 
   override def name(): String = s"DynamicClientQuotaPublisher $nodeType id=${conf.nodeId}"
 

--- a/core/src/main/scala/kafka/server/metadata/DynamicClientQuotaPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DynamicClientQuotaPublisher.scala
@@ -19,6 +19,7 @@ package kafka.server.metadata
 
 import kafka.server.KafkaConfig
 import kafka.utils.Logging
+import org.apache.kafka.common.utils.LogContext
 import org.apache.kafka.image.loader.LoaderManifest
 import org.apache.kafka.image.{MetadataDelta, MetadataImage}
 import org.apache.kafka.server.fault.FaultHandler
@@ -30,7 +31,7 @@ class DynamicClientQuotaPublisher(
   nodeType: String,
   clientQuotaMetadataManager: ClientQuotaMetadataManager,
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logContext = s"[${name()}] "
+  logIdent = LogContext.newBuilder(name()).build().logPrefix()
 
   override def name(): String = s"DynamicClientQuotaPublisher $nodeType id=${conf.nodeId}"
 

--- a/core/src/main/scala/kafka/server/metadata/DynamicConfigPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DynamicConfigPublisher.scala
@@ -22,6 +22,7 @@ import kafka.server.ConfigAdminManager.toLoggableProps
 import kafka.server.{ConfigEntityName, ConfigHandler, KafkaConfig}
 import kafka.utils.Logging
 import org.apache.kafka.common.config.ConfigResource.Type.{BROKER, CLIENT_METRICS, TOPIC}
+import org.apache.kafka.common.utils.LogContext
 import org.apache.kafka.image.loader.LoaderManifest
 import org.apache.kafka.image.{MetadataDelta, MetadataImage}
 import org.apache.kafka.server.config.ConfigType
@@ -34,7 +35,7 @@ class DynamicConfigPublisher(
   dynamicConfigHandlers: Map[String, ConfigHandler],
   nodeType: String,
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logContext = s"[${name()}] "
+  logIdent = LogContext.newBuilder(name()).build().logPrefix()
 
   override def name(): String = s"DynamicConfigPublisher $nodeType id=${conf.nodeId}"
 

--- a/core/src/main/scala/kafka/server/metadata/DynamicConfigPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DynamicConfigPublisher.scala
@@ -34,7 +34,7 @@ class DynamicConfigPublisher(
   dynamicConfigHandlers: Map[String, ConfigHandler],
   nodeType: String,
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logIdent = s"[${name()}] "
+  logContext = s"[${name()}] "
 
   override def name(): String = s"DynamicConfigPublisher $nodeType id=${conf.nodeId}"
 

--- a/core/src/main/scala/kafka/server/metadata/DynamicConfigPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/DynamicConfigPublisher.scala
@@ -35,7 +35,7 @@ class DynamicConfigPublisher(
   dynamicConfigHandlers: Map[String, ConfigHandler],
   nodeType: String,
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logIdent = LogContext.newBuilder(name()).build().logPrefix()
+  logIdent = LogContext.forComponent(name()).build().logPrefix()
 
   override def name(): String = s"DynamicConfigPublisher $nodeType id=${conf.nodeId}"
 

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -45,7 +45,7 @@ import scala.compat.java8.OptionConverters._
 
 
 class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging with ConfigRepository {
-  this.logIdent = s"[MetadataCache brokerId=$brokerId] "
+  this.logContext = s"[MetadataCache brokerId=$brokerId] "
 
   // This is the cache state. Every MetadataImage instance is immutable, and updates
   // replace this value with a completely new one. This means reads (which are not under

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -46,7 +46,7 @@ import scala.compat.java8.OptionConverters._
 
 
 class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging with ConfigRepository {
-  this.logIdent = LogContext.newBuilder("MetadataCache").withTag("brokerId", brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("MetadataCache").withTag("brokerId", brokerId).build().logPrefix()
 
   // This is the cache state. Every MetadataImage instance is immutable, and updates
   // replace this value with a completely new one. This means reads (which are not under

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -36,6 +36,7 @@ import java.util.concurrent.ThreadLocalRandom
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.message.{DescribeClientQuotasRequestData, DescribeClientQuotasResponseData}
 import org.apache.kafka.common.message.{DescribeUserScramCredentialsRequestData, DescribeUserScramCredentialsResponseData}
+import org.apache.kafka.common.utils.LogContext
 import org.apache.kafka.metadata.{BrokerRegistration, PartitionRegistration, Replicas}
 import org.apache.kafka.server.common.{Features, MetadataVersion}
 
@@ -45,7 +46,7 @@ import scala.compat.java8.OptionConverters._
 
 
 class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging with ConfigRepository {
-  this.logContext = s"[MetadataCache brokerId=$brokerId] "
+  this.logIdent = LogContext.newBuilder("MetadataCache").withTag("brokerId", brokerId).build().logPrefix()
 
   // This is the cache state. Every MetadataImage instance is immutable, and updates
   // replace this value with a completely new one. This means reads (which are not under

--- a/core/src/main/scala/kafka/server/metadata/ScramPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/ScramPublisher.scala
@@ -31,7 +31,7 @@ class ScramPublisher(
   nodeType: String,
   credentialProvider: CredentialProvider,
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logIdent = s"[${name()}] "
+  logContext = s"[${name()}] "
 
   override def name(): String = s"ScramPublisher $nodeType id=${conf.nodeId}"
 

--- a/core/src/main/scala/kafka/server/metadata/ScramPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/ScramPublisher.scala
@@ -20,6 +20,7 @@ package kafka.server.metadata
 import kafka.security.CredentialProvider
 import kafka.server.KafkaConfig
 import kafka.utils.Logging
+import org.apache.kafka.common.utils.LogContext
 import org.apache.kafka.image.loader.LoaderManifest
 import org.apache.kafka.image.{MetadataDelta, MetadataImage}
 import org.apache.kafka.server.fault.FaultHandler
@@ -31,7 +32,7 @@ class ScramPublisher(
   nodeType: String,
   credentialProvider: CredentialProvider,
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logContext = s"[${name()}] "
+  logIdent = LogContext.newBuilder(name()).build().logPrefix()
 
   override def name(): String = s"ScramPublisher $nodeType id=${conf.nodeId}"
 

--- a/core/src/main/scala/kafka/server/metadata/ScramPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/ScramPublisher.scala
@@ -32,7 +32,7 @@ class ScramPublisher(
   nodeType: String,
   credentialProvider: CredentialProvider,
 ) extends Logging with org.apache.kafka.image.publisher.MetadataPublisher {
-  logIdent = LogContext.newBuilder(name()).build().logPrefix()
+  logIdent = LogContext.forComponent(name()).build().logPrefix()
 
   override def name(): String = s"ScramPublisher $nodeType id=${conf.nodeId}"
 

--- a/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
@@ -135,7 +135,7 @@ class ZkMetadataCache(
     aliveBrokers = mutable.LongMap.empty,
     aliveNodes = mutable.LongMap.empty)
 
-  this.logIdent = LogContext.newBuilder("MetadataCache").withTag("brokerId", brokerId).build().logPrefix()
+  this.logIdent = LogContext.forComponent("MetadataCache").withTag("brokerId", brokerId).build().logPrefix()
   private val stateChangeLogger = new StateChangeLogger(brokerId, inControllerContext = false, None)
 
   // Features are updated via ZK notification (see FinalizedFeatureChangeListener)

--- a/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
@@ -134,7 +134,7 @@ class ZkMetadataCache(
     aliveBrokers = mutable.LongMap.empty,
     aliveNodes = mutable.LongMap.empty)
 
-  this.logIdent = s"[MetadataCache brokerId=$brokerId] "
+  this.logContext = s"[MetadataCache brokerId=$brokerId] "
   private val stateChangeLogger = new StateChangeLogger(brokerId, inControllerContext = false, None)
 
   // Features are updated via ZK notification (see FinalizedFeatureChangeListener)

--- a/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
@@ -40,6 +40,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractControlRequest, ApiVersionsResponse, MetadataResponse, UpdateMetadataRequest}
 import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.apache.kafka.common.utils.LogContext
 import org.apache.kafka.server.common.{Features, MetadataVersion}
 
 import java.util.concurrent.{ThreadLocalRandom, TimeUnit}
@@ -134,7 +135,7 @@ class ZkMetadataCache(
     aliveBrokers = mutable.LongMap.empty,
     aliveNodes = mutable.LongMap.empty)
 
-  this.logContext = s"[MetadataCache brokerId=$brokerId] "
+  this.logIdent = LogContext.newBuilder("MetadataCache").withTag("brokerId", brokerId).build().logPrefix()
   private val stateChangeLogger = new StateChangeLogger(brokerId, inControllerContext = false, None)
 
   // Features are updated via ZK notification (see FinalizedFeatureChangeListener)

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -191,7 +191,7 @@ object MirrorMaker extends Logging {
     private val shutdownLatch: CountDownLatch = new CountDownLatch(1)
     private var lastOffsetCommitMs = System.currentTimeMillis()
     @volatile private var shuttingDown: Boolean = false
-    this.logIdent = "[%s] ".format(threadName)
+    this.logContext = "[%s] ".format(threadName)
 
     setName(threadName)
 

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -191,7 +191,7 @@ object MirrorMaker extends Logging {
     private val shutdownLatch: CountDownLatch = new CountDownLatch(1)
     private var lastOffsetCommitMs = System.currentTimeMillis()
     @volatile private var shuttingDown: Boolean = false
-    this.logIdent = LogContext.newBuilder("MirrorMaker").withTag("threadName", threadName).build().logPrefix()
+    this.logIdent = LogContext.forComponent("MirrorMaker").withTag("threadName", threadName).build().logPrefix()
 
     setName(threadName)
 

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, Produce
 import org.apache.kafka.common.errors.{TimeoutException, WakeupException}
 import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer}
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{LogContext, Time, Utils}
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.{CommandDefaultOptions, CommandLineUtils}
@@ -191,7 +191,7 @@ object MirrorMaker extends Logging {
     private val shutdownLatch: CountDownLatch = new CountDownLatch(1)
     private var lastOffsetCommitMs = System.currentTimeMillis()
     @volatile private var shuttingDown: Boolean = false
-    this.logContext = "[%s] ".format(threadName)
+    this.logIdent = LogContext.newBuilder("MirrorMaker").withTag("threadName", threadName).build().logPrefix()
 
     setName(threadName)
 

--- a/core/src/main/scala/kafka/utils/Logging.scala
+++ b/core/src/main/scala/kafka/utils/Logging.scala
@@ -18,7 +18,6 @@
 package kafka.utils
 
 import com.typesafe.scalalogging.Logger
-import org.apache.kafka.common.utils.LogContext
 import org.slf4j.{LoggerFactory, Marker, MarkerFactory}
 
 
@@ -41,16 +40,16 @@ private object Logging {
 
 trait Logging {
 
-  protected lazy val logger: Logger = Logger(LoggerFactory.getLogger(loggerName))
+  protected lazy val logger = Logger(LoggerFactory.getLogger(loggerName))
 
-  protected var logContext: LogContext = _
+  protected var logIdent: String = _
 
   Log4jControllerRegistration
 
   protected def loggerName: String = getClass.getName
 
   protected def msgWithLogIdent(msg: String): String =
-    if (logContext == null) msg else logContext + msg
+    if (logIdent == null) msg else logIdent + msg
 
   def trace(msg: => String): Unit = logger.trace(msgWithLogIdent(msg))
 

--- a/core/src/main/scala/kafka/utils/Logging.scala
+++ b/core/src/main/scala/kafka/utils/Logging.scala
@@ -18,6 +18,7 @@
 package kafka.utils
 
 import com.typesafe.scalalogging.Logger
+import org.apache.kafka.common.utils.LogContext
 import org.slf4j.{LoggerFactory, Marker, MarkerFactory}
 
 
@@ -40,16 +41,16 @@ private object Logging {
 
 trait Logging {
 
-  protected lazy val logger = Logger(LoggerFactory.getLogger(loggerName))
+  protected lazy val logger: Logger = Logger(LoggerFactory.getLogger(loggerName))
 
-  protected var logIdent: String = _
+  protected var logContext: LogContext = _
 
   Log4jControllerRegistration
 
   protected def loggerName: String = getClass.getName
 
   protected def msgWithLogIdent(msg: String): String =
-    if (logIdent == null) msg else logIdent + msg
+    if (logContext == null) msg else logContext + msg
 
   def trace(msg: => String): Unit = logger.trace(msgWithLogIdent(msg))
 

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -72,7 +72,7 @@ class ZooKeeperClient(connectString: String,
   }
 
 
-  this.logIdent = LogContext.newBuilder("ZooKeeperClient").withTag("clientName", name).build().logPrefix()
+  this.logIdent = LogContext.forComponent("ZooKeeperClient").withTag("clientName", name).build().logPrefix()
   private val initializationLock = new ReentrantReadWriteLock()
   private val isConnectedOrExpiredLock = new ReentrantLock()
   private val isConnectedOrExpiredCondition = isConnectedOrExpiredLock.newCondition()

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -72,7 +72,7 @@ class ZooKeeperClient(connectString: String,
   }
 
 
-  this.logIdent = s"[ZooKeeperClient $name] "
+  this.logContext = s"[ZooKeeperClient $name] "
   private val initializationLock = new ReentrantReadWriteLock()
   private val isConnectedOrExpiredLock = new ReentrantLock()
   private val isConnectedOrExpiredCondition = isConnectedOrExpiredLock.newCondition()

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -25,7 +25,7 @@ import com.yammer.metrics.core.MetricName
 import kafka.utils.CoreUtils.{inLock, inReadLock, inWriteLock}
 import kafka.utils.Logging
 import kafka.zookeeper.ZooKeeperClient._
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.server.util.KafkaScheduler
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.zookeeper.AsyncCallback.{Children2Callback, DataCallback, StatCallback}
@@ -72,7 +72,7 @@ class ZooKeeperClient(connectString: String,
   }
 
 
-  this.logContext = s"[ZooKeeperClient $name] "
+  this.logIdent = LogContext.newBuilder("ZooKeeperClient").withTag("clientName", name).build().logPrefix()
   private val initializationLock = new ReentrantReadWriteLock()
   private val isConnectedOrExpiredLock = new ReentrantLock()
   private val isConnectedOrExpiredCondition = isConnectedOrExpiredLock.newCondition()

--- a/core/src/test/scala/kafka/server/RemoteLeaderEndPointTest.scala
+++ b/core/src/test/scala/kafka/server/RemoteLeaderEndPointTest.scala
@@ -60,7 +60,7 @@ class RemoteLeaderEndPointTest {
         val logPrefix = "remote-leader-endpoint"
         val sourceBroker: BrokerEndPoint = BrokerEndPoint(0, "localhost", 9092)
         val props = TestUtils.createBrokerConfig(sourceBroker.id, TestUtils.MockZkConnect, port = sourceBroker.port)
-        val fetchSessionHandler = new FetchSessionHandler(new LogContext(logPrefix), sourceBroker.id)
+        val fetchSessionHandler = new FetchSessionHandler(LogContext.newBuilder(logPrefix).build(), sourceBroker.id)
         val config = KafkaConfig.fromProps(props)
         blockingSend = new MockBlockingSender(offsets = new util.HashMap[TopicPartition, EpochEndOffset](),
             sourceBroker = sourceBroker, time = time)

--- a/core/src/test/scala/kafka/server/RemoteLeaderEndPointTest.scala
+++ b/core/src/test/scala/kafka/server/RemoteLeaderEndPointTest.scala
@@ -60,7 +60,7 @@ class RemoteLeaderEndPointTest {
         val logPrefix = "remote-leader-endpoint"
         val sourceBroker: BrokerEndPoint = BrokerEndPoint(0, "localhost", 9092)
         val props = TestUtils.createBrokerConfig(sourceBroker.id, TestUtils.MockZkConnect, port = sourceBroker.port)
-        val fetchSessionHandler = new FetchSessionHandler(LogContext.newBuilder(logPrefix).build(), sourceBroker.id)
+        val fetchSessionHandler = new FetchSessionHandler(LogContext.forComponent(logPrefix).build(), sourceBroker.id)
         val config = KafkaConfig.fromProps(props)
         blockingSend = new MockBlockingSender(offsets = new util.HashMap[TopicPartition, EpochEndOffset](),
             sourceBroker = sourceBroker, time = time)

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -103,7 +103,11 @@ class ReplicaFetcherThreadTest {
                                          replicaMgr: ReplicaManager,
                                          quota: ReplicaQuota,
                                          leaderEndpointBlockingSend: BlockingSend): ReplicaFetcherThread = {
-    val logContext = new LogContext(s"[ReplicaFetcher replicaId=${brokerConfig.brokerId}, leaderId=${leaderEndpointBlockingSend.brokerEndPoint().id}, fetcherId=$fetcherId] ")
+    val logContext = LogContext.newBuilder("ReplicaFetcher")
+      .withTag("replicaId", brokerConfig.brokerId)
+      .withTag("leaderId", leaderEndpointBlockingSend.brokerEndPoint().id)
+      .withTag("fetcherId", fetcherId)
+      .build()
     val fetchSessionHandler = new FetchSessionHandler(logContext, leaderEndpointBlockingSend.brokerEndPoint().id)
     val leader = new RemoteLeaderEndPoint(logContext.logPrefix, leaderEndpointBlockingSend, fetchSessionHandler,
       brokerConfig, replicaMgr, quota, () => brokerConfig.interBrokerProtocolVersion, () => 1)
@@ -583,7 +587,11 @@ class ReplicaFetcherThreadTest {
 
     // Create the fetcher thread
     val mockNetwork = new MockBlockingSender(Collections.emptyMap(), brokerEndPoint, new SystemTime())
-    val logContext = new LogContext(s"[ReplicaFetcher replicaId=${config.brokerId}, leaderId=${brokerEndPoint.id}, fetcherId=0] ")
+    val logContext = LogContext.newBuilder("ReplicaFetcher")
+      .withTag("replicaId", config.brokerId)
+      .withTag("leaderId", brokerEndPoint.id)
+      .withTag("fetcherId", "0")
+      .build()
     val fetchSessionHandler = new FetchSessionHandler(logContext, brokerEndPoint.id)
     val leader = new RemoteLeaderEndPoint(logContext.logPrefix, mockNetwork, fetchSessionHandler, config,
       replicaManager, quota, () => config.interBrokerProtocolVersion, () => 1)
@@ -687,7 +695,11 @@ class ReplicaFetcherThreadTest {
     when(partition.localLogOrException).thenReturn(log)
     when(partition.appendRecordsToFollowerOrFutureReplica(any(), any())).thenReturn(None)
 
-    val logContext = new LogContext(s"[ReplicaFetcher replicaId=${config.brokerId}, leaderId=${brokerEndPoint.id}, fetcherId=0] ")
+    val logContext = LogContext.newBuilder("ReplicaFetcher")
+      .withTag("replicaId", config.brokerId)
+      .withTag("leaderId", brokerEndPoint.id)
+      .withTag("fetcherId", "0")
+      .build()
 
     val mockNetwork = new MockBlockingSender(
       Collections.emptyMap(),
@@ -780,7 +792,11 @@ class ReplicaFetcherThreadTest {
       -1L
     )))
 
-    val logContext = new LogContext(s"[ReplicaFetcher replicaId=${config.brokerId}, leaderId=${brokerEndPoint.id}, fetcherId=0] ")
+    val logContext = LogContext.newBuilder("ReplicaFetcher")
+      .withTag("replicaId", config.brokerId)
+      .withTag("leaderId", brokerEndPoint.id)
+      .withTag("fetcherId", "0")
+      .build()
 
     val mockNetwork = new MockBlockingSender(
       Collections.emptyMap(),
@@ -1219,7 +1235,11 @@ class ReplicaFetcherThreadTest {
     when(replicaQuota.isThrottled(any[TopicPartition])).thenReturn(false)
     when(log.logStartOffset).thenReturn(0)
 
-    val logContext = new LogContext(s"[ReplicaFetcher replicaId=${config.brokerId}, leaderId=${brokerEndPoint.id}, fetcherId=0] ")
+    val logContext = LogContext.newBuilder("ReplicaFetcher")
+      .withTag("replicaId", config.brokerId)
+      .withTag("leaderId", brokerEndPoint.id)
+      .withTag("fetcherId", "0")
+      .build()
     val fetchSessionHandler = new FetchSessionHandler(logContext, brokerEndPoint.id)
     val leader = new RemoteLeaderEndPoint(logContext.logPrefix, mockBlockingSend, fetchSessionHandler, config,
       replicaManager, replicaQuota, () => config.interBrokerProtocolVersion, () => 1)

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -103,7 +103,7 @@ class ReplicaFetcherThreadTest {
                                          replicaMgr: ReplicaManager,
                                          quota: ReplicaQuota,
                                          leaderEndpointBlockingSend: BlockingSend): ReplicaFetcherThread = {
-    val logContext = LogContext.newBuilder("ReplicaFetcher")
+    val logContext = LogContext.forComponent("ReplicaFetcher")
       .withTag("replicaId", brokerConfig.brokerId)
       .withTag("leaderId", leaderEndpointBlockingSend.brokerEndPoint().id)
       .withTag("fetcherId", fetcherId)
@@ -587,7 +587,7 @@ class ReplicaFetcherThreadTest {
 
     // Create the fetcher thread
     val mockNetwork = new MockBlockingSender(Collections.emptyMap(), brokerEndPoint, new SystemTime())
-    val logContext = LogContext.newBuilder("ReplicaFetcher")
+    val logContext = LogContext.forComponent("ReplicaFetcher")
       .withTag("replicaId", config.brokerId)
       .withTag("leaderId", brokerEndPoint.id)
       .withTag("fetcherId", "0")
@@ -695,7 +695,7 @@ class ReplicaFetcherThreadTest {
     when(partition.localLogOrException).thenReturn(log)
     when(partition.appendRecordsToFollowerOrFutureReplica(any(), any())).thenReturn(None)
 
-    val logContext = LogContext.newBuilder("ReplicaFetcher")
+    val logContext = LogContext.forComponent("ReplicaFetcher")
       .withTag("replicaId", config.brokerId)
       .withTag("leaderId", brokerEndPoint.id)
       .withTag("fetcherId", "0")
@@ -792,7 +792,7 @@ class ReplicaFetcherThreadTest {
       -1L
     )))
 
-    val logContext = LogContext.newBuilder("ReplicaFetcher")
+    val logContext = LogContext.forComponent("ReplicaFetcher")
       .withTag("replicaId", config.brokerId)
       .withTag("leaderId", brokerEndPoint.id)
       .withTag("fetcherId", "0")
@@ -1235,7 +1235,7 @@ class ReplicaFetcherThreadTest {
     when(replicaQuota.isThrottled(any[TopicPartition])).thenReturn(false)
     when(log.logStartOffset).thenReturn(0)
 
-    val logContext = LogContext.newBuilder("ReplicaFetcher")
+    val logContext = LogContext.forComponent("ReplicaFetcher")
       .withTag("replicaId", config.brokerId)
       .withTag("leaderId", brokerEndPoint.id)
       .withTag("fetcherId", "0")

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -2912,7 +2912,7 @@ class ReplicaManagerTest {
         new ReplicaFetcherManager(this.config, rm, metrics, time, threadNamePrefix, replicationQuotaManager, () => this.metadataCache.metadataVersion(), () => 1) {
 
           override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): ReplicaFetcherThread = {
-            val logContext = LogContext.newBuilder("ReplicaFetcher")
+            val logContext = LogContext.forComponent("ReplicaFetcher")
               .withTag("replicaId", rm.config.brokerId)
               .withTag("leaderId", sourceBroker.id)
               .withTag("fetcherId", fetcherId)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -2912,8 +2912,11 @@ class ReplicaManagerTest {
         new ReplicaFetcherManager(this.config, rm, metrics, time, threadNamePrefix, replicationQuotaManager, () => this.metadataCache.metadataVersion(), () => 1) {
 
           override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): ReplicaFetcherThread = {
-            val logContext = new LogContext(s"[ReplicaFetcher replicaId=${rm.config.brokerId}, leaderId=${sourceBroker.id}, " +
-              s"fetcherId=$fetcherId] ")
+            val logContext = LogContext.newBuilder("ReplicaFetcher")
+              .withTag("replicaId", rm.config.brokerId)
+              .withTag("leaderId", sourceBroker.id)
+              .withTag("fetcherId", fetcherId)
+              .build()
             val fetchSessionHandler = new FetchSessionHandler(logContext, sourceBroker.id)
             val leader = new RemoteLeaderEndPoint(logContext.logPrefix, blockingSend, fetchSessionHandler, rm.config,
               rm, quotaManager.follower, () => rm.config.interBrokerProtocolVersion, () => 1)

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -166,14 +166,14 @@ public class GroupCoordinatorService implements GroupCoordinator {
             if (groupCoordinatorMetrics == null)
                 throw new IllegalArgumentException("GroupCoordinatorMetrics must be set.");
 
-            String logPrefix = String.format("GroupCoordinator id=%d", nodeId);
-            LogContext logContext = new LogContext(String.format("[%s] ", logPrefix));
+            LogContext.Builder logContextBuilder = LogContext.newBuilder("GroupCoordinator")
+                .withTag("id", nodeId);
 
             CoordinatorShardBuilderSupplier<GroupCoordinatorShard, Record> supplier = () ->
                 new GroupCoordinatorShard.Builder(config);
 
             CoordinatorEventProcessor processor = new MultiThreadedEventProcessor(
-                logContext,
+                logContextBuilder.build(),
                 "group-coordinator-event-processor-",
                 config.numThreads,
                 time,
@@ -184,8 +184,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
                 new CoordinatorRuntime.Builder<GroupCoordinatorShard, Record>()
                     .withTime(time)
                     .withTimer(timer)
-                    .withLogPrefix(logPrefix)
-                    .withLogContext(logContext)
+                    .withLogContextBuilder(logContextBuilder)
                     .withEventProcessor(processor)
                     .withPartitionWriter(writer)
                     .withLoader(loader)
@@ -197,7 +196,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     .build();
 
             return new GroupCoordinatorService(
-                logContext,
+                logContextBuilder.build(),
                 config,
                 runtime,
                 groupCoordinatorMetrics

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -166,7 +166,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
             if (groupCoordinatorMetrics == null)
                 throw new IllegalArgumentException("GroupCoordinatorMetrics must be set.");
 
-            LogContext.Builder logContextBuilder = LogContext.newBuilder("GroupCoordinator")
+            LogContext.Builder logContextBuilder = LogContext.forComponent("GroupCoordinator")
                 .withTag("id", nodeId);
 
             CoordinatorShardBuilderSupplier<GroupCoordinatorShard, Record> supplier = () ->

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -87,8 +87,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      * @param <U> The type of the record.
      */
     public static class Builder<S extends CoordinatorShard<U>, U> {
-        private String logPrefix;
-        private LogContext logContext;
+        private LogContext.Builder logContextBuilder;
         private CoordinatorEventProcessor eventProcessor;
         private PartitionWriter<U> partitionWriter;
         private CoordinatorLoader<U> loader;
@@ -99,13 +98,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         private CoordinatorRuntimeMetrics runtimeMetrics;
         private CoordinatorMetrics coordinatorMetrics;
 
-        public Builder<S, U> withLogPrefix(String logPrefix) {
-            this.logPrefix = logPrefix;
-            return this;
-        }
-
-        public Builder<S, U> withLogContext(LogContext logContext) {
-            this.logContext = logContext;
+        public Builder<S, U> withLogContextBuilder(LogContext.Builder logContextBuilder) {
+            this.logContextBuilder = logContextBuilder;
             return this;
         }
 
@@ -155,10 +149,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         }
 
         public CoordinatorRuntime<S, U> build() {
-            if (logPrefix == null)
-                logPrefix = "";
-            if (logContext == null)
-                logContext = new LogContext(logPrefix);
+            if (logContextBuilder == null)
+                logContextBuilder = LogContext.newBuilder("CoordinatorRuntime");
             if (eventProcessor == null)
                 throw new IllegalArgumentException("Event processor must be set.");
             if (partitionWriter == null)
@@ -177,8 +169,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 throw new IllegalArgumentException("CoordinatorMetrics must be set.");
 
             return new CoordinatorRuntime<>(
-                logPrefix,
-                logContext,
+                logContextBuilder,
                 eventProcessor,
                 partitionWriter,
                 loader,
@@ -446,11 +437,10 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         ) {
             this.lock = new ReentrantLock();
             this.tp = tp;
-            this.logContext = new LogContext(String.format("[%s topic=%s partition=%d] ",
-                logPrefix,
-                tp.topic(),
-                tp.partition()
-            ));
+            this.logContext = logContextBuilder
+                .withTag("topic", tp.topic())
+                .withTag("partition", tp.partition())
+                .build();
             this.state = CoordinatorState.INITIAL;
             this.epoch = -1;
             this.deferredEventQueue = new DeferredEventQueue(logContext);
@@ -1186,14 +1176,9 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
     }
 
     /**
-     * The log prefix.
-     */
-    private final String logPrefix;
-
-    /**
      * The log context.
      */
-    private final LogContext logContext;
+    private final LogContext.Builder logContextBuilder;
 
     /**
      * The logger.
@@ -1270,8 +1255,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
     /**
      * Constructor.
      *
-     * @param logPrefix                         The log prefix.
-     * @param logContext                        The log context.
+     * @param logContextBuilder                 The log context builder.
      * @param processor                         The event processor.
      * @param partitionWriter                   The partition writer.
      * @param loader                            The coordinator loader.
@@ -1281,8 +1265,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      * @param defaultWriteTimeout               The write operation timeout.
      */
     private CoordinatorRuntime(
-        String logPrefix,
-        LogContext logContext,
+        LogContext.Builder logContextBuilder,
         CoordinatorEventProcessor processor,
         PartitionWriter<U> partitionWriter,
         CoordinatorLoader<U> loader,
@@ -1293,9 +1276,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         CoordinatorRuntimeMetrics runtimeMetrics,
         CoordinatorMetrics coordinatorMetrics
     ) {
-        this.logPrefix = logPrefix;
-        this.logContext = logContext;
-        this.log = logContext.logger(CoordinatorRuntime.class);
+        this.logContextBuilder = logContextBuilder;
+        this.log = logContextBuilder.build().logger(CoordinatorRuntime.class);
         this.time = time;
         this.timer = timer;
         this.defaultWriteTimeout = defaultWriteTimeout;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -150,7 +150,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
 
         public CoordinatorRuntime<S, U> build() {
             if (logContextBuilder == null)
-                logContextBuilder = LogContext.newBuilder("CoordinatorRuntime");
+                logContextBuilder = LogContext.forComponent("CoordinatorRuntime");
             if (eventProcessor == null)
                 throw new IllegalArgumentException("Event processor must be set.");
             if (partitionWriter == null)

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
@@ -121,7 +121,7 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
             String name
         ) {
             super(name);
-            log = new LogContext("[" + name + "]: ").logger(EventProcessorThread.class);
+            log = LogContext.newBuilder(name).build().logger(EventProcessorThread.class);
             setDaemon(false);
         }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
@@ -121,7 +121,7 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
             String name
         ) {
             super(name);
-            log = LogContext.newBuilder(name).build().logger(EventProcessorThread.class);
+            log = LogContext.forComponent(name).build().logger(EventProcessorThread.class);
             setDaemon(false);
         }
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -291,7 +291,7 @@ public class ReplicaFetcherThreadBenchmark {
 
 
     static class ReplicaFetcherBenchThread extends ReplicaFetcherThread {
-        private static final LogContext.Builder LOG_CONTEXT_BUILDER = LogContext.newBuilder("ReplicaFetcher")
+        private static final LogContext.Builder LOG_CONTEXT_BUILDER = LogContext.forComponent("ReplicaFetcher")
             .withTag("leaderId", "3")
             .withTag("fetcherId", "3");
         private final Pool<TopicPartition, Partition> pool;

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -291,6 +291,9 @@ public class ReplicaFetcherThreadBenchmark {
 
 
     static class ReplicaFetcherBenchThread extends ReplicaFetcherThread {
+        private static final LogContext.Builder LOG_CONTEXT_BUILDER = LogContext.newBuilder("ReplicaFetcher")
+            .withTag("leaderId", "3")
+            .withTag("fetcherId", "3");
         private final Pool<TopicPartition, Partition> pool;
 
         ReplicaFetcherBenchThread(KafkaConfig config,
@@ -300,7 +303,7 @@ public class ReplicaFetcherThreadBenchmark {
                                   Partition> partitions) {
             super("name",
                     new RemoteLeaderEndPoint(
-                            String.format("[ReplicaFetcher replicaId=%d, leaderId=%d, fetcherId=%d", config.brokerId(), 3, 3),
+                            LOG_CONTEXT_BUILDER.withTag("replicaId", config.brokerId()).build().logPrefix(),
                             new BrokerBlockingSender(
                                     new BrokerEndPoint(3, "host", 3000),
                                     config,
@@ -308,10 +311,9 @@ public class ReplicaFetcherThreadBenchmark {
                                     Time.SYSTEM,
                                     3,
                                     String.format("broker-%d-fetcher-%d", 3, 3),
-                                    new LogContext(String.format("[ReplicaFetcher replicaId=%d, leaderId=%d, fetcherId=%d", config.brokerId(), 3, 3))
+                                    LOG_CONTEXT_BUILDER.withTag("replicaId", config.brokerId()).build()
                             ),
-                            new FetchSessionHandler(
-                                    new LogContext(String.format("[ReplicaFetcher replicaId=%d, leaderId=%d, fetcherId=%d", config.brokerId(), 3, 3)), 3),
+                            new FetchSessionHandler(LOG_CONTEXT_BUILDER.withTag("replicaId", config.brokerId()).build(), 3),
                             config,
                             replicaManager,
                             replicaQuota,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetchsession/FetchSessionBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetchsession/FetchSessionBenchmark.java
@@ -54,7 +54,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class FetchSessionBenchmark {
-    private static final LogContext LOG_CONTEXT = new LogContext("[BenchFetchSessionHandler]=");
+    private static final LogContext LOG_CONTEXT = LogContext.newBuilder("BenchFetchSessionHandler").build();
 
     @Param(value = {"10", "100", "1000"})
     private int partitionCount;

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetchsession/FetchSessionBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetchsession/FetchSessionBenchmark.java
@@ -54,7 +54,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class FetchSessionBenchmark {
-    private static final LogContext LOG_CONTEXT = LogContext.newBuilder("BenchFetchSessionHandler").build();
+    private static final LogContext LOG_CONTEXT = LogContext.forComponent("BenchFetchSessionHandler").build();
 
     @Param(value = {"10", "100", "1000"})
     private int partitionCount;

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -397,7 +397,7 @@ public final class QuorumController implements Controller {
                 threadNamePrefix = String.format("quorum-controller-%d-", nodeId);
             }
             if (logContext == null) {
-                logContext = new LogContext(String.format("[QuorumController id=%d] ", nodeId));
+                logContext = LogContext.newBuilder("QuorumController").withTag("id", nodeId).build();
             }
             if (controllerMetrics == null) {
                 controllerMetrics = new QuorumControllerMetrics(Optional.empty(), time, zkMigrationEnabled);

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -397,7 +397,7 @@ public final class QuorumController implements Controller {
                 threadNamePrefix = String.format("quorum-controller-%d-", nodeId);
             }
             if (logContext == null) {
-                logContext = LogContext.newBuilder("QuorumController").withTag("id", nodeId).build();
+                logContext = LogContext.forComponent("QuorumController").withTag("id", nodeId).build();
             }
             if (controllerMetrics == null) {
                 controllerMetrics = new QuorumControllerMetrics(Optional.empty(), time, zkMigrationEnabled);

--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -108,7 +108,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
 
         public MetadataLoader build() {
             if (logContext == null) {
-                logContext = LogContext.newBuilder("MetadataLoader").withTag("id", nodeId).build();
+                logContext = LogContext.forComponent("MetadataLoader").withTag("id", nodeId).build();
             }
             if (highWaterMarkAccessor == null) {
                 throw new RuntimeException("You must set the high water mark accessor.");

--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -108,7 +108,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
 
         public MetadataLoader build() {
             if (logContext == null) {
-                logContext = new LogContext("[MetadataLoader id=" + nodeId + "] ");
+                logContext = LogContext.newBuilder("MetadataLoader").withTag("id", nodeId).build();
             }
             if (highWaterMarkAccessor == null) {
                 throw new RuntimeException("You must set the high water mark accessor.");

--- a/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotEmitter.java
+++ b/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotEmitter.java
@@ -122,7 +122,10 @@ public class SnapshotEmitter implements SnapshotGenerator.Emitter {
         SnapshotEmitterMetrics metrics
     ) {
         this.time = time;
-        this.log = new LogContext("[SnapshotEmitter id=" + nodeId + "] ").logger(SnapshotEmitter.class);
+        this.log = LogContext.newBuilder("SnapshotEmitter")
+            .withTag("id", nodeId)
+            .build()
+            .logger(SnapshotEmitter.class);
         this.raftClient = raftClient;
         this.batchSize = batchSize;
         this.metrics = metrics;

--- a/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotEmitter.java
+++ b/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotEmitter.java
@@ -122,7 +122,7 @@ public class SnapshotEmitter implements SnapshotGenerator.Emitter {
         SnapshotEmitterMetrics metrics
     ) {
         this.time = time;
-        this.log = LogContext.newBuilder("SnapshotEmitter")
+        this.log = LogContext.forComponent("SnapshotEmitter")
             .withTag("id", nodeId)
             .build()
             .logger(SnapshotEmitter.class);

--- a/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotGenerator.java
@@ -190,7 +190,9 @@ public class SnapshotGenerator implements MetadataPublisher {
         this.faultHandler = faultHandler;
         this.maxBytesSinceLastSnapshot = maxBytesSinceLastSnapshot;
         this.maxTimeSinceLastSnapshotNs = maxTimeSinceLastSnapshotNs;
-        LogContext logContext = new LogContext("[SnapshotGenerator id=" + nodeId + "] ");
+        LogContext logContext = LogContext.newBuilder("SnapshotGenerator")
+            .withTag("id", nodeId)
+            .build();
         this.log = logContext.logger(SnapshotGenerator.class);
         this.disabledReason = disabledReason;
         this.eventQueue = new KafkaEventQueue(time, logContext, threadNamePrefix + "snapshot-generator-");

--- a/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotGenerator.java
@@ -190,7 +190,7 @@ public class SnapshotGenerator implements MetadataPublisher {
         this.faultHandler = faultHandler;
         this.maxBytesSinceLastSnapshot = maxBytesSinceLastSnapshot;
         this.maxTimeSinceLastSnapshotNs = maxTimeSinceLastSnapshotNs;
-        LogContext logContext = LogContext.newBuilder("SnapshotGenerator")
+        LogContext logContext = LogContext.forComponent("SnapshotGenerator")
             .withTag("id", nodeId)
             .build();
         this.log = logContext.logger(SnapshotGenerator.class);

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -111,7 +111,7 @@ public class StandardAuthorizerData {
 
 
     private static Logger createLogger(int nodeId) {
-        return LogContext.newBuilder("StandardAuthorizer")
+        return LogContext.forComponent("StandardAuthorizer")
             .withTag("nodeId", nodeId)
             .build()
             .logger(StandardAuthorizerData.class);

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -111,7 +111,10 @@ public class StandardAuthorizerData {
 
 
     private static Logger createLogger(int nodeId) {
-        return new LogContext("[StandardAuthorizer " + nodeId + "] ").logger(StandardAuthorizerData.class);
+        return LogContext.newBuilder("StandardAuthorizer")
+            .withTag("nodeId", nodeId)
+            .build()
+            .logger(StandardAuthorizerData.class);
     }
 
     private static Logger auditLogger() {

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
@@ -132,7 +132,7 @@ public class KRaftMigrationDriver implements MetadataPublisher {
         this.zkMigrationClient = zkMigrationClient;
         this.propagator = propagator;
         this.time = time;
-        LogContext logContext = LogContext.newBuilder("KRaftMigrationDriver").withTag("id", nodeId).build();
+        LogContext logContext = LogContext.forComponent("KRaftMigrationDriver").withTag("id", nodeId).build();
         this.controllerMetrics = controllerMetrics;
         this.log = logContext.logger(KRaftMigrationDriver.class);
         this.migrationState = MigrationDriverState.UNINITIALIZED;

--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
@@ -132,7 +132,7 @@ public class KRaftMigrationDriver implements MetadataPublisher {
         this.zkMigrationClient = zkMigrationClient;
         this.propagator = propagator;
         this.time = time;
-        LogContext logContext = new LogContext("[KRaftMigrationDriver id=" + nodeId + "] ");
+        LogContext logContext = LogContext.newBuilder("KRaftMigrationDriver").withTag("id", nodeId).build();
         this.controllerMetrics = controllerMetrics;
         this.log = logContext.logger(KRaftMigrationDriver.class);
         this.migrationState = MigrationDriverState.UNINITIALIZED;

--- a/metadata/src/main/java/org/apache/kafka/metadata/util/SnapshotFileReader.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/util/SnapshotFileReader.java
@@ -67,7 +67,7 @@ public final class SnapshotFileReader implements AutoCloseable {
         this.listener = listener;
         this.queue = new KafkaEventQueue(
             Time.SYSTEM,
-            LogContext.newBuilder("SnapshotReaderQueue").build(),
+            LogContext.forComponent("SnapshotReaderQueue").build(),
             "snapshotReaderQueue_",
             new ShutdownEvent()
         );

--- a/metadata/src/main/java/org/apache/kafka/metadata/util/SnapshotFileReader.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/util/SnapshotFileReader.java
@@ -65,8 +65,12 @@ public final class SnapshotFileReader implements AutoCloseable {
     public SnapshotFileReader(String snapshotPath, RaftClient.Listener<ApiMessageAndVersion> listener) {
         this.snapshotPath = snapshotPath;
         this.listener = listener;
-        this.queue = new KafkaEventQueue(Time.SYSTEM,
-            new LogContext("[snapshotReaderQueue] "), "snapshotReaderQueue_", new ShutdownEvent());
+        this.queue = new KafkaEventQueue(
+            Time.SYSTEM,
+            LogContext.newBuilder("SnapshotReaderQueue").build(),
+            "snapshotReaderQueue_",
+            new ShutdownEvent()
+        );
         this.caughtUpFuture = new CompletableFuture<>();
     }
 

--- a/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManagerTestEnv.java
+++ b/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManagerTestEnv.java
@@ -124,7 +124,7 @@ public class LocalLogManagerTestEnv implements AutoCloseable {
         try {
             for (int nodeId = 0; nodeId < numManagers; nodeId++) {
                 newLogManagers.add(new LocalLogManager(
-                    LogContext.newBuilder("LocalLogManager").withTag("id", nodeId).build(),
+                    LogContext.forComponent("LocalLogManager").withTag("id", nodeId).build(),
                     nodeId,
                     shared,
                     String.format("LocalLogManager-%d_", nodeId)));

--- a/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManagerTestEnv.java
+++ b/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManagerTestEnv.java
@@ -124,7 +124,7 @@ public class LocalLogManagerTestEnv implements AutoCloseable {
         try {
             for (int nodeId = 0; nodeId < numManagers; nodeId++) {
                 newLogManagers.add(new LocalLogManager(
-                    new LogContext(String.format("[LocalLogManager %d] ", nodeId)),
+                    LogContext.newBuilder("LocalLogManager").withTag("id", nodeId).build(),
                     nodeId,
                     shared,
                     String.format("LocalLogManager-%d_", nodeId)));

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -515,7 +515,7 @@ public class RaftEventSimulationTest {
             log = new MockLog(
                 METADATA_PARTITION,
                 Uuid.METADATA_TOPIC_ID,
-                LogContext.newBuilder("Node").withTag("id", nodeId).build()
+                LogContext.forComponent("Node").withTag("id", nodeId).build()
             );
         }
     }
@@ -713,7 +713,7 @@ public class RaftEventSimulationTest {
         }
 
         void start(int nodeId) {
-            LogContext logContext = LogContext.newBuilder("Node").withTag("id", nodeId).build();
+            LogContext logContext = LogContext.forComponent("Node").withTag("id", nodeId).build();
             PersistentState persistentState = nodes.get(nodeId);
             MockNetworkChannel channel = new MockNetworkChannel(correlationIdCounter, voters);
             MockMessageQueue messageQueue = new MockMessageQueue();

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -515,7 +515,7 @@ public class RaftEventSimulationTest {
             log = new MockLog(
                 METADATA_PARTITION,
                 Uuid.METADATA_TOPIC_ID,
-                new LogContext(String.format("[Node %s] ", nodeId))
+                LogContext.newBuilder("Node").withTag("id", nodeId).build()
             );
         }
     }
@@ -713,7 +713,7 @@ public class RaftEventSimulationTest {
         }
 
         void start(int nodeId) {
-            LogContext logContext = new LogContext("[Node " + nodeId + "] ");
+            LogContext logContext = LogContext.newBuilder("Node").withTag("id", nodeId).build();
             PersistentState persistentState = nodes.get(nodeId);
             MockNetworkChannel channel = new MockNetworkChannel(correlationIdCounter, voters);
             MockMessageQueue messageQueue = new MockMessageQueue();

--- a/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
@@ -69,7 +69,7 @@ public class KafkaRaftMetricsTest {
             fetchTimeoutMs,
             new MockQuorumStateStore(),
             time,
-            new LogContext("kafka-raft-metrics-test"),
+            LogContext.newBuilder("kafka-raft-metrics-test").build(),
             random
         );
     }

--- a/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
@@ -69,7 +69,7 @@ public class KafkaRaftMetricsTest {
             fetchTimeoutMs,
             new MockQuorumStateStore(),
             time,
-            LogContext.newBuilder("kafka-raft-metrics-test").build(),
+            LogContext.forComponent("kafka-raft-metrics-test").build(),
             random
         );
     }

--- a/server-common/src/main/java/org/apache/kafka/server/util/ShutdownableThread.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/ShutdownableThread.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 public abstract class ShutdownableThread extends Thread {
 
-    public final String logPrefix;
+    public final LogContext logContext;
 
     protected final Logger log;
 
@@ -43,15 +43,15 @@ public abstract class ShutdownableThread extends Thread {
     }
 
     public ShutdownableThread(String name, boolean isInterruptible) {
-        this(name, isInterruptible, "[" + name + "]: ");
+        this(name, isInterruptible, LogContext.newBuilder(name).build());
     }
 
     @SuppressWarnings("this-escape")
-    public ShutdownableThread(String name, boolean isInterruptible, String logPrefix) {
+    public ShutdownableThread(String name, boolean isInterruptible, LogContext logContext) {
         super(name);
         this.isInterruptible = isInterruptible;
-        this.logPrefix = logPrefix;
-        log = new LogContext(logPrefix).logger(this.getClass());
+        this.logContext = logContext;
+        log = logContext.logger(this.getClass());
         this.setDaemon(false);
     }
 

--- a/server-common/src/main/java/org/apache/kafka/server/util/ShutdownableThread.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/ShutdownableThread.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 public abstract class ShutdownableThread extends Thread {
 
-    public final LogContext logContext;
+    public final String logPrefix;
 
     protected final Logger log;
 
@@ -43,15 +43,15 @@ public abstract class ShutdownableThread extends Thread {
     }
 
     public ShutdownableThread(String name, boolean isInterruptible) {
-        this(name, isInterruptible, LogContext.newBuilder(name).build());
+        this(name, isInterruptible, "[" + name + "]: ");
     }
 
     @SuppressWarnings("this-escape")
-    public ShutdownableThread(String name, boolean isInterruptible, LogContext logContext) {
+    public ShutdownableThread(String name, boolean isInterruptible, String logPrefix) {
         super(name);
         this.isInterruptible = isInterruptible;
-        this.logContext = logContext;
-        log = logContext.logger(this.getClass());
+        this.logPrefix = logPrefix;
+        log = new LogContext(logPrefix).logger(this.getClass());
         this.setDaemon(false);
     }
 

--- a/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
@@ -51,8 +51,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.metadata.AssignmentsHelper.buildRequestData;
-
 public class AssignmentsManager {
 
     private static final Logger log = LoggerFactory.getLogger(AssignmentsManager.class);
@@ -96,7 +94,7 @@ public class AssignmentsManager {
         this.brokerId = brokerId;
         this.brokerEpochSupplier = brokerEpochSupplier;
         this.eventQueue = new KafkaEventQueue(time,
-                LogContext.newBuilder("AssignmentsManager").withTag("id", brokerId).build(),
+                LogContext.forComponent("AssignmentsManager").withTag("id", brokerId).build(),
                 "broker-" + brokerId + "-directory-assignments-manager-",
                 new ShutdownEvent());
         channelManager.start();

--- a/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
@@ -96,7 +96,7 @@ public class AssignmentsManager {
         this.brokerId = brokerId;
         this.brokerEpochSupplier = brokerEpochSupplier;
         this.eventQueue = new KafkaEventQueue(time,
-                new LogContext("[AssignmentsManager id=" + brokerId + "]"),
+                LogContext.newBuilder("AssignmentsManager").withTag("id", brokerId).build(),
                 "broker-" + brokerId + "-directory-assignments-manager-",
                 new ShutdownEvent());
         channelManager.start();

--- a/storage/src/main/java/org/apache/kafka/storage/internals/epoch/LeaderEpochFileCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/epoch/LeaderEpochFileCache.java
@@ -60,7 +60,9 @@ public class LeaderEpochFileCache {
     public LeaderEpochFileCache(TopicPartition topicPartition, LeaderEpochCheckpoint checkpoint) {
         this.checkpoint = checkpoint;
         this.topicPartition = topicPartition;
-        LogContext logContext = new LogContext("[LeaderEpochCache " + topicPartition + "] ");
+        LogContext logContext = LogContext.newBuilder("LeaderEpochCache")
+            .withTag("partition", topicPartition)
+            .build();
         log = logContext.logger(LeaderEpochFileCache.class);
         checkpoint.read().forEach(this::assign);
     }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/epoch/LeaderEpochFileCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/epoch/LeaderEpochFileCache.java
@@ -60,7 +60,7 @@ public class LeaderEpochFileCache {
     public LeaderEpochFileCache(TopicPartition topicPartition, LeaderEpochCheckpoint checkpoint) {
         this.checkpoint = checkpoint;
         this.topicPartition = topicPartition;
-        LogContext logContext = LogContext.newBuilder("LeaderEpochCache")
+        LogContext logContext = LogContext.forComponent("LeaderEpochCache")
             .withTag("partition", topicPartition)
             .build();
         log = logContext.logger(LeaderEpochFileCache.class);

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -141,7 +141,10 @@ public class ProducerStateManager {
         this.maxTransactionTimeoutMs = maxTransactionTimeoutMs;
         this.producerStateManagerConfig = producerStateManagerConfig;
         this.time = time;
-        log = new LogContext("[ProducerStateManager partition=" + topicPartition + "] ").logger(ProducerStateManager.class);
+        log = LogContext.newBuilder("ProducerStateManager")
+            .withTag("partition", topicPartition)
+            .build()
+            .logger(ProducerStateManager.class);
         snapshots = loadSnapshots();
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -141,7 +141,7 @@ public class ProducerStateManager {
         this.maxTransactionTimeoutMs = maxTransactionTimeoutMs;
         this.producerStateManagerConfig = producerStateManagerConfig;
         this.time = time;
-        log = LogContext.newBuilder("ProducerStateManager")
+        log = LogContext.forComponent("ProducerStateManager")
             .withTag("partition", topicPartition)
             .build()
             .logger(ProducerStateManager.class);

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageThreadPool.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteStorageThreadPool.java
@@ -45,7 +45,7 @@ public class RemoteStorageThreadPool extends ThreadPoolExecutor {
         logger = new LogContext() {
             @Override
             public String logPrefix() {
-                return "[" + Thread.currentThread().getName() + "]";
+                return "[" + Thread.currentThread().getName() + "] ";
             }
         }.logger(RemoteStorageThreadPool.class);
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorage.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorage.java
@@ -241,7 +241,10 @@ public final class LocalTieredStorage implements RemoteStorageManager {
         }
 
         brokerId = brokerIdInt;
-        logger = new LogContext(format("[LocalTieredStorage Id=%d] ", brokerId)).logger(this.getClass());
+        logger = LogContext.newBuilder("LocalTieredStorage")
+            .withTag("id", brokerId)
+            .build()
+            .logger(this.getClass());
 
         if (shouldDeleteOnClose != null) {
             deleteOnClose = Boolean.parseBoolean(shouldDeleteOnClose);

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorage.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorage.java
@@ -241,7 +241,7 @@ public final class LocalTieredStorage implements RemoteStorageManager {
         }
 
         brokerId = brokerIdInt;
-        logger = LogContext.newBuilder("LocalTieredStorage")
+        logger = LogContext.forComponent("LocalTieredStorage")
             .withTag("id", brokerId)
             .build()
             .logger(this.getClass());


### PR DESCRIPTION
By not having a space after closing the custom prefix, logs end up in the wrong format and potentially break log parsing tools.