### PR TITLE
MINOR: Log when remote fetch execution is rejected

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1263,6 +1263,7 @@ class ReplicaManager(val config: KafkaConfig,
     } catch {
       case e: RejectedExecutionException =>
         // Return the error if any in scheduling the remote fetch task
+        warn("Unable to fetch data from remote storage", e)
         return Some(createLogReadResult(e))
     }
 


### PR DESCRIPTION
Log at warning level when remote fetch execution is rejected. This can be potentially useful to troubleshoot `UNKNOWN_SERVER_ERROR` responses for remote fetch requests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
