### PR TITLE
KAFKA-14993: Improve TransactionIndex instance handling while copying to and fetching from RSM

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1336,7 +1336,7 @@ public class RemoteLogManager implements Closeable {
         // Search in remote segments first.
         Optional<RemoteLogSegmentMetadata> nextSegmentMetadataOpt = Optional.of(segmentMetadata);
         while (nextSegmentMetadataOpt.isPresent()) {
-            Optional<TransactionIndex> txnIndexOpt = indexCache.getIndexEntry(nextSegmentMetadataOpt.get()).txnIndexOpt();
+            Optional<TransactionIndex> txnIndexOpt = nextSegmentMetadataOpt.map(metadata -> indexCache.getIndexEntry(metadata).txnIndex());
             if (txnIndexOpt.isPresent()) {
                 TxnIndexSearchResult searchResult = txnIndexOpt.get().collectAbortedTxns(startOffset, upperBoundOffset);
                 accumulator.accept(searchResult.abortedTransactions);

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1336,7 +1336,7 @@ public class RemoteLogManager implements Closeable {
         // Search in remote segments first.
         Optional<RemoteLogSegmentMetadata> nextSegmentMetadataOpt = Optional.of(segmentMetadata);
         while (nextSegmentMetadataOpt.isPresent()) {
-            Optional<TransactionIndex> txnIndexOpt = nextSegmentMetadataOpt.map(metadata -> indexCache.getIndexEntry(metadata).txnIndex());
+            Optional<TransactionIndex> txnIndexOpt = indexCache.getIndexEntry(nextSegmentMetadataOpt.get()).txnIndexOpt();
             if (txnIndexOpt.isPresent()) {
                 TxnIndexSearchResult searchResult = txnIndexOpt.get().collectAbortedTxns(startOffset, upperBoundOffset);
                 accumulator.accept(searchResult.abortedTransactions);

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteStorageManager.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteStorageManager.java
@@ -123,7 +123,7 @@ public interface RemoteStorageManager extends Configurable, Closeable {
      * Returns the index for the respective log segment of {@link RemoteLogSegmentMetadata}.
      * <p>
      * Note: The transaction index may not exist because of no transactional records.
-     * In this case, it should still return an InputStream with empty content, instead of returning {@code null}.
+     * In this case, it should throw a RemoteResourceNotFoundException, instead of returning {@code null}.
      *
      * @param remoteLogSegmentMetadata metadata about the remote log segment.
      * @param indexType                type of the index to be fetched for the segment.

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -316,9 +316,12 @@ public class RemoteIndexCache implements Closeable {
         }
         if (index == null) {
             File tmpIndexFile = new File(indexFile.getParentFile(), indexFile.getName() + RemoteIndexCache.TMP_FILE_SUFFIX);
-            try (InputStream inputStream = fetchRemoteIndex.apply(remoteLogSegmentMetadata)) {
-                if (inputStream == null) return null;
+            InputStream inputStream = fetchRemoteIndex.apply(remoteLogSegmentMetadata);
+            if (inputStream == null) return null;
+            try {
                 Files.copy(inputStream, tmpIndexFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            } finally {
+                inputStream.close();
             }
             Utils.atomicMoveWithFallback(tmpIndexFile.toPath(), indexFile.toPath(), false);
             index = readIndex.apply(indexFile);

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -386,6 +386,7 @@ public class RemoteIndexCache implements Closeable {
                 try {
                     return remoteStorageManager.fetchIndex(rlsMetadata, IndexType.TRANSACTION);
                 } catch (RemoteResourceNotFoundException e) {
+                    // Don't throw an exception since the transaction index may not exist because of no transactional records.
                     return null;
                 } catch (RemoteStorageException e) {
                     throw new KafkaException(e);
@@ -456,6 +457,7 @@ public class RemoteIndexCache implements Closeable {
 
         private final OffsetIndex offsetIndex;
         private final TimeIndex timeIndex;
+        // Transaction index is optional because it may not exist for a segment if there are no transactional records.
         private final Optional<TransactionIndex> txnIndexOpt;
 
         // This lock is used to synchronize cleanup methods and read methods. This ensures that cleanup (which changes the

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorage.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorage.java
@@ -26,7 +26,6 @@ import org.apache.kafka.test.TestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -381,8 +380,14 @@ public final class LocalTieredStorage implements RemoteStorageManager {
                 final RemoteLogSegmentFileset fileset = openFileset(storageDirectory, metadata);
 
                 File file = fileset.getFile(fileType);
-                final InputStream inputStream = (fileType.isOptional() && !file.exists()) ?
-                        new ByteArrayInputStream(new byte[0]) : newInputStream(file.toPath(), READ);
+
+                final InputStream inputStream;
+                if (fileType.isOptional() && !file.exists()) {
+                    throw new RemoteResourceNotFoundException("Index file for type: " + indexType +
+                        " not found for segment " + metadata.remoteLogSegmentId());
+                } else {
+                    inputStream = newInputStream(file.toPath(), READ);
+                }
 
                 storageListeners.onStorageEvent(eventBuilder.withFileset(fileset).build());
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorageTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorageTest.java
@@ -70,7 +70,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import static org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType.LEADER_EPOCH;
 import static org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType.OFFSET;
@@ -347,12 +346,7 @@ public final class LocalTieredStorageTest {
         assertThrows(RemoteResourceNotFoundException.class, () -> tieredStorage.fetchIndex(metadata, TIMESTAMP));
         assertThrows(RemoteResourceNotFoundException.class, () -> tieredStorage.fetchIndex(metadata, LEADER_EPOCH));
         assertThrows(RemoteResourceNotFoundException.class, () -> tieredStorage.fetchIndex(metadata, PRODUCER_SNAPSHOT));
-
-        try {
-            assertArrayEquals(new byte[0], remoteStorageVerifier.readFully(tieredStorage.fetchIndex(metadata, TRANSACTION)));
-        } catch (Exception ex) {
-            fail("Shouldn't have thrown an exception when optional file doesn't exists in the remote store");
-        }
+        assertThrows(RemoteResourceNotFoundException.class, () -> tieredStorage.fetchIndex(metadata, TRANSACTION));
     }
 
     @Test


### PR DESCRIPTION
In this PR, we have updated the contract for RSM's fetchIndex to throw a ResourceNotFoundException if it does not have TransactionIndex, instead of returning an empty inputstream. 

Also, updated the LocalTieredStorage implementation to adhere to the new contract.

Added Unit Tests for the change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
