### PR TITLE
MINOR: Fix metadata.version reference in "ZooKeeper to KRaft Migration" documentation

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3722,7 +3722,8 @@ foo
   <pre>./bin/zookeeper-shell.sh localhost:2181 get /cluster/id</pre>
 
   <p>
-    The KRaft controller quorum should also be provisioned with the latest <code>metadata.version</code> of "3.4".
+    The KRaft controller quorum should also be provisioned with the latest <code>metadata.version</code>.
+    This is done automatically when you format the node with the <code>kafka-storage.sh</code> tool.
     For further instructions on KRaft deployment, please refer to <a href="#kraft_config">the above documentation</a>.
   </p>
 


### PR DESCRIPTION
In "ZooKeeper to KRaft Migration" documentation, we are still reporting 3.4 as metadata version. I'm reworking that phrase to make it more clear and avoid the need to update it in the future.