### PR TITLE
KAFKA-14855: Harden integration testing logic for asserting that a connector is deleted

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -431,9 +431,9 @@ public class ConnectWorkerIntegrationTest {
 
         // Delete the connector
         connect.deleteConnector(CONNECTOR_NAME);
-        connect.assertions().assertConnectorAndTasksAreNotRunning(
+        connect.assertions().assertConnectorDoesNotExist(
                 CONNECTOR_NAME,
-                "Connector tasks were not destroyed in time"
+                "Connector wasn't deleted in time"
         );
     }
 
@@ -505,9 +505,9 @@ public class ConnectWorkerIntegrationTest {
 
         // Can delete a stopped connector
         connect.deleteConnector(CONNECTOR_NAME);
-        connect.assertions().assertConnectorAndTasksAreNotRunning(
+        connect.assertions().assertConnectorDoesNotExist(
                 CONNECTOR_NAME,
-                "Connector and all of its tasks should no longer be running"
+                "Connector wasn't deleted in time"
         );
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorTopicsIntegrationTest.java
@@ -150,8 +150,8 @@ public class ConnectorTopicsIntegrationTest {
         // deleting a connector resets its active topics
         connect.deleteConnector(BAR_CONNECTOR);
 
-        connect.assertions().assertConnectorAndTasksAreNotRunning(BAR_CONNECTOR,
-                "Connector tasks did not stop in time.");
+        connect.assertions().assertConnectorDoesNotExist(BAR_CONNECTOR,
+                "Connector wasn't deleted in time.");
 
         connect.assertions().assertConnectorActiveTopics(BAR_CONNECTOR, Collections.emptyList(),
                 "Active topic set is not empty for deleted connector: " + BAR_CONNECTOR);
@@ -205,8 +205,8 @@ public class ConnectorTopicsIntegrationTest {
         // deleting a connector resets its active topics
         connect.deleteConnector(FOO_CONNECTOR);
 
-        connect.assertions().assertConnectorAndTasksAreNotRunning(FOO_CONNECTOR,
-                "Connector tasks did not stop in time.");
+        connect.assertions().assertConnectorDoesNotExist(FOO_CONNECTOR,
+                "Connector wasn't deleted in time.");
 
         connect.assertions().assertConnectorActiveTopics(FOO_CONNECTOR, Collections.emptyList(),
                 "Active topic set is not empty for deleted connector: " + FOO_CONNECTOR);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
@@ -179,8 +179,8 @@ public class ErrorHandlingIntegrationTest {
         }
 
         connect.deleteConnector(CONNECTOR_NAME);
-        connect.assertions().assertConnectorAndTasksAreNotRunning(CONNECTOR_NAME,
-                "Connector tasks did not stop in time.");
+        connect.assertions().assertConnectorDoesNotExist(CONNECTOR_NAME,
+                "Connector wasn't deleted in time.");
 
     }
 
@@ -248,8 +248,8 @@ public class ErrorHandlingIntegrationTest {
         ConsumerRecords<byte[], byte[]> messages = connect.kafka().consume(EXPECTED_INCORRECT_RECORDS, CONSUME_MAX_DURATION_MS, DLQ_TOPIC);
 
         connect.deleteConnector(CONNECTOR_NAME);
-        connect.assertions().assertConnectorAndTasksAreNotRunning(CONNECTOR_NAME,
-            "Connector tasks did not stop in time.");
+        connect.assertions().assertConnectorDoesNotExist(CONNECTOR_NAME,
+            "Connector wasn't deleted in time.");
     }
 
     /**

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
@@ -206,8 +206,8 @@ public class RebalanceSourceConnectorsIntegrationTest {
         // delete connector
         connect.deleteConnector(CONNECTOR_NAME + 3);
 
-        connect.assertions().assertConnectorAndTasksAreNotRunning(CONNECTOR_NAME + 3,
-                "Connector tasks did not stop in time.");
+        connect.assertions().assertConnectorDoesNotExist(CONNECTOR_NAME + 3,
+                "Connector wasn't deleted in time.");
 
         waitForCondition(this::assertConnectorAndTasksAreUniqueAndBalanced,
                 WORKER_SETUP_DURATION_MS, "Connect and tasks are imbalanced between the workers.");

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
@@ -455,47 +455,41 @@ public class EmbeddedConnectClusterAssertions {
     }
 
     /**
-     * Assert that a connector and its tasks are not running.
+     * Assert that a connector does not exist. This can be used to verify that a connector has been successfully deleted.
      *
      * @param connectorName the connector name
      * @param detailMessage the assertion message
      * @throws InterruptedException
      */
-    public void assertConnectorAndTasksAreNotRunning(String connectorName, String detailMessage)
+    public void assertConnectorDoesNotExist(String connectorName, String detailMessage)
             throws InterruptedException {
         try {
             waitForCondition(
-                () -> checkConnectorAndTasksAreNotRunning(connectorName),
+                () -> checkConnectorDoesNotExist(connectorName),
                 CONNECTOR_SETUP_DURATION_MS,
-                "At least the connector or one of its tasks is still running");
+                "The connector should not exist.");
         } catch (AssertionError e) {
             throw new AssertionError(detailMessage, e);
         }
     }
 
     /**
-     * Check whether the connector or any of its tasks are still in RUNNING state
+     * Check whether a connector exists by querying the <strong><em>GET /connectors/{connector}/status</em></strong> endpoint
      *
-     * @param connectorName the connector
-     * @return true if the connector and all the tasks are not in RUNNING state; false otherwise
+     * @param connectorName the connector name
+     * @return true if the connector does not exist; false otherwise
      */
-    protected boolean checkConnectorAndTasksAreNotRunning(String connectorName) {
-        ConnectorStateInfo info;
+    protected boolean checkConnectorDoesNotExist(String connectorName) {
         try {
-            info = connect.connectorStatus(connectorName);
+            connect.connectorStatus(connectorName);
         } catch (ConnectRestException e) {
             return e.statusCode() == Response.Status.NOT_FOUND.getStatusCode();
         } catch (Exception e) {
             log.error("Could not check connector state info.", e);
             return false;
         }
-        if (info == null) {
-            return true;
-        }
-        return !info.connector().state().equals(AbstractStatus.State.RUNNING.toString())
-                && info.tasks().stream().noneMatch(s -> s.state().equals(AbstractStatus.State.RUNNING.toString()));
+        return false;
     }
-
 
     /**
      * Assert that a connector is in the stopped state and has no tasks.


### PR DESCRIPTION
From https://issues.apache.org/jira/browse/KAFKA-14855:

> In the Connect embedded integration testing framework, the [EmbeddedConnectClusterAssertions::assertConnectorAndTasksAreStopped method](https://github.com/apache/kafka/blob/31440b00f3ed8de65f368d41d6cf2efb07ca4a5c/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java#L411-L428) is used in several places to verify that a connector has been deleted. (This method may be renamed in an upcoming PR to something like assertConnectorAndTasksAreNotRunning, but apart from that, its usage and semantics will remain unchanged.) However, the [underlying logic for that assertion](https://github.com/apache/kafka/blob/31440b00f3ed8de65f368d41d6cf2efb07ca4a5c/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java#L430-L451) doesn't strictly check for deletion (which can be done by verifying that the connector and its tasks no longer appear in the REST API at all), since it also allows for the Connector or tasks to appear in the REST API, but with a state that is not RUNNING.
>
> This constraint is a bit too lax and may be silently masking issues with our shutdown logic for to-be-deleted connectors. We should try to narrow the criteria for that method so that it fails if the Connector or any of its tasks still appear in the REST API, even with a non-RUNNING state.
>
> However, we should also be careful to ensure that current uses of that method are not relying on its semantics. If, for some reason, a test case requires the existing semantics, we should evaluate whether it's necessary to continue to rely on those semantics, and if so, probably preserve the existing method so that it can be used wherever applicable (but rewrite all other tests to use the new, stricter method).

- All usages of the `assertConnectorAndTasksAreNotRunning` method were to check for connector deletion so the assertion on non-running status of connectors and tasks isn't required.
- This patch removes that unnecessary extra assertion and hardens the logic for asserting that a connector is deleted.
- Note that `assertConnectorAndTasksAreNotRunning` (now renamed to `assertConnectorDoesNotExist`) only verifies that the connector has been wiped from the status backing store which is done by the leader worker after the post-deletion group rebalance. We don't verify whether the connectors and tasks have actually finished stopping - this is potentially a further improvement that could be made in the future.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
