### PR TITLE
KAFKA-15465: Don't throw if MirrorMaker not authorized to create topics.

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorUtils.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorUtils.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -286,6 +287,12 @@ public final class MirrorUtils {
             if (cause instanceof UnsupportedVersionException) {
                 log.debug("Unable to create topic '{}' since the brokers do not support the CreateTopics API." +
                                 " Falling back to assume topic exists or will be auto-created by the broker.",
+                        topicName);
+                return;
+            }
+            if (cause instanceof TopicAuthorizationException) {
+                log.debug("Not authorized to create topic(s) '{}' upon the brokers." +
+                                " Falling back to assume topic(s) exist or will be auto-created by the broker.",
                         topicName);
                 return;
             }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorUtils.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorUtils.java
@@ -287,11 +287,13 @@ public final class MirrorUtils {
                 log.debug("Unable to create topic '{}' since the brokers do not support the CreateTopics API." +
                                 " Falling back to assume topic exists or will be auto-created by the broker.",
                         topicName);
+                return;
             }
             if (cause instanceof ClusterAuthorizationException) {
                 log.debug("Not authorized to create topic '{}'." +
                                 " Falling back to assume topic exists or will be auto-created by the broker.",
                         topicName);
+                return;
             }
             if (cause instanceof InvalidConfigurationException) {
                 throw new ConnectException("Unable to create topic '" + topicName + "': " + cause.getMessage(),

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorUtilsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorUtilsTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -90,6 +91,19 @@ public class MirrorUtilsTest {
     public void testCreateCompactedTopicAssumeTopicAlreadyExistsWithClusterAuthorizationException() throws Exception {
         Map<String, KafkaFuture<Void>> values = Collections.singletonMap(TOPIC, future);
         when(future.get()).thenThrow(new ExecutionException(new ClusterAuthorizationException("not authorised")));
+        when(ctr.values()).thenReturn(values);
+        when(admin.createTopics(any(), any())).thenReturn(ctr);
+        MirrorUtils.createCompactedTopic(TOPIC, (short) 1, (short) 1, admin);
+
+        verify(future).get();
+        verify(ctr).values();
+        verify(admin).createTopics(any(), any());
+    }
+
+    @Test
+    public void testCreateCompactedTopicAssumeTopicAlreadyExistsWithTopicAuthorizationException() throws Exception {
+        Map<String, KafkaFuture<Void>> values = Collections.singletonMap(TOPIC, future);
+        when(future.get()).thenThrow(new ExecutionException(new TopicAuthorizationException("not authorised")));
         when(ctr.values()).thenReturn(values);
         when(admin.createTopics(any(), any())).thenReturn(ctr);
         MirrorUtils.createCompactedTopic(TOPIC, (short) 1, (short) 1, admin);

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorUtilsTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorUtilsTest.java
@@ -20,7 +20,10 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
+import org.apache.kafka.common.errors.InvalidConfigurationException;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicExistsException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.Test;
 
@@ -71,15 +74,54 @@ public class MirrorUtilsTest {
     }
 
     @Test
-    public void testCreateCompactedTopicFails() throws Exception {
+    public void testCreateCompactedTopicAssumeTopicAlreadyExistsWithUnsupportedVersionException() throws Exception {
         Map<String, KafkaFuture<Void>> values = Collections.singletonMap(TOPIC, future);
-        when(future.get()).thenThrow(new ExecutionException(new ClusterAuthorizationException("not authorized")));
+        when(future.get()).thenThrow(new ExecutionException(new UnsupportedVersionException("unsupported")));
+        when(ctr.values()).thenReturn(values);
+        when(admin.createTopics(any(), any())).thenReturn(ctr);
+        MirrorUtils.createCompactedTopic(TOPIC, (short) 1, (short) 1, admin);
+
+        verify(future).get();
+        verify(ctr).values();
+        verify(admin).createTopics(any(), any());
+    }
+
+    @Test
+    public void testCreateCompactedTopicAssumeTopicAlreadyExistsWithClusterAuthorizationException() throws Exception {
+        Map<String, KafkaFuture<Void>> values = Collections.singletonMap(TOPIC, future);
+        when(future.get()).thenThrow(new ExecutionException(new ClusterAuthorizationException("not authorised")));
+        when(ctr.values()).thenReturn(values);
+        when(admin.createTopics(any(), any())).thenReturn(ctr);
+        MirrorUtils.createCompactedTopic(TOPIC, (short) 1, (short) 1, admin);
+
+        verify(future).get();
+        verify(ctr).values();
+        verify(admin).createTopics(any(), any());
+    }
+
+    @Test
+    public void testCreateCompactedTopicFailsWithInvalidConfigurationException() throws Exception {
+        Map<String, KafkaFuture<Void>> values = Collections.singletonMap(TOPIC, future);
+        when(future.get()).thenThrow(new ExecutionException(new InvalidConfigurationException("wrong config")));
         when(ctr.values()).thenReturn(values);
         when(admin.createTopics(any(), any())).thenReturn(ctr);
         Throwable ce = assertThrows(ConnectException.class, () -> MirrorUtils.createCompactedTopic(TOPIC, (short) 1, (short) 1, admin), "Should have exception thrown");
 
-        assertTrue(ce.getCause() instanceof ExecutionException);
-        assertTrue(ce.getCause().getCause() instanceof ClusterAuthorizationException);
+        assertTrue(ce.getCause() instanceof InvalidConfigurationException);
+        verify(future).get();
+        verify(ctr).values();
+        verify(admin).createTopics(any(), any());
+    }
+
+    @Test
+    public void testCreateCompactedTopicFailsWithTimeoutException() throws Exception {
+        Map<String, KafkaFuture<Void>> values = Collections.singletonMap(TOPIC, future);
+        when(future.get()).thenThrow(new ExecutionException(new TimeoutException("Timeout")));
+        when(ctr.values()).thenReturn(values);
+        when(admin.createTopics(any(), any())).thenReturn(ctr);
+        Throwable ce = assertThrows(ConnectException.class, () -> MirrorUtils.createCompactedTopic(TOPIC, (short) 1, (short) 1, admin), "Should have exception thrown");
+
+        assertTrue(ce.getCause() instanceof TimeoutException);
         verify(future).get();
         verify(ctr).values();
         verify(admin).createTopics(any(), any());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-15465?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel

MM2 should work without throwing errors if it's not authorised to create internal topics. The changes align with`TopicAdmin.createOrFindTopics` behaviour. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
