### PR TITLE
MINOR: Implement toStringBase to avoid duplicated code

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
@@ -21,18 +21,27 @@ package org.apache.kafka.clients.consumer.internals.events;
  */
 abstract public class ApplicationEvent {
     public final Type type;
+    protected final String owner;
 
-    protected ApplicationEvent(Type type) {
+    protected ApplicationEvent(Type type, String owner) {
         this.type = type;
+        this.owner = owner;
     }
 
     @Override
     public String toString() {
-        return type + " ApplicationEvent";
+        return "ApplicationEvent{" +
+            toStringBase() +
+            '}';
     }
 
     public enum Type {
         NOOP, COMMIT, POLL, FETCH_COMMITTED_OFFSET, METADATA_UPDATE, ASSIGNMENT_CHANGE,
         LIST_OFFSETS, RESET_POSITIONS, VALIDATE_POSITIONS,
+    }
+
+    protected String toStringBase() {
+        return "owner='" + owner + '\'' +
+            ", type=" + type;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
@@ -21,11 +21,9 @@ package org.apache.kafka.clients.consumer.internals.events;
  */
 abstract public class ApplicationEvent {
     public final Type type;
-    protected final String owner;
 
-    protected ApplicationEvent(Type type, String owner) {
+    protected ApplicationEvent(Type type) {
         this.type = type;
-        this.owner = owner;
     }
 
     @Override
@@ -41,7 +39,6 @@ abstract public class ApplicationEvent {
     }
 
     protected String toStringBase() {
-        return "owner='" + owner + '\'' +
-            ", type=" + type;
+        return "type=" + type;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/AssignmentChangeApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/AssignmentChangeApplicationEvent.java
@@ -26,8 +26,17 @@ public class AssignmentChangeApplicationEvent extends ApplicationEvent {
     final long currentTimeMs;
 
     public AssignmentChangeApplicationEvent(final Map<TopicPartition, OffsetAndMetadata> offsets, final long currentTimeMs) {
-        super(Type.ASSIGNMENT_CHANGE);
+        super(Type.ASSIGNMENT_CHANGE, AssignmentChangeApplicationEvent.class.getSimpleName());
         this.offsets = offsets;
         this.currentTimeMs = currentTimeMs;
+    }
+
+    @Override
+    public String toString() {
+        return "AssignmentChangeApplicationEvent{" +
+            toStringBase() +
+            ", offsets=" + offsets +
+            ", currentTimeMs=" + currentTimeMs +
+            '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/AssignmentChangeApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/AssignmentChangeApplicationEvent.java
@@ -26,15 +26,14 @@ public class AssignmentChangeApplicationEvent extends ApplicationEvent {
     final long currentTimeMs;
 
     public AssignmentChangeApplicationEvent(final Map<TopicPartition, OffsetAndMetadata> offsets, final long currentTimeMs) {
-        super(Type.ASSIGNMENT_CHANGE, AssignmentChangeApplicationEvent.class.getSimpleName());
+        super(Type.ASSIGNMENT_CHANGE);
         this.offsets = offsets;
         this.currentTimeMs = currentTimeMs;
     }
 
     @Override
     public String toString() {
-        return "AssignmentChangeApplicationEvent{" +
-            toStringBase() +
+        return toStringBase() +
             ", offsets=" + offsets +
             ", currentTimeMs=" + currentTimeMs +
             '}';

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
@@ -28,7 +28,7 @@ public class CommitApplicationEvent extends ApplicationEvent {
     final private Map<TopicPartition, OffsetAndMetadata> offsets;
 
     public CommitApplicationEvent(final Map<TopicPartition, OffsetAndMetadata> offsets) {
-        super(Type.COMMIT);
+        super(Type.COMMIT, CommitApplicationEvent.class.getSimpleName());
         this.offsets = offsets;
         Optional<Exception> exception = isValid(offsets);
         if (exception.isPresent()) {
@@ -58,7 +58,9 @@ public class CommitApplicationEvent extends ApplicationEvent {
 
     @Override
     public String toString() {
-        return "CommitApplicationEvent("
-                + "offsets=" + offsets + ")";
+        return "CommitApplicationEvent{" +
+            toStringBase() +
+            ", offsets=" + offsets +
+            '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CommitApplicationEvent.java
@@ -28,7 +28,7 @@ public class CommitApplicationEvent extends ApplicationEvent {
     final private Map<TopicPartition, OffsetAndMetadata> offsets;
 
     public CommitApplicationEvent(final Map<TopicPartition, OffsetAndMetadata> offsets) {
-        super(Type.COMMIT, CommitApplicationEvent.class.getSimpleName());
+        super(Type.COMMIT);
         this.offsets = offsets;
         Optional<Exception> exception = isValid(offsets);
         if (exception.isPresent()) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CompletableApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CompletableApplicationEvent.java
@@ -35,8 +35,8 @@ public abstract class CompletableApplicationEvent<T> extends ApplicationEvent {
 
     protected final CompletableFuture<T> future;
 
-    protected CompletableApplicationEvent(Type type) {
-        super(type);
+    protected CompletableApplicationEvent(Type type, String owner) {
+        super(type, owner);
         this.future = new CompletableFuture<>();
     }
 
@@ -90,10 +90,15 @@ public abstract class CompletableApplicationEvent<T> extends ApplicationEvent {
     }
 
     @Override
+    public String toStringBase() {
+        return super.toStringBase() +
+            ", future=" + future;
+    }
+
+    @Override
     public String toString() {
-        return getClass().getSimpleName() + "{" +
-                "future=" + future +
-                ", type=" + type +
-                '}';
+        return "CompletableApplicationEvent{" +
+            toStringBase() +
+            '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CompletableApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/CompletableApplicationEvent.java
@@ -35,8 +35,8 @@ public abstract class CompletableApplicationEvent<T> extends ApplicationEvent {
 
     protected final CompletableFuture<T> future;
 
-    protected CompletableApplicationEvent(Type type, String owner) {
-        super(type, owner);
+    protected CompletableApplicationEvent(Type type) {
+        super(type);
         this.future = new CompletableFuture<>();
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsApplicationEvent.java
@@ -37,7 +37,7 @@ public class ListOffsetsApplicationEvent extends CompletableApplicationEvent<Map
     private final boolean requireTimestamps;
 
     public ListOffsetsApplicationEvent(Map<TopicPartition, Long> timestampToSearch, boolean requireTimestamps) {
-        super(Type.LIST_OFFSETS);
+        super(Type.LIST_OFFSETS, ListOffsetsApplicationEvent.class.getSimpleName());
         this.timestampsToSearch = Collections.unmodifiableMap(timestampToSearch);
         this.requireTimestamps = requireTimestamps;
     }
@@ -85,9 +85,10 @@ public class ListOffsetsApplicationEvent extends CompletableApplicationEvent<Map
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + " {" +
-                "timestampsToSearch=" + timestampsToSearch + ", " +
-                "requireTimestamps=" + requireTimestamps + '}';
+        return "ListOffsetsApplicationEvent{" +
+            toStringBase() +
+            ", timestampsToSearch=" + timestampsToSearch +
+            ", requireTimestamps=" + requireTimestamps +
+            '}';
     }
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ListOffsetsApplicationEvent.java
@@ -37,7 +37,7 @@ public class ListOffsetsApplicationEvent extends CompletableApplicationEvent<Map
     private final boolean requireTimestamps;
 
     public ListOffsetsApplicationEvent(Map<TopicPartition, Long> timestampToSearch, boolean requireTimestamps) {
-        super(Type.LIST_OFFSETS, ListOffsetsApplicationEvent.class.getSimpleName());
+        super(Type.LIST_OFFSETS);
         this.timestampsToSearch = Collections.unmodifiableMap(timestampToSearch);
         this.requireTimestamps = requireTimestamps;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NewTopicsMetadataUpdateRequestEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NewTopicsMetadataUpdateRequestEvent.java
@@ -19,6 +19,13 @@ package org.apache.kafka.clients.consumer.internals.events;
 public class NewTopicsMetadataUpdateRequestEvent extends ApplicationEvent {
 
     public NewTopicsMetadataUpdateRequestEvent() {
-        super(Type.METADATA_UPDATE);
+        super(Type.METADATA_UPDATE, NewTopicsMetadataUpdateRequestEvent.class.getSimpleName());
+    }
+
+    @Override
+    public String toString() {
+        return "NewTopicsMetadataUpdateRequestEvent{" +
+            toStringBase() +
+            '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NewTopicsMetadataUpdateRequestEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NewTopicsMetadataUpdateRequestEvent.java
@@ -19,7 +19,7 @@ package org.apache.kafka.clients.consumer.internals.events;
 public class NewTopicsMetadataUpdateRequestEvent extends ApplicationEvent {
 
     public NewTopicsMetadataUpdateRequestEvent() {
-        super(Type.METADATA_UPDATE, NewTopicsMetadataUpdateRequestEvent.class.getSimpleName());
+        super(Type.METADATA_UPDATE);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopApplicationEvent.java
@@ -23,12 +23,15 @@ public class NoopApplicationEvent extends ApplicationEvent {
     public final String message;
 
     public NoopApplicationEvent(final String message) {
-        super(Type.NOOP);
+        super(Type.NOOP, NoopApplicationEvent.class.getSimpleName());
         this.message = message;
     }
 
     @Override
     public String toString() {
-        return getClass() + "_" + this.message;
+        return "NoopApplicationEvent{" +
+            toStringBase() +
+            ", message='" + message + '\'' +
+            '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/NoopApplicationEvent.java
@@ -23,7 +23,7 @@ public class NoopApplicationEvent extends ApplicationEvent {
     public final String message;
 
     public NoopApplicationEvent(final String message) {
-        super(Type.NOOP, NoopApplicationEvent.class.getSimpleName());
+        super(Type.NOOP);
         this.message = message;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/OffsetFetchApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/OffsetFetchApplicationEvent.java
@@ -27,7 +27,7 @@ public class OffsetFetchApplicationEvent extends CompletableApplicationEvent<Map
     private final Set<TopicPartition> partitions;
 
     public OffsetFetchApplicationEvent(final Set<TopicPartition> partitions) {
-        super(Type.FETCH_COMMITTED_OFFSET);
+        super(Type.FETCH_COMMITTED_OFFSET, OffsetFetchApplicationEvent.class.getSimpleName());
         this.partitions = Collections.unmodifiableSet(partitions);
     }
 
@@ -55,10 +55,9 @@ public class OffsetFetchApplicationEvent extends CompletableApplicationEvent<Map
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "{" +
-                "partitions=" + partitions +
-                ", future=" + future +
-                ", type=" + type +
-                '}';
+        return "OffsetFetchApplicationEvent{" +
+            toStringBase() +
+            ", partitions=" + partitions +
+            '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/OffsetFetchApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/OffsetFetchApplicationEvent.java
@@ -27,7 +27,7 @@ public class OffsetFetchApplicationEvent extends CompletableApplicationEvent<Map
     private final Set<TopicPartition> partitions;
 
     public OffsetFetchApplicationEvent(final Set<TopicPartition> partitions) {
-        super(Type.FETCH_COMMITTED_OFFSET, OffsetFetchApplicationEvent.class.getSimpleName());
+        super(Type.FETCH_COMMITTED_OFFSET);
         this.partitions = Collections.unmodifiableSet(partitions);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/PollApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/PollApplicationEvent.java
@@ -20,7 +20,15 @@ public class PollApplicationEvent extends ApplicationEvent {
     public final long pollTimeMs;
 
     protected PollApplicationEvent(final long currentTimeMs) {
-        super(Type.POLL);
+        super(Type.POLL, PollApplicationEvent.class.getSimpleName());
         this.pollTimeMs = currentTimeMs;
+    }
+
+    @Override
+    public String toString() {
+        return "PollApplicationEvent{" +
+            toStringBase() +
+            ", pollTimeMs=" + pollTimeMs +
+            '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/PollApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/PollApplicationEvent.java
@@ -20,7 +20,7 @@ public class PollApplicationEvent extends ApplicationEvent {
     public final long pollTimeMs;
 
     protected PollApplicationEvent(final long currentTimeMs) {
-        super(Type.POLL, PollApplicationEvent.class.getSimpleName());
+        super(Type.POLL);
         this.pollTimeMs = currentTimeMs;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ResetPositionsApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ResetPositionsApplicationEvent.java
@@ -25,6 +25,13 @@ package org.apache.kafka.clients.consumer.internals.events;
 public class ResetPositionsApplicationEvent extends CompletableApplicationEvent<Void> {
 
     public ResetPositionsApplicationEvent() {
-        super(Type.RESET_POSITIONS);
+        super(Type.RESET_POSITIONS, ResetPositionsApplicationEvent.class.getSimpleName());
+    }
+
+    @Override
+    public String toString() {
+        return "ResetPositionsApplicationEvent{" +
+            toStringBase() +
+            '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ResetPositionsApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ResetPositionsApplicationEvent.java
@@ -25,7 +25,7 @@ package org.apache.kafka.clients.consumer.internals.events;
 public class ResetPositionsApplicationEvent extends CompletableApplicationEvent<Void> {
 
     public ResetPositionsApplicationEvent() {
-        super(Type.RESET_POSITIONS, ResetPositionsApplicationEvent.class.getSimpleName());
+        super(Type.RESET_POSITIONS);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ValidatePositionsApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ValidatePositionsApplicationEvent.java
@@ -25,6 +25,13 @@ package org.apache.kafka.clients.consumer.internals.events;
 public class ValidatePositionsApplicationEvent extends CompletableApplicationEvent<Void> {
 
     public ValidatePositionsApplicationEvent() {
-        super(Type.VALIDATE_POSITIONS);
+        super(Type.VALIDATE_POSITIONS, ValidatePositionsApplicationEvent.class.getSimpleName());
+    }
+
+    @Override
+    public String toString() {
+        return "ValidatePositionsApplicationEvent{" +
+            toStringBase() +
+            '}';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ValidatePositionsApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ValidatePositionsApplicationEvent.java
@@ -25,7 +25,7 @@ package org.apache.kafka.clients.consumer.internals.events;
 public class ValidatePositionsApplicationEvent extends CompletableApplicationEvent<Void> {
 
     public ValidatePositionsApplicationEvent() {
-        super(Type.VALIDATE_POSITIONS, ValidatePositionsApplicationEvent.class.getSimpleName());
+        super(Type.VALIDATE_POSITIONS);
     }
 
     @Override


### PR DESCRIPTION
This is a follow up of https://github.com/apache/kafka/pull/14386.

The goal of this PR is to refactor the toString method to reduce duplicated code.