### PR TITLE
MINOR: Fix format of allowed operations in kafka-acls error message

### DIFF
--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -487,7 +487,7 @@ object AclCommand extends Logging {
     for ((resource, acls) <- resourceToAcls) {
       val validOps = AclEntry.supportedOperations(resource.resourceType) + AclOperation.ALL
       if ((acls.map(_.operation) -- validOps).nonEmpty)
-        CommandLineUtils.printUsageAndExit(opts.parser, s"ResourceType ${resource.resourceType} only supports operations ${validOps.mkString(",")}")
+        CommandLineUtils.printUsageAndExit(opts.parser, s"ResourceType ${resource.resourceType} only supports operations ${validOps.map(JSecurityUtils.operationName(_)).mkString(", ")}")
     }
   }
 


### PR DESCRIPTION
kafka-acls cli prints the following error message on invalid operation:
```
$ kafka-acls --bootstrap-server xxx:9095 --remove --allow-principal "User:abc" --allow-host * --operation DESCRIBE_CONFIGS --topic xyz
ResourceType TOPIC only supports operations WRITE,DESCRIBE,ALL,READ,CREATE,ALTER,DELETE,DESCRIBE_CONFIGS,ALTER_CONFIGS
```
The following command actually works:
```
$ kafka-acls --bootstrap-server xxx:9095 --remove --allow-principal "User:abc" --allow-host * --operation DescribeConfigs --topic xyz
```

The operations are listed correctly in the cli --help:
```
--operation <String>                     Operation that is being allowed or     
                                           denied. Valid operation names are:   
                                         	Describe                              
                                         	DescribeConfigs                       
                                         	Alter                                 
                                         	IdempotentWrite                       
                                         	Read                                  
                                         	Delete                                
                                         	Create                                
                                         	ClusterAction                         
                                         	All                                   
                                         	Write                                 
                                         	AlterConfigs                          
                                         	CreateTokens                          
                                         	DescribeTokens    
```

This PR fixes the invalid formating of operations in the error message and adds a space after the comma.


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
