### PR TITLE
KAFKA-14133: Move KeyValueIteratorFacadeTest, KeyValueSegmentTest and MeteredKeyValueStoreTest to Mockito

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueIteratorFacadeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueIteratorFacadeTest.java
@@ -19,22 +19,20 @@ package org.apache.kafka.streams.state.internals;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 
-@RunWith(EasyMockRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class KeyValueIteratorFacadeTest {
     @Mock
     private KeyValueIterator<String, ValueAndTimestamp<String>> mockedKeyValueIterator;
@@ -48,40 +46,31 @@ public class KeyValueIteratorFacadeTest {
 
     @Test
     public void shouldForwardHasNext() {
-        expect(mockedKeyValueIterator.hasNext()).andReturn(true).andReturn(false);
-        replay(mockedKeyValueIterator);
+        when(mockedKeyValueIterator.hasNext()).thenReturn(true).thenReturn(false);
 
         assertTrue(keyValueIteratorFacade.hasNext());
         assertFalse(keyValueIteratorFacade.hasNext());
-        verify(mockedKeyValueIterator);
     }
 
     @Test
     public void shouldForwardPeekNextKey() {
-        expect(mockedKeyValueIterator.peekNextKey()).andReturn("key");
-        replay(mockedKeyValueIterator);
+        when(mockedKeyValueIterator.peekNextKey()).thenReturn("key");
 
         assertThat(keyValueIteratorFacade.peekNextKey(), is("key"));
-        verify(mockedKeyValueIterator);
     }
 
     @Test
     public void shouldReturnPlainKeyValuePairOnGet() {
-        expect(mockedKeyValueIterator.next()).andReturn(
+        when(mockedKeyValueIterator.next()).thenReturn(
             new KeyValue<>("key", ValueAndTimestamp.make("value", 42L)));
-        replay(mockedKeyValueIterator);
 
         assertThat(keyValueIteratorFacade.next(), is(KeyValue.pair("key", "value")));
-        verify(mockedKeyValueIterator);
     }
 
     @Test
     public void shouldCloseInnerIterator() {
-        mockedKeyValueIterator.close();
-        expectLastCall();
-        replay(mockedKeyValueIterator);
+        doNothing().when(mockedKeyValueIterator).close();
 
         keyValueIteratorFacade.close();
-        verify(mockedKeyValueIterator);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentTest.java
@@ -26,6 +26,8 @@ import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
 import org.apache.kafka.test.TestUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
 import java.util.HashSet;
@@ -34,15 +36,15 @@ import java.util.Set;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class KeyValueSegmentTest {
 
     private final RocksDBMetricsRecorder metricsRecorder =
@@ -63,9 +65,8 @@ public class KeyValueSegmentTest {
         final File directory = new File(directoryPath);
 
         final ProcessorContext mockContext = mock(ProcessorContext.class);
-        expect(mockContext.appConfigs()).andReturn(mkMap(mkEntry(METRICS_RECORDING_LEVEL_CONFIG, "INFO")));
-        expect(mockContext.stateDir()).andReturn(directory);
-        replay(mockContext);
+        when(mockContext.appConfigs()).thenReturn(mkMap(mkEntry(METRICS_RECORDING_LEVEL_CONFIG, "INFO")));
+        when(mockContext.stateDir()).thenReturn(directory);
 
         segment.openDB(mockContext.appConfigs(), mockContext.stateDir());
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
@@ -42,12 +42,11 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.test.KeyValueIteratorStub;
-import org.easymock.EasyMockRule;
-import org.easymock.Mock;
-import org.easymock.MockType;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 import java.util.List;
@@ -56,15 +55,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.aryEq;
-import static org.easymock.EasyMock.eq;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.niceMock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -74,11 +64,15 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class MeteredKeyValueStoreTest {
-
-    @Rule
-    public EasyMockRule rule = new EasyMockRule(this);
 
     private static final String APPLICATION_ID = "test-app";
     private static final String STORE_NAME = "store-name";
@@ -95,9 +89,9 @@ public class MeteredKeyValueStoreTest {
     private final String threadId = Thread.currentThread().getName();
     private final TaskId taskId = new TaskId(0, 0, "My-Topology");
 
-    @Mock(type = MockType.NICE)
+    @Mock
     private KeyValueStore<Bytes, byte[]> inner;
-    @Mock(type = MockType.NICE)
+    @Mock
     private InternalProcessorContext context;
 
     private MeteredKeyValueStore<String, String> metered;
@@ -115,13 +109,13 @@ public class MeteredKeyValueStoreTest {
             Serdes.String()
         );
         metrics.config().recordLevel(Sensor.RecordingLevel.DEBUG);
-        expect(context.applicationId()).andStubReturn(APPLICATION_ID);
-        expect(context.metrics()).andStubReturn(
+        when(context.applicationId()).thenReturn(APPLICATION_ID);
+        when(context.metrics()).thenReturn(
             new StreamsMetricsImpl(metrics, "test", StreamsConfig.METRICS_LATEST, mockTime)
         );
-        expect(context.taskId()).andStubReturn(taskId);
-        expect(context.changelogFor(STORE_NAME)).andStubReturn(CHANGELOG_TOPIC);
-        expect(inner.name()).andStubReturn(STORE_NAME);
+        when(context.taskId()).thenReturn(taskId);
+        when(context.changelogFor(STORE_NAME)).thenReturn(CHANGELOG_TOPIC);
+        when(inner.name()).thenReturn(STORE_NAME);
         tags = mkMap(
             mkEntry(THREAD_ID_TAG_KEY, threadId),
             mkEntry("task-id", taskId.toString()),
@@ -130,14 +124,12 @@ public class MeteredKeyValueStoreTest {
     }
 
     private void init() {
-        replay(inner, context);
         metered.init((StateStoreContext) context, metered);
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void shouldDelegateDeprecatedInit() {
-        final KeyValueStore<Bytes, byte[]> inner = mock(KeyValueStore.class);
         final MeteredKeyValueStore<String, String> outer = new MeteredKeyValueStore<>(
             inner,
             STORE_TYPE,
@@ -145,17 +137,12 @@ public class MeteredKeyValueStoreTest {
             Serdes.String(),
             Serdes.String()
         );
-        expect(inner.name()).andStubReturn("store");
-        inner.init((ProcessorContext) context, outer);
-        expectLastCall();
-        replay(inner, context);
+        doNothing().when(inner).init((ProcessorContext) context, outer);
         outer.init((ProcessorContext) context, outer);
-        verify(inner);
     }
 
     @Test
     public void shouldDelegateInit() {
-        final KeyValueStore<Bytes, byte[]> inner = mock(KeyValueStore.class);
         final MeteredKeyValueStore<String, String> outer = new MeteredKeyValueStore<>(
             inner,
             STORE_TYPE,
@@ -163,12 +150,8 @@ public class MeteredKeyValueStoreTest {
             Serdes.String(),
             Serdes.String()
         );
-        expect(inner.name()).andStubReturn("store");
-        inner.init((StateStoreContext) context, outer);
-        expectLastCall();
-        replay(inner, context);
+        doNothing().when(inner).init((StateStoreContext) context, outer);
         outer.init((StateStoreContext) context, outer);
-        verify(inner);
     }
 
     @Test
@@ -179,24 +162,24 @@ public class MeteredKeyValueStoreTest {
     @Test
     public void shouldPassDefaultChangelogTopicNameToStateStoreSerdeIfLoggingDisabled() {
         final String defaultChangelogTopicName = ProcessorStateManager.storeChangelogTopic(APPLICATION_ID, STORE_NAME, taskId.topologyName());
-        expect(context.changelogFor(STORE_NAME)).andReturn(null);
+        when(context.changelogFor(STORE_NAME)).thenReturn(null);
         doShouldPassChangelogTopicNameToStateStoreSerde(defaultChangelogTopicName);
     }
 
+    @SuppressWarnings("unchecked")
     private void doShouldPassChangelogTopicNameToStateStoreSerde(final String topic) {
-        final Serde<String> keySerde = niceMock(Serde.class);
+        final Serde<String> keySerde = mock(Serde.class);
         final Serializer<String> keySerializer = mock(Serializer.class);
-        final Serde<String> valueSerde = niceMock(Serde.class);
+        final Serde<String> valueSerde = mock(Serde.class);
         final Deserializer<String> valueDeserializer = mock(Deserializer.class);
         final Serializer<String> valueSerializer = mock(Serializer.class);
-        expect(keySerde.serializer()).andStubReturn(keySerializer);
-        expect(keySerializer.serialize(topic, KEY)).andStubReturn(KEY.getBytes());
-        expect(valueSerde.deserializer()).andStubReturn(valueDeserializer);
-        expect(valueDeserializer.deserialize(topic, VALUE_BYTES)).andStubReturn(VALUE);
-        expect(valueSerde.serializer()).andStubReturn(valueSerializer);
-        expect(valueSerializer.serialize(topic, VALUE)).andStubReturn(VALUE_BYTES);
-        expect(inner.get(KEY_BYTES)).andStubReturn(VALUE_BYTES);
-        replay(inner, context, keySerializer, keySerde, valueDeserializer, valueSerializer, valueSerde);
+        when(keySerde.serializer()).thenReturn(keySerializer);
+        when(keySerializer.serialize(topic, KEY)).thenReturn(KEY.getBytes());
+        when(valueSerde.deserializer()).thenReturn(valueDeserializer);
+        when(valueDeserializer.deserialize(topic, VALUE_BYTES)).thenReturn(VALUE);
+        when(valueSerde.serializer()).thenReturn(valueSerializer);
+        when(valueSerializer.serialize(topic, VALUE)).thenReturn(VALUE_BYTES);
+        when(inner.get(KEY_BYTES)).thenReturn(VALUE_BYTES);
         metered = new MeteredKeyValueStore<>(
             inner,
             STORE_TYPE,
@@ -208,8 +191,6 @@ public class MeteredKeyValueStoreTest {
 
         metered.get(KEY);
         metered.put(KEY, VALUE);
-
-        verify(keySerializer, valueDeserializer, valueSerializer);
     }
 
     @Test
@@ -233,7 +214,7 @@ public class MeteredKeyValueStoreTest {
 
     @Test
     public void shouldRecordRestoreLatencyOnInit() {
-        inner.init((StateStoreContext) context, metered);
+        doNothing().when(inner).init((StateStoreContext) context, metered);
 
         init();
 
@@ -241,76 +222,68 @@ public class MeteredKeyValueStoreTest {
         // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("restore-rate");
         assertThat((Double) metric.metricValue(), greaterThan(0.0));
-        verify(inner);
     }
 
     @Test
     public void shouldWriteBytesToInnerStoreAndRecordPutMetric() {
-        inner.put(eq(KEY_BYTES), aryEq(VALUE_BYTES));
-        expectLastCall();
+        doNothing().when(inner).put(KEY_BYTES, VALUE_BYTES);
         init();
 
         metered.put(KEY, VALUE);
 
         final KafkaMetric metric = metric("put-rate");
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     @Test
     public void shouldGetBytesFromInnerStoreAndReturnGetMetric() {
-        expect(inner.get(KEY_BYTES)).andReturn(VALUE_BYTES);
+        when(inner.get(KEY_BYTES)).thenReturn(VALUE_BYTES);
         init();
 
         assertThat(metered.get(KEY), equalTo(VALUE));
 
         final KafkaMetric metric = metric("get-rate");
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     @Test
     public void shouldPutIfAbsentAndRecordPutIfAbsentMetric() {
-        expect(inner.putIfAbsent(eq(KEY_BYTES), aryEq(VALUE_BYTES))).andReturn(null);
+        when(inner.putIfAbsent(KEY_BYTES, VALUE_BYTES)).thenReturn(null);
         init();
 
         metered.putIfAbsent(KEY, VALUE);
 
         final KafkaMetric metric = metric("put-if-absent-rate");
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void shouldPutAllToInnerStoreAndRecordPutAllMetric() {
-        inner.putAll(anyObject(List.class));
-        expectLastCall();
+        doNothing().when(inner).putAll(any(List.class));
         init();
 
         metered.putAll(Collections.singletonList(KeyValue.pair(KEY, VALUE)));
 
         final KafkaMetric metric = metric("put-all-rate");
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     @Test
     public void shouldDeleteFromInnerStoreAndRecordDeleteMetric() {
-        expect(inner.delete(KEY_BYTES)).andReturn(VALUE_BYTES);
+        when(inner.delete(KEY_BYTES)).thenReturn(VALUE_BYTES);
         init();
 
         metered.delete(KEY);
 
         final KafkaMetric metric = metric("delete-rate");
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     @Test
     public void shouldGetRangeFromInnerStoreAndRecordRangeMetric() {
-        expect(inner.range(KEY_BYTES, KEY_BYTES))
-            .andReturn(new KeyValueIteratorStub<>(Collections.singletonList(BYTE_KEY_VALUE_PAIR).iterator()));
+        when(inner.range(KEY_BYTES, KEY_BYTES))
+            .thenReturn(new KeyValueIteratorStub<>(Collections.singletonList(BYTE_KEY_VALUE_PAIR).iterator()));
         init();
 
         final KeyValueIterator<String, String> iterator = metered.range(KEY, KEY);
@@ -320,12 +293,11 @@ public class MeteredKeyValueStoreTest {
 
         final KafkaMetric metric = metric("range-rate");
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     @Test
     public void shouldGetAllFromInnerStoreAndRecordAllMetric() {
-        expect(inner.all()).andReturn(new KeyValueIteratorStub<>(Collections.singletonList(BYTE_KEY_VALUE_PAIR).iterator()));
+        when(inner.all()).thenReturn(new KeyValueIteratorStub<>(Collections.singletonList(BYTE_KEY_VALUE_PAIR).iterator()));
         init();
 
         final KeyValueIterator<String, String> iterator = metered.all();
@@ -335,20 +307,17 @@ public class MeteredKeyValueStoreTest {
 
         final KafkaMetric metric = metric(new MetricName("all-rate", STORE_LEVEL_GROUP, "", tags));
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     @Test
     public void shouldFlushInnerWhenFlushTimeRecords() {
-        inner.flush();
-        expectLastCall().once();
+        doNothing().when(inner).flush();
         init();
 
         metered.flush();
 
         final KafkaMetric metric = metric("flush-rate");
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     private interface CachedKeyValueStore extends KeyValueStore<Bytes, byte[]>, CachedStateStore<byte[], byte[]> { }
@@ -358,8 +327,7 @@ public class MeteredKeyValueStoreTest {
     public void shouldSetFlushListenerOnWrappedCachingStore() {
         final CachedKeyValueStore cachedKeyValueStore = mock(CachedKeyValueStore.class);
 
-        expect(cachedKeyValueStore.setFlushListener(anyObject(CacheFlushListener.class), eq(false))).andReturn(true);
-        replay(cachedKeyValueStore);
+        when(cachedKeyValueStore.setFlushListener(any(CacheFlushListener.class), eq(false))).thenReturn(true);
 
         metered = new MeteredKeyValueStore<>(
             cachedKeyValueStore,
@@ -369,13 +337,11 @@ public class MeteredKeyValueStoreTest {
             Serdes.String()
         );
         assertTrue(metered.setFlushListener(null, false));
-
-        verify(cachedKeyValueStore);
     }
 
     @Test
     public void shouldNotThrowNullPointerExceptionIfGetReturnsNull() {
-        expect(inner.get(Bytes.wrap("a".getBytes()))).andReturn(null);
+        when(inner.get(Bytes.wrap("a".getBytes()))).thenReturn(null);
 
         init();
         assertNull(metered.get("a"));
@@ -388,27 +354,23 @@ public class MeteredKeyValueStoreTest {
 
     @Test
     public void shouldRemoveMetricsOnClose() {
-        inner.close();
-        expectLastCall();
+        doNothing().when(inner).close();
         init(); // replays "inner"
 
         // There's always a "count" metric registered
         assertThat(storeMetrics(), not(empty()));
         metered.close();
         assertThat(storeMetrics(), empty());
-        verify(inner);
     }
 
     @Test
     public void shouldRemoveMetricsEvenIfWrappedStoreThrowsOnClose() {
-        inner.close();
-        expectLastCall().andThrow(new RuntimeException("Oops!"));
+        doThrow(new RuntimeException("Oops!")).when(inner).close();
         init(); // replays "inner"
 
         assertThat(storeMetrics(), not(empty()));
         assertThrows(RuntimeException.class, metered::close);
         assertThat(storeMetrics(), empty());
-        verify(inner);
     }
 
     @Test
@@ -465,8 +427,8 @@ public class MeteredKeyValueStoreTest {
     @Test
     public void shouldGetRecordsWithPrefixKey() {
         final StringSerializer stringSerializer = new StringSerializer();
-        expect(inner.prefixScan(KEY, stringSerializer))
-            .andReturn(new KeyValueIteratorStub<>(Collections.singletonList(BYTE_KEY_VALUE_PAIR).iterator()));
+        when(inner.prefixScan(KEY, stringSerializer))
+            .thenReturn(new KeyValueIteratorStub<>(Collections.singletonList(BYTE_KEY_VALUE_PAIR).iterator()));
         init();
 
         final KeyValueIterator<String, String> iterator = metered.prefixScan(KEY, stringSerializer);
@@ -475,7 +437,6 @@ public class MeteredKeyValueStoreTest {
 
         final KafkaMetric metric = metrics.metric(new MetricName("prefix-scan-rate", STORE_LEVEL_GROUP, "", tags));
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     private KafkaMetric metric(final MetricName metricName) {


### PR DESCRIPTION
This pull requests migrates mocks from KeyValueIteratorFacadeTest, KeyValueSegmentTest and MeteredKeyValueStoreTest to Mockito.