### PR TITLE
KAFKA-14274 [6, 7]: Introduction of fetch request manager

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -205,6 +205,10 @@
 
     <subpackage name="consumer">
       <allow pkg="org.apache.kafka.clients.consumer" />
+
+      <subpackage name="internals">
+        <allow pkg="org.apache.kafka.clients" />
+      </subpackage>
     </subpackage>
 
     <subpackage name="producer">

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -61,6 +61,8 @@
               files="AbstractRequest.java"/>
     <suppress checks="ClassFanOutComplexity"
               files="AbstractResponse.java"/>
+    <suppress checks="ClassFanOutComplexity"
+              files="PrototypeAsyncConsumer.java"/>
 
     <suppress checks="MethodLength"
               files="(KerberosLogin|RequestResponseTest|ConnectMetricsRegistry|KafkaConsumer|AbstractStickyAssignor).java"/>
@@ -68,7 +70,7 @@
     <suppress checks="ParameterNumber"
               files="(NetworkClient|FieldSpec|KafkaRaftClient).java"/>
     <suppress checks="ParameterNumber"
-              files="(KafkaConsumer|ConsumerCoordinator).java"/>
+              files="(KafkaConsumer|PrototypeAsyncConsumer|ConsumerCoordinator).java"/>
     <suppress checks="ParameterNumber"
               files="(RecordAccumulator|Sender).java"/>
     <suppress checks="ParameterNumber"
@@ -79,7 +81,7 @@
               files="MemoryRecordsBuilder.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(KafkaConsumer|ConsumerCoordinator|AbstractFetch|KafkaProducer|AbstractRequest|AbstractResponse|TransactionManager|Admin|KafkaAdminClient|MockAdminClient|KafkaRaftClient|KafkaRaftClientTest).java"/>
+              files="(KafkaConsumer|PrototypeAsyncConsumer|ConsumerCoordinator|AbstractFetch|KafkaProducer|AbstractRequest|AbstractResponse|TransactionManager|Admin|KafkaAdminClient|MockAdminClient|KafkaRaftClient|KafkaRaftClientTest).java"/>
     <suppress checks="ClassDataAbstractionCoupling"
               files="(Errors|SaslAuthenticatorTest|AgentTest|CoordinatorTest).java"/>
 
@@ -108,10 +110,10 @@
 
     <!-- Clients tests -->
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(Sender|Fetcher|OffsetFetcher|KafkaConsumer|Metrics|RequestResponse|TransactionManager|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
+              files="(Sender|Fetcher|FetchRequestManager|OffsetFetcher|KafkaConsumer|PrototypeAsyncConsumer|Metrics|RequestResponse|TransactionManager|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
 
     <suppress checks="ClassFanOutComplexity"
-              files="(ConsumerCoordinator|KafkaConsumer|RequestResponse|Fetcher|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
+              files="(ConsumerCoordinator|KafkaConsumer|RequestResponse|Fetcher|FetchRequestManager|KafkaAdminClient|Message|KafkaProducer)Test.java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="MockAdminClient.java"/>
@@ -120,7 +122,7 @@
               files="(OffsetFetcher|RequestResponse)Test.java"/>
 
     <suppress checks="JavaNCSS"
-              files="RequestResponseTest.java|FetcherTest.java|KafkaAdminClientTest.java"/>
+              files="RequestResponseTest.java|FetcherTest.java|FetchRequestManagerTest.java|KafkaAdminClientTest.java"/>
 
     <suppress checks="NPathComplexity"
               files="MemoryRecordsTest|MetricsTest|RequestResponseTest|TestSslUtils|AclAuthorizerBenchmark"/>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -752,7 +752,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                         config.getBoolean(ConsumerConfig.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED),
                         config.getString(ConsumerConfig.CLIENT_RACK_CONFIG));
             }
-            FetchConfig<K, V> fetchConfig = createFetchConfig(config, this.deserializers);
+            FetchConfig fetchConfig = createFetchConfig(config);
             this.fetcher = new Fetcher<>(
                     logContext,
                     this.client,
@@ -1252,7 +1252,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 Math.min(coordinator.timeToNextPoll(timer.currentTimeMs()), timer.remainingMs());
 
         // if data is available already, return it immediately
-        final Fetch<K, V> fetch = fetcher.collectFetch();
+        final Fetch<K, V> fetch = fetcher.collectFetch(deserializers);
         if (!fetch.isEmpty()) {
             return fetch;
         }
@@ -1279,7 +1279,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
         });
         timer.update(pollTimer.currentTimeMs());
 
-        return fetcher.collectFetch();
+        return fetcher.collectFetch(deserializers);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
@@ -18,10 +18,13 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.FetchSessionHandler;
+import org.apache.kafka.clients.KafkaClient;
+import org.apache.kafka.clients.NetworkClientUtils;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.internals.IdempotentCloser;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -37,11 +40,9 @@ import org.slf4j.Logger;
 import org.slf4j.helpers.MessageFormatter;
 
 import java.io.Closeable;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -58,7 +59,6 @@ public abstract class AbstractFetch<K, V> implements Closeable {
 
     private final Logger log;
     protected final LogContext logContext;
-    protected final ConsumerNetworkClient client;
     protected final ConsumerMetadata metadata;
     protected final SubscriptionState subscriptions;
     protected final FetchConfig<K, V> fetchConfig;
@@ -72,7 +72,6 @@ public abstract class AbstractFetch<K, V> implements Closeable {
     private final Map<Integer, FetchSessionHandler> sessionHandlers;
 
     public AbstractFetch(final LogContext logContext,
-                         final ConsumerNetworkClient client,
                          final ConsumerMetadata metadata,
                          final SubscriptionState subscriptions,
                          final FetchConfig<K, V> fetchConfig,
@@ -80,7 +79,6 @@ public abstract class AbstractFetch<K, V> implements Closeable {
                          final Time time) {
         this.log = logContext.logger(AbstractFetch.class);
         this.logContext = logContext;
-        this.client = client;
         this.metadata = metadata;
         this.subscriptions = subscriptions;
         this.fetchConfig = fetchConfig;
@@ -91,6 +89,23 @@ public abstract class AbstractFetch<K, V> implements Closeable {
         this.metricsManager = metricsManager;
         this.time = time;
     }
+
+    /**
+     * Check if the node is disconnected and unavailable for immediate reconnection (i.e. if it is in
+     * reconnect backoff window following the disconnect).
+     *
+     * @param node {@link Node} to check for availability
+     * @see NetworkClientUtils#isUnavailable(KafkaClient, Node, Time)
+     */
+    protected abstract boolean isUnavailable(Node node);
+
+    /**
+     * Checks for an authentication error on a given node and throws the exception if it exists.
+     *
+     * @param node {@link Node} to check for a previous {@link AuthenticationException}; if found it is thrown
+     * @see NetworkClientUtils#maybeThrowAuthFailure(KafkaClient, Node)
+     */
+    protected abstract void maybeThrowAuthFailure(Node node);
 
     /**
      * Return whether we have any completed fetches pending return to the user. This method is thread-safe. Has
@@ -317,7 +332,7 @@ public abstract class AbstractFetch<K, V> implements Closeable {
         }
     }
 
-    private Map<Node, FetchSessionHandler.FetchRequestData> prepareCloseFetchSessionRequests() {
+    protected Map<Node, FetchSessionHandler.FetchRequestData> prepareCloseFetchSessionRequests() {
         final Cluster cluster = metadata.fetch();
         Map<Node, FetchSessionHandler.Builder> fetchable = new LinkedHashMap<>();
 
@@ -330,7 +345,7 @@ public abstract class AbstractFetch<K, V> implements Closeable {
                 // skip sending the close request.
                 final Node fetchTarget = cluster.nodeById(fetchTargetNodeId);
 
-                if (fetchTarget == null || client.isUnavailable(fetchTarget)) {
+                if (fetchTarget == null || isUnavailable(fetchTarget)) {
                     log.debug("Skip sending close session request to broker {} since it is not reachable", fetchTarget);
                     return;
                 }
@@ -377,8 +392,8 @@ public abstract class AbstractFetch<K, V> implements Closeable {
             // Use the preferred read replica if set, otherwise the partition's leader
             Node node = selectReadReplica(partition, leaderOpt.get(), currentTimeMs);
 
-            if (client.isUnavailable(node)) {
-                client.maybeThrowAuthFailure(node);
+            if (isUnavailable(node)) {
+                maybeThrowAuthFailure(node);
 
                 // If we try to send during the reconnect backoff window, then the request is just
                 // going to be failed anyway before being sent, so skip sending the request for now
@@ -412,46 +427,6 @@ public abstract class AbstractFetch<K, V> implements Closeable {
         return reqs;
     }
 
-    protected void maybeCloseFetchSessions(final Timer timer) {
-        final List<RequestFuture<ClientResponse>> requestFutures = new ArrayList<>();
-        Map<Node, FetchSessionHandler.FetchRequestData> fetchRequestMap = prepareCloseFetchSessionRequests();
-
-        for (Map.Entry<Node, FetchSessionHandler.FetchRequestData> entry : fetchRequestMap.entrySet()) {
-            final Node fetchTarget = entry.getKey();
-            final FetchSessionHandler.FetchRequestData data = entry.getValue();
-            final FetchRequest.Builder request = createFetchRequest(fetchTarget, data);
-            final RequestFuture<ClientResponse> responseFuture = client.send(fetchTarget, request);
-
-            responseFuture.addListener(new RequestFutureListener<ClientResponse>() {
-                @Override
-                public void onSuccess(ClientResponse value) {
-                    handleCloseFetchSessionResponse(fetchTarget, data);
-                }
-
-                @Override
-                public void onFailure(RuntimeException e) {
-                    handleCloseFetchSessionResponse(fetchTarget, data, e);
-                }
-            });
-
-            requestFutures.add(responseFuture);
-        }
-
-        // Poll to ensure that request has been written to the socket. Wait until either the timer has expired or until
-        // all requests have received a response.
-        while (timer.notExpired() && !requestFutures.stream().allMatch(RequestFuture::isDone)) {
-            client.poll(timer, null, true);
-        }
-
-        if (!requestFutures.stream().allMatch(RequestFuture::isDone)) {
-            // we ran out of time before completing all futures. It is ok since we don't want to block the shutdown
-            // here.
-            log.debug("All requests couldn't be sent in the specific timeout period {}ms. " +
-                    "This may result in unnecessary fetch sessions at the broker. Consider increasing the timeout passed for " +
-                    "KafkaConsumer.close(Duration timeout)", timer.timeoutMs());
-        }
-    }
-
     // Visible for testing
     protected FetchSessionHandler sessionHandler(int node) {
         return sessionHandlers.get(node);
@@ -467,8 +442,6 @@ public abstract class AbstractFetch<K, V> implements Closeable {
     // Visible for testing
     protected void closeInternal(Timer timer) {
         // we do not need to re-enable wake-ups since we are closing already
-        client.disableWakeups();
-        maybeCloseFetchSessions(timer);
         Utils.closeQuietly(fetchBuffer, "fetchBuffer");
         Utils.closeQuietly(decompressionBufferSupplier, "decompressionBufferSupplier");
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractFetch.java
@@ -52,16 +52,14 @@ import static org.apache.kafka.clients.consumer.internals.FetchUtils.requestMeta
 
 /**
  * {@code AbstractFetch} represents the basic state and logic for record fetching processing.
- * @param <K> Type for the message key
- * @param <V> Type for the message value
  */
-public abstract class AbstractFetch<K, V> implements Closeable {
+public abstract class AbstractFetch implements Closeable {
 
     private final Logger log;
     protected final LogContext logContext;
     protected final ConsumerMetadata metadata;
     protected final SubscriptionState subscriptions;
-    protected final FetchConfig<K, V> fetchConfig;
+    protected final FetchConfig fetchConfig;
     protected final Time time;
     protected final FetchMetricsManager metricsManager;
     protected final FetchBuffer fetchBuffer;
@@ -74,7 +72,7 @@ public abstract class AbstractFetch<K, V> implements Closeable {
     public AbstractFetch(final LogContext logContext,
                          final ConsumerMetadata metadata,
                          final SubscriptionState subscriptions,
-                         final FetchConfig<K, V> fetchConfig,
+                         final FetchConfig fetchConfig,
                          final FetchMetricsManager metricsManager,
                          final Time time) {
         this.log = logContext.logger(AbstractFetch.class);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CachedSupplier.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CachedSupplier.java
@@ -16,20 +16,28 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
-
-import java.io.Closeable;
+import java.util.function.Supplier;
 
 /**
- * {@code PollResult} consist of {@code UnsentRequest} if there are requests to send; otherwise, return the time till
- * the next poll event.
+ * Simple {@link Supplier} that caches the initial creation of the object and stores it for later calls
+ * to {@link #get()}.
+ *
+ * <p/>
+ *
+ * <em>Note</em>: this class is not thread safe! Use only in contexts which are designed/guaranteed to be
+ * single-threaded.
  */
-public interface RequestManager extends Closeable {
+public abstract class CachedSupplier<T> implements Supplier<T> {
 
-    PollResult poll(long currentTimeMs);
+    private T result;
+
+    protected abstract T create();
 
     @Override
-    default void close() {
-        // Do nothing...
+    public T get() {
+        if (result == null)
+            result = create();
+
+        return result;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CompletedFetch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CompletedFetch.java
@@ -53,7 +53,7 @@ import java.util.Set;
 /**
  * {@link CompletedFetch} represents a {@link RecordBatch batch} of {@link Record records} that was returned from the
  * broker via a {@link FetchRequest}. It contains logic to maintain state between calls to
- * {@link #fetchRecords(FetchConfig, int)}.
+ * {@link #fetchRecords(FetchConfig, Deserializers, int)}.
  */
 public class CompletedFetch {
 
@@ -135,7 +135,8 @@ public class CompletedFetch {
     /**
      * Draining a {@link CompletedFetch} will signal that the data has been consumed and the underlying resources
      * are closed. This is somewhat analogous to {@link Closeable#close() closing}, though no error will result if a
-     * caller invokes {@link #fetchRecords(FetchConfig, int)}; an empty {@link List list} will be returned instead.
+     * caller invokes {@link #fetchRecords(FetchConfig, Deserializers, int)}; an empty {@link List list} will be
+     * returned instead.
      */
     void drain() {
         if (!isConsumed) {
@@ -151,7 +152,7 @@ public class CompletedFetch {
         }
     }
 
-    private <K, V> void maybeEnsureValid(FetchConfig<K, V> fetchConfig, RecordBatch batch) {
+    private <K, V> void maybeEnsureValid(FetchConfig fetchConfig, RecordBatch batch) {
         if (fetchConfig.checkCrcs && batch.magic() >= RecordBatch.MAGIC_VALUE_V2) {
             try {
                 batch.ensureValid();
@@ -162,7 +163,7 @@ public class CompletedFetch {
         }
     }
 
-    private <K, V> void maybeEnsureValid(FetchConfig<K, V> fetchConfig, Record record) {
+    private <K, V> void maybeEnsureValid(FetchConfig fetchConfig, Record record) {
         if (fetchConfig.checkCrcs) {
             try {
                 record.ensureValid();
@@ -180,7 +181,7 @@ public class CompletedFetch {
         }
     }
 
-    private <K, V> Record nextFetchedRecord(FetchConfig<K, V> fetchConfig) {
+    private <K, V> Record nextFetchedRecord(FetchConfig fetchConfig) {
         while (true) {
             if (records == null || !records.hasNext()) {
                 maybeCloseRecordStream();
@@ -249,7 +250,9 @@ public class CompletedFetch {
      * @param maxRecords The number of records to return; the number returned may be {@code 0 <= maxRecords}
      * @return {@link ConsumerRecord Consumer records}
      */
-    <K, V> List<ConsumerRecord<K, V>> fetchRecords(FetchConfig<K, V> fetchConfig, int maxRecords) {
+    <K, V> List<ConsumerRecord<K, V>> fetchRecords(FetchConfig fetchConfig,
+                                                   Deserializers<K, V> deserializers,
+                                                   int maxRecords) {
         // Error when fetching the next record before deserialization.
         if (corruptLastRecord)
             throw new KafkaException("Received exception when fetching the next record from " + partition
@@ -276,7 +279,7 @@ public class CompletedFetch {
 
                 Optional<Integer> leaderEpoch = maybeLeaderEpoch(currentBatch.partitionLeaderEpoch());
                 TimestampType timestampType = currentBatch.timestampType();
-                ConsumerRecord<K, V> record = parseRecord(fetchConfig, partition, leaderEpoch, timestampType, lastRecord);
+                ConsumerRecord<K, V> record = parseRecord(deserializers, partition, leaderEpoch, timestampType, lastRecord);
                 records.add(record);
                 recordsRead++;
                 bytesRead += lastRecord.sizeInBytes();
@@ -302,7 +305,7 @@ public class CompletedFetch {
     /**
      * Parse the record entry, deserializing the key / value fields if necessary
      */
-    <K, V> ConsumerRecord<K, V> parseRecord(FetchConfig<K, V> fetchConfig,
+    <K, V> ConsumerRecord<K, V> parseRecord(Deserializers<K, V> deserializers,
                                             TopicPartition partition,
                                             Optional<Integer> leaderEpoch,
                                             TimestampType timestampType,
@@ -312,16 +315,16 @@ public class CompletedFetch {
             long timestamp = record.timestamp();
             Headers headers = new RecordHeaders(record.headers());
             ByteBuffer keyBytes = record.key();
-            K key = keyBytes == null ? null : fetchConfig.deserializers.keyDeserializer.deserialize(partition.topic(), headers, keyBytes);
+            K key = keyBytes == null ? null : deserializers.keyDeserializer.deserialize(partition.topic(), headers, keyBytes);
             ByteBuffer valueBytes = record.value();
-            V value = valueBytes == null ? null : fetchConfig.deserializers.valueDeserializer.deserialize(partition.topic(), headers, valueBytes);
+            V value = valueBytes == null ? null : deserializers.valueDeserializer.deserialize(partition.topic(), headers, valueBytes);
             return new ConsumerRecord<>(partition.topic(), partition.partition(), offset,
                     timestamp, timestampType,
                     keyBytes == null ? ConsumerRecord.NULL_SIZE : keyBytes.remaining(),
                     valueBytes == null ? ConsumerRecord.NULL_SIZE : valueBytes.remaining(),
                     key, value, headers, leaderEpoch);
         } catch (RuntimeException e) {
-            log.error("Deserializers with error: {}", fetchConfig.deserializers);
+            log.error("Deserializers with error: {}", deserializers);
             throw new RecordDeserializationException(partition, record.offset(),
                     "Error deserializing key/value for partition " + partition +
                             " at offset " + record.offset() + ". If needed, please seek past the record to continue consumption.", e);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerUtils.java
@@ -142,10 +142,9 @@ public final class ConsumerUtils {
         return new FetchMetricsManager(metrics, metricsRegistry);
     }
 
-    public static <K, V> FetchConfig<K, V> createFetchConfig(ConsumerConfig config,
-                                                             Deserializers<K, V> deserializers) {
+    public static FetchConfig createFetchConfig(ConsumerConfig config) {
         IsolationLevel isolationLevel = configuredIsolationLevel(config);
-        return new FetchConfig<>(config, deserializers, isolationLevel);
+        return new FetchConfig(config, isolationLevel);
     }
 
     @SuppressWarnings("unchecked")

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -16,197 +16,78 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.ApiVersions;
-import org.apache.kafka.clients.ClientUtils;
-import org.apache.kafka.clients.GroupRebalanceConfig;
-import org.apache.kafka.clients.NetworkClient;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
-import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import org.apache.kafka.clients.consumer.internals.events.CompletableApplicationEvent;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.errors.WakeupException;
-import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.internals.IdempotentCloser;
 import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
+import java.io.Closeable;
+import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
-
-import static java.util.Objects.requireNonNull;
-import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION;
-import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_METRIC_GROUP_PREFIX;
-import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredIsolationLevel;
+import java.util.function.Supplier;
 
 /**
  * Background thread runnable that consumes {@code ApplicationEvent} and
  * produces {@code BackgroundEvent}. It uses an event loop to consume and
  * produce events, and poll the network client to handle network IO.
- * <p/>
+ * <p>
  * It holds a reference to the {@link SubscriptionState}, which is
  * initialized by the polling thread.
- * <p/>
- * For processing application events that have been submitted to the
- * {@link #applicationEventQueue}, this relies on an {@link ApplicationEventProcessor}. Processing includes generating requests and
- * handling responses with the appropriate {@link RequestManager}. The network operations for
- * actually sending the requests is delegated to the {@link NetworkClientDelegate}
- * </li>
  */
-public class DefaultBackgroundThread extends KafkaThread {
+public class DefaultBackgroundThread<K, V> extends KafkaThread implements Closeable {
+
     private static final long MAX_POLL_TIMEOUT_MS = 5000;
     private static final String BACKGROUND_THREAD_NAME = "consumer_background_thread";
     private final Time time;
     private final Logger log;
     private final BlockingQueue<ApplicationEvent> applicationEventQueue;
-    private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
-    private final ConsumerMetadata metadata;
-    private final ConsumerConfig config;
+    private final Supplier<ApplicationEventProcessor<K, V>> applicationEventProcessorSupplier;
+    private final Supplier<NetworkClientDelegate> networkClientDelegateSupplier;
+    private final Supplier<RequestManagers<K, V>> requestManagersSupplier;
     // empty if groupId is null
-    private final ApplicationEventProcessor applicationEventProcessor;
-    private final NetworkClientDelegate networkClientDelegate;
-    private final ErrorEventHandler errorEventHandler;
-    private final GroupState groupState;
-    private boolean running;
+    private ApplicationEventProcessor<K, V> applicationEventProcessor;
+    private NetworkClientDelegate networkClientDelegate;
+    private RequestManagers<K, V> requestManagers;
+    private volatile boolean running;
+    private final IdempotentCloser closer = new IdempotentCloser();
 
-    private final RequestManagers requestManagers;
-
-    // Visible for testing
-    DefaultBackgroundThread(final Time time,
-                            final ConsumerConfig config,
-                            final LogContext logContext,
-                            final BlockingQueue<ApplicationEvent> applicationEventQueue,
-                            final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                            final ErrorEventHandler errorEventHandler,
-                            final ApplicationEventProcessor processor,
-                            final ConsumerMetadata metadata,
-                            final NetworkClientDelegate networkClient,
-                            final GroupState groupState,
-                            final CoordinatorRequestManager coordinatorManager,
-                            final CommitRequestManager commitRequestManager,
-                            final OffsetsRequestManager offsetsRequestManager) {
+    public DefaultBackgroundThread(Time time,
+                                   LogContext logContext,
+                                   BlockingQueue<ApplicationEvent> applicationEventQueue,
+                                   Supplier<ApplicationEventProcessor<K, V>> applicationEventProcessorSupplier,
+                                   Supplier<NetworkClientDelegate> networkClientDelegateSupplier,
+                                   Supplier<RequestManagers<K, V>> requestManagersSupplier) {
         super(BACKGROUND_THREAD_NAME, true);
         this.time = time;
-        this.running = true;
         this.log = logContext.logger(getClass());
         this.applicationEventQueue = applicationEventQueue;
-        this.backgroundEventQueue = backgroundEventQueue;
-        this.applicationEventProcessor = processor;
-        this.config = config;
-        this.metadata = metadata;
-        this.networkClientDelegate = networkClient;
-        this.errorEventHandler = errorEventHandler;
-        this.groupState = groupState;
-
-        this.requestManagers = new RequestManagers(
-                offsetsRequestManager,
-                Optional.ofNullable(coordinatorManager),
-                Optional.ofNullable(commitRequestManager));
-    }
-
-    public DefaultBackgroundThread(final Time time,
-                                   final ConsumerConfig config,
-                                   final GroupRebalanceConfig rebalanceConfig,
-                                   final LogContext logContext,
-                                   final BlockingQueue<ApplicationEvent> applicationEventQueue,
-                                   final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                                   final ConsumerMetadata metadata,
-                                   final SubscriptionState subscriptionState,
-                                   final ApiVersions apiVersions,
-                                   final Metrics metrics,
-                                   final Sensor fetcherThrottleTimeSensor) {
-        super(BACKGROUND_THREAD_NAME, true);
-        requireNonNull(config);
-        requireNonNull(rebalanceConfig);
-        requireNonNull(logContext);
-        requireNonNull(applicationEventQueue);
-        requireNonNull(backgroundEventQueue);
-        requireNonNull(metadata);
-        requireNonNull(subscriptionState);
-        try {
-            this.time = time;
-            this.log = logContext.logger(getClass());
-            this.applicationEventQueue = applicationEventQueue;
-            this.backgroundEventQueue = backgroundEventQueue;
-            this.config = config;
-            this.metadata = metadata;
-            final NetworkClient networkClient = ClientUtils.createNetworkClient(config,
-                    metrics,
-                    CONSUMER_METRIC_GROUP_PREFIX,
-                    logContext,
-                    apiVersions,
-                    time,
-                    CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION,
-                    metadata,
-                    fetcherThrottleTimeSensor);
-            this.networkClientDelegate = new NetworkClientDelegate(
-                    this.time,
-                    this.config,
-                    logContext,
-                    networkClient);
-            this.running = true;
-            this.errorEventHandler = new ErrorEventHandler(this.backgroundEventQueue);
-            this.groupState = new GroupState(rebalanceConfig);
-            long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
-            long retryBackoffMaxMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MAX_MS_CONFIG);
-            final int requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
-
-            OffsetsRequestManager offsetsRequestManager =
-                    new OffsetsRequestManager(
-                            subscriptionState,
-                            metadata,
-                            configuredIsolationLevel(config),
-                            time,
-                            retryBackoffMs,
-                            requestTimeoutMs,
-                            apiVersions,
-                            networkClientDelegate,
-                            logContext);
-            CoordinatorRequestManager coordinatorRequestManager = null;
-            CommitRequestManager commitRequestManager = null;
-
-            if (groupState.groupId != null) {
-                coordinatorRequestManager = new CoordinatorRequestManager(
-                        this.time,
-                        logContext,
-                        retryBackoffMs,
-                        retryBackoffMaxMs,
-                        this.errorEventHandler,
-                        groupState.groupId);
-                commitRequestManager = new CommitRequestManager(
-                        this.time,
-                        logContext,
-                        subscriptionState,
-                        config,
-                        coordinatorRequestManager,
-                        groupState);
-            }
-
-            this.requestManagers = new RequestManagers(
-                    offsetsRequestManager,
-                    Optional.ofNullable(coordinatorRequestManager),
-                    Optional.ofNullable(commitRequestManager));
-
-            this.applicationEventProcessor = new ApplicationEventProcessor(
-                    backgroundEventQueue,
-                    requestManagers,
-                    metadata);
-
-        } catch (final Exception e) {
-            close();
-            throw new KafkaException("Failed to construct background processor", e.getCause());
-        }
+        this.applicationEventProcessorSupplier = applicationEventProcessorSupplier;
+        this.networkClientDelegateSupplier = networkClientDelegateSupplier;
+        this.requestManagersSupplier = requestManagersSupplier;
     }
 
     @Override
     public void run() {
+        closer.assertOpen("Consumer background thread is already closed");
+        running = true;
+
         try {
             log.debug("Background thread started");
+
+            // Wait until we're securely in the background thread to initialize these objects...
+            initializeResources();
+
             while (running) {
                 try {
                     runOnce();
@@ -217,11 +98,17 @@ public class DefaultBackgroundThread extends KafkaThread {
             }
         } catch (final Throwable t) {
             log.error("The background thread failed due to unexpected error", t);
-            throw new RuntimeException(t);
+            throw new KafkaException(t);
         } finally {
             close();
-            log.debug("{} closed", getClass());
+            log.debug("Background thread closed");
         }
+    }
+
+    void initializeResources() {
+        applicationEventProcessor = applicationEventProcessorSupplier.get();
+        networkClientDelegate = networkClientDelegateSupplier.get();
+        requestManagers = requestManagersSupplier.get();
     }
 
     /**
@@ -231,15 +118,13 @@ public class DefaultBackgroundThread extends KafkaThread {
      * 3. Poll the networkClient to send and retrieve the response.
      */
     void runOnce() {
-        if (!applicationEventQueue.isEmpty()) {
-            LinkedList<ApplicationEvent> res = new LinkedList<>();
-            this.applicationEventQueue.drainTo(res);
+        LinkedList<ApplicationEvent> events = new LinkedList<>();
+        applicationEventQueue.drainTo(events);
 
-            for (ApplicationEvent event : res) {
-                log.debug("Consuming application event: {}", event);
-                Objects.requireNonNull(event);
-                applicationEventProcessor.process(event);
-            }
+        for (ApplicationEvent event : events) {
+            log.trace("Dequeued event: {}", event);
+            Objects.requireNonNull(event);
+            applicationEventProcessor.process(event);
         }
 
         final long currentTimeMs = time.milliseconds();
@@ -259,17 +144,41 @@ public class DefaultBackgroundThread extends KafkaThread {
     }
 
     public boolean isRunning() {
-        return this.running;
+        return running;
     }
 
     public void wakeup() {
-        networkClientDelegate.wakeup();
+        if (networkClientDelegate != null)
+            networkClientDelegate.wakeup();
     }
 
+    @Override
     public void close() {
-        this.running = false;
-        this.wakeup();
-        Utils.closeQuietly(networkClientDelegate, "network client utils");
-        Utils.closeQuietly(metadata, "consumer metadata client");
+        closer.close(() -> {
+            log.debug("Closing the consumer background thread");
+            running = false;
+            wakeup();
+            Utils.closeQuietly(requestManagers, "Request managers client");
+            Utils.closeQuietly(networkClientDelegate, "network client utils");
+            log.debug("Closed the consumer background thread");
+            drainAndComplete();
+        }, () -> log.warn("The consumer background thread was previously closed"));
+    }
+
+
+    /**
+     * It is possible for the background thread to close before complete processing all the events in the queue. In
+     * this case, we need throw an exception to notify the user the consumer is closed.
+     */
+    private void drainAndComplete() {
+        List<ApplicationEvent> incompletedEvents = new ArrayList<>();
+        applicationEventQueue.drainTo(incompletedEvents);
+        incompletedEvents.forEach(event -> {
+            if (event instanceof CompletableApplicationEvent) {
+                ((CompletableApplicationEvent<?>) event).future().completeExceptionally(
+                        new KafkaException("The consumer is closed"));
+            }
+        });
+        log.debug("Discarding {} events because the consumer is closed", incompletedEvents.size());
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -16,197 +16,78 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.ApiVersions;
-import org.apache.kafka.clients.ClientUtils;
-import org.apache.kafka.clients.GroupRebalanceConfig;
-import org.apache.kafka.clients.NetworkClient;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
-import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import org.apache.kafka.clients.consumer.internals.events.CompletableApplicationEvent;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.errors.WakeupException;
-import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.internals.IdempotentCloser;
 import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
+import java.io.Closeable;
+import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
-
-import static java.util.Objects.requireNonNull;
-import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION;
-import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_METRIC_GROUP_PREFIX;
-import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredIsolationLevel;
+import java.util.function.Supplier;
 
 /**
  * Background thread runnable that consumes {@code ApplicationEvent} and
  * produces {@code BackgroundEvent}. It uses an event loop to consume and
  * produce events, and poll the network client to handle network IO.
- * <p/>
+ * <p>
  * It holds a reference to the {@link SubscriptionState}, which is
  * initialized by the polling thread.
- * <p/>
- * For processing application events that have been submitted to the
- * {@link #applicationEventQueue}, this relies on an {@link ApplicationEventProcessor}. Processing includes generating requests and
- * handling responses with the appropriate {@link RequestManager}. The network operations for
- * actually sending the requests is delegated to the {@link NetworkClientDelegate}
- * </li>
  */
-public class DefaultBackgroundThread extends KafkaThread {
+public class DefaultBackgroundThread extends KafkaThread implements Closeable {
+
     private static final long MAX_POLL_TIMEOUT_MS = 5000;
     private static final String BACKGROUND_THREAD_NAME = "consumer_background_thread";
     private final Time time;
     private final Logger log;
     private final BlockingQueue<ApplicationEvent> applicationEventQueue;
-    private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
-    private final ConsumerMetadata metadata;
-    private final ConsumerConfig config;
+    private final Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier;
+    private final Supplier<NetworkClientDelegate> networkClientDelegateSupplier;
+    private final Supplier<RequestManagers> requestManagersSupplier;
     // empty if groupId is null
-    private final ApplicationEventProcessor applicationEventProcessor;
-    private final NetworkClientDelegate networkClientDelegate;
-    private final ErrorEventHandler errorEventHandler;
-    private final GroupState groupState;
-    private boolean running;
+    private ApplicationEventProcessor applicationEventProcessor;
+    private NetworkClientDelegate networkClientDelegate;
+    private RequestManagers requestManagers;
+    private volatile boolean running;
+    private final IdempotentCloser closer = new IdempotentCloser();
 
-    private final RequestManagers requestManagers;
-
-    // Visible for testing
-    DefaultBackgroundThread(final Time time,
-                            final ConsumerConfig config,
-                            final LogContext logContext,
-                            final BlockingQueue<ApplicationEvent> applicationEventQueue,
-                            final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                            final ErrorEventHandler errorEventHandler,
-                            final ApplicationEventProcessor processor,
-                            final ConsumerMetadata metadata,
-                            final NetworkClientDelegate networkClient,
-                            final GroupState groupState,
-                            final CoordinatorRequestManager coordinatorManager,
-                            final CommitRequestManager commitRequestManager,
-                            final OffsetsRequestManager offsetsRequestManager) {
+    public DefaultBackgroundThread(Time time,
+                                   LogContext logContext,
+                                   BlockingQueue<ApplicationEvent> applicationEventQueue,
+                                   Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier,
+                                   Supplier<NetworkClientDelegate> networkClientDelegateSupplier,
+                                   Supplier<RequestManagers> requestManagersSupplier) {
         super(BACKGROUND_THREAD_NAME, true);
         this.time = time;
-        this.running = true;
         this.log = logContext.logger(getClass());
         this.applicationEventQueue = applicationEventQueue;
-        this.backgroundEventQueue = backgroundEventQueue;
-        this.applicationEventProcessor = processor;
-        this.config = config;
-        this.metadata = metadata;
-        this.networkClientDelegate = networkClient;
-        this.errorEventHandler = errorEventHandler;
-        this.groupState = groupState;
-
-        this.requestManagers = new RequestManagers(
-                offsetsRequestManager,
-                Optional.ofNullable(coordinatorManager),
-                Optional.ofNullable(commitRequestManager));
-    }
-
-    public DefaultBackgroundThread(final Time time,
-                                   final ConsumerConfig config,
-                                   final GroupRebalanceConfig rebalanceConfig,
-                                   final LogContext logContext,
-                                   final BlockingQueue<ApplicationEvent> applicationEventQueue,
-                                   final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                                   final ConsumerMetadata metadata,
-                                   final SubscriptionState subscriptionState,
-                                   final ApiVersions apiVersions,
-                                   final Metrics metrics,
-                                   final Sensor fetcherThrottleTimeSensor) {
-        super(BACKGROUND_THREAD_NAME, true);
-        requireNonNull(config);
-        requireNonNull(rebalanceConfig);
-        requireNonNull(logContext);
-        requireNonNull(applicationEventQueue);
-        requireNonNull(backgroundEventQueue);
-        requireNonNull(metadata);
-        requireNonNull(subscriptionState);
-        try {
-            this.time = time;
-            this.log = logContext.logger(getClass());
-            this.applicationEventQueue = applicationEventQueue;
-            this.backgroundEventQueue = backgroundEventQueue;
-            this.config = config;
-            this.metadata = metadata;
-            final NetworkClient networkClient = ClientUtils.createNetworkClient(config,
-                    metrics,
-                    CONSUMER_METRIC_GROUP_PREFIX,
-                    logContext,
-                    apiVersions,
-                    time,
-                    CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION,
-                    metadata,
-                    fetcherThrottleTimeSensor);
-            this.networkClientDelegate = new NetworkClientDelegate(
-                    this.time,
-                    this.config,
-                    logContext,
-                    networkClient);
-            this.running = true;
-            this.errorEventHandler = new ErrorEventHandler(this.backgroundEventQueue);
-            this.groupState = new GroupState(rebalanceConfig);
-            long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
-            long retryBackoffMaxMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MAX_MS_CONFIG);
-            final int requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
-
-            OffsetsRequestManager offsetsRequestManager =
-                    new OffsetsRequestManager(
-                            subscriptionState,
-                            metadata,
-                            configuredIsolationLevel(config),
-                            time,
-                            retryBackoffMs,
-                            requestTimeoutMs,
-                            apiVersions,
-                            networkClientDelegate,
-                            logContext);
-            CoordinatorRequestManager coordinatorRequestManager = null;
-            CommitRequestManager commitRequestManager = null;
-
-            if (groupState.groupId != null) {
-                coordinatorRequestManager = new CoordinatorRequestManager(
-                        this.time,
-                        logContext,
-                        retryBackoffMs,
-                        retryBackoffMaxMs,
-                        this.errorEventHandler,
-                        groupState.groupId);
-                commitRequestManager = new CommitRequestManager(
-                        this.time,
-                        logContext,
-                        subscriptionState,
-                        config,
-                        coordinatorRequestManager,
-                        groupState);
-            }
-
-            this.requestManagers = new RequestManagers(
-                    offsetsRequestManager,
-                    Optional.ofNullable(coordinatorRequestManager),
-                    Optional.ofNullable(commitRequestManager));
-
-            this.applicationEventProcessor = new ApplicationEventProcessor(
-                    backgroundEventQueue,
-                    requestManagers,
-                    metadata);
-
-        } catch (final Exception e) {
-            close();
-            throw new KafkaException("Failed to construct background processor", e.getCause());
-        }
+        this.applicationEventProcessorSupplier = applicationEventProcessorSupplier;
+        this.networkClientDelegateSupplier = networkClientDelegateSupplier;
+        this.requestManagersSupplier = requestManagersSupplier;
     }
 
     @Override
     public void run() {
+        closer.assertOpen("Consumer background thread is already closed");
+        running = true;
+
         try {
             log.debug("Background thread started");
+
+            // Wait until we're securely in the background thread to initialize these objects...
+            initializeResources();
+
             while (running) {
                 try {
                     runOnce();
@@ -217,11 +98,17 @@ public class DefaultBackgroundThread extends KafkaThread {
             }
         } catch (final Throwable t) {
             log.error("The background thread failed due to unexpected error", t);
-            throw new RuntimeException(t);
+            throw new KafkaException(t);
         } finally {
             close();
-            log.debug("{} closed", getClass());
+            log.debug("Background thread closed");
         }
+    }
+
+    void initializeResources() {
+        applicationEventProcessor = applicationEventProcessorSupplier.get();
+        networkClientDelegate = networkClientDelegateSupplier.get();
+        requestManagers = requestManagersSupplier.get();
     }
 
     /**
@@ -231,15 +118,13 @@ public class DefaultBackgroundThread extends KafkaThread {
      * 3. Poll the networkClient to send and retrieve the response.
      */
     void runOnce() {
-        if (!applicationEventQueue.isEmpty()) {
-            LinkedList<ApplicationEvent> res = new LinkedList<>();
-            this.applicationEventQueue.drainTo(res);
+        LinkedList<ApplicationEvent> events = new LinkedList<>();
+        applicationEventQueue.drainTo(events);
 
-            for (ApplicationEvent event : res) {
-                log.debug("Consuming application event: {}", event);
-                Objects.requireNonNull(event);
-                applicationEventProcessor.process(event);
-            }
+        for (ApplicationEvent event : events) {
+            log.trace("Dequeued event: {}", event);
+            Objects.requireNonNull(event);
+            applicationEventProcessor.process(event);
         }
 
         final long currentTimeMs = time.milliseconds();
@@ -259,17 +144,41 @@ public class DefaultBackgroundThread extends KafkaThread {
     }
 
     public boolean isRunning() {
-        return this.running;
+        return running;
     }
 
     public void wakeup() {
-        networkClientDelegate.wakeup();
+        if (networkClientDelegate != null)
+            networkClientDelegate.wakeup();
     }
 
+    @Override
     public void close() {
-        this.running = false;
-        this.wakeup();
-        Utils.closeQuietly(networkClientDelegate, "network client utils");
-        Utils.closeQuietly(metadata, "consumer metadata client");
+        closer.close(() -> {
+            log.debug("Closing the consumer background thread");
+            running = false;
+            wakeup();
+            Utils.closeQuietly(requestManagers, "Request managers client");
+            Utils.closeQuietly(networkClientDelegate, "network client utils");
+            log.debug("Closed the consumer background thread");
+            drainAndComplete();
+        }, () -> log.warn("The consumer background thread was previously closed"));
+    }
+
+
+    /**
+     * It is possible for the background thread to close before complete processing all the events in the queue. In
+     * this case, we need throw an exception to notify the user the consumer is closed.
+     */
+    private void drainAndComplete() {
+        List<ApplicationEvent> incompletedEvents = new ArrayList<>();
+        applicationEventQueue.drainTo(incompletedEvents);
+        incompletedEvents.forEach(event -> {
+            if (event instanceof CompletableApplicationEvent) {
+                ((CompletableApplicationEvent<?>) event).future().completeExceptionally(
+                        new KafkaException("The consumer is closed"));
+            }
+        });
+        log.debug("Discarding {} events because the consumer is closed", incompletedEvents.size());
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThread.java
@@ -45,29 +45,29 @@ import java.util.function.Supplier;
  * It holds a reference to the {@link SubscriptionState}, which is
  * initialized by the polling thread.
  */
-public class DefaultBackgroundThread<K, V> extends KafkaThread implements Closeable {
+public class DefaultBackgroundThread extends KafkaThread implements Closeable {
 
     private static final long MAX_POLL_TIMEOUT_MS = 5000;
     private static final String BACKGROUND_THREAD_NAME = "consumer_background_thread";
     private final Time time;
     private final Logger log;
     private final BlockingQueue<ApplicationEvent> applicationEventQueue;
-    private final Supplier<ApplicationEventProcessor<K, V>> applicationEventProcessorSupplier;
+    private final Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier;
     private final Supplier<NetworkClientDelegate> networkClientDelegateSupplier;
-    private final Supplier<RequestManagers<K, V>> requestManagersSupplier;
+    private final Supplier<RequestManagers> requestManagersSupplier;
     // empty if groupId is null
-    private ApplicationEventProcessor<K, V> applicationEventProcessor;
+    private ApplicationEventProcessor applicationEventProcessor;
     private NetworkClientDelegate networkClientDelegate;
-    private RequestManagers<K, V> requestManagers;
+    private RequestManagers requestManagers;
     private volatile boolean running;
     private final IdempotentCloser closer = new IdempotentCloser();
 
     public DefaultBackgroundThread(Time time,
                                    LogContext logContext,
                                    BlockingQueue<ApplicationEvent> applicationEventQueue,
-                                   Supplier<ApplicationEventProcessor<K, V>> applicationEventProcessorSupplier,
+                                   Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier,
                                    Supplier<NetworkClientDelegate> networkClientDelegateSupplier,
-                                   Supplier<RequestManagers<K, V>> requestManagersSupplier) {
+                                   Supplier<RequestManagers> requestManagersSupplier) {
         super(BACKGROUND_THREAD_NAME, true);
         this.time = time;
         this.log = logContext.logger(getClass());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -37,23 +37,22 @@ import java.util.function.Supplier;
  * An {@link EventHandler} that uses a single background thread to consume {@link ApplicationEvent} and produce
  * {@link BackgroundEvent} from the {@link DefaultBackgroundThread}.
  */
-public class DefaultEventHandler<K, V> implements EventHandler {
+public class DefaultEventHandler implements EventHandler {
 
     private final Logger log;
     private final BlockingQueue<ApplicationEvent> applicationEventQueue;
-    private final DefaultBackgroundThread<K, V> backgroundThread;
+    private final DefaultBackgroundThread backgroundThread;
     private final IdempotentCloser closer = new IdempotentCloser();
 
     public DefaultEventHandler(final Time time,
                                final LogContext logContext,
                                final BlockingQueue<ApplicationEvent> applicationEventQueue,
-                               final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                               final Supplier<ApplicationEventProcessor<K, V>> applicationEventProcessorSupplier,
+                               final Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier,
                                final Supplier<NetworkClientDelegate> networkClientDelegateSupplier,
-                               final Supplier<RequestManagers<K, V>> requestManagersSupplier) {
+                               final Supplier<RequestManagers> requestManagersSupplier) {
         this.log = logContext.logger(DefaultEventHandler.class);
         this.applicationEventQueue = applicationEventQueue;
-        this.backgroundThread = new DefaultBackgroundThread<>(time,
+        this.backgroundThread = new DefaultBackgroundThread(time,
                 logContext,
                 applicationEventQueue,
                 applicationEventProcessorSupplier,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandler.java
@@ -16,119 +16,55 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.ApiVersions;
-import org.apache.kafka.clients.ClientUtils;
-import org.apache.kafka.clients.GroupRebalanceConfig;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
+import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.CompletableApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.EventHandler;
-import org.apache.kafka.common.internals.ClusterResourceListeners;
-import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.internals.IdempotentCloser;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
+import org.slf4j.Logger;
 
-import java.net.InetSocketAddress;
-import java.util.List;
+import java.time.Duration;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Supplier;
 
 /**
- * An {@code EventHandler} that uses a single background thread to consume {@code ApplicationEvent} and produce
- * {@code BackgroundEvent} from the {@link DefaultBackgroundThread}.
+ * An {@link EventHandler} that uses a single background thread to consume {@link ApplicationEvent} and produce
+ * {@link BackgroundEvent} from the {@link DefaultBackgroundThread}.
  */
 public class DefaultEventHandler implements EventHandler {
 
+    private final Logger log;
     private final BlockingQueue<ApplicationEvent> applicationEventQueue;
-    private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
     private final DefaultBackgroundThread backgroundThread;
-
-    public DefaultEventHandler(final ConsumerConfig config,
-                               final GroupRebalanceConfig groupRebalanceConfig,
-                               final LogContext logContext,
-                               final SubscriptionState subscriptionState,
-                               final ApiVersions apiVersions,
-                               final Metrics metrics,
-                               final ClusterResourceListeners clusterResourceListeners,
-                               final Sensor fetcherThrottleTimeSensor) {
-        this(Time.SYSTEM,
-                config,
-                groupRebalanceConfig,
-                logContext,
-                new LinkedBlockingQueue<>(),
-                new LinkedBlockingQueue<>(),
-                subscriptionState,
-                apiVersions,
-                metrics,
-                clusterResourceListeners,
-                fetcherThrottleTimeSensor);
-    }
+    private final IdempotentCloser closer = new IdempotentCloser();
 
     public DefaultEventHandler(final Time time,
-                               final ConsumerConfig config,
-                               final GroupRebalanceConfig groupRebalanceConfig,
                                final LogContext logContext,
                                final BlockingQueue<ApplicationEvent> applicationEventQueue,
-                               final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                               final SubscriptionState subscriptionState,
-                               final ApiVersions apiVersions,
-                               final Metrics metrics,
-                               final ClusterResourceListeners clusterResourceListeners,
-                               final Sensor fetcherThrottleTimeSensor) {
+                               final Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier,
+                               final Supplier<NetworkClientDelegate> networkClientDelegateSupplier,
+                               final Supplier<RequestManagers> requestManagersSupplier) {
+        this.log = logContext.logger(DefaultEventHandler.class);
         this.applicationEventQueue = applicationEventQueue;
-        this.backgroundEventQueue = backgroundEventQueue;
-
-        // Bootstrap a metadata object with the bootstrap server IP address, which will be used once for the
-        // subsequent metadata refresh once the background thread has started up.
-        final ConsumerMetadata metadata = new ConsumerMetadata(config,
-                subscriptionState,
+        this.backgroundThread = new DefaultBackgroundThread(time,
                 logContext,
-                clusterResourceListeners);
-        final List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config);
-        metadata.bootstrap(addresses);
-
-        this.backgroundThread = new DefaultBackgroundThread(
-            time,
-            config,
-            groupRebalanceConfig,
-            logContext,
-            this.applicationEventQueue,
-            this.backgroundEventQueue,
-            metadata,
-            subscriptionState,
-            apiVersions,
-            metrics,
-            fetcherThrottleTimeSensor);
-        backgroundThread.start();
-    }
-
-    // VisibleForTesting
-    DefaultEventHandler(final DefaultBackgroundThread backgroundThread,
-                        final BlockingQueue<ApplicationEvent> applicationEventQueue,
-                        final BlockingQueue<BackgroundEvent> backgroundEventQueue) {
-        this.backgroundThread = backgroundThread;
-        this.applicationEventQueue = applicationEventQueue;
-        this.backgroundEventQueue = backgroundEventQueue;
-        backgroundThread.start();
-    }
-
-    @Override
-    public Optional<BackgroundEvent> poll() {
-        return Optional.ofNullable(backgroundEventQueue.poll());
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return backgroundEventQueue.isEmpty();
+                applicationEventQueue,
+                applicationEventProcessorSupplier,
+                networkClientDelegateSupplier,
+                requestManagersSupplier);
+        this.backgroundThread.start();
     }
 
     @Override
     public boolean add(final ApplicationEvent event) {
+        Objects.requireNonNull(event, "ApplicationEvent provided to add must be non-null");
+        log.trace("Enqueued event: {}", event);
         backgroundThread.wakeup();
         return applicationEventQueue.add(event);
     }
@@ -141,11 +77,25 @@ public class DefaultEventHandler implements EventHandler {
         return event.get(timer);
     }
 
-    public void close() {
-        try {
-            backgroundThread.close();
-        } catch (final Exception e) {
-            throw new RuntimeException(e);
-        }
+    public void close(final Duration timeout) {
+        Objects.requireNonNull(timeout, "Duration provided to close must be non-null");
+
+        closer.close(
+                () ->  {
+                    log.info("Closing the default consumer event handler");
+
+                    try {
+                        long timeoutMs = timeout.toMillis();
+
+                        if (timeoutMs < 0)
+                            throw new IllegalArgumentException("The timeout cannot be negative.");
+
+                        backgroundThread.close();
+                        log.info("The default consumer event handler was closed");
+                    } catch (final Exception e) {
+                        throw new KafkaException(e);
+                    }
+                },
+                () -> log.info("The default consumer event handler was already closed"));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Deserializers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Deserializers.java
@@ -75,4 +75,12 @@ public class Deserializers<K, V> implements AutoCloseable {
             throw new KafkaException("Failed to close deserializers", exception);
         }
     }
+
+    @Override
+    public String toString() {
+        return "Deserializers{" +
+                "keyDeserializer=" + keyDeserializer +
+                ", valueDeserializer=" + valueDeserializer +
+                '}';
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ErrorEventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ErrorEventHandler.java
@@ -22,13 +22,18 @@ import org.apache.kafka.clients.consumer.internals.events.ErrorBackgroundEvent;
 import java.util.Queue;
 
 public class ErrorEventHandler {
+
     private final Queue<BackgroundEvent> backgroundEventQueue;
 
     public ErrorEventHandler(Queue<BackgroundEvent> backgroundEventQueue) {
         this.backgroundEventQueue = backgroundEventQueue;
     }
 
-    public void handle(Throwable e) {
+    public void handle(RuntimeException e) {
         backgroundEventQueue.add(new ErrorBackgroundEvent(e));
+    }
+
+    public void handle(Throwable e) {
+        handle(new RuntimeException(e));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchConfig.java
@@ -21,8 +21,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.serialization.Deserializer;
 
-import java.util.Objects;
-
 /**
  * {@link FetchConfig} represents the static configuration for fetching records from Kafka. It is simply a way
  * to bundle the immutable settings that were presented at the time the {@link Consumer} was created for later use by
@@ -41,9 +39,6 @@ import java.util.Objects;
  *     <li>{@link #maxPollRecords}: {@link ConsumerConfig#MAX_POLL_RECORDS_CONFIG}</li>
  *     <li>{@link #checkCrcs}: {@link ConsumerConfig#CHECK_CRCS_CONFIG}</li>
  *     <li>{@link #clientRackId}: {@link ConsumerConfig#CLIENT_RACK_CONFIG}</li>
- *     <li>{@link #deserializers}:
- *         {@link ConsumerConfig#KEY_DESERIALIZER_CLASS_CONFIG}/{@link ConsumerConfig#VALUE_DESERIALIZER_CLASS_CONFIG}
- *     </li>
  *     <li>{@link #isolationLevel}: {@link ConsumerConfig#ISOLATION_LEVEL_CONFIG}</li>
  * </ul>
  *
@@ -54,11 +49,8 @@ import java.util.Objects;
  *
  * Note: the {@link Deserializer deserializers} used for the key and value are not closed by this class. They should be
  * closed by the creator of the {@link FetchConfig}.
- *
- * @param <K> Type used to {@link Deserializer deserialize} the message/record key
- * @param <V> Type used to {@link Deserializer deserialize} the message/record value
  */
-public class FetchConfig<K, V> {
+public class FetchConfig {
 
     final int minBytes;
     final int maxBytes;
@@ -67,7 +59,6 @@ public class FetchConfig<K, V> {
     final int maxPollRecords;
     final boolean checkCrcs;
     final String clientRackId;
-    final Deserializers<K, V> deserializers;
     final IsolationLevel isolationLevel;
 
     public FetchConfig(int minBytes,
@@ -77,7 +68,6 @@ public class FetchConfig<K, V> {
                        int maxPollRecords,
                        boolean checkCrcs,
                        String clientRackId,
-                       Deserializers<K, V> deserializers,
                        IsolationLevel isolationLevel) {
         this.minBytes = minBytes;
         this.maxBytes = maxBytes;
@@ -86,13 +76,10 @@ public class FetchConfig<K, V> {
         this.maxPollRecords = maxPollRecords;
         this.checkCrcs = checkCrcs;
         this.clientRackId = clientRackId;
-        this.deserializers = Objects.requireNonNull(deserializers, "Message deserializers provided to FetchConfig should not be null");
         this.isolationLevel = isolationLevel;
     }
 
-    public FetchConfig(ConsumerConfig config,
-                       Deserializers<K, V> deserializers,
-                       IsolationLevel isolationLevel) {
+    public FetchConfig(ConsumerConfig config, IsolationLevel isolationLevel) {
         this.minBytes = config.getInt(ConsumerConfig.FETCH_MIN_BYTES_CONFIG);
         this.maxBytes = config.getInt(ConsumerConfig.FETCH_MAX_BYTES_CONFIG);
         this.maxWaitMs = config.getInt(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG);
@@ -100,7 +87,6 @@ public class FetchConfig<K, V> {
         this.maxPollRecords = config.getInt(ConsumerConfig.MAX_POLL_RECORDS_CONFIG);
         this.checkCrcs = config.getBoolean(ConsumerConfig.CHECK_CRCS_CONFIG);
         this.clientRackId = config.getString(ConsumerConfig.CLIENT_RACK_CONFIG);
-        this.deserializers = Objects.requireNonNull(deserializers, "Message deserializers provided to FetchConfig should not be null");
         this.isolationLevel = isolationLevel;
     }
 
@@ -114,7 +100,6 @@ public class FetchConfig<K, V> {
                 ", maxPollRecords=" + maxPollRecords +
                 ", checkCrcs=" + checkCrcs +
                 ", clientRackId='" + clientRackId + '\'' +
-                ", deserializers=" + deserializers +
                 ", isolationLevel=" + isolationLevel +
                 '}';
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.FetchSessionHandler;
+import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
+import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.UnsentRequest;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+
+/**
+ * {@code FetchRequestManager} is responsible for generating {@link FetchRequest} that represent the
+ * {@link SubscriptionState#fetchablePartitions(Predicate)} based on the user's topic subscription/partition
+ * assignment.
+ */
+public class FetchRequestManager extends AbstractFetch implements RequestManager {
+
+    private final Logger log;
+    private final ErrorEventHandler errorEventHandler;
+    private final NetworkClientDelegate networkClientDelegate;
+
+    FetchRequestManager(final LogContext logContext,
+                        final Time time,
+                        final ErrorEventHandler errorEventHandler,
+                        final ConsumerMetadata metadata,
+                        final SubscriptionState subscriptions,
+                        final FetchConfig fetchConfig,
+                        final FetchMetricsManager metricsManager,
+                        final NetworkClientDelegate networkClientDelegate) {
+        super(logContext, metadata, subscriptions, fetchConfig, metricsManager, time);
+        this.log = logContext.logger(FetchRequestManager.class);
+        this.errorEventHandler = errorEventHandler;
+        this.networkClientDelegate = networkClientDelegate;
+    }
+
+    @Override
+    protected boolean isUnavailable(Node node) {
+        return networkClientDelegate.isUnavailable(node);
+    }
+
+    @Override
+    protected void maybeThrowAuthFailure(Node node) {
+        networkClientDelegate.maybeThrowAuthFailure(node);
+    }
+
+    @Override
+    public PollResult poll(long currentTimeMs) {
+        List<UnsentRequest> requests;
+
+        if (!idempotentCloser.isClosed()) {
+            // If the fetcher is open (i.e. not closed), we will issue the normal fetch requests
+            requests = prepareFetchRequests().entrySet().stream().map(entry -> {
+                final Node fetchTarget = entry.getKey();
+                final FetchSessionHandler.FetchRequestData data = entry.getValue();
+                final FetchRequest.Builder request = createFetchRequest(fetchTarget, data);
+                final BiConsumer<ClientResponse, Throwable> responseHandler = (clientResponse, t) -> {
+                    if (t != null) {
+                        handleFetchResponse(fetchTarget, t);
+                        log.warn("Attempt to fetch data from node {} failed due to fatal exception", fetchTarget, t);
+                        errorEventHandler.handle(t);
+                    } else {
+                        handleFetchResponse(fetchTarget, data, clientResponse);
+                    }
+                };
+
+                return new UnsentRequest(request, fetchTarget, responseHandler);
+            }).collect(Collectors.toList());
+        } else {
+            requests = prepareCloseFetchSessionRequests().entrySet().stream().map(entry -> {
+                final Node fetchTarget = entry.getKey();
+                final FetchSessionHandler.FetchRequestData data = entry.getValue();
+                final FetchRequest.Builder request = createFetchRequest(fetchTarget, data);
+                final BiConsumer<ClientResponse, Throwable> responseHandler = (clientResponse, t) -> {
+                    if (t != null) {
+                        handleCloseFetchSessionResponse(fetchTarget, data, t);
+                        log.warn("Attempt to close fetch session on node {} failed due to fatal exception", fetchTarget, t);
+                        errorEventHandler.handle(t);
+                    } else {
+                        handleCloseFetchSessionResponse(fetchTarget, data);
+                    }
+                };
+
+                return new UnsentRequest(request, fetchTarget, responseHandler);
+            }).collect(Collectors.toList());
+        }
+
+        return new PollResult(Long.MAX_VALUE, requests);
+    }
+
+    /**
+     * Drains any of the {@link CompletedFetch} objects from the internal buffer to the returned {@link Queue}.
+     *
+     * <p/>
+     *
+     * This is used by the {@link org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor} to
+     * pull off any fetch results that are stored in the background thread to provide them to the application thread.
+     *
+     * @return {@link Queue} containing zero or more {@link CompletedFetch}
+     */
+    public Queue<CompletedFetch> drain() {
+        Queue<CompletedFetch> q = new LinkedList<>();
+        CompletedFetch completedFetch = fetchBuffer.poll();
+
+        while (completedFetch != null) {
+            q.add(completedFetch);
+            completedFetch = fetchBuffer.poll();
+        }
+
+        return q;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.FetchSessionHandler;
+import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
+import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.UnsentRequest;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+
+/**
+ * {@code FetchRequestManager} is responsible for generating {@link FetchRequest} that represent the
+ * {@link SubscriptionState#fetchablePartitions(Predicate)} based on the user's topic subscription/partition
+ * assignment.
+ *
+ * @param <K> Record key type
+ * @param <V> Record value type
+ */
+public class FetchRequestManager<K, V> extends AbstractFetch<K, V> implements RequestManager {
+
+    private final Logger log;
+    private final ErrorEventHandler errorEventHandler;
+    private final NetworkClientDelegate networkClientDelegate;
+
+    FetchRequestManager(final LogContext logContext,
+                        final Time time,
+                        final ErrorEventHandler errorEventHandler,
+                        final ConsumerMetadata metadata,
+                        final SubscriptionState subscriptions,
+                        final FetchConfig<K, V> fetchConfig,
+                        final FetchMetricsManager metricsManager,
+                        final NetworkClientDelegate networkClientDelegate) {
+        super(logContext, metadata, subscriptions, fetchConfig, metricsManager, time);
+        this.log = logContext.logger(FetchRequestManager.class);
+        this.errorEventHandler = errorEventHandler;
+        this.networkClientDelegate = networkClientDelegate;
+    }
+
+    @Override
+    protected boolean isUnavailable(Node node) {
+        return networkClientDelegate.isUnavailable(node);
+    }
+
+    @Override
+    protected void maybeThrowAuthFailure(Node node) {
+        networkClientDelegate.maybeThrowAuthFailure(node);
+    }
+
+    @Override
+    public PollResult poll(long currentTimeMs) {
+        List<UnsentRequest> requests;
+
+        if (!idempotentCloser.isClosed()) {
+            // If the fetcher is open (i.e. not closed), we will issue the normal fetch requests
+            requests = prepareFetchRequests().entrySet().stream().map(entry -> {
+                final Node fetchTarget = entry.getKey();
+                final FetchSessionHandler.FetchRequestData data = entry.getValue();
+                final FetchRequest.Builder request = createFetchRequest(fetchTarget, data);
+                final BiConsumer<ClientResponse, Throwable> responseHandler = (clientResponse, t) -> {
+                    if (t != null) {
+                        handleFetchResponse(fetchTarget, t);
+                        log.warn("Attempt to fetch data from node {} failed due to fatal exception", fetchTarget, t);
+                        errorEventHandler.handle(t);
+                    } else {
+                        handleFetchResponse(fetchTarget, data, clientResponse);
+                    }
+                };
+
+                return new UnsentRequest(request, fetchTarget, responseHandler);
+            }).collect(Collectors.toList());
+        } else {
+            requests = prepareCloseFetchSessionRequests().entrySet().stream().map(entry -> {
+                final Node fetchTarget = entry.getKey();
+                final FetchSessionHandler.FetchRequestData data = entry.getValue();
+                final FetchRequest.Builder request = createFetchRequest(fetchTarget, data);
+                final BiConsumer<ClientResponse, Throwable> responseHandler = (clientResponse, t) -> {
+                    if (t != null) {
+                        handleCloseFetchSessionResponse(fetchTarget, data, t);
+                        log.warn("Attempt to close fetch session on node {} failed due to fatal exception", fetchTarget, t);
+                        errorEventHandler.handle(t);
+                    } else {
+                        handleCloseFetchSessionResponse(fetchTarget, data);
+                    }
+                };
+
+                return new UnsentRequest(request, fetchTarget, responseHandler);
+            }).collect(Collectors.toList());
+        }
+
+        return new PollResult(Long.MAX_VALUE, requests);
+    }
+
+    /**
+     * Drains any of the {@link CompletedFetch} objects from the internal buffer to the returned {@link Queue}.
+     *
+     * <p/>
+     *
+     * This is used by the {@link org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor} to
+     * pull off any fetch results that are stored in the background thread to provide them to the application thread.
+     *
+     * @return {@link Queue} containing zero or more {@link CompletedFetch}
+     */
+    public Queue<CompletedFetch> drain() {
+        Queue<CompletedFetch> q = new LinkedList<>();
+        CompletedFetch completedFetch = fetchBuffer.poll();
+
+        while (completedFetch != null) {
+            q.add(completedFetch);
+            completedFetch = fetchBuffer.poll();
+        }
+
+        return q;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
@@ -37,11 +37,8 @@ import org.slf4j.Logger;
  * {@code FetchRequestManager} is responsible for generating {@link FetchRequest} that represent the
  * {@link SubscriptionState#fetchablePartitions(Predicate)} based on the user's topic subscription/partition
  * assignment.
- *
- * @param <K> Record key type
- * @param <V> Record value type
  */
-public class FetchRequestManager<K, V> extends AbstractFetch<K, V> implements RequestManager {
+public class FetchRequestManager extends AbstractFetch implements RequestManager {
 
     private final Logger log;
     private final ErrorEventHandler errorEventHandler;
@@ -52,7 +49,7 @@ public class FetchRequestManager<K, V> extends AbstractFetch<K, V> implements Re
                         final ErrorEventHandler errorEventHandler,
                         final ConsumerMetadata metadata,
                         final SubscriptionState subscriptions,
-                        final FetchConfig<K, V> fetchConfig,
+                        final FetchConfig fetchConfig,
                         final FetchMetricsManager metricsManager,
                         final NetworkClientDelegate networkClientDelegate) {
         super(logContext, metadata, subscriptions, fetchConfig, metricsManager, time);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -52,7 +52,7 @@ import java.util.Map;
  *     on a different thread.</li>
  * </ul>
  */
-public class Fetcher<K, V> extends AbstractFetch<K, V> {
+public class Fetcher<K, V> extends AbstractFetch {
 
     private final Logger log;
     private final ConsumerNetworkClient client;
@@ -62,7 +62,7 @@ public class Fetcher<K, V> extends AbstractFetch<K, V> {
                    ConsumerNetworkClient client,
                    ConsumerMetadata metadata,
                    SubscriptionState subscriptions,
-                   FetchConfig<K, V> fetchConfig,
+                   FetchConfig fetchConfig,
                    FetchMetricsManager metricsManager,
                    Time time) {
         super(logContext, metadata, subscriptions, fetchConfig, metricsManager, time);
@@ -166,8 +166,8 @@ public class Fetcher<K, V> extends AbstractFetch<K, V> {
         }
     }
 
-    public Fetch<K, V> collectFetch() {
-        return fetchCollector.collectFetch(fetchBuffer);
+    public Fetch<K, V> collectFetch(Deserializers<K, V> deserializers) {
+        return fetchCollector.collectFetch(fetchBuffer, deserializers);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -20,12 +20,17 @@ import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.FetchSessionHandler;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.internals.IdempotentCloser;
 import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Timer;
+import org.slf4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -49,6 +54,8 @@ import java.util.Map;
  */
 public class Fetcher<K, V> extends AbstractFetch<K, V> {
 
+    private final Logger log;
+    private final ConsumerNetworkClient client;
     private final FetchCollector<K, V> fetchCollector;
 
     public Fetcher(LogContext logContext,
@@ -58,13 +65,25 @@ public class Fetcher<K, V> extends AbstractFetch<K, V> {
                    FetchConfig<K, V> fetchConfig,
                    FetchMetricsManager metricsManager,
                    Time time) {
-        super(logContext, client, metadata, subscriptions, fetchConfig, metricsManager, time);
+        super(logContext, metadata, subscriptions, fetchConfig, metricsManager, time);
+        this.log = logContext.logger(Fetcher.class);
+        this.client = client;
         this.fetchCollector = new FetchCollector<>(logContext,
                 metadata,
                 subscriptions,
                 fetchConfig,
                 metricsManager,
                 time);
+    }
+
+    @Override
+    protected boolean isUnavailable(Node node) {
+        return client.isUnavailable(node);
+    }
+
+    @Override
+    protected void maybeThrowAuthFailure(Node node) {
+        client.maybeThrowAuthFailure(node);
     }
 
     public void clearBufferedDataForUnassignedPartitions(Collection<TopicPartition> assignedPartitions) {
@@ -78,6 +97,7 @@ public class Fetcher<K, V> extends AbstractFetch<K, V> {
      */
     public synchronized int sendFetches() {
         Map<Node, FetchSessionHandler.FetchRequestData> fetchRequestMap = prepareFetchRequests();
+
 
         for (Map.Entry<Node, FetchSessionHandler.FetchRequestData> entry : fetchRequestMap.entrySet()) {
             final Node fetchTarget = entry.getKey();
@@ -106,7 +126,62 @@ public class Fetcher<K, V> extends AbstractFetch<K, V> {
         return fetchRequestMap.size();
     }
 
+    protected void maybeCloseFetchSessions(final Timer timer) {
+        final List<RequestFuture<ClientResponse>> requestFutures = new ArrayList<>();
+        Map<Node, FetchSessionHandler.FetchRequestData> fetchRequestMap = prepareCloseFetchSessionRequests();
+
+        for (Map.Entry<Node, FetchSessionHandler.FetchRequestData> entry : fetchRequestMap.entrySet()) {
+            final Node fetchTarget = entry.getKey();
+            final FetchSessionHandler.FetchRequestData data = entry.getValue();
+            final FetchRequest.Builder request = createFetchRequest(fetchTarget, data);
+            final RequestFuture<ClientResponse> responseFuture = client.send(fetchTarget, request);
+
+            responseFuture.addListener(new RequestFutureListener<ClientResponse>() {
+                @Override
+                public void onSuccess(ClientResponse value) {
+                    handleCloseFetchSessionResponse(fetchTarget, data);
+                }
+
+                @Override
+                public void onFailure(RuntimeException e) {
+                    handleCloseFetchSessionResponse(fetchTarget, data, e);
+                }
+            });
+
+            requestFutures.add(responseFuture);
+        }
+
+        // Poll to ensure that request has been written to the socket. Wait until either the timer has expired or until
+        // all requests have received a response.
+        while (timer.notExpired() && !requestFutures.stream().allMatch(RequestFuture::isDone)) {
+            client.poll(timer, null, true);
+        }
+
+        if (!requestFutures.stream().allMatch(RequestFuture::isDone)) {
+            // we ran out of time before completing all futures. It is ok since we don't want to block the shutdown
+            // here.
+            log.debug("All requests couldn't be sent in the specific timeout period {}ms. " +
+                    "This may result in unnecessary fetch sessions at the broker. Consider increasing the timeout passed for " +
+                    "KafkaConsumer.close(Duration timeout)", timer.timeoutMs());
+        }
+    }
+
     public Fetch<K, V> collectFetch() {
         return fetchCollector.collectFetch(fetchBuffer);
+    }
+
+    /**
+     * This method is called by {@link #close(Timer)} which is guarded by the {@link IdempotentCloser}) such as to only
+     * be executed once the first time that any of the {@link #close()} methods are called. Subclasses can override
+     * this method without the need for extra synchronization at the instance level.
+     *
+     * @param timer Timer to enforce time limit
+     */
+    // Visible for testing
+    protected void closeInternal(Timer timer) {
+        // we do not need to re-enable wake-ups since we are closing already
+        client.disableWakeups();
+        maybeCloseFetchSessions(timer);
+        super.closeInternal(timer);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -16,8 +16,10 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientRequest;
 import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.clients.NetworkClientUtils;
 import org.apache.kafka.clients.RequestCompletionHandler;
@@ -26,6 +28,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
@@ -35,26 +38,29 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_METRIC_GROUP_PREFIX;
 
 /**
  * A wrapper around the {@link org.apache.kafka.clients.NetworkClient} to handle network poll and send operations.
  */
 public class NetworkClientDelegate implements AutoCloseable {
+
     private final KafkaClient client;
     private final Time time;
     private final Logger log;
     private final int requestTimeoutMs;
     private final Queue<UnsentRequest> unsentRequests;
     private final long retryBackoffMs;
-    private final Set<Node> tryConnectNodes;
 
     public NetworkClientDelegate(
             final Time time,
@@ -67,9 +73,40 @@ public class NetworkClientDelegate implements AutoCloseable {
         this.unsentRequests = new ArrayDeque<>();
         this.requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
         this.retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
-        this.tryConnectNodes = new HashSet<>();
     }
 
+    // Visible for testing
+    Queue<UnsentRequest> unsentRequests() {
+        return unsentRequests;
+    }
+
+    /**
+     * Check if the node is disconnected and unavailable for immediate reconnection (i.e. if it is in
+     * reconnect backoff window following the disconnect).
+     *
+     * @param node {@link Node} to check for availability
+     * @see NetworkClientUtils#isUnavailable(KafkaClient, Node, Time)
+     */
+    public boolean isUnavailable(Node node) {
+        return NetworkClientUtils.isUnavailable(client, node, time);
+    }
+
+    /**
+     * Checks for an authentication error on a given node and throws the exception if it exists.
+     *
+     * @param node {@link Node} to check for a previous {@link AuthenticationException}; if found it is thrown
+     * @see NetworkClientUtils#maybeThrowAuthFailure(KafkaClient, Node)
+     */
+    public void maybeThrowAuthFailure(Node node) {
+        NetworkClientUtils.maybeThrowAuthFailure(client, node);
+    }
+
+    /**
+     * Initiate a connection if currently possible. This is only really useful for resetting
+     * the failed status of a socket.
+     *
+     * @param node The node to connect to
+     */
     public void tryConnect(Node node) {
         NetworkClientUtils.tryConnect(client, node, time);
     }
@@ -80,7 +117,6 @@ public class NetworkClientDelegate implements AutoCloseable {
      *
      * @param timeoutMs     timeout time
      * @param currentTimeMs current time
-     * @return a list of client response
      */
     public void poll(final long timeoutMs, final long currentTimeMs) {
         trySend(currentTimeMs);
@@ -118,8 +154,7 @@ public class NetworkClientDelegate implements AutoCloseable {
         }
     }
 
-    private boolean doSend(final UnsentRequest r,
-                           final long currentTimeMs) {
+    boolean doSend(final UnsentRequest r, final long currentTimeMs) {
         Node node = r.node.orElse(client.leastLoadedNode(currentTimeMs));
         if (node == null || nodeUnavailable(node)) {
             log.debug("No broker available to send the request: {}. Retrying.", r);
@@ -136,7 +171,7 @@ public class NetworkClientDelegate implements AutoCloseable {
         return true;
     }
 
-    private void checkDisconnects() {
+    protected void checkDisconnects() {
         // Check the connection of the unsent request. Disconnect the disconnected node if it is unable to be connected.
         Iterator<UnsentRequest> iter = unsentRequests.iterator();
         while (iter.hasNext()) {
@@ -208,7 +243,7 @@ public class NetworkClientDelegate implements AutoCloseable {
     public static class UnsentRequest {
         private final AbstractRequest.Builder<?> requestBuilder;
         private final FutureCompletionHandler handler;
-        private Optional<Node> node; // empty if random node can be chosen
+        private final Optional<Node> node; // empty if random node can be chosen
         private Timer timer;
 
         public UnsentRequest(final AbstractRequest.Builder<?> requestBuilder, final Optional<Node> node) {
@@ -224,6 +259,13 @@ public class NetworkClientDelegate implements AutoCloseable {
             this.handler = handler;
         }
 
+        public UnsentRequest(final AbstractRequest.Builder<?> requestBuilder,
+                             final Node node,
+                             final BiConsumer<ClientResponse, Throwable> responseHandler) {
+            this(requestBuilder, Optional.of(node));
+            future().whenComplete(responseHandler);
+        }
+
         public void setTimer(final Time time, final long requestTimeoutMs) {
             this.timer = time.timer(requestTimeoutMs);
         }
@@ -232,12 +274,16 @@ public class NetworkClientDelegate implements AutoCloseable {
             return handler.future;
         }
 
-        RequestCompletionHandler callback() {
+        FutureCompletionHandler callback() {
             return handler;
         }
 
         AbstractRequest.Builder<?> requestBuilder() {
             return requestBuilder;
+        }
+
+        Optional<Node> node() {
+            return node;
         }
 
         @Override
@@ -281,4 +327,31 @@ public class NetworkClientDelegate implements AutoCloseable {
         }
     }
 
+    /**
+     * Creates a {@link Supplier} for deferred creation during invocation by
+     * {@link org.apache.kafka.clients.consumer.internals.DefaultBackgroundThread}.
+     */
+    public static Supplier<NetworkClientDelegate> supplier(final Time time,
+                                                           final LogContext logContext,
+                                                           final ConsumerMetadata metadata,
+                                                           final ConsumerConfig config,
+                                                           final ApiVersions apiVersions,
+                                                           final Metrics metrics,
+                                                           final FetchMetricsManager fetchMetricsManager) {
+        return new CachedSupplier<NetworkClientDelegate>() {
+            @Override
+            protected NetworkClientDelegate create() {
+                KafkaClient client = ClientUtils.createNetworkClient(config,
+                        metrics,
+                        CONSUMER_METRIC_GROUP_PREFIX,
+                        logContext,
+                        apiVersions,
+                        time,
+                        CONSUMER_MAX_INFLIGHT_REQUESTS_PER_CONNECTION,
+                        metadata,
+                        fetchMetricsManager.throttleTimeSensor());
+                return new NetworkClientDelegate(time, config, logContext, client);
+            }
+        };
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -20,25 +20,34 @@ import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerInterceptor;
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.NoOffsetForPartitionException;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
+import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.AssignmentChangeApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.CommitApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.EventHandler;
+import org.apache.kafka.clients.consumer.internals.events.FetchEvent;
 import org.apache.kafka.clients.consumer.internals.events.ListOffsetsApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.NewTopicsMetadataUpdateRequestEvent;
 import org.apache.kafka.clients.consumer.internals.events.OffsetFetchApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ResetPositionsApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ValidatePositionsApplicationEvent;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
@@ -47,15 +56,17 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
-import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.slf4j.Logger;
+import org.slf4j.event.Level;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
@@ -66,30 +77,38 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Properties;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredConsumerInterceptors;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_JMX_PREFIX;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_METRIC_GROUP_PREFIX;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createFetchConfig;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createFetchMetricsManager;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createLogContext;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createMetrics;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createSubscriptionState;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredConsumerInterceptors;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredIsolationLevel;
 import static org.apache.kafka.common.utils.Utils.closeQuietly;
 import static org.apache.kafka.common.utils.Utils.isBlank;
 import static org.apache.kafka.common.utils.Utils.join;
 import static org.apache.kafka.common.utils.Utils.propsToMap;
+import static org.apache.kafka.common.utils.Utils.swallow;
 
 /**
  * This prototype consumer uses the EventHandler to process application
@@ -100,21 +119,35 @@ import static org.apache.kafka.common.utils.Utils.propsToMap;
 public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     static final long DEFAULT_CLOSE_TIMEOUT_MS = 30 * 1000;
 
-    private final LogContext logContext;
     private final EventHandler eventHandler;
     private final Time time;
     private final Optional<String> groupId;
-    private final Logger log;
+    private final KafkaConsumerMetrics kafkaConsumerMetrics;
+    private Logger log;
+    private final String clientId;
+    private final BackgroundEventProcessor backgroundEventProcessor;
     private final Deserializers<K, V> deserializers;
+    private final FetchBuffer fetchBuffer;
+    private final FetchCollector<K, V> fetchCollector;
+    private final ConsumerInterceptors<K, V> interceptors;
+    private final IsolationLevel isolationLevel;
+
     private final SubscriptionState subscriptions;
     private final ConsumerMetadata metadata;
     private final Metrics metrics;
+    private final long retryBackoffMs;
+    private final long requestTimeoutMs;
     private final long defaultApiTimeoutMs;
+    private volatile boolean closed = false;
+    private final List<ConsumerPartitionAssignor> assignors;
 
-    private WakeupTrigger wakeupTrigger = new WakeupTrigger();
-    public PrototypeAsyncConsumer(Properties properties,
-                         Deserializer<K> keyDeserializer,
-                         Deserializer<V> valueDeserializer) {
+    // to keep from repeatedly scanning subscriptions in poll(), cache the result during metadata updates
+    private boolean cachedSubscriptionHasAllFetchPositions;
+    private final WakeupTrigger wakeupTrigger = new WakeupTrigger();
+
+    public PrototypeAsyncConsumer(final Properties properties,
+                                  final Deserializer<K> keyDeserializer,
+                                  final Deserializer<V> valueDeserializer) {
         this(propsToMap(properties), keyDeserializer, valueDeserializer);
     }
 
@@ -127,56 +160,151 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     public PrototypeAsyncConsumer(final ConsumerConfig config,
                                   final Deserializer<K> keyDeserializer,
                                   final Deserializer<V> valueDeserializer) {
-        this.time = Time.SYSTEM;
-        GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
-                GroupRebalanceConfig.ProtocolType.CONSUMER);
-        this.groupId = Optional.ofNullable(groupRebalanceConfig.groupId);
-        this.defaultApiTimeoutMs = config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
-        this.logContext = createLogContext(config, groupRebalanceConfig);
-        this.log = logContext.logger(getClass());
-        this.deserializers = new Deserializers<>(config, keyDeserializer, valueDeserializer);
-        this.subscriptions = createSubscriptionState(config, logContext);
-        this.metrics = createMetrics(config, time);
-        List<ConsumerInterceptor<K, V>> interceptorList = configuredConsumerInterceptors(config);
-        ClusterResourceListeners clusterResourceListeners = ClientUtils.configureClusterResourceListeners(
-                metrics.reporters(),
-                interceptorList,
-                Arrays.asList(deserializers.keyDeserializer, deserializers.valueDeserializer));
-        this.metadata = new ConsumerMetadata(config, subscriptions, logContext, clusterResourceListeners);
-        final List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config);
-        metadata.bootstrap(addresses);
-        this.eventHandler = new DefaultEventHandler(
-                config,
-                groupRebalanceConfig,
-                logContext,
-                subscriptions,
-                new ApiVersions(),
-                this.metrics,
-                clusterResourceListeners,
-                null // this is coming from the fetcher, but we don't have one
-        );
+        this(Time.SYSTEM, config, keyDeserializer, valueDeserializer);
     }
 
-    // Visible for testing
-    PrototypeAsyncConsumer(Time time,
-                           LogContext logContext,
-                           ConsumerConfig config,
-                           SubscriptionState subscriptions,
-                           ConsumerMetadata metadata,
-                           EventHandler eventHandler,
-                           Metrics metrics,
-                           Optional<String> groupId,
-                           int defaultApiTimeoutMs) {
-        this.time = time;
-        this.logContext = logContext;
+    public PrototypeAsyncConsumer(final Time time,
+                                  final ConsumerConfig config,
+                                  final Deserializer<K> keyDeserializer,
+                                  final Deserializer<V> valueDeserializer) {
+        try {
+            GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
+                    GroupRebalanceConfig.ProtocolType.CONSUMER);
+
+            this.groupId = Optional.ofNullable(groupRebalanceConfig.groupId);
+            this.clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
+            LogContext logContext = createLogContext(config, groupRebalanceConfig);
+            this.log = logContext.logger(getClass());
+            groupId.ifPresent(groupIdStr -> {
+                if (groupIdStr.isEmpty()) {
+                    log.warn("Support for using the empty group id by consumers is deprecated and will be removed in the next major release.");
+                }
+            });
+
+            log.debug("Initializing the Kafka consumer");
+            this.requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
+            this.defaultApiTimeoutMs = config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
+            this.time = time;
+            this.metrics = createMetrics(config, time);
+            this.retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
+
+            List<ConsumerInterceptor<K, V>> interceptorList = configuredConsumerInterceptors(config);
+            this.interceptors = new ConsumerInterceptors<>(interceptorList);
+            this.deserializers = new Deserializers<>(config, keyDeserializer, valueDeserializer);
+            this.subscriptions = createSubscriptionState(config, logContext);
+            ClusterResourceListeners clusterResourceListeners = ClientUtils.configureClusterResourceListeners(metrics.reporters(),
+                    interceptorList,
+                    Arrays.asList(deserializers.keyDeserializer, deserializers.valueDeserializer));
+            this.metadata = new ConsumerMetadata(config, subscriptions, logContext, clusterResourceListeners);
+            final List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config);
+            metadata.bootstrap(addresses);
+
+            FetchMetricsManager fetchMetricsManager = createFetchMetricsManager(metrics);
+            this.isolationLevel = configuredIsolationLevel(config);
+
+            ApiVersions apiVersions = new ApiVersions();
+            final BlockingQueue<ApplicationEvent> applicationEventQueue = new LinkedBlockingQueue<>();
+            final BlockingQueue<BackgroundEvent> backgroundEventQueue = new LinkedBlockingQueue<>();
+            final Supplier<NetworkClientDelegate> networkClientDelegateSupplier = NetworkClientDelegate.supplier(time,
+                    logContext,
+                    metadata,
+                    config,
+                    apiVersions,
+                    metrics,
+                    fetchMetricsManager);
+            final Supplier<RequestManagers> requestManagersSupplier = RequestManagers.supplier(time,
+                    logContext,
+                    backgroundEventQueue,
+                    metadata,
+                    subscriptions,
+                    config,
+                    groupRebalanceConfig,
+                    apiVersions,
+                    fetchMetricsManager,
+                    networkClientDelegateSupplier);
+            final Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier = ApplicationEventProcessor.supplier(logContext,
+                    metadata,
+                    backgroundEventQueue,
+                    requestManagersSupplier);
+            this.eventHandler = new DefaultEventHandler(time,
+                    logContext,
+                    applicationEventQueue,
+                    applicationEventProcessorSupplier,
+                    networkClientDelegateSupplier,
+                    requestManagersSupplier);
+            this.backgroundEventProcessor = new BackgroundEventProcessor(logContext, backgroundEventQueue);
+            this.assignors = ConsumerPartitionAssignor.getAssignorInstances(
+                    config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG),
+                    config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId))
+            );
+
+            // no coordinator will be constructed for the default (null) group id
+            if (!groupId.isPresent()) {
+                config.ignore(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG);
+                //config.ignore(ConsumerConfig.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED);
+            }
+            // These are specific to the foreground thread
+            FetchConfig fetchConfig = createFetchConfig(config);
+            this.fetchBuffer = new FetchBuffer(logContext);
+            this.fetchCollector = new FetchCollector<>(logContext,
+                    metadata,
+                    subscriptions,
+                    fetchConfig,
+                    fetchMetricsManager,
+                    time);
+
+            this.kafkaConsumerMetrics = new KafkaConsumerMetrics(metrics, CONSUMER_METRIC_GROUP_PREFIX);
+
+            config.logUnused();
+            AppInfoParser.registerAppInfo(CONSUMER_JMX_PREFIX, clientId, metrics, time.milliseconds());
+            log.debug("Kafka consumer initialized");
+        } catch (Throwable t) {
+            // call close methods if internal objects are already constructed; this is to prevent resource leak. see KAFKA-2121
+            // we do not need to call `close` at all when `log` is null, which means no internal objects were initialized.
+            if (this.log != null) {
+                close(Duration.ZERO, true);
+            }
+            // now propagate the exception
+            throw new KafkaException("Failed to construct kafka consumer", t);
+        }
+    }
+
+    public PrototypeAsyncConsumer(LogContext logContext,
+                                  String clientId,
+                                  Deserializers<K, V> deserializers,
+                                  FetchBuffer fetchBuffer,
+                                  FetchCollector<K, V> fetchCollector,
+                                  ConsumerInterceptors<K, V> interceptors,
+                                  Time time,
+                                  EventHandler eventHandler,
+                                  BlockingQueue<BackgroundEvent> backgroundEventQueue,
+                                  Metrics metrics,
+                                  SubscriptionState subscriptions,
+                                  ConsumerMetadata metadata,
+                                  long retryBackoffMs,
+                                  long requestTimeoutMs,
+                                  int defaultApiTimeoutMs,
+                                  List<ConsumerPartitionAssignor> assignors,
+                                  String groupId) {
         this.log = logContext.logger(getClass());
         this.subscriptions = subscriptions;
-        this.metadata = metadata;
+        this.clientId = clientId;
+        this.fetchBuffer = fetchBuffer;
+        this.fetchCollector = fetchCollector;
+        this.isolationLevel = IsolationLevel.READ_UNCOMMITTED;
+        this.interceptors = Objects.requireNonNull(interceptors);
+        this.time = time;
+        this.backgroundEventProcessor = new BackgroundEventProcessor(logContext, backgroundEventQueue);
         this.metrics = metrics;
-        this.groupId = groupId;
+        this.groupId = Optional.ofNullable(groupId);
+        this.metadata = metadata;
+        this.retryBackoffMs = retryBackoffMs;
+        this.requestTimeoutMs = requestTimeoutMs;
         this.defaultApiTimeoutMs = defaultApiTimeoutMs;
-        this.deserializers = new Deserializers<>(config);
+        this.deserializers = deserializers;
         this.eventHandler = eventHandler;
+        this.assignors = assignors;
+        this.kafkaConsumerMetrics = new KafkaConsumerMetrics(metrics, "consumer");
     }
 
     /**
@@ -192,71 +320,38 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     @Override
     public ConsumerRecords<K, V> poll(final Duration timeout) {
         Timer timer = time.timer(timeout);
+
         try {
+            backgroundEventProcessor.process();
+
+            this.kafkaConsumerMetrics.recordPollStart(timer.currentTimeMs());
+
+            if (this.subscriptions.hasNoSubscriptionOrUserAssignment()) {
+                throw new IllegalStateException("Consumer is not subscribed to any topics or assigned any partitions");
+            }
+
             do {
-                if (!eventHandler.isEmpty()) {
-                    final Optional<BackgroundEvent> backgroundEvent = eventHandler.poll();
-                    // processEvent() may process 3 types of event:
-                    // 1. Errors
-                    // 2. Callback Invocation
-                    // 3. Fetch responses
-                    // Errors will be handled or rethrown.
-                    // Callback invocation will trigger callback function execution, which is blocking until completion.
-                    // Successful fetch responses will be added to the completedFetches in the fetcher, which will then
-                    // be processed in the collectFetches().
-                    backgroundEvent.ifPresent(event -> processEvent(event, timeout));
-                }
+                updateAssignmentMetadataIfNeeded(timer);
+                final Fetch<K, V> fetch = pollForFetches(timer);
 
-                updateFetchPositionsIfNeeded(timer);
-
-                // The idea here is to have the background thread sending fetches autonomously, and the fetcher
-                // uses the poll loop to retrieve successful fetchResponse and process them on the polling thread.
-                final Fetch<K, V> fetch = collectFetches();
                 if (!fetch.isEmpty()) {
-                    return processFetchResults(fetch);
+                    sendFetches();
+
+                    if (fetch.records().isEmpty()) {
+                        log.trace("Returning empty records from `poll()` "
+                                + "since the consumer's position has advanced for at least one topic partition");
+                    }
+
+                    return this.interceptors.onConsume(new ConsumerRecords<>(fetch.records()));
                 }
                 // We will wait for retryBackoffMs
-            } while (time.timer(timeout).notExpired());
-        } catch (final Exception e) {
-            throw new RuntimeException(e);
+            } while (timer.notExpired());
+
+            return ConsumerRecords.empty();
+        } finally {
+            this.kafkaConsumerMetrics.recordPollEnd(timer.currentTimeMs());
         }
         // TODO: Once we implement poll(), clear wakeupTrigger in a finally block: wakeupTrigger.clearActiveTask();
-
-        return ConsumerRecords.empty();
-    }
-
-    /**
-     * Set the fetch position to the committed position (if there is one) or reset it using the
-     * offset reset policy the user has configured (if partitions require reset)
-     *
-     * @return true if the operation completed without timing out
-     * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
-     * @throws NoOffsetForPartitionException                          If no offset is stored for a given partition and no offset reset policy is
-     *                                                                defined
-     */
-    private boolean updateFetchPositionsIfNeeded(final Timer timer) {
-        // If any partitions have been truncated due to a leader change, we need to validate the offsets
-        ValidatePositionsApplicationEvent validatePositionsEvent = new ValidatePositionsApplicationEvent();
-        eventHandler.add(validatePositionsEvent);
-
-        // If there are any partitions which do not have a valid position and are not
-        // awaiting reset, then we need to fetch committed offsets. We will only do a
-        // coordinator lookup if there are partitions which have missing positions, so
-        // a consumer with manually assigned partitions can avoid a coordinator dependence
-        // by always ensuring that assigned partitions have an initial position.
-        if (isCommittedOffsetsManagementEnabled() && !refreshCommittedOffsetsIfNeeded(timer))
-            return false;
-
-        // If there are partitions still needing a position and a reset policy is defined,
-        // request reset using the default policy. If no reset strategy is defined and there
-        // are partitions with a missing position, then we will raise a NoOffsetForPartitionException exception.
-        subscriptions.resetInitializingPositions();
-
-        // Finally send an asynchronous request to look up and update the positions of any
-        // partitions which are awaiting reset.
-        ResetPositionsApplicationEvent resetPositionsEvent = new ResetPositionsApplicationEvent();
-        eventHandler.add(resetPositionsEvent);
-        return true;
     }
 
     /**
@@ -266,20 +361,6 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     @Override
     public void commitSync() {
         commitSync(Duration.ofMillis(defaultApiTimeoutMs));
-    }
-
-    private void processEvent(final BackgroundEvent backgroundEvent, final Duration timeout) {
-        // stubbed class
-    }
-
-    private ConsumerRecords<K, V> processFetchResults(final Fetch<K, V> fetch) {
-        // stubbed class
-        return ConsumerRecords.empty();
-    }
-
-    private Fetch<K, V> collectFetches() {
-        // stubbed class
-        return Fetch.empty();
     }
 
     /**
@@ -306,7 +387,6 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
                 commitCallback.onComplete(offsets, null);
             }
         }).exceptionally(e -> {
-            System.out.println(e);
             throw new KafkaException(e);
         });
     }
@@ -325,44 +405,90 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void seek(TopicPartition partition, long offset) {
-        throw new KafkaException("method not implemented");
+        if (offset < 0)
+            throw new IllegalArgumentException("seek offset must not be a negative number");
+
+        log.info("Seeking to offset {} for partition {}", offset, partition);
+        SubscriptionState.FetchPosition newPosition = new SubscriptionState.FetchPosition(
+                offset,
+                Optional.empty(), // This will ensure we skip validation
+                this.metadata.currentLeader(partition));
+        this.subscriptions.seekUnvalidated(partition, newPosition);
     }
 
     @Override
     public void seek(TopicPartition partition, OffsetAndMetadata offsetAndMetadata) {
-        throw new KafkaException("method not implemented");
+        long offset = offsetAndMetadata.offset();
+        if (offset < 0) {
+            throw new IllegalArgumentException("seek offset must not be a negative number");
+        }
+
+        if (offsetAndMetadata.leaderEpoch().isPresent()) {
+            log.info("Seeking to offset {} for partition {} with epoch {}",
+                    offset, partition, offsetAndMetadata.leaderEpoch().get());
+        } else {
+            log.info("Seeking to offset {} for partition {}", offset, partition);
+        }
+        Metadata.LeaderAndEpoch currentLeaderAndEpoch = this.metadata.currentLeader(partition);
+        SubscriptionState.FetchPosition newPosition = new SubscriptionState.FetchPosition(
+                offsetAndMetadata.offset(),
+                offsetAndMetadata.leaderEpoch(),
+                currentLeaderAndEpoch);
+        this.updateLastSeenEpochIfNewer(partition, offsetAndMetadata);
+        this.subscriptions.seekUnvalidated(partition, newPosition);
     }
 
     @Override
     public void seekToBeginning(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        if (partitions == null)
+            throw new IllegalArgumentException("Partitions collection cannot be null");
+
+        Collection<TopicPartition> parts = partitions.size() == 0 ? this.subscriptions.assignedPartitions() : partitions;
+        subscriptions.requestOffsetReset(parts, OffsetResetStrategy.EARLIEST);
     }
 
     @Override
     public void seekToEnd(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        if (partitions == null)
+            throw new IllegalArgumentException("Partitions collection cannot be null");
+
+        Collection<TopicPartition> parts = partitions.size() == 0 ? this.subscriptions.assignedPartitions() : partitions;
+        subscriptions.requestOffsetReset(parts, OffsetResetStrategy.LATEST);
     }
 
     @Override
     public long position(TopicPartition partition) {
-        throw new KafkaException("method not implemented");
+        return position(partition, Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     @Override
     public long position(TopicPartition partition, Duration timeout) {
-        throw new KafkaException("method not implemented");
+        if (!this.subscriptions.isAssigned(partition))
+            throw new IllegalStateException("You can only check the position for partitions assigned to this consumer.");
+
+        Timer timer = time.timer(timeout);
+        do {
+            SubscriptionState.FetchPosition position = this.subscriptions.validPosition(partition);
+            if (position != null)
+                return position.offset;
+
+            updateFetchPositions(timer);
+        } while (timer.notExpired());
+
+        throw new TimeoutException("Timeout of " + timeout.toMillis() + "ms expired before the position " +
+                "for partition " + partition + " could be determined");
     }
 
     @Override
     @Deprecated
     public OffsetAndMetadata committed(TopicPartition partition) {
-        throw new KafkaException("method not implemented");
+        return committed(partition, Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     @Override
     @Deprecated
     public OffsetAndMetadata committed(TopicPartition partition, Duration timeout) {
-        throw new KafkaException("method not implemented");
+        return committed(Collections.singleton(partition), timeout).get(partition);
     }
 
     @Override
@@ -396,12 +522,12 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public Map<MetricName, ? extends Metric> metrics() {
-        throw new KafkaException("method not implemented");
+        return Collections.unmodifiableMap(this.metrics.metrics());
     }
 
     @Override
     public List<PartitionInfo> partitionsFor(String topic) {
-        throw new KafkaException("method not implemented");
+        return partitionsFor(topic, Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     @Override
@@ -411,7 +537,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public Map<String, List<PartitionInfo>> listTopics() {
-        throw new KafkaException("method not implemented");
+        return listTopics(Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     @Override
@@ -421,17 +547,23 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public Set<TopicPartition> paused() {
-        throw new KafkaException("method not implemented");
+        return Collections.unmodifiableSet(subscriptions.pausedPartitions());
     }
 
     @Override
     public void pause(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        log.debug("Pausing partitions {}", partitions);
+        for (TopicPartition partition: partitions) {
+            subscriptions.pause(partition);
+        }
     }
 
     @Override
     public void resume(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        log.debug("Resuming partitions {}", partitions);
+        for (TopicPartition partition: partitions) {
+            subscriptions.resume(partition);
+        }
     }
 
     @Override
@@ -503,7 +635,25 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public OptionalLong currentLag(TopicPartition topicPartition) {
-        throw new KafkaException("method not implemented");
+        final Long lag = subscriptions.partitionLag(topicPartition, isolationLevel);
+
+        // if the log end offset is not known and hence cannot return lag and there is
+        // no in-flight list offset requested yet,
+        // issue a list offset request for that partition so that next time
+        // we may get the answer; we do not need to wait for the return value
+        // since we would not try to poll the network client synchronously
+        if (lag == null) {
+            if (subscriptions.partitionEndOffset(topicPartition, isolationLevel) == null &&
+                    !subscriptions.partitionEndOffsetRequested(topicPartition)) {
+                log.info("Requesting the log end offset for {} in order to compute lag", topicPartition);
+                subscriptions.requestPartitionEndOffset(topicPartition);
+                endOffsets(Collections.singleton(topicPartition), Duration.ofMillis(0));
+            }
+
+            return OptionalLong.empty();
+        }
+
+        return OptionalLong.of(lag);
     }
 
     @Override
@@ -526,13 +676,57 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         close(Duration.ofMillis(DEFAULT_CLOSE_TIMEOUT_MS));
     }
 
+    private Timer createTimerForRequest(final Duration timeout) {
+        // this.time could be null if an exception occurs in constructor prior to setting the this.time field
+        final Time localTime = (time == null) ? Time.SYSTEM : time;
+        return localTime.timer(Math.min(timeout.toMillis(), requestTimeoutMs));
+    }
+
     @Override
     public void close(Duration timeout) {
+        if (timeout.toMillis() < 0)
+            throw new IllegalArgumentException("The timeout cannot be negative.");
+
+        try {
+            if (!closed) {
+                // need to close before setting the flag since the close function
+                // itself may trigger rebalance callback that needs the consumer to be open still
+                close(timeout, false);
+            }
+        } finally {
+            closed = true;
+        }
+    }
+
+    private void close(Duration timeout, boolean swallowException) {
+        log.trace("Closing the Kafka consumer");
         AtomicReference<Throwable> firstException = new AtomicReference<>();
+
+        final Timer closeTimer = createTimerForRequest(timeout);
+        if (fetchBuffer != null) {
+            // the timeout for the session close is at-most the requestTimeoutMs
+            long remainingDurationInTimeout = Math.max(0, timeout.toMillis() - closeTimer.elapsedMs());
+            if (remainingDurationInTimeout > 0) {
+                remainingDurationInTimeout = Math.min(requestTimeoutMs, remainingDurationInTimeout);
+            }
+
+            closeTimer.reset(remainingDurationInTimeout);
+
+            // This is a blocking call bound by the time remaining in closeTimer
+            swallow(log, Level.ERROR, "Failed to close fetcher", fetchBuffer::close, firstException);
+        }
+
+
+        closeQuietly(interceptors, "consumer interceptors", firstException);
+        closeQuietly(kafkaConsumerMetrics, "kafka consumer metrics", firstException);
+        closeQuietly(metrics, "consumer metrics", firstException);
         closeQuietly(this.eventHandler, "event handler", firstException);
+        closeQuietly(deserializers, "consumer deserializers", firstException);
+
+        AppInfoParser.unregisterAppInfo(CONSUMER_JMX_PREFIX, clientId, metrics);
         log.debug("Kafka consumer has been closed");
         Throwable exception = firstException.get();
-        if (exception != null) {
+        if (exception != null && !swallowException) {
             if (exception instanceof InterruptException) {
                 throw (InterruptException) exception;
             }
@@ -563,19 +757,14 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
-        CompletableFuture<Void> commitFuture = commit(offsets, true);
+        long commitStart = time.nanoseconds();
         try {
-            commitFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-        } catch (final TimeoutException e) {
-            throw new org.apache.kafka.common.errors.TimeoutException(e);
-        } catch (final InterruptedException e) {
-            throw new InterruptException(e);
-        } catch (final ExecutionException e) {
-            if (e.getCause() instanceof WakeupException)
-                throw new WakeupException();
-            throw new KafkaException(e);
+            CompletableFuture<Void> commitFuture = commit(offsets, true);
+            offsets.forEach(this::updateLastSeenEpochIfNewer);
+            ConsumerUtils.getResult(commitFuture, time.timer(timeout));
         } finally {
             wakeupTrigger.clearActiveTask();
+            kafkaConsumerMetrics.recordCommitSync(time.nanoseconds() - commitStart);
         }
     }
 
@@ -596,12 +785,38 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void subscribe(Collection<String> topics) {
-        throw new KafkaException("method not implemented");
+        subscribe(topics, new NoOpConsumerRebalanceListener());
     }
 
     @Override
     public void subscribe(Collection<String> topics, ConsumerRebalanceListener callback) {
-        throw new KafkaException("method not implemented");
+        maybeThrowInvalidGroupIdException();
+        if (topics == null)
+            throw new IllegalArgumentException("Topic collection to subscribe to cannot be null");
+        if (topics.isEmpty()) {
+            // treat subscribing to empty topic list as the same as unsubscribing
+            this.unsubscribe();
+        } else {
+            for (String topic : topics) {
+                if (isBlank(topic))
+                    throw new IllegalArgumentException("Topic collection to subscribe to cannot contain null or empty topic");
+            }
+
+            throwIfNoAssignorsConfigured();
+
+            // Clear the buffered data which are not a part of newly assigned topics
+            final Set<TopicPartition> currentTopicPartitions = new HashSet<>();
+
+            for (TopicPartition tp : subscriptions.assignedPartitions()) {
+                if (topics.contains(tp.topic()))
+                    currentTopicPartitions.add(tp);
+            }
+
+            fetchBuffer.retainAll(currentTopicPartitions);
+            log.info("Subscribed to topic(s): {}", join(topics, ", "));
+            if (this.subscriptions.subscribe(new HashSet<>(topics), callback))
+                metadata.requestUpdateForNewTopics();
+        }
     }
 
     @Override
@@ -611,8 +826,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         }
 
         if (partitions.isEmpty()) {
-            // TODO: implementation of unsubscribe() will be included in forthcoming commits.
-            // this.unsubscribe();
+            this.unsubscribe();
             return;
         }
 
@@ -622,12 +836,18 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
                 throw new IllegalArgumentException("Topic partitions to assign to cannot have null or empty topic");
         }
 
-        // TODO: implementation of refactored Fetcher will be included in forthcoming commits.
-        // fetcher.clearBufferedDataForUnassignedPartitions(partitions);
+        // Clear the buffered data which are not a part of newly assigned topics
+        final Set<TopicPartition> currentTopicPartitions = new HashSet<>();
 
-        // assignment change event will trigger autocommit if it is configured and the group id is specified. This is
-        // to make sure offsets of topic partitions the consumer is unsubscribing from are committed since there will
-        // be no following rebalance
+        for (TopicPartition tp : subscriptions.assignedPartitions()) {
+            if (partitions.contains(tp))
+                currentTopicPartitions.add(tp);
+        }
+
+        fetchBuffer.retainAll(currentTopicPartitions);
+
+        // make sure the offsets of topic partitions the consumer is unsubscribing from
+        // are committed since there will be no following rebalance
         eventHandler.add(new AssignmentChangeApplicationEvent(this.subscriptions.allConsumed(), time.milliseconds()));
 
         log.info("Assigned to partition(s): {}", join(partitions, ", "));
@@ -636,24 +856,52 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     }
 
     @Override
-    public void subscribe(Pattern pattern, ConsumerRebalanceListener callback) {
-        throw new KafkaException("method not implemented");
+    public void subscribe(Pattern pattern, ConsumerRebalanceListener listener) {
+        maybeThrowInvalidGroupIdException();
+        if (pattern == null || pattern.toString().equals(""))
+            throw new IllegalArgumentException("Topic pattern to subscribe to cannot be " + (pattern == null ?
+                    "null" : "empty"));
+
+        throwIfNoAssignorsConfigured();
+        log.info("Subscribed to pattern: '{}'", pattern);
+        this.subscriptions.subscribe(pattern, listener);
+        this.updatePatternSubscription(metadata.fetch());
+        this.metadata.requestUpdateForNewTopics();
+    }
+
+    /**
+     * TODO: remove this when we implement the KIP-848 protocol.
+     *
+     * <p>
+     * The contents of this method are shamelessly stolen from
+     * {@link ConsumerCoordinator#updatePatternSubscription(Cluster)} and are used here because we won't have access
+     * to a {@link ConsumerCoordinator} in this code. Perhaps it could be moved to a ConsumerUtils class?
+     *
+     * @param cluster Cluster from which we get the topics
+     */
+    private void updatePatternSubscription(Cluster cluster) {
+        final Set<String> topicsToSubscribe = cluster.topics().stream()
+                .filter(subscriptions::matchesSubscribedPattern)
+                .collect(Collectors.toSet());
+        if (subscriptions.subscribeFromPattern(topicsToSubscribe))
+            metadata.requestUpdateForNewTopics();
     }
 
     @Override
     public void subscribe(Pattern pattern) {
-        throw new KafkaException("method not implemented");
+        subscribe(pattern, new NoOpConsumerRebalanceListener());
     }
 
     @Override
     public void unsubscribe() {
-        throw new KafkaException("method not implemented");
+        fetchBuffer.retainAll(Collections.emptySet());
+        this.subscriptions.unsubscribe();
     }
 
     @Override
     @Deprecated
-    public ConsumerRecords<K, V> poll(long timeout) {
-        throw new KafkaException("method not implemented");
+    public ConsumerRecords<K, V> poll(final long timeoutMs) {
+        return poll(Duration.ofMillis(timeoutMs));
     }
 
     // Visible for testing
@@ -661,17 +909,95 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         return wakeupTrigger;
     }
 
-    private static <K, V> ClusterResourceListeners configureClusterResourceListeners(
-            final Deserializer<K> keyDeserializer,
-            final Deserializer<V> valueDeserializer,
-            final List<?>... candidateLists) {
-        ClusterResourceListeners clusterResourceListeners = new ClusterResourceListeners();
-        for (List<?> candidateList: candidateLists)
-            clusterResourceListeners.maybeAddAll(candidateList);
+    private void sendFetches() {
+        FetchEvent event = new FetchEvent();
+        eventHandler.add(event);
 
-        clusterResourceListeners.maybeAdd(keyDeserializer);
-        clusterResourceListeners.maybeAdd(valueDeserializer);
-        return clusterResourceListeners;
+        event.future().whenComplete((completedFetches, error) -> {
+            if (completedFetches != null && !completedFetches.isEmpty()) {
+                fetchBuffer.addAll(completedFetches);
+            }
+        });
+    }
+
+    /**
+     * @throws KafkaException if the rebalance callback throws exception
+     */
+    private Fetch<K, V> pollForFetches(Timer timer) {
+        long pollTimeout = timer.remainingMs();
+
+        // if data is available already, return it immediately
+        final Fetch<K, V> fetch = fetchCollector.collectFetch(fetchBuffer, deserializers);
+        if (!fetch.isEmpty()) {
+            return fetch;
+        }
+
+        // send any new fetches (won't resend pending fetches)
+        sendFetches();
+
+        // We do not want to be stuck blocking in poll if we are missing some positions
+        // since the offset lookup may be backing off after a failure
+
+        // NOTE: the use of cachedSubscriptionHasAllFetchPositions means we MUST call
+        // updateAssignmentMetadataIfNeeded before this method.
+        if (!cachedSubscriptionHasAllFetchPositions && pollTimeout > retryBackoffMs) {
+            pollTimeout = retryBackoffMs;
+        }
+
+        log.trace("Polling for fetches with timeout {}", pollTimeout);
+
+        Timer pollTimer = time.timer(pollTimeout);
+
+        // Attempt to fetch any data. It's OK if we time out here; it's a best case effort. The
+        // data may not be immediately available, but the calling method (poll) will correctly
+        // handle the overall timeout.
+        try {
+            Queue<CompletedFetch> completedFetches = eventHandler.addAndGet(new FetchEvent(), pollTimer);
+            if (completedFetches != null && !completedFetches.isEmpty()) {
+                fetchBuffer.addAll(completedFetches);
+            }
+        } catch (TimeoutException e) {
+            log.trace("Timeout during fetch", e);
+        } finally {
+            timer.update(pollTimer.currentTimeMs());
+        }
+
+        return fetchCollector.collectFetch(fetchBuffer, deserializers);
+    }
+
+    /**
+     * Set the fetch position to the committed position (if there is one)
+     * or reset it using the offset reset policy the user has configured.
+     *
+     * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
+     * @throws NoOffsetForPartitionException If no offset is stored for a given partition and no offset reset policy is
+     *             defined
+     * @return true iff the operation completed without timing out
+     */
+    private boolean updateFetchPositions(final Timer timer) {
+        // If any partitions have been truncated due to a leader change, we need to validate the offsets
+        eventHandler.add(new ValidatePositionsApplicationEvent());
+
+        cachedSubscriptionHasAllFetchPositions = subscriptions.hasAllFetchPositions();
+        if (cachedSubscriptionHasAllFetchPositions) return true;
+
+        // If there are any partitions which do not have a valid position and are not
+        // awaiting reset, then we need to fetch committed offsets. We will only do a
+        // coordinator lookup if there are partitions which have missing positions, so
+        // a consumer with manually assigned partitions can avoid a coordinator dependence
+        // by always ensuring that assigned partitions have an initial position.
+        if (isCommittedOffsetsManagementEnabled() && !refreshCommittedOffsetsIfNeeded(timer))
+            return false;
+
+        // If there are partitions still needing a position and a reset policy is defined,
+        // request reset using the default policy. If no reset strategy is defined and there
+        // are partitions with a missing position, then we will raise a NoOffsetForPartitionException exception.
+        subscriptions.resetInitializingPositions();
+
+        // Finally send an asynchronous request to look up and update the positions of any
+        // partitions which are awaiting reset.
+        eventHandler.add(new ResetPositionsApplicationEvent());
+        return true;
     }
 
     /**
@@ -684,7 +1010,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     }
 
     /**
-     * Refresh the committed offsets for partitions that require initialization.
+     * Refresh the committed offsets for provided partitions.
      *
      * @param timer Timer bounding how long this method can block
      * @return true iff the operation completed within the timeout
@@ -701,7 +1027,6 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
             return false;
         }
     }
-
 
     // This is here temporary as we don't have public access to the ConsumerConfig in this module.
     public static Map<String, Object> appendDeserializerToConfig(Map<String, Object> configs,
@@ -720,11 +1045,29 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         return newConfigs;
     }
 
+    private void throwIfNoAssignorsConfigured() {
+        if (assignors.isEmpty())
+            throw new IllegalStateException("Must configure at least one partition assigner class name to " +
+                    ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG + " configuration property");
+    }
+
+    private void updateLastSeenEpochIfNewer(TopicPartition topicPartition, OffsetAndMetadata offsetAndMetadata) {
+        if (offsetAndMetadata != null)
+            offsetAndMetadata.leaderEpoch().ifPresent(epoch -> metadata.updateLastSeenEpochIfNewer(topicPartition, epoch));
+    }
+
     private class DefaultOffsetCommitCallback implements OffsetCommitCallback {
         @Override
         public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
             if (exception != null)
                 log.error("Offset commit with offsets {} failed", offsets, exception);
         }
+    }
+
+    boolean updateAssignmentMetadataIfNeeded(Timer timer) {
+        // Keeping this updateAssignmentMetadataIfNeeded wrapping up the updateFetchPositions as
+        // in the previous implementation, because it will eventually involve group coordination
+        // logic
+        return updateFetchPositions(timer);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -212,7 +212,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
                     apiVersions,
                     metrics,
                     fetchMetricsManager);
-            final Supplier<RequestManagers<String, String>> requestManagersSupplier = RequestManagers.supplier(time,
+            final Supplier<RequestManagers> requestManagersSupplier = RequestManagers.supplier(time,
                     logContext,
                     backgroundEventQueue,
                     metadata,
@@ -222,14 +222,13 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
                     apiVersions,
                     fetchMetricsManager,
                     networkClientDelegateSupplier);
-            final Supplier<ApplicationEventProcessor<String, String>> applicationEventProcessorSupplier = ApplicationEventProcessor.supplier(logContext,
+            final Supplier<ApplicationEventProcessor> applicationEventProcessorSupplier = ApplicationEventProcessor.supplier(logContext,
                     metadata,
                     backgroundEventQueue,
                     requestManagersSupplier);
-            this.eventHandler = new DefaultEventHandler<>(time,
+            this.eventHandler = new DefaultEventHandler(time,
                     logContext,
                     applicationEventQueue,
-                    backgroundEventQueue,
                     applicationEventProcessorSupplier,
                     networkClientDelegateSupplier,
                     requestManagersSupplier);
@@ -245,7 +244,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
                 //config.ignore(ConsumerConfig.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED);
             }
             // These are specific to the foreground thread
-            FetchConfig<K, V> fetchConfig = createFetchConfig(config, deserializers);
+            FetchConfig fetchConfig = createFetchConfig(config);
             this.fetchBuffer = new FetchBuffer(logContext);
             this.fetchCollector = new FetchCollector<>(logContext,
                     metadata,
@@ -928,7 +927,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         long pollTimeout = timer.remainingMs();
 
         // if data is available already, return it immediately
-        final Fetch<K, V> fetch = fetchCollector.collectFetch(fetchBuffer);
+        final Fetch<K, V> fetch = fetchCollector.collectFetch(fetchBuffer, deserializers);
         if (!fetch.isEmpty()) {
             return fetch;
         }
@@ -963,7 +962,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
             timer.update(pollTimer.currentTimeMs());
         }
 
-        return fetchCollector.collectFetch(fetchBuffer);
+        return fetchCollector.collectFetch(fetchBuffer, deserializers);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -20,25 +20,34 @@ import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerInterceptor;
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.NoOffsetForPartitionException;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
+import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.AssignmentChangeApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.CommitApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.EventHandler;
+import org.apache.kafka.clients.consumer.internals.events.FetchEvent;
 import org.apache.kafka.clients.consumer.internals.events.ListOffsetsApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.NewTopicsMetadataUpdateRequestEvent;
 import org.apache.kafka.clients.consumer.internals.events.OffsetFetchApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ResetPositionsApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ValidatePositionsApplicationEvent;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
@@ -47,15 +56,17 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
-import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.slf4j.Logger;
+import org.slf4j.event.Level;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
@@ -66,30 +77,38 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Properties;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredConsumerInterceptors;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_JMX_PREFIX;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_METRIC_GROUP_PREFIX;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createFetchConfig;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createFetchMetricsManager;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createLogContext;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createMetrics;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createSubscriptionState;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredConsumerInterceptors;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredIsolationLevel;
 import static org.apache.kafka.common.utils.Utils.closeQuietly;
 import static org.apache.kafka.common.utils.Utils.isBlank;
 import static org.apache.kafka.common.utils.Utils.join;
 import static org.apache.kafka.common.utils.Utils.propsToMap;
+import static org.apache.kafka.common.utils.Utils.swallow;
 
 /**
  * This prototype consumer uses the EventHandler to process application
@@ -100,21 +119,35 @@ import static org.apache.kafka.common.utils.Utils.propsToMap;
 public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     static final long DEFAULT_CLOSE_TIMEOUT_MS = 30 * 1000;
 
-    private final LogContext logContext;
     private final EventHandler eventHandler;
     private final Time time;
     private final Optional<String> groupId;
-    private final Logger log;
+    private final KafkaConsumerMetrics kafkaConsumerMetrics;
+    private Logger log;
+    private final String clientId;
+    private final BackgroundEventProcessor backgroundEventProcessor;
     private final Deserializers<K, V> deserializers;
+    private final FetchBuffer fetchBuffer;
+    private final FetchCollector<K, V> fetchCollector;
+    private final ConsumerInterceptors<K, V> interceptors;
+    private final IsolationLevel isolationLevel;
+
     private final SubscriptionState subscriptions;
     private final ConsumerMetadata metadata;
     private final Metrics metrics;
+    private final long retryBackoffMs;
+    private final long requestTimeoutMs;
     private final long defaultApiTimeoutMs;
+    private volatile boolean closed = false;
+    private final List<ConsumerPartitionAssignor> assignors;
 
+    // to keep from repeatedly scanning subscriptions in poll(), cache the result during metadata updates
+    private boolean cachedSubscriptionHasAllFetchPositions;
     private WakeupTrigger wakeupTrigger = new WakeupTrigger();
-    public PrototypeAsyncConsumer(Properties properties,
-                         Deserializer<K> keyDeserializer,
-                         Deserializer<V> valueDeserializer) {
+
+    public PrototypeAsyncConsumer(final Properties properties,
+                                  final Deserializer<K> keyDeserializer,
+                                  final Deserializer<V> valueDeserializer) {
         this(propsToMap(properties), keyDeserializer, valueDeserializer);
     }
 
@@ -127,56 +160,152 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     public PrototypeAsyncConsumer(final ConsumerConfig config,
                                   final Deserializer<K> keyDeserializer,
                                   final Deserializer<V> valueDeserializer) {
-        this.time = Time.SYSTEM;
-        GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
-                GroupRebalanceConfig.ProtocolType.CONSUMER);
-        this.groupId = Optional.ofNullable(groupRebalanceConfig.groupId);
-        this.defaultApiTimeoutMs = config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
-        this.logContext = createLogContext(config, groupRebalanceConfig);
-        this.log = logContext.logger(getClass());
-        this.deserializers = new Deserializers<>(config, keyDeserializer, valueDeserializer);
-        this.subscriptions = createSubscriptionState(config, logContext);
-        this.metrics = createMetrics(config, time);
-        List<ConsumerInterceptor<K, V>> interceptorList = configuredConsumerInterceptors(config);
-        ClusterResourceListeners clusterResourceListeners = ClientUtils.configureClusterResourceListeners(
-                metrics.reporters(),
-                interceptorList,
-                Arrays.asList(deserializers.keyDeserializer, deserializers.valueDeserializer));
-        this.metadata = new ConsumerMetadata(config, subscriptions, logContext, clusterResourceListeners);
-        final List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config);
-        metadata.bootstrap(addresses);
-        this.eventHandler = new DefaultEventHandler(
-                config,
-                groupRebalanceConfig,
-                logContext,
-                subscriptions,
-                new ApiVersions(),
-                this.metrics,
-                clusterResourceListeners,
-                null // this is coming from the fetcher, but we don't have one
-        );
+        this(Time.SYSTEM, config, keyDeserializer, valueDeserializer);
     }
 
-    // Visible for testing
-    PrototypeAsyncConsumer(Time time,
-                           LogContext logContext,
-                           ConsumerConfig config,
-                           SubscriptionState subscriptions,
-                           ConsumerMetadata metadata,
-                           EventHandler eventHandler,
-                           Metrics metrics,
-                           Optional<String> groupId,
-                           int defaultApiTimeoutMs) {
-        this.time = time;
-        this.logContext = logContext;
+    public PrototypeAsyncConsumer(final Time time,
+                                  final ConsumerConfig config,
+                                  final Deserializer<K> keyDeserializer,
+                                  final Deserializer<V> valueDeserializer) {
+        try {
+            GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
+                    GroupRebalanceConfig.ProtocolType.CONSUMER);
+
+            this.groupId = Optional.ofNullable(groupRebalanceConfig.groupId);
+            this.clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
+            LogContext logContext = createLogContext(config, groupRebalanceConfig);
+            this.log = logContext.logger(getClass());
+            groupId.ifPresent(groupIdStr -> {
+                if (groupIdStr.isEmpty()) {
+                    log.warn("Support for using the empty group id by consumers is deprecated and will be removed in the next major release.");
+                }
+            });
+
+            log.debug("Initializing the Kafka consumer");
+            this.requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
+            this.defaultApiTimeoutMs = config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
+            this.time = time;
+            this.metrics = createMetrics(config, time);
+            this.retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
+
+            List<ConsumerInterceptor<K, V>> interceptorList = configuredConsumerInterceptors(config);
+            this.interceptors = new ConsumerInterceptors<>(interceptorList);
+            this.deserializers = new Deserializers<>(config, keyDeserializer, valueDeserializer);
+            this.subscriptions = createSubscriptionState(config, logContext);
+            ClusterResourceListeners clusterResourceListeners = ClientUtils.configureClusterResourceListeners(metrics.reporters(),
+                    interceptorList,
+                    Arrays.asList(deserializers.keyDeserializer, deserializers.valueDeserializer));
+            this.metadata = new ConsumerMetadata(config, subscriptions, logContext, clusterResourceListeners);
+            final List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config);
+            metadata.bootstrap(addresses);
+
+            FetchMetricsManager fetchMetricsManager = createFetchMetricsManager(metrics);
+            this.isolationLevel = configuredIsolationLevel(config);
+
+            ApiVersions apiVersions = new ApiVersions();
+            final BlockingQueue<ApplicationEvent> applicationEventQueue = new LinkedBlockingQueue<>();
+            final BlockingQueue<BackgroundEvent> backgroundEventQueue = new LinkedBlockingQueue<>();
+            final Supplier<NetworkClientDelegate> networkClientDelegateSupplier = NetworkClientDelegate.supplier(time,
+                    logContext,
+                    metadata,
+                    config,
+                    apiVersions,
+                    metrics,
+                    fetchMetricsManager);
+            final Supplier<RequestManagers<String, String>> requestManagersSupplier = RequestManagers.supplier(time,
+                    logContext,
+                    backgroundEventQueue,
+                    metadata,
+                    subscriptions,
+                    config,
+                    groupRebalanceConfig,
+                    apiVersions,
+                    fetchMetricsManager,
+                    networkClientDelegateSupplier);
+            final Supplier<ApplicationEventProcessor<String, String>> applicationEventProcessorSupplier = ApplicationEventProcessor.supplier(logContext,
+                    metadata,
+                    backgroundEventQueue,
+                    requestManagersSupplier);
+            this.eventHandler = new DefaultEventHandler<>(time,
+                    logContext,
+                    applicationEventQueue,
+                    backgroundEventQueue,
+                    applicationEventProcessorSupplier,
+                    networkClientDelegateSupplier,
+                    requestManagersSupplier);
+            this.backgroundEventProcessor = new BackgroundEventProcessor(logContext, backgroundEventQueue);
+            this.assignors = ConsumerPartitionAssignor.getAssignorInstances(
+                    config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG),
+                    config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId))
+            );
+
+            // no coordinator will be constructed for the default (null) group id
+            if (!groupId.isPresent()) {
+                config.ignore(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG);
+                //config.ignore(ConsumerConfig.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED);
+            }
+            // These are specific to the foreground thread
+            FetchConfig<K, V> fetchConfig = createFetchConfig(config, deserializers);
+            this.fetchBuffer = new FetchBuffer(logContext);
+            this.fetchCollector = new FetchCollector<>(logContext,
+                    metadata,
+                    subscriptions,
+                    fetchConfig,
+                    fetchMetricsManager,
+                    time);
+
+            this.kafkaConsumerMetrics = new KafkaConsumerMetrics(metrics, CONSUMER_METRIC_GROUP_PREFIX);
+
+            config.logUnused();
+            AppInfoParser.registerAppInfo(CONSUMER_JMX_PREFIX, clientId, metrics, time.milliseconds());
+            log.debug("Kafka consumer initialized");
+        } catch (Throwable t) {
+            // call close methods if internal objects are already constructed; this is to prevent resource leak. see KAFKA-2121
+            // we do not need to call `close` at all when `log` is null, which means no internal objects were initialized.
+            if (this.log != null) {
+                close(Duration.ZERO, true);
+            }
+            // now propagate the exception
+            throw new KafkaException("Failed to construct kafka consumer", t);
+        }
+    }
+
+    public PrototypeAsyncConsumer(LogContext logContext,
+                                  String clientId,
+                                  Deserializers<K, V> deserializers,
+                                  FetchBuffer fetchBuffer,
+                                  FetchCollector<K, V> fetchCollector,
+                                  ConsumerInterceptors<K, V> interceptors,
+                                  Time time,
+                                  EventHandler eventHandler,
+                                  BlockingQueue<BackgroundEvent> backgroundEventQueue,
+                                  Metrics metrics,
+                                  SubscriptionState subscriptions,
+                                  ConsumerMetadata metadata,
+                                  long retryBackoffMs,
+                                  long requestTimeoutMs,
+                                  int defaultApiTimeoutMs,
+                                  List<ConsumerPartitionAssignor> assignors,
+                                  String groupId) {
         this.log = logContext.logger(getClass());
         this.subscriptions = subscriptions;
-        this.metadata = metadata;
+        this.clientId = clientId;
+        this.fetchBuffer = fetchBuffer;
+        this.fetchCollector = fetchCollector;
+        this.isolationLevel = IsolationLevel.READ_UNCOMMITTED;
+        this.interceptors = Objects.requireNonNull(interceptors);
+        this.time = time;
+        this.backgroundEventProcessor = new BackgroundEventProcessor(logContext, backgroundEventQueue);
         this.metrics = metrics;
-        this.groupId = groupId;
+        this.groupId = Optional.ofNullable(groupId);
+        this.metadata = metadata;
+        this.retryBackoffMs = retryBackoffMs;
+        this.requestTimeoutMs = requestTimeoutMs;
         this.defaultApiTimeoutMs = defaultApiTimeoutMs;
-        this.deserializers = new Deserializers<>(config);
+        this.deserializers = deserializers;
         this.eventHandler = eventHandler;
+        this.assignors = assignors;
+        this.kafkaConsumerMetrics = new KafkaConsumerMetrics(metrics, "consumer");
     }
 
     /**
@@ -192,37 +321,39 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     @Override
     public ConsumerRecords<K, V> poll(final Duration timeout) {
         Timer timer = time.timer(timeout);
+
         try {
+            backgroundEventProcessor.process();
+
+            this.kafkaConsumerMetrics.recordPollStart(timer.currentTimeMs());
+
+            if (this.subscriptions.hasNoSubscriptionOrUserAssignment()) {
+                throw new IllegalStateException("Consumer is not subscribed to any topics or assigned any partitions");
+            }
+
             do {
-                if (!eventHandler.isEmpty()) {
-                    final Optional<BackgroundEvent> backgroundEvent = eventHandler.poll();
-                    // processEvent() may process 3 types of event:
-                    // 1. Errors
-                    // 2. Callback Invocation
-                    // 3. Fetch responses
-                    // Errors will be handled or rethrown.
-                    // Callback invocation will trigger callback function execution, which is blocking until completion.
-                    // Successful fetch responses will be added to the completedFetches in the fetcher, which will then
-                    // be processed in the collectFetches().
-                    backgroundEvent.ifPresent(event -> processEvent(event, timeout));
-                }
-
+                updateAssignmentMetadataIfNeeded(timer);
                 updateFetchPositionsIfNeeded(timer);
+                final Fetch<K, V> fetch = pollForFetches(timer);
 
-                // The idea here is to have the background thread sending fetches autonomously, and the fetcher
-                // uses the poll loop to retrieve successful fetchResponse and process them on the polling thread.
-                final Fetch<K, V> fetch = collectFetches();
                 if (!fetch.isEmpty()) {
-                    return processFetchResults(fetch);
+                    sendFetches();
+
+                    if (fetch.records().isEmpty()) {
+                        log.trace("Returning empty records from `poll()` "
+                                + "since the consumer's position has advanced for at least one topic partition");
+                    }
+
+                    return this.interceptors.onConsume(new ConsumerRecords<>(fetch.records()));
                 }
                 // We will wait for retryBackoffMs
-            } while (time.timer(timeout).notExpired());
-        } catch (final Exception e) {
-            throw new RuntimeException(e);
+            } while (timer.notExpired());
+
+            return ConsumerRecords.empty();
+        } finally {
+            this.kafkaConsumerMetrics.recordPollEnd(timer.currentTimeMs());
         }
         // TODO: Once we implement poll(), clear wakeupTrigger in a finally block: wakeupTrigger.clearActiveTask();
-
-        return ConsumerRecords.empty();
     }
 
     /**
@@ -268,20 +399,6 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         commitSync(Duration.ofMillis(defaultApiTimeoutMs));
     }
 
-    private void processEvent(final BackgroundEvent backgroundEvent, final Duration timeout) {
-        // stubbed class
-    }
-
-    private ConsumerRecords<K, V> processFetchResults(final Fetch<K, V> fetch) {
-        // stubbed class
-        return ConsumerRecords.empty();
-    }
-
-    private Fetch<K, V> collectFetches() {
-        // stubbed class
-        return Fetch.empty();
-    }
-
     /**
      * This method sends a commit event to the EventHandler and return.
      */
@@ -325,44 +442,90 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void seek(TopicPartition partition, long offset) {
-        throw new KafkaException("method not implemented");
+        if (offset < 0)
+            throw new IllegalArgumentException("seek offset must not be a negative number");
+
+        log.info("Seeking to offset {} for partition {}", offset, partition);
+        SubscriptionState.FetchPosition newPosition = new SubscriptionState.FetchPosition(
+                offset,
+                Optional.empty(), // This will ensure we skip validation
+                this.metadata.currentLeader(partition));
+        this.subscriptions.seekUnvalidated(partition, newPosition);
     }
 
     @Override
     public void seek(TopicPartition partition, OffsetAndMetadata offsetAndMetadata) {
-        throw new KafkaException("method not implemented");
+        long offset = offsetAndMetadata.offset();
+        if (offset < 0) {
+            throw new IllegalArgumentException("seek offset must not be a negative number");
+        }
+
+        if (offsetAndMetadata.leaderEpoch().isPresent()) {
+            log.info("Seeking to offset {} for partition {} with epoch {}",
+                    offset, partition, offsetAndMetadata.leaderEpoch().get());
+        } else {
+            log.info("Seeking to offset {} for partition {}", offset, partition);
+        }
+        Metadata.LeaderAndEpoch currentLeaderAndEpoch = this.metadata.currentLeader(partition);
+        SubscriptionState.FetchPosition newPosition = new SubscriptionState.FetchPosition(
+                offsetAndMetadata.offset(),
+                offsetAndMetadata.leaderEpoch(),
+                currentLeaderAndEpoch);
+        this.updateLastSeenEpochIfNewer(partition, offsetAndMetadata);
+        this.subscriptions.seekUnvalidated(partition, newPosition);
     }
 
     @Override
     public void seekToBeginning(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        if (partitions == null)
+            throw new IllegalArgumentException("Partitions collection cannot be null");
+
+        Collection<TopicPartition> parts = partitions.size() == 0 ? this.subscriptions.assignedPartitions() : partitions;
+        subscriptions.requestOffsetReset(parts, OffsetResetStrategy.EARLIEST);
     }
 
     @Override
     public void seekToEnd(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        if (partitions == null)
+            throw new IllegalArgumentException("Partitions collection cannot be null");
+
+        Collection<TopicPartition> parts = partitions.size() == 0 ? this.subscriptions.assignedPartitions() : partitions;
+        subscriptions.requestOffsetReset(parts, OffsetResetStrategy.LATEST);
     }
 
     @Override
     public long position(TopicPartition partition) {
-        throw new KafkaException("method not implemented");
+        return position(partition, Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     @Override
     public long position(TopicPartition partition, Duration timeout) {
-        throw new KafkaException("method not implemented");
+        if (!this.subscriptions.isAssigned(partition))
+            throw new IllegalStateException("You can only check the position for partitions assigned to this consumer.");
+
+        Timer timer = time.timer(timeout);
+        do {
+            SubscriptionState.FetchPosition position = this.subscriptions.validPosition(partition);
+            if (position != null)
+                return position.offset;
+
+            updateFetchPositions(timer);
+        } while (timer.notExpired());
+
+        throw new TimeoutException("Timeout of " + timeout.toMillis() + "ms expired before the position " +
+                "for partition " + partition + " could be determined");
     }
 
     @Override
     @Deprecated
     public OffsetAndMetadata committed(TopicPartition partition) {
-        throw new KafkaException("method not implemented");
+        return committed(partition, Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     @Override
     @Deprecated
     public OffsetAndMetadata committed(TopicPartition partition, Duration timeout) {
-        throw new KafkaException("method not implemented");
+        return committed(Collections.singleton(partition), timeout).get(partition);
     }
 
     @Override
@@ -396,12 +559,12 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public Map<MetricName, ? extends Metric> metrics() {
-        throw new KafkaException("method not implemented");
+        return Collections.unmodifiableMap(this.metrics.metrics());
     }
 
     @Override
     public List<PartitionInfo> partitionsFor(String topic) {
-        throw new KafkaException("method not implemented");
+        return partitionsFor(topic, Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     @Override
@@ -411,7 +574,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public Map<String, List<PartitionInfo>> listTopics() {
-        throw new KafkaException("method not implemented");
+        return listTopics(Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     @Override
@@ -421,17 +584,23 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public Set<TopicPartition> paused() {
-        throw new KafkaException("method not implemented");
+        return Collections.unmodifiableSet(subscriptions.pausedPartitions());
     }
 
     @Override
     public void pause(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        log.debug("Pausing partitions {}", partitions);
+        for (TopicPartition partition: partitions) {
+            subscriptions.pause(partition);
+        }
     }
 
     @Override
     public void resume(Collection<TopicPartition> partitions) {
-        throw new KafkaException("method not implemented");
+        log.debug("Resuming partitions {}", partitions);
+        for (TopicPartition partition: partitions) {
+            subscriptions.resume(partition);
+        }
     }
 
     @Override
@@ -503,7 +672,25 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public OptionalLong currentLag(TopicPartition topicPartition) {
-        throw new KafkaException("method not implemented");
+        final Long lag = subscriptions.partitionLag(topicPartition, isolationLevel);
+
+        // if the log end offset is not known and hence cannot return lag and there is
+        // no in-flight list offset requested yet,
+        // issue a list offset request for that partition so that next time
+        // we may get the answer; we do not need to wait for the return value
+        // since we would not try to poll the network client synchronously
+        if (lag == null) {
+            if (subscriptions.partitionEndOffset(topicPartition, isolationLevel) == null &&
+                    !subscriptions.partitionEndOffsetRequested(topicPartition)) {
+                log.info("Requesting the log end offset for {} in order to compute lag", topicPartition);
+                subscriptions.requestPartitionEndOffset(topicPartition);
+                endOffsets(Collections.singleton(topicPartition), Duration.ofMillis(0));
+            }
+
+            return OptionalLong.empty();
+        }
+
+        return OptionalLong.of(lag);
     }
 
     @Override
@@ -526,13 +713,57 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         close(Duration.ofMillis(DEFAULT_CLOSE_TIMEOUT_MS));
     }
 
+    private Timer createTimerForRequest(final Duration timeout) {
+        // this.time could be null if an exception occurs in constructor prior to setting the this.time field
+        final Time localTime = (time == null) ? Time.SYSTEM : time;
+        return localTime.timer(Math.min(timeout.toMillis(), requestTimeoutMs));
+    }
+
     @Override
     public void close(Duration timeout) {
+        if (timeout.toMillis() < 0)
+            throw new IllegalArgumentException("The timeout cannot be negative.");
+
+        try {
+            if (!closed) {
+                // need to close before setting the flag since the close function
+                // itself may trigger rebalance callback that needs the consumer to be open still
+                close(timeout, false);
+            }
+        } finally {
+            closed = true;
+        }
+    }
+
+    private void close(Duration timeout, boolean swallowException) {
+        log.trace("Closing the Kafka consumer");
         AtomicReference<Throwable> firstException = new AtomicReference<>();
+
+        final Timer closeTimer = createTimerForRequest(timeout);
+        if (fetchBuffer != null) {
+            // the timeout for the session close is at-most the requestTimeoutMs
+            long remainingDurationInTimeout = Math.max(0, timeout.toMillis() - closeTimer.elapsedMs());
+            if (remainingDurationInTimeout > 0) {
+                remainingDurationInTimeout = Math.min(requestTimeoutMs, remainingDurationInTimeout);
+            }
+
+            closeTimer.reset(remainingDurationInTimeout);
+
+            // This is a blocking call bound by the time remaining in closeTimer
+            swallow(log, Level.ERROR, "Failed to close fetcher", fetchBuffer::close, firstException);
+        }
+
+
+        closeQuietly(interceptors, "consumer interceptors", firstException);
+        closeQuietly(kafkaConsumerMetrics, "kafka consumer metrics", firstException);
+        closeQuietly(metrics, "consumer metrics", firstException);
         closeQuietly(this.eventHandler, "event handler", firstException);
+        closeQuietly(deserializers, "consumer deserializers", firstException);
+
+        AppInfoParser.unregisterAppInfo(CONSUMER_JMX_PREFIX, clientId, metrics);
         log.debug("Kafka consumer has been closed");
         Throwable exception = firstException.get();
-        if (exception != null) {
+        if (exception != null && !swallowException) {
             if (exception instanceof InterruptException) {
                 throw (InterruptException) exception;
             }
@@ -563,19 +794,13 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
-        CompletableFuture<Void> commitFuture = commit(offsets, true);
+        long commitStart = time.nanoseconds();
         try {
-            commitFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-        } catch (final TimeoutException e) {
-            throw new org.apache.kafka.common.errors.TimeoutException(e);
-        } catch (final InterruptedException e) {
-            throw new InterruptException(e);
-        } catch (final ExecutionException e) {
-            if (e.getCause() instanceof WakeupException)
-                throw new WakeupException();
-            throw new KafkaException(e);
+            maybeThrowInvalidGroupIdException();
+            offsets.forEach(this::updateLastSeenEpochIfNewer);
+            eventHandler.addAndGet(new CommitApplicationEvent(offsets), time.timer(timeout));
         } finally {
-            wakeupTrigger.clearActiveTask();
+            kafkaConsumerMetrics.recordCommitSync(time.nanoseconds() - commitStart);
         }
     }
 
@@ -596,12 +821,38 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
 
     @Override
     public void subscribe(Collection<String> topics) {
-        throw new KafkaException("method not implemented");
+        subscribe(topics, new NoOpConsumerRebalanceListener());
     }
 
     @Override
-    public void subscribe(Collection<String> topics, ConsumerRebalanceListener callback) {
-        throw new KafkaException("method not implemented");
+    public void subscribe(Collection<String> topics, ConsumerRebalanceListener listener) {
+        maybeThrowInvalidGroupIdException();
+        if (topics == null)
+            throw new IllegalArgumentException("Topic collection to subscribe to cannot be null");
+        if (topics.isEmpty()) {
+            // treat subscribing to empty topic list as the same as unsubscribing
+            this.unsubscribe();
+        } else {
+            for (String topic : topics) {
+                if (isBlank(topic))
+                    throw new IllegalArgumentException("Topic collection to subscribe to cannot contain null or empty topic");
+            }
+
+            throwIfNoAssignorsConfigured();
+
+            // Clear the buffered data which are not a part of newly assigned topics
+            final Set<TopicPartition> currentTopicPartitions = new HashSet<>();
+
+            for (TopicPartition tp : subscriptions.assignedPartitions()) {
+                if (topics.contains(tp.topic()))
+                    currentTopicPartitions.add(tp);
+            }
+
+            fetchBuffer.retainAll(currentTopicPartitions);
+            log.info("Subscribed to topic(s): {}", join(topics, ", "));
+            if (this.subscriptions.subscribe(new HashSet<>(topics), listener))
+                metadata.requestUpdateForNewTopics();
+        }
     }
 
     @Override
@@ -611,8 +862,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         }
 
         if (partitions.isEmpty()) {
-            // TODO: implementation of unsubscribe() will be included in forthcoming commits.
-            // this.unsubscribe();
+            this.unsubscribe();
             return;
         }
 
@@ -622,12 +872,18 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
                 throw new IllegalArgumentException("Topic partitions to assign to cannot have null or empty topic");
         }
 
-        // TODO: implementation of refactored Fetcher will be included in forthcoming commits.
-        // fetcher.clearBufferedDataForUnassignedPartitions(partitions);
+        // Clear the buffered data which are not a part of newly assigned topics
+        final Set<TopicPartition> currentTopicPartitions = new HashSet<>();
 
-        // assignment change event will trigger autocommit if it is configured and the group id is specified. This is
-        // to make sure offsets of topic partitions the consumer is unsubscribing from are committed since there will
-        // be no following rebalance
+        for (TopicPartition tp : subscriptions.assignedPartitions()) {
+            if (partitions.contains(tp))
+                currentTopicPartitions.add(tp);
+        }
+
+        fetchBuffer.retainAll(currentTopicPartitions);
+
+        // make sure the offsets of topic partitions the consumer is unsubscribing from
+        // are committed since there will be no following rebalance
         eventHandler.add(new AssignmentChangeApplicationEvent(this.subscriptions.allConsumed(), time.milliseconds()));
 
         log.info("Assigned to partition(s): {}", join(partitions, ", "));
@@ -636,24 +892,52 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
     }
 
     @Override
-    public void subscribe(Pattern pattern, ConsumerRebalanceListener callback) {
-        throw new KafkaException("method not implemented");
+    public void subscribe(Pattern pattern, ConsumerRebalanceListener listener) {
+        maybeThrowInvalidGroupIdException();
+        if (pattern == null || pattern.toString().equals(""))
+            throw new IllegalArgumentException("Topic pattern to subscribe to cannot be " + (pattern == null ?
+                    "null" : "empty"));
+
+        throwIfNoAssignorsConfigured();
+        log.info("Subscribed to pattern: '{}'", pattern);
+        this.subscriptions.subscribe(pattern, listener);
+        this.updatePatternSubscription(metadata.fetch());
+        this.metadata.requestUpdateForNewTopics();
+    }
+
+    /**
+     * TODO: remove this when we implement the KIP-848 protocol.
+     *
+     * <p>
+     * The contents of this method are shamelessly stolen from
+     * {@link ConsumerCoordinator#updatePatternSubscription(Cluster)} and are used here because we won't have access
+     * to a {@link ConsumerCoordinator} in this code. Perhaps it could be moved to a ConsumerUtils class?
+     *
+     * @param cluster Cluster from which we get the topics
+     */
+    private void updatePatternSubscription(Cluster cluster) {
+        final Set<String> topicsToSubscribe = cluster.topics().stream()
+                .filter(subscriptions::matchesSubscribedPattern)
+                .collect(Collectors.toSet());
+        if (subscriptions.subscribeFromPattern(topicsToSubscribe))
+            metadata.requestUpdateForNewTopics();
     }
 
     @Override
     public void subscribe(Pattern pattern) {
-        throw new KafkaException("method not implemented");
+        subscribe(pattern, new NoOpConsumerRebalanceListener());
     }
 
     @Override
     public void unsubscribe() {
-        throw new KafkaException("method not implemented");
+        fetchBuffer.retainAll(Collections.emptySet());
+        this.subscriptions.unsubscribe();
     }
 
     @Override
     @Deprecated
-    public ConsumerRecords<K, V> poll(long timeout) {
-        throw new KafkaException("method not implemented");
+    public ConsumerRecords<K, V> poll(final long timeoutMs) {
+        return poll(Duration.ofMillis(timeoutMs));
     }
 
     // Visible for testing
@@ -661,17 +945,98 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         return wakeupTrigger;
     }
 
-    private static <K, V> ClusterResourceListeners configureClusterResourceListeners(
-            final Deserializer<K> keyDeserializer,
-            final Deserializer<V> valueDeserializer,
-            final List<?>... candidateLists) {
-        ClusterResourceListeners clusterResourceListeners = new ClusterResourceListeners();
-        for (List<?> candidateList: candidateLists)
-            clusterResourceListeners.maybeAddAll(candidateList);
+    private void sendFetches() {
+        FetchEvent event = new FetchEvent();
+        eventHandler.add(event);
 
-        clusterResourceListeners.maybeAdd(keyDeserializer);
-        clusterResourceListeners.maybeAdd(valueDeserializer);
-        return clusterResourceListeners;
+        event.future().whenComplete((completedFetches, error) -> {
+            if (completedFetches != null && !completedFetches.isEmpty()) {
+                fetchBuffer.addAll(completedFetches);
+            }
+        });
+    }
+
+    /**
+     * @throws KafkaException if the rebalance callback throws exception
+     */
+    private Fetch<K, V> pollForFetches(Timer timer) {
+        long pollTimeout = timer.remainingMs();
+
+        // if data is available already, return it immediately
+        final Fetch<K, V> fetch = fetchCollector.collectFetch(fetchBuffer);
+        if (!fetch.isEmpty()) {
+            return fetch;
+        }
+
+        // send any new fetches (won't resend pending fetches)
+        sendFetches();
+
+        // We do not want to be stuck blocking in poll if we are missing some positions
+        // since the offset lookup may be backing off after a failure
+
+        // NOTE: the use of cachedSubscriptionHasAllFetchPositions means we MUST call
+        // updateAssignmentMetadataIfNeeded before this method.
+        if (!cachedSubscriptionHasAllFetchPositions && pollTimeout > retryBackoffMs) {
+            pollTimeout = retryBackoffMs;
+        }
+
+        log.trace("Polling for fetches with timeout {}", pollTimeout);
+
+        Timer pollTimer = time.timer(pollTimeout);
+
+        // Attempt to fetch any data. It's OK if we time out here; it's a best case effort. The
+        // data may not be immediately available, but the calling method (poll) will correctly
+        // handle the overall timeout.
+        try {
+            Queue<CompletedFetch> completedFetches = eventHandler.addAndGet(new FetchEvent(), pollTimer);
+            if (completedFetches != null && !completedFetches.isEmpty()) {
+                fetchBuffer.addAll(completedFetches);
+            }
+        } catch (TimeoutException e) {
+            log.trace("Timeout during fetch", e);
+        } finally {
+            timer.update(pollTimer.currentTimeMs());
+        }
+
+        return fetchCollector.collectFetch(fetchBuffer);
+    }
+
+    /**
+     * Set the fetch position to the committed position (if there is one)
+     * or reset it using the offset reset policy the user has configured.
+     *
+     * @throws org.apache.kafka.common.errors.AuthenticationException if authentication fails. See the exception for more details
+     * @throws NoOffsetForPartitionException If no offset is stored for a given partition and no offset reset policy is
+     *             defined
+     * @return true iff the operation completed without timing out
+     */
+    private boolean updateFetchPositions(final Timer timer) {
+        // If any partitions have been truncated due to a leader change, we need to validate the offsets
+        ValidatePositionsApplicationEvent validatePositionsEvent = new ValidatePositionsApplicationEvent();
+        eventHandler.add(validatePositionsEvent);
+
+        cachedSubscriptionHasAllFetchPositions = subscriptions.hasAllFetchPositions();
+        if (cachedSubscriptionHasAllFetchPositions) return true;
+
+        // If there are any partitions which do not have a valid position and are not
+        // awaiting reset, then we need to fetch committed offsets. We will only do a
+        // coordinator lookup if there are partitions which have missing positions, so
+        // a consumer with manually assigned partitions can avoid a coordinator dependence
+        // by always ensuring that assigned partitions have an initial position.
+        if (isCommittedOffsetsManagementEnabled() && !refreshCommittedOffsetsIfNeeded(timer))
+            return false;
+
+
+        // If there are partitions still needing a position and a reset policy is defined,
+        // request reset using the default policy. If no reset strategy is defined and there
+        // are partitions with a missing position, then we will raise a NoOffsetForPartitionException exception.
+        subscriptions.resetInitializingPositions();
+
+        // Finally send an asynchronous request to look up and update the positions of any
+        // partitions which are awaiting reset.
+        ResetPositionsApplicationEvent resetPositionsEvent = new ResetPositionsApplicationEvent();
+        eventHandler.add(resetPositionsEvent);
+        return true;
     }
 
     /**
@@ -683,8 +1048,9 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         return groupId.isPresent();
     }
 
+
     /**
-     * Refresh the committed offsets for partitions that require initialization.
+     * Refresh the committed offsets for provided partitions.
      *
      * @param timer Timer bounding how long this method can block
      * @return true iff the operation completed within the timeout
@@ -701,7 +1067,6 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
             return false;
         }
     }
-
 
     // This is here temporary as we don't have public access to the ConsumerConfig in this module.
     public static Map<String, Object> appendDeserializerToConfig(Map<String, Object> configs,
@@ -720,11 +1085,34 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         return newConfigs;
     }
 
+    private void throwIfNoAssignorsConfigured() {
+        if (assignors.isEmpty())
+            throw new IllegalStateException("Must configure at least one partition assigner class name to " +
+                    ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG + " configuration property");
+    }
+
+    private void updateLastSeenEpochIfNewer(TopicPartition topicPartition, OffsetAndMetadata offsetAndMetadata) {
+        if (offsetAndMetadata != null)
+            offsetAndMetadata.leaderEpoch().ifPresent(epoch -> metadata.updateLastSeenEpochIfNewer(topicPartition, epoch));
+    }
+
     private class DefaultOffsetCommitCallback implements OffsetCommitCallback {
         @Override
         public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
             if (exception != null)
                 log.error("Offset commit with offsets {} failed", offsets, exception);
         }
+    }
+
+    // Functions below are for testing only
+    String getClientId() {
+        return clientId;
+    }
+
+    boolean updateAssignmentMetadataIfNeeded(Timer timer) {
+        // Keeping this updateAssignmentMetadataIfNeeded wrapping up the updateFetchPositions as
+        // in the previous implementation, because it will eventually involve group coordination
+        // logic
+        return updateFetchPositions(timer);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -16,41 +16,160 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.internals.IdempotentCloser;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createFetchConfig;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredIsolationLevel;
 
 /**
  * {@code RequestManagers} provides a means to pass around the set of {@link RequestManager} instances in the system.
  * This allows callers to both use the specific {@link RequestManager} instance, or to iterate over the list via
  * the {@link #entries()} method.
  */
-public class RequestManagers {
+public class RequestManagers<K, V> implements Closeable {
 
+    private final Logger log;
     public final Optional<CoordinatorRequestManager> coordinatorRequestManager;
     public final Optional<CommitRequestManager> commitRequestManager;
     public final OffsetsRequestManager offsetsRequestManager;
-    private final List<Optional<? extends RequestManager>> entries;
+    public final FetchRequestManager<K, V> fetchRequestManager;
 
-    public RequestManagers(OffsetsRequestManager offsetsRequestManager,
+    private final List<Optional<? extends RequestManager>> entries;
+    private final IdempotentCloser closer = new IdempotentCloser();
+
+    public RequestManagers(LogContext logContext,
+                           OffsetsRequestManager offsetsRequestManager,
+                           FetchRequestManager<K, V> fetchRequestManager,
                            Optional<CoordinatorRequestManager> coordinatorRequestManager,
                            Optional<CommitRequestManager> commitRequestManager) {
-        this.offsetsRequestManager = requireNonNull(offsetsRequestManager,
-                "OffsetsRequestManager cannot be null");
+        this.log = logContext.logger(RequestManagers.class);
+        this.offsetsRequestManager = requireNonNull(offsetsRequestManager, "OffsetsRequestManager cannot be null");
         this.coordinatorRequestManager = coordinatorRequestManager;
         this.commitRequestManager = commitRequestManager;
+        this.fetchRequestManager = fetchRequestManager;
 
         List<Optional<? extends RequestManager>> list = new ArrayList<>();
         list.add(coordinatorRequestManager);
         list.add(commitRequestManager);
         list.add(Optional.of(offsetsRequestManager));
+        list.add(Optional.of(fetchRequestManager));
         entries = Collections.unmodifiableList(list);
     }
 
     public List<Optional<? extends RequestManager>> entries() {
         return entries;
+    }
+
+    @Override
+    public void close() {
+        closer.close(
+                () -> {
+                    log.debug("Closing RequestManagers");
+
+                    entries.forEach(rm -> {
+                        rm.ifPresent(requestManager -> {
+                            try {
+                                requestManager.close();
+                            } catch (Throwable t) {
+                                log.debug("Error closing request manager {}", requestManager.getClass().getSimpleName(), t);
+                            }
+                        });
+                    });
+                    log.debug("RequestManagers has been closed");
+                },
+                () -> log.debug("RequestManagers was already closed"));
+
+    }
+
+    /**
+     * Creates a {@link Supplier} for deferred creation during invocation by
+     * {@link org.apache.kafka.clients.consumer.internals.DefaultBackgroundThread}.
+     */
+    public static <K, V> Supplier<RequestManagers<K, V>> supplier(final Time time,
+                                                                  final LogContext logContext,
+                                                                  final BlockingQueue<BackgroundEvent> backgroundEventQueue,
+                                                                  final ConsumerMetadata metadata,
+                                                                  final SubscriptionState subscriptions,
+                                                                  final ConsumerConfig config,
+                                                                  final GroupRebalanceConfig groupRebalanceConfig,
+                                                                  final ApiVersions apiVersions,
+                                                                  final FetchMetricsManager fetchMetricsManager,
+                                                                  final Supplier<NetworkClientDelegate> networkClientDelegateSupplier) {
+        return new CachedSupplier<RequestManagers<K, V>>() {
+            @Override
+            protected RequestManagers<K, V> create() {
+                Deserializer<K> keyDeserializer = new NoopDeserializer<>();
+                Deserializer<V> valueDeserializer = new NoopDeserializer<>();
+                final NetworkClientDelegate networkClientDelegate = networkClientDelegateSupplier.get();
+                final ErrorEventHandler errorEventHandler = new ErrorEventHandler(backgroundEventQueue);
+                final IsolationLevel isolationLevel = configuredIsolationLevel(config);
+                final FetchConfig<K, V> fetchConfig = createFetchConfig(config, new Deserializers<>(keyDeserializer, valueDeserializer));
+                long retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
+                long retryBackoffMaxMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MAX_MS_CONFIG);
+                final int requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
+                final OffsetsRequestManager listOffsets = new OffsetsRequestManager(subscriptions,
+                        metadata,
+                        isolationLevel,
+                        time,
+                        retryBackoffMs,
+                        requestTimeoutMs,
+                        apiVersions,
+                        networkClientDelegate,
+                        logContext);
+                final FetchRequestManager<K, V> fetch = new FetchRequestManager<>(logContext,
+                        time,
+                        errorEventHandler,
+                        metadata,
+                        subscriptions,
+                        fetchConfig,
+                        fetchMetricsManager,
+                        networkClientDelegate);
+                CoordinatorRequestManager coordinator = null;
+                CommitRequestManager commit = null;
+
+                if (groupRebalanceConfig != null && groupRebalanceConfig.groupId != null) {
+                    final GroupState groupState = new GroupState(groupRebalanceConfig);
+                    coordinator = new CoordinatorRequestManager(time,
+                            logContext,
+                            retryBackoffMs,
+                            retryBackoffMaxMs,
+                            errorEventHandler,
+                            groupState.groupId);
+                    commit = new CommitRequestManager(time, logContext, subscriptions, config, coordinator, groupState);
+                }
+
+                return new RequestManagers<>(logContext,
+                        listOffsets,
+                        fetch,
+                        Optional.ofNullable(coordinator),
+                        Optional.ofNullable(commit));
+            }
+        };
+    }
+
+    private static class NoopDeserializer<T> implements Deserializer<T> {
+
+        @Override
+        public T deserialize(final String topic, final byte[] data) {
+            throw new RuntimeException("who dares call me!?!?!");
+        }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEvent.java
@@ -25,7 +25,7 @@ public abstract class ApplicationEvent {
 
     public enum Type {
         NOOP, COMMIT, POLL, FETCH_COMMITTED_OFFSET, METADATA_UPDATE, ASSIGNMENT_CHANGE,
-        LIST_OFFSETS, RESET_POSITIONS, VALIDATE_POSITIONS,
+        LIST_OFFSETS, RESET_POSITIONS, VALIDATE_POSITIONS, FETCH
     }
 
     private final Type type;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -17,20 +17,28 @@
 package org.apache.kafka.clients.consumer.internals.events;
 
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.internals.CachedSupplier;
 import org.apache.kafka.clients.consumer.internals.CommitRequestManager;
+import org.apache.kafka.clients.consumer.internals.CompletedFetch;
 import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
 import org.apache.kafka.clients.consumer.internals.RequestManagers;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 public class ApplicationEventProcessor {
 
     private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
+
+    private final Logger log;
 
     private final ConsumerMetadata metadata;
 
@@ -38,14 +46,22 @@ public class ApplicationEventProcessor {
 
     public ApplicationEventProcessor(final BlockingQueue<BackgroundEvent> backgroundEventQueue,
                                      final RequestManagers requestManagers,
-                                     final ConsumerMetadata metadata) {
+                                     final ConsumerMetadata metadata,
+                                     final LogContext logContext) {
+        this.log = logContext.logger(ApplicationEventProcessor.class);
         this.backgroundEventQueue = backgroundEventQueue;
         this.requestManagers = requestManagers;
         this.metadata = metadata;
     }
 
     public boolean process(final ApplicationEvent event) {
-        Objects.requireNonNull(event);
+        Objects.requireNonNull(event, "Attempt to process null ApplicationEvent");
+        Objects.requireNonNull(event.type(), "Attempt to process ApplicationEvent with null type: " + event);
+
+        log.trace("Processing event: {}", event);
+
+        // Make sure to use the event's type() method, not the type variable directly. This causes problems when
+        // unit tests mock the EventType.
         switch (event.type()) {
             case NOOP:
                 return process((NoopApplicationEvent) event);
@@ -61,6 +77,8 @@ public class ApplicationEventProcessor {
                 return process((AssignmentChangeApplicationEvent) event);
             case LIST_OFFSETS:
                 return process((ListOffsetsApplicationEvent) event);
+            case FETCH:
+                return process((FetchEvent) event);
             case RESET_POSITIONS:
                 return processResetPositionsEvent();
             case VALIDATE_POSITIONS:
@@ -152,5 +170,30 @@ public class ApplicationEventProcessor {
     private boolean processValidatePositionsEvent() {
         requestManagers.offsetsRequestManager.validatePositionsIfNeeded();
         return true;
+    }
+
+    private boolean process(final FetchEvent event) {
+        // The request manager keeps track of the completed fetches, so we pull any that are ready off, and return
+        // them to the application.
+        Queue<CompletedFetch> completedFetches = requestManagers.fetchRequestManager.drain();
+        event.future().complete(completedFetches);
+        return true;
+    }
+
+    /**
+     * Creates a {@link Supplier} for deferred creation during invocation by
+     * {@link org.apache.kafka.clients.consumer.internals.DefaultBackgroundThread}.
+     */
+    public static Supplier<ApplicationEventProcessor> supplier(final LogContext logContext,
+                                                               final ConsumerMetadata metadata,
+                                                               final BlockingQueue<BackgroundEvent> backgroundEventQueue,
+                                                               final Supplier<RequestManagers> requestManagersSupplier) {
+        return new CachedSupplier<ApplicationEventProcessor>() {
+            @Override
+            protected ApplicationEventProcessor create() {
+                RequestManagers requestManagers = requestManagersSupplier.get();
+                return new ApplicationEventProcessor(backgroundEventQueue, requestManagers, metadata, logContext);
+            }
+        };
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -34,7 +34,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
-public class ApplicationEventProcessor<K, V> {
+public class ApplicationEventProcessor {
 
     private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
 
@@ -42,10 +42,10 @@ public class ApplicationEventProcessor<K, V> {
 
     private final ConsumerMetadata metadata;
 
-    private final RequestManagers<K, V> requestManagers;
+    private final RequestManagers requestManagers;
 
     public ApplicationEventProcessor(final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                                     final RequestManagers<K, V> requestManagers,
+                                     final RequestManagers requestManagers,
                                      final ConsumerMetadata metadata,
                                      final LogContext logContext) {
         this.log = logContext.logger(ApplicationEventProcessor.class);
@@ -184,15 +184,15 @@ public class ApplicationEventProcessor<K, V> {
      * Creates a {@link Supplier} for deferred creation during invocation by
      * {@link org.apache.kafka.clients.consumer.internals.DefaultBackgroundThread}.
      */
-    public static <K, V> Supplier<ApplicationEventProcessor<K, V>> supplier(final LogContext logContext,
-                                                                            final ConsumerMetadata metadata,
-                                                                            final BlockingQueue<BackgroundEvent> backgroundEventQueue,
-                                                                            final Supplier<RequestManagers<K, V>> requestManagersSupplier) {
-        return new CachedSupplier<ApplicationEventProcessor<K, V>>() {
+    public static Supplier<ApplicationEventProcessor> supplier(final LogContext logContext,
+                                                               final ConsumerMetadata metadata,
+                                                               final BlockingQueue<BackgroundEvent> backgroundEventQueue,
+                                                               final Supplier<RequestManagers> requestManagersSupplier) {
+        return new CachedSupplier<ApplicationEventProcessor>() {
             @Override
-            protected ApplicationEventProcessor<K, V> create() {
-                RequestManagers<K, V> requestManagers = requestManagersSupplier.get();
-                return new ApplicationEventProcessor<>(backgroundEventQueue, requestManagers, metadata, logContext);
+            protected ApplicationEventProcessor create() {
+                RequestManagers requestManagers = requestManagersSupplier.get();
+                return new ApplicationEventProcessor(backgroundEventQueue, requestManagers, metadata, logContext);
             }
         };
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEventProcessor.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals.events;
+
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
+
+import java.util.LinkedList;
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+
+public class BackgroundEventProcessor {
+
+    private final Logger log;
+    private final BlockingQueue<BackgroundEvent> backgroundEventQueue;
+
+    public BackgroundEventProcessor(final LogContext logContext,
+                                    final BlockingQueue<BackgroundEvent> backgroundEventQueue) {
+        this.log = logContext.logger(BackgroundEventProcessor.class);
+        this.backgroundEventQueue = backgroundEventQueue;
+    }
+
+    /**
+     * Drains all available {@link BackgroundEvent}s, and then processes them in order. If any
+     * errors are thrown as a result of a {@link ErrorBackgroundEvent} or an error occurs while processing
+     * another type of {@link BackgroundEvent}, only the <em>first</em> exception will be thrown, all
+     * subsequent errors will simply be logged at <code>WARN</code> level.
+     *
+     * @throws RuntimeException or subclass
+     */
+    public void process() {
+        LinkedList<BackgroundEvent> events = new LinkedList<>();
+        backgroundEventQueue.drainTo(events);
+
+        RuntimeException first = null;
+        int errorCount = 0;
+
+        for (BackgroundEvent event : events) {
+            log.debug("Consuming background event: {}", event);
+
+            try {
+                process(event);
+            } catch (RuntimeException e) {
+                errorCount++;
+
+                if (first == null) {
+                    first = e;
+                    log.warn("Error #{} from background thread (will be logged and thrown): {}", errorCount, e.getMessage(), e);
+                } else {
+                    log.warn("Error #{} from background thread (will be logged only): {}", errorCount, e.getMessage(), e);
+                }
+            }
+        }
+
+        if (first != null) {
+            throw first;
+        }
+    }
+
+    private void process(final BackgroundEvent event) {
+        Objects.requireNonNull(event, "Attempt to process null BackgroundEvent");
+        Objects.requireNonNull(event.type(), "Attempt to process BackgroundEvent with null type: " + event);
+
+        log.debug("Processing event {}", event);
+
+        // Make sure to use the event's type() method, not the type variable directly. This causes problems when
+        // unit tests mock the EventType.
+        switch (event.type()) {
+            case NOOP:
+                process((NoopBackgroundEvent) event);
+                return;
+
+            case ERROR:
+                process((ErrorBackgroundEvent) event);
+                return;
+
+            default:
+                throw new IllegalArgumentException("Background event type " + event.type() + " was not expected");
+        }
+    }
+
+    private void process(final NoopBackgroundEvent event) {
+        log.debug("Received no-op background event with message: {}", event.message());
+    }
+
+    private void process(final ErrorBackgroundEvent event) {
+        throw event.error();
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ErrorBackgroundEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ErrorBackgroundEvent.java
@@ -18,14 +18,14 @@ package org.apache.kafka.clients.consumer.internals.events;
 
 public class ErrorBackgroundEvent extends BackgroundEvent {
 
-    private final Throwable error;
+    private final RuntimeException error;
 
-    public ErrorBackgroundEvent(Throwable error) {
+    public ErrorBackgroundEvent(RuntimeException error) {
         super(Type.ERROR);
         this.error = error;
     }
 
-    public Throwable error() {
+    public RuntimeException error() {
         return error;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/EventHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/EventHandler.java
@@ -19,7 +19,7 @@ package org.apache.kafka.clients.consumer.internals.events;
 import org.apache.kafka.common.utils.Timer;
 
 import java.io.Closeable;
-import java.util.Optional;
+import java.time.Duration;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -28,17 +28,6 @@ import java.util.concurrent.TimeUnit;
  * the {@code add()} method and to retrieve events via the {@code poll()} method.
  */
 public interface EventHandler extends Closeable {
-    /**
-     * Retrieves and removes a {@link BackgroundEvent}. Returns an empty Optional instance if there is nothing.
-     * @return an Optional of {@link BackgroundEvent} if the value is present. Otherwise, an empty Optional.
-     */
-    Optional<BackgroundEvent> poll();
-
-    /**
-     * Check whether there are pending {@code BackgroundEvent} await to be consumed.
-     * @return true if there are no pending event
-     */
-    boolean isEmpty();
 
     /**
      * Add an {@link ApplicationEvent} to the handler. The method returns true upon successful add; otherwise returns
@@ -62,4 +51,10 @@ public interface EventHandler extends Closeable {
      * @param <T>   Type of return value of the event
      */
     <T> T addAndGet(final CompletableApplicationEvent<T> event, final Timer timer);
+
+    default void close() {
+        close(Duration.ofMillis(Long.MAX_VALUE));
+    }
+
+    void close(Duration timeout);
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/FetchEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/FetchEvent.java
@@ -14,22 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.clients.consumer.internals;
+package org.apache.kafka.clients.consumer.internals.events;
 
-import org.apache.kafka.clients.consumer.internals.NetworkClientDelegate.PollResult;
+import org.apache.kafka.clients.consumer.internals.CompletedFetch;
 
-import java.io.Closeable;
+import java.util.Queue;
 
 /**
- * {@code PollResult} consist of {@code UnsentRequest} if there are requests to send; otherwise, return the time till
- * the next poll event.
+ * This event signals the background thread to submit a fetch request.
  */
-public interface RequestManager extends Closeable {
+public class FetchEvent extends CompletableApplicationEvent<Queue<CompletedFetch>> {
 
-    PollResult poll(long currentTimeMs);
-
-    @Override
-    default void close() {
-        // Do nothing...
+    public FetchEvent() {
+        super(Type.FETCH);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -29,7 +29,6 @@ import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
 import org.apache.kafka.clients.consumer.internals.ConsumerMetrics;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
-import org.apache.kafka.clients.consumer.internals.Deserializers;
 import org.apache.kafka.clients.consumer.internals.FetchConfig;
 import org.apache.kafka.clients.consumer.internals.FetchMetricsManager;
 import org.apache.kafka.clients.consumer.internals.Fetcher;
@@ -2674,7 +2673,7 @@ public class KafkaConsumerTest {
         }
         IsolationLevel isolationLevel = IsolationLevel.READ_UNCOMMITTED;
         FetchMetricsManager metricsManager = new FetchMetricsManager(metrics, metricsRegistry.fetcherMetrics);
-        FetchConfig<String, String> fetchConfig = new FetchConfig<>(
+        FetchConfig fetchConfig = new FetchConfig(
                 minBytes,
                 maxBytes,
                 maxWaitMs,
@@ -2682,7 +2681,6 @@ public class KafkaConsumerTest {
                 maxPollRecords,
                 checkCrcs,
                 CommonClientConfigs.DEFAULT_CLIENT_RACK,
-                new Deserializers<>(keyDeserializer, deserializer),
                 isolationLevel);
         Fetcher<String, String> fetcher = new Fetcher<>(
                 loggerFactory,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -2674,7 +2674,7 @@ public class KafkaConsumerTest {
         }
         IsolationLevel isolationLevel = IsolationLevel.READ_UNCOMMITTED;
         FetchMetricsManager metricsManager = new FetchMetricsManager(metrics, metricsRegistry.fetcherMetrics);
-        FetchConfig<String, String> fetchConfig = new FetchConfig<>(
+        FetchConfig fetchConfig = new FetchConfig(
                 minBytes,
                 maxBytes,
                 maxWaitMs,
@@ -2682,7 +2682,6 @@ public class KafkaConsumerTest {
                 maxPollRecords,
                 checkCrcs,
                 CommonClientConfigs.DEFAULT_CLIENT_RACK,
-                new Deserializers<>(keyDeserializer, deserializer),
                 isolationLevel);
         Fetcher<String, String> fetcher = new Fetcher<>(
                 loggerFactory,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -29,7 +29,6 @@ import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
 import org.apache.kafka.clients.consumer.internals.ConsumerMetrics;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
-import org.apache.kafka.clients.consumer.internals.Deserializers;
 import org.apache.kafka.clients.consumer.internals.FetchConfig;
 import org.apache.kafka.clients.consumer.internals.FetchMetricsManager;
 import org.apache.kafka.clients.consumer.internals.Fetcher;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -110,7 +110,7 @@ public class ConsumerTestBuilder implements Closeable {
         final long requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
         this.metrics = createMetrics(config, time);
 
-        this.subscriptions = createSubscriptionState(config, logContext);
+        this.subscriptions = spy(createSubscriptionState(config, logContext));
         this.metadata = spy(new ConsumerMetadata(config, subscriptions, logContext, new ClusterResourceListeners()));
         this.fetchConfig = createFetchConfig(config, new Deserializers<>(config));
         this.metricsManager = createFetchMetricsManager(metrics);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -69,16 +69,16 @@ public class ConsumerTestBuilder implements Closeable {
     final long retryBackoffMs;
     final SubscriptionState subscriptions;
     final ConsumerMetadata metadata;
-    final FetchConfig<String, String> fetchConfig;
+    final FetchConfig fetchConfig;
     final Metrics metrics;
     final FetchMetricsManager metricsManager;
     final NetworkClientDelegate networkClientDelegate;
     final OffsetsRequestManager offsetsRequestManager;
     final CoordinatorRequestManager coordinatorRequestManager;
     final CommitRequestManager commitRequestManager;
-    final FetchRequestManager<String, String> fetchRequestManager;
-    final RequestManagers<String, String> requestManagers;
-    final ApplicationEventProcessor<String, String> applicationEventProcessor;
+    final FetchRequestManager fetchRequestManager;
+    final RequestManagers requestManagers;
+    final ApplicationEventProcessor applicationEventProcessor;
     final BackgroundEventProcessor backgroundEventProcessor;
     final MockClient client;
 
@@ -112,7 +112,7 @@ public class ConsumerTestBuilder implements Closeable {
 
         this.subscriptions = spy(createSubscriptionState(config, logContext));
         this.metadata = spy(new ConsumerMetadata(config, subscriptions, logContext, new ClusterResourceListeners()));
-        this.fetchConfig = createFetchConfig(config, new Deserializers<>(config));
+        this.fetchConfig = createFetchConfig(config);
         this.metricsManager = createFetchMetricsManager(metrics);
 
         this.client = new MockClient(time, metadata);
@@ -151,7 +151,7 @@ public class ConsumerTestBuilder implements Closeable {
                 config,
                 coordinatorRequestManager,
                 groupState));
-        this.fetchRequestManager = spy(new FetchRequestManager<>(logContext,
+        this.fetchRequestManager = spy(new FetchRequestManager(logContext,
                 time,
                 errorEventHandler,
                 metadata,
@@ -159,12 +159,12 @@ public class ConsumerTestBuilder implements Closeable {
                 fetchConfig,
                 metricsManager,
                 networkClientDelegate));
-        this.requestManagers = new RequestManagers<>(logContext,
+        this.requestManagers = new RequestManagers(logContext,
                 offsetsRequestManager,
                 fetchRequestManager,
                 Optional.of(coordinatorRequestManager),
                 Optional.of(commitRequestManager));
-        this.applicationEventProcessor = spy(new ApplicationEventProcessor<>(
+        this.applicationEventProcessor = spy(new ApplicationEventProcessor(
                 backgroundEventQueue,
                 requestManagers,
                 metadata,
@@ -179,10 +179,10 @@ public class ConsumerTestBuilder implements Closeable {
 
     public static class DefaultBackgroundThreadTestBuilder extends ConsumerTestBuilder {
 
-        final DefaultBackgroundThread<String, String> backgroundThread;
+        final DefaultBackgroundThread backgroundThread;
 
         public DefaultBackgroundThreadTestBuilder() {
-            this.backgroundThread = new DefaultBackgroundThread<>(
+            this.backgroundThread = new DefaultBackgroundThread(
                     time,
                     logContext,
                     applicationEventQueue,
@@ -202,11 +202,10 @@ public class ConsumerTestBuilder implements Closeable {
         final EventHandler eventHandler;
 
         public DefaultEventHandlerTestBuilder() {
-            this.eventHandler = spy(new DefaultEventHandler<>(
+            this.eventHandler = spy(new DefaultEventHandler(
                     time,
                     logContext,
                     applicationEventQueue,
-                    backgroundEventQueue,
                     () -> applicationEventProcessor,
                     () -> networkClientDelegate,
                     () -> requestManagers));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.clients.MockClient;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
+import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
+import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEventProcessor;
+import org.apache.kafka.clients.consumer.internals.events.EventHandler;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.RequestTestUtils;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createFetchConfig;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createFetchMetricsManager;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createMetrics;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createSubscriptionState;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredIsolationLevel;
+import static org.mockito.Mockito.spy;
+
+public class ConsumerTestBuilder implements Closeable {
+
+    static final long RETRY_BACKOFF_MS = 80;
+    static final long RETRY_BACKOFF_MAX_MS = 1000;
+    static final int REQUEST_TIMEOUT_MS = 500;
+
+    final LogContext logContext = new LogContext();
+    final Time time = new MockTime(0);
+    final BlockingQueue<ApplicationEvent> applicationEventQueue;
+    final LinkedBlockingQueue<BackgroundEvent> backgroundEventQueue;
+    final ConsumerConfig config;
+    final long retryBackoffMs;
+    final SubscriptionState subscriptions;
+    final ConsumerMetadata metadata;
+    final FetchConfig<String, String> fetchConfig;
+    final Metrics metrics;
+    final FetchMetricsManager metricsManager;
+    final NetworkClientDelegate networkClientDelegate;
+    final OffsetsRequestManager offsetsRequestManager;
+    final CoordinatorRequestManager coordinatorRequestManager;
+    final CommitRequestManager commitRequestManager;
+    final FetchRequestManager<String, String> fetchRequestManager;
+    final RequestManagers<String, String> requestManagers;
+    final ApplicationEventProcessor<String, String> applicationEventProcessor;
+    final BackgroundEventProcessor backgroundEventProcessor;
+    final MockClient client;
+
+    public ConsumerTestBuilder() {
+        this.applicationEventQueue = new LinkedBlockingQueue<>();
+        this.backgroundEventQueue = new LinkedBlockingQueue<>();
+        ErrorEventHandler errorEventHandler = new ErrorEventHandler(backgroundEventQueue);
+        GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(
+                100,
+                100,
+                100,
+                "group_id",
+                Optional.empty(),
+                RETRY_BACKOFF_MS,
+                RETRY_BACKOFF_MAX_MS,
+                true);
+        GroupState groupState = new GroupState(groupRebalanceConfig);
+        ApiVersions apiVersions = new ApiVersions();
+
+        Properties properties = new Properties();
+        properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG, RETRY_BACKOFF_MS);
+        properties.put(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG, REQUEST_TIMEOUT_MS);
+
+        this.config = new ConsumerConfig(properties);
+        IsolationLevel isolationLevel = configuredIsolationLevel(config);
+        this.retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
+        final long requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
+        this.metrics = createMetrics(config, time);
+
+        this.subscriptions = createSubscriptionState(config, logContext);
+        this.metadata = spy(new ConsumerMetadata(config, subscriptions, logContext, new ClusterResourceListeners()));
+        this.fetchConfig = createFetchConfig(config, new Deserializers<>(config));
+        this.metricsManager = createFetchMetricsManager(metrics);
+
+        this.client = new MockClient(time, metadata);
+        MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWith(1, new HashMap<String, Integer>() {
+            {
+                String topic1 = "test1";
+                put(topic1, 1);
+                String topic2 = "test2";
+                put(topic2, 1);
+            }
+        });
+        this.client.updateMetadata(metadataResponse);
+
+        this.networkClientDelegate = spy(new NetworkClientDelegate(time,
+                config,
+                logContext,
+                client));
+        this.offsetsRequestManager = spy(new OffsetsRequestManager(subscriptions,
+                metadata,
+                isolationLevel,
+                time,
+                retryBackoffMs,
+                requestTimeoutMs,
+                apiVersions,
+                networkClientDelegate,
+                logContext));
+        this.coordinatorRequestManager = spy(new CoordinatorRequestManager(time,
+                logContext,
+                RETRY_BACKOFF_MS,
+                RETRY_BACKOFF_MAX_MS,
+                errorEventHandler,
+                "group_id"));
+        this.commitRequestManager = spy(new CommitRequestManager(time,
+                logContext,
+                subscriptions,
+                config,
+                coordinatorRequestManager,
+                groupState));
+        this.fetchRequestManager = spy(new FetchRequestManager<>(logContext,
+                time,
+                errorEventHandler,
+                metadata,
+                subscriptions,
+                fetchConfig,
+                metricsManager,
+                networkClientDelegate));
+        this.requestManagers = new RequestManagers<>(logContext,
+                offsetsRequestManager,
+                fetchRequestManager,
+                Optional.of(coordinatorRequestManager),
+                Optional.of(commitRequestManager));
+        this.applicationEventProcessor = spy(new ApplicationEventProcessor<>(
+                backgroundEventQueue,
+                requestManagers,
+                metadata,
+                logContext));
+        this.backgroundEventProcessor = spy(new BackgroundEventProcessor(logContext, backgroundEventQueue));
+    }
+
+    @Override
+    public void close() {
+        requestManagers.close();
+    }
+
+    public static class DefaultBackgroundThreadTestBuilder extends ConsumerTestBuilder {
+
+        final DefaultBackgroundThread<String, String> backgroundThread;
+
+        public DefaultBackgroundThreadTestBuilder() {
+            this.backgroundThread = new DefaultBackgroundThread<>(
+                    time,
+                    logContext,
+                    applicationEventQueue,
+                    () -> applicationEventProcessor,
+                    () -> networkClientDelegate,
+                    () -> requestManagers);
+        }
+
+        @Override
+        public void close() {
+            backgroundThread.close();
+        }
+    }
+
+    public static class DefaultEventHandlerTestBuilder extends ConsumerTestBuilder {
+
+        final EventHandler eventHandler;
+
+        public DefaultEventHandlerTestBuilder() {
+            this.eventHandler = spy(new DefaultEventHandler<>(
+                    time,
+                    logContext,
+                    applicationEventQueue,
+                    backgroundEventQueue,
+                    () -> applicationEventProcessor,
+                    () -> networkClientDelegate,
+                    () -> requestManagers));
+        }
+
+        @Override
+        public void close() {
+            eventHandler.close();
+        }
+    }
+
+    public static class PrototypeAsyncConsumerTestBuilder extends DefaultEventHandlerTestBuilder {
+
+        final PrototypeAsyncConsumer<String, String> consumer;
+
+        public PrototypeAsyncConsumerTestBuilder(Optional<String> groupIdOpt) {
+            String clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
+            List<ConsumerPartitionAssignor> assignors = ConsumerPartitionAssignor.getAssignorInstances(
+                    config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG),
+                    config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId))
+            );
+            FetchCollector<String, String> fetchCollector = new FetchCollector<>(logContext,
+                    metadata,
+                    subscriptions,
+                    fetchConfig,
+                    metricsManager,
+                    time);
+            this.consumer = spy(new PrototypeAsyncConsumer<>(
+                    logContext,
+                    clientId,
+                    new Deserializers<>(new StringDeserializer(), new StringDeserializer()),
+                    new FetchBuffer(logContext),
+                    fetchCollector,
+                    new ConsumerInterceptors<>(Collections.emptyList()),
+                    time,
+                    eventHandler,
+                    backgroundEventQueue,
+                    metrics,
+                    subscriptions,
+                    metadata,
+                    retryBackoffMs,
+                    REQUEST_TIMEOUT_MS,
+                    60000,
+                    assignors,
+                    groupIdOpt.orElse(null)));
+        }
+
+        @Override
+        public void close() {
+            consumer.close();
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.GroupRebalanceConfig;
+import org.apache.kafka.clients.MockClient;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
+import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
+import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEventProcessor;
+import org.apache.kafka.clients.consumer.internals.events.EventHandler;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.RequestTestUtils;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createFetchConfig;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createFetchMetricsManager;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createMetrics;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createSubscriptionState;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.configuredIsolationLevel;
+import static org.mockito.Mockito.spy;
+
+public class ConsumerTestBuilder implements Closeable {
+
+    static final long RETRY_BACKOFF_MS = 80;
+    static final long RETRY_BACKOFF_MAX_MS = 1000;
+    static final int REQUEST_TIMEOUT_MS = 500;
+
+    final LogContext logContext = new LogContext();
+    final Time time = new MockTime(0);
+    final BlockingQueue<ApplicationEvent> applicationEventQueue;
+    final LinkedBlockingQueue<BackgroundEvent> backgroundEventQueue;
+    final ConsumerConfig config;
+    final long retryBackoffMs;
+    final SubscriptionState subscriptions;
+    final ConsumerMetadata metadata;
+    final FetchConfig fetchConfig;
+    final Metrics metrics;
+    final FetchMetricsManager metricsManager;
+    final NetworkClientDelegate networkClientDelegate;
+    final OffsetsRequestManager offsetsRequestManager;
+    final CoordinatorRequestManager coordinatorRequestManager;
+    final CommitRequestManager commitRequestManager;
+    final FetchRequestManager fetchRequestManager;
+    final RequestManagers requestManagers;
+    final ApplicationEventProcessor applicationEventProcessor;
+    final BackgroundEventProcessor backgroundEventProcessor;
+    final MockClient client;
+
+    public ConsumerTestBuilder() {
+        this.applicationEventQueue = new LinkedBlockingQueue<>();
+        this.backgroundEventQueue = new LinkedBlockingQueue<>();
+        ErrorEventHandler errorEventHandler = new ErrorEventHandler(backgroundEventQueue);
+        GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(
+                100,
+                100,
+                100,
+                "group_id",
+                Optional.empty(),
+                RETRY_BACKOFF_MS,
+                RETRY_BACKOFF_MAX_MS,
+                true);
+        GroupState groupState = new GroupState(groupRebalanceConfig);
+        ApiVersions apiVersions = new ApiVersions();
+
+        Properties properties = new Properties();
+        properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG, RETRY_BACKOFF_MS);
+        properties.put(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG, REQUEST_TIMEOUT_MS);
+
+        this.config = new ConsumerConfig(properties);
+        IsolationLevel isolationLevel = configuredIsolationLevel(config);
+        this.retryBackoffMs = config.getLong(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG);
+        final long requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);
+        this.metrics = createMetrics(config, time);
+
+        this.subscriptions = spy(createSubscriptionState(config, logContext));
+        this.metadata = spy(new ConsumerMetadata(config, subscriptions, logContext, new ClusterResourceListeners()));
+        this.fetchConfig = createFetchConfig(config);
+        this.metricsManager = createFetchMetricsManager(metrics);
+
+        this.client = new MockClient(time, metadata);
+        MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWith(1, new HashMap<String, Integer>() {
+            {
+                String topic1 = "test1";
+                put(topic1, 1);
+                String topic2 = "test2";
+                put(topic2, 1);
+            }
+        });
+        this.client.updateMetadata(metadataResponse);
+
+        this.networkClientDelegate = spy(new NetworkClientDelegate(time,
+                config,
+                logContext,
+                client));
+        this.offsetsRequestManager = spy(new OffsetsRequestManager(subscriptions,
+                metadata,
+                isolationLevel,
+                time,
+                retryBackoffMs,
+                requestTimeoutMs,
+                apiVersions,
+                networkClientDelegate,
+                logContext));
+        this.coordinatorRequestManager = spy(new CoordinatorRequestManager(time,
+                logContext,
+                RETRY_BACKOFF_MS,
+                RETRY_BACKOFF_MAX_MS,
+                errorEventHandler,
+                "group_id"));
+        this.commitRequestManager = spy(new CommitRequestManager(time,
+                logContext,
+                subscriptions,
+                config,
+                coordinatorRequestManager,
+                groupState));
+        this.fetchRequestManager = spy(new FetchRequestManager(logContext,
+                time,
+                errorEventHandler,
+                metadata,
+                subscriptions,
+                fetchConfig,
+                metricsManager,
+                networkClientDelegate));
+        this.requestManagers = new RequestManagers(logContext,
+                offsetsRequestManager,
+                fetchRequestManager,
+                Optional.of(coordinatorRequestManager),
+                Optional.of(commitRequestManager));
+        this.applicationEventProcessor = spy(new ApplicationEventProcessor(
+                backgroundEventQueue,
+                requestManagers,
+                metadata,
+                logContext));
+        this.backgroundEventProcessor = spy(new BackgroundEventProcessor(logContext, backgroundEventQueue));
+    }
+
+    @Override
+    public void close() {
+        requestManagers.close();
+    }
+
+    public static class DefaultBackgroundThreadTestBuilder extends ConsumerTestBuilder {
+
+        final DefaultBackgroundThread backgroundThread;
+
+        public DefaultBackgroundThreadTestBuilder() {
+            this.backgroundThread = new DefaultBackgroundThread(
+                    time,
+                    logContext,
+                    applicationEventQueue,
+                    () -> applicationEventProcessor,
+                    () -> networkClientDelegate,
+                    () -> requestManagers);
+        }
+
+        @Override
+        public void close() {
+            backgroundThread.close();
+        }
+    }
+
+    public static class DefaultEventHandlerTestBuilder extends ConsumerTestBuilder {
+
+        final EventHandler eventHandler;
+
+        public DefaultEventHandlerTestBuilder() {
+            this.eventHandler = spy(new DefaultEventHandler(
+                    time,
+                    logContext,
+                    applicationEventQueue,
+                    () -> applicationEventProcessor,
+                    () -> networkClientDelegate,
+                    () -> requestManagers));
+        }
+
+        @Override
+        public void close() {
+            eventHandler.close();
+        }
+    }
+
+    public static class PrototypeAsyncConsumerTestBuilder extends DefaultEventHandlerTestBuilder {
+
+        final PrototypeAsyncConsumer<String, String> consumer;
+
+        public PrototypeAsyncConsumerTestBuilder(Optional<String> groupIdOpt) {
+            String clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
+            List<ConsumerPartitionAssignor> assignors = ConsumerPartitionAssignor.getAssignorInstances(
+                    config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG),
+                    config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId))
+            );
+            FetchCollector<String, String> fetchCollector = new FetchCollector<>(logContext,
+                    metadata,
+                    subscriptions,
+                    fetchConfig,
+                    metricsManager,
+                    time);
+            this.consumer = spy(new PrototypeAsyncConsumer<>(
+                    logContext,
+                    clientId,
+                    new Deserializers<>(new StringDeserializer(), new StringDeserializer()),
+                    new FetchBuffer(logContext),
+                    fetchCollector,
+                    new ConsumerInterceptors<>(Collections.emptyList()),
+                    time,
+                    eventHandler,
+                    backgroundEventQueue,
+                    metrics,
+                    subscriptions,
+                    metadata,
+                    retryBackoffMs,
+                    REQUEST_TIMEOUT_MS,
+                    60000,
+                    assignors,
+                    groupIdOpt.orElse(null)));
+        }
+
+        @Override
+        public void close() {
+            consumer.close();
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -56,7 +56,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -16,29 +16,28 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.GroupRebalanceConfig;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.LogTruncationException;
+import org.apache.kafka.clients.MockClient;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.AssignmentChangeApplicationEvent;
-import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.CommitApplicationEvent;
+import org.apache.kafka.clients.consumer.internals.events.CompletableApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ListOffsetsApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.NewTopicsMetadataUpdateRequestEvent;
 import org.apache.kafka.clients.consumer.internals.events.NoopApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ResetPositionsApplicationEvent;
-import org.apache.kafka.clients.consumer.internals.events.ValidatePositionsApplicationEvent;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
+import org.apache.kafka.common.message.OffsetCommitRequestData;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.OffsetCommitRequest;
+import org.apache.kafka.common.requests.RequestTestUtils;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -48,87 +47,79 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.CompletableFuture;
 
-import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.RETRY_BACKOFF_MS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DefaultBackgroundThreadTest {
-    private static final long RETRY_BACKOFF_MS = 100;
-    private final Properties properties = new Properties();
-    private MockTime time;
+
+    private ConsumerTestBuilder.DefaultBackgroundThreadTestBuilder testBuilder;
+    private Time time;
     private ConsumerMetadata metadata;
     private NetworkClientDelegate networkClient;
-    private BlockingQueue<BackgroundEvent> backgroundEventsQueue;
     private BlockingQueue<ApplicationEvent> applicationEventsQueue;
     private ApplicationEventProcessor applicationEventProcessor;
     private CoordinatorRequestManager coordinatorManager;
     private OffsetsRequestManager offsetsRequestManager;
-    private ErrorEventHandler errorEventHandler;
-    private final int requestTimeoutMs = 500;
-    private GroupState groupState;
     private CommitRequestManager commitManager;
+    private DefaultBackgroundThread backgroundThread;
+    private MockClient client;
 
     @BeforeEach
-    @SuppressWarnings("unchecked")
     public void setup() {
-        this.time = new MockTime(0);
-        this.metadata = mock(ConsumerMetadata.class);
-        this.networkClient = mock(NetworkClientDelegate.class);
-        this.applicationEventsQueue = (BlockingQueue<ApplicationEvent>) mock(BlockingQueue.class);
-        this.backgroundEventsQueue = (BlockingQueue<BackgroundEvent>) mock(BlockingQueue.class);
-        this.applicationEventProcessor = mock(ApplicationEventProcessor.class);
-        this.coordinatorManager = mock(CoordinatorRequestManager.class);
-        this.offsetsRequestManager = mock(OffsetsRequestManager.class);
-        this.errorEventHandler = mock(ErrorEventHandler.class);
-        GroupRebalanceConfig rebalanceConfig = new GroupRebalanceConfig(
-                100,
-                100,
-                100,
-                "group_id",
-                Optional.empty(),
-                100,
-                1000,
-                true);
-        this.groupState = new GroupState(rebalanceConfig);
-        this.commitManager = mock(CommitRequestManager.class);
+        this.testBuilder = new ConsumerTestBuilder.DefaultBackgroundThreadTestBuilder();
+        this.time = testBuilder.time;
+        this.metadata = testBuilder.metadata;
+        this.networkClient = testBuilder.networkClientDelegate;
+        this.client = testBuilder.client;
+        this.applicationEventsQueue = testBuilder.applicationEventQueue;
+        this.applicationEventProcessor = testBuilder.applicationEventProcessor;
+        this.coordinatorManager = testBuilder.coordinatorRequestManager;
+        this.commitManager = testBuilder.commitRequestManager;
+        this.offsetsRequestManager = testBuilder.offsetsRequestManager;
+        this.backgroundThread = testBuilder.backgroundThread;
+        this.backgroundThread.initializeResources();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (testBuilder != null)
+            testBuilder.close();
     }
 
     @Test
     public void testStartupAndTearDown() throws InterruptedException {
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-        backgroundThread.start();
-        TestUtils.waitForCondition(backgroundThread::isRunning, "Failed awaiting for the background thread to be running");
-        backgroundThread.close();
         assertFalse(backgroundThread.isRunning());
+        backgroundThread.start();
+
+        // There's a nonzero amount of time between starting the thread and having it
+        // begin to execute our code. Wait for a bit before checking...
+        int maxWaitMs = 1000;
+        TestUtils.waitForCondition(backgroundThread::isRunning,
+                maxWaitMs,
+                "Thread did not start within " + maxWaitMs + " ms");
+        backgroundThread.close();
+        TestUtils.waitForCondition(() -> !backgroundThread.isRunning(),
+                maxWaitMs,
+                "Thread did not stop within " + maxWaitMs + " ms");
     }
 
     @Test
     public void testApplicationEvent() {
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
         when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
         when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         ApplicationEvent e = new NoopApplicationEvent("noop event");
         this.applicationEventsQueue.add(e);
         backgroundThread.runOnce();
@@ -138,16 +129,8 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     public void testMetadataUpdateEvent() {
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        this.applicationEventProcessor = new ApplicationEventProcessor(
-                this.backgroundEventsQueue,
-                mockRequestManagers(),
-                metadata);
         when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
         when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         ApplicationEvent e = new NewTopicsMetadataUpdateRequestEvent();
         this.applicationEventsQueue.add(e);
         backgroundThread.runOnce();
@@ -157,12 +140,8 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     public void testCommitEvent() {
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
         when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
         when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         ApplicationEvent e = new CommitApplicationEvent(new HashMap<>());
         this.applicationEventsQueue.add(e);
         backgroundThread.runOnce();
@@ -170,15 +149,8 @@ public class DefaultBackgroundThreadTest {
         backgroundThread.close();
     }
 
-
     @Test
     public void testListOffsetsEventIsProcessed() {
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         Map<TopicPartition, Long> timestamps = Collections.singletonMap(new TopicPartition("topic1", 1), 5L);
         ApplicationEvent e = new ListOffsetsApplicationEvent(timestamps, true);
         this.applicationEventsQueue.add(e);
@@ -190,14 +162,8 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     public void testResetPositionsEventIsProcessed() {
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-        ResetPositionsApplicationEvent e = new ResetPositionsApplicationEvent();
-        this.applicationEventsQueue.add(e);
+        ResetPositionsApplicationEvent event = new ResetPositionsApplicationEvent();
+        this.applicationEventsQueue.add(event);
         backgroundThread.runOnce();
         verify(applicationEventProcessor).process(any(ResetPositionsApplicationEvent.class));
         assertTrue(applicationEventsQueue.isEmpty());
@@ -205,79 +171,20 @@ public class DefaultBackgroundThreadTest {
     }
 
     @Test
-    public void testResetPositionsProcessFailure() {
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        applicationEventProcessor = spy(new ApplicationEventProcessor(
-                this.backgroundEventsQueue,
-                mockRequestManagers(),
-                metadata));
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-
+    public void testResetPositionsProcessFailureInterruptsBackgroundThread() {
         TopicAuthorizationException authException = new TopicAuthorizationException("Topic authorization failed");
         doThrow(authException).when(offsetsRequestManager).resetPositionsIfNeeded();
 
         ResetPositionsApplicationEvent event = new ResetPositionsApplicationEvent();
         this.applicationEventsQueue.add(event);
-        assertThrows(TopicAuthorizationException.class, backgroundThread::runOnce);
+        assertThrows(TopicAuthorizationException.class, () -> backgroundThread.runOnce());
 
         verify(applicationEventProcessor).process(any(ResetPositionsApplicationEvent.class));
         backgroundThread.close();
     }
 
     @Test
-    public void testValidatePositionsEventIsProcessed() {
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-        ValidatePositionsApplicationEvent e = new ValidatePositionsApplicationEvent();
-        this.applicationEventsQueue.add(e);
-        backgroundThread.runOnce();
-        verify(applicationEventProcessor).process(any(ValidatePositionsApplicationEvent.class));
-        assertTrue(applicationEventsQueue.isEmpty());
-        backgroundThread.close();
-    }
-
-    @Test
-    public void testValidatePositionsProcessFailure() {
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        applicationEventProcessor = spy(new ApplicationEventProcessor(
-                this.backgroundEventsQueue,
-                mockRequestManagers(),
-                metadata));
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-
-        LogTruncationException logTruncationException = new LogTruncationException(Collections.emptyMap(), Collections.emptyMap());
-        doThrow(logTruncationException).when(offsetsRequestManager).validatePositionsIfNeeded();
-
-        ValidatePositionsApplicationEvent event = new ValidatePositionsApplicationEvent();
-        this.applicationEventsQueue.add(event);
-        assertThrows(LogTruncationException.class, backgroundThread::runOnce);
-
-        verify(applicationEventProcessor).process(any(ValidatePositionsApplicationEvent.class));
-        backgroundThread.close();
-    }
-
-    @Test
     public void testAssignmentChangeEvent() {
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        this.applicationEventProcessor = spy(new ApplicationEventProcessor(
-                this.backgroundEventsQueue,
-                mockRequestManagers(),
-            metadata));
-
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         HashMap<TopicPartition, OffsetAndMetadata> offset = mockTopicPartitionOffset();
 
         final long currentTimeMs = time.milliseconds();
@@ -286,7 +193,6 @@ public class DefaultBackgroundThreadTest {
 
         when(this.coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
         when(this.commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(this.offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
 
         backgroundThread.runOnce();
         verify(applicationEventProcessor).process(any(AssignmentChangeApplicationEvent.class));
@@ -299,10 +205,8 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     void testFindCoordinator() {
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-        when(this.coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(this.commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(this.offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
+        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
+        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
         backgroundThread.runOnce();
         Mockito.verify(coordinatorManager, times(1)).poll(anyLong());
         Mockito.verify(networkClient, times(1)).poll(anyLong(), anyLong());
@@ -311,17 +215,51 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     void testPollResultTimer() {
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         // purposely setting a non MAX time to ensure it is returning Long.MAX_VALUE upon success
         NetworkClientDelegate.PollResult success = new NetworkClientDelegate.PollResult(
                 10,
-                Collections.singletonList(findCoordinatorUnsentRequest(time, requestTimeoutMs)));
+                Collections.singletonList(findCoordinatorUnsentRequest()));
         assertEquals(10, backgroundThread.handlePollResult(success));
 
         NetworkClientDelegate.PollResult failure = new NetworkClientDelegate.PollResult(
                 10,
                 new ArrayList<>());
         assertEquals(10, backgroundThread.handlePollResult(failure));
+    }
+
+    @Test
+    void testRequestManagersArePolledOnce() {
+        backgroundThread.runOnce();
+        testBuilder.requestManagers.entries().forEach(requestManager ->
+                verify(requestManager.get(), times(1)).poll(anyLong()));
+        verify(networkClient, times(1)).poll(anyLong(), anyLong());
+        backgroundThread.close();
+    }
+
+    @Test
+    void testEnsureMetadataUpdateOnPoll() {
+        MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWith(2, Collections.emptyMap());
+        client.prepareMetadataUpdate(metadataResponse);
+        metadata.requestUpdate(false);
+        backgroundThread.runOnce();
+        verify(this.metadata, times(1)).updateWithCurrentRequestVersion(eq(metadataResponse), eq(false), anyLong());
+        backgroundThread.close();
+    }
+
+    @Test
+    void testEnsureEventsAreCompleted() {
+        CompletableApplicationEvent event = mock(CompletableApplicationEvent.class);
+        ApplicationEvent e  = mock(ApplicationEvent.class);
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        when(event.future()).thenReturn(future);
+        applicationEventsQueue.add(event);
+        applicationEventsQueue.add(e);
+        assertFalse(future.isDone());
+        assertFalse(applicationEventsQueue.isEmpty());
+
+        backgroundThread.close();
+        assertTrue(future.isCompletedExceptionally());
+        assertTrue(applicationEventsQueue.isEmpty());
     }
 
     private HashMap<TopicPartition, OffsetAndMetadata> mockTopicPartitionOffset() {
@@ -333,61 +271,38 @@ public class DefaultBackgroundThreadTest {
         return topicPartitionOffsets;
     }
 
-    private RequestManagers mockRequestManagers() {
-        return new RequestManagers(
-                offsetsRequestManager,
-                Optional.of(coordinatorManager),
-                Optional.of(commitManager));
-    }
-
-    private static NetworkClientDelegate.UnsentRequest findCoordinatorUnsentRequest(
-            final Time time,
-            final long timeout
-    ) {
+    private NetworkClientDelegate.UnsentRequest findCoordinatorUnsentRequest() {
         NetworkClientDelegate.UnsentRequest req = new NetworkClientDelegate.UnsentRequest(
                 new FindCoordinatorRequest.Builder(
                         new FindCoordinatorRequestData()
                                 .setKeyType(FindCoordinatorRequest.CoordinatorType.TRANSACTION.id())
                                 .setKey("foobar")),
                 Optional.empty());
-        req.setTimer(time, timeout);
+        req.setTimer(time, ConsumerTestBuilder.REQUEST_TIMEOUT_MS);
         return req;
-    }
-
-    private DefaultBackgroundThread mockBackgroundThread() {
-        properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(RETRY_BACKOFF_MS_CONFIG, RETRY_BACKOFF_MS);
-
-        return new DefaultBackgroundThread(
-                this.time,
-                new ConsumerConfig(properties),
-                new LogContext(),
-                applicationEventsQueue,
-                backgroundEventsQueue,
-                this.errorEventHandler,
-                applicationEventProcessor,
-                this.metadata,
-                this.networkClient,
-                this.groupState,
-                this.coordinatorManager,
-                this.commitManager,
-                this.offsetsRequestManager);
     }
 
     private NetworkClientDelegate.PollResult mockPollCoordinatorResult() {
         return new NetworkClientDelegate.PollResult(
-                RETRY_BACKOFF_MS,
-                Collections.singletonList(findCoordinatorUnsentRequest(time, requestTimeoutMs)));
+                ConsumerTestBuilder.RETRY_BACKOFF_MS,
+                Collections.singletonList(findCoordinatorUnsentRequest()));
     }
 
     private NetworkClientDelegate.PollResult mockPollCommitResult() {
         return new NetworkClientDelegate.PollResult(
-                RETRY_BACKOFF_MS,
-                Collections.singletonList(findCoordinatorUnsentRequest(time, requestTimeoutMs)));
+                ConsumerTestBuilder.RETRY_BACKOFF_MS,
+                Collections.singletonList(offsetCommitUnsentRequest()));
     }
 
-    private NetworkClientDelegate.PollResult emptyPollOffsetsRequestResult() {
-        return new NetworkClientDelegate.PollResult(Long.MAX_VALUE, Collections.emptyList());
+    private NetworkClientDelegate.UnsentRequest offsetCommitUnsentRequest() {
+        NetworkClientDelegate.UnsentRequest req = new NetworkClientDelegate.UnsentRequest(
+                new OffsetCommitRequest.Builder(
+                        new OffsetCommitRequestData()
+                                .setGroupId("groupId")
+                                .setMemberId("m1")
+                                .setGroupInstanceId("i1")
+                                .setTopics(new ArrayList<>())), Optional.empty());
+        req.setTimer(time, ConsumerTestBuilder.REQUEST_TIMEOUT_MS);
+        return req;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -70,11 +70,11 @@ public class DefaultBackgroundThreadTest {
     private ConsumerMetadata metadata;
     private NetworkClientDelegate networkClient;
     private BlockingQueue<ApplicationEvent> applicationEventsQueue;
-    private ApplicationEventProcessor<String, String> applicationEventProcessor;
+    private ApplicationEventProcessor applicationEventProcessor;
     private CoordinatorRequestManager coordinatorManager;
     private OffsetsRequestManager offsetsRequestManager;
     private CommitRequestManager commitManager;
-    private DefaultBackgroundThread<String, String> backgroundThread;
+    private DefaultBackgroundThread backgroundThread;
     private MockClient client;
 
     @BeforeEach

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultBackgroundThreadTest.java
@@ -16,29 +16,28 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.GroupRebalanceConfig;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.LogTruncationException;
+import org.apache.kafka.clients.MockClient;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProcessor;
 import org.apache.kafka.clients.consumer.internals.events.AssignmentChangeApplicationEvent;
-import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.CommitApplicationEvent;
+import org.apache.kafka.clients.consumer.internals.events.CompletableApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ListOffsetsApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.NewTopicsMetadataUpdateRequestEvent;
 import org.apache.kafka.clients.consumer.internals.events.NoopApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ResetPositionsApplicationEvent;
-import org.apache.kafka.clients.consumer.internals.events.ValidatePositionsApplicationEvent;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
+import org.apache.kafka.common.message.OffsetCommitRequestData;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.OffsetCommitRequest;
+import org.apache.kafka.common.requests.RequestTestUtils;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -48,87 +47,80 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.CompletableFuture;
 
-import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.RETRY_BACKOFF_MS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DefaultBackgroundThreadTest {
-    private static final long RETRY_BACKOFF_MS = 100;
-    private final Properties properties = new Properties();
-    private MockTime time;
+
+    private ConsumerTestBuilder.DefaultBackgroundThreadTestBuilder testBuilder;
+    private Time time;
     private ConsumerMetadata metadata;
     private NetworkClientDelegate networkClient;
-    private BlockingQueue<BackgroundEvent> backgroundEventsQueue;
     private BlockingQueue<ApplicationEvent> applicationEventsQueue;
-    private ApplicationEventProcessor applicationEventProcessor;
+    private ApplicationEventProcessor<String, String> applicationEventProcessor;
     private CoordinatorRequestManager coordinatorManager;
     private OffsetsRequestManager offsetsRequestManager;
-    private ErrorEventHandler errorEventHandler;
-    private final int requestTimeoutMs = 500;
-    private GroupState groupState;
     private CommitRequestManager commitManager;
+    private DefaultBackgroundThread<String, String> backgroundThread;
+    private MockClient client;
 
     @BeforeEach
-    @SuppressWarnings("unchecked")
     public void setup() {
-        this.time = new MockTime(0);
-        this.metadata = mock(ConsumerMetadata.class);
-        this.networkClient = mock(NetworkClientDelegate.class);
-        this.applicationEventsQueue = (BlockingQueue<ApplicationEvent>) mock(BlockingQueue.class);
-        this.backgroundEventsQueue = (BlockingQueue<BackgroundEvent>) mock(BlockingQueue.class);
-        this.applicationEventProcessor = mock(ApplicationEventProcessor.class);
-        this.coordinatorManager = mock(CoordinatorRequestManager.class);
-        this.offsetsRequestManager = mock(OffsetsRequestManager.class);
-        this.errorEventHandler = mock(ErrorEventHandler.class);
-        GroupRebalanceConfig rebalanceConfig = new GroupRebalanceConfig(
-                100,
-                100,
-                100,
-                "group_id",
-                Optional.empty(),
-                100,
-                1000,
-                true);
-        this.groupState = new GroupState(rebalanceConfig);
-        this.commitManager = mock(CommitRequestManager.class);
+        this.testBuilder = new ConsumerTestBuilder.DefaultBackgroundThreadTestBuilder();
+        this.time = testBuilder.time;
+        this.metadata = testBuilder.metadata;
+        this.networkClient = testBuilder.networkClientDelegate;
+        this.client = testBuilder.client;
+        this.applicationEventsQueue = testBuilder.applicationEventQueue;
+        this.applicationEventProcessor = testBuilder.applicationEventProcessor;
+        this.coordinatorManager = testBuilder.coordinatorRequestManager;
+        this.commitManager = testBuilder.commitRequestManager;
+        this.offsetsRequestManager = testBuilder.offsetsRequestManager;
+        this.backgroundThread = testBuilder.backgroundThread;
+        this.backgroundThread.initializeResources();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (testBuilder != null)
+            testBuilder.close();
     }
 
     @Test
     public void testStartupAndTearDown() throws InterruptedException {
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-        backgroundThread.start();
-        TestUtils.waitForCondition(backgroundThread::isRunning, "Failed awaiting for the background thread to be running");
-        backgroundThread.close();
         assertFalse(backgroundThread.isRunning());
+        backgroundThread.start();
+
+        // There's a nonzero amount of time between starting the thread and having it
+        // begin to execute our code. Wait for a bit before checking...
+        int maxWaitMs = 1000;
+        TestUtils.waitForCondition(backgroundThread::isRunning,
+                maxWaitMs,
+                "Thread did not start within " + maxWaitMs + " ms");
+        backgroundThread.close();
+        TestUtils.waitForCondition(() -> !backgroundThread.isRunning(),
+                maxWaitMs,
+                "Thread did not stop within " + maxWaitMs + " ms");
     }
 
     @Test
     public void testApplicationEvent() {
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
         when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
         when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         ApplicationEvent e = new NoopApplicationEvent("noop event");
         this.applicationEventsQueue.add(e);
         backgroundThread.runOnce();
@@ -138,16 +130,8 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     public void testMetadataUpdateEvent() {
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        this.applicationEventProcessor = new ApplicationEventProcessor(
-                this.backgroundEventsQueue,
-                mockRequestManagers(),
-                metadata);
         when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
         when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         ApplicationEvent e = new NewTopicsMetadataUpdateRequestEvent();
         this.applicationEventsQueue.add(e);
         backgroundThread.runOnce();
@@ -157,12 +141,8 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     public void testCommitEvent() {
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
         when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
         when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         ApplicationEvent e = new CommitApplicationEvent(new HashMap<>());
         this.applicationEventsQueue.add(e);
         backgroundThread.runOnce();
@@ -170,15 +150,8 @@ public class DefaultBackgroundThreadTest {
         backgroundThread.close();
     }
 
-
     @Test
     public void testListOffsetsEventIsProcessed() {
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         Map<TopicPartition, Long> timestamps = Collections.singletonMap(new TopicPartition("topic1", 1), 5L);
         ApplicationEvent e = new ListOffsetsApplicationEvent(timestamps, true);
         this.applicationEventsQueue.add(e);
@@ -190,14 +163,8 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     public void testResetPositionsEventIsProcessed() {
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-        ResetPositionsApplicationEvent e = new ResetPositionsApplicationEvent();
-        this.applicationEventsQueue.add(e);
+        ResetPositionsApplicationEvent event = new ResetPositionsApplicationEvent();
+        this.applicationEventsQueue.add(event);
         backgroundThread.runOnce();
         verify(applicationEventProcessor).process(any(ResetPositionsApplicationEvent.class));
         assertTrue(applicationEventsQueue.isEmpty());
@@ -205,79 +172,20 @@ public class DefaultBackgroundThreadTest {
     }
 
     @Test
-    public void testResetPositionsProcessFailure() {
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        applicationEventProcessor = spy(new ApplicationEventProcessor(
-                this.backgroundEventsQueue,
-                mockRequestManagers(),
-                metadata));
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-
+    public void testResetPositionsProcessFailureInterruptsBackgroundThread() {
         TopicAuthorizationException authException = new TopicAuthorizationException("Topic authorization failed");
         doThrow(authException).when(offsetsRequestManager).resetPositionsIfNeeded();
 
         ResetPositionsApplicationEvent event = new ResetPositionsApplicationEvent();
         this.applicationEventsQueue.add(event);
-        assertThrows(TopicAuthorizationException.class, backgroundThread::runOnce);
+        assertThrows(TopicAuthorizationException.class, () -> backgroundThread.runOnce());
 
         verify(applicationEventProcessor).process(any(ResetPositionsApplicationEvent.class));
         backgroundThread.close();
     }
 
     @Test
-    public void testValidatePositionsEventIsProcessed() {
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-        ValidatePositionsApplicationEvent e = new ValidatePositionsApplicationEvent();
-        this.applicationEventsQueue.add(e);
-        backgroundThread.runOnce();
-        verify(applicationEventProcessor).process(any(ValidatePositionsApplicationEvent.class));
-        assertTrue(applicationEventsQueue.isEmpty());
-        backgroundThread.close();
-    }
-
-    @Test
-    public void testValidatePositionsProcessFailure() {
-        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        applicationEventProcessor = spy(new ApplicationEventProcessor(
-                this.backgroundEventsQueue,
-                mockRequestManagers(),
-                metadata));
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-
-        LogTruncationException logTruncationException = new LogTruncationException(Collections.emptyMap(), Collections.emptyMap());
-        doThrow(logTruncationException).when(offsetsRequestManager).validatePositionsIfNeeded();
-
-        ValidatePositionsApplicationEvent event = new ValidatePositionsApplicationEvent();
-        this.applicationEventsQueue.add(event);
-        assertThrows(LogTruncationException.class, backgroundThread::runOnce);
-
-        verify(applicationEventProcessor).process(any(ValidatePositionsApplicationEvent.class));
-        backgroundThread.close();
-    }
-
-    @Test
     public void testAssignmentChangeEvent() {
-        this.applicationEventsQueue = new LinkedBlockingQueue<>();
-        this.backgroundEventsQueue = new LinkedBlockingQueue<>();
-        this.applicationEventProcessor = spy(new ApplicationEventProcessor(
-                this.backgroundEventsQueue,
-                mockRequestManagers(),
-            metadata));
-
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         HashMap<TopicPartition, OffsetAndMetadata> offset = mockTopicPartitionOffset();
 
         final long currentTimeMs = time.milliseconds();
@@ -286,7 +194,6 @@ public class DefaultBackgroundThreadTest {
 
         when(this.coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
         when(this.commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(this.offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
 
         backgroundThread.runOnce();
         verify(applicationEventProcessor).process(any(AssignmentChangeApplicationEvent.class));
@@ -299,10 +206,8 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     void testFindCoordinator() {
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
-        when(this.coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
-        when(this.commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
-        when(this.offsetsRequestManager.poll(anyLong())).thenReturn(emptyPollOffsetsRequestResult());
+        when(coordinatorManager.poll(anyLong())).thenReturn(mockPollCoordinatorResult());
+        when(commitManager.poll(anyLong())).thenReturn(mockPollCommitResult());
         backgroundThread.runOnce();
         Mockito.verify(coordinatorManager, times(1)).poll(anyLong());
         Mockito.verify(networkClient, times(1)).poll(anyLong(), anyLong());
@@ -311,17 +216,51 @@ public class DefaultBackgroundThreadTest {
 
     @Test
     void testPollResultTimer() {
-        DefaultBackgroundThread backgroundThread = mockBackgroundThread();
         // purposely setting a non MAX time to ensure it is returning Long.MAX_VALUE upon success
         NetworkClientDelegate.PollResult success = new NetworkClientDelegate.PollResult(
                 10,
-                Collections.singletonList(findCoordinatorUnsentRequest(time, requestTimeoutMs)));
+                Collections.singletonList(findCoordinatorUnsentRequest()));
         assertEquals(10, backgroundThread.handlePollResult(success));
 
         NetworkClientDelegate.PollResult failure = new NetworkClientDelegate.PollResult(
                 10,
                 new ArrayList<>());
         assertEquals(10, backgroundThread.handlePollResult(failure));
+    }
+
+    @Test
+    void testRequestManagersArePolledOnce() {
+        backgroundThread.runOnce();
+        testBuilder.requestManagers.entries().forEach(requestManager ->
+                verify(requestManager.get(), times(1)).poll(anyLong()));
+        verify(networkClient, times(1)).poll(anyLong(), anyLong());
+        backgroundThread.close();
+    }
+
+    @Test
+    void testEnsureMetadataUpdateOnPoll() {
+        MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWith(2, Collections.emptyMap());
+        client.prepareMetadataUpdate(metadataResponse);
+        metadata.requestUpdate(false);
+        backgroundThread.runOnce();
+        verify(this.metadata, times(1)).updateWithCurrentRequestVersion(eq(metadataResponse), eq(false), anyLong());
+        backgroundThread.close();
+    }
+
+    @Test
+    void testEnsureEventsAreCompleted() {
+        CompletableApplicationEvent event = mock(CompletableApplicationEvent.class);
+        ApplicationEvent e  = mock(ApplicationEvent.class);
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        when(event.future()).thenReturn(future);
+        applicationEventsQueue.add(event);
+        applicationEventsQueue.add(e);
+        assertFalse(future.isDone());
+        assertFalse(applicationEventsQueue.isEmpty());
+
+        backgroundThread.close();
+        assertTrue(future.isCompletedExceptionally());
+        assertTrue(applicationEventsQueue.isEmpty());
     }
 
     private HashMap<TopicPartition, OffsetAndMetadata> mockTopicPartitionOffset() {
@@ -333,61 +272,38 @@ public class DefaultBackgroundThreadTest {
         return topicPartitionOffsets;
     }
 
-    private RequestManagers mockRequestManagers() {
-        return new RequestManagers(
-                offsetsRequestManager,
-                Optional.of(coordinatorManager),
-                Optional.of(commitManager));
-    }
-
-    private static NetworkClientDelegate.UnsentRequest findCoordinatorUnsentRequest(
-            final Time time,
-            final long timeout
-    ) {
+    private NetworkClientDelegate.UnsentRequest findCoordinatorUnsentRequest() {
         NetworkClientDelegate.UnsentRequest req = new NetworkClientDelegate.UnsentRequest(
                 new FindCoordinatorRequest.Builder(
                         new FindCoordinatorRequestData()
                                 .setKeyType(FindCoordinatorRequest.CoordinatorType.TRANSACTION.id())
                                 .setKey("foobar")),
                 Optional.empty());
-        req.setTimer(time, timeout);
+        req.setTimer(time, ConsumerTestBuilder.REQUEST_TIMEOUT_MS);
         return req;
-    }
-
-    private DefaultBackgroundThread mockBackgroundThread() {
-        properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(RETRY_BACKOFF_MS_CONFIG, RETRY_BACKOFF_MS);
-
-        return new DefaultBackgroundThread(
-                this.time,
-                new ConsumerConfig(properties),
-                new LogContext(),
-                applicationEventsQueue,
-                backgroundEventsQueue,
-                this.errorEventHandler,
-                applicationEventProcessor,
-                this.metadata,
-                this.networkClient,
-                this.groupState,
-                this.coordinatorManager,
-                this.commitManager,
-                this.offsetsRequestManager);
     }
 
     private NetworkClientDelegate.PollResult mockPollCoordinatorResult() {
         return new NetworkClientDelegate.PollResult(
-                RETRY_BACKOFF_MS,
-                Collections.singletonList(findCoordinatorUnsentRequest(time, requestTimeoutMs)));
+                ConsumerTestBuilder.RETRY_BACKOFF_MS,
+                Collections.singletonList(findCoordinatorUnsentRequest()));
     }
 
     private NetworkClientDelegate.PollResult mockPollCommitResult() {
         return new NetworkClientDelegate.PollResult(
-                RETRY_BACKOFF_MS,
-                Collections.singletonList(findCoordinatorUnsentRequest(time, requestTimeoutMs)));
+                ConsumerTestBuilder.RETRY_BACKOFF_MS,
+                Collections.singletonList(offsetCommitUnsentRequest()));
     }
 
-    private NetworkClientDelegate.PollResult emptyPollOffsetsRequestResult() {
-        return new NetworkClientDelegate.PollResult(Long.MAX_VALUE, Collections.emptyList());
+    private NetworkClientDelegate.UnsentRequest offsetCommitUnsentRequest() {
+        NetworkClientDelegate.UnsentRequest req = new NetworkClientDelegate.UnsentRequest(
+                new OffsetCommitRequest.Builder(
+                        new OffsetCommitRequestData()
+                                .setGroupId("groupId")
+                                .setMemberId("m1")
+                                .setGroupInstanceId("i1")
+                                .setTopics(new ArrayList<>())), Optional.empty());
+        req.setTimer(time, ConsumerTestBuilder.REQUEST_TIMEOUT_MS);
+        return req;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/DefaultEventHandlerTest.java
@@ -16,66 +16,39 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.GroupRebalanceConfig;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
-import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import org.apache.kafka.clients.consumer.internals.events.EventHandler;
 import org.apache.kafka.clients.consumer.internals.events.NoopApplicationEvent;
-import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 
-import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.RETRY_BACKOFF_MS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 public class DefaultEventHandlerTest {
-    private int sessionTimeoutMs = 1000;
-    private int rebalanceTimeoutMs = 1000;
-    private int heartbeatIntervalMs = 1000;
-    private String groupId = "g-1";
-    private Optional<String> groupInstanceId = Optional.of("g-1");
-    private long retryBackoffMs = 1000;
-    private final Properties properties = new Properties();
-    private GroupRebalanceConfig rebalanceConfig;
+
+    private ConsumerTestBuilder.DefaultEventHandlerTestBuilder testBuilder;
+    private EventHandler handler;
+    private BlockingQueue<ApplicationEvent> aq;
 
     @BeforeEach
     public void setup() {
-        properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(RETRY_BACKOFF_MS_CONFIG, "100");
+        testBuilder = new ConsumerTestBuilder.DefaultEventHandlerTestBuilder();
+        handler = testBuilder.eventHandler;
+        aq = testBuilder.applicationEventQueue;
+    }
 
-        this.rebalanceConfig = new GroupRebalanceConfig(sessionTimeoutMs,
-                rebalanceTimeoutMs,
-                heartbeatIntervalMs,
-                groupId,
-                groupInstanceId,
-                retryBackoffMs,
-                retryBackoffMs,
-                true);
+    @AfterEach
+    public void tearDown() {
+        if (testBuilder != null)
+            testBuilder.close();
     }
 
     @Test
     public void testBasicHandlerOps() {
-        final DefaultBackgroundThread bt = mock(DefaultBackgroundThread.class);
-        final BlockingQueue<ApplicationEvent> aq = new LinkedBlockingQueue<>();
-        final BlockingQueue<BackgroundEvent> bq = new LinkedBlockingQueue<>();
-        final DefaultEventHandler handler = new DefaultEventHandler(bt, aq, bq);
-        assertTrue(handler.isEmpty());
-        assertFalse(handler.poll().isPresent());
         handler.add(new NoopApplicationEvent("test"));
         assertEquals(1, aq.size());
-        handler.close();
-        verify(bt, times(1)).close();
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ErrorEventHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ErrorEventHandlerTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEventProcessor;
+import org.apache.kafka.clients.consumer.internals.events.ErrorBackgroundEvent;
+import org.apache.kafka.clients.consumer.internals.events.NoopBackgroundEvent;
+import org.apache.kafka.common.KafkaException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.BlockingQueue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ErrorEventHandlerTest {
+
+    private ConsumerTestBuilder.DefaultEventHandlerTestBuilder testBuilder;
+    private BlockingQueue<BackgroundEvent> backgroundEventQueue;
+    private ErrorEventHandler errorEventHandler;
+    private BackgroundEventProcessor backgroundEventProcessor;
+
+    @BeforeEach
+    public void setup() {
+        testBuilder = new ConsumerTestBuilder.DefaultEventHandlerTestBuilder();
+        backgroundEventQueue = testBuilder.backgroundEventQueue;
+        errorEventHandler = new ErrorEventHandler(backgroundEventQueue);
+        backgroundEventProcessor = new BackgroundEventProcessor(testBuilder.logContext, backgroundEventQueue);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (testBuilder != null)
+            testBuilder.close();
+    }
+
+    @Test
+    public void testNoEvents() {
+        assertTrue(backgroundEventQueue.isEmpty());
+        backgroundEventProcessor.process();
+        assertTrue(backgroundEventQueue.isEmpty());
+    }
+
+    @Test
+    public void testSingleEvent() {
+        BackgroundEvent event = new NoopBackgroundEvent("A");
+        backgroundEventQueue.add(event);
+        assertPeeked(event);
+        backgroundEventProcessor.process();
+        assertTrue(backgroundEventQueue.isEmpty());
+    }
+
+    @Test
+    public void testSingleErrorEvent() {
+        KafkaException error = new KafkaException("error");
+        BackgroundEvent event = new ErrorBackgroundEvent(error);
+        errorEventHandler.handle(error);
+        assertPeeked(event);
+        assertThrows(error);
+    }
+
+    @Test
+    public void testInvalidEvent() {
+        String message = "I'm a naughty error!";
+        BackgroundEvent event = new BackgroundEvent(BackgroundEvent.Type.NOOP) {
+            @Override
+            public Type type() {
+                return null;
+            }
+
+            @Override
+            public String toString() {
+                return message;
+            }
+        };
+
+        backgroundEventQueue.add(event);
+        assertPeeked(event);
+
+        Exception error = new NullPointerException(String.format("Attempt to process BackgroundEvent with null type: %s", message));
+        assertThrows(error);
+    }
+
+    @Test
+    public void testMultipleEvents() {
+        BackgroundEvent event1 = new NoopBackgroundEvent("A");
+        backgroundEventQueue.add(event1);
+        backgroundEventQueue.add(new NoopBackgroundEvent("B"));
+        backgroundEventQueue.add(new NoopBackgroundEvent("C"));
+
+        assertPeeked(event1);
+        backgroundEventProcessor.process();
+        assertTrue(backgroundEventQueue.isEmpty());
+    }
+
+    @Test
+    public void testMultipleErrorEvents() {
+        Throwable error1 = new Throwable("error1");
+        KafkaException error2 = new KafkaException("error2");
+        KafkaException error3 = new KafkaException("error3");
+
+        errorEventHandler.handle(error1);
+        errorEventHandler.handle(error2);
+        errorEventHandler.handle(error3);
+
+        assertThrows(new RuntimeException(error1));
+    }
+
+    @Test
+    public void testMixedEventsWithErrorEvents() {
+        Throwable error1 = new Throwable("error1");
+        KafkaException error2 = new KafkaException("error2");
+        KafkaException error3 = new KafkaException("error3");
+
+        backgroundEventQueue.add(new NoopBackgroundEvent("A"));
+        errorEventHandler.handle(error1);
+        backgroundEventQueue.add(new NoopBackgroundEvent("B"));
+        errorEventHandler.handle(error2);
+        backgroundEventQueue.add(new NoopBackgroundEvent("C"));
+        errorEventHandler.handle(error3);
+        backgroundEventQueue.add(new NoopBackgroundEvent("D"));
+
+        assertThrows(new RuntimeException(error1));
+    }
+
+    private void assertPeeked(BackgroundEvent event) {
+        BackgroundEvent peekEvent = backgroundEventQueue.peek();
+        assertNotNull(peekEvent);
+        assertEquals(event, peekEvent);
+    }
+
+    private void assertThrows(Throwable error) {
+        assertFalse(backgroundEventQueue.isEmpty());
+
+        try {
+            backgroundEventProcessor.process();
+            fail("Should have thrown error: " + error);
+        } catch (Throwable t) {
+            assertEquals(error.getClass(), t.getClass());
+            assertEquals(error.getMessage(), t.getMessage());
+        }
+
+        assertTrue(backgroundEventQueue.isEmpty());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchConfigTest.java
@@ -19,13 +19,10 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FetchConfigTest {
 
@@ -35,60 +32,27 @@ public class FetchConfigTest {
      */
     @Test
     public void testBasicFromConsumerConfig() {
-        try (StringDeserializer keyDeserializer = new StringDeserializer(); StringDeserializer valueDeserializer = new StringDeserializer()) {
-            newFetchConfigFromConsumerConfig(keyDeserializer, valueDeserializer);
-            newFetchConfigFromValues(keyDeserializer, valueDeserializer);
-        }
+        newFetchConfigFromConsumerConfig();
+        newFetchConfigFromValues();
     }
 
-    /**
-     * Verify an exception is thrown if the key {@link Deserializer deserializer} provided to the
-     * {@link FetchConfig} constructors is {@code null}.
-     */
-    @Test
-    public void testPreventNullKeyDeserializer() {
-        try (StringDeserializer valueDeserializer = new StringDeserializer()) {
-            assertThrows(NullPointerException.class, () -> newFetchConfigFromConsumerConfig(null, valueDeserializer));
-            assertThrows(NullPointerException.class, () -> newFetchConfigFromValues(null, valueDeserializer));
-        }
-    }
-
-    /**
-     * Verify an exception is thrown if the value {@link Deserializer deserializer} provided to the
-     * {@link FetchConfig} constructors is {@code null}.
-     */
-    @Test
-    @SuppressWarnings("resources")
-    public void testPreventNullValueDeserializer() {
-        try (StringDeserializer keyDeserializer = new StringDeserializer()) {
-            assertThrows(NullPointerException.class, () -> newFetchConfigFromConsumerConfig(keyDeserializer, null));
-            assertThrows(NullPointerException.class, () -> newFetchConfigFromValues(keyDeserializer, null));
-        }
-    }
-
-    private void newFetchConfigFromConsumerConfig(Deserializer<String> keyDeserializer,
-                                                  Deserializer<String> valueDeserializer) {
+    private void newFetchConfigFromConsumerConfig() {
         Properties p = new Properties();
         p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         ConsumerConfig config = new ConsumerConfig(p);
-        new FetchConfig<>(
-                config,
-                new Deserializers<>(keyDeserializer, valueDeserializer),
-                IsolationLevel.READ_UNCOMMITTED);
+        new FetchConfig(config, IsolationLevel.READ_UNCOMMITTED);
     }
 
-    private void newFetchConfigFromValues(Deserializer<String> keyDeserializer,
-                                          Deserializer<String> valueDeserializer) {
-        new FetchConfig<>(ConsumerConfig.DEFAULT_FETCH_MIN_BYTES,
+    private void newFetchConfigFromValues() {
+        new FetchConfig(ConsumerConfig.DEFAULT_FETCH_MIN_BYTES,
                 ConsumerConfig.DEFAULT_FETCH_MAX_BYTES,
                 ConsumerConfig.DEFAULT_FETCH_MAX_WAIT_MS,
                 ConsumerConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES,
                 ConsumerConfig.DEFAULT_MAX_POLL_RECORDS,
                 true,
                 ConsumerConfig.DEFAULT_CLIENT_RACK,
-                new Deserializers<>(keyDeserializer, valueDeserializer),
                 IsolationLevel.READ_UNCOMMITTED);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
@@ -1,0 +1,3564 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.ClientRequest;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.KafkaClient;
+import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.MockClient;
+import org.apache.kafka.clients.NetworkClient;
+import org.apache.kafka.clients.NodeApiVersions;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.DisconnectException;
+import org.apache.kafka.common.errors.RecordTooLargeException;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.message.ApiMessageType;
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.OffsetForLeaderTopicResult;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.network.NetworkReceive;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.ControlRecordType;
+import org.apache.kafka.common.record.DefaultRecordBatch;
+import org.apache.kafka.common.record.EndTransactionMarker;
+import org.apache.kafka.common.record.LegacyRecord;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.record.Records;
+import org.apache.kafka.common.record.SimpleRecord;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.requests.ApiVersionsResponse;
+import org.apache.kafka.common.requests.FetchMetadata;
+import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.requests.FetchRequest.PartitionData;
+import org.apache.kafka.common.requests.FetchResponse;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
+import org.apache.kafka.common.requests.RequestTestUtils;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Timer;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.test.DelayedReceive;
+import org.apache.kafka.test.MockSelector;
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.common.requests.FetchMetadata.INVALID_SESSION_ID;
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.test.TestUtils.assertOptional;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class FetchRequestManagerTest {
+
+    private static final double EPSILON = 0.0001;
+
+    private ConsumerRebalanceListener listener = new NoOpConsumerRebalanceListener();
+    private String topicName = "test";
+    private String groupId = "test-group";
+    private Uuid topicId = Uuid.randomUuid();
+    private Map<String, Uuid> topicIds = new HashMap<String, Uuid>() {
+        {
+            put(topicName, topicId);
+        }
+    };
+    private Map<Uuid, String> topicNames = singletonMap(topicId, topicName);
+    private final String metricGroup = "consumer" + groupId + "-fetch-manager-metrics";
+    private TopicPartition tp0 = new TopicPartition(topicName, 0);
+    private TopicPartition tp1 = new TopicPartition(topicName, 1);
+    private TopicPartition tp2 = new TopicPartition(topicName, 2);
+    private TopicPartition tp3 = new TopicPartition(topicName, 3);
+    private TopicIdPartition tidp0 = new TopicIdPartition(topicId, tp0);
+    private TopicIdPartition tidp1 = new TopicIdPartition(topicId, tp1);
+    private TopicIdPartition tidp2 = new TopicIdPartition(topicId, tp2);
+    private TopicIdPartition tidp3 = new TopicIdPartition(topicId, tp3);
+    private int validLeaderEpoch = 0;
+    private MetadataResponse initialUpdateResponse =
+            RequestTestUtils.metadataUpdateWithIds(1, singletonMap(topicName, 4), topicIds);
+
+    private int minBytes = 1;
+    private int maxBytes = Integer.MAX_VALUE;
+    private int maxWaitMs = 0;
+    private int fetchSize = 1000;
+    private long retryBackoffMs = 100;
+    private long requestTimeoutMs = 30000;
+    private MockTime time = new MockTime(1);
+    private SubscriptionState subscriptions;
+    private ConsumerMetadata metadata;
+    private FetchMetricsRegistry metricsRegistry;
+    private FetchMetricsManager metricsManager;
+    private MockClient client;
+    private Metrics metrics;
+    private ApiVersions apiVersions = new ApiVersions();
+    private ConsumerNetworkClient oldConsumerClient;
+    private TestableFetchRequestManager<?, ?> fetcher;
+    private TestableNetworkClientDelegate consumerClient;
+    private OffsetFetcher offsetFetcher;
+
+    private MemoryRecords records;
+    private MemoryRecords nextRecords;
+    private MemoryRecords emptyRecords;
+    private MemoryRecords partialRecords;
+
+    @BeforeEach
+    public void setup() {
+        records = buildRecords(1L, 3, 1);
+        nextRecords = buildRecords(4L, 2, 4);
+        emptyRecords = buildRecords(0L, 0, 0);
+        partialRecords = buildRecords(4L, 1, 0);
+        partialRecords.buffer().putInt(Records.SIZE_OFFSET, 10000);
+    }
+
+    private void assignFromUser(Set<TopicPartition> partitions) {
+        subscriptions.assignFromUser(partitions);
+        client.updateMetadata(initialUpdateResponse);
+
+        // A dummy metadata update to ensure valid leader epoch.
+        metadata.updateWithCurrentRequestVersion(RequestTestUtils.metadataUpdateWithIds("dummy", 1,
+                Collections.emptyMap(), singletonMap(topicName, 4),
+                tp -> validLeaderEpoch, topicIds), false, 0L);
+    }
+
+    private void assignFromUserNoId(Set<TopicPartition> partitions) {
+        subscriptions.assignFromUser(partitions);
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(1, singletonMap("noId", 1), Collections.emptyMap()));
+
+        // A dummy metadata update to ensure valid leader epoch.
+        metadata.update(9, RequestTestUtils.metadataUpdateWithIds("dummy", 1,
+                Collections.emptyMap(), singletonMap("noId", 1),
+                tp -> validLeaderEpoch, topicIds), false, 0L);
+    }
+
+    @AfterEach
+    public void teardown() throws Exception {
+        if (metrics != null)
+            this.metrics.close();
+        if (fetcher != null)
+            this.fetcher.close();
+    }
+
+    private int sendFetches() {
+        offsetFetcher.validatePositionsOnMetadataChange();
+        return fetcher.sendFetches();
+    }
+
+    @Test
+    public void testFetchNormal() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionRecords = fetchedRecords();
+        assertTrue(partitionRecords.containsKey(tp0));
+
+        List<ConsumerRecord<byte[], byte[]>> records = partitionRecords.get(tp0);
+        assertEquals(3, records.size());
+        assertEquals(4L, subscriptions.position(tp0).offset); // this is the next fetching position
+        long offset = 1;
+        for (ConsumerRecord<byte[], byte[]> record : records) {
+            assertEquals(offset, record.offset());
+            offset += 1;
+        }
+    }
+
+    @Test
+    public void testInflightFetchOnPendingPartitions() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        subscriptions.markPendingRevocation(singleton(tp0));
+
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertNull(fetchedRecords().get(tp0));
+    }
+
+    @Test
+    public void testCloseShouldBeIdempotent() {
+        buildFetcher();
+
+        fetcher.close();
+        fetcher.close();
+        fetcher.close();
+
+        verify(fetcher, times(1)).closeInternal(any(Timer.class));
+    }
+
+    @Test
+    public void testFetcherCloseClosesFetchSessionsInBroker() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        final FetchResponse fetchResponse = fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0);
+        client.prepareResponse(fetchResponse);
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        assertEquals(0, consumerClient.pendingRequestCount());
+
+        final ArgumentCaptor<NetworkClientDelegate.UnsentRequest> argument = ArgumentCaptor.forClass(NetworkClientDelegate.UnsentRequest.class);
+
+        // send request to close the fetcher
+        Timer timer = time.timer(Duration.ofSeconds(10));
+        this.fetcher.close(timer);
+        NetworkClientDelegate.PollResult pollResult = fetcher.poll(time.milliseconds());
+        consumerClient.addAll(pollResult.unsentRequests);
+        consumerClient.poll(timer);
+
+        // validate that Fetcher.close() has sent a request with final epoch. 2 requests are sent, one for the normal
+        // fetch earlier and another for the finish fetch here.
+        verify(consumerClient, times(2)).doSend(argument.capture(), any(Long.class));
+        NetworkClientDelegate.UnsentRequest unsentRequest = argument.getValue();
+        FetchRequest.Builder builder = (FetchRequest.Builder) unsentRequest.requestBuilder();
+        // session Id is the same
+        assertEquals(fetchResponse.sessionId(), builder.metadata().sessionId());
+        // contains final epoch
+        assertEquals(FetchMetadata.FINAL_EPOCH, builder.metadata().epoch());  // final epoch indicates we want to close the session
+        assertTrue(builder.fetchData().isEmpty()); // partition data should be empty
+    }
+
+    @Test
+    public void testFetchingPendingPartitions() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        fetchedRecords();
+        assertEquals(4L, subscriptions.position(tp0).offset); // this is the next fetching position
+
+        // mark partition unfetchable
+        subscriptions.markPendingRevocation(singleton(tp0));
+        assertEquals(0, sendFetches());
+        consumerClient.poll(time.timer(0));
+        assertFalse(fetcher.hasCompletedFetches());
+        fetchedRecords();
+        assertEquals(4L, subscriptions.position(tp0).offset);
+    }
+
+    @Test
+    public void testFetchWithNoTopicId() {
+        // Should work and default to using old request type.
+        buildFetcher();
+
+        TopicIdPartition noId = new TopicIdPartition(Uuid.ZERO_UUID, new TopicPartition("noId", 0));
+        assignFromUserNoId(singleton(noId.topicPartition()));
+        subscriptions.seek(noId.topicPartition(), 0);
+
+        // Fetch should use request version 12
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(
+                fetchRequestMatcher((short) 12, noId, 0, Optional.of(validLeaderEpoch)),
+                fullFetchResponse(noId, this.records, Errors.NONE, 100L, 0)
+        );
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionRecords = fetchedRecords();
+        assertTrue(partitionRecords.containsKey(noId.topicPartition()));
+
+        List<ConsumerRecord<byte[], byte[]>> records = partitionRecords.get(noId.topicPartition());
+        assertEquals(3, records.size());
+        assertEquals(4L, subscriptions.position(noId.topicPartition()).offset); // this is the next fetching position
+        long offset = 1;
+        for (ConsumerRecord<byte[], byte[]> record : records) {
+            assertEquals(offset, record.offset());
+            offset += 1;
+        }
+    }
+
+    @Test
+    public void testFetchWithTopicId() {
+        buildFetcher();
+
+        TopicIdPartition tp = new TopicIdPartition(topicId, new TopicPartition(topicName, 0));
+        assignFromUser(singleton(tp.topicPartition()));
+        subscriptions.seek(tp.topicPartition(), 0);
+
+        // Fetch should use latest version
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(
+                fetchRequestMatcher(ApiKeys.FETCH.latestVersion(), tp, 0, Optional.of(validLeaderEpoch)),
+                fullFetchResponse(tp, this.records, Errors.NONE, 100L, 0)
+        );
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionRecords = fetchedRecords();
+        assertTrue(partitionRecords.containsKey(tp.topicPartition()));
+
+        List<ConsumerRecord<byte[], byte[]>> records = partitionRecords.get(tp.topicPartition());
+        assertEquals(3, records.size());
+        assertEquals(4L, subscriptions.position(tp.topicPartition()).offset); // this is the next fetching position
+        long offset = 1;
+        for (ConsumerRecord<byte[], byte[]> record : records) {
+            assertEquals(offset, record.offset());
+            offset += 1;
+        }
+    }
+
+    @Test
+    public void testFetchForgetTopicIdWhenUnassigned() {
+        buildFetcher();
+
+        TopicIdPartition foo = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 0));
+        TopicIdPartition bar = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("bar", 0));
+
+        // Assign foo and bar.
+        subscriptions.assignFromUser(singleton(foo.topicPartition()));
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(1, singleton(foo), tp -> validLeaderEpoch));
+        subscriptions.seek(foo.topicPartition(), 0);
+
+        // Fetch should use latest version.
+        assertEquals(1, sendFetches());
+
+        client.prepareResponse(
+                fetchRequestMatcher(ApiKeys.FETCH.latestVersion(),
+                        singletonMap(foo, new PartitionData(
+                                foo.topicId(),
+                                0,
+                                FetchRequest.INVALID_LOG_START_OFFSET,
+                                fetchSize,
+                                Optional.of(validLeaderEpoch))
+                        ),
+                        emptyList()
+                ),
+                fullFetchResponse(1, foo, this.records, Errors.NONE, 100L, 0)
+        );
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        fetchedRecords();
+
+        // Assign bar and unassign foo.
+        subscriptions.assignFromUser(singleton(bar.topicPartition()));
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(1, singleton(bar), tp -> validLeaderEpoch));
+        subscriptions.seek(bar.topicPartition(), 0);
+
+        // Fetch should use latest version.
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(
+                fetchRequestMatcher(ApiKeys.FETCH.latestVersion(),
+                        singletonMap(bar, new PartitionData(
+                                bar.topicId(),
+                                0,
+                                FetchRequest.INVALID_LOG_START_OFFSET,
+                                fetchSize,
+                                Optional.of(validLeaderEpoch))
+                        ),
+                        singletonList(foo)
+                ),
+                fullFetchResponse(1, bar, this.records, Errors.NONE, 100L, 0)
+        );
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        fetchedRecords();
+    }
+
+    @Test
+    public void testFetchForgetTopicIdWhenReplaced() {
+        buildFetcher();
+
+        TopicIdPartition fooWithOldTopicId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 0));
+        TopicIdPartition fooWithNewTopicId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 0));
+
+        // Assign foo with old topic id.
+        subscriptions.assignFromUser(singleton(fooWithOldTopicId.topicPartition()));
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(1, singleton(fooWithOldTopicId), tp -> validLeaderEpoch));
+        subscriptions.seek(fooWithOldTopicId.topicPartition(), 0);
+
+        // Fetch should use latest version.
+        assertEquals(1, sendFetches());
+
+        client.prepareResponse(
+                fetchRequestMatcher(ApiKeys.FETCH.latestVersion(),
+                        singletonMap(fooWithOldTopicId, new PartitionData(
+                                fooWithOldTopicId.topicId(),
+                                0,
+                                FetchRequest.INVALID_LOG_START_OFFSET,
+                                fetchSize,
+                                Optional.of(validLeaderEpoch))
+                        ),
+                        emptyList()
+                ),
+                fullFetchResponse(1, fooWithOldTopicId, this.records, Errors.NONE, 100L, 0)
+        );
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        fetchedRecords();
+
+        // Replace foo with old topic id with foo with new topic id.
+        subscriptions.assignFromUser(singleton(fooWithNewTopicId.topicPartition()));
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(1, singleton(fooWithNewTopicId), tp -> validLeaderEpoch));
+        subscriptions.seek(fooWithNewTopicId.topicPartition(), 0);
+
+        // Fetch should use latest version.
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        // foo with old topic id should be removed from the session.
+        client.prepareResponse(
+                fetchRequestMatcher(ApiKeys.FETCH.latestVersion(),
+                        singletonMap(fooWithNewTopicId, new PartitionData(
+                                fooWithNewTopicId.topicId(),
+                                0,
+                                FetchRequest.INVALID_LOG_START_OFFSET,
+                                fetchSize,
+                                Optional.of(validLeaderEpoch))
+                        ),
+                        singletonList(fooWithOldTopicId)
+                ),
+                fullFetchResponse(1, fooWithNewTopicId, this.records, Errors.NONE, 100L, 0)
+        );
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        fetchedRecords();
+    }
+
+    @Test
+    public void testFetchTopicIdUpgradeDowngrade() {
+        buildFetcher();
+
+        TopicIdPartition fooWithoutId = new TopicIdPartition(Uuid.ZERO_UUID, new TopicPartition("foo", 0));
+        TopicIdPartition fooWithId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 0));
+
+        // Assign foo without a topic id.
+        subscriptions.assignFromUser(singleton(fooWithoutId.topicPartition()));
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(1, singleton(fooWithoutId), tp -> validLeaderEpoch));
+        subscriptions.seek(fooWithoutId.topicPartition(), 0);
+
+        // Fetch should use version 12.
+        assertEquals(1, sendFetches());
+
+        client.prepareResponse(
+                fetchRequestMatcher((short) 12,
+                        singletonMap(fooWithoutId, new PartitionData(
+                                fooWithoutId.topicId(),
+                                0,
+                                FetchRequest.INVALID_LOG_START_OFFSET,
+                                fetchSize,
+                                Optional.of(validLeaderEpoch))
+                        ),
+                        emptyList()
+                ),
+                fullFetchResponse(1, fooWithoutId, this.records, Errors.NONE, 100L, 0)
+        );
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        fetchedRecords();
+
+        // Upgrade.
+        subscriptions.assignFromUser(singleton(fooWithId.topicPartition()));
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(1, singleton(fooWithId), tp -> validLeaderEpoch));
+        subscriptions.seek(fooWithId.topicPartition(), 0);
+
+        // Fetch should use latest version.
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        // foo with old topic id should be removed from the session.
+        client.prepareResponse(
+                fetchRequestMatcher(ApiKeys.FETCH.latestVersion(),
+                        singletonMap(fooWithId, new PartitionData(
+                                fooWithId.topicId(),
+                                0,
+                                FetchRequest.INVALID_LOG_START_OFFSET,
+                                fetchSize,
+                                Optional.of(validLeaderEpoch))
+                        ),
+                        emptyList()
+                ),
+                fullFetchResponse(1, fooWithId, this.records, Errors.NONE, 100L, 0)
+        );
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        fetchedRecords();
+
+        // Downgrade.
+        subscriptions.assignFromUser(singleton(fooWithoutId.topicPartition()));
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(1, singleton(fooWithoutId), tp -> validLeaderEpoch));
+        subscriptions.seek(fooWithoutId.topicPartition(), 0);
+
+        // Fetch should use version 12.
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        // foo with old topic id should be removed from the session.
+        client.prepareResponse(
+                fetchRequestMatcher((short) 12,
+                        singletonMap(fooWithoutId, new PartitionData(
+                                fooWithoutId.topicId(),
+                                0,
+                                FetchRequest.INVALID_LOG_START_OFFSET,
+                                fetchSize,
+                                Optional.of(validLeaderEpoch))
+                        ),
+                        emptyList()
+                ),
+                fullFetchResponse(1, fooWithoutId, this.records, Errors.NONE, 100L, 0)
+        );
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        fetchedRecords();
+    }
+
+    private MockClient.RequestMatcher fetchRequestMatcher(
+            short expectedVersion,
+            TopicIdPartition tp,
+            long expectedFetchOffset,
+            Optional<Integer> expectedCurrentLeaderEpoch
+    ) {
+        return fetchRequestMatcher(
+                expectedVersion,
+                singletonMap(tp, new PartitionData(
+                        tp.topicId(),
+                        expectedFetchOffset,
+                        FetchRequest.INVALID_LOG_START_OFFSET,
+                        fetchSize,
+                        expectedCurrentLeaderEpoch
+                )),
+                emptyList()
+        );
+    }
+
+    private MockClient.RequestMatcher fetchRequestMatcher(
+            short expectedVersion,
+            Map<TopicIdPartition, PartitionData> fetch,
+            List<TopicIdPartition> forgotten
+    ) {
+        return body -> {
+            if (body instanceof FetchRequest) {
+                FetchRequest fetchRequest = (FetchRequest) body;
+                assertEquals(expectedVersion, fetchRequest.version());
+                assertEquals(fetch, fetchRequest.fetchData(topicNames(new ArrayList<>(fetch.keySet()))));
+                assertEquals(forgotten, fetchRequest.forgottenTopics(topicNames(forgotten)));
+                return true;
+            } else {
+                fail("Should have seen FetchRequest");
+                return false;
+            }
+        };
+    }
+
+    private Map<Uuid, String> topicNames(List<TopicIdPartition> partitions) {
+        Map<Uuid, String> topicNames = new HashMap<>();
+        partitions.forEach(partition -> topicNames.putIfAbsent(partition.topicId(), partition.topic()));
+        return topicNames;
+    }
+
+    @Test
+    public void testMissingLeaderEpochInRecords() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, RecordBatch.MAGIC_VALUE_V0,
+                CompressionType.NONE, TimestampType.CREATE_TIME, 0L, System.currentTimeMillis(),
+                RecordBatch.NO_PARTITION_LEADER_EPOCH);
+        builder.append(0L, "key".getBytes(), "1".getBytes());
+        builder.append(0L, "key".getBytes(), "2".getBytes());
+        MemoryRecords records = builder.build();
+
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tidp0, records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionRecords = fetchedRecords();
+        assertTrue(partitionRecords.containsKey(tp0));
+        assertEquals(2, partitionRecords.get(tp0).size());
+
+        for (ConsumerRecord<byte[], byte[]> record : partitionRecords.get(tp0)) {
+            assertEquals(Optional.empty(), record.leaderEpoch());
+        }
+    }
+
+    @Test
+    public void testLeaderEpochInConsumerRecord() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        Integer partitionLeaderEpoch = 1;
+
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE,
+                CompressionType.NONE, TimestampType.CREATE_TIME, 0L, System.currentTimeMillis(),
+                partitionLeaderEpoch);
+        builder.append(0L, "key".getBytes(), partitionLeaderEpoch.toString().getBytes());
+        builder.append(0L, "key".getBytes(), partitionLeaderEpoch.toString().getBytes());
+        builder.close();
+
+        partitionLeaderEpoch += 7;
+
+        builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE,
+                TimestampType.CREATE_TIME, 2L, System.currentTimeMillis(), partitionLeaderEpoch);
+        builder.append(0L, "key".getBytes(), partitionLeaderEpoch.toString().getBytes());
+        builder.close();
+
+        partitionLeaderEpoch += 5;
+        builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE,
+                TimestampType.CREATE_TIME, 3L, System.currentTimeMillis(), partitionLeaderEpoch);
+        builder.append(0L, "key".getBytes(), partitionLeaderEpoch.toString().getBytes());
+        builder.append(0L, "key".getBytes(), partitionLeaderEpoch.toString().getBytes());
+        builder.append(0L, "key".getBytes(), partitionLeaderEpoch.toString().getBytes());
+        builder.close();
+
+        buffer.flip();
+        MemoryRecords records = MemoryRecords.readableRecords(buffer);
+
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tidp0, records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionRecords = fetchedRecords();
+        assertTrue(partitionRecords.containsKey(tp0));
+        assertEquals(6, partitionRecords.get(tp0).size());
+
+        for (ConsumerRecord<byte[], byte[]> record : partitionRecords.get(tp0)) {
+            int expectedLeaderEpoch = Integer.parseInt(Utils.utf8(record.value()));
+            assertEquals(Optional.of(expectedLeaderEpoch), record.leaderEpoch());
+        }
+    }
+
+    @Test
+    public void testClearBufferedDataForTopicPartitions() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        Set<TopicPartition> newAssignedTopicPartitions = new HashSet<>();
+        newAssignedTopicPartitions.add(tp1);
+
+        fetcher.clearBufferedDataForUnassignedPartitions(newAssignedTopicPartitions);
+        assertFalse(fetcher.hasCompletedFetches());
+    }
+
+    @Test
+    public void testFetchSkipsBlackedOutNodes() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+        Node node = initialUpdateResponse.brokers().iterator().next();
+
+        client.backoff(node, 500);
+        assertEquals(0, sendFetches());
+
+        time.sleep(500);
+        assertEquals(1, sendFetches());
+    }
+
+    @Test
+    public void testFetcherIgnoresControlRecords() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        long producerId = 1;
+        short producerEpoch = 0;
+        int baseSequence = 0;
+        int partitionLeaderEpoch = 0;
+
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        MemoryRecordsBuilder builder = MemoryRecords.idempotentBuilder(buffer, CompressionType.NONE, 0L, producerId,
+                producerEpoch, baseSequence);
+        builder.append(0L, "key".getBytes(), null);
+        builder.close();
+
+        MemoryRecords.writeEndTransactionalMarker(buffer, 1L, time.milliseconds(), partitionLeaderEpoch, producerId, producerEpoch,
+                new EndTransactionMarker(ControlRecordType.ABORT, 0));
+
+        buffer.flip();
+
+        client.prepareResponse(fullFetchResponse(tidp0, MemoryRecords.readableRecords(buffer), Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionRecords = fetchedRecords();
+        assertTrue(partitionRecords.containsKey(tp0));
+
+        List<ConsumerRecord<byte[], byte[]>> records = partitionRecords.get(tp0);
+        assertEquals(1, records.size());
+        assertEquals(2L, subscriptions.position(tp0).offset);
+
+        ConsumerRecord<byte[], byte[]> record = records.get(0);
+        assertArrayEquals("key".getBytes(), record.key());
+    }
+
+    @Test
+    public void testFetchError() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NOT_LEADER_OR_FOLLOWER, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionRecords = fetchedRecords();
+        assertFalse(partitionRecords.containsKey(tp0));
+    }
+
+    private MockClient.RequestMatcher matchesOffset(final TopicIdPartition tp, final long offset) {
+        return body -> {
+            FetchRequest fetch = (FetchRequest) body;
+            Map<TopicIdPartition, FetchRequest.PartitionData> fetchData = fetch.fetchData(topicNames);
+            return fetchData.containsKey(tp) &&
+                    fetchData.get(tp).fetchOffset == offset;
+        };
+    }
+
+    @Test
+    public void testFetchedRecordsRaisesOnSerializationErrors() {
+        // raise an exception from somewhere in the middle of the fetch response
+        // so that we can verify that our position does not advance after raising
+        ByteArrayDeserializer deserializer = new ByteArrayDeserializer() {
+            int i = 0;
+            @Override
+            public byte[] deserialize(String topic, byte[] data) {
+                if (i++ % 2 == 1) {
+                    // Should be blocked on the value deserialization of the first record.
+                    assertEquals("value-1", new String(data, StandardCharsets.UTF_8));
+                    throw new SerializationException();
+                }
+                return data;
+            }
+        };
+
+        buildFetcher(deserializer, deserializer);
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 1);
+
+        client.prepareResponse(matchesOffset(tidp0, 1), fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+
+        assertEquals(1, sendFetches());
+        consumerClient.poll(time.timer(0));
+        // The fetcher should block on Deserialization error
+        for (int i = 0; i < 2; i++) {
+            try {
+                fetcher.collectFetch();
+                fail("fetchedRecords should have raised");
+            } catch (SerializationException e) {
+                // the position should not advance since no data has been returned
+                assertEquals(1, subscriptions.position(tp0).offset);
+            }
+        }
+    }
+
+    @Test
+    public void testParseCorruptedRecord() throws Exception {
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        DataOutputStream out = new DataOutputStream(new ByteBufferOutputStream(buffer));
+
+        byte magic = RecordBatch.MAGIC_VALUE_V1;
+        byte[] key = "foo".getBytes();
+        byte[] value = "baz".getBytes();
+        long offset = 0;
+        long timestamp = 500L;
+
+        int size = LegacyRecord.recordSize(magic, key.length, value.length);
+        byte attributes = LegacyRecord.computeAttributes(magic, CompressionType.NONE, TimestampType.CREATE_TIME);
+        long crc = LegacyRecord.computeChecksum(magic, attributes, timestamp, key, value);
+
+        // write one valid record
+        out.writeLong(offset);
+        out.writeInt(size);
+        LegacyRecord.write(out, magic, crc, LegacyRecord.computeAttributes(magic, CompressionType.NONE, TimestampType.CREATE_TIME), timestamp, key, value);
+
+        // and one invalid record (note the crc)
+        out.writeLong(offset + 1);
+        out.writeInt(size);
+        LegacyRecord.write(out, magic, crc + 1, LegacyRecord.computeAttributes(magic, CompressionType.NONE, TimestampType.CREATE_TIME), timestamp, key, value);
+
+        // write one valid record
+        out.writeLong(offset + 2);
+        out.writeInt(size);
+        LegacyRecord.write(out, magic, crc, LegacyRecord.computeAttributes(magic, CompressionType.NONE, TimestampType.CREATE_TIME), timestamp, key, value);
+
+        // Write a record whose size field is invalid.
+        out.writeLong(offset + 3);
+        out.writeInt(1);
+
+        // write one valid record
+        out.writeLong(offset + 4);
+        out.writeInt(size);
+        LegacyRecord.write(out, magic, crc, LegacyRecord.computeAttributes(magic, CompressionType.NONE, TimestampType.CREATE_TIME), timestamp, key, value);
+
+        buffer.flip();
+
+        subscriptions.seekUnvalidated(tp0, new SubscriptionState.FetchPosition(0, Optional.empty(), metadata.currentLeader(tp0)));
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, MemoryRecords.readableRecords(buffer), Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+
+        // the first fetchedRecords() should return the first valid message
+        assertEquals(1, fetchedRecords().get(tp0).size());
+        assertEquals(1, subscriptions.position(tp0).offset);
+
+        ensureBlockOnRecord(1L);
+        seekAndConsumeRecord(buffer, 2L);
+        ensureBlockOnRecord(3L);
+        try {
+            // For a record that cannot be retrieved from the iterator, we cannot seek over it within the batch.
+            seekAndConsumeRecord(buffer, 4L);
+            fail("Should have thrown exception when fail to retrieve a record from iterator.");
+        } catch (KafkaException ke) {
+            // let it go
+        }
+        ensureBlockOnRecord(4L);
+    }
+
+    private void ensureBlockOnRecord(long blockedOffset) {
+        // the fetchedRecords() should always throw exception due to the invalid message at the starting offset.
+        for (int i = 0; i < 2; i++) {
+            try {
+                fetcher.collectFetch();
+                fail("fetchedRecords should have raised KafkaException");
+            } catch (KafkaException e) {
+                assertEquals(blockedOffset, subscriptions.position(tp0).offset);
+            }
+        }
+    }
+
+    private void seekAndConsumeRecord(ByteBuffer responseBuffer, long toOffset) {
+        // Seek to skip the bad record and fetch again.
+        subscriptions.seekUnvalidated(tp0, new SubscriptionState.FetchPosition(toOffset, Optional.empty(), metadata.currentLeader(tp0)));
+        // Should not throw exception after the seek.
+        fetcher.collectFetch();
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, MemoryRecords.readableRecords(responseBuffer), Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> recordsByPartition = fetchedRecords();
+        List<ConsumerRecord<byte[], byte[]>> records = recordsByPartition.get(tp0);
+        assertEquals(1, records.size());
+        assertEquals(toOffset, records.get(0).offset());
+        assertEquals(toOffset + 1, subscriptions.position(tp0).offset);
+    }
+
+    @Test
+    public void testInvalidDefaultRecordBatch() {
+        buildFetcher();
+
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        ByteBufferOutputStream out = new ByteBufferOutputStream(buffer);
+
+        MemoryRecordsBuilder builder = new MemoryRecordsBuilder(out,
+                DefaultRecordBatch.CURRENT_MAGIC_VALUE,
+                CompressionType.NONE,
+                TimestampType.CREATE_TIME,
+                0L, 10L, 0L, (short) 0, 0, false, false, 0, 1024);
+        builder.append(10L, "key".getBytes(), "value".getBytes());
+        builder.close();
+        buffer.flip();
+
+        // Garble the CRC
+        buffer.position(17);
+        buffer.put("beef".getBytes());
+        buffer.position(0);
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, MemoryRecords.readableRecords(buffer), Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+
+        // the fetchedRecords() should always throw exception due to the bad batch.
+        for (int i = 0; i < 2; i++) {
+            try {
+                fetcher.collectFetch();
+                fail("fetchedRecords should have raised KafkaException");
+            } catch (KafkaException e) {
+                assertEquals(0, subscriptions.position(tp0).offset);
+            }
+        }
+    }
+
+    @Test
+    public void testParseInvalidRecordBatch() {
+        buildFetcher();
+        MemoryRecords records = MemoryRecords.withRecords(RecordBatch.MAGIC_VALUE_V2, 0L,
+                CompressionType.NONE, TimestampType.CREATE_TIME,
+                new SimpleRecord(1L, "a".getBytes(), "1".getBytes()),
+                new SimpleRecord(2L, "b".getBytes(), "2".getBytes()),
+                new SimpleRecord(3L, "c".getBytes(), "3".getBytes()));
+        ByteBuffer buffer = records.buffer();
+
+        // flip some bits to fail the crc
+        buffer.putInt(32, buffer.get(32) ^ 87238423);
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, MemoryRecords.readableRecords(buffer), Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        try {
+            fetcher.collectFetch();
+            fail("fetchedRecords should have raised");
+        } catch (KafkaException e) {
+            // the position should not advance since no data has been returned
+            assertEquals(0, subscriptions.position(tp0).offset);
+        }
+    }
+
+    @Test
+    public void testHeaders() {
+        buildFetcher();
+
+        MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE, TimestampType.CREATE_TIME, 1L);
+        builder.append(0L, "key".getBytes(), "value-1".getBytes());
+
+        Header[] headersArray = new Header[1];
+        headersArray[0] = new RecordHeader("headerKey", "headerValue".getBytes(StandardCharsets.UTF_8));
+        builder.append(0L, "key".getBytes(), "value-2".getBytes(), headersArray);
+
+        Header[] headersArray2 = new Header[2];
+        headersArray2[0] = new RecordHeader("headerKey", "headerValue".getBytes(StandardCharsets.UTF_8));
+        headersArray2[1] = new RecordHeader("headerKey", "headerValue2".getBytes(StandardCharsets.UTF_8));
+        builder.append(0L, "key".getBytes(), "value-3".getBytes(), headersArray2);
+
+        MemoryRecords memoryRecords = builder.build();
+
+        List<ConsumerRecord<byte[], byte[]>> records;
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 1);
+
+        client.prepareResponse(matchesOffset(tidp0, 1), fullFetchResponse(tidp0, memoryRecords, Errors.NONE, 100L, 0));
+
+        assertEquals(1, sendFetches());
+        consumerClient.poll(time.timer(0));
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> recordsByPartition = fetchedRecords();
+        records = recordsByPartition.get(tp0);
+
+        assertEquals(3, records.size());
+
+        Iterator<ConsumerRecord<byte[], byte[]>> recordIterator = records.iterator();
+
+        ConsumerRecord<byte[], byte[]> record = recordIterator.next();
+        assertNull(record.headers().lastHeader("headerKey"));
+
+        record = recordIterator.next();
+        assertEquals("headerValue", new String(record.headers().lastHeader("headerKey").value(), StandardCharsets.UTF_8));
+        assertEquals("headerKey", record.headers().lastHeader("headerKey").key());
+
+        record = recordIterator.next();
+        assertEquals("headerValue2", new String(record.headers().lastHeader("headerKey").value(), StandardCharsets.UTF_8));
+        assertEquals("headerKey", record.headers().lastHeader("headerKey").key());
+    }
+
+    @Test
+    public void testFetchMaxPollRecords() {
+        buildFetcher(2);
+
+        List<ConsumerRecord<byte[], byte[]>> records;
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 1);
+
+        client.prepareResponse(matchesOffset(tidp0, 1), fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        client.prepareResponse(matchesOffset(tidp0, 4), fullFetchResponse(tidp0, this.nextRecords, Errors.NONE, 100L, 0));
+
+        assertEquals(1, sendFetches());
+        consumerClient.poll(time.timer(0));
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> recordsByPartition = fetchedRecords();
+        records = recordsByPartition.get(tp0);
+        assertEquals(2, records.size());
+        assertEquals(3L, subscriptions.position(tp0).offset);
+        assertEquals(1, records.get(0).offset());
+        assertEquals(2, records.get(1).offset());
+
+        assertEquals(0, sendFetches());
+        consumerClient.poll(time.timer(0));
+        recordsByPartition = fetchedRecords();
+        records = recordsByPartition.get(tp0);
+        assertEquals(1, records.size());
+        assertEquals(4L, subscriptions.position(tp0).offset);
+        assertEquals(3, records.get(0).offset());
+
+        assertTrue(sendFetches() > 0);
+        consumerClient.poll(time.timer(0));
+        recordsByPartition = fetchedRecords();
+        records = recordsByPartition.get(tp0);
+        assertEquals(2, records.size());
+        assertEquals(6L, subscriptions.position(tp0).offset);
+        assertEquals(4, records.get(0).offset());
+        assertEquals(5, records.get(1).offset());
+    }
+
+    /**
+     * Test the scenario where a partition with fetched but not consumed records (i.e. max.poll.records is
+     * less than the number of fetched records) is unassigned and a different partition is assigned. This is a
+     * pattern used by Streams state restoration and KAFKA-5097 would have been caught by this test.
+     */
+    @Test
+    public void testFetchAfterPartitionWithFetchedRecordsIsUnassigned() {
+        buildFetcher(2);
+
+        List<ConsumerRecord<byte[], byte[]>> records;
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 1);
+
+        // Returns 3 records while `max.poll.records` is configured to 2
+        client.prepareResponse(matchesOffset(tidp0, 1), fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+
+        assertEquals(1, sendFetches());
+        consumerClient.poll(time.timer(0));
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> recordsByPartition = fetchedRecords();
+        records = recordsByPartition.get(tp0);
+        assertEquals(2, records.size());
+        assertEquals(3L, subscriptions.position(tp0).offset);
+        assertEquals(1, records.get(0).offset());
+        assertEquals(2, records.get(1).offset());
+
+        assignFromUser(singleton(tp1));
+        client.prepareResponse(matchesOffset(tidp1, 4), fullFetchResponse(tidp1, this.nextRecords, Errors.NONE, 100L, 0));
+        subscriptions.seek(tp1, 4);
+
+        assertEquals(1, sendFetches());
+        consumerClient.poll(time.timer(0));
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
+        assertNull(fetchedRecords.get(tp0));
+        records = fetchedRecords.get(tp1);
+        assertEquals(2, records.size());
+        assertEquals(6L, subscriptions.position(tp1).offset);
+        assertEquals(4, records.get(0).offset());
+        assertEquals(5, records.get(1).offset());
+    }
+
+    @Test
+    public void testFetchNonContinuousRecords() {
+        // if we are fetching from a compacted topic, there may be gaps in the returned records
+        // this test verifies the fetcher updates the current fetched/consumed positions correctly for this case
+        buildFetcher();
+
+        MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE,
+                TimestampType.CREATE_TIME, 0L);
+        builder.appendWithOffset(15L, 0L, "key".getBytes(), "value-1".getBytes());
+        builder.appendWithOffset(20L, 0L, "key".getBytes(), "value-2".getBytes());
+        builder.appendWithOffset(30L, 0L, "key".getBytes(), "value-3".getBytes());
+        MemoryRecords records = builder.build();
+
+        List<ConsumerRecord<byte[], byte[]>> consumerRecords;
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> recordsByPartition = fetchedRecords();
+        consumerRecords = recordsByPartition.get(tp0);
+        assertEquals(3, consumerRecords.size());
+        assertEquals(31L, subscriptions.position(tp0).offset); // this is the next fetching position
+
+        assertEquals(15L, consumerRecords.get(0).offset());
+        assertEquals(20L, consumerRecords.get(1).offset());
+        assertEquals(30L, consumerRecords.get(2).offset());
+    }
+
+    /**
+     * Test the case where the client makes a pre-v3 FetchRequest, but the server replies with only a partial
+     * request. This happens when a single message is larger than the per-partition limit.
+     */
+    @Test
+    public void testFetchRequestWhenRecordTooLarge() {
+        try {
+            buildFetcher();
+
+            client.setNodeApiVersions(NodeApiVersions.create(ApiKeys.FETCH.id, (short) 2, (short) 2));
+            makeFetchRequestWithIncompleteRecord();
+            try {
+                fetcher.collectFetch();
+                fail("RecordTooLargeException should have been raised");
+            } catch (RecordTooLargeException e) {
+                assertTrue(e.getMessage().startsWith("There are some messages at [Partition=Offset]: "));
+                // the position should not advance since no data has been returned
+                assertEquals(0, subscriptions.position(tp0).offset);
+            }
+        } finally {
+            client.setNodeApiVersions(NodeApiVersions.create());
+        }
+    }
+
+    /**
+     * Test the case where the client makes a post KIP-74 FetchRequest, but the server replies with only a
+     * partial request. For v3 and later FetchRequests, the implementation of KIP-74 changed the behavior
+     * so that at least one message is always returned. Therefore, this case should not happen, and it indicates
+     * that an internal error has taken place.
+     */
+    @Test
+    public void testFetchRequestInternalError() {
+        buildFetcher();
+        makeFetchRequestWithIncompleteRecord();
+        try {
+            fetcher.collectFetch();
+            fail("RecordTooLargeException should have been raised");
+        } catch (KafkaException e) {
+            assertTrue(e.getMessage().startsWith("Failed to make progress reading messages"));
+            // the position should not advance since no data has been returned
+            assertEquals(0, subscriptions.position(tp0).offset);
+        }
+    }
+
+    private void makeFetchRequestWithIncompleteRecord() {
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+        MemoryRecords partialRecord = MemoryRecords.readableRecords(
+                ByteBuffer.wrap(new byte[]{0, 0, 0, 0, 0, 0, 0, 0}));
+        client.prepareResponse(fullFetchResponse(tidp0, partialRecord, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+    }
+
+    @Test
+    public void testUnauthorizedTopic() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        // resize the limit of the buffer to pretend it is only fetch-size large
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.TOPIC_AUTHORIZATION_FAILED, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        try {
+            fetcher.collectFetch();
+            fail("fetchedRecords should have thrown");
+        } catch (TopicAuthorizationException e) {
+            assertEquals(singleton(topicName), e.unauthorizedTopics());
+        }
+    }
+
+    @Test
+    public void testFetchDuringEagerRebalance() {
+        buildFetcher();
+
+        subscriptions.subscribe(singleton(topicName), listener);
+        subscriptions.assignFromSubscribed(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(
+                1, singletonMap(topicName, 4), tp -> validLeaderEpoch, topicIds));
+
+        assertEquals(1, sendFetches());
+
+        // Now the eager rebalance happens and fetch positions are cleared
+        subscriptions.assignFromSubscribed(Collections.emptyList());
+
+        subscriptions.assignFromSubscribed(singleton(tp0));
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+
+        // The active fetch should be ignored since its position is no longer valid
+        assertTrue(fetchedRecords().isEmpty());
+    }
+
+    @Test
+    public void testFetchDuringCooperativeRebalance() {
+        buildFetcher();
+
+        subscriptions.subscribe(singleton(topicName), listener);
+        subscriptions.assignFromSubscribed(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(
+                1, singletonMap(topicName, 4), tp -> validLeaderEpoch, topicIds));
+
+        assertEquals(1, sendFetches());
+
+        // Now the cooperative rebalance happens and fetch positions are NOT cleared for unrevoked partitions
+        subscriptions.assignFromSubscribed(singleton(tp0));
+
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
+
+        // The active fetch should NOT be ignored since the position for tp0 is still valid
+        assertEquals(1, fetchedRecords.size());
+        assertEquals(3, fetchedRecords.get(tp0).size());
+    }
+
+    @Test
+    public void testInFlightFetchOnPausedPartition() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        subscriptions.pause(tp0);
+
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertNull(fetchedRecords().get(tp0));
+    }
+
+    @Test
+    public void testFetchOnPausedPartition() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        subscriptions.pause(tp0);
+        assertFalse(sendFetches() > 0);
+        assertTrue(client.requests().isEmpty());
+    }
+
+    @Test
+    public void testFetchOnCompletedFetchesForPausedAndResumedPartitions() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+
+        subscriptions.pause(tp0);
+
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+
+        assertEmptyFetch("Should not return any records or advance position when partition is paused");
+
+        assertTrue(fetcher.hasCompletedFetches(), "Should still contain completed fetches");
+        assertFalse(fetcher.hasAvailableFetches(), "Should not have any available (non-paused) completed fetches");
+        assertEquals(0, sendFetches());
+
+        subscriptions.resume(tp0);
+
+        assertTrue(fetcher.hasAvailableFetches(), "Should have available (non-paused) completed fetches");
+
+        consumerClient.poll(time.timer(0));
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
+        assertEquals(1, fetchedRecords.size(), "Should return records when partition is resumed");
+        assertNotNull(fetchedRecords.get(tp0));
+        assertEquals(3, fetchedRecords.get(tp0).size());
+
+        consumerClient.poll(time.timer(0));
+        assertEmptyFetch("Should not return records or advance position after previously paused partitions are fetched");
+        assertFalse(fetcher.hasCompletedFetches(), "Should no longer contain completed fetches");
+    }
+
+    @Test
+    public void testFetchOnCompletedFetchesForSomePausedPartitions() {
+        buildFetcher();
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords;
+
+        assignFromUser(mkSet(tp0, tp1));
+
+        // seek to tp0 and tp1 in two polls to generate 2 complete requests and responses
+
+        // #1 seek, request, poll, response
+        subscriptions.seekUnvalidated(tp0, new SubscriptionState.FetchPosition(1, Optional.empty(), metadata.currentLeader(tp0)));
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+
+        // #2 seek, request, poll, response
+        subscriptions.seekUnvalidated(tp1, new SubscriptionState.FetchPosition(1, Optional.empty(), metadata.currentLeader(tp1)));
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp1, this.nextRecords, Errors.NONE, 100L, 0));
+
+        subscriptions.pause(tp0);
+        consumerClient.poll(time.timer(0));
+
+        fetchedRecords = fetchedRecords();
+        assertEquals(1, fetchedRecords.size(), "Should return completed fetch for unpaused partitions");
+        assertTrue(fetcher.hasCompletedFetches(), "Should still contain completed fetches");
+        assertNotNull(fetchedRecords.get(tp1));
+        assertNull(fetchedRecords.get(tp0));
+
+        assertEmptyFetch("Should not return records or advance position for remaining paused partition");
+        assertTrue(fetcher.hasCompletedFetches(), "Should still contain completed fetches");
+    }
+
+    @Test
+    public void testFetchOnCompletedFetchesForAllPausedPartitions() {
+        buildFetcher();
+
+        assignFromUser(mkSet(tp0, tp1));
+
+        // seek to tp0 and tp1 in two polls to generate 2 complete requests and responses
+
+        // #1 seek, request, poll, response
+        subscriptions.seekUnvalidated(tp0, new SubscriptionState.FetchPosition(1, Optional.empty(), metadata.currentLeader(tp0)));
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+
+        // #2 seek, request, poll, response
+        subscriptions.seekUnvalidated(tp1, new SubscriptionState.FetchPosition(1, Optional.empty(), metadata.currentLeader(tp1)));
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp1, this.nextRecords, Errors.NONE, 100L, 0));
+
+        subscriptions.pause(tp0);
+        subscriptions.pause(tp1);
+
+        consumerClient.poll(time.timer(0));
+
+        assertEmptyFetch("Should not return records or advance position for all paused partitions");
+        assertTrue(fetcher.hasCompletedFetches(), "Should still contain completed fetches");
+        assertFalse(fetcher.hasAvailableFetches(), "Should not have any available (non-paused) completed fetches");
+    }
+
+    @Test
+    public void testPartialFetchWithPausedPartitions() {
+        // this test sends creates a completed fetch with 3 records and a max poll of 2 records to assert
+        // that a fetch that must be returned over at least 2 polls can be cached successfully when its partition is
+        // paused, then returned successfully after its been resumed again later
+        buildFetcher(2);
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords;
+
+        assignFromUser(mkSet(tp0, tp1));
+
+        subscriptions.seek(tp0, 1);
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+
+        fetchedRecords = fetchedRecords();
+
+        assertEquals(2, fetchedRecords.get(tp0).size(), "Should return 2 records from fetch with 3 records");
+        assertFalse(fetcher.hasCompletedFetches(), "Should have no completed fetches");
+
+        subscriptions.pause(tp0);
+        consumerClient.poll(time.timer(0));
+
+        fetchedRecords = fetchedRecords();
+
+        assertEmptyFetch("Should not return records or advance position for paused partitions");
+        assertTrue(fetcher.hasCompletedFetches(), "Should have 1 entry in completed fetches");
+        assertFalse(fetcher.hasAvailableFetches(), "Should not have any available (non-paused) completed fetches");
+
+        subscriptions.resume(tp0);
+
+        consumerClient.poll(time.timer(0));
+
+        fetchedRecords = fetchedRecords();
+
+        assertEquals(1, fetchedRecords.get(tp0).size(), "Should return last remaining record");
+        assertFalse(fetcher.hasCompletedFetches(), "Should have no completed fetches");
+    }
+
+    @Test
+    public void testFetchDiscardedAfterPausedPartitionResumedAndSeekedToNewOffset() {
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        subscriptions.pause(tp0);
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+
+        subscriptions.seek(tp0, 3);
+        subscriptions.resume(tp0);
+        consumerClient.poll(time.timer(0));
+
+        assertTrue(fetcher.hasCompletedFetches(), "Should have 1 entry in completed fetches");
+        Fetch<byte[], byte[]> fetch = collectFetch();
+        assertEquals(emptyMap(), fetch.records(), "Should not return any records because we seeked to a new offset");
+        assertFalse(fetch.positionAdvanced());
+        assertFalse(fetcher.hasCompletedFetches(), "Should have no completed fetches");
+    }
+
+    @Test
+    public void testFetchNotLeaderOrFollower() {
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NOT_LEADER_OR_FOLLOWER, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertEmptyFetch("Should not return records or advance position on fetch error");
+        assertEquals(0L, metadata.timeToNextUpdate(time.milliseconds()));
+    }
+
+    @Test
+    public void testFetchUnknownTopicOrPartition() {
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.UNKNOWN_TOPIC_OR_PARTITION, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertEmptyFetch("Should not return records or advance position on fetch error");
+        assertEquals(0L, metadata.timeToNextUpdate(time.milliseconds()));
+    }
+
+    @Test
+    public void testFetchUnknownTopicId() {
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.UNKNOWN_TOPIC_ID, -1L, 0));
+        consumerClient.poll(time.timer(0));
+        assertEmptyFetch("Should not return records or advance position on fetch error");
+        assertEquals(0L, metadata.timeToNextUpdate(time.milliseconds()));
+    }
+
+    @Test
+    public void testFetchSessionIdError() {
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fetchResponseWithTopLevelError(tidp0, Errors.FETCH_SESSION_TOPIC_ID_ERROR, 0));
+        consumerClient.poll(time.timer(0));
+        assertEmptyFetch("Should not return records or advance position on fetch error");
+        assertEquals(0L, metadata.timeToNextUpdate(time.milliseconds()));
+    }
+
+    @Test
+    public void testFetchInconsistentTopicId() {
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.INCONSISTENT_TOPIC_ID, -1L, 0));
+        consumerClient.poll(time.timer(0));
+        assertEmptyFetch("Should not return records or advance position on fetch error");
+        assertEquals(0L, metadata.timeToNextUpdate(time.milliseconds()));
+    }
+
+    @Test
+    public void testFetchFencedLeaderEpoch() {
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.FENCED_LEADER_EPOCH, 100L, 0));
+        consumerClient.poll(time.timer(0));
+
+        assertEmptyFetch("Should not return records or advance position on fetch error");
+        assertEquals(0L, metadata.timeToNextUpdate(time.milliseconds()), "Should have requested metadata update");
+    }
+
+    @Test
+    public void testFetchUnknownLeaderEpoch() {
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.UNKNOWN_LEADER_EPOCH, 100L, 0));
+        consumerClient.poll(time.timer(0));
+
+        assertEmptyFetch("Should not return records or advance position on fetch error");
+        assertNotEquals(0L, metadata.timeToNextUpdate(time.milliseconds()), "Should not have requested metadata update");
+    }
+
+    @Test
+    public void testEpochSetInFetchRequest() {
+        buildFetcher();
+        subscriptions.assignFromUser(singleton(tp0));
+        MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWithIds("dummy", 1,
+                Collections.emptyMap(), Collections.singletonMap(topicName, 4), tp -> 99, topicIds);
+        client.updateMetadata(metadataResponse);
+
+        subscriptions.seek(tp0, 10);
+        assertEquals(1, sendFetches());
+
+        // Check for epoch in outgoing request
+        MockClient.RequestMatcher matcher = body -> {
+            if (body instanceof FetchRequest) {
+                FetchRequest fetchRequest = (FetchRequest) body;
+                fetchRequest.fetchData(topicNames).values().forEach(partitionData -> {
+                    assertTrue(partitionData.currentLeaderEpoch.isPresent(), "Expected Fetcher to set leader epoch in request");
+                    assertEquals(99, partitionData.currentLeaderEpoch.get().longValue(), "Expected leader epoch to match epoch from metadata update");
+                });
+                return true;
+            } else {
+                fail("Should have seen FetchRequest");
+                return false;
+            }
+        };
+        client.prepareResponse(matcher, fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.pollNoWakeup();
+    }
+
+    @Test
+    public void testFetchOffsetOutOfRange() {
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.OFFSET_OUT_OF_RANGE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertEmptyFetch("Should not return records or advance position on fetch error");
+        assertTrue(subscriptions.isOffsetResetNeeded(tp0));
+        assertNull(subscriptions.validPosition(tp0));
+        assertNull(subscriptions.position(tp0));
+    }
+
+    @Test
+    public void testStaleOutOfRangeError() {
+        // verify that an out of range error which arrives after a seek
+        // does not cause us to reset our position or throw an exception
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.OFFSET_OUT_OF_RANGE, 100L, 0));
+        subscriptions.seek(tp0, 1);
+        consumerClient.poll(time.timer(0));
+        assertEmptyFetch("Should not return records or advance position on fetch error");
+        assertFalse(subscriptions.isOffsetResetNeeded(tp0));
+        assertEquals(1, subscriptions.position(tp0).offset);
+    }
+
+    @Test
+    public void testFetchedRecordsAfterSeek() {
+        buildFetcher(OffsetResetStrategy.NONE, new ByteArrayDeserializer(),
+                new ByteArrayDeserializer(), 2, IsolationLevel.READ_UNCOMMITTED);
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertTrue(sendFetches() > 0);
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.OFFSET_OUT_OF_RANGE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertFalse(subscriptions.isOffsetResetNeeded(tp0));
+        subscriptions.seek(tp0, 2);
+        assertEmptyFetch("Should not return records or advance position after seeking to end of topic partition");
+    }
+
+    @Test
+    public void testFetchOffsetOutOfRangeException() {
+        buildFetcher(OffsetResetStrategy.NONE, new ByteArrayDeserializer(),
+                new ByteArrayDeserializer(), 2, IsolationLevel.READ_UNCOMMITTED);
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        sendFetches();
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.OFFSET_OUT_OF_RANGE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+
+        assertFalse(subscriptions.isOffsetResetNeeded(tp0));
+        for (int i = 0; i < 2; i++) {
+            OffsetOutOfRangeException e = assertThrows(OffsetOutOfRangeException.class, () ->
+                    fetcher.collectFetch());
+            assertEquals(singleton(tp0), e.offsetOutOfRangePartitions().keySet());
+            assertEquals(0L, e.offsetOutOfRangePartitions().get(tp0).longValue());
+        }
+    }
+
+    @Test
+    public void testFetchPositionAfterException() {
+        // verify the advancement in the next fetch offset equals to the number of fetched records when
+        // some fetched partitions cause Exception. This ensures that consumer won't lose record upon exception
+        buildFetcher(OffsetResetStrategy.NONE, new ByteArrayDeserializer(),
+                new ByteArrayDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_UNCOMMITTED);
+        assignFromUser(mkSet(tp0, tp1));
+        subscriptions.seek(tp0, 1);
+        subscriptions.seek(tp1, 1);
+
+        assertEquals(1, sendFetches());
+
+        Map<TopicIdPartition, FetchResponseData.PartitionData> partitions = new LinkedHashMap<>();
+        partitions.put(tidp1, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp1.partition())
+                .setHighWatermark(100)
+                .setRecords(records));
+        partitions.put(tidp0, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp0.partition())
+                .setErrorCode(Errors.OFFSET_OUT_OF_RANGE.code())
+                .setHighWatermark(100));
+        client.prepareResponse(FetchResponse.of(Errors.NONE, 0, INVALID_SESSION_ID, new LinkedHashMap<>(partitions)));
+        consumerClient.poll(time.timer(0));
+
+        List<ConsumerRecord<byte[], byte[]>> allFetchedRecords = new ArrayList<>();
+        fetchRecordsInto(allFetchedRecords);
+
+        assertEquals(1, subscriptions.position(tp0).offset);
+        assertEquals(4, subscriptions.position(tp1).offset);
+        assertEquals(3, allFetchedRecords.size());
+
+        OffsetOutOfRangeException e = assertThrows(OffsetOutOfRangeException.class, () ->
+                fetchRecordsInto(allFetchedRecords));
+
+        assertEquals(singleton(tp0), e.offsetOutOfRangePartitions().keySet());
+        assertEquals(1L, e.offsetOutOfRangePartitions().get(tp0).longValue());
+
+        assertEquals(1, subscriptions.position(tp0).offset);
+        assertEquals(4, subscriptions.position(tp1).offset);
+        assertEquals(3, allFetchedRecords.size());
+    }
+
+    private void fetchRecordsInto(List<ConsumerRecord<byte[], byte[]>> allFetchedRecords) {
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
+        fetchedRecords.values().forEach(allFetchedRecords::addAll);
+    }
+
+    @Test
+    public void testCompletedFetchRemoval() {
+        // Ensure the removal of completed fetches that cause an Exception if and only if they contain empty records.
+        buildFetcher(OffsetResetStrategy.NONE, new ByteArrayDeserializer(),
+                new ByteArrayDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_UNCOMMITTED);
+        assignFromUser(mkSet(tp0, tp1, tp2, tp3));
+
+        subscriptions.seek(tp0, 1);
+        subscriptions.seek(tp1, 1);
+        subscriptions.seek(tp2, 1);
+        subscriptions.seek(tp3, 1);
+
+        assertEquals(1, sendFetches());
+
+        Map<TopicIdPartition, FetchResponseData.PartitionData> partitions = new LinkedHashMap<>();
+        partitions.put(tidp1, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp1.partition())
+                .setHighWatermark(100)
+                .setRecords(records));
+        partitions.put(tidp0, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp0.partition())
+                .setErrorCode(Errors.OFFSET_OUT_OF_RANGE.code())
+                .setHighWatermark(100));
+        partitions.put(tidp2, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp2.partition())
+                .setHighWatermark(100)
+                .setLastStableOffset(4)
+                .setLogStartOffset(0)
+                .setRecords(nextRecords));
+        partitions.put(tidp3, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp3.partition())
+                .setHighWatermark(100)
+                .setLastStableOffset(4)
+                .setLogStartOffset(0)
+                .setRecords(partialRecords));
+        client.prepareResponse(FetchResponse.of(Errors.NONE, 0, INVALID_SESSION_ID, new LinkedHashMap<>(partitions)));
+        consumerClient.poll(time.timer(0));
+
+        List<ConsumerRecord<byte[], byte[]>> fetchedRecords = new ArrayList<>();
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> recordsByPartition = fetchedRecords();
+        for (List<ConsumerRecord<byte[], byte[]>> records : recordsByPartition.values())
+            fetchedRecords.addAll(records);
+
+        assertEquals(fetchedRecords.size(), subscriptions.position(tp1).offset - 1);
+        assertEquals(4, subscriptions.position(tp1).offset);
+        assertEquals(3, fetchedRecords.size());
+
+        List<OffsetOutOfRangeException> oorExceptions = new ArrayList<>();
+        try {
+            recordsByPartition = fetchedRecords();
+            for (List<ConsumerRecord<byte[], byte[]>> records : recordsByPartition.values())
+                fetchedRecords.addAll(records);
+        } catch (OffsetOutOfRangeException oor) {
+            oorExceptions.add(oor);
+        }
+
+        // Should have received one OffsetOutOfRangeException for partition tp1
+        assertEquals(1, oorExceptions.size());
+        OffsetOutOfRangeException oor = oorExceptions.get(0);
+        assertTrue(oor.offsetOutOfRangePartitions().containsKey(tp0));
+        assertEquals(oor.offsetOutOfRangePartitions().size(), 1);
+
+        recordsByPartition = fetchedRecords();
+        for (List<ConsumerRecord<byte[], byte[]>> records : recordsByPartition.values())
+            fetchedRecords.addAll(records);
+
+        // Should not have received an Exception for tp2.
+        assertEquals(6, subscriptions.position(tp2).offset);
+        assertEquals(5, fetchedRecords.size());
+
+        int numExceptionsExpected = 3;
+        List<KafkaException> kafkaExceptions = new ArrayList<>();
+        for (int i = 1; i <= numExceptionsExpected; i++) {
+            try {
+                recordsByPartition = fetchedRecords();
+                for (List<ConsumerRecord<byte[], byte[]>> records : recordsByPartition.values())
+                    fetchedRecords.addAll(records);
+            } catch (KafkaException e) {
+                kafkaExceptions.add(e);
+            }
+        }
+        // Should have received as much as numExceptionsExpected Kafka exceptions for tp3.
+        assertEquals(numExceptionsExpected, kafkaExceptions.size());
+    }
+
+    @Test
+    public void testSeekBeforeException() {
+        buildFetcher(OffsetResetStrategy.NONE, new ByteArrayDeserializer(),
+                new ByteArrayDeserializer(), 2, IsolationLevel.READ_UNCOMMITTED);
+
+        assignFromUser(mkSet(tp0));
+        subscriptions.seek(tp0, 1);
+        assertEquals(1, sendFetches());
+        Map<TopicIdPartition, FetchResponseData.PartitionData> partitions = new HashMap<>();
+        partitions.put(tidp0, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp0.partition())
+                .setHighWatermark(100)
+                .setRecords(records));
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+
+        assertEquals(2, fetchedRecords().get(tp0).size());
+
+        subscriptions.assignFromUser(mkSet(tp0, tp1));
+        subscriptions.seekUnvalidated(tp1, new SubscriptionState.FetchPosition(1, Optional.empty(), metadata.currentLeader(tp1)));
+
+        assertEquals(1, sendFetches());
+        partitions = new HashMap<>();
+        partitions.put(tidp1, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp1.partition())
+                .setErrorCode(Errors.OFFSET_OUT_OF_RANGE.code())
+                .setHighWatermark(100));
+        client.prepareResponse(FetchResponse.of(Errors.NONE, 0, INVALID_SESSION_ID, new LinkedHashMap<>(partitions)));
+        consumerClient.poll(time.timer(0));
+        assertEquals(1, fetchedRecords().get(tp0).size());
+
+        subscriptions.seek(tp1, 10);
+        // Should not throw OffsetOutOfRangeException after the seek
+        assertEmptyFetch("Should not return records or advance position after seeking to end of topic partitions");
+    }
+
+    @Test
+    public void testFetchDisconnected() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0), true);
+        consumerClient.poll(time.timer(0));
+        assertEmptyFetch("Should not return records or advance position on disconnect");
+
+        // disconnects should have no affect on subscription state
+        assertFalse(subscriptions.isOffsetResetNeeded(tp0));
+        assertTrue(subscriptions.isFetchable(tp0));
+        assertEquals(0, subscriptions.position(tp0).offset);
+    }
+
+    /*
+     * Send multiple requests. Verify that the client side quota metrics have the right values
+     */
+    @Test
+    public void testQuotaMetrics() {
+        buildFetcher();
+
+        MockSelector selector = new MockSelector(time);
+        Cluster cluster = TestUtils.singletonCluster("test", 1);
+        Node node = cluster.nodes().get(0);
+        NetworkClient client = new NetworkClient(selector, metadata, "mock", Integer.MAX_VALUE,
+                1000, 1000, 64 * 1024, 64 * 1024, 1000, 10 * 1000, 127 * 1000,
+                time, true, new ApiVersions(), metricsManager.throttleTimeSensor(), new LogContext());
+
+        ApiVersionsResponse apiVersionsResponse = TestUtils.defaultApiVersionsResponse(
+                400, ApiMessageType.ListenerType.ZK_BROKER);
+        ByteBuffer buffer = RequestTestUtils.serializeResponseWithHeader(apiVersionsResponse, ApiKeys.API_VERSIONS.latestVersion(), 0);
+
+        selector.delayedReceive(new DelayedReceive(node.idString(), new NetworkReceive(node.idString(), buffer)));
+        while (!client.ready(node, time.milliseconds())) {
+            client.poll(1, time.milliseconds());
+            // If a throttled response is received, advance the time to ensure progress.
+            time.sleep(client.throttleDelayMs(node, time.milliseconds()));
+        }
+        selector.clear();
+
+        for (int i = 1; i <= 3; i++) {
+            int throttleTimeMs = 100 * i;
+            FetchRequest.Builder builder = FetchRequest.Builder.forConsumer(ApiKeys.FETCH.latestVersion(), 100, 100, new LinkedHashMap<>());
+            builder.rackId("");
+            ClientRequest request = client.newClientRequest(node.idString(), builder, time.milliseconds(), true);
+            client.send(request, time.milliseconds());
+            client.poll(1, time.milliseconds());
+            FetchResponse response = fullFetchResponse(tidp0, nextRecords, Errors.NONE, i, throttleTimeMs);
+            buffer = RequestTestUtils.serializeResponseWithHeader(response, ApiKeys.FETCH.latestVersion(), request.correlationId());
+            selector.completeReceive(new NetworkReceive(node.idString(), buffer));
+            client.poll(1, time.milliseconds());
+            // If a throttled response is received, advance the time to ensure progress.
+            time.sleep(client.throttleDelayMs(node, time.milliseconds()));
+            selector.clear();
+        }
+        Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
+        KafkaMetric avgMetric = allMetrics.get(metrics.metricInstance(metricsRegistry.fetchThrottleTimeAvg));
+        KafkaMetric maxMetric = allMetrics.get(metrics.metricInstance(metricsRegistry.fetchThrottleTimeMax));
+        // Throttle times are ApiVersions=400, Fetch=(100, 200, 300)
+        assertEquals(250, (Double) avgMetric.metricValue(), EPSILON);
+        assertEquals(400, (Double) maxMetric.metricValue(), EPSILON);
+        client.close();
+    }
+
+    /*
+     * Send multiple requests. Verify that the client side quota metrics have the right values
+     */
+    @Test
+    public void testFetcherMetrics() {
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        MetricName maxLagMetric = metrics.metricInstance(metricsRegistry.recordsLagMax);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("topic", tp0.topic());
+        tags.put("partition", String.valueOf(tp0.partition()));
+        MetricName partitionLagMetric = metrics.metricName("records-lag", metricGroup, tags);
+
+        Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
+        KafkaMetric recordsFetchLagMax = allMetrics.get(maxLagMetric);
+
+        // recordsFetchLagMax should be initialized to NaN
+        assertEquals(Double.NaN, (Double) recordsFetchLagMax.metricValue(), EPSILON);
+
+        // recordsFetchLagMax should be hw - fetchOffset after receiving an empty FetchResponse
+        fetchRecords(tidp0, MemoryRecords.EMPTY, Errors.NONE, 100L, 0);
+        assertEquals(100, (Double) recordsFetchLagMax.metricValue(), EPSILON);
+
+        KafkaMetric partitionLag = allMetrics.get(partitionLagMetric);
+        assertEquals(100, (Double) partitionLag.metricValue(), EPSILON);
+
+        // recordsFetchLagMax should be hw - offset of the last message after receiving a non-empty FetchResponse
+        MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE,
+                TimestampType.CREATE_TIME, 0L);
+        for (int v = 0; v < 3; v++)
+            builder.appendWithOffset(v, RecordBatch.NO_TIMESTAMP, "key".getBytes(), ("value-" + v).getBytes());
+        fetchRecords(tidp0, builder.build(), Errors.NONE, 200L, 0);
+        assertEquals(197, (Double) recordsFetchLagMax.metricValue(), EPSILON);
+        assertEquals(197, (Double) partitionLag.metricValue(), EPSILON);
+
+        // verify de-registration of partition lag
+        subscriptions.unsubscribe();
+        sendFetches();
+        assertFalse(allMetrics.containsKey(partitionLagMetric));
+    }
+
+    @Test
+    public void testFetcherLeadMetric() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        MetricName minLeadMetric = metrics.metricInstance(metricsRegistry.recordsLeadMin);
+        Map<String, String> tags = new HashMap<>(2);
+        tags.put("topic", tp0.topic());
+        tags.put("partition", String.valueOf(tp0.partition()));
+        MetricName partitionLeadMetric = metrics.metricName("records-lead", metricGroup, "", tags);
+
+        Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
+        KafkaMetric recordsFetchLeadMin = allMetrics.get(minLeadMetric);
+
+        // recordsFetchLeadMin should be initialized to NaN
+        assertEquals(Double.NaN, (Double) recordsFetchLeadMin.metricValue(), EPSILON);
+
+        // recordsFetchLeadMin should be position - logStartOffset after receiving an empty FetchResponse
+        fetchRecords(tidp0, MemoryRecords.EMPTY, Errors.NONE, 100L, -1L, 0L, 0);
+        assertEquals(0L, (Double) recordsFetchLeadMin.metricValue(), EPSILON);
+
+        KafkaMetric partitionLead = allMetrics.get(partitionLeadMetric);
+        assertEquals(0L, (Double) partitionLead.metricValue(), EPSILON);
+
+        // recordsFetchLeadMin should be position - logStartOffset after receiving a non-empty FetchResponse
+        MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE,
+                TimestampType.CREATE_TIME, 0L);
+        for (int v = 0; v < 3; v++) {
+            builder.appendWithOffset(v, RecordBatch.NO_TIMESTAMP, "key".getBytes(), ("value-" + v).getBytes());
+        }
+        fetchRecords(tidp0, builder.build(), Errors.NONE, 200L, -1L, 0L, 0);
+        assertEquals(0L, (Double) recordsFetchLeadMin.metricValue(), EPSILON);
+        assertEquals(3L, (Double) partitionLead.metricValue(), EPSILON);
+
+        // verify de-registration of partition lag
+        subscriptions.unsubscribe();
+        sendFetches();
+        assertFalse(allMetrics.containsKey(partitionLeadMetric));
+    }
+
+    @Test
+    public void testReadCommittedLagMetric() {
+        buildFetcher(OffsetResetStrategy.EARLIEST, new ByteArrayDeserializer(),
+                new ByteArrayDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_COMMITTED);
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        MetricName maxLagMetric = metrics.metricInstance(metricsRegistry.recordsLagMax);
+
+        Map<String, String> tags = new HashMap<>();
+        tags.put("topic", tp0.topic());
+        tags.put("partition", String.valueOf(tp0.partition()));
+        MetricName partitionLagMetric = metrics.metricName("records-lag", metricGroup, tags);
+
+        Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
+        KafkaMetric recordsFetchLagMax = allMetrics.get(maxLagMetric);
+
+        // recordsFetchLagMax should be initialized to NaN
+        assertEquals(Double.NaN, (Double) recordsFetchLagMax.metricValue(), EPSILON);
+
+        // recordsFetchLagMax should be lso - fetchOffset after receiving an empty FetchResponse
+        fetchRecords(tidp0, MemoryRecords.EMPTY, Errors.NONE, 100L, 50L, 0);
+        assertEquals(50, (Double) recordsFetchLagMax.metricValue(), EPSILON);
+
+        KafkaMetric partitionLag = allMetrics.get(partitionLagMetric);
+        assertEquals(50, (Double) partitionLag.metricValue(), EPSILON);
+
+        // recordsFetchLagMax should be lso - offset of the last message after receiving a non-empty FetchResponse
+        MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE,
+                TimestampType.CREATE_TIME, 0L);
+        for (int v = 0; v < 3; v++)
+            builder.appendWithOffset(v, RecordBatch.NO_TIMESTAMP, "key".getBytes(), ("value-" + v).getBytes());
+        fetchRecords(tidp0, builder.build(), Errors.NONE, 200L, 150L, 0);
+        assertEquals(147, (Double) recordsFetchLagMax.metricValue(), EPSILON);
+        assertEquals(147, (Double) partitionLag.metricValue(), EPSILON);
+
+        // verify de-registration of partition lag
+        subscriptions.unsubscribe();
+        sendFetches();
+        assertFalse(allMetrics.containsKey(partitionLagMetric));
+    }
+
+    @Test
+    public void testFetchResponseMetrics() {
+        buildFetcher();
+
+        String topic1 = "foo";
+        String topic2 = "bar";
+        TopicPartition tp1 = new TopicPartition(topic1, 0);
+        TopicPartition tp2 = new TopicPartition(topic2, 0);
+
+        subscriptions.assignFromUser(mkSet(tp1, tp2));
+
+        Map<String, Integer> partitionCounts = new HashMap<>();
+        partitionCounts.put(topic1, 1);
+        partitionCounts.put(topic2, 1);
+        topicIds.put(topic1, Uuid.randomUuid());
+        topicIds.put(topic2, Uuid.randomUuid());
+        TopicIdPartition tidp1 = new TopicIdPartition(topicIds.get(topic1), tp1);
+        TopicIdPartition tidp2 = new TopicIdPartition(topicIds.get(topic2), tp2);
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(1, partitionCounts, tp -> validLeaderEpoch, topicIds));
+
+        int expectedBytes = 0;
+        LinkedHashMap<TopicIdPartition, FetchResponseData.PartitionData> fetchPartitionData = new LinkedHashMap<>();
+
+        for (TopicIdPartition tp : mkSet(tidp1, tidp2)) {
+            subscriptions.seek(tp.topicPartition(), 0);
+
+            MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE,
+                    TimestampType.CREATE_TIME, 0L);
+            for (int v = 0; v < 3; v++)
+                builder.appendWithOffset(v, RecordBatch.NO_TIMESTAMP, "key".getBytes(), ("value-" + v).getBytes());
+            MemoryRecords records = builder.build();
+            for (Record record : records.records())
+                expectedBytes += record.sizeInBytes();
+
+            fetchPartitionData.put(tp, new FetchResponseData.PartitionData()
+                    .setPartitionIndex(tp.topicPartition().partition())
+                    .setHighWatermark(15)
+                    .setLogStartOffset(0)
+                    .setRecords(records));
+        }
+
+        assertEquals(1, sendFetches());
+        client.prepareResponse(FetchResponse.of(Errors.NONE, 0, INVALID_SESSION_ID, fetchPartitionData));
+        consumerClient.poll(time.timer(0));
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
+        assertEquals(3, fetchedRecords.get(tp1).size());
+        assertEquals(3, fetchedRecords.get(tp2).size());
+
+        Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
+        KafkaMetric fetchSizeAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.fetchSizeAvg));
+        KafkaMetric recordsCountAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.recordsPerRequestAvg));
+        assertEquals(expectedBytes, (Double) fetchSizeAverage.metricValue(), EPSILON);
+        assertEquals(6, (Double) recordsCountAverage.metricValue(), EPSILON);
+    }
+
+    @Test
+    public void testFetchResponseMetricsPartialResponse() {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 1);
+
+        Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
+        KafkaMetric fetchSizeAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.fetchSizeAvg));
+        KafkaMetric recordsCountAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.recordsPerRequestAvg));
+
+        MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE,
+                TimestampType.CREATE_TIME, 0L);
+        for (int v = 0; v < 3; v++)
+            builder.appendWithOffset(v, RecordBatch.NO_TIMESTAMP, "key".getBytes(), ("value-" + v).getBytes());
+        MemoryRecords records = builder.build();
+
+        int expectedBytes = 0;
+        for (Record record : records.records()) {
+            if (record.offset() >= 1)
+                expectedBytes += record.sizeInBytes();
+        }
+
+        fetchRecords(tidp0, records, Errors.NONE, 100L, 0);
+        assertEquals(expectedBytes, (Double) fetchSizeAverage.metricValue(), EPSILON);
+        assertEquals(2, (Double) recordsCountAverage.metricValue(), EPSILON);
+    }
+
+    @Test
+    public void testFetchResponseMetricsWithOnePartitionError() {
+        buildFetcher();
+        assignFromUser(mkSet(tp0, tp1));
+        subscriptions.seek(tp0, 0);
+        subscriptions.seek(tp1, 0);
+
+        Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
+        KafkaMetric fetchSizeAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.fetchSizeAvg));
+        KafkaMetric recordsCountAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.recordsPerRequestAvg));
+
+        MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE,
+                TimestampType.CREATE_TIME, 0L);
+        for (int v = 0; v < 3; v++)
+            builder.appendWithOffset(v, RecordBatch.NO_TIMESTAMP, "key".getBytes(), ("value-" + v).getBytes());
+        MemoryRecords records = builder.build();
+
+        Map<TopicIdPartition, FetchResponseData.PartitionData> partitions = new HashMap<>();
+        partitions.put(tidp0, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp0.partition())
+                .setHighWatermark(100)
+                .setLogStartOffset(0)
+                .setRecords(records));
+        partitions.put(tidp1, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp1.partition())
+                .setErrorCode(Errors.OFFSET_OUT_OF_RANGE.code())
+                .setHighWatermark(100)
+                .setLogStartOffset(0));
+
+        assertEquals(1, sendFetches());
+        client.prepareResponse(FetchResponse.of(Errors.NONE, 0, INVALID_SESSION_ID, new LinkedHashMap<>(partitions)));
+        consumerClient.poll(time.timer(0));
+        fetcher.collectFetch();
+
+        int expectedBytes = 0;
+        for (Record record : records.records())
+            expectedBytes += record.sizeInBytes();
+
+        assertEquals(expectedBytes, (Double) fetchSizeAverage.metricValue(), EPSILON);
+        assertEquals(3, (Double) recordsCountAverage.metricValue(), EPSILON);
+    }
+
+    @Test
+    public void testFetchResponseMetricsWithOnePartitionAtTheWrongOffset() {
+        buildFetcher();
+
+        assignFromUser(mkSet(tp0, tp1));
+        subscriptions.seek(tp0, 0);
+        subscriptions.seek(tp1, 0);
+
+        Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
+        KafkaMetric fetchSizeAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.fetchSizeAvg));
+        KafkaMetric recordsCountAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.recordsPerRequestAvg));
+
+        // send the fetch and then seek to a new offset
+        assertEquals(1, sendFetches());
+        subscriptions.seek(tp1, 5);
+
+        MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE,
+                TimestampType.CREATE_TIME, 0L);
+        for (int v = 0; v < 3; v++)
+            builder.appendWithOffset(v, RecordBatch.NO_TIMESTAMP, "key".getBytes(), ("value-" + v).getBytes());
+        MemoryRecords records = builder.build();
+
+        Map<TopicIdPartition, FetchResponseData.PartitionData> partitions = new HashMap<>();
+        partitions.put(tidp0, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp0.partition())
+                .setHighWatermark(100)
+                .setLogStartOffset(0)
+                .setRecords(records));
+        partitions.put(tidp1, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp1.partition())
+                .setHighWatermark(100)
+                .setLogStartOffset(0)
+                .setRecords(MemoryRecords.withRecords(CompressionType.NONE, new SimpleRecord("val".getBytes()))));
+
+        client.prepareResponse(FetchResponse.of(Errors.NONE, 0, INVALID_SESSION_ID, new LinkedHashMap<>(partitions)));
+        consumerClient.poll(time.timer(0));
+        fetcher.collectFetch();
+
+        // we should have ignored the record at the wrong offset
+        int expectedBytes = 0;
+        for (Record record : records.records())
+            expectedBytes += record.sizeInBytes();
+
+        assertEquals(expectedBytes, (Double) fetchSizeAverage.metricValue(), EPSILON);
+        assertEquals(3, (Double) recordsCountAverage.metricValue(), EPSILON);
+    }
+
+    @Test
+    public void testFetcherMetricsTemplates() {
+        Map<String, String> clientTags = Collections.singletonMap("client-id", "clientA");
+        buildFetcher(new MetricConfig().tags(clientTags), OffsetResetStrategy.EARLIEST, new ByteArrayDeserializer(),
+                new ByteArrayDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_UNCOMMITTED);
+
+        // Fetch from topic to generate topic metrics
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionRecords = fetchedRecords();
+        assertTrue(partitionRecords.containsKey(tp0));
+
+        // Verify that all metrics except metrics-count have registered templates
+        Set<MetricNameTemplate> allMetrics = new HashSet<>();
+        for (MetricName n : metrics.metrics().keySet()) {
+            String name = n.name().replaceAll(tp0.toString(), "{topic}-{partition}");
+            if (!n.group().equals("kafka-metrics-count"))
+                allMetrics.add(new MetricNameTemplate(name, n.group(), "", n.tags().keySet()));
+        }
+        TestUtils.checkEquals(allMetrics, new HashSet<>(metricsRegistry.getAllTemplates()), "metrics", "templates");
+    }
+
+    private Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchRecords(
+            TopicIdPartition tp, MemoryRecords records, Errors error, long hw, int throttleTime) {
+        return fetchRecords(tp, records, error, hw, FetchResponse.INVALID_LAST_STABLE_OFFSET, throttleTime);
+    }
+
+    private Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchRecords(
+            TopicIdPartition tp, MemoryRecords records, Errors error, long hw, long lastStableOffset, int throttleTime) {
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tp, records, error, hw, lastStableOffset, throttleTime));
+        consumerClient.poll(time.timer(0));
+        return fetchedRecords();
+    }
+
+    private Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchRecords(
+            TopicIdPartition tp, MemoryRecords records, Errors error, long hw, long lastStableOffset, long logStartOffset, int throttleTime) {
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fetchResponse(tp, records, error, hw, lastStableOffset, logStartOffset, throttleTime));
+        consumerClient.poll(time.timer(0));
+        return fetchedRecords();
+    }
+
+    @Test
+    public void testSkippingAbortedTransactions() {
+        buildFetcher(OffsetResetStrategy.EARLIEST, new ByteArrayDeserializer(),
+                new ByteArrayDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_COMMITTED);
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        int currentOffset = 0;
+
+        currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
+                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()),
+                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()));
+
+        abortTransaction(buffer, 1L, currentOffset);
+
+        buffer.flip();
+
+        List<FetchResponseData.AbortedTransaction> abortedTransactions = Collections.singletonList(
+                new FetchResponseData.AbortedTransaction().setProducerId(1).setFirstOffset(0));
+        MemoryRecords records = MemoryRecords.readableRecords(buffer);
+        assignFromUser(singleton(tp0));
+
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponseWithAbortedTransactions(records, abortedTransactions, Errors.NONE, 100L, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Fetch<byte[], byte[]> fetch = collectFetch();
+        assertEquals(emptyMap(), fetch.records());
+        assertTrue(fetch.positionAdvanced());
+    }
+
+    @Test
+    public void testReturnCommittedTransactions() {
+        buildFetcher(OffsetResetStrategy.EARLIEST, new ByteArrayDeserializer(),
+                new ByteArrayDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_COMMITTED);
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        int currentOffset = 0;
+
+        currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
+                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()),
+                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()));
+
+        commitTransaction(buffer, 1L, currentOffset);
+        buffer.flip();
+
+        MemoryRecords records = MemoryRecords.readableRecords(buffer);
+        assignFromUser(singleton(tp0));
+
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+        client.prepareResponse(body -> {
+            FetchRequest request = (FetchRequest) body;
+            assertEquals(IsolationLevel.READ_COMMITTED, request.isolationLevel());
+            return true;
+        }, fullFetchResponseWithAbortedTransactions(records, Collections.emptyList(), Errors.NONE, 100L, 100L, 0));
+
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
+        assertTrue(fetchedRecords.containsKey(tp0));
+        assertEquals(fetchedRecords.get(tp0).size(), 2);
+    }
+
+    @Test
+    public void testReadCommittedWithCommittedAndAbortedTransactions() {
+        buildFetcher(OffsetResetStrategy.EARLIEST, new ByteArrayDeserializer(),
+                new ByteArrayDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_COMMITTED);
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+
+        List<FetchResponseData.AbortedTransaction> abortedTransactions = new ArrayList<>();
+
+        long pid1 = 1L;
+        long pid2 = 2L;
+
+        // Appends for producer 1 (eventually committed)
+        appendTransactionalRecords(buffer, pid1, 0L,
+                new SimpleRecord("commit1-1".getBytes(), "value".getBytes()),
+                new SimpleRecord("commit1-2".getBytes(), "value".getBytes()));
+
+        // Appends for producer 2 (eventually aborted)
+        appendTransactionalRecords(buffer, pid2, 2L,
+                new SimpleRecord("abort2-1".getBytes(), "value".getBytes()));
+
+        // commit producer 1
+        commitTransaction(buffer, pid1, 3L);
+
+        // append more for producer 2 (eventually aborted)
+        appendTransactionalRecords(buffer, pid2, 4L,
+                new SimpleRecord("abort2-2".getBytes(), "value".getBytes()));
+
+        // abort producer 2
+        abortTransaction(buffer, pid2, 5L);
+        abortedTransactions.add(new FetchResponseData.AbortedTransaction().setProducerId(pid2).setFirstOffset(2L));
+
+        // New transaction for producer 1 (eventually aborted)
+        appendTransactionalRecords(buffer, pid1, 6L,
+                new SimpleRecord("abort1-1".getBytes(), "value".getBytes()));
+
+        // New transaction for producer 2 (eventually committed)
+        appendTransactionalRecords(buffer, pid2, 7L,
+                new SimpleRecord("commit2-1".getBytes(), "value".getBytes()));
+
+        // Add messages for producer 1 (eventually aborted)
+        appendTransactionalRecords(buffer, pid1, 8L,
+                new SimpleRecord("abort1-2".getBytes(), "value".getBytes()));
+
+        // abort producer 1
+        abortTransaction(buffer, pid1, 9L);
+        abortedTransactions.add(new FetchResponseData.AbortedTransaction().setProducerId(1).setFirstOffset(6));
+
+        // commit producer 2
+        commitTransaction(buffer, pid2, 10L);
+
+        buffer.flip();
+
+        MemoryRecords records = MemoryRecords.readableRecords(buffer);
+        assignFromUser(singleton(tp0));
+
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponseWithAbortedTransactions(records, abortedTransactions, Errors.NONE, 100L, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
+        assertTrue(fetchedRecords.containsKey(tp0));
+        // There are only 3 committed records
+        List<ConsumerRecord<byte[], byte[]>> fetchedConsumerRecords = fetchedRecords.get(tp0);
+        Set<String> fetchedKeys = new HashSet<>();
+        for (ConsumerRecord<byte[], byte[]> consumerRecord : fetchedConsumerRecords) {
+            fetchedKeys.add(new String(consumerRecord.key(), StandardCharsets.UTF_8));
+        }
+        assertEquals(mkSet("commit1-1", "commit1-2", "commit2-1"), fetchedKeys);
+    }
+
+    @Test
+    public void testMultipleAbortMarkers() {
+        buildFetcher(OffsetResetStrategy.EARLIEST, new ByteArrayDeserializer(),
+                new ByteArrayDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_COMMITTED);
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        int currentOffset = 0;
+
+        currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
+                new SimpleRecord(time.milliseconds(), "abort1-1".getBytes(), "value".getBytes()),
+                new SimpleRecord(time.milliseconds(), "abort1-2".getBytes(), "value".getBytes()));
+
+        currentOffset += abortTransaction(buffer, 1L, currentOffset);
+        // Duplicate abort -- should be ignored.
+        currentOffset += abortTransaction(buffer, 1L, currentOffset);
+        // Now commit a transaction.
+        currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
+                new SimpleRecord(time.milliseconds(), "commit1-1".getBytes(), "value".getBytes()),
+                new SimpleRecord(time.milliseconds(), "commit1-2".getBytes(), "value".getBytes()));
+        commitTransaction(buffer, 1L, currentOffset);
+        buffer.flip();
+
+        List<FetchResponseData.AbortedTransaction> abortedTransactions = Collections.singletonList(
+                new FetchResponseData.AbortedTransaction().setProducerId(1).setFirstOffset(0)
+        );
+        MemoryRecords records = MemoryRecords.readableRecords(buffer);
+        assignFromUser(singleton(tp0));
+
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponseWithAbortedTransactions(records, abortedTransactions, Errors.NONE, 100L, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
+        assertTrue(fetchedRecords.containsKey(tp0));
+        assertEquals(fetchedRecords.get(tp0).size(), 2);
+        List<ConsumerRecord<byte[], byte[]>> fetchedConsumerRecords = fetchedRecords.get(tp0);
+        Set<String> committedKeys = new HashSet<>(Arrays.asList("commit1-1", "commit1-2"));
+        Set<String> actuallyCommittedKeys = new HashSet<>();
+        for (ConsumerRecord<byte[], byte[]> consumerRecord : fetchedConsumerRecords) {
+            actuallyCommittedKeys.add(new String(consumerRecord.key(), StandardCharsets.UTF_8));
+        }
+        assertEquals(actuallyCommittedKeys, committedKeys);
+    }
+
+    @Test
+    public void testReadCommittedAbortMarkerWithNoData() {
+        buildFetcher(OffsetResetStrategy.EARLIEST, new StringDeserializer(),
+                new StringDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_COMMITTED);
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+
+        long producerId = 1L;
+
+        abortTransaction(buffer, producerId, 5L);
+
+        appendTransactionalRecords(buffer, producerId, 6L,
+                new SimpleRecord("6".getBytes(), null),
+                new SimpleRecord("7".getBytes(), null),
+                new SimpleRecord("8".getBytes(), null));
+
+        commitTransaction(buffer, producerId, 9L);
+
+        buffer.flip();
+
+        // send the fetch
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+        assertEquals(1, sendFetches());
+
+        // prepare the response. the aborted transactions begin at offsets which are no longer in the log
+        List<FetchResponseData.AbortedTransaction> abortedTransactions = Collections.singletonList(
+                new FetchResponseData.AbortedTransaction().setProducerId(producerId).setFirstOffset(0L));
+
+        client.prepareResponse(fullFetchResponseWithAbortedTransactions(MemoryRecords.readableRecords(buffer),
+                abortedTransactions, Errors.NONE, 100L, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<String, String>>> allFetchedRecords = fetchedRecords();
+        assertTrue(allFetchedRecords.containsKey(tp0));
+        List<ConsumerRecord<String, String>> fetchedRecords = allFetchedRecords.get(tp0);
+        assertEquals(3, fetchedRecords.size());
+        assertEquals(Arrays.asList(6L, 7L, 8L), collectRecordOffsets(fetchedRecords));
+    }
+
+    @Test
+    public void testUpdatePositionWithLastRecordMissingFromBatch() {
+        buildFetcher();
+
+        MemoryRecords records = MemoryRecords.withRecords(CompressionType.NONE,
+                new SimpleRecord("0".getBytes(), "v".getBytes()),
+                new SimpleRecord("1".getBytes(), "v".getBytes()),
+                new SimpleRecord("2".getBytes(), "v".getBytes()),
+                new SimpleRecord(null, "value".getBytes()));
+
+        // Remove the last record to simulate compaction
+        MemoryRecords.FilterResult result = records.filterTo(tp0, new MemoryRecords.RecordFilter(0, 0) {
+            @Override
+            protected BatchRetentionResult checkBatchRetention(RecordBatch batch) {
+                return new BatchRetentionResult(BatchRetention.DELETE_EMPTY, false);
+            }
+
+            @Override
+            protected boolean shouldRetainRecord(RecordBatch recordBatch, Record record) {
+                return record.key() != null;
+            }
+        }, ByteBuffer.allocate(1024), Integer.MAX_VALUE, BufferSupplier.NO_CACHING);
+        result.outputBuffer().flip();
+        MemoryRecords compactedRecords = MemoryRecords.readableRecords(result.outputBuffer());
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, compactedRecords, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> allFetchedRecords = fetchedRecords();
+        assertTrue(allFetchedRecords.containsKey(tp0));
+        List<ConsumerRecord<byte[], byte[]>> fetchedRecords = allFetchedRecords.get(tp0);
+        assertEquals(3, fetchedRecords.size());
+
+        for (int i = 0; i < 3; i++) {
+            assertEquals(Integer.toString(i), new String(fetchedRecords.get(i).key()));
+        }
+
+        // The next offset should point to the next batch
+        assertEquals(4L, subscriptions.position(tp0).offset);
+    }
+
+    @Test
+    public void testUpdatePositionOnEmptyBatch() {
+        buildFetcher();
+
+        long producerId = 1;
+        short producerEpoch = 0;
+        int sequence = 1;
+        long baseOffset = 37;
+        long lastOffset = 54;
+        int partitionLeaderEpoch = 7;
+        ByteBuffer buffer = ByteBuffer.allocate(DefaultRecordBatch.RECORD_BATCH_OVERHEAD);
+        DefaultRecordBatch.writeEmptyHeader(buffer, RecordBatch.CURRENT_MAGIC_VALUE, producerId, producerEpoch,
+                sequence, baseOffset, lastOffset, partitionLeaderEpoch, TimestampType.CREATE_TIME,
+                System.currentTimeMillis(), false, false);
+        buffer.flip();
+        MemoryRecords recordsWithEmptyBatch = MemoryRecords.readableRecords(buffer);
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+        assertEquals(1, sendFetches());
+        client.prepareResponse(fullFetchResponse(tidp0, recordsWithEmptyBatch, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Fetch<byte[], byte[]> fetch = collectFetch();
+        assertEquals(emptyMap(), fetch.records());
+        assertTrue(fetch.positionAdvanced());
+
+        // The next offset should point to the next batch
+        assertEquals(lastOffset + 1, subscriptions.position(tp0).offset);
+    }
+
+    @Test
+    public void testReadCommittedWithCompactedTopic() {
+        buildFetcher(OffsetResetStrategy.EARLIEST, new StringDeserializer(),
+                new StringDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_COMMITTED);
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+
+        long pid1 = 1L;
+        long pid2 = 2L;
+        long pid3 = 3L;
+
+        appendTransactionalRecords(buffer, pid3, 3L,
+                new SimpleRecord("3".getBytes(), "value".getBytes()),
+                new SimpleRecord("4".getBytes(), "value".getBytes()));
+
+        appendTransactionalRecords(buffer, pid2, 15L,
+                new SimpleRecord("15".getBytes(), "value".getBytes()),
+                new SimpleRecord("16".getBytes(), "value".getBytes()),
+                new SimpleRecord("17".getBytes(), "value".getBytes()));
+
+        appendTransactionalRecords(buffer, pid1, 22L,
+                new SimpleRecord("22".getBytes(), "value".getBytes()),
+                new SimpleRecord("23".getBytes(), "value".getBytes()));
+
+        abortTransaction(buffer, pid2, 28L);
+
+        appendTransactionalRecords(buffer, pid3, 30L,
+                new SimpleRecord("30".getBytes(), "value".getBytes()),
+                new SimpleRecord("31".getBytes(), "value".getBytes()),
+                new SimpleRecord("32".getBytes(), "value".getBytes()));
+
+        commitTransaction(buffer, pid3, 35L);
+
+        appendTransactionalRecords(buffer, pid1, 39L,
+                new SimpleRecord("39".getBytes(), "value".getBytes()),
+                new SimpleRecord("40".getBytes(), "value".getBytes()));
+
+        // transaction from pid1 is aborted, but the marker is not included in the fetch
+
+        buffer.flip();
+
+        // send the fetch
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+        assertEquals(1, sendFetches());
+
+        // prepare the response. the aborted transactions begin at offsets which are no longer in the log
+        List<FetchResponseData.AbortedTransaction> abortedTransactions = Arrays.asList(
+                new FetchResponseData.AbortedTransaction().setProducerId(pid2).setFirstOffset(6),
+                new FetchResponseData.AbortedTransaction().setProducerId(pid1).setFirstOffset(0)
+        );
+
+        client.prepareResponse(fullFetchResponseWithAbortedTransactions(MemoryRecords.readableRecords(buffer),
+                abortedTransactions, Errors.NONE, 100L, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<String, String>>> allFetchedRecords = fetchedRecords();
+        assertTrue(allFetchedRecords.containsKey(tp0));
+        List<ConsumerRecord<String, String>> fetchedRecords = allFetchedRecords.get(tp0);
+        assertEquals(5, fetchedRecords.size());
+        assertEquals(Arrays.asList(3L, 4L, 30L, 31L, 32L), collectRecordOffsets(fetchedRecords));
+    }
+
+    @Test
+    public void testReturnAbortedTransactionsinUncommittedMode() {
+        buildFetcher(OffsetResetStrategy.EARLIEST, new ByteArrayDeserializer(),
+                new ByteArrayDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_UNCOMMITTED);
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        int currentOffset = 0;
+
+        currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
+                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()),
+                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()));
+
+        abortTransaction(buffer, 1L, currentOffset);
+
+        buffer.flip();
+
+        List<FetchResponseData.AbortedTransaction> abortedTransactions = Collections.singletonList(
+                new FetchResponseData.AbortedTransaction().setProducerId(1).setFirstOffset(0));
+        MemoryRecords records = MemoryRecords.readableRecords(buffer);
+        assignFromUser(singleton(tp0));
+
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponseWithAbortedTransactions(records, abortedTransactions, Errors.NONE, 100L, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
+        assertTrue(fetchedRecords.containsKey(tp0));
+    }
+
+    @Test
+    public void testConsumerPositionUpdatedWhenSkippingAbortedTransactions() {
+        buildFetcher(OffsetResetStrategy.EARLIEST, new ByteArrayDeserializer(),
+                new ByteArrayDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_COMMITTED);
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        long currentOffset = 0;
+
+        currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
+                new SimpleRecord(time.milliseconds(), "abort1-1".getBytes(), "value".getBytes()),
+                new SimpleRecord(time.milliseconds(), "abort1-2".getBytes(), "value".getBytes()));
+
+        currentOffset += abortTransaction(buffer, 1L, currentOffset);
+        buffer.flip();
+
+        List<FetchResponseData.AbortedTransaction> abortedTransactions = Collections.singletonList(
+                new FetchResponseData.AbortedTransaction().setProducerId(1).setFirstOffset(0));
+        MemoryRecords records = MemoryRecords.readableRecords(buffer);
+        assignFromUser(singleton(tp0));
+
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponseWithAbortedTransactions(records, abortedTransactions, Errors.NONE, 100L, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
+
+        // Ensure that we don't return any of the aborted records, but yet advance the consumer position.
+        assertFalse(fetchedRecords.containsKey(tp0));
+        assertEquals(currentOffset, subscriptions.position(tp0).offset);
+    }
+
+    @Test
+    public void testConsumingViaIncrementalFetchRequests() {
+        buildFetcher(2);
+
+        List<ConsumerRecord<byte[], byte[]>> records;
+        assignFromUser(new HashSet<>(Arrays.asList(tp0, tp1)));
+        subscriptions.seekValidated(tp0, new SubscriptionState.FetchPosition(0, Optional.empty(), metadata.currentLeader(tp0)));
+        subscriptions.seekValidated(tp1, new SubscriptionState.FetchPosition(1, Optional.empty(), metadata.currentLeader(tp1)));
+
+        // Fetch some records and establish an incremental fetch session.
+        LinkedHashMap<TopicIdPartition, FetchResponseData.PartitionData> partitions1 = new LinkedHashMap<>();
+        partitions1.put(tidp0, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp0.partition())
+                .setHighWatermark(2)
+                .setLastStableOffset(2)
+                .setLogStartOffset(0)
+                .setRecords(this.records));
+        partitions1.put(tidp1, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp1.partition())
+                .setHighWatermark(100)
+                .setLogStartOffset(0)
+                .setRecords(emptyRecords));
+        FetchResponse resp1 = FetchResponse.of(Errors.NONE, 0, 123, partitions1);
+        client.prepareResponse(resp1);
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
+        assertFalse(fetchedRecords.containsKey(tp1));
+        records = fetchedRecords.get(tp0);
+        assertEquals(2, records.size());
+        assertEquals(3L, subscriptions.position(tp0).offset);
+        assertEquals(1L, subscriptions.position(tp1).offset);
+        assertEquals(1, records.get(0).offset());
+        assertEquals(2, records.get(1).offset());
+
+        // There is still a buffered record.
+        assertEquals(0, sendFetches());
+        fetchedRecords = fetchedRecords();
+        assertFalse(fetchedRecords.containsKey(tp1));
+        records = fetchedRecords.get(tp0);
+        assertEquals(1, records.size());
+        assertEquals(3, records.get(0).offset());
+        assertEquals(4L, subscriptions.position(tp0).offset);
+
+        // The second response contains no new records.
+        LinkedHashMap<TopicIdPartition, FetchResponseData.PartitionData> partitions2 = new LinkedHashMap<>();
+        FetchResponse resp2 = FetchResponse.of(Errors.NONE, 0, 123, partitions2);
+        client.prepareResponse(resp2);
+        assertEquals(1, sendFetches());
+        consumerClient.poll(time.timer(0));
+        fetchedRecords = fetchedRecords();
+        assertTrue(fetchedRecords.isEmpty());
+        assertEquals(4L, subscriptions.position(tp0).offset);
+        assertEquals(1L, subscriptions.position(tp1).offset);
+
+        // The third response contains some new records for tp0.
+        LinkedHashMap<TopicIdPartition, FetchResponseData.PartitionData> partitions3 = new LinkedHashMap<>();
+        partitions3.put(tidp0, new FetchResponseData.PartitionData()
+                .setPartitionIndex(tp0.partition())
+                .setHighWatermark(100)
+                .setLastStableOffset(4)
+                .setLogStartOffset(0)
+                .setRecords(this.nextRecords));
+        FetchResponse resp3 = FetchResponse.of(Errors.NONE, 0, 123, partitions3);
+        client.prepareResponse(resp3);
+        assertEquals(1, sendFetches());
+        consumerClient.poll(time.timer(0));
+        fetchedRecords = fetchedRecords();
+        assertFalse(fetchedRecords.containsKey(tp1));
+        records = fetchedRecords.get(tp0);
+        assertEquals(2, records.size());
+        assertEquals(6L, subscriptions.position(tp0).offset);
+        assertEquals(1L, subscriptions.position(tp1).offset);
+        assertEquals(4, records.get(0).offset());
+        assertEquals(5, records.get(1).offset());
+    }
+
+    @Test
+    public void testEmptyControlBatch() {
+        buildFetcher(OffsetResetStrategy.EARLIEST, new ByteArrayDeserializer(),
+                new ByteArrayDeserializer(), Integer.MAX_VALUE, IsolationLevel.READ_COMMITTED);
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        int currentOffset = 1;
+
+        // Empty control batch should not cause an exception
+        DefaultRecordBatch.writeEmptyHeader(buffer, RecordBatch.MAGIC_VALUE_V2, 1L,
+                (short) 0, -1, 0, 0,
+                RecordBatch.NO_PARTITION_LEADER_EPOCH, TimestampType.CREATE_TIME, time.milliseconds(),
+                true, true);
+
+        currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
+                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()),
+                new SimpleRecord(time.milliseconds(), "key".getBytes(), "value".getBytes()));
+
+        commitTransaction(buffer, 1L, currentOffset);
+        buffer.flip();
+
+        MemoryRecords records = MemoryRecords.readableRecords(buffer);
+        assignFromUser(singleton(tp0));
+
+        subscriptions.seek(tp0, 0);
+
+        // normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+        client.prepareResponse(body -> {
+            FetchRequest request = (FetchRequest) body;
+            assertEquals(IsolationLevel.READ_COMMITTED, request.isolationLevel());
+            return true;
+        }, fullFetchResponseWithAbortedTransactions(records, Collections.emptyList(), Errors.NONE, 100L, 100L, 0));
+
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
+        assertTrue(fetchedRecords.containsKey(tp0));
+        assertEquals(fetchedRecords.get(tp0).size(), 2);
+    }
+
+    private MemoryRecords buildRecords(long baseOffset, int count, long firstMessageId) {
+        MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE, TimestampType.CREATE_TIME, baseOffset);
+        for (int i = 0; i < count; i++)
+            builder.append(0L, "key".getBytes(), ("value-" + (firstMessageId + i)).getBytes());
+        return builder.build();
+    }
+
+    private int appendTransactionalRecords(ByteBuffer buffer, long pid, long baseOffset, int baseSequence, SimpleRecord... records) {
+        MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE,
+                TimestampType.CREATE_TIME, baseOffset, time.milliseconds(), pid, (short) 0, baseSequence, true,
+                RecordBatch.NO_PARTITION_LEADER_EPOCH);
+
+        for (SimpleRecord record : records) {
+            builder.append(record);
+        }
+        builder.build();
+        return records.length;
+    }
+
+    private int appendTransactionalRecords(ByteBuffer buffer, long pid, long baseOffset, SimpleRecord... records) {
+        return appendTransactionalRecords(buffer, pid, baseOffset, (int) baseOffset, records);
+    }
+
+    private void commitTransaction(ByteBuffer buffer, long producerId, long baseOffset) {
+        short producerEpoch = 0;
+        int partitionLeaderEpoch = 0;
+        MemoryRecords.writeEndTransactionalMarker(buffer, baseOffset, time.milliseconds(), partitionLeaderEpoch, producerId, producerEpoch,
+                new EndTransactionMarker(ControlRecordType.COMMIT, 0));
+    }
+
+    private int abortTransaction(ByteBuffer buffer, long producerId, long baseOffset) {
+        short producerEpoch = 0;
+        int partitionLeaderEpoch = 0;
+        MemoryRecords.writeEndTransactionalMarker(buffer, baseOffset, time.milliseconds(), partitionLeaderEpoch, producerId, producerEpoch,
+                new EndTransactionMarker(ControlRecordType.ABORT, 0));
+        return 1;
+    }
+
+    @Test
+    public void testSubscriptionPositionUpdatedWithEpoch() {
+        // Create some records that include a leader epoch (1)
+        MemoryRecordsBuilder builder = MemoryRecords.builder(
+                ByteBuffer.allocate(1024),
+                RecordBatch.CURRENT_MAGIC_VALUE,
+                CompressionType.NONE,
+                TimestampType.CREATE_TIME,
+                0L,
+                RecordBatch.NO_TIMESTAMP,
+                RecordBatch.NO_PRODUCER_ID,
+                RecordBatch.NO_PRODUCER_EPOCH,
+                RecordBatch.NO_SEQUENCE,
+                false,
+                1
+        );
+        builder.appendWithOffset(0L, 0L, "key".getBytes(), "value-1".getBytes());
+        builder.appendWithOffset(1L, 0L, "key".getBytes(), "value-2".getBytes());
+        builder.appendWithOffset(2L, 0L, "key".getBytes(), "value-3".getBytes());
+        MemoryRecords records = builder.build();
+
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+
+        // Initialize the epoch=1
+        Map<String, Integer> partitionCounts = new HashMap<>();
+        partitionCounts.put(tp0.topic(), 4);
+        MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWithIds("dummy", 1, Collections.emptyMap(), partitionCounts, tp -> 1, topicIds);
+        metadata.updateWithCurrentRequestVersion(metadataResponse, false, 0L);
+
+        // Seek
+        subscriptions.seek(tp0, 0);
+
+        // Do a normal fetch
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tidp0, records, Errors.NONE, 100L, 0));
+        consumerClient.pollNoWakeup();
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionRecords = fetchedRecords();
+        assertTrue(partitionRecords.containsKey(tp0));
+
+        assertEquals(subscriptions.position(tp0).offset, 3L);
+        assertOptional(subscriptions.position(tp0).offsetEpoch, value -> assertEquals(value.intValue(), 1));
+    }
+
+    @Test
+    public void testPreferredReadReplica() {
+        buildFetcher(new MetricConfig(), OffsetResetStrategy.EARLIEST, new BytesDeserializer(), new BytesDeserializer(),
+                Integer.MAX_VALUE, IsolationLevel.READ_COMMITTED, Duration.ofMinutes(5).toMillis());
+
+        subscriptions.assignFromUser(singleton(tp0));
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(2, singletonMap(topicName, 4), tp -> validLeaderEpoch, topicIds, false));
+        subscriptions.seek(tp0, 0);
+
+        // Node preferred replica before first fetch response
+        Node selected = fetcher.selectReadReplica(tp0, Node.noNode(), time.milliseconds());
+        assertEquals(-1, selected.id());
+
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        // Set preferred read replica to node=1
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L,
+                FetchResponse.INVALID_LAST_STABLE_OFFSET, 0, Optional.of(1)));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionRecords = fetchedRecords();
+        assertTrue(partitionRecords.containsKey(tp0));
+
+        // Verify
+        selected = fetcher.selectReadReplica(tp0, Node.noNode(), time.milliseconds());
+        assertEquals(1, selected.id());
+
+
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        // Set preferred read replica to node=2, which isn't in our metadata, should revert to leader
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L,
+                FetchResponse.INVALID_LAST_STABLE_OFFSET, 0, Optional.of(2)));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        fetchedRecords();
+        selected = fetcher.selectReadReplica(tp0, Node.noNode(), time.milliseconds());
+        assertEquals(-1, selected.id());
+    }
+
+    @Test
+    public void testFetchDisconnectedShouldClearPreferredReadReplica() {
+        buildFetcher(new MetricConfig(), OffsetResetStrategy.EARLIEST, new BytesDeserializer(), new BytesDeserializer(),
+                Integer.MAX_VALUE, IsolationLevel.READ_COMMITTED, Duration.ofMinutes(5).toMillis());
+
+        subscriptions.assignFromUser(singleton(tp0));
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(2, singletonMap(topicName, 4), tp -> validLeaderEpoch, topicIds, false));
+        subscriptions.seek(tp0, 0);
+        assertEquals(1, sendFetches());
+
+        // Set preferred read replica to node=1
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L,
+                FetchResponse.INVALID_LAST_STABLE_OFFSET, 0, Optional.of(1)));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        fetchedRecords();
+
+        // Verify
+        Node selected = fetcher.selectReadReplica(tp0, Node.noNode(), time.milliseconds());
+        assertEquals(1, selected.id());
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        // Disconnect - preferred read replica should be cleared.
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0), true);
+
+        consumerClient.poll(time.timer(0));
+        assertFalse(fetcher.hasCompletedFetches());
+        fetchedRecords();
+        selected = fetcher.selectReadReplica(tp0, Node.noNode(), time.milliseconds());
+        assertEquals(-1, selected.id());
+    }
+
+    @Test
+    public void testFetchDisconnectedShouldNotClearPreferredReadReplicaIfUnassigned() {
+        buildFetcher(new MetricConfig(), OffsetResetStrategy.EARLIEST, new BytesDeserializer(), new BytesDeserializer(),
+                Integer.MAX_VALUE, IsolationLevel.READ_COMMITTED, Duration.ofMinutes(5).toMillis());
+
+        subscriptions.assignFromUser(singleton(tp0));
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(2, singletonMap(topicName, 4), tp -> validLeaderEpoch, topicIds, false));
+        subscriptions.seek(tp0, 0);
+        assertEquals(1, sendFetches());
+
+        // Set preferred read replica to node=1
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L,
+                FetchResponse.INVALID_LAST_STABLE_OFFSET, 0, Optional.of(1)));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        fetchedRecords();
+
+        // Verify
+        Node selected = fetcher.selectReadReplica(tp0, Node.noNode(), time.milliseconds());
+        assertEquals(1, selected.id());
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        // Disconnect and remove tp0 from assignment
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L, 0), true);
+        subscriptions.assignFromUser(emptySet());
+
+        // Preferred read replica should not be cleared
+        consumerClient.poll(time.timer(0));
+        assertFalse(fetcher.hasCompletedFetches());
+        fetchedRecords();
+        selected = fetcher.selectReadReplica(tp0, Node.noNode(), time.milliseconds());
+        assertEquals(-1, selected.id());
+    }
+
+    @Test
+    public void testFetchErrorShouldClearPreferredReadReplica() {
+        buildFetcher(new MetricConfig(), OffsetResetStrategy.EARLIEST, new BytesDeserializer(), new BytesDeserializer(),
+                Integer.MAX_VALUE, IsolationLevel.READ_COMMITTED, Duration.ofMinutes(5).toMillis());
+
+        subscriptions.assignFromUser(singleton(tp0));
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(2, singletonMap(topicName, 4), tp -> validLeaderEpoch, topicIds, false));
+        subscriptions.seek(tp0, 0);
+        assertEquals(1, sendFetches());
+
+        // Set preferred read replica to node=1
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L,
+                FetchResponse.INVALID_LAST_STABLE_OFFSET, 0, Optional.of(1)));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        fetchedRecords();
+
+        // Verify
+        Node selected = fetcher.selectReadReplica(tp0, Node.noNode(), time.milliseconds());
+        assertEquals(1, selected.id());
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        // Error - preferred read replica should be cleared. An actual error response will contain -1 as the
+        // preferred read replica. In the test we want to ensure that we are handling the error.
+        client.prepareResponse(fullFetchResponse(tidp0, MemoryRecords.EMPTY, Errors.NOT_LEADER_OR_FOLLOWER, -1L,
+                FetchResponse.INVALID_LAST_STABLE_OFFSET, 0, Optional.of(1)));
+
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+        fetchedRecords();
+        selected = fetcher.selectReadReplica(tp0, Node.noNode(), time.milliseconds());
+        assertEquals(-1, selected.id());
+    }
+
+    @Test
+    public void testPreferredReadReplicaOffsetError() {
+        buildFetcher(new MetricConfig(), OffsetResetStrategy.EARLIEST, new BytesDeserializer(), new BytesDeserializer(),
+                Integer.MAX_VALUE, IsolationLevel.READ_COMMITTED, Duration.ofMinutes(5).toMillis());
+
+        subscriptions.assignFromUser(singleton(tp0));
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(2, singletonMap(topicName, 4), tp -> validLeaderEpoch, topicIds, false));
+
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.NONE, 100L,
+                FetchResponse.INVALID_LAST_STABLE_OFFSET, 0, Optional.of(1)));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        fetchedRecords();
+
+        Node selected = fetcher.selectReadReplica(tp0, Node.noNode(), time.milliseconds());
+        assertEquals(selected.id(), 1);
+
+        // Return an error, should unset the preferred read replica
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tidp0, this.records, Errors.OFFSET_OUT_OF_RANGE, 100L,
+                FetchResponse.INVALID_LAST_STABLE_OFFSET, 0, Optional.empty()));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        fetchedRecords();
+
+        selected = fetcher.selectReadReplica(tp0, Node.noNode(), time.milliseconds());
+        assertEquals(selected.id(), -1);
+    }
+
+    @Test
+    public void testFetchCompletedBeforeHandlerAdded() {
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+        sendFetches();
+        client.prepareResponse(fullFetchResponse(tidp0, buildRecords(1L, 1, 1), Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        fetchedRecords();
+
+        Metadata.LeaderAndEpoch leaderAndEpoch = subscriptions.position(tp0).currentLeader;
+        assertTrue(leaderAndEpoch.leader.isPresent());
+        Node readReplica = fetcher.selectReadReplica(tp0, leaderAndEpoch.leader.get(), time.milliseconds());
+
+        AtomicBoolean wokenUp = new AtomicBoolean(false);
+        client.setWakeupHook(() -> {
+            if (!wokenUp.getAndSet(true)) {
+                consumerClient.disconnectAsync(readReplica);
+                consumerClient.poll(time.timer(0));
+            }
+        });
+
+        assertEquals(1, sendFetches());
+
+        consumerClient.disconnectAsync(readReplica);
+        consumerClient.poll(time.timer(0));
+
+        assertEquals(1, sendFetches());
+    }
+
+    @Test
+    public void testCorruptMessageError() {
+        buildFetcher();
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        // Prepare a response with the CORRUPT_MESSAGE error.
+        client.prepareResponse(fullFetchResponse(
+                tidp0,
+                buildRecords(1L, 1, 1),
+                Errors.CORRUPT_MESSAGE,
+                100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        // Trigger the exception.
+        assertThrows(KafkaException.class, this::fetchedRecords);
+    }
+
+    private OffsetsForLeaderEpochResponse prepareOffsetsForLeaderEpochResponse(
+            TopicPartition topicPartition,
+            Errors error,
+            int leaderEpoch,
+            long endOffset
+    ) {
+        OffsetForLeaderEpochResponseData data = new OffsetForLeaderEpochResponseData();
+        data.topics().add(new OffsetForLeaderTopicResult()
+                .setTopic(topicPartition.topic())
+                .setPartitions(Collections.singletonList(new EpochEndOffset()
+                        .setPartition(topicPartition.partition())
+                        .setErrorCode(error.code())
+                        .setLeaderEpoch(leaderEpoch)
+                        .setEndOffset(endOffset))));
+        return new OffsetsForLeaderEpochResponse(data);
+    }
+
+    private FetchResponse fetchResponseWithTopLevelError(TopicIdPartition tp, Errors error, int throttleTime) {
+        Map<TopicIdPartition, FetchResponseData.PartitionData> partitions = Collections.singletonMap(tp,
+                new FetchResponseData.PartitionData()
+                        .setPartitionIndex(tp.topicPartition().partition())
+                        .setErrorCode(error.code())
+                        .setHighWatermark(FetchResponse.INVALID_HIGH_WATERMARK));
+        return FetchResponse.of(error, throttleTime, INVALID_SESSION_ID, new LinkedHashMap<>(partitions));
+    }
+
+    private FetchResponse fullFetchResponseWithAbortedTransactions(MemoryRecords records,
+                                                                   List<FetchResponseData.AbortedTransaction> abortedTransactions,
+                                                                   Errors error,
+                                                                   long lastStableOffset,
+                                                                   long hw,
+                                                                   int throttleTime) {
+        Map<TopicIdPartition, FetchResponseData.PartitionData> partitions = Collections.singletonMap(tidp0,
+                new FetchResponseData.PartitionData()
+                        .setPartitionIndex(tp0.partition())
+                        .setErrorCode(error.code())
+                        .setHighWatermark(hw)
+                        .setLastStableOffset(lastStableOffset)
+                        .setLogStartOffset(0)
+                        .setAbortedTransactions(abortedTransactions)
+                        .setRecords(records));
+        return FetchResponse.of(Errors.NONE, throttleTime, INVALID_SESSION_ID, new LinkedHashMap<>(partitions));
+    }
+
+    private FetchResponse fullFetchResponse(int sessionId, TopicIdPartition tp, MemoryRecords records, Errors error, long hw, int throttleTime) {
+        return fullFetchResponse(sessionId, tp, records, error, hw, FetchResponse.INVALID_LAST_STABLE_OFFSET, throttleTime);
+    }
+
+    private FetchResponse fullFetchResponse(TopicIdPartition tp, MemoryRecords records, Errors error, long hw, int throttleTime) {
+        return fullFetchResponse(tp, records, error, hw, FetchResponse.INVALID_LAST_STABLE_OFFSET, throttleTime);
+    }
+
+    private FetchResponse fullFetchResponse(TopicIdPartition tp, MemoryRecords records, Errors error, long hw,
+                                            long lastStableOffset, int throttleTime) {
+        return fullFetchResponse(INVALID_SESSION_ID, tp, records, error, hw, lastStableOffset, throttleTime);
+    }
+
+    private FetchResponse fullFetchResponse(int sessionId, TopicIdPartition tp, MemoryRecords records, Errors error, long hw,
+                                            long lastStableOffset, int throttleTime) {
+        Map<TopicIdPartition, FetchResponseData.PartitionData> partitions = Collections.singletonMap(tp,
+                new FetchResponseData.PartitionData()
+                        .setPartitionIndex(tp.topicPartition().partition())
+                        .setErrorCode(error.code())
+                        .setHighWatermark(hw)
+                        .setLastStableOffset(lastStableOffset)
+                        .setLogStartOffset(0)
+                        .setRecords(records));
+        return FetchResponse.of(Errors.NONE, throttleTime, sessionId, new LinkedHashMap<>(partitions));
+    }
+
+    private FetchResponse fullFetchResponse(TopicIdPartition tp, MemoryRecords records, Errors error, long hw,
+                                            long lastStableOffset, int throttleTime, Optional<Integer> preferredReplicaId) {
+        Map<TopicIdPartition, FetchResponseData.PartitionData> partitions = Collections.singletonMap(tp,
+                new FetchResponseData.PartitionData()
+                        .setPartitionIndex(tp.topicPartition().partition())
+                        .setErrorCode(error.code())
+                        .setHighWatermark(hw)
+                        .setLastStableOffset(lastStableOffset)
+                        .setLogStartOffset(0)
+                        .setRecords(records)
+                        .setPreferredReadReplica(preferredReplicaId.orElse(FetchResponse.INVALID_PREFERRED_REPLICA_ID)));
+        return FetchResponse.of(Errors.NONE, throttleTime, INVALID_SESSION_ID, new LinkedHashMap<>(partitions));
+    }
+
+    private FetchResponse fetchResponse(TopicIdPartition tp, MemoryRecords records, Errors error, long hw,
+                                        long lastStableOffset, long logStartOffset, int throttleTime) {
+        Map<TopicIdPartition, FetchResponseData.PartitionData> partitions = Collections.singletonMap(tp,
+                new FetchResponseData.PartitionData()
+                        .setPartitionIndex(tp.topicPartition().partition())
+                        .setErrorCode(error.code())
+                        .setHighWatermark(hw)
+                        .setLastStableOffset(lastStableOffset)
+                        .setLogStartOffset(logStartOffset)
+                        .setRecords(records));
+        return FetchResponse.of(Errors.NONE, throttleTime, INVALID_SESSION_ID, new LinkedHashMap<>(partitions));
+    }
+
+    /**
+     * Assert that the {@link Fetcher#collectFetch() latest fetch} does not contain any
+     * {@link Fetch#records() user-visible records}, did not
+     * {@link Fetch#positionAdvanced() advance the consumer's position},
+     * and is {@link Fetch#isEmpty() empty}.
+     * @param reason the reason to include for assertion methods such as {@link org.junit.jupiter.api.Assertions#assertTrue(boolean, String)}
+     */
+    private void assertEmptyFetch(String reason) {
+        Fetch<?, ?> fetch = collectFetch();
+        assertEquals(Collections.emptyMap(), fetch.records(), reason);
+        assertFalse(fetch.positionAdvanced(), reason);
+        assertTrue(fetch.isEmpty(), reason);
+    }
+
+    private <K, V> Map<TopicPartition, List<ConsumerRecord<K, V>>> fetchedRecords() {
+        Fetch<K, V> fetch = collectFetch();
+        return fetch.records();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <K, V> Fetch<K, V> collectFetch() {
+        return (Fetch) fetcher.collectFetch();
+    }
+
+    private void buildFetcher(int maxPollRecords) {
+        buildFetcher(OffsetResetStrategy.EARLIEST, new ByteArrayDeserializer(), new ByteArrayDeserializer(),
+                maxPollRecords, IsolationLevel.READ_UNCOMMITTED);
+    }
+
+    private void buildFetcher() {
+        buildFetcher(Integer.MAX_VALUE);
+    }
+
+    private void buildFetcher(Deserializer<?> keyDeserializer,
+                              Deserializer<?> valueDeserializer) {
+        buildFetcher(OffsetResetStrategy.EARLIEST, keyDeserializer, valueDeserializer,
+                Integer.MAX_VALUE, IsolationLevel.READ_UNCOMMITTED);
+    }
+
+    private <K, V> void buildFetcher(OffsetResetStrategy offsetResetStrategy,
+                                     Deserializer<K> keyDeserializer,
+                                     Deserializer<V> valueDeserializer,
+                                     int maxPollRecords,
+                                     IsolationLevel isolationLevel) {
+        buildFetcher(new MetricConfig(), offsetResetStrategy, keyDeserializer, valueDeserializer,
+                maxPollRecords, isolationLevel);
+    }
+
+    private <K, V> void buildFetcher(MetricConfig metricConfig,
+                                     OffsetResetStrategy offsetResetStrategy,
+                                     Deserializer<K> keyDeserializer,
+                                     Deserializer<V> valueDeserializer,
+                                     int maxPollRecords,
+                                     IsolationLevel isolationLevel) {
+        buildFetcher(metricConfig, offsetResetStrategy, keyDeserializer, valueDeserializer, maxPollRecords, isolationLevel, Long.MAX_VALUE);
+    }
+
+    private <K, V> void buildFetcher(MetricConfig metricConfig,
+                                     OffsetResetStrategy offsetResetStrategy,
+                                     Deserializer<K> keyDeserializer,
+                                     Deserializer<V> valueDeserializer,
+                                     int maxPollRecords,
+                                     IsolationLevel isolationLevel,
+                                     long metadataExpireMs) {
+        LogContext logContext = new LogContext();
+        SubscriptionState subscriptionState = new SubscriptionState(logContext, offsetResetStrategy);
+        buildFetcher(metricConfig, keyDeserializer, valueDeserializer, maxPollRecords, isolationLevel, metadataExpireMs,
+                subscriptionState, logContext);
+    }
+
+    private <K, V> void buildFetcher(MetricConfig metricConfig,
+                                     Deserializer<K> keyDeserializer,
+                                     Deserializer<V> valueDeserializer,
+                                     int maxPollRecords,
+                                     IsolationLevel isolationLevel,
+                                     long metadataExpireMs,
+                                     SubscriptionState subscriptionState,
+                                     LogContext logContext) {
+        buildDependencies(metricConfig, metadataExpireMs, subscriptionState, logContext);
+        FetchConfig<K, V> fetchConfig = new FetchConfig<>(
+                minBytes,
+                maxBytes,
+                maxWaitMs,
+                fetchSize,
+                maxPollRecords,
+                true, // check crc
+                CommonClientConfigs.DEFAULT_CLIENT_RACK,
+                new Deserializers<>(keyDeserializer, valueDeserializer),
+                isolationLevel);
+        FetchCollector<K, V> fetchCollector = new FetchCollector<>(logContext,
+                metadata,
+                subscriptions,
+                fetchConfig,
+                metricsManager,
+                time);
+        fetcher = spy(new TestableFetchRequestManager<>(
+                logContext,
+                time,
+                new ErrorEventHandler(new LinkedBlockingQueue<>()),
+                metadata,
+                subscriptionState,
+                fetchConfig,
+                metricsManager,
+                consumerClient,
+                fetchCollector));
+        offsetFetcher = new OffsetFetcher(logContext,
+                oldConsumerClient,
+                metadata,
+                subscriptions,
+                time,
+                retryBackoffMs,
+                requestTimeoutMs,
+                isolationLevel,
+                apiVersions);
+    }
+
+    private void buildDependencies(MetricConfig metricConfig,
+                                   long metadataExpireMs,
+                                   SubscriptionState subscriptionState,
+                                   LogContext logContext) {
+        time = new MockTime(1, 0, 0);
+        subscriptions = subscriptionState;
+        metadata = new ConsumerMetadata(0, 0, metadataExpireMs, false, false,
+                subscriptions, logContext, new ClusterResourceListeners());
+        client = new MockClient(time, metadata);
+        metrics = new Metrics(metricConfig, time);
+        oldConsumerClient = spy(new ConsumerNetworkClient(logContext, client, metadata, time,
+                retryBackoffMs, (int) requestTimeoutMs, Integer.MAX_VALUE));
+        metricsRegistry = new FetchMetricsRegistry(metricConfig.tags().keySet(), "consumer" + groupId);
+        metricsManager = new FetchMetricsManager(metrics, metricsRegistry);
+
+        Properties properties = new Properties();
+        properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.setProperty(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, String.valueOf(requestTimeoutMs));
+        properties.setProperty(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, String.valueOf(retryBackoffMs));
+        ConsumerConfig config = new ConsumerConfig(properties);
+        consumerClient = spy(new TestableNetworkClientDelegate(time, config, logContext, client));
+    }
+
+    private <T> List<Long> collectRecordOffsets(List<ConsumerRecord<T, T>> records) {
+        return records.stream().map(ConsumerRecord::offset).collect(Collectors.toList());
+    }
+
+    private class TestableFetchRequestManager<K, V> extends FetchRequestManager<K, V> {
+
+        private final FetchCollector<K, V> fetchCollector;
+
+        public TestableFetchRequestManager(LogContext logContext,
+                                           Time time,
+                                           ErrorEventHandler errorEventHandler,
+                                           ConsumerMetadata metadata,
+                                           SubscriptionState subscriptions,
+                                           FetchConfig<K, V> fetchConfig,
+                                           FetchMetricsManager metricsManager,
+                                           NetworkClientDelegate networkClientDelegate,
+                                           FetchCollector<K, V> fetchCollector) {
+            super(logContext, time, errorEventHandler, metadata, subscriptions, fetchConfig, metricsManager, networkClientDelegate);
+            this.fetchCollector = fetchCollector;
+        }
+
+        private Fetch<K, V> collectFetch() {
+            return fetchCollector.collectFetch(fetchBuffer);
+        }
+
+        private int sendFetches() {
+            NetworkClientDelegate.PollResult pollResult = fetcher.poll(time.milliseconds());
+            consumerClient.addAll(pollResult.unsentRequests);
+            return pollResult.unsentRequests.size();
+        }
+
+        private void clearBufferedDataForUnassignedPartitions(Set<TopicPartition> partitions) {
+            fetchBuffer.retainAll(partitions);
+        }
+    }
+
+    private class TestableNetworkClientDelegate extends NetworkClientDelegate {
+
+        private final Logger log = LoggerFactory.getLogger(NetworkClientDelegate.class);
+        private final ConcurrentLinkedQueue<Node> pendingDisconnects = new ConcurrentLinkedQueue<>();
+
+        public TestableNetworkClientDelegate(Time time,
+                                             ConsumerConfig config,
+                                             LogContext logContext,
+                                             KafkaClient client) {
+            super(time, config, logContext, client);
+        }
+
+        @Override
+        public void poll(final long timeoutMs, final long currentTimeMs) {
+            handlePendingDisconnects();
+            super.poll(timeoutMs, currentTimeMs);
+        }
+
+        public void pollNoWakeup() {
+            poll(time.timer(0));
+        }
+
+        public int pendingRequestCount() {
+            return unsentRequests().size() + client.inFlightRequestCount();
+        }
+
+        public void poll(final Timer timer) {
+            long pollTimeout = Math.min(timer.remainingMs(), requestTimeoutMs);
+            if (client.inFlightRequestCount() == 0)
+                pollTimeout = Math.min(pollTimeout, retryBackoffMs);
+            poll(pollTimeout, timer.currentTimeMs());
+        }
+
+        private Set<Node> unsentRequestNodes() {
+            Set<Node> set = new HashSet<>();
+
+            for (UnsentRequest u : unsentRequests())
+                u.node().ifPresent(set::add);
+
+            return set;
+        }
+
+        private List<UnsentRequest> removeUnsentRequestByNode(Node node) {
+            List<UnsentRequest> list = new ArrayList<>();
+
+            Iterator<UnsentRequest> iter = unsentRequests().iterator();
+
+            while (iter.hasNext()) {
+                UnsentRequest u = iter.next();
+
+                if (node.equals(u.node().orElse(null))) {
+                    iter.remove();
+                    list.add(u);
+                }
+            }
+
+            return list;
+        }
+
+        @Override
+        protected void checkDisconnects() {
+            // any disconnects affecting requests that have already been transmitted will be handled
+            // by NetworkClient, so we just need to check whether connections for any of the unsent
+            // requests have been disconnected; if they have, then we complete the corresponding future
+            // and set the disconnect flag in the ClientResponse
+            for (Node node : unsentRequestNodes()) {
+                if (client.connectionFailed(node)) {
+                    // Remove entry before invoking request callback to avoid callbacks handling
+                    // coordinator failures traversing the unsent list again.
+                    for (UnsentRequest unsentRequest : removeUnsentRequestByNode(node)) {
+                        // TODO: this should likely emulate what's done in ConsumerNetworkClient
+                        log.error("checkDisconnects - please update! unsentRequest: {}", unsentRequest);
+                    }
+                }
+            }
+        }
+
+        private void handlePendingDisconnects() {
+            while (true) {
+                Node node = pendingDisconnects.poll();
+                if (node == null)
+                    break;
+
+                failUnsentRequests(node, DisconnectException.INSTANCE);
+                client.disconnect(node.idString());
+            }
+        }
+
+        public void disconnectAsync(Node node) {
+            pendingDisconnects.offer(node);
+            client.wakeup();
+        }
+
+        private void failUnsentRequests(Node node, RuntimeException e) {
+            // clear unsent requests to node and fail their corresponding futures
+            for (UnsentRequest unsentRequest : removeUnsentRequestByNode(node)) {
+                FutureCompletionHandler handler = unsentRequest.callback();
+                handler.onFailure(e);
+            }
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherTest.java
@@ -56,7 +56,6 @@ import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochRequest;
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
 import org.apache.kafka.common.requests.RequestTestUtils;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherTest.java
@@ -1246,7 +1246,7 @@ public class OffsetFetcherTest {
         buildFetcher(metricConfig, isolationLevel, metadataExpireMs, subscriptionState, logContext);
 
         FetchMetricsRegistry metricsRegistry = new FetchMetricsRegistry(metricConfig.tags().keySet(), "consumertest-group");
-        FetchConfig<byte[], byte[]> fetchConfig = new FetchConfig<>(
+        FetchConfig fetchConfig = new FetchConfig(
                 minBytes,
                 maxBytes,
                 maxWaitMs,
@@ -1254,7 +1254,6 @@ public class OffsetFetcherTest {
                 maxPollRecords,
                 true, // check crc
                 CommonClientConfigs.DEFAULT_CLIENT_RACK,
-                new Deserializers<>(new ByteArrayDeserializer(), new ByteArrayDeserializer()),
                 isolationLevel);
         Fetcher<byte[], byte[]> fetcher = new Fetcher<>(
                 logContext,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherTest.java
@@ -56,7 +56,6 @@ import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochRequest;
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
 import org.apache.kafka.common.requests.RequestTestUtils;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;
@@ -1246,7 +1245,7 @@ public class OffsetFetcherTest {
         buildFetcher(metricConfig, isolationLevel, metadataExpireMs, subscriptionState, logContext);
 
         FetchMetricsRegistry metricsRegistry = new FetchMetricsRegistry(metricConfig.tags().keySet(), "consumertest-group");
-        FetchConfig<byte[], byte[]> fetchConfig = new FetchConfig<>(
+        FetchConfig fetchConfig = new FetchConfig(
                 minBytes,
                 maxBytes,
                 maxWaitMs,
@@ -1254,7 +1253,6 @@ public class OffsetFetcherTest {
                 maxPollRecords,
                 true, // check crc
                 CommonClientConfigs.DEFAULT_CLIENT_RACK,
-                new Deserializers<>(new ByteArrayDeserializer(), new ByteArrayDeserializer()),
                 isolationLevel);
         Fetcher<byte[], byte[]> fetcher = new Fetcher<>(
                 logContext,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -16,14 +16,11 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.AssignmentChangeApplicationEvent;
-import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.EventHandler;
 import org.apache.kafka.clients.consumer.internals.events.ListOffsetsApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.NewTopicsMetadataUpdateRequestEvent;
@@ -35,12 +32,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.WakeupException;
-import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -57,20 +48,15 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singleton;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -79,56 +65,44 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class PrototypeAsyncConsumerTest {
 
     private PrototypeAsyncConsumer<?, ?> consumer;
-    private final Map<String, Object> consumerProps = new HashMap<>();
+    private static final Optional<String> DEFAULT_GROUP_ID = Optional.of("group.id");
 
-    private final Time time = new MockTime();
-    private LogContext logContext;
-    private SubscriptionState subscriptions;
-    private ConsumerMetadata metadata;
+    private ConsumerTestBuilder.PrototypeAsyncConsumerTestBuilder testBuilder;
     private EventHandler eventHandler;
-    private Metrics metrics;
-
-    private String groupId = "group.id";
-    private ConsumerConfig config;
 
     @BeforeEach
     public void setup() {
-        injectConsumerConfigs();
-        this.config = new ConsumerConfig(consumerProps);
-        this.logContext = new LogContext();
-        this.subscriptions = mock(SubscriptionState.class);
-        this.metadata = mock(ConsumerMetadata.class);
-        final DefaultBackgroundThread bt = mock(DefaultBackgroundThread.class);
-        final BlockingQueue<ApplicationEvent> aq = new LinkedBlockingQueue<>();
-        final BlockingQueue<BackgroundEvent> bq = new LinkedBlockingQueue<>();
-        this.eventHandler = spy(new DefaultEventHandler(bt, aq, bq));
-        this.metrics = new Metrics(time);
+        setup(DEFAULT_GROUP_ID);
     }
 
     @AfterEach
     public void cleanup() {
-        if (consumer != null) {
-            consumer.close(Duration.ZERO);
+        if (testBuilder != null) {
+            testBuilder.close();
         }
+    }
+
+    private void setup(Optional<String> groupIdOpt) {
+        testBuilder = new ConsumerTestBuilder.PrototypeAsyncConsumerTestBuilder(groupIdOpt);
+        eventHandler = testBuilder.eventHandler;
+        consumer = testBuilder.consumer;
     }
 
     @Test
     public void testSuccessfulStartupShutdown() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertDoesNotThrow(() -> consumer.close());
     }
 
     @Test
     public void testInvalidGroupId() {
-        this.groupId = null;
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        cleanup();
+        setup(Optional.empty());
         assertThrows(InvalidGroupIdException.class, () -> consumer.committed(new HashSet<>()));
     }
 
@@ -139,11 +113,10 @@ public class PrototypeAsyncConsumerTest {
         offsets.put(new TopicPartition("my-topic", 0), new OffsetAndMetadata(100L));
         offsets.put(new TopicPartition("my-topic", 1), new OffsetAndMetadata(200L));
 
-        PrototypeAsyncConsumer<?, ?> mockedConsumer = spy(newConsumer(time, new StringDeserializer(), new StringDeserializer()));
-        doReturn(future).when(mockedConsumer).commit(offsets, false);
-        mockedConsumer.commitAsync(offsets, null);
+        doReturn(future).when(consumer).commit(offsets, false);
+        consumer.commitAsync(offsets, null);
         future.complete(null);
-        TestUtils.waitForCondition(() -> future.isDone(),
+        TestUtils.waitForCondition(future::isDone,
                 2000,
                 "commit future should complete");
 
@@ -158,11 +131,9 @@ public class PrototypeAsyncConsumerTest {
         offsets.put(new TopicPartition("my-topic", 0), new OffsetAndMetadata(100L));
         offsets.put(new TopicPartition("my-topic", 1), new OffsetAndMetadata(200L));
 
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
-        PrototypeAsyncConsumer<?, ?> mockedConsumer = spy(consumer);
-        doReturn(future).when(mockedConsumer).commit(offsets, false);
+        doReturn(future).when(consumer).commit(offsets, false);
         OffsetCommitCallback customCallback = mock(OffsetCommitCallback.class);
-        mockedConsumer.commitAsync(offsets, customCallback);
+        consumer.commitAsync(offsets, customCallback);
         future.complete(null);
         verify(customCallback).onComplete(offsets, null);
     }
@@ -174,7 +145,6 @@ public class PrototypeAsyncConsumerTest {
         committedFuture.complete(offsets);
 
         try (MockedConstruction<OffsetFetchApplicationEvent> ignored = offsetFetchEventMocker(committedFuture)) {
-            this.consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
             assertDoesNotThrow(() -> consumer.committed(offsets.keySet(), Duration.ofMillis(1000)));
             verify(eventHandler).add(ArgumentMatchers.isA(OffsetFetchApplicationEvent.class));
         }
@@ -187,7 +157,6 @@ public class PrototypeAsyncConsumerTest {
         committedFuture.completeExceptionally(new KafkaException("Test exception"));
 
         try (MockedConstruction<OffsetFetchApplicationEvent> ignored = offsetFetchEventMocker(committedFuture)) {
-            this.consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
             assertThrows(KafkaException.class, () -> consumer.committed(offsets.keySet(), Duration.ofMillis(1000)));
             verify(eventHandler).add(ArgumentMatchers.isA(OffsetFetchApplicationEvent.class));
         }
@@ -229,8 +198,6 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testAssign() {
-        this.subscriptions = new SubscriptionState(logContext, OffsetResetStrategy.EARLIEST);
-        this.consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         final TopicPartition tp = new TopicPartition("foo", 3);
         consumer.assign(singleton(tp));
         assertTrue(consumer.subscription().isEmpty());
@@ -241,13 +208,11 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testAssignOnNullTopicPartition() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(IllegalArgumentException.class, () -> consumer.assign(null));
     }
 
     @Test
     public void testAssignOnEmptyTopicPartition() {
-        consumer = spy(newConsumer(time, new StringDeserializer(), new StringDeserializer()));
         consumer.assign(Collections.emptyList());
         assertTrue(consumer.subscription().isEmpty());
         assertTrue(consumer.assignment().isEmpty());
@@ -255,26 +220,22 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testAssignOnNullTopicInPartition() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(IllegalArgumentException.class, () -> consumer.assign(singleton(new TopicPartition(null, 0))));
     }
 
     @Test
     public void testAssignOnEmptyTopicInPartition() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(IllegalArgumentException.class, () -> consumer.assign(singleton(new TopicPartition("  ", 0))));
     }
 
     @Test
     public void testBeginningOffsetsFailsIfNullPartitions() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(NullPointerException.class, () -> consumer.beginningOffsets(null,
                 Duration.ofMillis(1)));
     }
 
     @Test
     public void testBeginningOffsets() {
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         Map<TopicPartition, OffsetAndTimestamp> expectedOffsetsAndTimestamp =
                 mockOffsetAndTimestamp();
         Set<TopicPartition> partitions = expectedOffsetsAndTimestamp.keySet();
@@ -283,7 +244,7 @@ public class PrototypeAsyncConsumerTest {
                 assertDoesNotThrow(() -> consumer.beginningOffsets(partitions,
                         Duration.ofMillis(1)));
         Map<TopicPartition, Long> expectedOffsets = expectedOffsetsAndTimestamp.entrySet().stream()
-                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().offset()));
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().offset()));
         assertEquals(expectedOffsets, result);
         verify(eventHandler).addAndGet(ArgumentMatchers.isA(ListOffsetsApplicationEvent.class),
                 ArgumentMatchers.isA(Timer.class));
@@ -291,7 +252,6 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testBeginningOffsetsThrowsKafkaExceptionForUnderlyingExecutionFailure() {
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         Set<TopicPartition> partitions = mockTopicPartitionOffset().keySet();
         Throwable eventProcessingFailure = new KafkaException("Unexpected failure " +
                 "processing List Offsets event");
@@ -305,7 +265,6 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testBeginningOffsetsTimeoutOnEventProcessingTimeout() {
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         doThrow(new TimeoutException()).when(eventHandler).addAndGet(any(), any());
         assertThrows(TimeoutException.class,
                 () -> consumer.beginningOffsets(
@@ -317,14 +276,12 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testOffsetsForTimesOnNullPartitions() {
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(NullPointerException.class, () -> consumer.offsetsForTimes(null,
                 Duration.ofMillis(1)));
     }
 
     @Test
     public void testOffsetsForTimes() {
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         Map<TopicPartition, OffsetAndTimestamp> expectedResult = mockOffsetAndTimestamp();
         Map<TopicPartition, Long> timestampToSearch = mockTimestampToSearch();
 
@@ -341,7 +298,6 @@ public class PrototypeAsyncConsumerTest {
     // OffsetAndTimestamp as value.
     @Test
     public void testOffsetsForTimesWithZeroTimeout() {
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         TopicPartition tp = new TopicPartition("topic1", 0);
         Map<TopicPartition, OffsetAndTimestamp> expectedResult =
                 Collections.singletonMap(tp, null);
@@ -357,8 +313,6 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testWakeup_committed() {
-        consumer = newConsumer(time, new StringDeserializer(),
-            new StringDeserializer());
         consumer.wakeup();
         assertThrows(WakeupException.class, () -> consumer.committed(mockTopicPartitionOffset().keySet()));
         assertNoPendingWakeup(consumer.wakeupTrigger());
@@ -366,20 +320,25 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testRefreshCommittedOffsetsSuccess() {
-        Map<TopicPartition, OffsetAndMetadata> committedOffsets =
-                Collections.singletonMap(new TopicPartition("t1", 1), new OffsetAndMetadata(10L));
-        testRefreshCommittedOffsetsSuccess(committedOffsets);
+        TopicPartition partition = new TopicPartition("t1", 1);
+        Set<TopicPartition> partitions = Collections.singleton(partition);
+        Map<TopicPartition, OffsetAndMetadata> committedOffsets = Collections.singletonMap(partition, new OffsetAndMetadata(10L));
+        testRefreshCommittedOffsetsSuccess(partitions, committedOffsets);
     }
 
     @Test
     public void testRefreshCommittedOffsetsSuccessButNoCommittedOffsetsFound() {
-        testRefreshCommittedOffsetsSuccess(Collections.emptyMap());
+        TopicPartition partition = new TopicPartition("t1", 1);
+        Set<TopicPartition> partitions = Collections.singleton(partition);
+        Map<TopicPartition, OffsetAndMetadata> committedOffsets = Collections.emptyMap();
+        testRefreshCommittedOffsetsSuccess(partitions, committedOffsets);
     }
 
     @Test
     public void testRefreshCommittedOffsetsShouldNotResetIfFailedWithTimeout() {
         // Create consumer with group id to enable committed offset usage
-        this.groupId = "consumer-group-1";
+        cleanup();
+        setup(Optional.of("consumer-group-1"));
 
         testUpdateFetchPositionsWithFetchCommittedOffsetsTimeout(true);
     }
@@ -387,22 +346,20 @@ public class PrototypeAsyncConsumerTest {
     @Test
     public void testRefreshCommittedOffsetsNotCalledIfNoGroupId() {
         // Create consumer without group id so committed offsets are not used for updating positions
-        this.groupId = null;
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        cleanup();
+        setup(Optional.empty());
 
         testUpdateFetchPositionsWithFetchCommittedOffsetsTimeout(false);
     }
 
     private void testUpdateFetchPositionsWithFetchCommittedOffsetsTimeout(boolean committedOffsetsEnabled) {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
-
         // Uncompleted future that will time out if used
         CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> committedFuture = new CompletableFuture<>();
 
-        when(subscriptions.initializingPartitions()).thenReturn(Collections.singleton(new TopicPartition("t1", 1)));
+
+        consumer.assign(singleton(new TopicPartition("t1", 1)));
 
         try (MockedConstruction<OffsetFetchApplicationEvent> ignored = offsetFetchEventMocker(committedFuture)) {
-
             // Poll with 0 timeout to run a single iteration of the poll loop
             consumer.poll(Duration.ofMillis(0));
 
@@ -422,17 +379,17 @@ public class PrototypeAsyncConsumerTest {
         }
     }
 
-    private void testRefreshCommittedOffsetsSuccess(Map<TopicPartition, OffsetAndMetadata> committedOffsets) {
+    private void testRefreshCommittedOffsetsSuccess(Set<TopicPartition> partitions,
+                                                    Map<TopicPartition, OffsetAndMetadata> committedOffsets) {
         CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> committedFuture = new CompletableFuture<>();
         committedFuture.complete(committedOffsets);
 
         // Create consumer with group id to enable committed offset usage
-        this.groupId = "consumer-group-1";
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        cleanup();
+        setup(Optional.of("consumer-group-id"));
+        consumer.assign(partitions);
 
         try (MockedConstruction<OffsetFetchApplicationEvent> ignored = offsetFetchEventMocker(committedFuture)) {
-            when(subscriptions.initializingPartitions()).thenReturn(committedOffsets.keySet());
-
             // Poll with 0 timeout to run a single iteration of the poll loop
             consumer.poll(Duration.ofMillis(0));
 
@@ -443,10 +400,10 @@ public class PrototypeAsyncConsumerTest {
     }
 
     private void assertNoPendingWakeup(final WakeupTrigger wakeupTrigger) {
-        assertTrue(wakeupTrigger.getPendingTask() == null);
+        assertNull(wakeupTrigger.getPendingTask());
     }
 
-    private Map<TopicPartition, OffsetAndMetadata> mockTopicPartitionOffset() {
+    private HashMap<TopicPartition, OffsetAndMetadata> mockTopicPartitionOffset() {
         final TopicPartition t0 = new TopicPartition("t0", 2);
         final TopicPartition t1 = new TopicPartition("t0", 3);
         HashMap<TopicPartition, OffsetAndMetadata> topicPartitionOffsets = new HashMap<>();
@@ -455,7 +412,7 @@ public class PrototypeAsyncConsumerTest {
         return topicPartitionOffsets;
     }
 
-    private Map<TopicPartition, OffsetAndTimestamp> mockOffsetAndTimestamp() {
+    private HashMap<TopicPartition, OffsetAndTimestamp> mockOffsetAndTimestamp() {
         final TopicPartition t0 = new TopicPartition("t0", 2);
         final TopicPartition t1 = new TopicPartition("t0", 3);
         HashMap<TopicPartition, OffsetAndTimestamp> offsetAndTimestamp = new HashMap<>();
@@ -464,38 +421,13 @@ public class PrototypeAsyncConsumerTest {
         return offsetAndTimestamp;
     }
 
-    private Map<TopicPartition, Long> mockTimestampToSearch() {
+    private HashMap<TopicPartition, Long> mockTimestampToSearch() {
         final TopicPartition t0 = new TopicPartition("t0", 2);
         final TopicPartition t1 = new TopicPartition("t0", 3);
         HashMap<TopicPartition, Long> timestampToSearch = new HashMap<>();
         timestampToSearch.put(t0, 1L);
         timestampToSearch.put(t1, 2L);
         return timestampToSearch;
-    }
-
-    private void injectConsumerConfigs() {
-        consumerProps.put(BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
-        consumerProps.put(DEFAULT_API_TIMEOUT_MS_CONFIG, "60000");
-        consumerProps.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        consumerProps.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    }
-
-    private PrototypeAsyncConsumer<?, ?> newConsumer(final Time time,
-                                                     final Deserializer<?> keyDeserializer,
-                                                     final Deserializer<?> valueDeserializer) {
-        consumerProps.put(KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.getClass());
-        consumerProps.put(VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.getClass());
-
-        return new PrototypeAsyncConsumer<>(
-                time,
-                logContext,
-                config,
-                subscriptions,
-                metadata,
-                eventHandler,
-                metrics,
-                Optional.ofNullable(this.groupId),
-                config.getInt(DEFAULT_API_TIMEOUT_MS_CONFIG));
     }
 }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -16,14 +16,11 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.consumer.internals.events.ApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.AssignmentChangeApplicationEvent;
-import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.EventHandler;
 import org.apache.kafka.clients.consumer.internals.events.ListOffsetsApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.NewTopicsMetadataUpdateRequestEvent;
@@ -35,12 +32,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.WakeupException;
-import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -57,20 +48,15 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singleton;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -79,56 +65,46 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class PrototypeAsyncConsumerTest {
 
     private PrototypeAsyncConsumer<?, ?> consumer;
-    private final Map<String, Object> consumerProps = new HashMap<>();
+    private static final Optional<String> DEFAULT_GROUP_ID = Optional.of("group.id");
 
-    private final Time time = new MockTime();
-    private LogContext logContext;
+    private ConsumerTestBuilder.PrototypeAsyncConsumerTestBuilder testBuilder;
     private SubscriptionState subscriptions;
-    private ConsumerMetadata metadata;
     private EventHandler eventHandler;
-    private Metrics metrics;
-
-    private String groupId = "group.id";
-    private ConsumerConfig config;
 
     @BeforeEach
     public void setup() {
-        injectConsumerConfigs();
-        this.config = new ConsumerConfig(consumerProps);
-        this.logContext = new LogContext();
-        this.subscriptions = mock(SubscriptionState.class);
-        this.metadata = mock(ConsumerMetadata.class);
-        final DefaultBackgroundThread bt = mock(DefaultBackgroundThread.class);
-        final BlockingQueue<ApplicationEvent> aq = new LinkedBlockingQueue<>();
-        final BlockingQueue<BackgroundEvent> bq = new LinkedBlockingQueue<>();
-        this.eventHandler = spy(new DefaultEventHandler(bt, aq, bq));
-        this.metrics = new Metrics(time);
+        setup(DEFAULT_GROUP_ID);
     }
 
     @AfterEach
     public void cleanup() {
-        if (consumer != null) {
-            consumer.close(Duration.ZERO);
+        if (testBuilder != null) {
+            testBuilder.close();
         }
+    }
+
+    private void setup(Optional<String> groupIdOpt) {
+        testBuilder = new ConsumerTestBuilder.PrototypeAsyncConsumerTestBuilder(groupIdOpt);
+        subscriptions = testBuilder.subscriptions;
+        eventHandler = testBuilder.eventHandler;
+        consumer = testBuilder.consumer;
     }
 
     @Test
     public void testSuccessfulStartupShutdown() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertDoesNotThrow(() -> consumer.close());
     }
 
     @Test
     public void testInvalidGroupId() {
-        this.groupId = null;
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        cleanup();
+        setup(Optional.empty());
         assertThrows(InvalidGroupIdException.class, () -> consumer.committed(new HashSet<>()));
     }
 
@@ -139,9 +115,8 @@ public class PrototypeAsyncConsumerTest {
         offsets.put(new TopicPartition("my-topic", 0), new OffsetAndMetadata(100L));
         offsets.put(new TopicPartition("my-topic", 1), new OffsetAndMetadata(200L));
 
-        PrototypeAsyncConsumer<?, ?> mockedConsumer = spy(newConsumer(time, new StringDeserializer(), new StringDeserializer()));
-        doReturn(future).when(mockedConsumer).commit(offsets, false);
-        mockedConsumer.commitAsync(offsets, null);
+        doReturn(future).when(consumer).commit(offsets, false);
+        consumer.commitAsync(offsets, null);
         future.complete(null);
         TestUtils.waitForCondition(() -> future.isDone(),
                 2000,
@@ -158,11 +133,9 @@ public class PrototypeAsyncConsumerTest {
         offsets.put(new TopicPartition("my-topic", 0), new OffsetAndMetadata(100L));
         offsets.put(new TopicPartition("my-topic", 1), new OffsetAndMetadata(200L));
 
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
-        PrototypeAsyncConsumer<?, ?> mockedConsumer = spy(consumer);
-        doReturn(future).when(mockedConsumer).commit(offsets, false);
+        doReturn(future).when(consumer).commit(offsets, false);
         OffsetCommitCallback customCallback = mock(OffsetCommitCallback.class);
-        mockedConsumer.commitAsync(offsets, customCallback);
+        consumer.commitAsync(offsets, customCallback);
         future.complete(null);
         verify(customCallback).onComplete(offsets, null);
     }
@@ -174,7 +147,6 @@ public class PrototypeAsyncConsumerTest {
         committedFuture.complete(offsets);
 
         try (MockedConstruction<OffsetFetchApplicationEvent> ignored = offsetFetchEventMocker(committedFuture)) {
-            this.consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
             assertDoesNotThrow(() -> consumer.committed(offsets.keySet(), Duration.ofMillis(1000)));
             verify(eventHandler).add(ArgumentMatchers.isA(OffsetFetchApplicationEvent.class));
         }
@@ -187,7 +159,6 @@ public class PrototypeAsyncConsumerTest {
         committedFuture.completeExceptionally(new KafkaException("Test exception"));
 
         try (MockedConstruction<OffsetFetchApplicationEvent> ignored = offsetFetchEventMocker(committedFuture)) {
-            this.consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
             assertThrows(KafkaException.class, () -> consumer.committed(offsets.keySet(), Duration.ofMillis(1000)));
             verify(eventHandler).add(ArgumentMatchers.isA(OffsetFetchApplicationEvent.class));
         }
@@ -229,8 +200,6 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testAssign() {
-        this.subscriptions = new SubscriptionState(logContext, OffsetResetStrategy.EARLIEST);
-        this.consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         final TopicPartition tp = new TopicPartition("foo", 3);
         consumer.assign(singleton(tp));
         assertTrue(consumer.subscription().isEmpty());
@@ -241,13 +210,11 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testAssignOnNullTopicPartition() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(IllegalArgumentException.class, () -> consumer.assign(null));
     }
 
     @Test
     public void testAssignOnEmptyTopicPartition() {
-        consumer = spy(newConsumer(time, new StringDeserializer(), new StringDeserializer()));
         consumer.assign(Collections.emptyList());
         assertTrue(consumer.subscription().isEmpty());
         assertTrue(consumer.assignment().isEmpty());
@@ -255,26 +222,22 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testAssignOnNullTopicInPartition() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(IllegalArgumentException.class, () -> consumer.assign(singleton(new TopicPartition(null, 0))));
     }
 
     @Test
     public void testAssignOnEmptyTopicInPartition() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(IllegalArgumentException.class, () -> consumer.assign(singleton(new TopicPartition("  ", 0))));
     }
 
     @Test
     public void testBeginningOffsetsFailsIfNullPartitions() {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(NullPointerException.class, () -> consumer.beginningOffsets(null,
                 Duration.ofMillis(1)));
     }
 
     @Test
     public void testBeginningOffsets() {
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         Map<TopicPartition, OffsetAndTimestamp> expectedOffsetsAndTimestamp =
                 mockOffsetAndTimestamp();
         Set<TopicPartition> partitions = expectedOffsetsAndTimestamp.keySet();
@@ -291,7 +254,6 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testBeginningOffsetsThrowsKafkaExceptionForUnderlyingExecutionFailure() {
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         Set<TopicPartition> partitions = mockTopicPartitionOffset().keySet();
         Throwable eventProcessingFailure = new KafkaException("Unexpected failure " +
                 "processing List Offsets event");
@@ -305,7 +267,6 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testBeginningOffsetsTimeoutOnEventProcessingTimeout() {
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         doThrow(new TimeoutException()).when(eventHandler).addAndGet(any(), any());
         assertThrows(TimeoutException.class,
                 () -> consumer.beginningOffsets(
@@ -317,14 +278,12 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testOffsetsForTimesOnNullPartitions() {
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(NullPointerException.class, () -> consumer.offsetsForTimes(null,
                 Duration.ofMillis(1)));
     }
 
     @Test
     public void testOffsetsForTimes() {
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         Map<TopicPartition, OffsetAndTimestamp> expectedResult = mockOffsetAndTimestamp();
         Map<TopicPartition, Long> timestampToSearch = mockTimestampToSearch();
 
@@ -341,7 +300,6 @@ public class PrototypeAsyncConsumerTest {
     // OffsetAndTimestamp as value.
     @Test
     public void testOffsetsForTimesWithZeroTimeout() {
-        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         TopicPartition tp = new TopicPartition("topic1", 0);
         Map<TopicPartition, OffsetAndTimestamp> expectedResult =
                 Collections.singletonMap(tp, null);
@@ -357,8 +315,6 @@ public class PrototypeAsyncConsumerTest {
 
     @Test
     public void testWakeup_committed() {
-        consumer = newConsumer(time, new StringDeserializer(),
-            new StringDeserializer());
         consumer.wakeup();
         assertThrows(WakeupException.class, () -> consumer.committed(mockTopicPartitionOffset().keySet()));
         assertNoPendingWakeup(consumer.wakeupTrigger());
@@ -379,7 +335,8 @@ public class PrototypeAsyncConsumerTest {
     @Test
     public void testRefreshCommittedOffsetsShouldNotResetIfFailedWithTimeout() {
         // Create consumer with group id to enable committed offset usage
-        this.groupId = "consumer-group-1";
+        cleanup();
+        setup(Optional.of("consumer-group-1"));
 
         testUpdateFetchPositionsWithFetchCommittedOffsetsTimeout(true);
     }
@@ -387,15 +344,13 @@ public class PrototypeAsyncConsumerTest {
     @Test
     public void testRefreshCommittedOffsetsNotCalledIfNoGroupId() {
         // Create consumer without group id so committed offsets are not used for updating positions
-        this.groupId = null;
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        cleanup();
+        setup(Optional.empty());
 
         testUpdateFetchPositionsWithFetchCommittedOffsetsTimeout(false);
     }
 
     private void testUpdateFetchPositionsWithFetchCommittedOffsetsTimeout(boolean committedOffsetsEnabled) {
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
-
         // Uncompleted future that will time out if used
         CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> committedFuture = new CompletableFuture<>();
 
@@ -427,8 +382,8 @@ public class PrototypeAsyncConsumerTest {
         committedFuture.complete(committedOffsets);
 
         // Create consumer with group id to enable committed offset usage
-        this.groupId = "consumer-group-1";
-        consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        cleanup();
+        setup(Optional.of("consumer-group-id"));
 
         try (MockedConstruction<OffsetFetchApplicationEvent> ignored = offsetFetchEventMocker(committedFuture)) {
             when(subscriptions.initializingPartitions()).thenReturn(committedOffsets.keySet());
@@ -443,10 +398,10 @@ public class PrototypeAsyncConsumerTest {
     }
 
     private void assertNoPendingWakeup(final WakeupTrigger wakeupTrigger) {
-        assertTrue(wakeupTrigger.getPendingTask() == null);
+        assertNull(wakeupTrigger.getPendingTask());
     }
 
-    private Map<TopicPartition, OffsetAndMetadata> mockTopicPartitionOffset() {
+    private HashMap<TopicPartition, OffsetAndMetadata> mockTopicPartitionOffset() {
         final TopicPartition t0 = new TopicPartition("t0", 2);
         final TopicPartition t1 = new TopicPartition("t0", 3);
         HashMap<TopicPartition, OffsetAndMetadata> topicPartitionOffsets = new HashMap<>();
@@ -455,7 +410,7 @@ public class PrototypeAsyncConsumerTest {
         return topicPartitionOffsets;
     }
 
-    private Map<TopicPartition, OffsetAndTimestamp> mockOffsetAndTimestamp() {
+    private HashMap<TopicPartition, OffsetAndTimestamp> mockOffsetAndTimestamp() {
         final TopicPartition t0 = new TopicPartition("t0", 2);
         final TopicPartition t1 = new TopicPartition("t0", 3);
         HashMap<TopicPartition, OffsetAndTimestamp> offsetAndTimestamp = new HashMap<>();
@@ -464,38 +419,13 @@ public class PrototypeAsyncConsumerTest {
         return offsetAndTimestamp;
     }
 
-    private Map<TopicPartition, Long> mockTimestampToSearch() {
+    private HashMap<TopicPartition, Long> mockTimestampToSearch() {
         final TopicPartition t0 = new TopicPartition("t0", 2);
         final TopicPartition t1 = new TopicPartition("t0", 3);
         HashMap<TopicPartition, Long> timestampToSearch = new HashMap<>();
         timestampToSearch.put(t0, 1L);
         timestampToSearch.put(t1, 2L);
         return timestampToSearch;
-    }
-
-    private void injectConsumerConfigs() {
-        consumerProps.put(BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
-        consumerProps.put(DEFAULT_API_TIMEOUT_MS_CONFIG, "60000");
-        consumerProps.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        consumerProps.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    }
-
-    private PrototypeAsyncConsumer<?, ?> newConsumer(final Time time,
-                                                     final Deserializer<?> keyDeserializer,
-                                                     final Deserializer<?> valueDeserializer) {
-        consumerProps.put(KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.getClass());
-        consumerProps.put(VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.getClass());
-
-        return new PrototypeAsyncConsumer<>(
-                time,
-                logContext,
-                config,
-                subscriptions,
-                metadata,
-                eventHandler,
-                metrics,
-                Optional.ofNullable(this.groupId),
-                config.getInt(DEFAULT_API_TIMEOUT_MS_CONFIG));
     }
 }
 


### PR DESCRIPTION
Changes:

1. Introduces `FetchRequestManager` that implements the `RequestManager` API for fetching messages from brokers. Unlike `Fetcher`, record decompression and deserialization is performed on the application thread inside `CompletedFetch`.
2. Restructured the code so that objects owned by the background thread are not instantiated until the background thread runs (via `Supplier`) to ensure that there are no references available to the application thread.
3. Ensuring resources are properly using `Closeable` and using `IdempotentCloser` to ensure they're only closed once.
4. Introduces `ConsumerTestBuilder` to reduce a lot of inconsistency in the way the objects were built up for tests.