### PR TITLE
KAFKA-15471: Allow independently stop KRaft controllers or brokers

### DIFF
--- a/bin/kafka-server-stop.sh
+++ b/bin/kafka-server-stop.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 SIGNAL=${SIGNAL:-TERM}
 
-if [[ "$1" == "--process-role" ]]; then
+if [[ "$1" == "--process.roles" ]]; then
     ProcessRole="$2"
 fi
 
@@ -28,22 +28,27 @@ if [[ "$OSNAME" == "OS/390" ]]; then
 elif [[ "$OSNAME" == "OS400" ]]; then
     PIDS=$(ps -Af | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $2}')
 else
-    PIDS=$(ps ax | grep ' kafka\.Kafka ' | grep java | grep -v grep | awk '{print $1}')
-    ConfigFiles=$(ps ax | grep ' kafka\.Kafka ' | grep java | grep -v grep | awk 'NF>1{print $NF}')
+    PIDS=$(ps ax | grep ' kafka\.Kafka ' | grep java | grep -v grep | awk '{print $1}'| xargs)
+    ConfigFiles=$(ps ax | grep ' kafka\.Kafka ' | grep java | grep -v grep | sed 's/--override property=[^ ]*//g' | awk 'NF>1{print $NF}' | xargs)
 fi
 
 if [ -z "$PIDS" ]; then
   echo "No kafka server to stop"
   exit 1
 else
-  if [ -z "$ConfigFile" ]; then
+  if [ -z "$ProcessRole" ]; then
     kill -s $SIGNAL $PIDS
   else
+    IFS=' ' read -ra ConfigFilesArray <<< "$ConfigFiles"
+    IFS=' ' read -ra PIDSArray <<< "$PIDS"
     keyword="process.roles="
-    for ((i = 0; i < ${#ConfigFiles[@]}; i++)); do
-        PRCRole=$(sed -n "s/$keyword//p" "${ConfigFiles[i]}")
+    for ((i = 0; i < ${#ConfigFilesArray[@]}; i++)); do
+        PRCRole=$(sed -n "/$keyword/ { s/$keyword//p; q; }" "${ConfigFilesArray[i]}")
         if [ "$PRCRole" == "$ProcessRole" ]; then
-          kill -s $SIGNAL ${PIDS[i]}
+          kill -s $SIGNAL ${PIDSArray[i]}
+#          echo "Killed ${PRCRole} with PID ${PIDSArray[i]}"
+#        else
+#          echo "Skip killing ${PRCRole} with PID ${PIDSArray[i]}"
         fi
     done
   fi


### PR DESCRIPTION
[KIP-979: Allow independently stop KRaft processes](https://cwiki.apache.org/confluence/display/KAFKA/KIP-979%3A+Allow+independently+stop+KRaft+processes)

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*
- Get a controller running in a terminal with node.id = 1
- Get a broker running in another terminal with node.id = 2
- Get a broker running in the third terminal with node.id = 3

### Test `--process-role`: 
- Run `./bin/kafka-server-stop.sh --process-role=controller`, the controller is killed only.
`[2023-12-11 10:38:44,732] INFO App info kafka.server for 1 unregistered (org.apache.kafka.common.utils.AppInfoParser)`
- Run `./bin/kafka-server-stop.sh --process-role=broker`, both brokers are killed.
```
[2023-12-11 10:43:52,402] INFO App info kafka.server for 2 unregistered 
[2023-12-11 10:44:20,410] INFO App info kafka.server for 3 unregistered
```
### Test `--node.id`:
- Run `./bin/kafka-server-stop.sh --node-id=1 `, the controller is killed only.
`[2023-12-11 01:04:53,863] INFO App info kafka.server for 1 unregistered`
- Run `./bin/kafka-server-stop.sh --node-id=2 `, the broker with node.id = 2 is killed only.
`[2023-12-11 01:05:51,500] INFO App info kafka.server for 2 unregistered`

### Test with both `--node.id` and `--process-role` 
- Run `./bin/kafka-server-stop.sh --node-id=2 --process-role=controller`.
As noted in the KIP-979, node-id with take precedence, a log message is shown, and the broker with node.id = 2 is killed only.
`When both node-id and process-role are provided, the value for node-id will take precedence`
`[2023-12-11 10:50:13,403] INFO App info kafka.server for 2 unregistered `

### Also tested when relative paths to the config files are given in the `./bin/kafka-server-start.sh` command, behavior are same as above.

### Also tested when a `--override property=value` is provided at the back of the `./bin/kafka-server-start.sh` command, behavior are same as above.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
