### PR TITLE
MINOR: Push logic to resolve the transaction coordinator into the AddPartitionsToTxnManager

### DIFF
--- a/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
+++ b/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
@@ -73,18 +73,17 @@ class AddPartitionsToTxnManager(
   val verificationFailureRate = metricsGroup.newMeter(VerificationFailureRateMetricName, "failures", TimeUnit.SECONDS)
   val verificationTimeMs = metricsGroup.newHistogram(VerificationTimeMsMetricName)
 
-  def addTxnData(
+  def verifyTransaction(
     transactionalId: String,
     producerId: Long,
     producerEpoch: Short,
-    verifyOnly: Boolean,
     topicPartitions: Seq[TopicPartition],
     callback: AddPartitionsToTxnManager.AppendCallback
   ): Unit = {
     val (error, node) = getTransactionCoordinator(partitionFor(transactionalId))
 
     if (error != Errors.NONE) {
-      callback(topicPartitions.map { tp => tp -> error }.toMap)
+      callback(topicPartitions.map(tp => tp -> error).toMap)
     } else {
       val topicCollection = new AddPartitionsToTxnTopicCollection()
       topicPartitions.groupBy(_.topic).forKeyValue { (topic, tps) =>
@@ -97,7 +96,7 @@ class AddPartitionsToTxnManager(
         .setTransactionalId(transactionalId)
         .setProducerId(producerId)
         .setProducerEpoch(producerEpoch)
-        .setVerifyOnly(verifyOnly)
+        .setVerifyOnly(true)
         .setTopics(topicCollection)
 
       addTxnData(node, transactionData, callback)

--- a/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
+++ b/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
@@ -18,19 +18,22 @@
 package kafka.server
 
 import kafka.server.AddPartitionsToTxnManager.{VerificationFailureRateMetricName, VerificationTimeMsMetricName}
+import kafka.utils.Implicits.MapExtensionMethods
 import kafka.utils.Logging
 import org.apache.kafka.clients.{ClientResponse, NetworkClient, RequestCompletionHandler}
+import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.{Node, TopicPartition}
-import org.apache.kafka.common.message.AddPartitionsToTxnRequestData.{AddPartitionsToTxnTransaction, AddPartitionsToTxnTransactionCollection}
+import org.apache.kafka.common.message.AddPartitionsToTxnRequestData.{AddPartitionsToTxnTopic, AddPartitionsToTxnTopicCollection, AddPartitionsToTxnTransaction, AddPartitionsToTxnTransactionCollection}
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.requests.{AddPartitionsToTxnRequest, AddPartitionsToTxnResponse}
+import org.apache.kafka.common.requests.{AddPartitionsToTxnRequest, AddPartitionsToTxnResponse, MetadataResponse}
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.{InterBrokerSendThread, RequestAndCompletionHandler}
 
 import java.util
 import java.util.concurrent.TimeUnit
-import scala.collection.mutable
+import scala.collection.{Set, Seq, mutable}
+import scala.jdk.CollectionConverters._
 
 object AddPartitionsToTxnManager {
   type AppendCallback = Map[TopicPartition, Errors] => Unit
@@ -38,7 +41,6 @@ object AddPartitionsToTxnManager {
   val VerificationFailureRateMetricName = "VerificationFailureRate"
   val VerificationTimeMsMetricName = "VerificationTimeMs"
 }
-
 
 /*
  * Data structure to hold the transactional data to send to a node. Note -- at most one request per transactional ID
@@ -49,10 +51,18 @@ class TransactionDataAndCallbacks(val transactionData: AddPartitionsToTxnTransac
                                   val callbacks: mutable.Map[String, AddPartitionsToTxnManager.AppendCallback],
                                   val startTimeMs: mutable.Map[String, Long])
 
-
-class AddPartitionsToTxnManager(config: KafkaConfig, client: NetworkClient, time: Time)
-  extends InterBrokerSendThread("AddPartitionsToTxnSenderThread-" + config.brokerId, client, config.requestTimeoutMs, time)
-  with Logging {
+class AddPartitionsToTxnManager(
+  config: KafkaConfig,
+  client: NetworkClient,
+  metadataCache: MetadataCache,
+  partitionFor: String => Int,
+  time: Time
+) extends InterBrokerSendThread(
+  "AddPartitionsToTxnSenderThread-" + config.brokerId,
+  client,
+  config.requestTimeoutMs,
+  time
+) with Logging {
 
   this.logIdent = logPrefix
 
@@ -63,7 +73,42 @@ class AddPartitionsToTxnManager(config: KafkaConfig, client: NetworkClient, time
   val verificationFailureRate = metricsGroup.newMeter(VerificationFailureRateMetricName, "failures", TimeUnit.SECONDS)
   val verificationTimeMs = metricsGroup.newHistogram(VerificationTimeMsMetricName)
 
-  def addTxnData(node: Node, transactionData: AddPartitionsToTxnTransaction, callback: AddPartitionsToTxnManager.AppendCallback): Unit = {
+  def addTxnData(
+    transactionalId: String,
+    producerId: Long,
+    producerEpoch: Short,
+    verifyOnly: Boolean,
+    topicPartitions: Seq[TopicPartition],
+    callback: AddPartitionsToTxnManager.AppendCallback
+  ): Unit = {
+    val (error, node) = getTransactionCoordinator(partitionFor(transactionalId))
+
+    if (error != Errors.NONE) {
+      callback(topicPartitions.map { tp => tp -> error }.toMap)
+    } else {
+      val topicCollection = new AddPartitionsToTxnTopicCollection()
+      topicPartitions.groupBy(_.topic).forKeyValue { (topic, tps) =>
+        topicCollection.add(new AddPartitionsToTxnTopic()
+          .setName(topic)
+          .setPartitions(tps.map(tp => Int.box(tp.partition)).toList.asJava))
+      }
+
+      val transactionData = new AddPartitionsToTxnTransaction()
+        .setTransactionalId(transactionalId)
+        .setProducerId(producerId)
+        .setProducerEpoch(producerEpoch)
+        .setVerifyOnly(verifyOnly)
+        .setTopics(topicCollection)
+
+      addTxnData(node, transactionData, callback)
+    }
+  }
+
+  private def addTxnData(
+    node: Node,
+    transactionData: AddPartitionsToTxnTransaction,
+    callback: AddPartitionsToTxnManager.AppendCallback
+  ): Unit = {
     nodesToTransactions.synchronized {
       val curTime = time.milliseconds()
       // Check if we have already have either node or individual transaction. Add the Node if it isn't there.
@@ -99,6 +144,33 @@ class AddPartitionsToTxnManager(config: KafkaConfig, client: NetworkClient, time
       existingNodeAndTransactionData.callbacks.put(transactionData.transactionalId, callback)
       existingNodeAndTransactionData.startTimeMs.put(transactionData.transactionalId, curTime)
       wakeup()
+    }
+  }
+
+  private def getTransactionCoordinator(partition: Int): (Errors, Node) = {
+    val listenerName = config.interBrokerListenerName
+
+    val topicMetadata = metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), listenerName)
+
+    if (topicMetadata.headOption.isEmpty) {
+      // If topic is not created, then the transaction is definitely not started.
+      (Errors.COORDINATOR_NOT_AVAILABLE, Node.noNode)
+    } else {
+      if (topicMetadata.head.errorCode != Errors.NONE.code) {
+        (Errors.COORDINATOR_NOT_AVAILABLE, Node.noNode)
+      } else {
+        val coordinatorEndpoint = topicMetadata.head.partitions.asScala
+          .find(_.partitionIndex == partition)
+          .filter(_.leaderId != MetadataResponse.NO_LEADER_ID)
+          .flatMap(metadata => metadataCache.getAliveBrokerNode(metadata.leaderId, listenerName))
+
+        coordinatorEndpoint match {
+          case Some(endpoint) =>
+            (Errors.NONE, endpoint)
+          case _ =>
+            (Errors.COORDINATOR_NOT_AVAILABLE, Node.noNode)
+        }
+      }
     }
   }
 

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -28,7 +28,6 @@ import kafka.security.CredentialProvider
 import kafka.server.metadata.{AclPublisher, BrokerMetadataPublisher, ClientQuotaMetadataManager,
 DynamicClientQuotaPublisher, DynamicConfigPublisher, KRaftMetadataCache, ScramPublisher, DelegationTokenPublisher}
 import kafka.utils.CoreUtils
-import org.apache.kafka.clients.NetworkClient
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.feature.SupportedVersionRange
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
@@ -256,11 +255,13 @@ class BrokerServer(
       alterPartitionManager.start()
 
       val addPartitionsLogContext = new LogContext(s"[AddPartitionsToTxnManager broker=${config.brokerId}]")
-      val addPartitionsToTxnNetworkClient: NetworkClient = NetworkUtils.buildNetworkClient("AddPartitionsManager", config, metrics, time, addPartitionsLogContext)
-      val addPartitionsToTxnManager: AddPartitionsToTxnManager = new AddPartitionsToTxnManager(
+      val addPartitionsToTxnNetworkClient = NetworkUtils.buildNetworkClient("AddPartitionsManager", config, metrics, time, addPartitionsLogContext)
+      val addPartitionsToTxnManager = new AddPartitionsToTxnManager(
         config,
         addPartitionsToTxnNetworkClient,
         metadataCache,
+        // The transaction coordinator is not created at this point so we must
+        // use a lambda here.
         transactionalId => transactionCoordinator.partitionFor(transactionalId),
         time
       )

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -261,7 +261,7 @@ class BrokerServer(
         config,
         addPartitionsToTxnNetworkClient,
         metadataCache,
-        transactionCoordinator.partitionFor,
+        transactionalId => transactionCoordinator.partitionFor(transactionalId),
         time
       )
 

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -257,7 +257,13 @@ class BrokerServer(
 
       val addPartitionsLogContext = new LogContext(s"[AddPartitionsToTxnManager broker=${config.brokerId}]")
       val addPartitionsToTxnNetworkClient: NetworkClient = NetworkUtils.buildNetworkClient("AddPartitionsManager", config, metrics, time, addPartitionsLogContext)
-      val addPartitionsToTxnManager: AddPartitionsToTxnManager = new AddPartitionsToTxnManager(config, addPartitionsToTxnNetworkClient, time)
+      val addPartitionsToTxnManager: AddPartitionsToTxnManager = new AddPartitionsToTxnManager(
+        config,
+        addPartitionsToTxnNetworkClient,
+        metadataCache,
+        transactionCoordinator.partitionFor,
+        time
+      )
 
       this._replicaManager = new ReplicaManager(
         config = config,

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -677,12 +677,6 @@ class KafkaApis(val requestChannel: RequestChannel,
     else {
       val internalTopicsAllowed = request.header.clientId == AdminUtils.ADMIN_CLIENT_ID
 
-      val transactionStatePartition =
-        if (produceRequest.transactionalId() == null)
-          None
-        else
-          Some(txnCoordinator.partitionFor(produceRequest.transactionalId()))
-
       // call the replica manager to append messages to the replicas
       replicaManager.appendRecords(
         timeout = produceRequest.timeout.toLong,
@@ -693,8 +687,8 @@ class KafkaApis(val requestChannel: RequestChannel,
         requestLocal = requestLocal,
         responseCallback = sendResponseCallback,
         recordConversionStatsCallback = processingStatsCallback,
-        transactionalId = produceRequest.transactionalId(),
-        transactionStatePartition = transactionStatePartition)
+        transactionalId = produceRequest.transactionalId()
+      )
 
       // if the request is put into the purgatory, it will have a held reference and hence cannot be garbage collected;
       // hence we clear its data here in order to let GC reclaim its memory since it is already appended to log

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -48,10 +48,6 @@ object KafkaRequestHandler {
   def setBypassThreadCheck(bypassCheck: Boolean): Unit = {
     bypassThreadCheck = bypassCheck
   }
-  
-  def currentRequestOnThread(): RequestChannel.Request = {
-    threadCurrentRequest.get()
-  }
 
   /**
    * Wrap callback to schedule it on a request thread.

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -634,7 +634,7 @@ class KafkaServer(
       config,
       addPartitionsToTxnNetworkClient,
       metadataCache,
-      transactionCoordinator.partitionFor,
+      transactionalId => transactionCoordinator.partitionFor(transactionalId),
       time
     )
 

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -629,11 +629,13 @@ class KafkaServer(
 
   protected def createReplicaManager(isShuttingDown: AtomicBoolean): ReplicaManager = {
     val addPartitionsLogContext = new LogContext(s"[AddPartitionsToTxnManager broker=${config.brokerId}]")
-    val addPartitionsToTxnNetworkClient: NetworkClient = NetworkUtils.buildNetworkClient("AddPartitionsManager", config, metrics, time, addPartitionsLogContext)
-    val addPartitionsToTxnManager: AddPartitionsToTxnManager = new AddPartitionsToTxnManager(
+    val addPartitionsToTxnNetworkClient = NetworkUtils.buildNetworkClient("AddPartitionsManager", config, metrics, time, addPartitionsLogContext)
+    val addPartitionsToTxnManager = new AddPartitionsToTxnManager(
       config,
       addPartitionsToTxnNetworkClient,
       metadataCache,
+      // The transaction coordinator is not created at this point so we must
+      // use a lambda here.
       transactionalId => transactionCoordinator.partitionFor(transactionalId),
       time
     )

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -630,7 +630,13 @@ class KafkaServer(
   protected def createReplicaManager(isShuttingDown: AtomicBoolean): ReplicaManager = {
     val addPartitionsLogContext = new LogContext(s"[AddPartitionsToTxnManager broker=${config.brokerId}]")
     val addPartitionsToTxnNetworkClient: NetworkClient = NetworkUtils.buildNetworkClient("AddPartitionsManager", config, metrics, time, addPartitionsLogContext)
-    val addPartitionsToTxnManager: AddPartitionsToTxnManager = new AddPartitionsToTxnManager(config, addPartitionsToTxnNetworkClient, time)
+    val addPartitionsToTxnManager: AddPartitionsToTxnManager = new AddPartitionsToTxnManager(
+      config,
+      addPartitionsToTxnNetworkClient,
+      metadataCache,
+      transactionCoordinator.partitionFor,
+      time
+    )
 
     new ReplicaManager(
       metrics = metrics,

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -845,11 +845,10 @@ class ReplicaManager(val config: KafkaConfig,
         // For unverified entries, send a request to verify. When verified, the append process will proceed via the callback.
         // We verify above that all partitions use the same producer ID.
         val batchInfo = notYetVerifiedEntriesPerPartition.head._2.firstBatch()
-        addPartitionsToTxnManager.foreach(_.addTxnData(
+        addPartitionsToTxnManager.foreach(_.verifyTransaction(
           transactionalId = transactionalId,
           producerId = batchInfo.producerId,
           producerEpoch = batchInfo.producerEpoch,
-          verifyOnly = true,
           topicPartitions = notYetVerifiedEntriesPerPartition.keySet.toSeq,
           callback = KafkaRequestHandler.wrap(appendEntries(entriesPerPartition)(_))
         ))

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -33,7 +33,6 @@ import kafka.utils._
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic
-import org.apache.kafka.common.message.AddPartitionsToTxnRequestData.{AddPartitionsToTxnTopic, AddPartitionsToTxnTopicCollection, AddPartitionsToTxnTransaction}
 import org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.message.LeaderAndIsrResponseData.{LeaderAndIsrPartitionError, LeaderAndIsrTopicError}
@@ -711,7 +710,6 @@ class ReplicaManager(val config: KafkaConfig,
    * @param recordConversionStatsCallback callback for updating stats on record conversions
    * @param requestLocal                  container for the stateful instances scoped to this request
    * @param transactionalId               transactional ID if the request is from a producer and the producer is transactional
-   * @param transactionStatePartition     partition that holds the transactional state if transactionalId is present
    * @param actionQueue                   the action queue to use. ReplicaManager#actionQueue is used by default.
    */
   def appendRecords(timeout: Long,
@@ -724,14 +722,13 @@ class ReplicaManager(val config: KafkaConfig,
                     recordConversionStatsCallback: Map[TopicPartition, RecordConversionStats] => Unit = _ => (),
                     requestLocal: RequestLocal = RequestLocal.NoCaching,
                     transactionalId: String = null,
-                    transactionStatePartition: Option[Int] = None,
                     actionQueue: ActionQueue = this.actionQueue): Unit = {
     if (isValidRequiredAcks(requiredAcks)) {
       val sTime = time.milliseconds
 
       val verificationGuards: mutable.Map[TopicPartition, Object] = mutable.Map[TopicPartition, Object]()
       val (verifiedEntriesPerPartition, notYetVerifiedEntriesPerPartition, errorsPerPartition) =
-        if (transactionStatePartition.isEmpty || !config.transactionPartitionVerificationEnable)
+        if (transactionalId == null || !config.transactionPartitionVerificationEnable)
           (entriesPerPartition, Map.empty[TopicPartition, MemoryRecords], Map.empty[TopicPartition, Errors])
         else {
           val verifiedEntries = mutable.Map[TopicPartition, MemoryRecords]()
@@ -846,33 +843,16 @@ class ReplicaManager(val config: KafkaConfig,
         appendEntries(verifiedEntriesPerPartition)(Map.empty)
       } else {
         // For unverified entries, send a request to verify. When verified, the append process will proceed via the callback.
-        val (error, node) = getTransactionCoordinator(transactionStatePartition.get)
-
-        if (error != Errors.NONE) {
-          appendEntries(entriesPerPartition)(notYetVerifiedEntriesPerPartition.map {
-            case (tp, _) => (tp, error)
-          }.toMap)
-        } else {
-          val topicGrouping = notYetVerifiedEntriesPerPartition.keySet.groupBy(tp => tp.topic())
-          val topicCollection = new AddPartitionsToTxnTopicCollection()
-          topicGrouping.foreach { case (topic, tps) =>
-            topicCollection.add(new AddPartitionsToTxnTopic()
-              .setName(topic)
-              .setPartitions(tps.map(tp => Integer.valueOf(tp.partition())).toList.asJava))
-          }
-
-          // Map not yet verified partitions to a request object.
-          // We verify above that all partitions use the same producer ID.
-          val batchInfo = notYetVerifiedEntriesPerPartition.head._2.firstBatch()
-          val notYetVerifiedTransaction = new AddPartitionsToTxnTransaction()
-            .setTransactionalId(transactionalId)
-            .setProducerId(batchInfo.producerId())
-            .setProducerEpoch(batchInfo.producerEpoch())
-            .setVerifyOnly(true)
-            .setTopics(topicCollection)
-
-          addPartitionsToTxnManager.foreach(_.addTxnData(node, notYetVerifiedTransaction, KafkaRequestHandler.wrap(appendEntries(entriesPerPartition)(_))))
-        }
+        // We verify above that all partitions use the same producer ID.
+        val batchInfo = notYetVerifiedEntriesPerPartition.head._2.firstBatch()
+        addPartitionsToTxnManager.foreach(_.addTxnData(
+          transactionalId = transactionalId,
+          producerId = batchInfo.producerId,
+          producerEpoch = batchInfo.producerEpoch,
+          verifyOnly = true,
+          topicPartitions = notYetVerifiedEntriesPerPartition.keySet.toSeq,
+          callback = KafkaRequestHandler.wrap(appendEntries(entriesPerPartition)(_))
+        ))
       }
     } else {
       // If required.acks is outside accepted range, something is wrong with the client
@@ -2641,34 +2621,6 @@ class ReplicaManager(val config: KafkaConfig,
         case e: Throwable =>
           stateChangeLogger.error(s"Unable to delete stray replica $topicPartition because " +
             s"we got an unexpected ${e.getClass.getName} exception: ${e.getMessage}", e)
-      }
-    }
-  }
-
-  private[server] def getTransactionCoordinator(partition: Int): (Errors, Node) = {
-    val listenerName = config.interBrokerListenerName
-
-    val topicMetadata = metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), listenerName)
-
-    if (topicMetadata.headOption.isEmpty) {
-      // If topic is not created, then the transaction is definitely not started.
-      (Errors.COORDINATOR_NOT_AVAILABLE, Node.noNode)
-    } else {
-      if (topicMetadata.head.errorCode != Errors.NONE.code) {
-        (Errors.COORDINATOR_NOT_AVAILABLE, Node.noNode)
-      } else {
-        val coordinatorEndpoint = topicMetadata.head.partitions.asScala
-          .find(_.partitionIndex == partition)
-          .filter(_.leaderId != MetadataResponse.NO_LEADER_ID)
-          .flatMap(metadata => metadataCache.
-            getAliveBrokerNode(metadata.leaderId, listenerName))
-
-        coordinatorEndpoint match {
-          case Some(endpoint) =>
-            (Errors.NONE, endpoint)
-          case _ =>
-            (Errors.COORDINATOR_NOT_AVAILABLE, Node.noNode)
-        }
       }
     }
   }

--- a/core/src/test/scala/kafka/server/KafkaRequestHandlerTest.scala
+++ b/core/src/test/scala/kafka/server/KafkaRequestHandlerTest.scala
@@ -36,6 +36,7 @@ import org.mockito.Mockito.{mock, when}
 
 import java.net.InetAddress
 import java.nio.ByteBuffer
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicInteger
 
 class KafkaRequestHandlerTest {
@@ -53,14 +54,15 @@ class KafkaRequestHandlerTest {
       val request = makeRequest(time, metrics)
       requestChannel.sendRequest(request)
 
-      def callback(ms: Int): Unit = {
-        time.sleep(ms)
-        handler.stop()
-      }
-
       when(apiHandler.handle(ArgumentMatchers.eq(request), any())).thenAnswer { _ =>
         time.sleep(2)
-        KafkaRequestHandler.wrap(callback(_: Int))(1)
+        // Prepare the callback.
+        val callback = KafkaRequestHandler.wrap((ms: Int) => {
+          time.sleep(ms)
+          handler.stop()
+        })
+        // Execute the callback asynchronously.
+        CompletableFuture.runAsync(() => callback(1))
         request.apiLocalCompleteTimeNanos = time.nanoseconds
       }
 
@@ -86,16 +88,17 @@ class KafkaRequestHandlerTest {
     var handledCount = 0
     var tryCompleteActionCount = 0
 
-    def callback(x: Int): Unit = {
-      handler.stop()
-    }
-
     val request = makeRequest(time, metrics)
     requestChannel.sendRequest(request)
 
     when(apiHandler.handle(ArgumentMatchers.eq(request), any())).thenAnswer { _ =>
       handledCount = handledCount + 1
-      KafkaRequestHandler.wrap(callback(_: Int))(1)
+      // Prepare the callback.
+      val callback = KafkaRequestHandler.wrap((ms: Int) => {
+        handler.stop()
+      })
+      // Execute the callback asynchronously.
+      CompletableFuture.runAsync(() => callback(1))
     }
 
     when(apiHandler.tryCompleteActions()).thenAnswer { _ =>

--- a/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
@@ -180,7 +180,6 @@ object AbstractCoordinatorConcurrencyTest {
                                processingStatsCallback: Map[TopicPartition, RecordConversionStats] => Unit = _ => (),
                                requestLocal: RequestLocal = RequestLocal.NoCaching,
                                transactionalId: String = null,
-                               transactionStatePartition: Option[Int],
                                actionQueue: ActionQueue = null): Unit = {
 
       if (entriesPerPartition.isEmpty)

--- a/core/src/test/scala/unit/kafka/coordinator/group/CoordinatorPartitionWriterTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/CoordinatorPartitionWriterTest.scala
@@ -112,7 +112,6 @@ class CoordinatorPartitionWriterTest {
       ArgumentMatchers.any(),
       ArgumentMatchers.any(),
       ArgumentMatchers.any(),
-      ArgumentMatchers.any(),
       ArgumentMatchers.any()
     )).thenAnswer( _ => {
       callbackCapture.getValue.apply(Map(
@@ -179,7 +178,6 @@ class CoordinatorPartitionWriterTest {
       ArgumentMatchers.eq(AppendOrigin.COORDINATOR),
       recordsCapture.capture(),
       callbackCapture.capture(),
-      ArgumentMatchers.any(),
       ArgumentMatchers.any(),
       ArgumentMatchers.any(),
       ArgumentMatchers.any(),

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -3865,7 +3865,6 @@ class GroupCoordinatorTest {
       any(),
       any(),
       any(),
-      any(),
       any()
     )).thenAnswer(_ => {
       capturedArgument.getValue.apply(
@@ -3901,7 +3900,6 @@ class GroupCoordinatorTest {
       any[Option[ReentrantLock]],
       any(),
       any(), 
-      any(),
       any(),
       any())).thenAnswer(_ => {
         capturedArgument.getValue.apply(
@@ -4049,9 +4047,8 @@ class GroupCoordinatorTest {
       any(),
       any(),
       any(),
-      any(),
-      any())
-    ).thenAnswer(_ => {
+      any()
+    )).thenAnswer(_ => {
       capturedArgument.getValue.apply(
         Map(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, groupPartitionId) ->
           new PartitionResponse(Errors.NONE, 0L, RecordBatch.NO_TIMESTAMP, 0L)
@@ -4085,9 +4082,8 @@ class GroupCoordinatorTest {
       any(),
       any(),
       any(),
-      any(),
-      any())
-    ).thenAnswer(_ => {
+      any()
+    )).thenAnswer(_ => {
       capturedArgument.getValue.apply(
         Map(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, groupCoordinator.partitionFor(groupId)) ->
           new PartitionResponse(Errors.NONE, 0L, RecordBatch.NO_TIMESTAMP, 0L)

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
@@ -1185,7 +1185,6 @@ class GroupMetadataManagerTest {
       any(),
       any(),
       any(),
-      any(),
       any())
     verify(replicaManager).getMagic(any())
   }
@@ -1221,7 +1220,6 @@ class GroupMetadataManagerTest {
       any(),
       any(),
       any[Option[ReentrantLock]],
-      any(),
       any(),
       any(),
       any(),
@@ -1301,7 +1299,6 @@ class GroupMetadataManagerTest {
       any(),
       any(),
       any(),
-      any(),
       any())
     // Will update sensor after commit
     assertEquals(1, TestUtils.totalMetricValue(metrics, "offset-commit-count"))
@@ -1341,7 +1338,6 @@ class GroupMetadataManagerTest {
       any[Map[TopicPartition, MemoryRecords]],
       capturedResponseCallback.capture(),
       any[Option[ReentrantLock]],
-      any(),
       any(),
       any(),
       any(),
@@ -1405,7 +1401,6 @@ class GroupMetadataManagerTest {
       any(),
       any(),
       any(),
-      any(),
       any())
     verify(replicaManager).getMagic(any())
   }
@@ -1453,7 +1448,6 @@ class GroupMetadataManagerTest {
       any[Map[TopicPartition, MemoryRecords]],
       any(),
       any[Option[ReentrantLock]],
-      any(),
       any(),
       any(),
       any(),
@@ -1609,7 +1603,6 @@ class GroupMetadataManagerTest {
       any(),
       any(),
       any(),
-      any(),
       any())
     verify(replicaManager).getMagic(any())
     assertEquals(1, TestUtils.totalMetricValue(metrics, "offset-commit-count"))
@@ -1714,7 +1707,6 @@ class GroupMetadataManagerTest {
       any(),
       any(),
       any[Option[ReentrantLock]],
-      any(),
       any(),
       any(),
       any(),
@@ -2825,7 +2817,6 @@ class GroupMetadataManagerTest {
       any(),
       any(),
       any(),
-      any(),
       any())
     capturedArgument
   }
@@ -2843,9 +2834,8 @@ class GroupMetadataManagerTest {
       any(),
       any(),
       any(),
-      any(),
-      any())
-    ).thenAnswer(_ => {
+      any()
+    )).thenAnswer(_ => {
       capturedCallback.getValue.apply(
         Map(groupTopicPartition ->
           new PartitionResponse(error, 0L, RecordBatch.NO_TIMESTAMP, 0L)

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -658,7 +658,6 @@ class TransactionStateManagerTest {
       any(),
       any(),
       any(),
-      any(),
       any()
     )
 
@@ -704,7 +703,6 @@ class TransactionStateManagerTest {
       any(),
       any(),
       any(),
-      any(),
       any()
     )
 
@@ -744,7 +742,6 @@ class TransactionStateManagerTest {
       any(),
       any(),
       any[Option[ReentrantLock]],
-      any(),
       any(),
       any(),
       any(),
@@ -803,7 +800,6 @@ class TransactionStateManagerTest {
       any(),
       any(),
       any[Option[ReentrantLock]],
-      any(),
       any(),
       any(),
       any(),
@@ -954,7 +950,6 @@ class TransactionStateManagerTest {
       recordsCapture.capture(),
       callbackCapture.capture(),
       any[Option[ReentrantLock]],
-      any(),
       any(),
       any(),
       any(),
@@ -1110,9 +1105,8 @@ class TransactionStateManagerTest {
       any(),
       any(),
       any(),
-      any(),
-      any())
-    ).thenAnswer(_ => capturedArgument.getValue.apply(
+      any()
+    )).thenAnswer(_ => capturedArgument.getValue.apply(
       Map(new TopicPartition(TRANSACTION_STATE_TOPIC_NAME, partitionId) ->
         new PartitionResponse(error, 0L, RecordBatch.NO_TIMESTAMP, 0L)))
     )

--- a/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnManagerTest.scala
@@ -15,15 +15,16 @@
  * limitations under the License.
  */
 
-package unit.kafka.server
+package kafka.server
 
 import com.yammer.metrics.core.{Histogram, Meter}
-import kafka.server.{AddPartitionsToTxnManager, KafkaConfig}
+import kafka.utils.Implicits.MapExtensionMethods
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.{ClientResponse, NetworkClient}
 import org.apache.kafka.common.errors.{AuthenticationException, SaslAuthenticationException, UnsupportedVersionException}
+import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.message.AddPartitionsToTxnRequestData.{AddPartitionsToTxnTopic, AddPartitionsToTxnTopicCollection, AddPartitionsToTxnTransaction, AddPartitionsToTxnTransactionCollection}
-import org.apache.kafka.common.message.AddPartitionsToTxnResponseData
+import org.apache.kafka.common.message.{AddPartitionsToTxnResponseData, MetadataResponseData}
 import org.apache.kafka.common.message.AddPartitionsToTxnResponseData.AddPartitionsToTxnResultCollection
 import org.apache.kafka.common.{Node, TopicPartition}
 import org.apache.kafka.common.protocol.Errors
@@ -44,13 +45,15 @@ import scala.jdk.CollectionConverters._
 
 class AddPartitionsToTxnManagerTest {
   private val networkClient: NetworkClient = mock(classOf[NetworkClient])
+  private val metadataCache: MetadataCache = mock(classOf[MetadataCache])
+  private val partitionFor: String => Int = mock(classOf[String => Int])
 
   private val time = new MockTime
 
   private var addPartitionsToTxnManager: AddPartitionsToTxnManager = _
 
-  val topic = "foo"
-  val topicPartitions = List(new TopicPartition(topic, 1), new TopicPartition(topic, 2), new TopicPartition(topic, 3))
+  private val topic = "foo"
+  private val topicPartitions = List(new TopicPartition(topic, 1), new TopicPartition(topic, 2), new TopicPartition(topic, 3))
 
   private val node0 = new Node(0, "host1", 0)
   private val node1 = new Node(1, "host2", 1)
@@ -68,12 +71,17 @@ class AddPartitionsToTxnManagerTest {
   private val versionMismatchResponse = clientResponse(null, mismatchException = new UnsupportedVersionException(""))
   private val disconnectedResponse = clientResponse(null, disconnected = true)
 
+  private val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(1, "localhost:2181"))
+
   @BeforeEach
   def setup(): Unit = {
     addPartitionsToTxnManager = new AddPartitionsToTxnManager(
-      KafkaConfig.fromProps(TestUtils.createBrokerConfig(1, "localhost:2181")),
+      config,
       networkClient,
-      time)
+      metadataCache,
+      partitionFor,
+      time
+    )
   }
 
   @AfterEach
@@ -81,21 +89,40 @@ class AddPartitionsToTxnManagerTest {
     addPartitionsToTxnManager.shutdown()
   }
 
-  def setErrors(errors: mutable.Map[TopicPartition, Errors])(callbackErrors: Map[TopicPartition, Errors]): Unit = {
-    callbackErrors.foreach {
-      case (tp, error) => errors.put(tp, error)
-    }
+  private def setErrors(errors: mutable.Map[TopicPartition, Errors])(callbackErrors: Map[TopicPartition, Errors]): Unit = {
+    callbackErrors.forKeyValue(errors.put)
   }
 
   @Test
   def testAddTxnData(): Unit = {
+    when(partitionFor.apply(transactionalId1)).thenReturn(0)
+    when(partitionFor.apply(transactionalId2)).thenReturn(1)
+    when(partitionFor.apply(transactionalId3)).thenReturn(0)
+    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
+      .thenReturn(Seq(
+        new MetadataResponseData.MetadataResponseTopic()
+          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setPartitions(List(
+            new MetadataResponseData.MetadataResponsePartition()
+              .setPartitionIndex(0)
+              .setLeaderId(0),
+            new MetadataResponseData.MetadataResponsePartition()
+              .setPartitionIndex(1)
+              .setLeaderId(1)
+          ).asJava)
+      ))
+    when(metadataCache.getAliveBrokerNode(0, config.interBrokerListenerName))
+      .thenReturn(Some(node0))
+    when(metadataCache.getAliveBrokerNode(1, config.interBrokerListenerName))
+      .thenReturn(Some(node1))
+
     val transaction1Errors = mutable.Map[TopicPartition, Errors]()
     val transaction2Errors = mutable.Map[TopicPartition, Errors]()
     val transaction3Errors = mutable.Map[TopicPartition, Errors]()
 
-    addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1), setErrors(transaction1Errors))
-    addPartitionsToTxnManager.addTxnData(node1, transactionData(transactionalId2, producerId2), setErrors(transaction2Errors))
-    addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId3, producerId3), setErrors(transaction3Errors))
+    addPartitionsToTxnManager.addTxnData(transactionalId1, producerId1, producerEpoch = 0, verifyOnly = true, topicPartitions, setErrors(transaction1Errors))
+    addPartitionsToTxnManager.addTxnData(transactionalId2, producerId2, producerEpoch = 0, verifyOnly = true, topicPartitions, setErrors(transaction2Errors))
+    addPartitionsToTxnManager.addTxnData(transactionalId3, producerId3, producerEpoch = 0, verifyOnly = true, topicPartitions, setErrors(transaction3Errors))
 
     // We will try to add transaction1 3 more times (retries). One will have the same epoch, one will have a newer epoch, and one will have an older epoch than the new one we just added.
     val transaction1RetryWithSameEpochErrors = mutable.Map[TopicPartition, Errors]()
@@ -103,52 +130,84 @@ class AddPartitionsToTxnManagerTest {
     val transaction1RetryWithOldEpochErrors = mutable.Map[TopicPartition, Errors]()
 
     // Trying to add more transactional data for the same transactional ID, producer ID, and epoch should simply replace the old data and send a retriable response.
-    addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1), setErrors(transaction1RetryWithSameEpochErrors))
+    addPartitionsToTxnManager.addTxnData(transactionalId1, producerId1, producerEpoch = 0, verifyOnly = true, topicPartitions, setErrors(transaction1RetryWithSameEpochErrors))
     val expectedNetworkErrors = topicPartitions.map(_ -> Errors.NETWORK_EXCEPTION).toMap
     assertEquals(expectedNetworkErrors, transaction1Errors)
 
     // Trying to add more transactional data for the same transactional ID and producer ID, but new epoch should replace the old data and send an error response for it.
-    addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1, producerEpoch = 1), setErrors(transaction1RetryWithNewerEpochErrors))
+    addPartitionsToTxnManager.addTxnData(transactionalId1, producerId1, producerEpoch = 1, verifyOnly = true, topicPartitions, setErrors(transaction1RetryWithNewerEpochErrors))
     val expectedEpochErrors = topicPartitions.map(_ -> Errors.INVALID_PRODUCER_EPOCH).toMap
     assertEquals(expectedEpochErrors, transaction1RetryWithSameEpochErrors)
 
     // Trying to add more transactional data for the same transactional ID and producer ID, but an older epoch should immediately return with error and keep the old data queued to send.
-    addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1, producerEpoch = 0), setErrors(transaction1RetryWithOldEpochErrors))
+    addPartitionsToTxnManager.addTxnData(transactionalId1, producerId1, producerEpoch = 0, verifyOnly = true, topicPartitions, setErrors(transaction1RetryWithOldEpochErrors))
     assertEquals(expectedEpochErrors, transaction1RetryWithOldEpochErrors)
 
     val requestsAndHandlers = addPartitionsToTxnManager.generateRequests().asScala
     requestsAndHandlers.foreach { requestAndHandler =>
       if (requestAndHandler.destination == node0) {
         assertEquals(time.milliseconds(), requestAndHandler.creationTimeMs)
-        assertEquals(AddPartitionsToTxnRequest.Builder.forBroker(
-          new AddPartitionsToTxnTransactionCollection(Seq(transactionData(transactionalId3, producerId3), transactionData(transactionalId1, producerId1, producerEpoch = 1)).iterator.asJava)).data,
-          requestAndHandler.request.asInstanceOf[AddPartitionsToTxnRequest.Builder].data) // insertion order
+        assertEquals(
+          AddPartitionsToTxnRequest.Builder.forBroker(
+            new AddPartitionsToTxnTransactionCollection(Seq(
+              transactionData(transactionalId3, producerId3, verifyOnly = true),
+              transactionData(transactionalId1, producerId1, producerEpoch = 1, verifyOnly = true)
+            ).iterator.asJava)
+          ).data,
+          requestAndHandler.request.asInstanceOf[AddPartitionsToTxnRequest.Builder].data // insertion order
+        )
       } else {
-        verifyRequest(node1, transactionalId2, producerId2, requestAndHandler)
+        verifyRequest(node1, transactionalId2, producerId2, requestAndHandler, verifyOnly = true)
       }
     }
   }
 
   @Test
   def testGenerateRequests(): Unit = {
+    when(partitionFor.apply(transactionalId1)).thenReturn(0)
+    when(partitionFor.apply(transactionalId2)).thenReturn(1)
+    when(partitionFor.apply(transactionalId3)).thenReturn(2)
+    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
+      .thenReturn(Seq(
+        new MetadataResponseData.MetadataResponseTopic()
+          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setPartitions(List(
+            new MetadataResponseData.MetadataResponsePartition()
+              .setPartitionIndex(0)
+              .setLeaderId(0),
+            new MetadataResponseData.MetadataResponsePartition()
+              .setPartitionIndex(1)
+              .setLeaderId(1),
+            new MetadataResponseData.MetadataResponsePartition()
+              .setPartitionIndex(2)
+              .setLeaderId(2)
+          ).asJava)
+      ))
+    when(metadataCache.getAliveBrokerNode(0, config.interBrokerListenerName))
+      .thenReturn(Some(node0))
+    when(metadataCache.getAliveBrokerNode(1, config.interBrokerListenerName))
+      .thenReturn(Some(node1))
+    when(metadataCache.getAliveBrokerNode(2, config.interBrokerListenerName))
+      .thenReturn(Some(node2))
+
     val transactionErrors = mutable.Map[TopicPartition, Errors]()
 
-    addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1), setErrors(transactionErrors))
-    addPartitionsToTxnManager.addTxnData(node1, transactionData(transactionalId2, producerId2), setErrors(transactionErrors))
+    addPartitionsToTxnManager.addTxnData(transactionalId1, producerId1, producerEpoch = 0, verifyOnly = true, topicPartitions, setErrors(transactionErrors))
+    addPartitionsToTxnManager.addTxnData(transactionalId2, producerId2, producerEpoch = 0, verifyOnly = false, topicPartitions, setErrors(transactionErrors))
 
     val requestsAndHandlers = addPartitionsToTxnManager.generateRequests().asScala
     assertEquals(2, requestsAndHandlers.size)
     // Note: handlers are tested in testAddPartitionsToTxnHandlerErrorHandling
-    requestsAndHandlers.foreach{ requestAndHandler =>
+    requestsAndHandlers.foreach { requestAndHandler =>
       if (requestAndHandler.destination == node0) {
-        verifyRequest(node0, transactionalId1, producerId1, requestAndHandler)
+        verifyRequest(node0, transactionalId1, producerId1, requestAndHandler, verifyOnly = true)
       } else {
-        verifyRequest(node1, transactionalId2, producerId2, requestAndHandler)
+        verifyRequest(node1, transactionalId2, producerId2, requestAndHandler, verifyOnly = false)
       }
     }
 
-    addPartitionsToTxnManager.addTxnData(node1, transactionData(transactionalId2, producerId2), setErrors(transactionErrors))
-    addPartitionsToTxnManager.addTxnData(node2, transactionData(transactionalId3, producerId3), setErrors(transactionErrors))
+    addPartitionsToTxnManager.addTxnData(transactionalId2, producerId2, producerEpoch = 0, verifyOnly = true, topicPartitions, setErrors(transactionErrors))
+    addPartitionsToTxnManager.addTxnData(transactionalId3, producerId3, producerEpoch = 0, verifyOnly = false, topicPartitions, setErrors(transactionErrors))
 
     // Test creationTimeMs increases too.
     time.sleep(10)
@@ -157,7 +216,7 @@ class AddPartitionsToTxnManagerTest {
     // The request for node1 should not be added because one request is already inflight.
     assertEquals(1, requestsAndHandlers2.size)
     requestsAndHandlers2.foreach { requestAndHandler =>
-      verifyRequest(node2, transactionalId3, producerId3, requestAndHandler)
+      verifyRequest(node2, transactionalId3, producerId3, requestAndHandler, verifyOnly = false)
     }
 
     // Complete the request for node1 so the new one can go through.
@@ -165,12 +224,97 @@ class AddPartitionsToTxnManagerTest {
     val requestsAndHandlers3 = addPartitionsToTxnManager.generateRequests().asScala
     assertEquals(1, requestsAndHandlers3.size)
     requestsAndHandlers3.foreach { requestAndHandler =>
-      verifyRequest(node1, transactionalId2, producerId2, requestAndHandler)
+      verifyRequest(node1, transactionalId2, producerId2, requestAndHandler, verifyOnly = true)
     }
   }
 
   @Test
+  def testTransactionCoordinatorResolution(): Unit = {
+    when(partitionFor.apply(transactionalId1)).thenReturn(0)
+
+    def checkError(): Unit = {
+      val errors = mutable.Map[TopicPartition, Errors]()
+
+      addPartitionsToTxnManager.addTxnData(
+        transactionalId1,
+        producerId1,
+        producerEpoch = 0,
+        verifyOnly = true,
+        topicPartitions,
+        setErrors(errors)
+      )
+
+      assertEquals(topicPartitions.map(tp => tp -> Errors.COORDINATOR_NOT_AVAILABLE).toMap, errors)
+    }
+
+    // The transaction state topic does not exist.
+    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
+      .thenReturn(Seq())
+    checkError()
+
+    // The metadata of the transaction state topic returns an error.
+    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
+      .thenReturn(Seq(
+        new MetadataResponseData.MetadataResponseTopic()
+          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setErrorCode(Errors.BROKER_NOT_AVAILABLE.code)
+      ))
+    checkError()
+
+    // The partition does not exist.
+    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
+      .thenReturn(Seq(
+        new MetadataResponseData.MetadataResponseTopic()
+          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+      ))
+    checkError()
+
+    // The partition has not leader.
+    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
+      .thenReturn(Seq(
+        new MetadataResponseData.MetadataResponseTopic()
+          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setErrorCode(Errors.BROKER_NOT_AVAILABLE.code)
+          .setPartitions(List(
+            new MetadataResponseData.MetadataResponsePartition()
+              .setPartitionIndex(0)
+              .setLeaderId(-1)
+          ).asJava)
+      ))
+    checkError()
+
+    // The leader is not available.
+    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
+      .thenReturn(Seq(
+        new MetadataResponseData.MetadataResponseTopic()
+          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setErrorCode(Errors.BROKER_NOT_AVAILABLE.code)
+          .setPartitions(List(
+            new MetadataResponseData.MetadataResponsePartition()
+              .setPartitionIndex(0)
+              .setLeaderId(0)
+          ).asJava)
+      ))
+    checkError()
+  }
+
+  @Test
   def testAddPartitionsToTxnHandlerErrorHandling(): Unit = {
+    when(partitionFor.apply(transactionalId1)).thenReturn(0)
+    when(partitionFor.apply(transactionalId2)).thenReturn(0)
+    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
+      .thenReturn(Seq(
+        new MetadataResponseData.MetadataResponseTopic()
+          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setPartitions(List(
+            new MetadataResponseData.MetadataResponsePartition()
+              .setPartitionIndex(0)
+              .setLeaderId(0)
+          ).asJava)
+      ))
+    when(metadataCache.getAliveBrokerNode(0, config.interBrokerListenerName))
+      .thenReturn(Some(node0))
+
     val transaction1Errors = mutable.Map[TopicPartition, Errors]()
     val transaction2Errors = mutable.Map[TopicPartition, Errors]()
 
@@ -178,8 +322,8 @@ class AddPartitionsToTxnManagerTest {
       transaction1Errors.clear()
       transaction2Errors.clear()
 
-      addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId1, producerId1), setErrors(transaction1Errors))
-      addPartitionsToTxnManager.addTxnData(node0, transactionData(transactionalId2, producerId2), setErrors(transaction2Errors))
+      addPartitionsToTxnManager.addTxnData(transactionalId1, producerId1, producerEpoch = 0, verifyOnly = false, topicPartitions, setErrors(transaction1Errors))
+      addPartitionsToTxnManager.addTxnData(transactionalId2, producerId2, producerEpoch = 0, verifyOnly = false, topicPartitions, setErrors(transaction2Errors))
     }
 
     val expectedAuthErrors = topicPartitions.map(_ -> Errors.SASL_AUTHENTICATION_FAILED).toMap
@@ -237,29 +381,49 @@ class AddPartitionsToTxnManagerTest {
     val mockVerificationFailureMeter = mock(classOf[Meter])
     val mockVerificationTime = mock(classOf[Histogram])
 
+    when(partitionFor.apply(transactionalId1)).thenReturn(0)
+    when(partitionFor.apply(transactionalId2)).thenReturn(1)
+    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
+      .thenReturn(Seq(
+        new MetadataResponseData.MetadataResponseTopic()
+          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setPartitions(List(
+            new MetadataResponseData.MetadataResponsePartition()
+              .setPartitionIndex(0)
+              .setLeaderId(0),
+            new MetadataResponseData.MetadataResponsePartition()
+              .setPartitionIndex(1)
+              .setLeaderId(1)
+          ).asJava)
+      ))
+    when(metadataCache.getAliveBrokerNode(0, config.interBrokerListenerName))
+      .thenReturn(Some(node0))
+    when(metadataCache.getAliveBrokerNode(1, config.interBrokerListenerName))
+      .thenReturn(Some(node1))
+
     // Update max verification time when we see a higher verification time.
-    when(mockVerificationTime.update(anyLong())).thenAnswer(
-      {
-        invocation =>
-          val newTime = invocation.getArgument(0).asInstanceOf[Long]
-          if (newTime > maxVerificationTime)
-            maxVerificationTime = newTime
-      }
-    )
+    when(mockVerificationTime.update(anyLong())).thenAnswer { invocation =>
+      val newTime = invocation.getArgument(0).asInstanceOf[Long]
+      if (newTime > maxVerificationTime)
+        maxVerificationTime = newTime
+    }
 
     val mockMetricsGroupCtor = mockConstruction(classOf[KafkaMetricsGroup], (mock: KafkaMetricsGroup, context: Context) => {
-        when(mock.newMeter(ArgumentMatchers.eq(AddPartitionsToTxnManager.VerificationFailureRateMetricName), anyString(), any(classOf[TimeUnit]))).thenReturn(mockVerificationFailureMeter)
-        when(mock.newHistogram(ArgumentMatchers.eq(AddPartitionsToTxnManager.VerificationTimeMsMetricName))).thenReturn(mockVerificationTime)
-      })
+      when(mock.newMeter(ArgumentMatchers.eq(AddPartitionsToTxnManager.VerificationFailureRateMetricName), anyString(), any(classOf[TimeUnit]))).thenReturn(mockVerificationFailureMeter)
+      when(mock.newHistogram(ArgumentMatchers.eq(AddPartitionsToTxnManager.VerificationTimeMsMetricName))).thenReturn(mockVerificationTime)
+    })
 
     val addPartitionsManagerWithMockedMetrics = new AddPartitionsToTxnManager(
-      KafkaConfig.fromProps(TestUtils.createBrokerConfig(1, "localhost:2181")),
+      config,
       networkClient,
-      time)
+      metadataCache,
+      partitionFor,
+      time
+    )
 
     try {
-      addPartitionsManagerWithMockedMetrics.addTxnData(node0, transactionData(transactionalId1, producerId1), setErrors(transactionErrors))
-      addPartitionsManagerWithMockedMetrics.addTxnData(node1, transactionData(transactionalId2, producerId2), setErrors(transactionErrors))
+      addPartitionsManagerWithMockedMetrics.addTxnData(transactionalId1, producerId1, producerEpoch = 0, verifyOnly = false, topicPartitions, setErrors(transactionErrors))
+      addPartitionsManagerWithMockedMetrics.addTxnData(transactionalId2, producerId2, producerEpoch = 0, verifyOnly = false, topicPartitions, setErrors(transactionErrors))
 
       time.sleep(100)
 
@@ -297,15 +461,26 @@ class AddPartitionsToTxnManagerTest {
     }
   }
 
-  private def clientResponse(response: AbstractResponse, authException: AuthenticationException = null, mismatchException: UnsupportedVersionException = null, disconnected: Boolean = false): ClientResponse = {
+  private def clientResponse(
+    response: AbstractResponse,
+    authException: AuthenticationException = null,
+    mismatchException: UnsupportedVersionException = null,
+    disconnected: Boolean = false
+  ): ClientResponse = {
     new ClientResponse(null, null, null, 0, 0, disconnected, mismatchException, authException, response)
   }
 
-  private def transactionData(transactionalId: String, producerId: Long, producerEpoch: Short = 0): AddPartitionsToTxnTransaction = {
+  private def transactionData(
+    transactionalId: String,
+    producerId: Long,
+    producerEpoch: Short = 0,
+    verifyOnly: Boolean
+  ): AddPartitionsToTxnTransaction = {
     new AddPartitionsToTxnTransaction()
       .setTransactionalId(transactionalId)
       .setProducerId(producerId)
       .setProducerEpoch(producerEpoch)
+      .setVerifyOnly(verifyOnly)
       .setTopics(new AddPartitionsToTxnTopicCollection(
         Seq(new AddPartitionsToTxnTopic()
           .setName(topic)
@@ -316,11 +491,22 @@ class AddPartitionsToTxnManagerTest {
     addPartitionsToTxnManager.generateRequests().asScala.head.handler.onComplete(response)
   }
 
-  private def verifyRequest(expectedDestination: Node, transactionalId: String, producerId: Long, requestAndHandler: RequestAndCompletionHandler): Unit = {
+  private def verifyRequest(
+    expectedDestination: Node,
+    transactionalId: String,
+    producerId: Long,
+    requestAndHandler: RequestAndCompletionHandler,
+    verifyOnly: Boolean
+  ): Unit = {
     assertEquals(time.milliseconds(), requestAndHandler.creationTimeMs)
     assertEquals(expectedDestination, requestAndHandler.destination)
-    assertEquals(AddPartitionsToTxnRequest.Builder.forBroker(
-      new AddPartitionsToTxnTransactionCollection(Seq(transactionData(transactionalId, producerId)).iterator.asJava)).data,
-      requestAndHandler.request.asInstanceOf[AddPartitionsToTxnRequest.Builder].data)
+    assertEquals(
+      AddPartitionsToTxnRequest.Builder.forBroker(
+        new AddPartitionsToTxnTransactionCollection(
+          Seq(transactionData(transactionalId, producerId, verifyOnly = verifyOnly)).iterator.asJava
+        )
+      ).data,
+      requestAndHandler.request.asInstanceOf[AddPartitionsToTxnRequest.Builder].data
+    )
   }
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -2326,9 +2326,8 @@ class KafkaApisTest {
         any(),
         any(),
         any(),
-        any(),
-        any())
-      ).thenAnswer(_ => responseCallback.getValue.apply(Map(tp -> new PartitionResponse(Errors.INVALID_PRODUCER_EPOCH))))
+        any()
+      )).thenAnswer(_ => responseCallback.getValue.apply(Map(tp -> new PartitionResponse(Errors.INVALID_PRODUCER_EPOCH))))
 
       when(clientRequestQuotaManager.maybeRecordAndGetThrottleTimeMs(any[RequestChannel.Request](),
         any[Long])).thenReturn(0)
@@ -2351,7 +2350,6 @@ class KafkaApisTest {
   def testTransactionalParametersSetCorrectly(): Unit = {
     val topic = "topic"
     val transactionalId = "txn1"
-    val transactionCoordinatorPartition = 35
 
     addTopicToMetadataCache(topic, numPartitions = 2)
 
@@ -2379,10 +2377,6 @@ class KafkaApisTest {
 
       val kafkaApis = createKafkaApis()
       
-      when(txnCoordinator.partitionFor(
-        ArgumentMatchers.eq(transactionalId))
-      ).thenReturn(transactionCoordinatorPartition)
-      
       kafkaApis.handleProduceRequest(request, RequestLocal.withThreadConfinedCaching)
       
       verify(replicaManager).appendRecords(anyLong,
@@ -2395,7 +2389,6 @@ class KafkaApisTest {
         any(),
         any(),
         ArgumentMatchers.eq(transactionalId),
-        ArgumentMatchers.eq(Some(transactionCoordinatorPartition)),
         any())
     }
   }
@@ -2523,9 +2516,8 @@ class KafkaApisTest {
       any(),
       ArgumentMatchers.eq(requestLocal),
       any(),
-      any(),
-      any())
-    ).thenAnswer(_ => responseCallback.getValue.apply(Map(tp2 -> new PartitionResponse(Errors.NONE))))
+      any()
+    )).thenAnswer(_ => responseCallback.getValue.apply(Map(tp2 -> new PartitionResponse(Errors.NONE))))
 
     createKafkaApis().handleWriteTxnMarkersRequest(request, requestLocal)
 
@@ -2656,9 +2648,8 @@ class KafkaApisTest {
       any(),
       ArgumentMatchers.eq(requestLocal),
       any(),
-      any(),
-      any())
-    ).thenAnswer(_ => responseCallback.getValue.apply(Map(tp2 -> new PartitionResponse(Errors.NONE))))
+      any()
+    )).thenAnswer(_ => responseCallback.getValue.apply(Map(tp2 -> new PartitionResponse(Errors.NONE))))
 
     createKafkaApis().handleWriteTxnMarkersRequest(request, requestLocal)
     verify(requestChannel).sendResponse(
@@ -2690,7 +2681,6 @@ class KafkaApisTest {
       any(),
       any(),
       ArgumentMatchers.eq(requestLocal),
-      any(),
       any(),
       any())
   }


### PR DESCRIPTION
This patch refactors the ReplicaManager.appendRecords method and the AddPartitionsToTxnManager class in order to move the logic to identify the transaction coordinator based on the transaction id from the former to the latter. While working on KAFKA-14505, I found pretty annoying that we require to pass the transaction state partition to appendRecords because we have to do the same from the group coordinator. It seems preferable to delegate that job to the AddPartitionsToTxnManager.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
