### PR TITLE
KAFKA-14506: Implement DeleteGroups API and OffsetDelete API

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -326,7 +326,7 @@
     <suppress checks="(NPathComplexity|MethodLength)"
               files="(GroupMetadataManager|ConsumerGroupTest|GroupMetadataManagerTest).java"/>
     <suppress checks="ClassFanOutComplexity"
-              files="(GroupMetadataManager|GroupMetadataManagerTest|GroupCoordinatorServiceTest).java"/>
+              files="(GroupMetadataManager|GroupMetadataManagerTest|GroupCoordinatorService|GroupCoordinatorServiceTest).java"/>
     <suppress checks="ParameterNumber"
               files="(ConsumerGroupMember|GroupMetadataManager).java"/>
     <suppress checks="ClassDataAbstractionCouplingCheck"

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -330,7 +330,7 @@
     <suppress checks="ParameterNumber"
               files="(ConsumerGroupMember|GroupMetadataManager).java"/>
     <suppress checks="ClassDataAbstractionCouplingCheck"
-              files="(RecordHelpersTest|GroupMetadataManager|GroupMetadataManagerTest|GroupCoordinatorServiceTest).java"/>
+              files="(RecordHelpersTest|GroupMetadataManager|GroupMetadataManagerTest|GroupCoordinatorServiceTest|GroupCoordinatorShardTest).java"/>
     <suppress checks="JavaNCSS"
               files="GroupMetadataManagerTest.java"/>
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteGroupsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteGroupsRequest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 
 public class DeleteGroupsRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<DeleteGroupsRequest> {
@@ -77,5 +78,19 @@ public class DeleteGroupsRequest extends AbstractRequest {
     @Override
     public DeleteGroupsRequestData data() {
         return data;
+    }
+
+    public static DeleteGroupsResponseData.DeletableGroupResultCollection getErrorResultCollection(
+        List<String> groupIds,
+        Errors error
+    ) {
+        DeleteGroupsResponseData.DeletableGroupResultCollection resultCollection =
+            new DeleteGroupsResponseData.DeletableGroupResultCollection();
+        groupIds.forEach(groupId -> resultCollection.add(
+            new DeleteGroupsResponseData.DeletableGroupResult()
+                .setGroupId(groupId)
+                .setErrorCode(error.code())
+        ));
+        return resultCollection;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteGroupsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteGroupsRequest.java
@@ -18,8 +18,6 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.DeleteGroupsRequestData;
 import org.apache.kafka.common.message.DeleteGroupsResponseData;
-import org.apache.kafka.common.message.DeleteGroupsResponseData.DeletableGroupResult;
-import org.apache.kafka.common.message.DeleteGroupsResponseData.DeletableGroupResultCollection;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
@@ -56,18 +54,9 @@ public class DeleteGroupsRequest extends AbstractRequest {
 
     @Override
     public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
-        Errors error = Errors.forException(e);
-        DeletableGroupResultCollection groupResults = new DeletableGroupResultCollection();
-        for (String groupId : data.groupsNames()) {
-            groupResults.add(new DeletableGroupResult()
-                                 .setGroupId(groupId)
-                                 .setErrorCode(error.code()));
-        }
-
-        return new DeleteGroupsResponse(
-            new DeleteGroupsResponseData()
-                .setResults(groupResults)
-                .setThrottleTimeMs(throttleTimeMs)
+        return new DeleteGroupsResponse(new DeleteGroupsResponseData()
+            .setResults(getErrorResultCollection(data.groupsNames(), Errors.forException(e)))
+            .setThrottleTimeMs(throttleTimeMs)
         );
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/DeleteGroupsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/DeleteGroupsRequestTest.java
@@ -28,11 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DeleteGroupsRequestTest {
 
-    protected static String groupId1 = "group-id-1";
-    protected static String groupId2 = "group-id-2";
-
     @Test
     public void testGetErrorResultCollection() {
+        String groupId1 = "group-id-1";
+        String groupId2 = "group-id-2";
         DeleteGroupsRequestData data = new DeleteGroupsRequestData()
             .setGroupsNames(Arrays.asList(groupId1, groupId2));
         DeleteGroupsResponseData.DeletableGroupResultCollection expectedResultCollection =

--- a/clients/src/test/java/org/apache/kafka/common/requests/DeleteGroupsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/DeleteGroupsRequestTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.DeleteGroupsRequestData;
 import org.apache.kafka.common.message.DeleteGroupsResponseData;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -32,16 +31,10 @@ public class DeleteGroupsRequestTest {
     protected static String groupId1 = "group-id-1";
     protected static String groupId2 = "group-id-2";
 
-    private static DeleteGroupsRequestData data;
-
-    @BeforeEach
-    public void setUp() {
-        data = new DeleteGroupsRequestData()
-            .setGroupsNames(Arrays.asList(groupId1, groupId2));
-    }
-
     @Test
     public void testGetErrorResultCollection() {
+        DeleteGroupsRequestData data = new DeleteGroupsRequestData()
+            .setGroupsNames(Arrays.asList(groupId1, groupId2));
         DeleteGroupsResponseData.DeletableGroupResultCollection expectedResultCollection =
             new DeleteGroupsResponseData.DeletableGroupResultCollection(Arrays.asList(
                 new DeleteGroupsResponseData.DeletableGroupResult()

--- a/clients/src/test/java/org/apache/kafka/common/requests/DeleteGroupsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/DeleteGroupsRequestTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.DeleteGroupsRequestData;
+import org.apache.kafka.common.message.DeleteGroupsResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.apache.kafka.common.requests.DeleteGroupsRequest.getErrorResultCollection;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DeleteGroupsRequestTest {
+
+    protected static String groupId1 = "group-id-1";
+    protected static String groupId2 = "group-id-2";
+
+    private static DeleteGroupsRequestData data;
+
+    @BeforeEach
+    public void setUp() {
+        data = new DeleteGroupsRequestData()
+            .setGroupsNames(Arrays.asList(groupId1, groupId2));
+    }
+
+    @Test
+    public void testGetErrorResultCollection() {
+        DeleteGroupsResponseData.DeletableGroupResultCollection expectedResultCollection =
+            new DeleteGroupsResponseData.DeletableGroupResultCollection(Arrays.asList(
+                new DeleteGroupsResponseData.DeletableGroupResult()
+                    .setGroupId(groupId1)
+                    .setErrorCode(Errors.COORDINATOR_LOAD_IN_PROGRESS.code()),
+                new DeleteGroupsResponseData.DeletableGroupResult()
+                    .setGroupId(groupId2)
+                    .setErrorCode(Errors.COORDINATOR_LOAD_IN_PROGRESS.code())
+            ).iterator());
+
+        assertEquals(expectedResultCollection, getErrorResultCollection(data.groupsNames(), Errors.COORDINATOR_LOAD_IN_PROGRESS));
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
@@ -110,6 +110,7 @@ public interface Group {
      * @return Whether the group is subscribed to the topic.
      */
     boolean isSubscribedToTopic(String topic);
+    
     /**
      * Populates the list of records with tombstone(s) for deleting the group.
      *

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
@@ -99,15 +99,15 @@ public interface Group {
     void validateOffsetDelete() throws KafkaException;
 
     /**
-     * Validates the GroupDelete request.
+     * Validates the DeleteGroups request.
      */
-    void validateGroupDelete() throws KafkaException;
+    void validateDeleteGroup() throws KafkaException;
 
     /**
      * Returns true if the group is actively subscribed to the topic.
      *
      * @param topic The topic name.
-     * @return whether the group is subscribed to the topic.
+     * @return Whether the group is subscribed to the topic.
      */
     boolean isSubscribedToTopic(String topic);
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
@@ -116,5 +116,5 @@ public interface Group {
      *
      * @return The list of tombstone record(s).
      */
-    List<Record> createMetadataTombstoneRecords();
+    List<Record> createGroupTombstoneRecords();
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
@@ -92,15 +92,20 @@ public interface Group {
     ) throws KafkaException;
 
     /**
+     * Validates the OffsetDelete request.
+     */
+    void validateOffsetDelete() throws KafkaException;
+
+    /**
+     * Validates the GroupDelete request
+     */
+    void validateGroupDelete() throws KafkaException;
+
+    /**
      * Returns true if the group is actively subscribed to the topic.
      *
      * @param topic the topic name.
      * @return whether the group is subscribed to the topic.
      */
-    public boolean isSubscribedToTopic(String topic);
-
-    /**
-     * Returns true if the group is DEAD.
-     */
-    public boolean isDead();
+     boolean isSubscribedToTopic(String topic);
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
@@ -90,4 +90,17 @@ public interface Group {
         int memberEpoch,
         long lastCommittedOffset
     ) throws KafkaException;
+
+    /**
+     * Returns true if the group is actively subscribed to the topic.
+     *
+     * @param topic the topic name.
+     * @return whether the group is subscribed to the topic.
+     */
+    public boolean isSubscribedToTopic(String topic);
+
+    /**
+     * Returns true if the group is DEAD.
+     */
+    public boolean isDead();
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
@@ -108,4 +108,11 @@ public interface Group {
      * @return whether the group is subscribed to the topic.
      */
     boolean isSubscribedToTopic(String topic);
+
+    /**
+     * Creates a GroupMetadata tombstone.
+     *
+     * @return The record.
+     */
+    Record createMetadataTombstoneRecord();
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
@@ -110,11 +110,10 @@ public interface Group {
      * @return Whether the group is subscribed to the topic.
      */
     boolean isSubscribedToTopic(String topic);
-
     /**
-     * Creates tombstone(s) for deleting the group.
+     * Populates the list of records with tombstone(s) for deleting the group.
      *
-     * @return The list of tombstone record(s).
+     * @param records The list of records.
      */
-    List<Record> createGroupTombstoneRecords();
+    void createGroupTombstoneRecords(List<Record> records);
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
@@ -19,6 +19,8 @@ package org.apache.kafka.coordinator.group;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.message.ListGroupsResponseData;
 
+import java.util.List;
+
 /**
  * Interface common for all groups.
  */
@@ -97,22 +99,22 @@ public interface Group {
     void validateOffsetDelete() throws KafkaException;
 
     /**
-     * Validates the GroupDelete request
+     * Validates the GroupDelete request.
      */
     void validateGroupDelete() throws KafkaException;
 
     /**
      * Returns true if the group is actively subscribed to the topic.
      *
-     * @param topic the topic name.
+     * @param topic The topic name.
      * @return whether the group is subscribed to the topic.
      */
     boolean isSubscribedToTopic(String topic);
 
     /**
-     * Creates a GroupMetadata tombstone.
+     * Creates tombstone(s) for deleting the group.
      *
-     * @return The record.
+     * @return The list of tombstone record(s).
      */
-    Record createMetadataTombstoneRecord();
+    List<Record> createMetadataTombstoneRecords();
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/Group.java
@@ -107,5 +107,5 @@ public interface Group {
      * @param topic the topic name.
      * @return whether the group is subscribed to the topic.
      */
-     boolean isSubscribedToTopic(String topic);
+    boolean isSubscribedToTopic(String topic);
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -548,7 +548,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
         groupsByTopicPartition.forEach((topicPartition, groupList) -> {
             CompletableFuture<DeleteGroupsResponseData.DeletableGroupResultCollection> future =
                 runtime.scheduleWriteOperation(
-                    "delete-group",
+                    "delete-groups",
                     topicPartition,
                     coordinator -> coordinator.deleteGroups(context, groupList)
                 ).exceptionally(exception -> {
@@ -784,7 +784,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
         }
 
         return runtime.scheduleWriteOperation(
-            "delete-offset",
+            "delete-offsets",
             topicPartitionFor(request.groupId()),
             coordinator -> coordinator.deleteOffsets(context, request)
         ).exceptionally(exception -> {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -745,29 +745,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
                 "delete-offset",
                 topicPartitionFor(request.groupId()),
                 coordinator -> coordinator.deleteOffsets(context, request)
-        ).exceptionally(exception -> {
-            if (exception instanceof UnknownTopicOrPartitionException ||
-                    exception instanceof NotEnoughReplicasException) {
-                return new OffsetDeleteResponseData()
-                        .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code());
-            }
-
-            if (exception instanceof NotLeaderOrFollowerException ||
-                    exception instanceof KafkaStorageException) {
-                return new OffsetDeleteResponseData()
-                        .setErrorCode(Errors.NOT_COORDINATOR.code());
-            }
-
-            if (exception instanceof RecordTooLargeException ||
-                    exception instanceof RecordBatchTooLargeException ||
-                    exception instanceof InvalidFetchSizeException) {
-                return new OffsetDeleteResponseData()
-                        .setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code());
-            }
-
-            return new OffsetDeleteResponseData()
-                    .setErrorCode(Errors.forException(exception).code());
-        });
+        );
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -531,7 +531,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
 
         final Map<TopicPartition, List<String>> groupsByTopicPartition = new HashMap<>();
         groupIds.forEach(groupId -> {
-            // For backwards compatibility, we support fetch commits for the empty group id.
+            // For backwards compatibility, we support DeleteGroups for the empty group id.
             if (groupId == null) {
                 futures.add(CompletableFuture.completedFuture(DeleteGroupsRequest.getErrorResultCollection(
                     Collections.singletonList(null),

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -540,7 +540,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
         });
 
         final CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-        return allFutures.thenApply(v -> {
+        return allFutures.thenApply(__ -> {
             final DeleteGroupsResponseData.DeletableGroupResultCollection res = new DeleteGroupsResponseData.DeletableGroupResultCollection();
             futures.forEach(future ->
                 // We don't use res.addAll(future.join()) because DeletableGroupResultCollection is an ImplicitLinkedHashMultiCollection,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -541,7 +541,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
             CompletableFuture<DeleteGroupsResponseData.DeletableGroupResultCollection> future =
                     runtime.scheduleWriteOperation("delete-group",
                             new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, partition),
-                            coordinator -> coordinator.DeleteGroups(context, groupList));
+                            coordinator -> coordinator.deleteGroups(context, groupList));
             futures.add(future);
         }
 
@@ -744,7 +744,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return runtime.scheduleWriteOperation(
                 "delete-offset",
                 topicPartitionFor(request.groupId()),
-                coordinator -> coordinator.DeleteOffsets(context, request)
+                coordinator -> coordinator.deleteOffsets(context, request)
         ).exceptionally(exception -> {
             if (exception instanceof UnknownTopicOrPartitionException ||
                     exception instanceof NotEnoughReplicasException) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -741,7 +741,29 @@ public class GroupCoordinatorService implements GroupCoordinator {
             "delete-offset",
             topicPartitionFor(request.groupId()),
             coordinator -> coordinator.deleteOffsets(context, request)
-        );
+        ).exceptionally(exception -> {
+            if (exception instanceof UnknownTopicOrPartitionException ||
+                exception instanceof NotEnoughReplicasException) {
+                return new OffsetDeleteResponseData()
+                    .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code());
+            }
+
+            if (exception instanceof NotLeaderOrFollowerException ||
+                exception instanceof KafkaStorageException) {
+                return new OffsetDeleteResponseData()
+                    .setErrorCode(Errors.NOT_COORDINATOR.code());
+            }
+
+            if (exception instanceof RecordTooLargeException ||
+                exception instanceof RecordBatchTooLargeException ||
+                exception instanceof InvalidFetchSizeException) {
+                return new OffsetDeleteResponseData()
+                    .setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code());
+            }
+
+            return new OffsetDeleteResponseData()
+                .setErrorCode(Errors.forException(exception).code());
+        });
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -581,6 +581,8 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return allFutures.thenApply(v -> {
             final DeleteGroupsResponseData.DeletableGroupResultCollection res = new DeleteGroupsResponseData.DeletableGroupResultCollection();
             futures.forEach(future ->
+                // We don't use res.addAll(future.join()) because DeletableGroupResultCollection is an ImplicitLinkedHashMultiCollection,
+                // which has requirements for adding elements (see org/apache/kafka/common/utils/ImplicitLinkedHashCollection.java#add).
                 future.join().forEach(result ->
                     res.add(result.duplicate())
                 )

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -580,9 +580,11 @@ public class GroupCoordinatorService implements GroupCoordinator {
         final CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         return allFutures.thenApply(v -> {
             final DeleteGroupsResponseData.DeletableGroupResultCollection res = new DeleteGroupsResponseData.DeletableGroupResultCollection();
-            futures.forEach(future -> res.addAll(future.join()));
-            // TODO: res.addAll(future.join()) returns false
-            // res.addAll(new DeleteGroupsResponseData.DeletableGroupResult()) returns true
+            futures.forEach(future ->
+                future.join().forEach(result ->
+                    res.add(result.duplicate())
+                )
+            );
             return res;
         });
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -529,7 +529,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
         groupIds.forEach(groupId -> {
             final TopicPartition topicPartition = topicPartitionFor(groupId);
             groupsByTopicPartition
-                .computeIfAbsent(topicPartition, __ -> new ArrayList())
+                .computeIfAbsent(topicPartition, __ -> new ArrayList<>())
                 .add(groupId);
         });
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -546,7 +546,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     if (exception instanceof UnknownTopicOrPartitionException ||
                         exception instanceof NotEnoughReplicasException) {
                         return DeleteGroupsRequest.getErrorResultCollection(
-                            groupIds,
+                            groupList,
                             Errors.COORDINATOR_NOT_AVAILABLE
                         );
                     }
@@ -554,7 +554,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     if (exception instanceof NotLeaderOrFollowerException ||
                         exception instanceof KafkaStorageException) {
                         return DeleteGroupsRequest.getErrorResultCollection(
-                            groupIds,
+                            groupList,
                             Errors.NOT_COORDINATOR
                         );
                     }
@@ -563,13 +563,13 @@ public class GroupCoordinatorService implements GroupCoordinator {
                         exception instanceof RecordBatchTooLargeException ||
                         exception instanceof InvalidFetchSizeException) {
                         return DeleteGroupsRequest.getErrorResultCollection(
-                            groupIds,
+                            groupList,
                             Errors.UNKNOWN_SERVER_ERROR
                         );
                     }
 
                     return DeleteGroupsRequest.getErrorResultCollection(
-                        groupIds,
+                        groupList,
                         Errors.forException(exception)
                     );
                 });

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -544,9 +544,10 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     DeleteGroupsResponseData.DeletableGroupResultCollection resultCollection =
                         new DeleteGroupsResponseData.DeletableGroupResultCollection();
                     groupIds.forEach(groupId -> {
-                        resultCollection.add(new DeleteGroupsResponseData.DeletableGroupResult()
-                            .setGroupId(groupId)
-                            .setErrorCode(Errors.forException(exception).code())
+                        resultCollection.add(
+                            new DeleteGroupsResponseData.DeletableGroupResult()
+                                .setGroupId(groupId)
+                                .setErrorCode(Errors.forException(exception).code())
                         );
                     });
                     return resultCollection;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -77,7 +77,6 @@ import org.slf4j.Logger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.OptionalInt;
@@ -535,20 +534,20 @@ public class GroupCoordinatorService implements GroupCoordinator {
             groupsByPartition.put(partition, groupList);
         }
 
-        List<CompletableFuture<DeleteGroupsResponseData.DeletableGroupResultCollection>> futures = new ArrayList<>();
+        final List<CompletableFuture<DeleteGroupsResponseData.DeletableGroupResultCollection>> futures = new ArrayList<>();
         for (Map.Entry<Integer, List<String>> entry : groupsByPartition.entrySet()) {
             int partition = entry.getKey();
             List<String> groupList = entry.getValue();
             CompletableFuture<DeleteGroupsResponseData.DeletableGroupResultCollection> future =
                     runtime.scheduleWriteOperation("delete-group",
                             new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, partition),
-                            coordinator -> coordinator.genericGroupDelete(context, groupList));
+                            coordinator -> coordinator.DeleteGroups(context, groupList));
             futures.add(future);
         }
 
-        CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        final CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         return allFutures.thenApply(v -> {
-            DeleteGroupsResponseData.DeletableGroupResultCollection res = new DeleteGroupsResponseData.DeletableGroupResultCollection();
+            final DeleteGroupsResponseData.DeletableGroupResultCollection res = new DeleteGroupsResponseData.DeletableGroupResultCollection();
             for (CompletableFuture<DeleteGroupsResponseData.DeletableGroupResultCollection> future : futures) {
                 try {
                     DeleteGroupsResponseData.DeletableGroupResultCollection result = future.get();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -581,6 +581,8 @@ public class GroupCoordinatorService implements GroupCoordinator {
         return allFutures.thenApply(v -> {
             final DeleteGroupsResponseData.DeletableGroupResultCollection res = new DeleteGroupsResponseData.DeletableGroupResultCollection();
             futures.forEach(future -> res.addAll(future.join()));
+            // TODO: res.addAll(future.join()) returns false
+            // res.addAll(new DeleteGroupsResponseData.DeletableGroupResult()) returns true
             return res;
         });
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -268,7 +268,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
     }
 
     /**
-     * Handles a GroupDelete request.
+     * Handles a DeleteGroups request.
      *
      * @param context   The request context.
      * @param groupIds  The groupIds of the groups to be deleted

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -286,7 +286,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
 
         final List<Record> records = groupDeleteCoordinatorResult.records();
         records.addAll(deleteOffsetCoordinatorResult.records());
-        return new CoordinatorResult(records, groupDeleteCoordinatorResult.response());
+        return new CoordinatorResult<>(records, groupDeleteCoordinatorResult.response());
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -280,7 +280,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
         List<String> groupIds
     ) throws ApiException {
         final DeleteGroupsResponseData.DeletableGroupResultCollection resultCollection =
-            new DeleteGroupsResponseData.DeletableGroupResultCollection();
+            new DeleteGroupsResponseData.DeletableGroupResultCollection(groupIds.size());
         final List<Record> records = new ArrayList<>();
 
         groupIds.forEach(groupId -> {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -271,6 +271,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
             RequestContext context,
             List<String> groupIds
     ) throws ApiException {
+
         CoordinatorResult<DeleteGroupsResponseData.DeletableGroupResultCollection, Record> groupDeleteCoordinatorResult =
                 groupMetadataManager.groupDelete(context, groupIds);
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -316,7 +316,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
             }
         });
 
-        log.info("The following groups were deleted: {}. A total of {} offsets were removed",
+        log.info("The following groups were deleted: {}. A total of {} offsets were removed.",
             String.join(", ", deletedGroups),
             numDeletedOffsets
         );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -285,7 +285,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
 
         groupIds.forEach(groupId -> {
             try {
-                groupMetadataManager.validateGroupDelete(groupId);
+                groupMetadataManager.validateDeleteGroup(groupId);
                 offsetMetadataManager.deleteAllOffsets(groupId, records);
                 groupMetadataManager.deleteGroup(groupId, records);
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -267,7 +267,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
         );
     }
 
-    public CoordinatorResult<DeleteGroupsResponseData.DeletableGroupResultCollection, Record> DeleteGroups(
+    public CoordinatorResult<DeleteGroupsResponseData.DeletableGroupResultCollection, Record> deleteGroups(
             RequestContext context,
             List<String> groupIds
     ) throws ApiException {
@@ -378,7 +378,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
      * @return A Result containing the OffsetDeleteResponse response and
      *         a list of records to update the state machine.
      */
-    public CoordinatorResult<OffsetDeleteResponseData, Record> DeleteOffsets(
+    public CoordinatorResult<OffsetDeleteResponseData, Record> deleteOffsets(
             RequestContext context,
             OffsetDeleteRequestData request
     ) throws ApiException {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.message.OffsetFetchRequestData;
 import org.apache.kafka.common.message.OffsetFetchResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
+import org.apache.kafka.common.message.*;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.requests.RequestContext;
@@ -262,6 +263,14 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
         );
     }
 
+    public CoordinatorResult<DeleteGroupsResponseData.DeletableGroupResultCollection, Record> genericGroupDelete(
+            RequestContext context,
+            List<String> groupIds
+    ) {
+//        CoordinatorResult<DeleteGroupsResponseData, Record> cleanupGroupCoordinatorResult = groupMetadataManager.cleanupGroupMetadata(...);
+//        CoordinatorResult<OffsetDeleteResponseData, Record> deleteOffsetCoordinatorResult = offsetMetadataManager.deleteAllOffsets();
+    }
+
     /**
      * Fetch offsets for a given set of partitions and a given group.
      *
@@ -339,6 +348,22 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
         LeaveGroupRequestData request
     ) throws ApiException {
         return groupMetadataManager.genericGroupLeave(context, request);
+    }
+
+    /**
+     * Handles a OffsetDelete request.
+     *
+     * @param context The request context.
+     * @param request The actual OffsetDelete request.
+     *
+     * @return A Result containing the OffsetDeleteResponse response and
+     *         a list of records to update the state machine.
+     */
+    public CoordinatorResult<OffsetDeleteResponseData, Record> DeleteOffsets(
+            RequestContext context,
+            OffsetDeleteRequestData request
+    ) throws ApiException {
+        return offsetMetadataManager.deleteOffsets(context, request);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -293,8 +293,8 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
         final DeleteGroupsResponseData.DeletableGroupResultCollection resultCollection =
             new DeleteGroupsResponseData.DeletableGroupResultCollection(groupIds.size());
         final List<Record> records = new ArrayList<>();
-        AtomicInteger numDeletedOffsets = new AtomicInteger();
-        List<String> deletedGroups = new ArrayList<>();
+        final AtomicInteger numDeletedOffsets = new AtomicInteger();
+        final List<String> deletedGroups = new ArrayList<>();
 
         groupIds.forEach(groupId -> {
             try {
@@ -356,7 +356,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
     }
 
     /**
-     * Handles a OffsetCommit request.
+     * Handles an OffsetCommit request.
      *
      * @param context The request context.
      * @param request The actual OffsetCommit request.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -270,8 +270,8 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
     /**
      * Handles a GroupDelete request.
      *
-     * @param context The request context.
-     * @param groupIds The groupIds of the groups to be deleted
+     * @param context   The request context.
+     * @param groupIds  The groupIds of the groups to be deleted
      * @return A Result containing the DeleteGroupsResponseData.DeletableGroupResultCollection response and
      *         a list of records to update the state machine.
      */
@@ -286,13 +286,13 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
         groupIds.forEach(groupId -> {
             try {
                 groupMetadataManager.validateGroupDelete(groupId);
+                offsetMetadataManager.deleteAllOffsets(groupId, records);
+                groupMetadataManager.deleteGroup(groupId, records);
 
-                offsetMetadataManager.populateRecordListToDeleteAllOffsets(context, groupId, records);
-                final CoordinatorResult<DeleteGroupsResponseData.DeletableGroupResult, Record> deleteGroupCoordinatorResult =
-                    groupMetadataManager.groupDelete(context, groupId);
-                records.addAll(deleteGroupCoordinatorResult.records());
-
-                resultCollection.add(deleteGroupCoordinatorResult.response());
+                resultCollection.add(
+                    new DeleteGroupsResponseData.DeletableGroupResult()
+                        .setGroupId(groupId)
+                );
             } catch (ApiException exception) {
                 resultCollection.add(
                     new DeleteGroupsResponseData.DeletableGroupResult()
@@ -303,7 +303,6 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
         });
 
         return new CoordinatorResult<>(records, resultCollection);
-
     }
 
     /**
@@ -398,7 +397,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
         RequestContext context,
         OffsetDeleteRequestData request
     ) throws ApiException {
-        return offsetMetadataManager.deleteOffsets(context, request);
+        return offsetMetadataManager.deleteOffsets(request);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3092,12 +3092,6 @@ public class GroupMetadataManager {
      * @param groupId The group id of the group to be deleted.
      */
     void validateGroupDelete(String groupId) throws ApiException {
-
-        // For backwards compatibility, we support group delete for the empty groupId.
-        if (groupId == null) {
-            throw Errors.INVALID_GROUP_ID.exception();
-        }
-
         Group group = group(groupId);
         group.validateGroupDelete();
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3077,17 +3077,15 @@ public class GroupMetadataManager {
      * Validations are done in {@link GroupCoordinatorShard#deleteGroups(RequestContext, List)} by
      * calling {@link GroupMetadataManager#validateDeleteGroup(String)}.
      *
-     * @param groupId The ID of the group to be deleted.
+     * @param groupId The ID of the group to be deleted. It has been checked in GroupMetadataManager#validateDeleteGroup.
      * @param records The record list to populate.
      */
     public void deleteGroup(
         String groupId,
         List<Record> records
     ) {
-        // groupId has been checked in GroupMetadataManager#validateDeleteGroup.
         // In this method, we only populate records with tombstone records, so we don't expect an exception to be thrown here.
-
-        records.addAll(group(groupId).createGroupTombstoneRecords());
+        group(groupId).createGroupTombstoneRecords(records);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3077,21 +3077,21 @@ public class GroupMetadataManager {
      * Validations are done in {@link GroupCoordinatorShard#deleteGroups(RequestContext, List)} by
      * calling {@link GroupMetadataManager#validateDeleteGroup(String)}.
      *
-     * @param groupId The ID of the group to be deleted. It has been checked in {@link GroupMetadataManager#validateDeleteGroup}.
+     * @param groupId The id of the group to be deleted. It has been checked in {@link GroupMetadataManager#validateDeleteGroup}.
      * @param records The record list to populate.
      */
     public void deleteGroup(
         String groupId,
         List<Record> records
     ) {
-        // In this method, we only populate records with tombstone records, so we don't expect an exception to be thrown here.
+        // At this point, we have already validated the group id, so we know that the group exists and that no exception will be thrown.
         group(groupId).createGroupTombstoneRecords(records);
     }
 
     /**
      * Validates the DeleteGroups request.
      *
-     * @param groupId The ID of the group to be deleted.
+     * @param groupId The id of the group to be deleted.
      */
     void validateDeleteGroup(String groupId) throws ApiException {
         Group group = group(groupId);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -31,7 +31,6 @@ import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnsupportedAssignorException;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
-import org.apache.kafka.common.message.DeleteGroupsResponseData;
 import org.apache.kafka.common.message.HeartbeatRequestData;
 import org.apache.kafka.common.message.HeartbeatResponseData;
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocol;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3072,28 +3072,32 @@ public class GroupMetadataManager {
     }
 
     /**
-     * Handles a GroupDelete request.
+     * Handles a DeleteGroups request.
      * Populates the record list passed in with record to update the state machine.
-     * Validations are done in deleteGroups method in GroupCoordinatorShard.
+     * Validations are done in {@link GroupCoordinatorShard#deleteGroups(RequestContext, List)} by
+     * calling {@link GroupMetadataManager#validateDeleteGroup(String)}.
      *
-     * @param groupId The group id of the group to be deleted.
+     * @param groupId The ID of the group to be deleted.
      * @param records The record list to populate.
      */
     public void deleteGroup(
         String groupId,
         List<Record> records
     ) {
+        // groupId has been checked in GroupMetadataManager#validateDeleteGroup.
+        // In this method, we only populate records with tombstone records, so we don't expect an exception to be thrown here.
+
         records.addAll(group(groupId).createGroupTombstoneRecords());
     }
 
     /**
-     * Validates the GroupDelete request.
+     * Validates the DeleteGroups request.
      *
-     * @param groupId The group id of the group to be deleted.
+     * @param groupId The ID of the group to be deleted.
      */
-    void validateGroupDelete(String groupId) throws ApiException {
+    void validateDeleteGroup(String groupId) throws ApiException {
         Group group = group(groupId);
-        group.validateGroupDelete();
+        group.validateDeleteGroup();
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3083,7 +3083,7 @@ public class GroupMetadataManager {
         String groupId,
         List<Record> records
     ) {
-        records.addAll(group(groupId).createMetadataTombstoneRecords());
+        records.addAll(group(groupId).createGroupTombstoneRecords());
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3077,7 +3077,7 @@ public class GroupMetadataManager {
      * Validations are done in {@link GroupCoordinatorShard#deleteGroups(RequestContext, List)} by
      * calling {@link GroupMetadataManager#validateDeleteGroup(String)}.
      *
-     * @param groupId The ID of the group to be deleted. It has been checked in GroupMetadataManager#validateDeleteGroup.
+     * @param groupId The ID of the group to be deleted. It has been checked in {@link GroupMetadataManager#validateDeleteGroup}.
      * @param records The record list to populate.
      */
     public void deleteGroup(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3074,25 +3074,24 @@ public class GroupMetadataManager {
 
     /**
      * Handles a GroupDelete request.
+     * Populates the record list passed in with record to update the state machine.
+     * Validations are done in deleteGroups method in GroupCoordinatorShard.
      *
-     * @param context The request context.
      * @param groupId The group id of the group to be deleted.
-     * @return A Result containing the DeleteGroupsResponseData.DeletableGroupResult response and
-     *         a list of records to update the state machine.
+     * @param records The record list to populate.
      */
-    public CoordinatorResult<DeleteGroupsResponseData.DeletableGroupResult, Record> groupDelete(
-            RequestContext context,
-            String groupId
+    public void deleteGroup(
+        String groupId,
+        List<Record> records
     ) throws ApiException {
-        DeleteGroupsResponseData.DeletableGroupResult result =
-            new DeleteGroupsResponseData.DeletableGroupResult().setGroupId(groupId);
-
-        final List<Record> records = new ArrayList<>();
-        records.add(group(groupId).createMetadataTombstoneRecord());
-
-        return new CoordinatorResult<>(records, result);
+        records.addAll(group(groupId).createMetadataTombstoneRecords());
     }
 
+    /**
+     * Validates the GroupDelete request.
+     *
+     * @param groupId The group id of the group to be deleted.
+     */
     void validateGroupDelete(String groupId) throws ApiException {
 
         // For backwards compatibility, we support group delete for the empty groupId.
@@ -3103,7 +3102,6 @@ public class GroupMetadataManager {
         Group group = group(groupId);
         group.validateGroupDelete();
     }
-
 
     /**
      * Checks whether the given protocol type or name in the request is inconsistent with the group's.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3082,7 +3082,7 @@ public class GroupMetadataManager {
     public void deleteGroup(
         String groupId,
         List<Record> records
-    ) throws ApiException {
+    ) {
         records.addAll(group(groupId).createMetadataTombstoneRecords());
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -401,7 +401,7 @@ public class OffsetMetadataManager {
     }
 
     /**
-     * Handles a GroupDelete request.
+     * Deletes offsets as part of a DeleteGroups request.
      * Populates the record list passed in with records to update the state machine.
      * Validations are done in deleteGroups method in GroupCoordinatorShard.
      *

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -382,16 +382,16 @@ public class OffsetMetadataManager {
                 );
             } else {
                 topic.partitions().forEach(partition -> {
-                    final OffsetDeleteResponseData.OffsetDeleteResponsePartition responsePartition =
-                        new OffsetDeleteResponseData.OffsetDeleteResponsePartition().setPartitionIndex(partition.partitionIndex());
                     if (offsetsByPartition != null && offsetsByPartition.containsKey(partition.partitionIndex())) {
+                        responsePartitionCollection.add(new OffsetDeleteResponseData.OffsetDeleteResponsePartition()
+                            .setPartitionIndex(partition.partitionIndex())
+                        );
                         records.add(RecordHelpers.newOffsetCommitTombstoneRecord(
                             request.groupId(),
                             topic.name(),
                             partition.partitionIndex()
                         ));
                     }
-                    responsePartitionCollection.add(responsePartition);
                 });
             }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -414,7 +414,7 @@ public class OffsetMetadataManager {
      * Populates the record list passed in with records to update the state machine.
      * Validations are done in {@link GroupCoordinatorShard#deleteGroups(RequestContext, List)}
      *
-     * @param groupId The ID of the given group.
+     * @param groupId The id of the given group.
      * @param records The record list to populate.
      *
      * @return The number of offsets to be deleted.
@@ -428,7 +428,7 @@ public class OffsetMetadataManager {
 
         if (offsetsByTopic != null) {
             offsetsByTopic.forEach((topic, offsetsByPartition) ->
-                offsetsByPartition.forEach((partition, __) -> {
+                offsetsByPartition.keySet().forEach(partition -> {
                     records.add(RecordHelpers.newOffsetCommitTombstoneRecord(groupId, topic, partition));
                     numDeletedOffsets.getAndIncrement();
                 })

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -411,7 +411,7 @@ public class OffsetMetadataManager {
     public void deleteAllOffsets(
         String groupId,
         List<Record> records
-    ) throws ApiException {
+    ) {
         TimelineHashMap<String, TimelineHashMap<Integer, OffsetAndMetadata>> offsetsByTopic = offsetsByGroup.get(groupId);
 
         if (offsetsByTopic != null) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -370,14 +370,13 @@ public class OffsetMetadataManager {
         request.topics().forEach(topic -> {
             final OffsetDeleteResponseData.OffsetDeleteResponsePartitionCollection responsePartitionCollection =
                 new OffsetDeleteResponseData.OffsetDeleteResponsePartitionCollection();
-            final boolean subscribedToTopic = group.isSubscribedToTopic(topic.name());
             final TimelineHashMap<Integer, OffsetAndMetadata> offsetsByPartition = offsetsByTopic == null ?
                 null : offsetsByTopic.get(topic.name());
 
             topic.partitions().forEach(partition -> {
                 final OffsetDeleteResponseData.OffsetDeleteResponsePartition responsePartition =
                     new OffsetDeleteResponseData.OffsetDeleteResponsePartition().setPartitionIndex(partition.partitionIndex());
-                if (subscribedToTopic) {
+                if (group.isSubscribedToTopic(topic.name())) {
                     responsePartition.setErrorCode(Errors.GROUP_SUBSCRIBED_TO_TOPIC.code());
                 } else if (offsetsByPartition != null && offsetsByPartition.containsKey(partition.partitionIndex())) {
                     records.add(RecordHelpers.newOffsetCommitTombstoneRecord(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -16,13 +16,16 @@
  */
 package org.apache.kafka.coordinator.group;
 
-import com.sun.tools.javac.util.DefinedBy;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.StaleMemberEpochException;
-import org.apache.kafka.common.message.*;
+import org.apache.kafka.common.message.OffsetCommitRequestData;
+import org.apache.kafka.common.message.OffsetCommitResponseData;
 import org.apache.kafka.common.message.OffsetCommitResponseData.OffsetCommitResponseTopic;
 import org.apache.kafka.common.message.OffsetCommitResponseData.OffsetCommitResponsePartition;
+import org.apache.kafka.common.message.OffsetDeleteRequestData;
+import org.apache.kafka.common.message.OffsetFetchRequestData;
+import org.apache.kafka.common.message.OffsetFetchResponseData;
 import org.apache.kafka.common.message.OffsetDeleteResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.OffsetCommitRequest;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
@@ -455,25 +455,6 @@ public class RecordHelpers {
     }
 
     /**
-     * Creates a ConsumerGroupMetadata tombstone.
-     *
-     * @param groupId  The group id.
-     * @return The record.
-     */
-    public static Record newConsumerGroupMetadataTombstoneRecord(
-        String groupId
-    ) {
-        return new Record(
-            new ApiMessageAndVersion(
-                new GroupMetadataKey()
-                    .setGroup(groupId),
-                (short) 3
-            ),
-            null // Tombstone
-        );
-    }
-
-    /**
      * Creates an empty GroupMetadata record.
      *
      * @param group              The generic group.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/RecordHelpers.java
@@ -455,6 +455,25 @@ public class RecordHelpers {
     }
 
     /**
+     * Creates a ConsumerGroupMetadata tombstone.
+     *
+     * @param groupId  The group id.
+     * @return The record.
+     */
+    public static Record newConsumerGroupMetadataTombstoneRecord(
+        String groupId
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new GroupMetadataKey()
+                    .setGroup(groupId),
+                (short) 3
+            ),
+            null // Tombstone
+        );
+    }
+
+    /**
      * Creates an empty GroupMetadata record.
      *
      * @param group              The generic group.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -25,6 +25,8 @@ import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.coordinator.group.Group;
+import org.apache.kafka.coordinator.group.Record;
+import org.apache.kafka.coordinator.group.RecordHelpers;
 import org.apache.kafka.image.ClusterImage;
 import org.apache.kafka.image.TopicImage;
 import org.apache.kafka.image.TopicsImage;
@@ -351,7 +353,7 @@ public class ConsumerGroup implements Group {
      * @return a boolean indicating whether the group is subscribed to the topic.
      */
     public boolean isSubscribedToTopic(String topic) {
-        return subscribedTopicNames.keySet().contains(topic);
+        return subscribedTopicNames.containsKey(topic);
     }
 
     /**
@@ -623,8 +625,8 @@ public class ConsumerGroup implements Group {
         if (state() == ConsumerGroupState.DEAD) {
             throw new GroupIdNotFoundException(String.format("Group %s is in dead state.", groupId));
         } else if (state() == ConsumerGroupState.STABLE
-                || state() == ConsumerGroupState.ASSIGNING
-                || state() == ConsumerGroupState.RECONCILING) {
+            || state() == ConsumerGroupState.ASSIGNING
+            || state() == ConsumerGroupState.RECONCILING) {
             throw Errors.NON_EMPTY_GROUP.exception();
         }
 
@@ -633,6 +635,15 @@ public class ConsumerGroup implements Group {
         if (groupEpoch() <= 0) {
             throw Errors.UNKNOWN_SERVER_ERROR.exception();
         }
+    }
+
+    /**
+     * Creates a GroupMetadata tombstone.
+     *
+     * @return The record.
+     */
+    public Record createMetadataTombstoneRecord() {
+        return RecordHelpers.newConsumerGroupMetadataTombstoneRecord(groupId());
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -618,12 +618,8 @@ public class ConsumerGroup implements Group {
      */
     @Override
     public void validateDeleteGroup() throws ApiException {
-        switch (state()) {
-            case STABLE:
-            case ASSIGNING:
-            case RECONCILING:
-                throw Errors.NON_EMPTY_GROUP.exception();
-            default:
+        if (state() != ConsumerGroupState.EMPTY) {
+            throw Errors.NON_EMPTY_GROUP.exception();
         }
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -628,6 +628,7 @@ public class ConsumerGroup implements Group {
      *
      * @param records The list of records.
      */
+    @Override
     public void createGroupTombstoneRecords(List<Record> records) {
         records.add(RecordHelpers.newTargetAssignmentEpochTombstoneRecord(groupId()));
         records.add(RecordHelpers.newGroupSubscriptionMetadataTombstoneRecord(groupId()));

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -19,7 +19,6 @@ package org.apache.kafka.coordinator.group.consumer;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ApiException;
-import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.StaleMemberEpochException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.message.ListGroupsResponseData;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -34,7 +34,6 @@ import org.apache.kafka.timeline.TimelineHashMap;
 import org.apache.kafka.timeline.TimelineInteger;
 import org.apache.kafka.timeline.TimelineObject;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -629,16 +628,14 @@ public class ConsumerGroup implements Group {
     }
 
     /**
-     * Creates tombstone(s) for deleting the group.
+     * Populates the list of records with tombstone(s) for deleting the group.
      *
-     * @return The list of tombstone record(s).
+     * @param records The list of records.
      */
-    public List<Record> createGroupTombstoneRecords() {
-        return Arrays.asList(
-            RecordHelpers.newTargetAssignmentEpochTombstoneRecord(groupId()),
-            RecordHelpers.newGroupSubscriptionMetadataTombstoneRecord(groupId()),
-            RecordHelpers.newGroupEpochTombstoneRecord(groupId())
-        );
+    public void createGroupTombstoneRecords(List<Record> records) {
+        records.add(RecordHelpers.newTargetAssignmentEpochTombstoneRecord(groupId()));
+        records.add(RecordHelpers.newGroupSubscriptionMetadataTombstoneRecord(groupId()));
+        records.add(RecordHelpers.newGroupEpochTombstoneRecord(groupId()));
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -615,10 +615,10 @@ public class ConsumerGroup implements Group {
     public void validateOffsetDelete() {}
 
     /**
-     * Validates the GroupDelete request.
+     * Validates the DeleteGroups request.
      */
     @Override
-    public void validateGroupDelete() throws ApiException {
+    public void validateDeleteGroup() throws ApiException {
         switch (state()) {
             case STABLE:
             case ASSIGNING:

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -643,7 +643,7 @@ public class ConsumerGroup implements Group {
      * @return The record.
      */
     public Record createMetadataTombstoneRecord() {
-        return RecordHelpers.newConsumerGroupMetadataTombstoneRecord(groupId());
+        return RecordHelpers.newGroupEpochTombstoneRecord(groupId());
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.errors.StaleMemberEpochException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.coordinator.group.Group;
+import org.apache.kafka.coordinator.group.generic.GenericGroupState;
 import org.apache.kafka.image.ClusterImage;
 import org.apache.kafka.image.TopicImage;
 import org.apache.kafka.image.TopicsImage;
@@ -199,6 +200,16 @@ public class ConsumerGroup implements Group {
     }
 
     /**
+     * Returns true if the current state is DEAD.
+     *
+     * @return a boolean indicating if the current state is DEAD.
+     */
+    @Override
+    public boolean isDead() {
+        return this.state.get() == ConsumerGroupState.DEAD;
+    }
+
+    /**
      * @return The group id.
      */
     @Override
@@ -339,6 +350,16 @@ public class ConsumerGroup implements Group {
      */
     public Set<String> subscribedTopicNames() {
         return Collections.unmodifiableSet(subscribedTopicNames.keySet());
+    }
+
+    /**
+     * Returns true if the consumer group is actively subscribed to the topic.
+     *
+     * @param topic the topic name.
+     * @return a boolean indicating whether the group is subscribed to the topic.
+     */
+    public boolean isSubscribedToTopic(String topic) {
+        return subscribedTopicNames.keySet().contains(topic);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -633,7 +633,7 @@ public class ConsumerGroup implements Group {
      *
      * @return The list of tombstone record(s).
      */
-    public List<Record> createMetadataTombstoneRecords() {
+    public List<Record> createGroupTombstoneRecords() {
         return Arrays.asList(
             RecordHelpers.newTargetAssignmentEpochTombstoneRecord(groupId()),
             RecordHelpers.newGroupSubscriptionMetadataTombstoneRecord(groupId()),

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
@@ -253,6 +253,14 @@ public class GenericGroup implements Group {
     }
 
     /**
+     * @return ture if the current state is DEAD.
+     */
+    @Override
+    public boolean isDead() {
+        return this.state == GenericGroupState.DEAD;
+    }
+
+    /**
      * @return the group id.
      */
     public String groupId() {
@@ -1015,7 +1023,7 @@ public class GenericGroup implements Group {
 
     /**
      * Returns true if the consumer group is actively subscribed to the topic. When the consumer
-     * group does not know, because the information is not available yet or because the it has
+     * group does not know, because the information is not available yet or because it has
      * failed to parse the Consumer Protocol, it returns true to be safe.
      *
      * @param topic the topic name.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
@@ -893,6 +893,7 @@ public class GenericGroup implements Group {
      *
      * @param records The list of records.
      */
+    @Override
     public void createGroupTombstoneRecords(List<Record> records) {
         records.add(RecordHelpers.newGroupMetadataTombstoneRecord(groupId()));
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
@@ -860,6 +860,10 @@ public class GenericGroup implements Group {
     public void validateOffsetDelete() throws GroupIdNotFoundException {
         if (isInState(DEAD)) {
             throw new GroupIdNotFoundException(String.format("Group %s is in dead state.", groupId));
+        } else if (isInState(STABLE)
+            || isInState(PREPARING_REBALANCE)
+            || isInState(COMPLETING_REBALANCE)) {
+            throw Errors.NON_EMPTY_GROUP.exception();
         }
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
@@ -33,6 +33,8 @@ import org.apache.kafka.common.protocol.types.SchemaException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.Group;
+import org.apache.kafka.coordinator.group.Record;
+import org.apache.kafka.coordinator.group.RecordHelpers;
 import org.slf4j.Logger;
 
 import java.nio.ByteBuffer;
@@ -869,8 +871,8 @@ public class GenericGroup implements Group {
         if (isInState(DEAD)) {
             throw new GroupIdNotFoundException(String.format("Group %s is in dead state.", groupId));
         } else if (isInState(STABLE)
-                || isInState(PREPARING_REBALANCE)
-                || isInState(COMPLETING_REBALANCE)) {
+            || isInState(PREPARING_REBALANCE)
+            || isInState(COMPLETING_REBALANCE)) {
             throw Errors.NON_EMPTY_GROUP.exception();
         }
 
@@ -879,6 +881,16 @@ public class GenericGroup implements Group {
         if (generationId() <= 0) {
             throw Errors.UNKNOWN_SERVER_ERROR.exception();
         }
+    }
+
+
+    /**
+     * Creates a GroupMetadata tombstone.
+     *
+     * @return The record.
+     */
+    public Record createMetadataTombstoneRecord() {
+        return RecordHelpers.newGroupMetadataTombstoneRecord(groupId());
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
@@ -38,6 +38,7 @@ import org.apache.kafka.coordinator.group.RecordHelpers;
 import org.slf4j.Logger;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -875,22 +876,15 @@ public class GenericGroup implements Group {
             || isInState(COMPLETING_REBALANCE)) {
             throw Errors.NON_EMPTY_GROUP.exception();
         }
-
-        // We avoid writing the tombstone when the generationId is 0, since this group is only using
-        // Kafka for offset storage.
-        if (generationId() <= 0) {
-            throw Errors.UNKNOWN_SERVER_ERROR.exception();
-        }
     }
 
-
     /**
-     * Creates a GroupMetadata tombstone.
+     * Creates tombstone(s) for deleting the group.
      *
-     * @return The record.
+     * @return The list of tombstone record(s).
      */
-    public Record createMetadataTombstoneRecord() {
-        return RecordHelpers.newGroupMetadataTombstoneRecord(groupId());
+    public List<Record> createMetadataTombstoneRecords() {
+        return Arrays.asList(RecordHelpers.newGroupMetadataTombstoneRecord(groupId()));
     }
 
     /**
@@ -1062,7 +1056,7 @@ public class GenericGroup implements Group {
      * group does not know, because the information is not available yet or because it has
      * failed to parse the Consumer Protocol, it returns true to be safe.
      *
-     * @param topic the topic name.
+     * @param topic The topic name.
      * @return whether the group is subscribed to the topic.
      */
     public boolean isSubscribedToTopic(String topic) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
@@ -857,7 +857,7 @@ public class GenericGroup implements Group {
      * Validates the OffsetDelete request.
      */
     @Override
-    public void validateOffsetDelete() throws GroupIdNotFoundException {
+    public void validateOffsetDelete() throws ApiException {
         if (isInState(DEAD)) {
             throw new GroupIdNotFoundException(String.format("Group %s is in dead state.", groupId));
         } else if (isInState(STABLE)

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
@@ -886,7 +886,7 @@ public class GenericGroup implements Group {
      *
      * @return The list of tombstone record(s).
      */
-    public List<Record> createMetadataTombstoneRecords() {
+    public List<Record> createGroupTombstoneRecords() {
         return Collections.singletonList(RecordHelpers.newGroupMetadataTombstoneRecord(groupId()));
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
@@ -860,18 +860,17 @@ public class GenericGroup implements Group {
     public void validateOffsetDelete() throws ApiException {
         if (isInState(DEAD)) {
             throw new GroupIdNotFoundException(String.format("Group %s is in dead state.", groupId));
-        } else if (isInState(STABLE)
-            || isInState(PREPARING_REBALANCE)
-            || isInState(COMPLETING_REBALANCE)) {
+        } else if (!usesConsumerGroupProtocol()
+            && (isInState(STABLE) || isInState(PREPARING_REBALANCE) || isInState(COMPLETING_REBALANCE))) {
             throw Errors.NON_EMPTY_GROUP.exception();
         }
     }
 
     /**
-     * Validates the GroupDelete request.
+     * Validates the DeleteGroups request.
      */
     @Override
-    public void validateGroupDelete() throws ApiException {
+    public void validateDeleteGroup() throws ApiException {
         if (isInState(DEAD)) {
             throw new GroupIdNotFoundException(String.format("Group %s is in dead state.", groupId));
         } else if (isInState(STABLE)

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
@@ -38,7 +38,6 @@ import org.apache.kafka.coordinator.group.RecordHelpers;
 import org.slf4j.Logger;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -884,7 +883,7 @@ public class GenericGroup implements Group {
      * @return The list of tombstone record(s).
      */
     public List<Record> createMetadataTombstoneRecords() {
-        return Arrays.asList(RecordHelpers.newGroupMetadataTombstoneRecord(groupId()));
+        return Collections.singletonList(RecordHelpers.newGroupMetadataTombstoneRecord(groupId()));
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -1131,7 +1131,7 @@ public class GroupCoordinatorServiceTest {
         )).thenAnswer(invocation -> CompletableFuture.supplyAsync(() -> {
             try {
                 assertTrue(latch.await(5, TimeUnit.SECONDS));
-            } catch (InterruptedException ignored) {}
+            } catch (InterruptedException ignored) { }
             return resultCollection2;
         }));
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -975,7 +975,6 @@ public class GroupCoordinatorServiceTest {
         OffsetDeleteResponseData response = new OffsetDeleteResponseData()
             .setTopics(responseTopicCollection);
 
-
         when(runtime.scheduleWriteOperation(
             ArgumentMatchers.eq("delete-offset"),
             ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -194,7 +194,7 @@ public class GroupCoordinatorServiceTest {
             Arguments.arguments(new KafkaStorageException(), Errors.NOT_COORDINATOR.code(), null),
             Arguments.arguments(new RecordTooLargeException(), Errors.UNKNOWN_SERVER_ERROR.code(), null),
             Arguments.arguments(new RecordBatchTooLargeException(), Errors.UNKNOWN_SERVER_ERROR.code(), null),
-            Arguments.arguments(new InvalidFetchSizeException(null), Errors.UNKNOWN_SERVER_ERROR.code(), null),
+            Arguments.arguments(new InvalidFetchSizeException(""), Errors.UNKNOWN_SERVER_ERROR.code(), null),
             Arguments.arguments(new InvalidRequestException("Invalid"), Errors.INVALID_REQUEST.code(), "Invalid")
         );
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -991,6 +991,7 @@ public class GroupCoordinatorServiceTest {
         assertTrue(future.isDone());
         assertEquals(response, future.get());
     }
+
     @Test
     public void testDeleteOffsetsInvalidGroupId() throws Exception {
         CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
@@ -1031,6 +1032,7 @@ public class GroupCoordinatorServiceTest {
         assertTrue(future.isDone());
         assertEquals(response, future.get());
     }
+
     @Test
     public void testDeleteOffsetsCoordinatorNotAvailableException() throws Exception {
         CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
@@ -1104,6 +1106,7 @@ public class GroupCoordinatorServiceTest {
         assertTrue(future.isDone());
         assertEquals(resultCollection, future.get());
     }
+
     @Test
     public void testDeleteGroupsCoordinatorNotAvailableException() throws Exception {
         CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -1105,7 +1105,12 @@ public class GroupCoordinatorServiceTest {
 
         DeleteGroupsResponseData.DeletableGroupResultCollection expectedResultCollection =
             new DeleteGroupsResponseData.DeletableGroupResultCollection();
-        expectedResultCollection.addAll(Arrays.asList(result1.duplicate(), result2.duplicate(), result3.duplicate()));
+        expectedResultCollection.addAll(Arrays.asList(
+            new DeleteGroupsResponseData.DeletableGroupResult().setGroupId(null).setErrorCode(Errors.INVALID_GROUP_ID.code()),
+            result1.duplicate(),
+            result2.duplicate(),
+            result3.duplicate()
+        ));
 
         when(runtime.partitions()).thenReturn(Sets.newSet(
             new TopicPartition("__consumer_offsets", 0),
@@ -1134,7 +1139,7 @@ public class GroupCoordinatorServiceTest {
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(new CoordinatorLoadInProgressException(null)));
 
-        List<String> groupIds = Arrays.asList("group-id-1", "group-id-2", "group-id-3");
+        List<String> groupIds = Arrays.asList("group-id-1", "group-id-2", "group-id-3", null);
         CompletableFuture<DeleteGroupsResponseData.DeletableGroupResultCollection> future =
             service.deleteGroups(requestContext(ApiKeys.DELETE_GROUPS), groupIds, BufferSupplier.NO_CACHING);
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -977,7 +977,7 @@ public class GroupCoordinatorServiceTest {
             .setTopics(responseTopicCollection);
 
         when(runtime.scheduleWriteOperation(
-            ArgumentMatchers.eq("delete-offset"),
+            ArgumentMatchers.eq("delete-offsets"),
             ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(response));
@@ -1018,7 +1018,7 @@ public class GroupCoordinatorServiceTest {
             .setErrorCode(Errors.INVALID_GROUP_ID.code());
 
         when(runtime.scheduleWriteOperation(
-            ArgumentMatchers.eq("delete-offset"),
+            ArgumentMatchers.eq("delete-offsets"),
             ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(response));
@@ -1059,7 +1059,7 @@ public class GroupCoordinatorServiceTest {
             .setErrorCode(Errors.COORDINATOR_LOAD_IN_PROGRESS.code());
 
         when(runtime.scheduleWriteOperation(
-            ArgumentMatchers.eq("delete-offset"),
+            ArgumentMatchers.eq("delete-offsets"),
             ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(
@@ -1119,13 +1119,13 @@ public class GroupCoordinatorServiceTest {
         ));
 
         when(runtime.scheduleWriteOperation(
-            ArgumentMatchers.eq("delete-group"),
+            ArgumentMatchers.eq("delete-groups"),
             ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 2)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(resultCollection1));
 
         when(runtime.scheduleWriteOperation(
-            ArgumentMatchers.eq("delete-group"),
+            ArgumentMatchers.eq("delete-groups"),
             ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
             ArgumentMatchers.any()
         )).thenAnswer(invocation -> CompletableFuture.supplyAsync(() -> {
@@ -1136,7 +1136,7 @@ public class GroupCoordinatorServiceTest {
         }));
 
         when(runtime.scheduleWriteOperation(
-            ArgumentMatchers.eq("delete-group"),
+            ArgumentMatchers.eq("delete-groups"),
             ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 1)),
             ArgumentMatchers.any()
         )).thenReturn(FutureUtils.failedFuture(new CoordinatorLoadInProgressException(null)));

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -1028,12 +1028,8 @@ public class GroupCoordinatorServiceTest {
         assertEquals(response, future.get());
     }
 
-    private static Stream<Arguments> testDeleteOffsetsWithExceptionSource() {
-        return testConsumerGroupHeartbeatWithExceptionSource();
-    }
-
     @ParameterizedTest
-    @MethodSource("testDeleteOffsetsWithExceptionSource")
+    @MethodSource("testConsumerGroupHeartbeatWithExceptionSource")
     public void testDeleteOffsetsWithException(
         Throwable exception,
         short expectedErrorCode
@@ -1144,15 +1140,12 @@ public class GroupCoordinatorServiceTest {
         assertFalse(future.isDone());
         resultCollectionFuture.complete(resultCollection2);
 
+        assertTrue(future.isDone());
         assertEquals(expectedResultCollection, future.get());
     }
 
-    private static Stream<Arguments> testDeleteGroupsWithExceptionSource() {
-        return testConsumerGroupHeartbeatWithExceptionSource();
-    }
-
     @ParameterizedTest
-    @MethodSource("testDeleteGroupsWithExceptionSource")
+    @MethodSource("testConsumerGroupHeartbeatWithExceptionSource")
     public void testDeleteGroupsWithException(
         Throwable exception,
         short expectedErrorCode

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -961,19 +961,16 @@ public class GroupCoordinatorServiceTest {
         OffsetDeleteRequestData request = new OffsetDeleteRequestData().setGroupId("group")
             .setTopics(requestTopicCollection);
 
-
         OffsetDeleteResponseData.OffsetDeleteResponsePartitionCollection responsePartitionCollection =
             new OffsetDeleteResponseData.OffsetDeleteResponsePartitionCollection();
         responsePartitionCollection.add(
             new OffsetDeleteResponseData.OffsetDeleteResponsePartition().setPartitionIndex(0)
         );
-
         OffsetDeleteResponseData.OffsetDeleteResponseTopicCollection responseTopicCollection =
             new OffsetDeleteResponseData.OffsetDeleteResponseTopicCollection();
         responseTopicCollection.add(
             new OffsetDeleteResponseData.OffsetDeleteResponseTopic().setPartitions(responsePartitionCollection)
         );
-
         OffsetDeleteResponseData response = new OffsetDeleteResponseData()
             .setTopics(responseTopicCollection);
 
@@ -1076,8 +1073,34 @@ public class GroupCoordinatorServiceTest {
         assertEquals(response, future.get());
     }
 
-    // TODO: test invalid state?
-
-    @Test
-    public void testDeleteGroups() throws Exception {}
+//    @Test
+//    public void testDeleteGroups() throws Exception {
+//        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
+//        GroupCoordinatorService service = new GroupCoordinatorService(
+//            new LogContext(),
+//            createConfig(),
+//            runtime
+//        );
+//        service.startup(() -> 1);
+//
+//        List<String> groupIds = Collections.singletonList("foo");
+//        DeleteGroupsResponseData.DeletableGroupResultCollection resultCollection =
+//            new DeleteGroupsResponseData.DeletableGroupResultCollection();
+//        resultCollection.add(new DeleteGroupsResponseData.DeletableGroupResult().setGroupId("foo"));
+//
+//        when(runtime.scheduleWriteOperation(
+//            ArgumentMatchers.eq("delete-group"),
+//            ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
+//            ArgumentMatchers.any()
+//        )).thenReturn(CompletableFuture.completedFuture(resultCollection));
+//
+//        CompletableFuture<DeleteGroupsResponseData.DeletableGroupResultCollection> future = service.deleteGroups(
+//            requestContext(ApiKeys.DELETE_GROUPS),
+//            groupIds,
+//            BufferSupplier.NO_CACHING
+//        );
+//
+//        assertTrue(future.isDone());
+//        assertEquals(resultCollection, future.get());
+//    }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.message.OffsetCommitResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataKey;
@@ -73,6 +74,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -97,6 +99,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -121,6 +124,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -143,12 +147,12 @@ public class GroupCoordinatorShardTest {
         );
 
         doNothing().when(groupMetadataManager).validateDeleteGroup(ArgumentMatchers.anyString());
-        doAnswer(invocation -> {
+        when(offsetMetadataManager.deleteAllOffsets(anyString(), anyList())).thenAnswer(invocation -> {
             String groupId = invocation.getArgument(0);
             List<Record> records = invocation.getArgument(1);
             records.add(RecordHelpers.newOffsetCommitTombstoneRecord(groupId, "topic-name", 0));
-            return null;
-        }).when(offsetMetadataManager).deleteAllOffsets(anyString(), anyList());
+            return 1;
+        });
         doAnswer(invocation -> {
             String groupId = invocation.getArgument(0);
             List<Record> records = invocation.getArgument(1);
@@ -172,6 +176,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -233,6 +238,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -258,6 +264,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -282,6 +289,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -302,6 +310,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -321,6 +330,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -341,6 +351,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -360,6 +371,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -380,6 +392,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -399,6 +412,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -419,6 +433,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -438,6 +453,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -458,6 +474,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -477,6 +494,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -497,6 +515,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -516,6 +535,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -528,6 +548,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -547,6 +568,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -566,6 +588,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );
@@ -586,6 +609,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
+            new LogContext(),
             groupMetadataManager,
             offsetMetadataManager
         );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -165,7 +165,7 @@ public class GroupCoordinatorShardTest {
     }
 
     @Test
-    public void testDeleteInvalidGroup() {
+    public void testDeleteGroupsInvalidGroupId() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -60,7 +60,6 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -146,13 +145,13 @@ public class GroupCoordinatorShardTest {
             expectedResultCollection
         );
 
-        doNothing().when(groupMetadataManager).validateDeleteGroup(ArgumentMatchers.anyString());
         when(offsetMetadataManager.deleteAllOffsets(anyString(), anyList())).thenAnswer(invocation -> {
             String groupId = invocation.getArgument(0);
             List<Record> records = invocation.getArgument(1);
             records.add(RecordHelpers.newOffsetCommitTombstoneRecord(groupId, "topic-name", 0));
             return 1;
         });
+        // Mockito#when only stubs method returning non-void value, so we use Mockito#doAnswer instead.
         doAnswer(invocation -> {
             String groupId = invocation.getArgument(0);
             List<Record> records = invocation.getArgument(1);
@@ -205,6 +204,7 @@ public class GroupCoordinatorShardTest {
             expectedResultCollection
         );
 
+        // Mockito#when only stubs method returning non-void value, so we use Mockito#doAnswer and Mockito#doThrow instead.
         doThrow(Errors.INVALID_GROUP_ID.exception())
             .when(groupMetadataManager).validateDeleteGroup(ArgumentMatchers.eq("group-id-2"));
         doAnswer(invocation -> {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -140,7 +140,7 @@ public class GroupCoordinatorShardTest {
             expectedResultCollection
         );
 
-        doNothing().when(groupMetadataManager).validateGroupDelete(ArgumentMatchers.anyString());
+        doNothing().when(groupMetadataManager).validateDeleteGroup(ArgumentMatchers.anyString());
         doAnswer(invocation -> {
             String groupId = invocation.getArgument(0);
             List<Record> records = invocation.getArgument(1);
@@ -157,7 +157,7 @@ public class GroupCoordinatorShardTest {
             coordinator.deleteGroups(context, groupIds);
 
         for (String groupId : groupIds) {
-            verify(groupMetadataManager, times(1)).validateGroupDelete(ArgumentMatchers.eq(groupId));
+            verify(groupMetadataManager, times(1)).validateDeleteGroup(ArgumentMatchers.eq(groupId));
             verify(groupMetadataManager, times(1)).deleteGroup(ArgumentMatchers.eq(groupId), anyList());
             verify(offsetMetadataManager, times(1)).deleteAllOffsets(ArgumentMatchers.eq(groupId), anyList());
         }
@@ -194,7 +194,7 @@ public class GroupCoordinatorShardTest {
         );
 
         doThrow(Errors.INVALID_GROUP_ID.exception())
-            .when(groupMetadataManager).validateGroupDelete(ArgumentMatchers.eq("group-id-2"));
+            .when(groupMetadataManager).validateDeleteGroup(ArgumentMatchers.eq("group-id-2"));
         doAnswer(invocation -> {
             String groupId = invocation.getArgument(0);
             List<Record> records = invocation.getArgument(1);
@@ -210,7 +210,7 @@ public class GroupCoordinatorShardTest {
         CoordinatorResult<DeleteGroupsResponseData.DeletableGroupResultCollection, Record> coordinatorResult =
             coordinator.deleteGroups(context, groupIds);
 
-        verify(groupMetadataManager, times(3)).validateGroupDelete(anyString());
+        verify(groupMetadataManager, times(3)).validateDeleteGroup(anyString());
         verify(groupMetadataManager, times(2)).deleteGroup(anyString(), anyList());
         verify(offsetMetadataManager, times(2)).deleteAllOffsets(anyString(), anyList());
         assertEquals(expectedResult, coordinatorResult);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -26,7 +26,6 @@ import org.apache.kafka.common.errors.FencedMemberEpochException;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.GroupMaxSizeReachedException;
 import org.apache.kafka.common.errors.IllegalGenerationException;
-import org.apache.kafka.common.errors.InvalidGroupIdException;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.errors.UnknownServerException;
@@ -9432,13 +9431,6 @@ public class GroupMetadataManagerTest {
         List<Record> records = new ArrayList<>();
         context.groupMetadataManager.deleteGroup("group-id", records);
         assertEquals(expectedRecords, records);
-    }
-
-    @Test
-    public void testValidateGroupDelete() {
-        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-            .build();
-        assertThrows(InvalidGroupIdException.class, () -> context.groupMetadataManager.validateGroupDelete(null));
     }
 
     private static void assertNoOrEmptyResult(List<ExpiredTimeout<Void, Record>> timeouts) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
@@ -1567,7 +1567,7 @@ public class OffsetMetadataManagerTest {
             () -> context.fetchAllOffsets("group", "member", 10, Long.MAX_VALUE));
     }
 
-    private void testOffsetDeleteWith(
+    static private void testOffsetDeleteWith(
         OffsetMetadataManagerTestContext context,
         String groupId,
         String topic,

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
@@ -1725,7 +1725,7 @@ public class OffsetMetadataManagerTest {
 
     @ParameterizedTest
     @ValueSource(classes = {GenericGroup.class, ConsumerGroup.class})
-    public void testGroupDeleteAllOffsets(Class groupClass) {
+    public void testDeleteGroupAllOffsets(Class groupClass) {
         OffsetMetadataManagerTestContext context = new OffsetMetadataManagerTestContext.Builder().build();
         Group group = null;
         if (groupClass == GenericGroup.class) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
@@ -681,7 +681,7 @@ public class ConsumerGroupTest {
         ConsumerGroup consumerGroup = createConsumerGroup("foo");
 
         assertEquals(ConsumerGroup.ConsumerGroupState.EMPTY, consumerGroup.state());
-        assertDoesNotThrow(() -> consumerGroup.validateGroupDelete());
+        assertDoesNotThrow(consumerGroup::validateGroupDelete);
 
         ConsumerGroupMember member1 = new ConsumerGroupMember.Builder("member1")
             .setMemberEpoch(1)
@@ -691,16 +691,16 @@ public class ConsumerGroupTest {
         consumerGroup.updateMember(member1);
 
         assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, consumerGroup.state());
-        assertThrows(GroupNotEmptyException.class, () -> consumerGroup.validateGroupDelete());
+        assertThrows(GroupNotEmptyException.class, consumerGroup::validateGroupDelete);
 
         consumerGroup.setGroupEpoch(1);
 
         assertEquals(ConsumerGroup.ConsumerGroupState.ASSIGNING, consumerGroup.state());
-        assertThrows(GroupNotEmptyException.class, () -> consumerGroup.validateGroupDelete());
+        assertThrows(GroupNotEmptyException.class, consumerGroup::validateGroupDelete);
 
         consumerGroup.setTargetAssignmentEpoch(1);
 
         assertEquals(ConsumerGroup.ConsumerGroupState.STABLE, consumerGroup.state());
-        assertThrows(GroupNotEmptyException.class, () -> consumerGroup.validateGroupDelete());
+        assertThrows(GroupNotEmptyException.class, consumerGroup::validateGroupDelete);
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
@@ -678,7 +678,6 @@ public class ConsumerGroupTest {
 
     @Test
     public void testValidateGroupDelete() {
-        Uuid fooTopicId = Uuid.randomUuid();
         ConsumerGroup consumerGroup = createConsumerGroup("foo");
         assertEquals(ConsumerGroup.ConsumerGroupState.EMPTY, consumerGroup.state());
         assertDoesNotThrow(() -> consumerGroup.validateGroupDelete());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.coordinator.group.consumer;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.GroupNotEmptyException;
 import org.apache.kafka.common.errors.StaleMemberEpochException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.utils.LogContext;
@@ -35,6 +36,7 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
 import static org.apache.kafka.coordinator.group.RecordHelpersTest.mkMapOfPartitionRacks;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -672,5 +674,33 @@ public class ConsumerGroupTest {
 
         // This should succeed.
         group.validateOffsetFetch("member-id", 0, Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testValidateGroupDelete() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        ConsumerGroup consumerGroup = createConsumerGroup("foo");
+        assertEquals(ConsumerGroup.ConsumerGroupState.EMPTY, consumerGroup.state());
+        assertDoesNotThrow(() -> consumerGroup.validateGroupDelete());
+
+        ConsumerGroupMember member1 = new ConsumerGroupMember.Builder("member1")
+            .setMemberEpoch(1)
+            .setPreviousMemberEpoch(0)
+            .setTargetMemberEpoch(1)
+            .build();
+        consumerGroup.updateMember(member1);
+
+        assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, consumerGroup.state());
+        assertThrows(GroupNotEmptyException.class, () -> consumerGroup.validateGroupDelete());
+
+        consumerGroup.setGroupEpoch(1);
+
+        assertEquals(ConsumerGroup.ConsumerGroupState.ASSIGNING, consumerGroup.state());
+        assertThrows(GroupNotEmptyException.class, () -> consumerGroup.validateGroupDelete());
+
+        consumerGroup.setTargetAssignmentEpoch(1);
+
+        assertEquals(ConsumerGroup.ConsumerGroupState.STABLE, consumerGroup.state());
+        assertThrows(GroupNotEmptyException.class, () -> consumerGroup.validateGroupDelete());
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
@@ -679,6 +679,7 @@ public class ConsumerGroupTest {
     @Test
     public void testValidateGroupDelete() {
         ConsumerGroup consumerGroup = createConsumerGroup("foo");
+
         assertEquals(ConsumerGroup.ConsumerGroupState.EMPTY, consumerGroup.state());
         assertDoesNotThrow(() -> consumerGroup.validateGroupDelete());
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
@@ -677,11 +677,11 @@ public class ConsumerGroupTest {
     }
 
     @Test
-    public void testValidateGroupDelete() {
+    public void testValidateDeleteGroup() {
         ConsumerGroup consumerGroup = createConsumerGroup("foo");
 
         assertEquals(ConsumerGroup.ConsumerGroupState.EMPTY, consumerGroup.state());
-        assertDoesNotThrow(consumerGroup::validateGroupDelete);
+        assertDoesNotThrow(consumerGroup::validateDeleteGroup);
 
         ConsumerGroupMember member1 = new ConsumerGroupMember.Builder("member1")
             .setMemberEpoch(1)
@@ -691,16 +691,16 @@ public class ConsumerGroupTest {
         consumerGroup.updateMember(member1);
 
         assertEquals(ConsumerGroup.ConsumerGroupState.RECONCILING, consumerGroup.state());
-        assertThrows(GroupNotEmptyException.class, consumerGroup::validateGroupDelete);
+        assertThrows(GroupNotEmptyException.class, consumerGroup::validateDeleteGroup);
 
         consumerGroup.setGroupEpoch(1);
 
         assertEquals(ConsumerGroup.ConsumerGroupState.ASSIGNING, consumerGroup.state());
-        assertThrows(GroupNotEmptyException.class, consumerGroup::validateGroupDelete);
+        assertThrows(GroupNotEmptyException.class, consumerGroup::validateDeleteGroup);
 
         consumerGroup.setTargetAssignmentEpoch(1);
 
         assertEquals(ConsumerGroup.ConsumerGroupState.STABLE, consumerGroup.state());
-        assertThrows(GroupNotEmptyException.class, consumerGroup::validateGroupDelete);
+        assertThrows(GroupNotEmptyException.class, consumerGroup::validateDeleteGroup);
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/generic/GenericGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/generic/GenericGroupTest.java
@@ -63,24 +63,24 @@ public class GenericGroupTest {
     private final int sessionTimeoutMs = 10000;
 
     private GenericGroup group = null;
-
+    
     @BeforeEach
     public void initialize() {
         group = new GenericGroup(new LogContext(), "groupId", EMPTY, Time.SYSTEM);
     }
-
+    
     @Test
     public void testCanRebalanceWhenStable() {
         assertTrue(group.canRebalance());
     }
-
+    
     @Test
     public void testCanRebalanceWhenCompletingRebalance() {
         group.transitionTo(PREPARING_REBALANCE);
         group.transitionTo(COMPLETING_REBALANCE);
-        assertTrue(group.canRebalance());
+        assertTrue(group.canRebalance()); 
     }
-
+    
     @Test
     public void testCannotRebalanceWhenPreparingRebalance() {
         group.transitionTo(PREPARING_REBALANCE);
@@ -311,6 +311,7 @@ public class GenericGroupTest {
         member2Protocols.add(new JoinGroupRequestProtocol()
             .setName("foo")
             .setMetadata(new byte[0]));
+
 
         GenericGroupMember member2 = new GenericGroupMember(
             "member2",
@@ -777,7 +778,7 @@ public class GenericGroupTest {
             protocolType,
             protocols
         );
-
+        
         group.add(member);
         assertTrue(group.hasMemberId(memberId));
         assertTrue(group.hasStaticMember(groupInstanceId));
@@ -815,7 +816,7 @@ public class GenericGroupTest {
             protocolType,
             protocols
         );
-
+        
         group.add(member);
         assertTrue(group.addPendingSyncMember(memberId));
         assertEquals(Collections.singleton(memberId), group.allPendingSyncMembers());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/generic/GenericGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/generic/GenericGroupTest.java
@@ -1032,16 +1032,16 @@ public class GenericGroupTest {
     @Test
     public void testValidateOffsetDelete() {
         group.transitionTo(PREPARING_REBALANCE);
-        assertThrows(GroupNotEmptyException.class, () -> group.validateOffsetDelete());
+        assertThrows(GroupNotEmptyException.class, group::validateOffsetDelete);
         group.transitionTo(COMPLETING_REBALANCE);
-        assertThrows(GroupNotEmptyException.class, () -> group.validateOffsetDelete());
+        assertThrows(GroupNotEmptyException.class, group::validateOffsetDelete);
         group.transitionTo(STABLE);
-        assertThrows(GroupNotEmptyException.class, () -> group.validateOffsetDelete());
+        assertThrows(GroupNotEmptyException.class, group::validateOffsetDelete);
         group.transitionTo(PREPARING_REBALANCE);
         group.transitionTo(EMPTY);
-        assertDoesNotThrow(() -> group.validateOffsetDelete());
+        assertDoesNotThrow(group::validateOffsetDelete);
         group.transitionTo(DEAD);
-        assertThrows(GroupIdNotFoundException.class, () -> group.validateOffsetDelete());
+        assertThrows(GroupIdNotFoundException.class, group::validateOffsetDelete);
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/generic/GenericGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/generic/GenericGroupTest.java
@@ -1030,6 +1030,12 @@ public class GenericGroupTest {
 
     @Test
     public void testValidateOffsetDelete() {
+        group.transitionTo(PREPARING_REBALANCE);
+        assertThrows(GroupNotEmptyException.class, () -> group.validateOffsetDelete());
+        group.transitionTo(COMPLETING_REBALANCE);
+        assertThrows(GroupNotEmptyException.class, () -> group.validateOffsetDelete());
+        group.transitionTo(STABLE);
+        assertThrows(GroupNotEmptyException.class, () -> group.validateOffsetDelete());
         group.transitionTo(DEAD);
         assertThrows(GroupIdNotFoundException.class, () -> group.validateOffsetDelete());
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/generic/GenericGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/generic/GenericGroupTest.java
@@ -47,6 +47,7 @@ import static org.apache.kafka.coordinator.group.generic.GenericGroupState.DEAD;
 import static org.apache.kafka.coordinator.group.generic.GenericGroupState.EMPTY;
 import static org.apache.kafka.coordinator.group.generic.GenericGroupState.PREPARING_REBALANCE;
 import static org.apache.kafka.coordinator.group.generic.GenericGroupState.STABLE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -311,7 +312,6 @@ public class GenericGroupTest {
         member2Protocols.add(new JoinGroupRequestProtocol()
             .setName("foo")
             .setMetadata(new byte[0]));
-
 
         GenericGroupMember member2 = new GenericGroupMember(
             "member2",
@@ -778,7 +778,7 @@ public class GenericGroupTest {
             protocolType,
             protocols
         );
-        
+
         group.add(member);
         assertTrue(group.hasMemberId(memberId));
         assertTrue(group.hasStaticMember(groupInstanceId));
@@ -1036,6 +1036,9 @@ public class GenericGroupTest {
         assertThrows(GroupNotEmptyException.class, () -> group.validateOffsetDelete());
         group.transitionTo(STABLE);
         assertThrows(GroupNotEmptyException.class, () -> group.validateOffsetDelete());
+        group.transitionTo(PREPARING_REBALANCE);
+        group.transitionTo(EMPTY);
+        assertDoesNotThrow(() -> group.validateOffsetDelete());
         group.transitionTo(DEAD);
         assertThrows(GroupIdNotFoundException.class, () -> group.validateOffsetDelete());
     }
@@ -1048,6 +1051,9 @@ public class GenericGroupTest {
         assertThrows(GroupNotEmptyException.class, () -> group.validateGroupDelete());
         group.transitionTo(STABLE);
         assertThrows(GroupNotEmptyException.class, () -> group.validateGroupDelete());
+        group.transitionTo(PREPARING_REBALANCE);
+        group.transitionTo(EMPTY);
+        assertDoesNotThrow(() -> group.validateGroupDelete());
         group.transitionTo(DEAD);
         assertThrows(GroupIdNotFoundException.class, () -> group.validateGroupDelete());
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/generic/GenericGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/generic/GenericGroupTest.java
@@ -1047,16 +1047,16 @@ public class GenericGroupTest {
     @Test
     public void testValidateGroupDelete() {
         group.transitionTo(PREPARING_REBALANCE);
-        assertThrows(GroupNotEmptyException.class, () -> group.validateGroupDelete());
+        assertThrows(GroupNotEmptyException.class, group::validateGroupDelete);
         group.transitionTo(COMPLETING_REBALANCE);
-        assertThrows(GroupNotEmptyException.class, () -> group.validateGroupDelete());
+        assertThrows(GroupNotEmptyException.class, group::validateGroupDelete);
         group.transitionTo(STABLE);
-        assertThrows(GroupNotEmptyException.class, () -> group.validateGroupDelete());
+        assertThrows(GroupNotEmptyException.class, group::validateGroupDelete);
         group.transitionTo(PREPARING_REBALANCE);
         group.transitionTo(EMPTY);
-        assertDoesNotThrow(() -> group.validateGroupDelete());
+        assertDoesNotThrow(group::validateGroupDelete);
         group.transitionTo(DEAD);
-        assertThrows(GroupIdNotFoundException.class, () -> group.validateGroupDelete());
+        assertThrows(GroupIdNotFoundException.class, group::validateGroupDelete);
     }
 
     private void assertState(GenericGroup group, GenericGroupState targetState) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/generic/GenericGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/generic/GenericGroupTest.java
@@ -313,6 +313,7 @@ public class GenericGroupTest {
             .setName("foo")
             .setMetadata(new byte[0]));
 
+
         GenericGroupMember member2 = new GenericGroupMember(
             "member2",
             Optional.empty(),


### PR DESCRIPTION
This pr implements DeleteGroups and OffsetDelete API according to the implementation in the old GroupCoordinator but with the new model.

### Jira
https://issues.apache.org/jira/browse/KAFKA-14506

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
