### PR TITLE
KAFKA-14133: Move MeteredTimestampedKeyValueStoreTest, ReadOnlyWindowStoreFacadeTest and TimestampedWindowStoreBuilderTest to Mockito

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
@@ -44,28 +44,18 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.internals.MeteredTimestampedKeyValueStore.RawAndDeserializedValue;
 import org.apache.kafka.test.KeyValueIteratorStub;
-import org.easymock.EasyMockRule;
-import org.easymock.Mock;
-import org.easymock.MockType;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
- 
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.aryEq;
-import static org.easymock.EasyMock.eq;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.niceMock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
@@ -73,12 +63,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("this-escape")
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class MeteredTimestampedKeyValueStoreTest {
-
-    @Rule
-    public EasyMockRule rule = new EasyMockRule(this);
 
     private static final String APPLICATION_ID = "test-app";
     private static final String STORE_NAME = "store-name";
@@ -96,9 +89,9 @@ public class MeteredTimestampedKeyValueStoreTest {
 
     private final String threadId = Thread.currentThread().getName();
     private final TaskId taskId = new TaskId(0, 0, "My-Topology");
-    @Mock(type = MockType.NICE)
+    @Mock
     private KeyValueStore<Bytes, byte[]> inner;
-    @Mock(type = MockType.NICE)
+    @Mock
     private InternalProcessorContext context;
 
     private final static Map<String, Object> CONFIGS =  mkMap(mkEntry(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE, APPLICATION_ID));
@@ -121,14 +114,14 @@ public class MeteredTimestampedKeyValueStoreTest {
             new ValueAndTimestampSerde<>(Serdes.String())
         );
         metrics.config().recordLevel(Sensor.RecordingLevel.DEBUG);
-        expect(context.applicationId()).andStubReturn(APPLICATION_ID);
-        expect(context.metrics())
-            .andStubReturn(new StreamsMetricsImpl(metrics, "test", StreamsConfig.METRICS_LATEST, mockTime));
-        expect(context.taskId()).andStubReturn(taskId);
-        expect(context.changelogFor(STORE_NAME)).andStubReturn(CHANGELOG_TOPIC);
+        when(context.applicationId()).thenReturn(APPLICATION_ID);
+        when(context.metrics())
+            .thenReturn(new StreamsMetricsImpl(metrics, "test", StreamsConfig.METRICS_LATEST, mockTime));
+        when(context.taskId()).thenReturn(taskId);
+        when(context.changelogFor(STORE_NAME)).thenReturn(CHANGELOG_TOPIC);
         expectSerdes();
-        expect(inner.name()).andStubReturn(STORE_NAME);
-        expect(context.appConfigs()).andStubReturn(CONFIGS);
+        when(inner.name()).thenReturn(STORE_NAME);
+        when(context.appConfigs()).thenReturn(CONFIGS);
         tags = mkMap(
             mkEntry(THREAD_ID_TAG_KEY, threadId),
             mkEntry("task-id", taskId.toString()),
@@ -139,19 +132,17 @@ public class MeteredTimestampedKeyValueStoreTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     private void expectSerdes() {
-        expect(context.keySerde()).andStubReturn((Serde) Serdes.String());
-        expect(context.valueSerde()).andStubReturn((Serde) Serdes.Long());
+        when(context.keySerde()).thenReturn((Serde) Serdes.String());
+        when(context.valueSerde()).thenReturn((Serde) Serdes.Long());
     }
 
     private void init() {
-        replay(inner, context);
         metered.init((StateStoreContext) context, metered);
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void shouldDelegateDeprecatedInit() {
-        final KeyValueStore<Bytes, byte[]> inner = mock(InMemoryKeyValueStore.class);
         final MeteredTimestampedKeyValueStore<String, String> outer = new MeteredTimestampedKeyValueStore<>(
             inner,
             STORE_TYPE,
@@ -159,17 +150,12 @@ public class MeteredTimestampedKeyValueStoreTest {
             Serdes.String(),
             new ValueAndTimestampSerde<>(Serdes.String())
         );
-        expect(inner.name()).andStubReturn("store");
-        inner.init((ProcessorContext) context, outer);
-        expectLastCall();
-        replay(inner, context);
+        doNothing().when(inner).init((ProcessorContext) context, outer);
         outer.init((ProcessorContext) context, outer);
-        verify(inner);
     }
 
     @Test
     public void shouldDelegateInit() {
-        final KeyValueStore<Bytes, byte[]> inner = mock(InMemoryKeyValueStore.class);
         final MeteredTimestampedKeyValueStore<String, String> outer = new MeteredTimestampedKeyValueStore<>(
             inner,
             STORE_TYPE,
@@ -177,12 +163,8 @@ public class MeteredTimestampedKeyValueStoreTest {
             Serdes.String(),
             new ValueAndTimestampSerde<>(Serdes.String())
         );
-        expect(inner.name()).andStubReturn("store");
-        inner.init((StateStoreContext) context, outer);
-        expectLastCall();
-        replay(inner, context);
+        doNothing().when(inner).init((StateStoreContext) context, outer);
         outer.init((StateStoreContext) context, outer);
-        verify(inner);
     }
 
     @Test
@@ -193,24 +175,24 @@ public class MeteredTimestampedKeyValueStoreTest {
     @Test
     public void shouldPassDefaultChangelogTopicNameToStateStoreSerdeIfLoggingDisabled() {
         final String defaultChangelogTopicName = ProcessorStateManager.storeChangelogTopic(APPLICATION_ID, STORE_NAME, taskId.topologyName());
-        expect(context.changelogFor(STORE_NAME)).andReturn(null);
+        when(context.changelogFor(STORE_NAME)).thenReturn(null);
         doShouldPassChangelogTopicNameToStateStoreSerde(defaultChangelogTopicName);
     }
 
+    @SuppressWarnings("unchecked")
     private void doShouldPassChangelogTopicNameToStateStoreSerde(final String topic) {
-        final Serde<String> keySerde = niceMock(Serde.class);
+        final Serde<String> keySerde = mock(Serde.class);
         final Serializer<String> keySerializer = mock(Serializer.class);
-        final Serde<ValueAndTimestamp<String>> valueSerde = niceMock(Serde.class);
+        final Serde<ValueAndTimestamp<String>> valueSerde = mock(Serde.class);
         final Deserializer<ValueAndTimestamp<String>> valueDeserializer = mock(Deserializer.class);
         final Serializer<ValueAndTimestamp<String>> valueSerializer = mock(Serializer.class);
-        expect(keySerde.serializer()).andStubReturn(keySerializer);
-        expect(keySerializer.serialize(topic, KEY)).andStubReturn(KEY.getBytes());
-        expect(valueSerde.deserializer()).andStubReturn(valueDeserializer);
-        expect(valueDeserializer.deserialize(topic, VALUE_AND_TIMESTAMP_BYTES)).andStubReturn(VALUE_AND_TIMESTAMP);
-        expect(valueSerde.serializer()).andStubReturn(valueSerializer);
-        expect(valueSerializer.serialize(topic, VALUE_AND_TIMESTAMP)).andStubReturn(VALUE_AND_TIMESTAMP_BYTES);
-        expect(inner.get(KEY_BYTES)).andStubReturn(VALUE_AND_TIMESTAMP_BYTES);
-        replay(inner, context, keySerializer, keySerde, valueDeserializer, valueSerializer, valueSerde);
+        when(keySerde.serializer()).thenReturn(keySerializer);
+        when(keySerializer.serialize(topic, KEY)).thenReturn(KEY.getBytes());
+        when(valueSerde.deserializer()).thenReturn(valueDeserializer);
+        when(valueDeserializer.deserialize(topic, VALUE_AND_TIMESTAMP_BYTES)).thenReturn(VALUE_AND_TIMESTAMP);
+        when(valueSerde.serializer()).thenReturn(valueSerializer);
+        when(valueSerializer.serialize(topic, VALUE_AND_TIMESTAMP)).thenReturn(VALUE_AND_TIMESTAMP_BYTES);
+        when(inner.get(KEY_BYTES)).thenReturn(VALUE_AND_TIMESTAMP_BYTES);
         metered = new MeteredTimestampedKeyValueStore<>(
             inner,
             STORE_TYPE,
@@ -222,8 +204,6 @@ public class MeteredTimestampedKeyValueStoreTest {
 
         metered.get(KEY);
         metered.put(KEY, VALUE_AND_TIMESTAMP);
-
-        verify(keySerializer, valueDeserializer, valueSerializer);
     }
 
     @Test
@@ -246,23 +226,19 @@ public class MeteredTimestampedKeyValueStoreTest {
     }
     @Test
     public void shouldWriteBytesToInnerStoreAndRecordPutMetric() {
-        inner.put(eq(KEY_BYTES), aryEq(VALUE_AND_TIMESTAMP_BYTES));
-        expectLastCall();
+        doNothing().when(inner).put(KEY_BYTES, VALUE_AND_TIMESTAMP_BYTES);
         init();
 
         metered.put(KEY, VALUE_AND_TIMESTAMP);
 
         final KafkaMetric metric = metric("put-rate");
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     @Test
     public void shouldGetWithBinary() {
-        expect(inner.get(KEY_BYTES)).andReturn(VALUE_AND_TIMESTAMP_BYTES);
+        when(inner.get(KEY_BYTES)).thenReturn(VALUE_AND_TIMESTAMP_BYTES);
 
-        inner.put(eq(KEY_BYTES), aryEq(VALUE_AND_TIMESTAMP_BYTES));
-        expectLastCall();
         init();
 
         final RawAndDeserializedValue<String> valueWithBinary = metered.getWithBinary(KEY);
@@ -281,14 +257,12 @@ public class MeteredTimestampedKeyValueStoreTest {
 
         final ValueAndTimestamp<String> newValueAndTimestamp = ValueAndTimestamp.make("value", 98L);
         assertFalse(metered.putIfDifferentValues(KEY, newValueAndTimestamp, encodedOldValue));
-        verify(inner);
     }
 
     @SuppressWarnings("resource")
     @Test
     public void shouldPutIfOutOfOrder() {
-        inner.put(eq(KEY_BYTES), aryEq(VALUE_AND_TIMESTAMP_BYTES));
-        expectLastCall();
+        doNothing().when(inner).put(KEY_BYTES, VALUE_AND_TIMESTAMP_BYTES);
         init();
 
         metered.put(KEY, VALUE_AND_TIMESTAMP);
@@ -298,31 +272,28 @@ public class MeteredTimestampedKeyValueStoreTest {
 
         final ValueAndTimestamp<String> outOfOrderValueAndTimestamp = ValueAndTimestamp.make("value", 95L);
         assertTrue(metered.putIfDifferentValues(KEY, outOfOrderValueAndTimestamp, encodedOldValue));
-        verify(inner);
     }
 
     @Test
     public void shouldGetBytesFromInnerStoreAndReturnGetMetric() {
-        expect(inner.get(KEY_BYTES)).andReturn(VALUE_AND_TIMESTAMP_BYTES);
+        when(inner.get(KEY_BYTES)).thenReturn(VALUE_AND_TIMESTAMP_BYTES);
         init();
 
         assertThat(metered.get(KEY), equalTo(VALUE_AND_TIMESTAMP));
 
         final KafkaMetric metric = metric("get-rate");
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     @Test
     public void shouldPutIfAbsentAndRecordPutIfAbsentMetric() {
-        expect(inner.putIfAbsent(eq(KEY_BYTES), aryEq(VALUE_AND_TIMESTAMP_BYTES))).andReturn(null);
+        when(inner.putIfAbsent(KEY_BYTES, VALUE_AND_TIMESTAMP_BYTES)).thenReturn(null);
         init();
 
         metered.putIfAbsent(KEY, VALUE_AND_TIMESTAMP);
 
         final KafkaMetric metric = metric("put-if-absent-rate");
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     private KafkaMetric metric(final String name) {
@@ -332,32 +303,29 @@ public class MeteredTimestampedKeyValueStoreTest {
     @SuppressWarnings("unchecked")
     @Test
     public void shouldPutAllToInnerStoreAndRecordPutAllMetric() {
-        inner.putAll(anyObject(List.class));
-        expectLastCall();
+        doNothing().when(inner).putAll(any(List.class));
         init();
 
         metered.putAll(Collections.singletonList(KeyValue.pair(KEY, VALUE_AND_TIMESTAMP)));
 
         final KafkaMetric metric = metric("put-all-rate");
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     @Test
     public void shouldDeleteFromInnerStoreAndRecordDeleteMetric() {
-        expect(inner.delete(KEY_BYTES)).andReturn(VALUE_AND_TIMESTAMP_BYTES);
+        when(inner.delete(KEY_BYTES)).thenReturn(VALUE_AND_TIMESTAMP_BYTES);
         init();
 
         metered.delete(KEY);
 
         final KafkaMetric metric = metric("delete-rate");
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     @Test
     public void shouldGetRangeFromInnerStoreAndRecordRangeMetric() {
-        expect(inner.range(KEY_BYTES, KEY_BYTES)).andReturn(
+        when(inner.range(KEY_BYTES, KEY_BYTES)).thenReturn(
             new KeyValueIteratorStub<>(Collections.singletonList(byteKeyValueTimestampPair).iterator()));
         init();
 
@@ -368,13 +336,12 @@ public class MeteredTimestampedKeyValueStoreTest {
 
         final KafkaMetric metric = metric("range-rate");
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     @Test
     public void shouldGetAllFromInnerStoreAndRecordAllMetric() {
-        expect(inner.all())
-            .andReturn(new KeyValueIteratorStub<>(Collections.singletonList(byteKeyValueTimestampPair).iterator()));
+        when(inner.all())
+            .thenReturn(new KeyValueIteratorStub<>(Collections.singletonList(byteKeyValueTimestampPair).iterator()));
         init();
 
         final KeyValueIterator<String, ValueAndTimestamp<String>> iterator = metered.all();
@@ -384,20 +351,17 @@ public class MeteredTimestampedKeyValueStoreTest {
 
         final KafkaMetric metric = metric(new MetricName("all-rate", STORE_LEVEL_GROUP, "", tags));
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     @Test
     public void shouldFlushInnerWhenFlushTimeRecords() {
-        inner.flush();
-        expectLastCall().once();
+        doNothing().when(inner).flush();
         init();
 
         metered.flush();
 
         final KafkaMetric metric = metric("flush-rate");
         assertTrue((Double) metric.metricValue() > 0);
-        verify(inner);
     }
 
     private interface CachedKeyValueStore extends KeyValueStore<Bytes, byte[]>, CachedStateStore<byte[], byte[]> { }
@@ -407,8 +371,7 @@ public class MeteredTimestampedKeyValueStoreTest {
     public void shouldSetFlushListenerOnWrappedCachingStore() {
         final CachedKeyValueStore cachedKeyValueStore = mock(CachedKeyValueStore.class);
 
-        expect(cachedKeyValueStore.setFlushListener(anyObject(CacheFlushListener.class), eq(false))).andReturn(true);
-        replay(cachedKeyValueStore);
+        when(cachedKeyValueStore.setFlushListener(any(CacheFlushListener.class), eq(false))).thenReturn(true);
 
         metered = new MeteredTimestampedKeyValueStore<>(
             cachedKeyValueStore,
@@ -417,8 +380,6 @@ public class MeteredTimestampedKeyValueStoreTest {
             Serdes.String(),
             new ValueAndTimestampSerde<>(Serdes.String()));
         assertTrue(metered.setFlushListener(null, false));
-
-        verify(cachedKeyValueStore);
     }
 
     @Test
@@ -439,7 +400,6 @@ public class MeteredTimestampedKeyValueStoreTest {
             null,
             null
         );
-        replay(inner, context);
         store.init((StateStoreContext) context, inner);
 
         try {
@@ -459,8 +419,6 @@ public class MeteredTimestampedKeyValueStoreTest {
     @Test
     @SuppressWarnings("unchecked")
     public void shouldNotThrowExceptionIfSerdesCorrectlySetFromConstructorParameters() {
-        expect(context.keySerde()).andStubReturn((Serde) Serdes.String());
-        expect(context.valueSerde()).andStubReturn((Serde) Serdes.Long());
         final MeteredTimestampedKeyValueStore<String, Long> store = new MeteredTimestampedKeyValueStore<>(
             inner,
             STORE_TYPE,
@@ -468,7 +426,6 @@ public class MeteredTimestampedKeyValueStoreTest {
             Serdes.String(),
             new ValueAndTimestampSerde<>(Serdes.Long())
         );
-        replay(inner, context);
         store.init((StateStoreContext) context, inner);
 
         try {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ReadOnlyWindowStoreFacadeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ReadOnlyWindowStoreFacadeTest.java
@@ -23,22 +23,20 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.WindowStoreIterator;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.Instant;
 
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
 
-@RunWith(EasyMockRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class ReadOnlyWindowStoreFacadeTest {
     @Mock
     private TimestampedWindowStore<String, String> mockedWindowTimestampStore;
@@ -56,152 +54,135 @@ public class ReadOnlyWindowStoreFacadeTest {
 
     @Test
     public void shouldReturnPlainKeyValuePairsOnSingleKeyFetch() {
-        expect(mockedWindowTimestampStore.fetch("key1", 21L))
-            .andReturn(ValueAndTimestamp.make("value1", 42L));
-        expect(mockedWindowTimestampStore.fetch("unknownKey", 21L))
-            .andReturn(null);
-        replay(mockedWindowTimestampStore);
+        when(mockedWindowTimestampStore.fetch("key1", 21L))
+            .thenReturn(ValueAndTimestamp.make("value1", 42L));
+        when(mockedWindowTimestampStore.fetch("unknownKey", 21L))
+            .thenReturn(null);
 
         assertThat(readOnlyWindowStoreFacade.fetch("key1", 21L), is("value1"));
         assertNull(readOnlyWindowStoreFacade.fetch("unknownKey", 21L));
-
-        verify(mockedWindowTimestampStore);
     }
 
     @Test
     public void shouldReturnPlainKeyValuePairsOnSingleKeyFetchLongParameters() {
-        expect(mockedWindowTimestampIterator.next())
-            .andReturn(KeyValue.pair(21L, ValueAndTimestamp.make("value1", 22L)))
-            .andReturn(KeyValue.pair(42L, ValueAndTimestamp.make("value2", 23L)));
-        expect(mockedWindowTimestampStore.fetch("key1", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
-            .andReturn(mockedWindowTimestampIterator);
-        replay(mockedWindowTimestampIterator, mockedWindowTimestampStore);
+        when(mockedWindowTimestampIterator.next())
+            .thenReturn(KeyValue.pair(21L, ValueAndTimestamp.make("value1", 22L)))
+            .thenReturn(KeyValue.pair(42L, ValueAndTimestamp.make("value2", 23L)));
+        when(mockedWindowTimestampStore.fetch("key1", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
+            .thenReturn(mockedWindowTimestampIterator);
 
         final WindowStoreIterator<String> iterator =
             readOnlyWindowStoreFacade.fetch("key1", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
         assertThat(iterator.next(), is(KeyValue.pair(21L, "value1")));
         assertThat(iterator.next(), is(KeyValue.pair(42L, "value2")));
-        verify(mockedWindowTimestampIterator, mockedWindowTimestampStore);
     }
 
     @Test
     public void shouldReturnPlainKeyValuePairsOnSingleKeyFetchInstantParameters() {
-        expect(mockedWindowTimestampIterator.next())
-            .andReturn(KeyValue.pair(21L, ValueAndTimestamp.make("value1", 22L)))
-            .andReturn(KeyValue.pair(42L, ValueAndTimestamp.make("value2", 23L)));
-        expect(mockedWindowTimestampStore.fetch("key1", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
-            .andReturn(mockedWindowTimestampIterator);
-        replay(mockedWindowTimestampIterator, mockedWindowTimestampStore);
+        when(mockedWindowTimestampIterator.next())
+            .thenReturn(KeyValue.pair(21L, ValueAndTimestamp.make("value1", 22L)))
+            .thenReturn(KeyValue.pair(42L, ValueAndTimestamp.make("value2", 23L)));
+        when(mockedWindowTimestampStore.fetch("key1", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
+            .thenReturn(mockedWindowTimestampIterator);
 
         final WindowStoreIterator<String> iterator =
             readOnlyWindowStoreFacade.fetch("key1", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
         assertThat(iterator.next(), is(KeyValue.pair(21L, "value1")));
         assertThat(iterator.next(), is(KeyValue.pair(42L, "value2")));
-        verify(mockedWindowTimestampIterator, mockedWindowTimestampStore);
     }
 
     @Test
     public void shouldReturnPlainKeyValuePairsOnRangeFetchLongParameters() {
-        expect(mockedKeyValueWindowTimestampIterator.next())
-            .andReturn(KeyValue.pair(
+        when(mockedKeyValueWindowTimestampIterator.next())
+            .thenReturn(KeyValue.pair(
                 new Windowed<>("key1", new TimeWindow(21L, 22L)),
                 ValueAndTimestamp.make("value1", 22L)))
-            .andReturn(KeyValue.pair(
+            .thenReturn(KeyValue.pair(
                 new Windowed<>("key2", new TimeWindow(42L, 43L)),
                 ValueAndTimestamp.make("value2", 100L)));
-        expect(mockedWindowTimestampStore.fetch("key1", "key2", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
-            .andReturn(mockedKeyValueWindowTimestampIterator);
-        replay(mockedKeyValueWindowTimestampIterator, mockedWindowTimestampStore);
+        when(mockedWindowTimestampStore.fetch("key1", "key2", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
+            .thenReturn(mockedKeyValueWindowTimestampIterator);
 
         final KeyValueIterator<Windowed<String>, String> iterator =
             readOnlyWindowStoreFacade.fetch("key1", "key2", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
         assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1")));
         assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2")));
-        verify(mockedKeyValueWindowTimestampIterator, mockedWindowTimestampStore);
     }
 
     @Test
     public void shouldReturnPlainKeyValuePairsOnRangeFetchInstantParameters() {
-        expect(mockedKeyValueWindowTimestampIterator.next())
-            .andReturn(KeyValue.pair(
+        when(mockedKeyValueWindowTimestampIterator.next())
+            .thenReturn(KeyValue.pair(
                 new Windowed<>("key1", new TimeWindow(21L, 22L)),
                 ValueAndTimestamp.make("value1", 22L)))
-            .andReturn(KeyValue.pair(
+            .thenReturn(KeyValue.pair(
                 new Windowed<>("key2", new TimeWindow(42L, 43L)),
                 ValueAndTimestamp.make("value2", 100L)));
-        expect(mockedWindowTimestampStore.fetch("key1", "key2", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
-            .andReturn(mockedKeyValueWindowTimestampIterator);
-        replay(mockedKeyValueWindowTimestampIterator, mockedWindowTimestampStore);
+        when(mockedWindowTimestampStore.fetch("key1", "key2", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
+            .thenReturn(mockedKeyValueWindowTimestampIterator);
 
         final KeyValueIterator<Windowed<String>, String> iterator =
             readOnlyWindowStoreFacade.fetch("key1", "key2", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
         assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1")));
         assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2")));
-        verify(mockedKeyValueWindowTimestampIterator, mockedWindowTimestampStore);
     }
 
     @Test
     public void shouldReturnPlainKeyValuePairsOnFetchAllLongParameters() {
-        expect(mockedKeyValueWindowTimestampIterator.next())
-            .andReturn(KeyValue.pair(
+        when(mockedKeyValueWindowTimestampIterator.next())
+            .thenReturn(KeyValue.pair(
                 new Windowed<>("key1", new TimeWindow(21L, 22L)),
                 ValueAndTimestamp.make("value1", 22L)))
-            .andReturn(KeyValue.pair(
+            .thenReturn(KeyValue.pair(
                 new Windowed<>("key2", new TimeWindow(42L, 43L)),
                 ValueAndTimestamp.make("value2", 100L)));
-        expect(mockedWindowTimestampStore.fetchAll(Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
-            .andReturn(mockedKeyValueWindowTimestampIterator);
-        replay(mockedKeyValueWindowTimestampIterator, mockedWindowTimestampStore);
+        when(mockedWindowTimestampStore.fetchAll(Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
+            .thenReturn(mockedKeyValueWindowTimestampIterator);
 
         final KeyValueIterator<Windowed<String>, String> iterator =
             readOnlyWindowStoreFacade.fetchAll(Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
         assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1")));
         assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2")));
-        verify(mockedKeyValueWindowTimestampIterator, mockedWindowTimestampStore);
     }
 
     @Test
     public void shouldReturnPlainKeyValuePairsOnFetchAllInstantParameters() {
-        expect(mockedKeyValueWindowTimestampIterator.next())
-            .andReturn(KeyValue.pair(
+        when(mockedKeyValueWindowTimestampIterator.next())
+            .thenReturn(KeyValue.pair(
                 new Windowed<>("key1", new TimeWindow(21L, 22L)),
                 ValueAndTimestamp.make("value1", 22L)))
-            .andReturn(KeyValue.pair(
+            .thenReturn(KeyValue.pair(
                 new Windowed<>("key2", new TimeWindow(42L, 43L)),
                 ValueAndTimestamp.make("value2", 100L)));
-        expect(mockedWindowTimestampStore.fetchAll(Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
-            .andReturn(mockedKeyValueWindowTimestampIterator);
-        replay(mockedKeyValueWindowTimestampIterator, mockedWindowTimestampStore);
+        when(mockedWindowTimestampStore.fetchAll(Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
+            .thenReturn(mockedKeyValueWindowTimestampIterator);
 
         final KeyValueIterator<Windowed<String>, String> iterator =
             readOnlyWindowStoreFacade.fetchAll(Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
         assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1")));
         assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2")));
-        verify(mockedKeyValueWindowTimestampIterator, mockedWindowTimestampStore);
     }
 
     @Test
     public void shouldReturnPlainKeyValuePairsOnAll() {
-        expect(mockedKeyValueWindowTimestampIterator.next())
-            .andReturn(KeyValue.pair(
+        when(mockedKeyValueWindowTimestampIterator.next())
+            .thenReturn(KeyValue.pair(
                 new Windowed<>("key1", new TimeWindow(21L, 22L)),
                 ValueAndTimestamp.make("value1", 22L)))
-            .andReturn(KeyValue.pair(
+            .thenReturn(KeyValue.pair(
                 new Windowed<>("key2", new TimeWindow(42L, 43L)),
                 ValueAndTimestamp.make("value2", 100L)));
-        expect(mockedWindowTimestampStore.all()).andReturn(mockedKeyValueWindowTimestampIterator);
-        replay(mockedKeyValueWindowTimestampIterator, mockedWindowTimestampStore);
+        when(mockedWindowTimestampStore.all()).thenReturn(mockedKeyValueWindowTimestampIterator);
 
         final KeyValueIterator<Windowed<String>, String> iterator = readOnlyWindowStoreFacade.all();
 
         assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1")));
         assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2")));
-        verify(mockedKeyValueWindowTimestampIterator, mockedWindowTimestampStore);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilderTest.java
@@ -27,42 +27,36 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
-import org.easymock.EasyMockRule;
-import org.easymock.Mock;
-import org.easymock.MockType;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Collections;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.reset;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
 
-@RunWith(Parameterized.class)
 @SuppressWarnings("this-escape")
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class TimestampedWindowStoreBuilderTest {
     private static final String TIMESTAMP_STORE_NAME = "Timestamped Store";
     private static final String TIMEORDERED_STORE_NAME = "TimeOrdered Store";
 
-    @Rule
-    public EasyMockRule rule = new EasyMockRule(this);
-    @Mock(type = MockType.NICE)
+    @Mock
     private WindowBytesStoreSupplier supplier;
-    @Mock(type = MockType.NICE)
+    @Mock
     private RocksDBTimestampedWindowStore timestampedStore;
-    @Mock(type = MockType.NICE)
+    @Mock
     private RocksDBTimeOrderedWindowStore timeOrderedStore;
     private TimestampedWindowStoreBuilder<String, String> builder;
     private boolean isTimeOrderedStore;
@@ -84,11 +78,9 @@ public class TimestampedWindowStoreBuilderTest {
     public void setUp() {
         isTimeOrderedStore = TIMEORDERED_STORE_NAME.equals(storeName);
         inner = isTimeOrderedStore ? timeOrderedStore : timestampedStore;
-        expect(supplier.get()).andReturn(inner);
-        expect(supplier.name()).andReturn("name");
-        expect(supplier.metricsScope()).andReturn("metricScope");
-        expect(inner.persistent()).andReturn(true).anyTimes();
-        replay(supplier, inner);
+        when(supplier.get()).thenReturn(inner);
+        when(supplier.name()).thenReturn("name");
+        when(supplier.metricsScope()).thenReturn("metricScope");
 
         builder = new TimestampedWindowStoreBuilder<>(
             supplier,
@@ -160,8 +152,7 @@ public class TimestampedWindowStoreBuilderTest {
 
     @Test
     public void shouldNotWrapTimestampedByteStore() {
-        reset(supplier);
-        expect(supplier.get()).andReturn(new RocksDBTimestampedWindowStore(
+        when(supplier.get()).thenReturn(new RocksDBTimestampedWindowStore(
             new RocksDBTimestampedSegmentedBytesStore(
                 "name",
                 "metric-scope",
@@ -170,8 +161,6 @@ public class TimestampedWindowStoreBuilderTest {
                 new WindowKeySchema()),
             false,
             1L));
-        expect(supplier.name()).andReturn("name");
-        replay(supplier);
 
         final TimestampedWindowStore<String, String> store = builder
             .withLoggingDisabled()
@@ -182,8 +171,7 @@ public class TimestampedWindowStoreBuilderTest {
 
     @Test
     public void shouldWrapPlainKeyValueStoreAsTimestampStore() {
-        reset(supplier);
-        expect(supplier.get()).andReturn(new RocksDBWindowStore(
+        when(supplier.get()).thenReturn(new RocksDBWindowStore(
             new RocksDBSegmentedBytesStore(
                 "name",
                 "metric-scope",
@@ -192,8 +180,6 @@ public class TimestampedWindowStoreBuilderTest {
                 new WindowKeySchema()),
             false,
             1L));
-        expect(supplier.name()).andReturn("name");
-        replay(supplier);
 
         final TimestampedWindowStore<String, String> store = builder
             .withLoggingDisabled()
@@ -225,37 +211,16 @@ public class TimestampedWindowStoreBuilderTest {
     }
 
     @Test
-    public void shouldThrowNullPointerIfKeySerdeIsNull() {
-        assertThrows(NullPointerException.class, () -> new TimestampedWindowStoreBuilder<>(supplier, null, Serdes.String(), new MockTime()));
-    }
-
-    @Test
-    public void shouldThrowNullPointerIfValueSerdeIsNull() {
-        assertThrows(NullPointerException.class, () -> new TimestampedWindowStoreBuilder<>(supplier, Serdes.String(), null, new MockTime()));
-    }
-
-    @Test
     public void shouldThrowNullPointerIfTimeIsNull() {
         assertThrows(NullPointerException.class, () -> new TimestampedWindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), null));
     }
 
     @Test
     public void shouldThrowNullPointerIfMetricsScopeIsNull() {
-        reset(supplier);
-        expect(supplier.get()).andReturn(new RocksDBTimestampedWindowStore(
-            new RocksDBTimestampedSegmentedBytesStore(
-                "name",
-                null,
-                10L,
-                5L,
-                new WindowKeySchema()),
-            false,
-            1L));
-        expect(supplier.name()).andReturn("name");
-        replay(supplier);
+        when(supplier.metricsScope()).thenReturn(null);
         final Exception e = assertThrows(NullPointerException.class,
             () -> new TimestampedWindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
-        assertThat(e.getMessage(), equalTo("storeSupplier's metricsScope can't be null"));
+        assertEquals(e.getMessage(), "storeSupplier's metricsScope can't be null");
     }
 
 }


### PR DESCRIPTION
This pull requests migrates mocks from MeteredTimestampedKeyValueStoreTest, ReadOnlyWindowStoreFacadeTest and TimestampedWindowStoreBuilderTest to Mockito.