### PR TITLE
KAFKA-14519; [1/N] Implement coordinator runtime metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1262,6 +1262,7 @@ project(':group-coordinator') {
     implementation project(':clients')
     implementation project(':metadata')
     implementation libs.slf4jApi
+    implementation libs.metrics
 
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':server-common').sourceSets.test.output

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -239,6 +239,11 @@
       <allow pkg="org.apache.kafka.server.util"/>
       <allow pkg="org.apache.kafka.test" />
       <allow pkg="org.apache.kafka.timeline" />
+      <subpackage name="metrics">
+        <allow pkg="com.yammer.metrics"/>
+        <allow pkg="org.apache.kafka.common.metrics" />
+        <allow pkg="org.apache.kafka.server.metrics" />
+      </subpackage>
     </subpackage>
   </subpackage>
 

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -240,7 +240,6 @@
       <allow pkg="org.apache.kafka.test" />
       <allow pkg="org.apache.kafka.timeline" />
       <subpackage name="metrics">
-        <allow pkg="com.yammer.metrics"/>
         <allow pkg="org.apache.kafka.common.metrics" />
         <allow pkg="org.apache.kafka.server.metrics" />
       </subpackage>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -325,6 +325,8 @@
               files="(ConsumerGroupMember|GroupMetadataManager).java"/>
     <suppress checks="(NPathComplexity|MethodLength)"
               files="(GroupMetadataManager|ConsumerGroupTest|GroupMetadataManagerTest).java"/>
+    <suppress checks="NPathComplexity"
+              files="CoordinatorRuntime.java"/>
     <suppress checks="ClassFanOutComplexity"
               files="(GroupMetadataManager|GroupMetadataManagerTest|GroupCoordinatorService|GroupCoordinatorServiceTest).java"/>
     <suppress checks="ParameterNumber"

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -36,6 +36,7 @@ import org.apache.kafka.common.security.token.delegation.internals.DelegationTok
 import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.common.{ClusterResource, KafkaException, TopicPartition}
 import org.apache.kafka.coordinator.group
+import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics
 import org.apache.kafka.coordinator.group.util.SystemTimerReaper
 import org.apache.kafka.coordinator.group.{GroupCoordinator, GroupCoordinatorConfig, GroupCoordinatorService, RecordSerde}
 import org.apache.kafka.image.publisher.MetadataPublisher
@@ -529,6 +530,7 @@ class BrokerServer(
         new SystemTimer("group-coordinator")
       )
       val loader = new CoordinatorLoaderImpl[group.Record](
+        time,
         replicaManager,
         serde,
         config.offsetsLoadBufferSize
@@ -544,6 +546,7 @@ class BrokerServer(
         .withTimer(timer)
         .withLoader(loader)
         .withWriter(writer)
+        .withCoordinatorRuntimeMetrics(new GroupCoordinatorRuntimeMetrics(KafkaYammerMetrics.defaultRegistry(), metrics))
         .build()
     } else {
       GroupCoordinatorAdapter(

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -546,7 +546,7 @@ class BrokerServer(
         .withTimer(timer)
         .withLoader(loader)
         .withWriter(writer)
-        .withCoordinatorRuntimeMetrics(new GroupCoordinatorRuntimeMetrics(KafkaYammerMetrics.defaultRegistry(), metrics))
+        .withCoordinatorRuntimeMetrics(new GroupCoordinatorRuntimeMetrics(metrics))
         .build()
     } else {
       GroupCoordinatorAdapter(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/CoordinatorRuntimeMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/CoordinatorRuntimeMetrics.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.metrics;
+
+import org.apache.kafka.coordinator.group.runtime.CoordinatorRuntime.CoordinatorState;
+
+import java.util.function.Supplier;
+
+/**
+ * Used by the group and transaction coordinator runtimes, the metrics suite holds partition state gauges and sensors.
+ */
+public interface CoordinatorRuntimeMetrics extends AutoCloseable {
+
+    /**
+     * Called when the partition state changes.
+     * @param oldState The old state.
+     * @param newState The new state to transition to.
+     */
+    void recordPartitionStateChange(CoordinatorState oldState, CoordinatorState newState);
+
+    /**
+     * Record the partition load metric.
+     * @param startTimeMs The partition load start time.
+     * @param endTimeMs   The partition load end time.
+     */
+    void recordPartitionLoadSensor(long startTimeMs, long endTimeMs);
+
+    /**
+     * Update the event queue time.
+     *
+     * @param durationMs The queue time.
+     */
+    void recordEventQueueTime(long durationMs);
+
+    /**
+     * Update the event queue processing time.
+     *
+     * @param durationMs The event processing time.
+     */
+    void recordEventQueueProcessingTime(long durationMs);
+
+    /**
+     * Record the thread idle ratio.
+     * @param ratio The idle ratio.
+     */
+    void recordThreadIdleRatio(double ratio);
+
+    /**
+     * Register the event queue size gauge.
+     *
+     * @param sizeSupplier The size supplier.
+     */
+    void registerEventQueueSizeGauge(Supplier<Integer> sizeSupplier);
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.metrics;
+
+import com.yammer.metrics.core.Histogram;
+import com.yammer.metrics.core.MetricsRegistry;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Min;
+import org.apache.kafka.coordinator.group.runtime.CoordinatorRuntime.CoordinatorState;
+import org.apache.kafka.server.metrics.KafkaYammerMetrics;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class GroupCoordinatorRuntimeMetrics implements CoordinatorRuntimeMetrics {
+    /**
+     * The metrics group.
+     */
+    public static final String METRICS_GROUP = "group-coordinator-metrics";
+
+    /**
+     * The partition count metric name.
+     */
+    public static final String NUM_PARTITIONS_METRIC_NAME = "num-partitions";
+
+    /**
+     * Metric to count the number of partitions in Loading state.
+     */
+    private final MetricName numPartitionsLoading;
+    private final AtomicLong numPartitionsLoadingCounter = new AtomicLong(0);
+
+    /**
+     * Metric to count the number of partitions in Active state.
+     */
+    private final MetricName numPartitionsActive;
+    private final AtomicLong numPartitionsActiveCounter = new AtomicLong(0);
+
+    /**
+     * Metric to count the number of partitions in Failed state.
+     */
+    private final MetricName numPartitionsFailed;
+    private final AtomicLong numPartitionsFailedCounter = new AtomicLong(0);
+
+    /**
+     * Metric to count the size of the processor queue.
+     */
+    private final MetricName eventQueueSize;
+
+    /**
+     * Metric to measure the event queue time.
+     */
+    private final com.yammer.metrics.core.MetricName eventQueueTimeMs =
+        KafkaYammerMetrics.getMetricName("kafka.coordinator.group", METRICS_GROUP, "EventQueueTimeMs");
+
+    /**
+     * Metric to measure the event processing time.
+     */
+    private final com.yammer.metrics.core.MetricName eventQueueProcessingTimeMs =
+        KafkaYammerMetrics.getMetricName("kafka.coordinator.group", METRICS_GROUP, "EventQueueProcessingTimeMs");
+
+    /**
+     * The yammer metrics registry.
+     */
+    private final MetricsRegistry registry;
+
+    /**
+     * The Kafka metrics registry.
+     */
+    private final Metrics metrics;
+
+    /**
+     * The partition load sensor.
+     */
+    private Sensor partitionLoadSensor;
+
+    /**
+     * The thread idle sensor.
+     */
+    private Sensor threadIdleRatioSensor;
+
+    /**
+     * The event queue time updater.
+     */
+    private final Consumer<Long> eventQueueTimeUpdater;
+
+    /**
+     * The event queue processing time updater.
+     */
+    private final Consumer<Long> eventQueueProcessingTimeUpdater;
+
+    public GroupCoordinatorRuntimeMetrics(MetricsRegistry registry, Metrics metrics) {
+        this.registry = Objects.requireNonNull(registry);
+        this.metrics = Objects.requireNonNull(metrics);
+
+        this.numPartitionsLoading = kafkaMetricName(
+            NUM_PARTITIONS_METRIC_NAME,
+            "The number of partitions in Loading state.",
+            "state", "loading"
+        );
+
+        this.numPartitionsActive = kafkaMetricName(
+            NUM_PARTITIONS_METRIC_NAME,
+            "The number of partitions in Active state.",
+            "state", "active"
+        );
+
+        this.numPartitionsFailed = kafkaMetricName(
+            NUM_PARTITIONS_METRIC_NAME,
+            "The number of partitions in Failed state.",
+            "state", "failed"
+        );
+
+        this.eventQueueSize = kafkaMetricName("event-queue-size", "The event accumulator queue size.");
+
+        metrics.addMetric(numPartitionsLoading, (Gauge<Long>) (config, now) -> numPartitionsLoadingCounter.get());
+        metrics.addMetric(numPartitionsActive, (Gauge<Long>) (config, now) -> numPartitionsActiveCounter.get());
+        metrics.addMetric(numPartitionsFailed, (Gauge<Long>) (config, now) -> numPartitionsFailedCounter.get());
+
+        this.partitionLoadSensor = metrics.sensor("GroupPartitionLoadTime");
+        this.partitionLoadSensor.add(
+            metrics.metricName(
+                "partition-load-time-max",
+                METRICS_GROUP,
+                "The max time it took to load the partitions in the last 30 sec."
+            ), new Max());
+        this.partitionLoadSensor.add(
+            metrics.metricName(
+                "partition-load-time-avg",
+                METRICS_GROUP,
+                "The average time it took to load the partitions in the last 30 sec."
+            ), new Avg());
+
+        this.threadIdleRatioSensor = metrics.sensor("ThreadIdleRatio");
+        this.threadIdleRatioSensor.add(
+            metrics.metricName(
+                "thread-idle-ratio-min",
+                METRICS_GROUP,
+                "The minimum thread idle ratio over the last 30 seconds."
+            ), new Min());
+        this.threadIdleRatioSensor.add(
+            metrics.metricName(
+                "thread-idle-ratio-avg",
+                METRICS_GROUP,
+                "The average thread idle ratio over the last 30 seconds."
+            ), new Avg());
+
+        eventQueueTimeUpdater = newHistogram(eventQueueTimeMs);
+        eventQueueProcessingTimeUpdater = newHistogram(eventQueueProcessingTimeMs);
+    }
+
+    /**
+     * Retrieve the kafka metric name.
+     *
+     * @param name The name of the metric.
+     *
+     * @return The kafka metric name.
+     */
+    private MetricName kafkaMetricName(String name, String description, String... keyValue) {
+        return metrics.metricName(name, METRICS_GROUP, description, keyValue);
+    }
+
+    private Consumer<Long> newHistogram(com.yammer.metrics.core.MetricName name) {
+        Histogram histogram = registry.newHistogram(name, true);
+        return histogram::update;
+    }
+
+    @Override
+    public void close() {
+        Arrays.asList(
+            numPartitionsLoading,
+            numPartitionsActive,
+            numPartitionsFailed,
+            eventQueueSize
+        ).forEach(metrics::removeMetric);
+
+        Arrays.asList(
+            eventQueueTimeMs,
+            eventQueueProcessingTimeMs
+        ).forEach(registry::removeMetric);
+
+        metrics.removeSensor(partitionLoadSensor.name());
+        metrics.removeSensor(threadIdleRatioSensor.name());
+    }
+
+    /**
+     * Called when the partition state changes. Decrement the old state and increment the new state.
+     *
+     * @param oldState The old state.
+     * @param newState The new state to transition to.
+     */
+    @Override
+    public void recordPartitionStateChange(CoordinatorState oldState, CoordinatorState newState) {
+        switch (oldState) {
+            case INITIAL:
+            case CLOSED:
+                break;
+            case LOADING:
+                numPartitionsLoadingCounter.decrementAndGet();
+                break;
+            case ACTIVE:
+                numPartitionsActiveCounter.decrementAndGet();
+                break;
+            case FAILED:
+                numPartitionsFailedCounter.decrementAndGet();
+        }
+
+        switch (newState) {
+            case INITIAL:
+            case CLOSED:
+                break;
+            case LOADING:
+                numPartitionsLoadingCounter.incrementAndGet();
+                break;
+            case ACTIVE:
+                numPartitionsActiveCounter.incrementAndGet();
+                break;
+            case FAILED:
+                numPartitionsFailedCounter.incrementAndGet();
+        }
+    }
+
+    @Override
+    public void recordPartitionLoadSensor(long startTimeMs, long endTimeMs) {
+        this.partitionLoadSensor.record(endTimeMs - startTimeMs, endTimeMs, false);
+    }
+
+    @Override
+    public void recordEventQueueTime(long durationMs) {
+        eventQueueTimeUpdater.accept(durationMs);
+    }
+
+    @Override
+    public void recordEventQueueProcessingTime(long durationMs) {
+        eventQueueProcessingTimeUpdater.accept(durationMs);
+    }
+
+    @Override
+    public void recordThreadIdleRatio(double ratio) {
+        threadIdleRatioSensor.record(ratio);
+    }
+
+    @Override
+    public void registerEventQueueSizeGauge(Supplier<Integer> sizeSupplier) {
+        metrics.addMetric(eventQueueSize, (Gauge<Long>) (config, now) -> (long) sizeSupplier.get());
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorEvent.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorEvent.java
@@ -37,14 +37,7 @@ public interface CoordinatorEvent extends EventAccumulator.Event<TopicPartition>
     void complete(Throwable exception);
 
     /**
-     * @return The enqueue time in milliseconds.
+     * @return The created time in milliseconds.
      */
-    long enqueueTimeMs();
-
-    /**
-     * Sets the enqueue time.
-     *
-     * @param enqueueTimeMs The enqueue time in milliseconds.
-     */
-    void setEnqueueTimeMs(long enqueueTimeMs);
+    long createdTimeMs();
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorEvent.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorEvent.java
@@ -35,4 +35,16 @@ public interface CoordinatorEvent extends EventAccumulator.Event<TopicPartition>
      * @param exception An exception if the processing of the event failed or null otherwise.
      */
     void complete(Throwable exception);
+
+    /**
+     * @return The enqueue time in milliseconds.
+     */
+    long enqueueTimeMs();
+
+    /**
+     * Sets the enqueue time.
+     *
+     * @param enqueueTimeMs The enqueue time in milliseconds.
+     */
+    void setEnqueueTimeMs(long enqueueTimeMs);
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorLoader.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorLoader.java
@@ -47,6 +47,50 @@ public interface CoordinatorLoader<U> extends AutoCloseable {
     }
 
     /**
+     * Object that is returned as part of the future from load(). Holds the partition load time and the
+     * end time.
+     */
+    class LoadSummary {
+        private final long startTimeMs;
+        private final long endTimeMs;
+        private final long numRecords;
+        private final long numBytes;
+
+        public LoadSummary(long startTimeMs, long endTimeMs, long numRecords, long numBytes) {
+            this.startTimeMs = startTimeMs;
+            this.endTimeMs = endTimeMs;
+            this.numRecords = numRecords;
+            this.numBytes = numBytes;
+        }
+
+        public long startTimeMs() {
+            return startTimeMs;
+        }
+
+        public long endTimeMs() {
+            return endTimeMs;
+        }
+
+        public long numRecords() {
+            return numRecords;
+        }
+
+        public long numBytes() {
+            return numBytes;
+        }
+
+
+        @Override
+        public String toString() {
+            return "LoadSummary(" +
+                "startTimeMs=" + startTimeMs +
+                ", endTimeMs=" + endTimeMs +
+                ", numRecords=" + numRecords +
+                ", numBytes=" + numBytes + ")";
+        }
+    }
+
+    /**
      * Deserializer to translates bytes to T.
      *
      * @param <T> The record type.
@@ -69,7 +113,7 @@ public interface CoordinatorLoader<U> extends AutoCloseable {
      * @param tp            The TopicPartition to read from.
      * @param coordinator   The object to apply records to.
      */
-    CompletableFuture<Void> load(
+    CompletableFuture<LoadSummary> load(
         TopicPartition tp,
         CoordinatorPlayback<U> coordinator
     );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorLoader.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorLoader.java
@@ -79,7 +79,6 @@ public interface CoordinatorLoader<U> extends AutoCloseable {
             return numBytes;
         }
 
-
         @Override
         public String toString() {
             return "LoadSummary(" +

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.coordinator.group.metrics.CoordinatorRuntimeMetrics;
 import org.apache.kafka.deferred.DeferredEvent;
 import org.apache.kafka.deferred.DeferredEventQueue;
 import org.apache.kafka.image.MetadataDelta;
@@ -89,6 +90,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         private CoordinatorShardBuilderSupplier<S, U> coordinatorShardBuilderSupplier;
         private Time time = Time.SYSTEM;
         private Timer timer;
+        private CoordinatorRuntimeMetrics runtimeMetrics;
 
         public Builder<S, U> withLogPrefix(String logPrefix) {
             this.logPrefix = logPrefix;
@@ -130,6 +132,11 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             return this;
         }
 
+        public Builder<S, U> withCoordinatorRuntimeMetrics(CoordinatorRuntimeMetrics runtimeMetrics) {
+            this.runtimeMetrics = runtimeMetrics;
+            return this;
+        }
+
         public CoordinatorRuntime<S, U> build() {
             if (logPrefix == null)
                 logPrefix = "";
@@ -147,6 +154,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 throw new IllegalArgumentException("Time must be set.");
             if (timer == null)
                 throw new IllegalArgumentException("Timer must be set.");
+            if (runtimeMetrics == null)
+                throw new IllegalArgumentException("CoordinatorRuntimeMetrics must be set.");
 
             return new CoordinatorRuntime<>(
                 logPrefix,
@@ -156,7 +165,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 loader,
                 coordinatorShardBuilderSupplier,
                 time,
-                timer
+                timer,
+                runtimeMetrics
             );
         }
     }
@@ -164,7 +174,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
     /**
      * The various state that a coordinator for a partition can be in.
      */
-    enum CoordinatorState {
+    public enum CoordinatorState {
         /**
          * Initial state when a coordinator is created.
          */
@@ -501,6 +511,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 throw new IllegalStateException("Cannot transition from " + state + " to " + newState);
             }
 
+            CoordinatorState oldState = state;
             log.debug("Transition from {} to {}.", state, newState);
             switch (newState) {
                 case LOADING:
@@ -537,6 +548,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 default:
                     throw new IllegalArgumentException("Transitioning to " + newState + " is not supported.");
             }
+
+            runtimeMetrics.recordPartitionStateChange(oldState, state);
         }
 
         /**
@@ -607,6 +620,11 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
          * if an exception is thrown before it is assigned.
          */
         CoordinatorResult<T, U> result;
+
+        /**
+         * The time this event was queued.
+         */
+        private long enqueueTimeMs;
 
         /**
          * Constructor.
@@ -710,6 +728,16 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         }
 
         @Override
+        public long enqueueTimeMs() {
+            return this.enqueueTimeMs;
+        }
+
+        @Override
+        public void setEnqueueTimeMs(long enqueueTimeMs) {
+            this.enqueueTimeMs = enqueueTimeMs;
+        }
+
+        @Override
         public String toString() {
             return "CoordinatorWriteEvent(name=" + name + ")";
         }
@@ -767,6 +795,11 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
          * if an exception is thrown before it is assigned.
          */
         T response;
+
+        /**
+         * The time this event was queued.
+         */
+        private long enqueueTimeMs;
 
         /**
          * Constructor.
@@ -833,6 +866,16 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         }
 
         @Override
+        public long enqueueTimeMs() {
+            return this.enqueueTimeMs;
+        }
+
+        @Override
+        public void setEnqueueTimeMs(long enqueueTimeMs) {
+            this.enqueueTimeMs = enqueueTimeMs;
+        }
+
+        @Override
         public String toString() {
             return "CoordinatorReadEvent(name=" + name + ")";
         }
@@ -856,6 +899,11 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
          * The internal operation to execute.
          */
         final Runnable op;
+
+        /**
+         * The time this event was queued.
+         */
+        private long enqueueTimeMs;
 
         /**
          * Constructor.
@@ -905,6 +953,16 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             if (exception != null) {
                 log.error("Execution of {} failed due to {}.", name, exception.getMessage(), exception);
             }
+        }
+
+        @Override
+        public long enqueueTimeMs() {
+            return this.enqueueTimeMs;
+        }
+
+        @Override
+        public void setEnqueueTimeMs(long enqueueTimeMs) {
+            this.enqueueTimeMs = enqueueTimeMs;
         }
 
         @Override
@@ -996,6 +1054,11 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
     private final CoordinatorShardBuilderSupplier<S, U> coordinatorShardBuilderSupplier;
 
     /**
+     * The coordinator runtime metrics.
+     */
+    private final CoordinatorRuntimeMetrics runtimeMetrics;
+
+    /**
      * Atomic boolean indicating whether the runtime is running.
      */
     private final AtomicBoolean isRunning = new AtomicBoolean(true);
@@ -1025,7 +1088,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         CoordinatorLoader<U> loader,
         CoordinatorShardBuilderSupplier<S, U> coordinatorShardBuilderSupplier,
         Time time,
-        Timer timer
+        Timer timer,
+        CoordinatorRuntimeMetrics runtimeMetrics
     ) {
         this.logPrefix = logPrefix;
         this.logContext = logContext;
@@ -1038,6 +1102,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         this.highWatermarklistener = new HighWatermarkListener();
         this.loader = loader;
         this.coordinatorShardBuilderSupplier = coordinatorShardBuilderSupplier;
+        this.runtimeMetrics = runtimeMetrics;
     }
 
     /**
@@ -1242,7 +1307,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         case FAILED:
                         case INITIAL:
                             context.transitionTo(CoordinatorState.LOADING);
-                            loader.load(tp, context.coordinator).whenComplete((state, exception) -> {
+                            loader.load(tp, context.coordinator).whenComplete((summary, exception) -> {
                                 scheduleInternalOperation("CompleteLoad(tp=" + tp + ", epoch=" + partitionEpoch + ")", tp, () -> {
                                     withContextOrThrow(tp, ctx -> {
                                         if (ctx.state != CoordinatorState.LOADING) {
@@ -1254,8 +1319,11 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                                         try {
                                             if (exception != null) throw exception;
                                             ctx.transitionTo(CoordinatorState.ACTIVE);
-                                            log.info("Finished loading of metadata from {} with epoch {}.",
-                                                tp, partitionEpoch
+                                            if (summary != null) {
+                                                runtimeMetrics.recordPartitionLoadSensor(summary.startTimeMs(), summary.endTimeMs());
+                                            }
+                                            log.info("Finished loading of metadata from {} with epoch {} and LoadSummary={}.",
+                                                tp, partitionEpoch, summary
                                             );
                                         } catch (Throwable ex) {
                                             log.error("Failed to load metadata from {} with epoch {} due to {}.",
@@ -1373,6 +1441,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             context.transitionTo(CoordinatorState.CLOSED);
         });
         coordinators.clear();
+        Utils.closeQuietly(runtimeMetrics, "runtime metrics");
         log.info("Coordinator runtime closed.");
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -622,9 +622,9 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         CoordinatorResult<T, U> result;
 
         /**
-         * The time this event was queued.
+         * The time this event was created.
          */
-        private long enqueueTimeMs;
+        private final long createdTimeMs;
 
         /**
          * Constructor.
@@ -642,6 +642,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             this.name = name;
             this.op = op;
             this.future = new CompletableFuture<>();
+            this.createdTimeMs = time.milliseconds();
         }
 
         /**
@@ -728,13 +729,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         }
 
         @Override
-        public long enqueueTimeMs() {
-            return this.enqueueTimeMs;
-        }
-
-        @Override
-        public void setEnqueueTimeMs(long enqueueTimeMs) {
-            this.enqueueTimeMs = enqueueTimeMs;
+        public long createdTimeMs() {
+            return this.createdTimeMs;
         }
 
         @Override
@@ -797,9 +793,9 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         T response;
 
         /**
-         * The time this event was queued.
+         * The time this event was created.
          */
-        private long enqueueTimeMs;
+        private final long createdTimeMs;
 
         /**
          * Constructor.
@@ -817,6 +813,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             this.name = name;
             this.op = op;
             this.future = new CompletableFuture<>();
+            this.createdTimeMs = time.milliseconds();
         }
 
         /**
@@ -866,13 +863,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         }
 
         @Override
-        public long enqueueTimeMs() {
-            return this.enqueueTimeMs;
-        }
-
-        @Override
-        public void setEnqueueTimeMs(long enqueueTimeMs) {
-            this.enqueueTimeMs = enqueueTimeMs;
+        public long createdTimeMs() {
+            return this.createdTimeMs;
         }
 
         @Override
@@ -901,9 +893,9 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         final Runnable op;
 
         /**
-         * The time this event was queued.
+         * The time this event was created.
          */
-        private long enqueueTimeMs;
+        private final long createdTimeMs;
 
         /**
          * Constructor.
@@ -920,6 +912,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             this.tp = tp;
             this.name = name;
             this.op = op;
+            this.createdTimeMs = time.milliseconds();
         }
 
         /**
@@ -956,13 +949,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         }
 
         @Override
-        public long enqueueTimeMs() {
-            return this.enqueueTimeMs;
-        }
-
-        @Override
-        public void setEnqueueTimeMs(long enqueueTimeMs) {
-            this.enqueueTimeMs = enqueueTimeMs;
+        public long createdTimeMs() {
+            return this.createdTimeMs;
         }
 
         @Override

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
@@ -134,7 +134,7 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
                     try {
                         log.debug("Executing event: {}.", event);
                         long dequeuedTimeMs = time.milliseconds();
-                        metrics.recordEventQueueTime(dequeuedTimeMs - event.enqueueTimeMs());
+                        metrics.recordEventQueueTime(dequeuedTimeMs - event.createdTimeMs());
                         event.run();
                         metrics.recordEventQueueProcessingTime(time.milliseconds() - dequeuedTimeMs);
                     } catch (Throwable t) {
@@ -152,7 +152,7 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
             while (event != null) {
                 try {
                     log.debug("Draining event: {}.", event);
-                    metrics.recordEventQueueTime(time.milliseconds() - event.enqueueTimeMs());
+                    metrics.recordEventQueueTime(time.milliseconds() - event.createdTimeMs());
                     event.complete(new RejectedExecutionException("EventProcessor is closed."));
                 } catch (Throwable t) {
                     log.error("Failed to reject event {} due to: {}.", event, t.getMessage(), t);
@@ -208,7 +208,6 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
      */
     @Override
     public void enqueue(CoordinatorEvent event) throws RejectedExecutionException {
-        event.setEnqueueTimeMs(time.milliseconds());
         accumulator.add(event);
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
@@ -18,9 +18,12 @@ package org.apache.kafka.coordinator.group.runtime;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.coordinator.group.metrics.CoordinatorRuntimeMetrics;
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -53,20 +56,49 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
     private volatile boolean shuttingDown;
 
     /**
+     * The coordinator runtime metrics.
+     */
+    private final CoordinatorRuntimeMetrics metrics;
+
+    /**
+     * The time.
+     */
+    private final Time time;
+
+    public MultiThreadedEventProcessor(
+        LogContext logContext,
+        String threadPrefix,
+        int numThreads,
+        Time time,
+        CoordinatorRuntimeMetrics metrics
+    ) {
+        this(logContext, threadPrefix, numThreads, time, metrics, new EventAccumulator<>());
+    }
+
+    /**
      * Constructor.
      *
-     * @param logContext    The log context.
-     * @param threadPrefix  The thread prefix.
-     * @param numThreads    The number of threads.
+     * @param logContext        The log context.
+     * @param threadPrefix      The thread prefix.
+     * @param numThreads        The number of threads.
+     * @param metrics           The coordinator runtime metrics.
+     * @param time              The time.
+     * @param eventAccumulator  The event accumulator.
      */
     public MultiThreadedEventProcessor(
         LogContext logContext,
         String threadPrefix,
-        int numThreads
+        int numThreads,
+        Time time,
+        CoordinatorRuntimeMetrics metrics,
+        EventAccumulator<TopicPartition, CoordinatorEvent> eventAccumulator
     ) {
         this.log = logContext.logger(MultiThreadedEventProcessor.class);
         this.shuttingDown = false;
-        this.accumulator = new EventAccumulator<>();
+        this.accumulator = eventAccumulator;
+        this.time = Objects.requireNonNull(time);
+        this.metrics = Objects.requireNonNull(metrics);
+        this.metrics.registerEventQueueSizeGauge(accumulator::size);
         this.threads = IntStream.range(0, numThreads).mapToObj(threadId ->
             new EventProcessorThread(
                 threadPrefix + threadId
@@ -81,6 +113,9 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
      */
     private class EventProcessorThread extends Thread {
         private final Logger log;
+        private long pollStartMs;
+        private long timeSinceLastPollMs;
+        private long lastPollMs;
 
         EventProcessorThread(
             String name
@@ -92,11 +127,16 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
 
         private void handleEvents() {
             while (!shuttingDown) {
+                recordPollStartTime(time.milliseconds());
                 CoordinatorEvent event = accumulator.poll();
+                recordPollEndTime(time.milliseconds());
                 if (event != null) {
                     try {
                         log.debug("Executing event: {}.", event);
+                        long dequeuedTimeMs = time.milliseconds();
+                        metrics.recordEventQueueTime(dequeuedTimeMs - event.enqueueTimeMs());
                         event.run();
+                        metrics.recordEventQueueProcessingTime(time.milliseconds() - dequeuedTimeMs);
                     } catch (Throwable t) {
                         log.error("Failed to run event {} due to: {}.", event, t.getMessage(), t);
                         event.complete(t);
@@ -112,6 +152,7 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
             while (event != null) {
                 try {
                     log.debug("Draining event: {}.", event);
+                    metrics.recordEventQueueTime(time.milliseconds() - event.enqueueTimeMs());
                     event.complete(new RejectedExecutionException("EventProcessor is closed."));
                 } catch (Throwable t) {
                     log.error("Failed to reject event {} due to: {}.", event, t.getMessage(), t);
@@ -145,6 +186,18 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
                 log.info("Shutdown completed");
             }
         }
+
+        private void recordPollStartTime(long pollStartMs) {
+            this.pollStartMs = pollStartMs;
+            this.timeSinceLastPollMs = lastPollMs != 0L ? pollStartMs - lastPollMs : 0;
+            this.lastPollMs = pollStartMs;
+        }
+
+        private void recordPollEndTime(long pollEndMs) {
+            long pollTimeMs = pollEndMs - pollStartMs;
+            double pollIdleRatio = pollTimeMs * 1.0 / (pollTimeMs + timeSinceLastPollMs);
+            metrics.recordThreadIdleRatio(pollIdleRatio);
+        }
     }
 
     /**
@@ -155,6 +208,7 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
      */
     @Override
     public void enqueue(CoordinatorEvent event) throws RejectedExecutionException {
+        event.setEnqueueTimeMs(time.milliseconds());
         accumulator.add(event);
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetricsTest.java
@@ -16,22 +16,16 @@
  */
 package org.apache.kafka.coordinator.group.metrics;
 
-import com.yammer.metrics.core.Histogram;
-import com.yammer.metrics.core.MetricsRegistry;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.runtime.CoordinatorRuntime.CoordinatorState;
-import org.apache.kafka.server.metrics.KafkaYammerMetrics;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.stream.IntStream;
 
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics.METRICS_GROUP;
@@ -44,7 +38,6 @@ public class GroupCoordinatorRuntimeMetricsTest {
     
     @Test
     public void testMetricNames() {
-        MetricsRegistry registry = new MetricsRegistry();
         Metrics metrics = new Metrics();
 
         HashSet<org.apache.kafka.common.MetricName> expectedMetrics = new HashSet<>(Arrays.asList(
@@ -58,36 +51,19 @@ public class GroupCoordinatorRuntimeMetricsTest {
             metrics.metricName("thread-idle-ratio-avg", METRICS_GROUP)
         ));
 
-        try {
-            try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(
-                registry,
-                metrics
-            )) {
-                HashSet<String> expectedRegistry = new HashSet<>(Arrays.asList(
-                    "kafka.coordinator.group:type=group-coordinator-metrics,name=EventQueueTimeMs",
-                    "kafka.coordinator.group:type=group-coordinator-metrics,name=EventQueueProcessingTimeMs"
-                ));
-                runtimeMetrics.registerEventQueueSizeGauge(() -> 0);
-
-                assertMetricsForTypeEqual(registry, "kafka.coordinator.group", expectedRegistry);
-                expectedMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
-
-            }
-            assertMetricsForTypeEqual(registry, "kafka.coordinator.group", Collections.emptySet());
-            expectedMetrics.forEach(metricName -> assertFalse(metrics.metrics().containsKey(metricName)));
-        } finally {
-            registry.shutdown();
+        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(metrics)) {
+            runtimeMetrics.registerEventQueueSizeGauge(() -> 0);
+            expectedMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
         }
+
+        expectedMetrics.forEach(metricName -> assertFalse(metrics.metrics().containsKey(metricName)));
     }
 
     @Test
     public void testUpdateNumPartitionsMetrics() {
         Metrics metrics = new Metrics();
 
-        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(
-            KafkaYammerMetrics.defaultRegistry(),
-            metrics
-        )) {
+        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(metrics)) {
             IntStream.range(0, 10)
                 .forEach(__ -> runtimeMetrics.recordPartitionStateChange(CoordinatorState.INITIAL, CoordinatorState.LOADING));
             IntStream.range(0, 8)
@@ -107,9 +83,8 @@ public class GroupCoordinatorRuntimeMetricsTest {
     public void testPartitionLoadSensorMetrics() {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
-        MetricsRegistry registry = new MetricsRegistry();
 
-        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(registry, metrics)) {
+        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(metrics)) {
             long startTimeMs = time.milliseconds();
             runtimeMetrics.recordPartitionLoadSensor(startTimeMs, startTimeMs + 1000);
             runtimeMetrics.recordPartitionLoadSensor(startTimeMs, startTimeMs + 2000);
@@ -124,8 +99,6 @@ public class GroupCoordinatorRuntimeMetricsTest {
                 "partition-load-time-max", METRICS_GROUP);
             metric = metrics.metrics().get(metricName);
             assertEquals(2000.0, metric.metricValue());
-        } finally {
-            registry.shutdown();
         }
     }
 
@@ -133,9 +106,8 @@ public class GroupCoordinatorRuntimeMetricsTest {
     public void testThreadIdleRatioSensor() {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
-        MetricsRegistry registry = new MetricsRegistry();
 
-        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(registry, metrics)) {
+        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(metrics)) {
             IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordThreadIdleRatio(1.0 / (i + 1)));
 
             org.apache.kafka.common.MetricName metricName = metrics.metricName(
@@ -148,40 +120,6 @@ public class GroupCoordinatorRuntimeMetricsTest {
                 "thread-idle-ratio-min", METRICS_GROUP);
             metric = metrics.metrics().get(metricName);
             assertEquals(1.0 / 3.0, metric.metricValue());
-        } finally {
-            registry.shutdown();
-        }
-    }
-
-    @Test
-    public void testEventQueueTime() {
-        Time time = new MockTime();
-        Metrics metrics = new Metrics(time);
-        MetricsRegistry registry = new MetricsRegistry();
-
-        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(registry, metrics)) {
-            IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordEventQueueTime((i + 1) * 1000L));
-
-            assertMetricHistogram(registry,
-                yammerMetricName(METRICS_GROUP, "EventQueueTimeMs"), 3, 6000);
-        } finally {
-            registry.shutdown();
-        }
-    }
-
-    @Test
-    public void testEventQueueProcessingTime() {
-        Time time = new MockTime();
-        Metrics metrics = new Metrics(time);
-        MetricsRegistry registry = new MetricsRegistry();
-
-        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(registry, metrics)) {
-            IntStream.range(0, 4).forEach(i -> runtimeMetrics.recordEventQueueProcessingTime((i + 1) * 1000L));
-
-            assertMetricHistogram(registry,
-                yammerMetricName(METRICS_GROUP, "EventQueueProcessingTimeMs"), 4, 10000);
-        } finally {
-            registry.shutdown();
         }
     }
 
@@ -189,30 +127,15 @@ public class GroupCoordinatorRuntimeMetricsTest {
     public void testEventQueueSize() {
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
-        MetricsRegistry registry = new MetricsRegistry();
 
-        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(registry, metrics)) {
+        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(metrics)) {
             runtimeMetrics.registerEventQueueSizeGauge(() -> 5);
             assertMetricGauge(metrics, kafkaMetricName(metrics, "event-queue-size"), 5);
-        } finally {
-            registry.shutdown();
         }
     }
 
     private static void assertMetricGauge(Metrics metrics, org.apache.kafka.common.MetricName metricName, long count) {
         assertEquals(count, (long) metrics.metric(metricName).metricValue());
-    }
-
-    private static void assertMetricHistogram(
-        MetricsRegistry registry,
-        com.yammer.metrics.core.MetricName metricName,
-        long count,
-        double sum
-    ) {
-        Histogram histogram = (Histogram) registry.allMetrics().get(metricName);
-
-        assertEquals(count, histogram.count());
-        assertEquals(sum, histogram.sum(), .1);
     }
 
     private static com.yammer.metrics.core.MetricName yammerMetricName(String type, String name) {
@@ -222,23 +145,5 @@ public class GroupCoordinatorRuntimeMetricsTest {
 
     private static MetricName kafkaMetricName(Metrics metrics, String name, String... keyValue) {
         return metrics.metricName(name, METRICS_GROUP, "", keyValue);
-    }
-    
-    private static void assertMetricsForTypeEqual(
-        MetricsRegistry registry,
-        String expectedPrefix,
-        Set<String> expected
-    ) {
-        Set<String> actual = new TreeSet<>();
-        registry.allMetrics().forEach((name, __) -> {
-            StringBuilder bld = new StringBuilder();
-            bld.append(name.getGroup());
-            bld.append(":type=").append(name.getType());
-            bld.append(",name=").append(name.getName());
-            if (bld.toString().startsWith(expectedPrefix)) {
-                actual.add(bld.toString());
-            }
-        });
-        assertEquals(new TreeSet<>(expected), actual);
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetricsTest.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.metrics;
+
+import com.yammer.metrics.core.Histogram;
+import com.yammer.metrics.core.MetricsRegistry;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.coordinator.group.runtime.CoordinatorRuntime.CoordinatorState;
+import org.apache.kafka.server.metrics.KafkaYammerMetrics;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.IntStream;
+
+import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics.METRICS_GROUP;
+import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics.NUM_PARTITIONS_METRIC_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GroupCoordinatorRuntimeMetricsTest {
+    
+    @Test
+    public void testMetricNames() {
+        MetricsRegistry registry = new MetricsRegistry();
+        Metrics metrics = new Metrics();
+
+        HashSet<org.apache.kafka.common.MetricName> expectedMetrics = new HashSet<>(Arrays.asList(
+            kafkaMetricName(metrics, NUM_PARTITIONS_METRIC_NAME, "state", "loading"),
+            kafkaMetricName(metrics, NUM_PARTITIONS_METRIC_NAME, "state", "active"),
+            kafkaMetricName(metrics, NUM_PARTITIONS_METRIC_NAME, "state", "failed"),
+            metrics.metricName("event-queue-size", METRICS_GROUP),
+            metrics.metricName("partition-load-time-max", METRICS_GROUP),
+            metrics.metricName("partition-load-time-avg", METRICS_GROUP),
+            metrics.metricName("thread-idle-ratio-min", METRICS_GROUP),
+            metrics.metricName("thread-idle-ratio-avg", METRICS_GROUP)
+        ));
+
+        try {
+            try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(
+                registry,
+                metrics
+            )) {
+                HashSet<String> expectedRegistry = new HashSet<>(Arrays.asList(
+                    "kafka.coordinator.group:type=group-coordinator-metrics,name=EventQueueTimeMs",
+                    "kafka.coordinator.group:type=group-coordinator-metrics,name=EventQueueProcessingTimeMs"
+                ));
+                runtimeMetrics.registerEventQueueSizeGauge(() -> 0);
+
+                assertMetricsForTypeEqual(registry, "kafka.coordinator.group", expectedRegistry);
+                expectedMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName)));
+
+            }
+            assertMetricsForTypeEqual(registry, "kafka.coordinator.group", Collections.emptySet());
+            expectedMetrics.forEach(metricName -> assertFalse(metrics.metrics().containsKey(metricName)));
+        } finally {
+            registry.shutdown();
+        }
+    }
+
+    @Test
+    public void testUpdateNumPartitionsMetrics() {
+        Metrics metrics = new Metrics();
+
+        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(
+            KafkaYammerMetrics.defaultRegistry(),
+            metrics
+        )) {
+            IntStream.range(0, 10)
+                .forEach(__ -> runtimeMetrics.recordPartitionStateChange(CoordinatorState.INITIAL, CoordinatorState.LOADING));
+            IntStream.range(0, 8)
+                .forEach(__ -> runtimeMetrics.recordPartitionStateChange(CoordinatorState.LOADING, CoordinatorState.ACTIVE));
+            IntStream.range(0, 8)
+                .forEach(__ -> runtimeMetrics.recordPartitionStateChange(CoordinatorState.ACTIVE, CoordinatorState.FAILED));
+            IntStream.range(0, 2)
+                .forEach(__ -> runtimeMetrics.recordPartitionStateChange(CoordinatorState.FAILED, CoordinatorState.CLOSED));
+
+            assertMetricGauge(metrics, kafkaMetricName(metrics, NUM_PARTITIONS_METRIC_NAME, "state", "loading"), 2);
+            assertMetricGauge(metrics, kafkaMetricName(metrics, NUM_PARTITIONS_METRIC_NAME, "state", "active"), 0);
+            assertMetricGauge(metrics, kafkaMetricName(metrics, NUM_PARTITIONS_METRIC_NAME, "state", "failed"), 6);
+        }
+    }
+
+    @Test
+    public void testPartitionLoadSensorMetrics() {
+        Time time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        MetricsRegistry registry = new MetricsRegistry();
+
+        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(registry, metrics)) {
+            long startTimeMs = time.milliseconds();
+            runtimeMetrics.recordPartitionLoadSensor(startTimeMs, startTimeMs + 1000);
+            runtimeMetrics.recordPartitionLoadSensor(startTimeMs, startTimeMs + 2000);
+
+            org.apache.kafka.common.MetricName metricName = metrics.metricName(
+                "partition-load-time-avg", METRICS_GROUP);
+
+            KafkaMetric metric = metrics.metrics().get(metricName);
+            assertEquals(1500.0, metric.metricValue());
+
+            metricName = metrics.metricName(
+                "partition-load-time-max", METRICS_GROUP);
+            metric = metrics.metrics().get(metricName);
+            assertEquals(2000.0, metric.metricValue());
+        } finally {
+            registry.shutdown();
+        }
+    }
+
+    @Test
+    public void testThreadIdleRatioSensor() {
+        Time time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        MetricsRegistry registry = new MetricsRegistry();
+
+        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(registry, metrics)) {
+            IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordThreadIdleRatio(1.0 / (i + 1)));
+
+            org.apache.kafka.common.MetricName metricName = metrics.metricName(
+                "thread-idle-ratio-avg", METRICS_GROUP);
+
+            KafkaMetric metric = metrics.metrics().get(metricName);
+            assertEquals((11.0 / 6.0) / 3.0, metric.metricValue()); // (6/6 + 3/6 + 2/6) / 3
+
+            metricName = metrics.metricName(
+                "thread-idle-ratio-min", METRICS_GROUP);
+            metric = metrics.metrics().get(metricName);
+            assertEquals(1.0 / 3.0, metric.metricValue());
+        } finally {
+            registry.shutdown();
+        }
+    }
+
+    @Test
+    public void testEventQueueTime() {
+        Time time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        MetricsRegistry registry = new MetricsRegistry();
+
+        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(registry, metrics)) {
+            IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordEventQueueTime((i + 1) * 1000L));
+
+            assertMetricHistogram(registry,
+                yammerMetricName(METRICS_GROUP, "EventQueueTimeMs"), 3, 6000);
+        } finally {
+            registry.shutdown();
+        }
+    }
+
+    @Test
+    public void testEventQueueProcessingTime() {
+        Time time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        MetricsRegistry registry = new MetricsRegistry();
+
+        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(registry, metrics)) {
+            IntStream.range(0, 4).forEach(i -> runtimeMetrics.recordEventQueueProcessingTime((i + 1) * 1000L));
+
+            assertMetricHistogram(registry,
+                yammerMetricName(METRICS_GROUP, "EventQueueProcessingTimeMs"), 4, 10000);
+        } finally {
+            registry.shutdown();
+        }
+    }
+
+    @Test
+    public void testEventQueueSize() {
+        Time time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        MetricsRegistry registry = new MetricsRegistry();
+
+        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(registry, metrics)) {
+            runtimeMetrics.registerEventQueueSizeGauge(() -> 5);
+            assertMetricGauge(metrics, kafkaMetricName(metrics, "event-queue-size"), 5);
+        } finally {
+            registry.shutdown();
+        }
+    }
+
+    private static void assertMetricGauge(Metrics metrics, org.apache.kafka.common.MetricName metricName, long count) {
+        assertEquals(count, (long) metrics.metric(metricName).metricValue());
+    }
+
+    private static void assertMetricHistogram(
+        MetricsRegistry registry,
+        com.yammer.metrics.core.MetricName metricName,
+        long count,
+        double sum
+    ) {
+        Histogram histogram = (Histogram) registry.allMetrics().get(metricName);
+
+        assertEquals(count, histogram.count());
+        assertEquals(sum, histogram.sum(), .1);
+    }
+
+    private static com.yammer.metrics.core.MetricName yammerMetricName(String type, String name) {
+        String mBeanName = String.format("kafka.coordinator.group:type=%s,name=%s", type, name);
+        return new com.yammer.metrics.core.MetricName("kafka.coordinator.group", type, name, null, mBeanName);
+    }
+
+    private static MetricName kafkaMetricName(Metrics metrics, String name, String... keyValue) {
+        return metrics.metricName(name, METRICS_GROUP, "", keyValue);
+    }
+    
+    private static void assertMetricsForTypeEqual(
+        MetricsRegistry registry,
+        String expectedPrefix,
+        Set<String> expected
+    ) {
+        Set<String> actual = new TreeSet<>();
+        registry.allMetrics().forEach((name, __) -> {
+            StringBuilder bld = new StringBuilder();
+            bld.append(name.getGroup());
+            bld.append(":type=").append(name.getType());
+            bld.append(",name=").append(name.getName());
+            if (bld.toString().startsWith(expectedPrefix)) {
+                actual.add(bld.toString());
+            }
+        });
+        assertEquals(new TreeSet<>(expected), actual);
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
@@ -18,16 +18,24 @@ package org.apache.kafka.coordinator.group.runtime;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorRuntimeMetrics;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.mockito.ArgumentCaptor;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
@@ -37,9 +45,63 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @Timeout(value = 60)
 public class MultiThreadedEventProcessorTest {
+    private static class MockEventAccumulator<T> extends EventAccumulator<TopicPartition, CoordinatorEvent> {
+        private final Time time;
+        private final Queue<CoordinatorEvent> events;
+        private final long timeToPollMs;
+        private final AtomicBoolean isClosed;
+
+        public MockEventAccumulator(Time time, long timeToPollMs) {
+            this.time = time;
+            this.events = new LinkedList<>();
+            this.timeToPollMs = timeToPollMs;
+            this.isClosed = new AtomicBoolean(false);
+        }
+
+        @Override
+        public CoordinatorEvent poll() {
+            synchronized (events) {
+                while (events.isEmpty() && !isClosed.get()) {
+                    try {
+                        events.wait();
+                    } catch (Exception ignored) {
+                        
+                    }
+                }
+                time.sleep(timeToPollMs);
+                return events.poll();
+            }
+        }
+
+        @Override
+        public CoordinatorEvent poll(long timeout, TimeUnit unit) {
+            return null;
+        }
+
+        @Override
+        public void add(CoordinatorEvent event) throws RejectedExecutionException {
+            synchronized (events) {
+                events.add(event);
+                events.notifyAll();
+            }
+        }
+
+        @Override
+        public void close() {
+            isClosed.set(true);
+            synchronized (events) {
+                events.notifyAll();
+            }
+        }
+    }
 
     private static class FutureEvent<T> implements CoordinatorEvent {
         private final TopicPartition key;
@@ -48,12 +110,13 @@ public class MultiThreadedEventProcessorTest {
         private final boolean block;
         private final CountDownLatch latch;
         private final CountDownLatch executed;
+        private long enqueueTimeMs;
 
         FutureEvent(
             TopicPartition key,
             Supplier<T> supplier
         ) {
-            this(key, supplier, false);
+            this(key, supplier, false, 0L);
         }
 
         FutureEvent(
@@ -61,12 +124,22 @@ public class MultiThreadedEventProcessorTest {
             Supplier<T> supplier,
             boolean block
         ) {
+            this(key, supplier, block, 0L);
+        }
+
+        FutureEvent(
+            TopicPartition key,
+            Supplier<T> supplier,
+            boolean block,
+            long enqueueTimeMs
+        ) {
             this.key = key;
             this.future = new CompletableFuture<>();
             this.supplier = supplier;
             this.block = block;
             this.latch = new CountDownLatch(1);
             this.executed = new CountDownLatch(1);
+            this.enqueueTimeMs = enqueueTimeMs;
         }
 
         @Override
@@ -88,6 +161,16 @@ public class MultiThreadedEventProcessorTest {
         @Override
         public void complete(Throwable ex) {
             future.completeExceptionally(ex);
+        }
+
+        @Override
+        public long enqueueTimeMs() {
+            return enqueueTimeMs;
+        }
+
+        @Override
+        public void setEnqueueTimeMs(long enqueueTimeMs) {
+            this.enqueueTimeMs = enqueueTimeMs;
         }
 
         @Override
@@ -118,7 +201,9 @@ public class MultiThreadedEventProcessorTest {
         CoordinatorEventProcessor eventProcessor = new MultiThreadedEventProcessor(
             new LogContext(),
             "event-processor-",
-            2
+            2,
+            Time.SYSTEM,
+            mock(GroupCoordinatorRuntimeMetrics.class)
         );
         eventProcessor.close();
     }
@@ -128,7 +213,9 @@ public class MultiThreadedEventProcessorTest {
         try (CoordinatorEventProcessor eventProcessor = new MultiThreadedEventProcessor(
             new LogContext(),
             "event-processor-",
-            2
+            2,
+            Time.SYSTEM,
+            mock(GroupCoordinatorRuntimeMetrics.class)
         )) {
             AtomicInteger numEventsExecuted = new AtomicInteger(0);
 
@@ -163,7 +250,9 @@ public class MultiThreadedEventProcessorTest {
         try (CoordinatorEventProcessor eventProcessor = new MultiThreadedEventProcessor(
             new LogContext(),
             "event-processor-",
-            2
+            2,
+            Time.SYSTEM,
+            mock(GroupCoordinatorRuntimeMetrics.class)
         )) {
             AtomicInteger numEventsExecuted = new AtomicInteger(0);
 
@@ -246,7 +335,9 @@ public class MultiThreadedEventProcessorTest {
         CoordinatorEventProcessor eventProcessor = new MultiThreadedEventProcessor(
             new LogContext(),
             "event-processor-",
-            2
+            2,
+            Time.SYSTEM,
+            mock(GroupCoordinatorRuntimeMetrics.class)
         );
 
         eventProcessor.close();
@@ -260,7 +351,9 @@ public class MultiThreadedEventProcessorTest {
         try (MultiThreadedEventProcessor eventProcessor = new MultiThreadedEventProcessor(
             new LogContext(),
             "event-processor-",
-            1 // Use a single thread to block event in the processor.
+            1, // Use a single thread to block event in the processor.
+            Time.SYSTEM,
+            mock(GroupCoordinatorRuntimeMetrics.class)
         )) {
             AtomicInteger numEventsExecuted = new AtomicInteger(0);
 
@@ -315,6 +408,145 @@ public class MultiThreadedEventProcessorTest {
 
             // The other events should not have been processed.
             assertEquals(1, numEventsExecuted.get());
+        }
+    }
+
+    @Test
+    public void testMetrics() throws Exception {
+        GroupCoordinatorRuntimeMetrics mockRuntimeMetrics = mock(GroupCoordinatorRuntimeMetrics.class);
+        Time mockTime = new MockTime();
+        AtomicInteger numEventsExecuted = new AtomicInteger(0);
+
+        // Special event which blocks until the latch is released.
+        FutureEvent<Integer> blockingEvent = new FutureEvent<>(
+            new TopicPartition("foo", 0), () -> {
+                mockTime.sleep(4000L);
+                return numEventsExecuted.incrementAndGet();
+            }, true
+        );
+
+        FutureEvent<Integer> otherEvent = new FutureEvent<>(
+            new TopicPartition("foo", 0), () -> {
+                mockTime.sleep(5000L);
+                return numEventsExecuted.incrementAndGet();
+            }
+        );
+
+        try (MultiThreadedEventProcessor eventProcessor = new MultiThreadedEventProcessor(
+            new LogContext(),
+            "event-processor-",
+            1, // Use a single thread to block event in the processor.
+            mockTime,
+            mockRuntimeMetrics,
+            new MockEventAccumulator<>(mockTime, 500L)
+        )) {
+            // Enqueue the blocking event.
+            eventProcessor.enqueue(blockingEvent);
+
+            // Ensure that the blocking event is executed.
+            waitForCondition(() -> numEventsExecuted.get() > 0,
+                "Blocking event not executed.");
+
+            // Enqueue the other event.
+            eventProcessor.enqueue(otherEvent);
+
+            // Pass the time.
+            mockTime.sleep(3000L);
+
+            // Events should not be completed.
+            assertFalse(otherEvent.future.isDone());
+
+            // Release the blocking event to unblock the thread.
+            blockingEvent.release();
+
+            // The blocking event should be completed.
+            blockingEvent.future.get(DEFAULT_MAX_WAIT_MS, TimeUnit.SECONDS);
+            assertTrue(blockingEvent.future.isDone());
+            assertFalse(blockingEvent.future.isCompletedExceptionally());
+
+            // The other event should also be completed.
+            otherEvent.future.get(DEFAULT_MAX_WAIT_MS, TimeUnit.SECONDS);
+            assertTrue(otherEvent.future.isDone());
+            assertFalse(otherEvent.future.isCompletedExceptionally());
+            assertEquals(2, numEventsExecuted.get());
+
+            // e1 poll time = 500
+            // e1 processing time = 4000
+            // e2 enqueue time = 3000
+            // e2 poll time = 500
+            // e2 processing time = 5000
+
+            // e1 poll time / e1 poll time
+            verify(mockRuntimeMetrics, times(1)).recordThreadIdleRatio(1.0);
+            // e1 poll time
+            verify(mockRuntimeMetrics, times(1)).recordEventQueueTime(500L);
+            // e1 processing time + e2 enqueue time
+            verify(mockRuntimeMetrics, times(1)).recordEventQueueProcessingTime(7000L);
+
+            // Second event (e2)
+
+            // idle ratio = e2 poll time / (e1 poll time + e1 processing time + e2 enqueue time + e2 poll time)
+            verify(mockRuntimeMetrics, times(1)).recordThreadIdleRatio(500.0 / (500.0 + 7000.0 + 500.0));
+            // event queue time = e2 enqueue time + e2 poll time
+            verify(mockRuntimeMetrics, times(1)).recordEventQueueTime(3500L);
+            // e2 processing time
+            verify(mockRuntimeMetrics, times(1)).recordEventQueueProcessingTime(5000L);
+        }
+    }
+
+    @Test
+    public void testRecordThreadIdleRatioTwoThreads() throws Exception {
+        GroupCoordinatorRuntimeMetrics mockRuntimeMetrics = mock(GroupCoordinatorRuntimeMetrics.class);
+
+        try (CoordinatorEventProcessor eventProcessor = new MultiThreadedEventProcessor(
+            new LogContext(),
+            "event-processor-",
+            2,
+            Time.SYSTEM,
+            mockRuntimeMetrics,
+            new MockEventAccumulator<>(Time.SYSTEM, 100L)
+        )) {
+            List<Double> recordedRatios = new ArrayList<>();
+            AtomicInteger numEventsExecuted = new AtomicInteger(0);
+            ArgumentCaptor<Double> ratioCaptured = ArgumentCaptor.forClass(Double.class);
+            doAnswer(invocation -> {
+                double threadIdleRatio = ratioCaptured.getValue();
+                assertTrue(threadIdleRatio > 0.0);
+                synchronized (recordedRatios) {
+                    recordedRatios.add(threadIdleRatio);
+                }
+                return null;
+            }).when(mockRuntimeMetrics).recordThreadIdleRatio(ratioCaptured.capture());
+
+            List<FutureEvent<Integer>> events = Arrays.asList(
+                new FutureEvent<>(new TopicPartition("foo", 0), numEventsExecuted::incrementAndGet),
+                new FutureEvent<>(new TopicPartition("foo", 1), numEventsExecuted::incrementAndGet),
+                new FutureEvent<>(new TopicPartition("foo", 2), numEventsExecuted::incrementAndGet),
+                new FutureEvent<>(new TopicPartition("foo", 0), numEventsExecuted::incrementAndGet),
+                new FutureEvent<>(new TopicPartition("foo", 1), numEventsExecuted::incrementAndGet),
+                new FutureEvent<>(new TopicPartition("foo", 2), numEventsExecuted::incrementAndGet),
+                new FutureEvent<>(new TopicPartition("foo", 2), numEventsExecuted::incrementAndGet)
+            );
+
+            events.forEach(eventProcessor::enqueue);
+
+            CompletableFuture.allOf(events
+                .stream()
+                .map(FutureEvent::future)
+                .toArray(CompletableFuture[]::new)
+            ).get(10, TimeUnit.SECONDS);
+
+            events.forEach(event -> {
+                assertTrue(event.future.isDone());
+                assertFalse(event.future.isCompletedExceptionally());
+            });
+
+            assertEquals(events.size(), numEventsExecuted.get());
+            verify(mockRuntimeMetrics, times(7)).recordThreadIdleRatio(anyDouble());
+
+            assertEquals(7, recordedRatios.size());
+            double average = recordedRatios.stream().mapToDouble(Double::doubleValue).sum() / 7;
+            assertTrue(average > 0.0 && average < 1.0);
         }
     }
 }


### PR DESCRIPTION
Implements the following metrics:
* kafka.server:type=group-coordinator-metrics,name=num-partitions,state=loading
* kafka.server:type=group-coordinator-metrics,name=num-partitions,state=active
* kafka.server:type=group-coordinator-metrics,name=num-partitions,state=failed
* kafka.server:type=group-coordinator-metrics,name=event-queue-size
* kafka.server:type=group-coordinator-metrics,name=partition-load-time-max
* kafka.server:type=group-coordinator-metrics,name=partition-load-time-avg
* kafka.server:type=group-coordinator-metrics,name=thread-idle-ratio-min
* kafka.server:type=group-coordinator-metrics,name=thread-idle-ratio-avg

The PR makes these metrics generic so that in the future the transaction coordinator runtime can implement the same metrics in a similar fashion.

Also, `CoordinatorLoaderImpl#load` will now return `LoadSummary` which encapsulates the start time, end time, number of records/bytes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
