### PR TITLE
MINOR: Fix kraft upgrade system test

### DIFF
--- a/tests/kafkatest/tests/core/kraft_upgrade_test.py
+++ b/tests/kafkatest/tests/core/kraft_upgrade_test.py
@@ -23,7 +23,7 @@ from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.utils import is_int
 from kafkatest.version import LATEST_3_1, LATEST_3_2, LATEST_3_3, LATEST_3_4, LATEST_3_5, \
-    DEV_BRANCH, DEV_VERSION, KafkaVersion, LATEST_METADATA_VERSION
+    DEV_BRANCH, KafkaVersion, LATEST_METADATA_VERSION
 
 #
 # Test upgrading between different KRaft versions.
@@ -114,7 +114,7 @@ class TestKRaftUpgrade(ProduceConsumeValidateTest):
     @parametrize(from_kafka_version=str(LATEST_3_3), metadata_quorum=combined_kraft)
     @parametrize(from_kafka_version=str(LATEST_3_4), metadata_quorum=combined_kraft)
     @parametrize(from_kafka_version=str(LATEST_3_5), metadata_quorum=combined_kraft)
-    @parametrize(from_kafka_version=str(DEV_VERSION), metadata_quorum=combined_kraft)
+    @parametrize(from_kafka_version=str(DEV_BRANCH), metadata_quorum=combined_kraft)
     def test_combined_mode_upgrade(self, from_kafka_version, metadata_quorum):
         self.run_upgrade(from_kafka_version)
 
@@ -124,7 +124,7 @@ class TestKRaftUpgrade(ProduceConsumeValidateTest):
     @parametrize(from_kafka_version=str(LATEST_3_3), metadata_quorum=isolated_kraft)
     @parametrize(from_kafka_version=str(LATEST_3_4), metadata_quorum=isolated_kraft)
     @parametrize(from_kafka_version=str(LATEST_3_5), metadata_quorum=isolated_kraft)
-    @parametrize(from_kafka_version=str(DEV_VERSION), metadata_quorum=isolated_kraft)
+    @parametrize(from_kafka_version=str(DEV_BRANCH), metadata_quorum=isolated_kraft)
     def test_isolated_mode_upgrade(self, from_kafka_version, metadata_quorum):
         self.run_upgrade(from_kafka_version)
 


### PR DESCRIPTION
We should use `DEV_BRANCH` instead of `DEV_VERSION` in this case, otherwise, error will be thrown:
```
RunnerClient: kafkatest.tests.core.kraft_upgrade_test.TestKRaftUpgrade.test_isolated_mode_upgrade.from_kafka_version=3.6.0-SNAPSHOT.metadata_quorum=ISOLATED_KRAFT: FAIL: RemoteCommandError({'ssh_config': {'host': 'ducker10', 'hostname': 'ducker10', 'user': 'ducker', 'port': 22, 'password': '', 'identityfile': '/home/ducker/.ssh/id_rsa', 'connecttimeout': None}, 'hostname': 'ducker10', 'ssh_hostname': 'ducker10', 'user': 'ducker', 'externally_routable_ip': 'ducker10', '_logger': <Logger kafkatest.tests.core.kraft_upgrade_test.TestKRaftUpgrade.test_isolated_mode_upgrade.from_kafka_version=3.6.0-SNAPSHOT.metadata_quorum=ISOLATED_KRAFT-2 (DEBUG)>, 'os': 'linux', '_ssh_client': <paramiko.client.SSHClient object at 0xffffb35d5820>, '_sftp_client': <paramiko.sftp_client.SFTPClient object at 0xffffb35f8ca0>, '_custom_ssh_exception_checks': None}, '/opt/kafka-3.6.0-SNAPSHOT/bin/kafka-storage.sh format --ignore-formatted --config /mnt/kafka/kafka.properties --cluster-id I2eXt9rvSnyhct8BYmW6-w', 127, b'bash: line 1: /opt/kafka-3.6.0-SNAPSHOT/bin/kafka-storage.sh: No such file or directory\n')
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
