### PR TITLE
KAFKA-15485: Upgrade gradle, plugins and test libraries (2/N)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,15 +31,15 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.ben-manes.versions' version '0.47.0'
+  id 'com.github.ben-manes.versions' version '0.48.0'
   id 'idea'
   id 'jacoco'
   id 'java-library'
   id 'org.owasp.dependencycheck' version '8.2.1'
-  id 'org.nosphere.apache.rat' version "0.8.0"
-  id "io.swagger.core.v3.swagger-gradle-plugin" version "2.2.8"
+  id 'org.nosphere.apache.rat' version "0.8.1"
+  id "io.swagger.core.v3.swagger-gradle-plugin" version "2.2.16"
 
-  id "com.github.spotbugs" version '5.0.13' apply false
+  id "com.github.spotbugs" version '5.1.3' apply false
   id 'org.scoverage' version '7.0.1' apply false
   id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
   id 'com.diffplug.spotless' version '6.14.0' apply false // 6.14.1 and newer require Java 11 at compile time, so we can't upgrade until AK 4.0
@@ -909,7 +909,6 @@ project(':core') {
     testImplementation project(':storage:api').sourceSets.test.output
     testImplementation libs.bcpkix
     testImplementation libs.mockitoCore
-    testImplementation libs.mockitoInline // supports mocking static methods, final classes, etc.
     testImplementation(libs.apacheda) {
       exclude group: 'xml-apis', module: 'xml-apis'
       // `mina-core` is a transitive dependency for `apacheds` and `apacheda`.
@@ -1194,7 +1193,6 @@ project(':metadata') {
     testImplementation libs.jqwik
     testImplementation libs.hamcrest
     testImplementation libs.mockitoCore
-    testImplementation libs.mockitoInline
     testImplementation libs.slf4jlog4j
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':raft').sourceSets.test.output
@@ -1354,7 +1352,7 @@ project(':clients') {
     testImplementation libs.jose4j
     testImplementation libs.junitJupiter
     testImplementation libs.log4j
-    testImplementation libs.mockitoInline
+    testImplementation libs.mockitoCore
 
     testRuntimeOnly libs.slf4jlog4j
     testRuntimeOnly libs.jacksonDatabind
@@ -1579,7 +1577,6 @@ project(':server-common') {
     testImplementation project(':clients').sourceSets.test.output
     testImplementation libs.junitJupiter
     testImplementation libs.mockitoCore
-    testImplementation libs.mockitoInline // supports mocking static methods, final classes, etc.
     testImplementation libs.hamcrest
 
     testRuntimeOnly libs.slf4jlog4j
@@ -1906,7 +1903,7 @@ project(':tools') {
     testImplementation project(':connect:runtime')
     testImplementation project(':connect:runtime').sourceSets.test.output
     testImplementation libs.junitJupiter
-    testImplementation libs.mockitoInline // supports mocking static methods, final classes, etc.
+    testImplementation libs.mockitoCore
     testImplementation libs.mockitoJunitJupiter // supports MockitoExtension
     testImplementation libs.bcpkix // required by the clients test module, but we have to specify it explicitly as gradle does not include the transitive test dependency automatically
     testRuntimeOnly libs.slf4jlog4j
@@ -1957,7 +1954,7 @@ project(':trogdor') {
     testImplementation project(':clients')
     testImplementation libs.junitJupiter
     testImplementation project(':clients').sourceSets.test.output
-    testImplementation libs.mockitoInline // supports mocking static methods, final classes, etc.
+    testImplementation libs.mockitoCore
 
     testRuntimeOnly libs.slf4jlog4j
   }
@@ -2061,7 +2058,7 @@ project(':streams') {
     testImplementation libs.powermockEasymock
     testImplementation libs.bcpkix
     testImplementation libs.hamcrest
-    testImplementation libs.mockitoInline // supports mocking static methods, final classes, etc.
+    testImplementation libs.mockitoCore
     testImplementation libs.mockitoJunitJupiter // supports MockitoExtension
 
     testRuntimeOnly project(':streams:test-utils')
@@ -2808,7 +2805,7 @@ project(':connect:runtime') {
     testImplementation libs.junitVintageEngine
     testImplementation libs.powermockJunit4
     testImplementation libs.powermockEasymock
-    testImplementation libs.mockitoInline
+    testImplementation libs.mockitoCore
     testImplementation libs.httpclient
 
     testRuntimeOnly libs.slf4jlog4j

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -53,20 +53,34 @@ if ( !versions.scala.contains('-') ) {
   versions["baseScala"] = versions.scala
 }
 
-// We use Mockito 4.11 with Scala 2.13+ for Java 20 support and Mockito 4.9 with Scala 2.12
-// to workaround ambiguous reference to `Mockito.spy` compiler errors. Since Scala 2.12 support
-// is going away soon, this is simpler than adjusting the code.
+// mockito 5.5 is required for Java 21 and mockito 5.x requires at least Java 11
+// mockito 4.9 is required for Scala 2.12 as a workaround for compiler errors due to ambiguous reference to `Mockito.spy`
+// since Scala 2.12 support is going away soon, this is simpler than adjusting the code.
+// mockito 4.11 is used with Java 8 and Scala 2.13
 String mockitoVersion
 if (scalaVersion == "2.12")
   mockitoVersion = "4.9.0"
+else if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11))
+  mockitoVersion = "5.5.0"
 else
   mockitoVersion = "4.11.0"
 
-// easymock 5.1 is required for Java 20 support, but it breaks tests using powermock
-// powermock doesn't work with Java 16 or newer and hence it's safe to use easymock 5.1 in this case only
+// mockito 4.x has two mocking strategies: subclass (mockito-core) and inline (mockito-inline).
+// mockito 5.x has two mocking strategies: inline (mockito-core) and subclass (mockito-subclass).
+// The default strategy (i.e. what `mockito-core` uses) changed to `inline` in 5.x because it works better with newer
+// Java versions.
+// We always use the `inline` strategy.
+String mockitoArtifactName
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11))
+  mockitoArtifactName = "mockito-core"
+else
+  mockitoArtifactName = "mockito-inline"
+
+// easymock 5.2 is required for Java 21 support, but it breaks tests using powermock
+// powermock doesn't work with Java 16 or newer and hence it's safe to use the newer version in this case only
 String easymockVersion
 if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16))
-  easymockVersion = "5.1.0"
+  easymockVersion = "5.2.0"
 else
   easymockVersion = "4.3"
 
@@ -83,7 +97,7 @@ versions += [
   commonsCli: "1.4",
   commonsValidator: "1.7",
   dropwizardMetrics: "4.1.12.1",
-  gradle: "8.2.1",
+  gradle: "8.3",
   grgit: "4.1.1",
   httpclient: "4.5.14",
   jackson: "2.13.5",
@@ -93,7 +107,7 @@ versions += [
   jetty: "9.4.51.v20230217",
   jersey: "2.39.1",
   jline: "3.22.0",
-  jmh: "1.36",
+  jmh: "1.37",
   hamcrest: "2.2",
   scalaLogging: "3.9.4",
   jaxAnnotation: "1.3.2",
@@ -102,7 +116,7 @@ versions += [
   jfreechart: "1.0.0",
   jopt: "5.0.4",
   jose4j: "0.9.3",
-  junit: "5.9.3",
+  junit: "5.10.0",
   jqwik: "1.7.4",
   kafka_0100: "0.10.0.1",
   kafka_0101: "0.10.1.1",
@@ -221,8 +235,7 @@ libs += [
   lz4: "org.lz4:lz4-java:$versions.lz4",
   metrics: "com.yammer.metrics:metrics-core:$versions.metrics",
   dropwizardMetrics: "io.dropwizard.metrics:metrics-core:$versions.dropwizardMetrics",
-  mockitoCore: "org.mockito:mockito-core:$mockitoVersion",
-  mockitoInline: "org.mockito:mockito-inline:$mockitoVersion",
+  mockitoCore: "org.mockito:$mockitoArtifactName:$mockitoVersion",
   mockitoJunitJupiter: "org.mockito:mockito-junit-jupiter:$mockitoVersion",
   nettyHandler: "io.netty:netty-handler:$versions.netty",
   nettyTransportNativeEpoll: "io.netty:netty-transport-native-epoll:$versions.netty",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7c3ad722e9b0ce8205b91560fd6ce8296ac3eadf065672242fd73c06b8eeb6ee
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
+distributionSha256Sum=bb09982fdf52718e4c7b25023d10df6d35a5fff969860bdf5a5bd27a3ab27a9e
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
 networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -115,7 +115,7 @@ esac
 # Loop in case we encounter an error.
 for attempt in 1 2 3; do
   if [ ! -e "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" ]; then
-    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v8.2.1/gradle/wrapper/gradle-wrapper.jar"; then
+    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v8.3.0/gradle/wrapper/gradle-wrapper.jar"; then
       rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
       # Pause for a bit before looping in case the server throttled us.
       sleep 5
@@ -143,10 +143,13 @@ location of your Java installation."
     fi
 else
     JAVACMD=java
-    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+    if ! command -v java >/dev/null 2>&1
+    then
+        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
 Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
+    fi
 fi
 
 # Increase the maximum file descriptors if we can.


### PR DESCRIPTION
To prepare Java 21 support, upgrade gradle, its plugins and test libraries.
Release notes for major and minor updates included below.

The highlight is faster Java compilation by not shutting down the daemon at the end of the build.
Gradle's internal performance tests show up to a 30% build time improvement for builds that are
dominated by compiling Java sources.

Mockito turns out to be a complex case where we use one of 3 different versions depending on
the Scala and Java versions used. In addition, the default mocking strategy changed from `subclass`
to `inline` in Mockito 5.0. We now use `inline` across the board (we previously used both `subclass`
and `inline`). See comments in the relevant parts of the code for more details.

* Gradle 8.3 release notes: https://docs.gradle.org/8.3/release-notes.html
* jmh 1.37: virtual thread support and various bug fixes
* JUnit 5.10.0 release notes: https://junit.org/junit5/docs/5.10.0/release-notes/index.html
* Mockito 5.x release notes:
  * https://github.com/mockito/mockito/releases/tag/v5.0.0
  * https://github.com/mockito/mockito/releases/tag/v5.1.0
  * https://github.com/mockito/mockito/releases/tag/v5.2.0
  * https://github.com/mockito/mockito/releases/tag/v5.3.0
  * https://github.com/mockito/mockito/releases/tag/v5.4.0
  * https://github.com/mockito/mockito/releases/tag/v5.5.0
* EasyMock 5.2.0 release notes: https://github.com/easymock/easymock/releases/tag/easymock-5.2.0

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
