### PR TITLE
KAFKA-14516: [1/N] Static Member leave, join, re-join request using ConsumerGroupHeartbeats

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatRequest.java
@@ -30,6 +30,7 @@ public class ConsumerGroupHeartbeatRequest extends AbstractRequest {
      * A member epoch of <code>-1</code> means that the member wants to leave the group.
      */
     public static final int LEAVE_GROUP_MEMBER_EPOCH = -1;
+    public static final int LEAVE_GROUP_STATIC_MEMBER_EPOCH = -2;
 
     /**
      * A member epoch of <code>0</code> means that the member wants to join the group.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -890,7 +890,7 @@ public class GroupMetadataManager {
         if (instanceId == null) {
             member = group.getOrMaybeCreateMember(memberId, createIfNotExists);
         } else {
-            existingStaticMember = group.getStaticMember(instanceId);
+            existingStaticMember = group.staticMember(instanceId);
             throwIfStaticMemberValidationFails(groupId, instanceId, existingStaticMember, memberEpoch, memberId);
             member = group.getOrMaybeCreateMember(memberId, createIfNotExists);
         }
@@ -1091,7 +1091,7 @@ public class GroupMetadataManager {
         try {
             TargetAssignmentBuilder.TargetAssignmentResult assignmentResult =
                 new TargetAssignmentBuilder(groupId, groupEpoch, assignors.get(preferredServerAssignor))
-                    .withMembers(group.members())
+                    .removeMember(member.memberId())
                     .withSubscriptionMetadata(subscriptionMetadata)
                     .withTargetAssignment(group.targetAssignment())
                     .addOrUpdateMember(memberId, updatedMember)
@@ -1128,7 +1128,7 @@ public class GroupMetadataManager {
     ) throws ApiException {
         ConsumerGroup group = getOrMaybeCreateConsumerGroup(groupId, false);
         ConsumerGroupMember member = memberEpoch == LEAVE_GROUP_STATIC_MEMBER_EPOCH ?
-                group.getStaticMember(instanceId) :
+                group.staticMember(instanceId) :
                 group.getOrMaybeCreateMember(memberId, false);
 
         List<Record> records = new ArrayList<>();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -689,7 +689,7 @@ public class GroupMetadataManager {
             }
         } else if (request.memberEpoch() == -2) {
             throwIfEmptyString(request.memberId(), "MemberId can't be empty.");
-            throwIfNull(request.instanceId(), "InstanceId can't be empty for Static Member.");
+            throwIfNull(request.instanceId(), "InstanceId can't be null for Static Member.");
         } else {
             throw new InvalidRequestException("MemberEpoch is invalid.");
         }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -891,6 +891,12 @@ public class GroupMetadataManager {
                     groupId, memberId, updatedMember.subscribedTopicRegex());
                 bumpGroupEpoch = true;
             }
+        } else {
+            // A new static member replaces an older one with the same instance id, assignments etc.
+            // We will create a new member subscription record for this new member.
+            if (instanceId != null) {
+                records.add(newMemberSubscriptionRecord(groupId, updatedMember));
+            }
         }
 
         if (bumpGroupEpoch || group.hasMetadataExpired(currentTimeMs)) {
@@ -1022,8 +1028,8 @@ public class GroupMetadataManager {
     ) throws ApiException {
         ConsumerGroup group = getOrMaybeCreateConsumerGroup(groupId, false);
         ConsumerGroupMember member = memberEpoch == -2 ?
-                group.getOrMaybeCreateStaticMember(memberId, instanceId,false) :
-                group.getOrMaybeCreateMember(memberId,false);
+                group.getOrMaybeCreateStaticMember(memberId, instanceId, false) :
+                group.getOrMaybeCreateMember(memberId, false);
 
         List<Record> records = new ArrayList<>();
         // The departing member is a static one. We don't need to fence this member because it is

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1031,6 +1031,11 @@ public class GroupMetadataManager {
         if (memberEpoch == -2) {
             log.info("[GroupId {}] Member {} with instance id {} is a static member and will not be fenced from the group",
                     groupId, memberId, member.instanceId());
+            // We will write a member epoch of -2 for this departing static member.
+            ConsumerGroupMember leavingStaticMember = new ConsumerGroupMember.Builder(member)
+                    .setMemberEpoch(-2)
+                    .build();
+            records.add(newCurrentAssignmentRecord(group.groupId(), leavingStaticMember));
         } else {
             log.info("[GroupId {}] Member {} left the consumer group.", groupId, memberId);
             records.addAll(consumerGroupFenceMember(group, member));

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -899,7 +899,11 @@ public class GroupMetadataManager {
         ConsumerGroupMember updatedMember;
         boolean assignmentUpdated = false;
         if (memberEpoch == 0) {
-            log.info("[GroupId {}] Member {} joins the consumer group.", groupId, memberId);
+            if (instanceId != null) {
+                log.info("[GroupId {}] Member {}, Instance-Id {} joins the consumer group.", groupId, instanceId, memberId);
+            } else {
+                log.info("[GroupId {}] Member {} joins the consumer group.", groupId, memberId);
+            }
         }
 
         int groupEpoch = group.groupEpoch();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -688,8 +688,9 @@ public class GroupMetadataManager {
                 throw new InvalidRequestException("SubscribedTopicNames must be set in first request.");
             }
         } else if (request.memberEpoch() == -2) {
-            throwIfEmptyString(request.memberId(), "MemberId can't be empty.");
-            throwIfNull(request.instanceId(), "InstanceId can't be null for Static Member.");
+            throwIfEmptyString(request.memberId(), "MemberId can't be empty. GroupId: " + request.groupId());
+            throwIfNull(request.instanceId(), "InstanceId can't be null for Static Member. GroupId: "
+                    + request.groupId() + " MemberId: " + request.memberId());
         } else {
             throw new InvalidRequestException("MemberEpoch is invalid.");
         }
@@ -1023,7 +1024,8 @@ public class GroupMetadataManager {
         // The departing member is a static one. We don't need to fence this member because it is
         // expected to come back within session timeout
         if (memberEpoch == -2) {
-            log.info("Member {} with instance id {} is a static member and will not be fenced from the group", memberId, member.instanceId());
+            log.info("[GroupId {}] Member {} with instance id {} is a static member and will not be fenced from the group",
+                    groupId, memberId, member.instanceId());
         } else {
             log.info("[GroupId {}] Member {} left the consumer group.", groupId, memberId);
             records.addAll(consumerGroupFenceMember(group, member));

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -712,8 +712,7 @@ public class GroupMetadataManager {
             }
         } else if (request.memberEpoch() == LEAVE_GROUP_STATIC_MEMBER_EPOCH) {
             throwIfEmptyString(request.memberId(), "MemberId can't be empty.");
-            throwIfNull(request.instanceId(), "InstanceId can't be null. GroupId: "
-                    + request.groupId() + ", MemberId: " + request.memberId());
+            throwIfNull(request.instanceId(), "InstanceId can't be null.");
         } else {
             throw new InvalidRequestException("MemberEpoch is invalid.");
         }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1048,7 +1048,7 @@ public class GroupMetadataManager {
         }
         return new CoordinatorResult<>(records, new ConsumerGroupHeartbeatResponseData()
             .setMemberId(memberId)
-            .setMemberEpoch(LEAVE_GROUP_MEMBER_EPOCH));
+            .setMemberEpoch(memberEpoch));
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -818,7 +818,7 @@ public class GroupMetadataManager {
         if (member.memberEpoch() != LEAVE_GROUP_STATIC_MEMBER_EPOCH) {
             // The new member can't join.
             log.info("[GroupId {}] Static member {} with instance id {} cannot join the group because the instance id is" +
-                    " in owned by member {}.", groupId, receivedMemberId, receivedInstanceId, member.memberId());
+                    " is owned by member {}.", groupId, receivedMemberId, receivedInstanceId, member.memberId());
             throw Errors.UNRELEASED_INSTANCE_ID.exception("Static member " + receivedMemberId + " with instance id "
                 + receivedInstanceId + " cannot join the group because the instance id is owned by " + member.memberId() + " member.");
         }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -411,6 +411,13 @@ public class ConsumerGroup implements Group {
     }
 
     /**
+     * @return An immutable Map containing all the static members keyed by instance id.
+     */
+    public Map<String, String> staticMembers() {
+        return Collections.unmodifiableMap(staticMembers);
+    }
+
+    /**
      * @return An immutable Set containing all the subscribed topic names.
      */
     public Set<String> subscribedTopicNames() {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -308,7 +308,7 @@ public class ConsumerGroup implements Group {
     /**
      * Gets a static member.
      *
-     * @param instanceId        The group instance id.
+     * @param instanceId The group instance id.
      *
      * @return The member corresponding to the given instance id or null if it does not exist
      */

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -271,8 +271,9 @@ public class ConsumerGroup implements Group {
      * Get member id of a static member that matches the given group
      * instance id.
      *
-     * @param groupInstanceId the group instance id.
-     * @return the static member if it exists.
+     * @param groupInstanceId The group instance id.
+     *
+     * @return The member id corresponding to the given instance id or null if it does not exist
      */
     public String staticMemberId(String groupInstanceId) {
         return staticMembers.get(groupInstanceId);
@@ -304,7 +305,14 @@ public class ConsumerGroup implements Group {
         return member;
     }
 
-    public ConsumerGroupMember getStaticMember(String instanceId) {
+    /**
+     * Gets a static member.
+     *
+     * @param instanceId        The group instance id.
+     *
+     * @return The member corresponding to the given instance id or null if it does not exist
+     */
+    public ConsumerGroupMember staticMember(String instanceId) {
         String existingMemberId = staticMemberId(instanceId);
         return existingMemberId == null ? null : getOrMaybeCreateMember(existingMemberId, false);
     }
@@ -322,7 +330,16 @@ public class ConsumerGroup implements Group {
         maybeUpdateSubscribedTopicNames(oldMember, newMember);
         maybeUpdateServerAssignors(oldMember, newMember);
         maybeUpdatePartitionEpoch(oldMember, newMember);
+        updateStaticMember(newMember);
         maybeUpdateGroupState();
+    }
+
+    /**
+     * Updates the member id stored against the instance id if the member is a static member.
+     *
+     * @param newMember The new member state.
+     */
+    private void updateStaticMember(ConsumerGroupMember newMember) {
         if (newMember.instanceId() != null) {
             staticMembers.put(newMember.instanceId(), newMember.memberId());
         }
@@ -338,7 +355,16 @@ public class ConsumerGroup implements Group {
         maybeUpdateSubscribedTopicNames(oldMember, null);
         maybeUpdateServerAssignors(oldMember, null);
         maybeRemovePartitionEpoch(oldMember);
+        removeStaticMember(oldMember);
         maybeUpdateGroupState();
+    }
+
+    /**
+     * Remove the static member mapping if the removed member is static.
+     *
+     * @param oldMember The member to remove.
+     */
+    private void removeStaticMember(ConsumerGroupMember oldMember) {
         if (oldMember.instanceId() != null) {
             staticMembers.remove(oldMember.instanceId());
         }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
@@ -87,6 +87,28 @@ public class ConsumerGroupMember {
             this.partitionsPendingAssignment = member.partitionsPendingAssignment;
         }
 
+        public Builder(String memberId, ConsumerGroupMember member) {
+            Objects.requireNonNull(memberId);
+            Objects.requireNonNull(member);
+
+            this.memberId = memberId;
+            this.memberEpoch = member.memberEpoch;
+            this.previousMemberEpoch = member.previousMemberEpoch;
+            this.targetMemberEpoch = member.targetMemberEpoch;
+            this.instanceId = member.instanceId;
+            this.rackId = member.rackId;
+            this.rebalanceTimeoutMs = member.rebalanceTimeoutMs;
+            this.clientId = member.clientId;
+            this.clientHost = member.clientHost;
+            this.subscribedTopicNames = member.subscribedTopicNames;
+            this.subscribedTopicRegex = member.subscribedTopicRegex;
+            this.serverAssignorName = member.serverAssignorName;
+            this.clientAssignors = member.clientAssignors;
+            this.assignedPartitions = member.assignedPartitions;
+            this.partitionsPendingRevocation = member.partitionsPendingRevocation;
+            this.partitionsPendingAssignment = member.partitionsPendingAssignment;
+        }
+
         public Builder setMemberEpoch(int memberEpoch) {
             this.memberEpoch = memberEpoch;
             return this;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
@@ -87,28 +87,6 @@ public class ConsumerGroupMember {
             this.partitionsPendingAssignment = member.partitionsPendingAssignment;
         }
 
-        public Builder(String memberId, ConsumerGroupMember member) {
-            Objects.requireNonNull(memberId);
-            Objects.requireNonNull(member);
-
-            this.memberId = memberId;
-            this.memberEpoch = member.memberEpoch;
-            this.previousMemberEpoch = member.previousMemberEpoch;
-            this.targetMemberEpoch = member.targetMemberEpoch;
-            this.instanceId = member.instanceId;
-            this.rackId = member.rackId;
-            this.rebalanceTimeoutMs = member.rebalanceTimeoutMs;
-            this.clientId = member.clientId;
-            this.clientHost = member.clientHost;
-            this.subscribedTopicNames = member.subscribedTopicNames;
-            this.subscribedTopicRegex = member.subscribedTopicRegex;
-            this.serverAssignorName = member.serverAssignorName;
-            this.clientAssignors = member.clientAssignors;
-            this.assignedPartitions = member.assignedPartitions;
-            this.partitionsPendingRevocation = member.partitionsPendingRevocation;
-            this.partitionsPendingAssignment = member.partitionsPendingAssignment;
-        }
-
         public Builder setMemberEpoch(int memberEpoch) {
             this.memberEpoch = memberEpoch;
             return this;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilder.java
@@ -130,7 +130,7 @@ public class TargetAssignmentBuilder {
     /**
      * The static members in the group.
      */
-    private final Map<String, String> staticMembers = new HashMap<>();
+    private Map<String, String> staticMembers = new HashMap<>();
 
     /**
      * Constructs the object.
@@ -159,6 +159,19 @@ public class TargetAssignmentBuilder {
         Map<String, ConsumerGroupMember> members
     ) {
         this.members = members;
+        return this;
+    }
+
+    /**
+     * Adds all the existing static members.
+     *
+     * @param staticMembers   The existing static members in the consumer group.
+     * @return This object.
+     */
+    public TargetAssignmentBuilder withStaticMembers(
+        Map<String, String> staticMembers
+    ) {
+        this.staticMembers = staticMembers;
         return this;
     }
 
@@ -193,18 +206,13 @@ public class TargetAssignmentBuilder {
      * not yet materialized in memory.
      *
      * @param memberId  The member id.
-     * @param instanceId The instance id.
      * @param member    The member to add or update.
      * @return This object.
      */
     public TargetAssignmentBuilder addOrUpdateMember(
         String memberId,
-        String instanceId,
         ConsumerGroupMember member
     ) {
-        if (instanceId != null && member != null) {
-            this.staticMembers.put(instanceId, memberId);
-        }
         this.updatedMembers.put(memberId, member);
         return this;
     }
@@ -214,17 +222,12 @@ public class TargetAssignmentBuilder {
      * is not yet materialized in memory.
      *
      * @param memberId The member id.
-     * @param instanceId The instance id.
      * @return This object.
      */
     public TargetAssignmentBuilder removeMember(
-        String memberId,
-        String instanceId
+        String memberId
     ) {
-        if (instanceId != null) {
-            this.staticMembers.remove(instanceId);
-        }
-        return addOrUpdateMember(memberId, instanceId, null);
+        return addOrUpdateMember(memberId, null);
     }
 
     /**
@@ -238,13 +241,11 @@ public class TargetAssignmentBuilder {
         Map<String, AssignmentMemberSpec> memberSpecs = new HashMap<>();
 
         // Prepare the member spec for all members.
-        members.forEach((memberId, member) -> {
-            memberSpecs.put(memberId, createAssignmentMemberSpec(
-                member,
-                targetAssignment.getOrDefault(memberId, Assignment.EMPTY),
-                subscriptionMetadata
-            ));
-        });
+        members.forEach((memberId, member) -> memberSpecs.put(memberId, createAssignmentMemberSpec(
+            member,
+            targetAssignment.getOrDefault(memberId, Assignment.EMPTY),
+            subscriptionMetadata
+        )));
 
         // Update the member spec if updated or deleted members.
         updatedMembers.forEach((memberId, updatedMemberOrNull) -> {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -1926,127 +1926,127 @@ public class GroupMetadataManagerTest {
 
         // Consumer group with two static members.
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-                .withAssignors(Collections.singletonList(assignor))
-                .withMetadataImage(new MetadataImageBuilder()
-                        .addTopic(fooTopicId, fooTopicName, 6)
-                        .addTopic(barTopicId, barTopicName, 3)
-                        .addRacks()
-                        .build())
-                .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
-                        .withMember(new ConsumerGroupMember.Builder(memberId1)
-                                .setInstanceId(memberId1)
-                                .setMemberEpoch(10)
-                                .setPreviousMemberEpoch(9)
-                                .setTargetMemberEpoch(10)
-                                .setClientId("client")
-                                .setClientHost("localhost/127.0.0.1")
-                                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                                .setServerAssignorName("range")
-                                .setAssignedPartitions(mkAssignment(
-                                        mkTopicAssignment(fooTopicId, 0, 1, 2),
-                                        mkTopicAssignment(barTopicId, 0, 1)))
-                                .build())
-                        .withMember(new ConsumerGroupMember.Builder(memberId2)
-                                .setInstanceId(memberId2)
-                                .setMemberEpoch(10)
-                                .setPreviousMemberEpoch(9)
-                                .setTargetMemberEpoch(10)
-                                .setClientId("client")
-                                .setClientHost("localhost/127.0.0.1")
-                                // Use zar only here to ensure that metadata needs to be recomputed.
-                                .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
-                                .setServerAssignorName("range")
-                                .setAssignedPartitions(mkAssignment(
-                                        mkTopicAssignment(fooTopicId, 3, 4, 5),
-                                        mkTopicAssignment(barTopicId, 2)))
-                                .build())
-                        .withAssignment(memberId1, mkAssignment(
-                                mkTopicAssignment(fooTopicId, 0, 1, 2),
-                                mkTopicAssignment(barTopicId, 0, 1)))
-                        .withAssignment(memberId2, mkAssignment(
-                                mkTopicAssignment(fooTopicId, 3, 4, 5),
-                                mkTopicAssignment(barTopicId, 2)))
-                        .withAssignmentEpoch(10))
-                .build();
+            .withAssignors(Collections.singletonList(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .addRacks()
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setInstanceId(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setTargetMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssignedPartitions(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                        mkTopicAssignment(barTopicId, 0, 1)))
+                    .build())
+                .withMember(new ConsumerGroupMember.Builder(memberId2)
+                    .setInstanceId(memberId2)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setTargetMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    // Use zar only here to ensure that metadata needs to be recomputed.
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
+                    .setServerAssignorName("range")
+                    .setAssignedPartitions(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                        mkTopicAssignment(barTopicId, 2)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1)))
+                .withAssignment(memberId2, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 2)))
+                .withAssignmentEpoch(10))
+            .build();
 
         assignor.prepareGroupAssignment(new GroupAssignment(
-                new HashMap<String, MemberAssignment>() {
-                    {
-                        put(memberId1, new MemberAssignment(mkAssignment(
-                                mkTopicAssignment(fooTopicId, 0, 1),
-                                mkTopicAssignment(barTopicId, 0)
-                        )));
-                        put(memberId2, new MemberAssignment(mkAssignment(
-                                mkTopicAssignment(fooTopicId, 2, 3),
-                                mkTopicAssignment(barTopicId, 1)
-                        )));
-                        put(memberId3, new MemberAssignment(mkAssignment(
-                                mkTopicAssignment(fooTopicId, 4, 5),
-                                mkTopicAssignment(barTopicId, 2)
-                        )));
-                    }
+            new HashMap<String, MemberAssignment>() {
+                {
+                    put(memberId1, new MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1),
+                        mkTopicAssignment(barTopicId, 0)
+                    )));
+                    put(memberId2, new MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 2, 3),
+                        mkTopicAssignment(barTopicId, 1)
+                    )));
+                    put(memberId3, new MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 4, 5),
+                        mkTopicAssignment(barTopicId, 2)
+                    )));
                 }
-        ));
+            }
+            ));
 
         // Member 3 joins the consumer group.
         CoordinatorResult<ConsumerGroupHeartbeatResponseData, Record> result = context.consumerGroupHeartbeat(
-                new ConsumerGroupHeartbeatRequestData()
-                        .setGroupId(groupId)
-                        .setMemberId(memberId3)
-                        .setInstanceId(memberId3)
-                        .setMemberEpoch(0)
-                        .setRebalanceTimeoutMs(5000)
-                        .setServerAssignor("range")
-                        .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                        .setTopicPartitions(Collections.emptyList()));
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId3)
+                .setInstanceId(memberId3)
+                .setMemberEpoch(0)
+                .setRebalanceTimeoutMs(5000)
+                .setServerAssignor("range")
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList()));
 
         assertResponseEquals(
-                new ConsumerGroupHeartbeatResponseData()
-                        .setMemberId(memberId3)
-                        .setMemberEpoch(11)
-                        .setHeartbeatIntervalMs(5000)
-                        .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()),
-                result.response()
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId3)
+                .setMemberEpoch(11)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()),
+            result.response()
         );
 
         ConsumerGroupMember expectedMember3 = new ConsumerGroupMember.Builder(memberId3)
-                .setMemberEpoch(11)
-                .setInstanceId(memberId3)
-                .setPreviousMemberEpoch(0)
-                .setTargetMemberEpoch(11)
-                .setClientId("client")
-                .setClientHost("localhost/127.0.0.1")
-                .setRebalanceTimeoutMs(5000)
-                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                .setServerAssignorName("range")
-                .setPartitionsPendingAssignment(mkAssignment(
-                        mkTopicAssignment(fooTopicId, 4, 5),
-                        mkTopicAssignment(barTopicId, 2)))
-                .build();
+            .setMemberEpoch(11)
+            .setInstanceId(memberId3)
+            .setPreviousMemberEpoch(0)
+            .setTargetMemberEpoch(11)
+            .setClientId("client")
+            .setClientHost("localhost/127.0.0.1")
+            .setRebalanceTimeoutMs(5000)
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setServerAssignorName("range")
+            .setPartitionsPendingAssignment(mkAssignment(
+                mkTopicAssignment(fooTopicId, 4, 5),
+                mkTopicAssignment(barTopicId, 2)))
+            .build();
 
         List<Record> expectedRecords = Arrays.asList(
-                RecordHelpers.newMemberSubscriptionRecord(groupId, expectedMember3),
-                RecordHelpers.newGroupSubscriptionMetadataRecord(groupId, new HashMap<String, TopicMetadata>() {
-                    {
-                        put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 6, mkMapOfPartitionRacks(6)));
-                        put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 3, mkMapOfPartitionRacks(3)));
-                    }
-                }),
-                RecordHelpers.newGroupEpochRecord(groupId, 11),
-                RecordHelpers.newTargetAssignmentRecord(groupId, memberId1, mkAssignment(
-                        mkTopicAssignment(fooTopicId, 0, 1),
-                        mkTopicAssignment(barTopicId, 0)
-                )),
-                RecordHelpers.newTargetAssignmentRecord(groupId, memberId2, mkAssignment(
-                        mkTopicAssignment(fooTopicId, 2, 3),
-                        mkTopicAssignment(barTopicId, 1)
-                )),
-                RecordHelpers.newTargetAssignmentRecord(groupId, memberId3, mkAssignment(
-                        mkTopicAssignment(fooTopicId, 4, 5),
-                        mkTopicAssignment(barTopicId, 2)
-                )),
-                RecordHelpers.newTargetAssignmentEpochRecord(groupId, 11),
-                RecordHelpers.newCurrentAssignmentRecord(groupId, expectedMember3)
+            RecordHelpers.newMemberSubscriptionRecord(groupId, expectedMember3),
+            RecordHelpers.newGroupSubscriptionMetadataRecord(groupId, new HashMap<String, TopicMetadata>() {
+                {
+                    put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 6, mkMapOfPartitionRacks(6)));
+                    put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 3, mkMapOfPartitionRacks(3)));
+                }
+            }),
+            RecordHelpers.newGroupEpochRecord(groupId, 11),
+            RecordHelpers.newTargetAssignmentRecord(groupId, memberId1, mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1),
+                mkTopicAssignment(barTopicId, 0)
+            )),
+            RecordHelpers.newTargetAssignmentRecord(groupId, memberId2, mkAssignment(
+                mkTopicAssignment(fooTopicId, 2, 3),
+                mkTopicAssignment(barTopicId, 1)
+            )),
+            RecordHelpers.newTargetAssignmentRecord(groupId, memberId3, mkAssignment(
+                mkTopicAssignment(fooTopicId, 4, 5),
+                mkTopicAssignment(barTopicId, 2)
+            )),
+            RecordHelpers.newTargetAssignmentEpochRecord(groupId, 11),
+            RecordHelpers.newCurrentAssignmentRecord(groupId, expectedMember3)
         );
 
         assertRecordsEquals(expectedRecords.subList(0, 3), result.records().subList(0, 3));
@@ -2069,97 +2069,97 @@ public class GroupMetadataManagerTest {
 
         MockPartitionAssignor assignor = new MockPartitionAssignor("range");
         ConsumerGroupMember member1 = new ConsumerGroupMember.Builder(memberId1)
-                .setInstanceId(memberId1)
-                .setMemberEpoch(10)
-                .setPreviousMemberEpoch(9)
-                .setTargetMemberEpoch(10)
-                .setClientId("client")
-                .setClientHost("localhost/127.0.0.1")
-                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                .setServerAssignorName("range")
-                .setAssignedPartitions(mkAssignment(
-                        mkTopicAssignment(fooTopicId, 0, 1, 2),
-                        mkTopicAssignment(barTopicId, 0, 1)))
-                .build();
+            .setInstanceId(memberId1)
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setTargetMemberEpoch(10)
+            .setClientId("client")
+            .setClientHost("localhost/127.0.0.1")
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setServerAssignorName("range")
+            .setAssignedPartitions(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2),
+                mkTopicAssignment(barTopicId, 0, 1)))
+            .build();
         ConsumerGroupMember member2 = new ConsumerGroupMember.Builder(memberId2)
-                .setInstanceId(memberId2)
-                .setMemberEpoch(10)
-                .setPreviousMemberEpoch(9)
-                .setTargetMemberEpoch(10)
-                .setRebalanceTimeoutMs(5000)
-                .setClientId("client")
-                .setClientHost("localhost/127.0.0.1")
-                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                .setServerAssignorName("range")
-                .setAssignedPartitions(mkAssignment(
-                        mkTopicAssignment(fooTopicId, 3, 4, 5),
-                        mkTopicAssignment(barTopicId, 2)))
-                .build();
+            .setInstanceId(memberId2)
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setTargetMemberEpoch(10)
+            .setRebalanceTimeoutMs(5000)
+            .setClientId("client")
+            .setClientHost("localhost/127.0.0.1")
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setServerAssignorName("range")
+            .setAssignedPartitions(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 2)))
+            .build();
 
         // Consumer group with two static members.
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-                .withAssignors(Collections.singletonList(assignor))
-                .withMetadataImage(new MetadataImageBuilder()
-                        .addTopic(fooTopicId, fooTopicName, 6)
-                        .addTopic(barTopicId, barTopicName, 3)
-                        .addRacks()
-                        .build())
-                .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
-                        .withMember(member1)
-                        .withMember(member2)
-                        .withAssignment(memberId1, mkAssignment(
-                                mkTopicAssignment(fooTopicId, 0, 1, 2),
-                                mkTopicAssignment(barTopicId, 0, 1)))
-                        .withAssignment(memberId2, mkAssignment(
-                                mkTopicAssignment(fooTopicId, 3, 4, 5),
-                                mkTopicAssignment(barTopicId, 2)))
-                        .withAssignmentEpoch(10))
-                .build();
+            .withAssignors(Collections.singletonList(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .addRacks()
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(member1)
+                .withMember(member2)
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1)))
+                .withAssignment(memberId2, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 2)))
+                .withAssignmentEpoch(10))
+            .build();
 
         assignor.prepareGroupAssignment(new GroupAssignment(
-                new HashMap<String, MemberAssignment>() {
-                    {
-                        put(memberId1, new MemberAssignment(mkAssignment(
-                                mkTopicAssignment(fooTopicId, 0, 1, 2),
-                                mkTopicAssignment(barTopicId, 0, 1)
-                        )));
-                        put(memberId2, new MemberAssignment(mkAssignment(
-                                mkTopicAssignment(fooTopicId, 3, 4, 5),
-                                mkTopicAssignment(barTopicId, 2)
-                        )));
-                        // When the member rejoins, it gets the same assignments.
-                        put(member2RejoinId, new MemberAssignment(mkAssignment(
-                                mkTopicAssignment(fooTopicId, 3, 4, 5),
-                                mkTopicAssignment(barTopicId, 2)
-                        )));
-                    }
+            new HashMap<String, MemberAssignment>() {
+                {
+                    put(memberId1, new MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                        mkTopicAssignment(barTopicId, 0, 1)
+                    )));
+                    put(memberId2, new MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                        mkTopicAssignment(barTopicId, 2)
+                    )));
+                    // When the member rejoins, it gets the same assignments.
+                    put(member2RejoinId, new MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                        mkTopicAssignment(barTopicId, 2)
+                    )));
                 }
+            }
         ));
 
         // Member 2 leaves the consumer group.
         CoordinatorResult<ConsumerGroupHeartbeatResponseData, Record> result = context.consumerGroupHeartbeat(
-                new ConsumerGroupHeartbeatRequestData()
-                        .setGroupId(groupId)
-                        .setMemberId(memberId2)
-                        .setInstanceId(memberId2)
-                        .setMemberEpoch(-2)
-                        .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                        .setTopicPartitions(Collections.emptyList()));
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId2)
+                .setInstanceId(memberId2)
+                .setMemberEpoch(-2)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList()));
 
         // member epoch of the response would be set to -2
         assertResponseEquals(
-                new ConsumerGroupHeartbeatResponseData()
-                        .setMemberId(memberId2)
-                        .setMemberEpoch(-2),
-                result.response()
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId2)
+                .setMemberEpoch(-2),
+            result.response()
         );
 
         ConsumerGroupMember member2UpdatedEpoch = new ConsumerGroupMember.Builder(member2)
-                .setMemberEpoch(-2)
-                .build();
+            .setMemberEpoch(-2)
+            .build();
         // The departing static member will have it's epoch set to -2.
         List<Record> expectedRecords = Collections.singletonList(
-                RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch)
+            RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch)
         );
 
         assertEquals(result.records(), expectedRecords);
@@ -2168,64 +2168,58 @@ public class GroupMetadataManagerTest {
 
         // member 2 rejoins the group with the same instance id
         CoordinatorResult<ConsumerGroupHeartbeatResponseData, Record> rejoinResult = context.consumerGroupHeartbeat(
-                new ConsumerGroupHeartbeatRequestData()
-                        .setMemberId(member2RejoinId)
-                        .setGroupId(groupId)
-                        .setInstanceId(memberId2)
-                        .setMemberEpoch(0)
-                        .setRebalanceTimeoutMs(5000)
-                        .setServerAssignor("range")
-                        .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                        .setTopicPartitions(Collections.emptyList()));
+            new ConsumerGroupHeartbeatRequestData()
+                .setMemberId(member2RejoinId)
+                .setGroupId(groupId)
+                .setInstanceId(memberId2)
+                .setMemberEpoch(0)
+                .setRebalanceTimeoutMs(5000)
+                .setServerAssignor("range")
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList()));
 
         assertResponseEquals(
-                new ConsumerGroupHeartbeatResponseData()
-                        .setMemberId(member2RejoinId)
-                        .setMemberEpoch(11)
-                        .setHeartbeatIntervalMs(5000)
-                        .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
-                                .setTopicPartitions(Arrays.asList(
-                                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
-                                                .setTopicId(fooTopicId)
-                                                .setPartitions(Arrays.asList(3, 4, 5)),
-                                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
-                                                .setTopicId(barTopicId)
-                                                .setPartitions(Collections.singletonList(2))
-                                ))),
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(member2RejoinId)
+                .setMemberEpoch(10)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setTopicPartitions(Arrays.asList(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(Arrays.asList(3, 4, 5)),
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(barTopicId)
+                            .setPartitions(Collections.singletonList(2))
+                    ))),
                 rejoinResult.response()
         );
 
         ConsumerGroupMember expectedRejoinedMember = new ConsumerGroupMember.Builder(member2RejoinId)
-                .setMemberEpoch(11)
-                .setInstanceId(memberId2)
-                .setPreviousMemberEpoch(10)
-                .setTargetMemberEpoch(11)
-                .setClientId("client")
-                .setClientHost("localhost/127.0.0.1")
-                .setRebalanceTimeoutMs(5000)
-                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                .setServerAssignorName("range")
-                .setAssignedPartitions(mkAssignment(
-                        mkTopicAssignment(fooTopicId, 3, 4, 5),
-                        mkTopicAssignment(barTopicId, 2)))
-                .build();
+            .setMemberEpoch(10)
+            .setInstanceId(memberId2)
+            .setPreviousMemberEpoch(9)
+            .setTargetMemberEpoch(10)
+            .setClientId("client")
+            .setClientHost("localhost/127.0.0.1")
+            .setRebalanceTimeoutMs(5000)
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setServerAssignorName("range")
+            .setAssignedPartitions(mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 2)))
+            .build();
 
         List<Record> expectedRecordsAfterRejoin = Arrays.asList(
-                RecordHelpers.newMemberSubscriptionRecord(groupId, expectedRejoinedMember),
-                RecordHelpers.newGroupSubscriptionMetadataRecord(groupId, new HashMap<String, TopicMetadata>() {
-                    {
-                        put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 6, mkMapOfPartitionRacks(6)));
-                        put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 3, mkMapOfPartitionRacks(3)));
-                    }
-                }),
-                // A Group epoch bump seems imminent here
-                RecordHelpers.newGroupEpochRecord(groupId, 11),
-                RecordHelpers.newTargetAssignmentRecord(groupId, member2RejoinId, mkAssignment(
-                        mkTopicAssignment(fooTopicId, 3, 4, 5),
-                        mkTopicAssignment(barTopicId, 2)
-                )),
-                RecordHelpers.newTargetAssignmentEpochRecord(groupId, 11),
-                RecordHelpers.newCurrentAssignmentRecord(groupId, expectedRejoinedMember)
+            RecordHelpers.newCurrentAssignmentTombstoneRecord(groupId, memberId2),
+            RecordHelpers.newTargetAssignmentTombstoneRecord(groupId, memberId2),
+            RecordHelpers.newMemberSubscriptionTombstoneRecord(groupId, memberId2),
+            RecordHelpers.newMemberSubscriptionRecord(groupId, expectedRejoinedMember),
+            RecordHelpers.newTargetAssignmentRecord(groupId, member2RejoinId, mkAssignment(
+                mkTopicAssignment(fooTopicId, 3, 4, 5),
+                mkTopicAssignment(barTopicId, 2))),
+            RecordHelpers.newTargetAssignmentEpochRecord(groupId, 10),
+            RecordHelpers.newCurrentAssignmentRecord(groupId, expectedRejoinedMember)
         );
 
         assertRecordsEquals(expectedRecordsAfterRejoin, rejoinResult.records());
@@ -2248,75 +2242,75 @@ public class GroupMetadataManagerTest {
 
         // Consumer group with two static members.
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-                .withAssignors(Collections.singletonList(assignor))
-                .withMetadataImage(new MetadataImageBuilder()
-                        .addTopic(fooTopicId, fooTopicName, 6)
-                        .addTopic(barTopicId, barTopicName, 3)
-                        .addRacks()
-                        .build())
-                .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
-                        .withMember(new ConsumerGroupMember.Builder(memberId1)
-                                .setInstanceId(memberId1)
-                                .setMemberEpoch(10)
-                                .setPreviousMemberEpoch(9)
-                                .setTargetMemberEpoch(10)
-                                .setClientId("client")
-                                .setClientHost("localhost/127.0.0.1")
-                                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                                .setServerAssignorName("range")
-                                .setAssignedPartitions(mkAssignment(
-                                        mkTopicAssignment(fooTopicId, 0, 1, 2),
-                                        mkTopicAssignment(barTopicId, 0, 1)))
-                                .build())
-                        .withMember(new ConsumerGroupMember.Builder(memberId2)
-                                .setInstanceId(memberId2)
-                                .setMemberEpoch(10)
-                                .setPreviousMemberEpoch(9)
-                                .setTargetMemberEpoch(10)
-                                .setClientId("client")
-                                .setClientHost("localhost/127.0.0.1")
-                                // Use zar only here to ensure that metadata needs to be recomputed.
-                                .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
-                                .setServerAssignorName("range")
-                                .setAssignedPartitions(mkAssignment(
-                                        mkTopicAssignment(fooTopicId, 3, 4, 5),
-                                        mkTopicAssignment(barTopicId, 2)))
-                                .build())
-                        .withAssignment(memberId1, mkAssignment(
-                                mkTopicAssignment(fooTopicId, 0, 1, 2),
-                                mkTopicAssignment(barTopicId, 0, 1)))
-                        .withAssignment(memberId2, mkAssignment(
-                                mkTopicAssignment(fooTopicId, 3, 4, 5),
-                                mkTopicAssignment(barTopicId, 2)))
-                        .withAssignmentEpoch(10))
-                .build();
+            .withAssignors(Collections.singletonList(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .addRacks()
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setInstanceId(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setTargetMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssignedPartitions(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                        mkTopicAssignment(barTopicId, 0, 1)))
+                    .build())
+                .withMember(new ConsumerGroupMember.Builder(memberId2)
+                    .setInstanceId(memberId2)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setTargetMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    // Use zar only here to ensure that metadata needs to be recomputed.
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
+                    .setServerAssignorName("range")
+                    .setAssignedPartitions(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                        mkTopicAssignment(barTopicId, 2)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1)))
+                .withAssignment(memberId2, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 2)))
+                .withAssignmentEpoch(10))
+            .build();
 
         assignor.prepareGroupAssignment(new GroupAssignment(
-                new HashMap<String, MemberAssignment>() {
-                    {
-                        put(memberId1, new MemberAssignment(mkAssignment(
-                                mkTopicAssignment(fooTopicId, 0, 1),
-                                mkTopicAssignment(barTopicId, 0)
-                        )));
-                        put(memberId2, new MemberAssignment(mkAssignment(
-                                mkTopicAssignment(fooTopicId, 2, 3),
-                                mkTopicAssignment(barTopicId, 1)
-                        )));
-                    }
+            new HashMap<String, MemberAssignment>() {
+                {
+                    put(memberId1, new MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1),
+                        mkTopicAssignment(barTopicId, 0)
+                    )));
+                    put(memberId2, new MemberAssignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 2, 3),
+                        mkTopicAssignment(barTopicId, 1)
+                    )));
                 }
-        ));
+            }
+            ));
 
         // Member 3 joins the consumer group with an in-use instance id.
         assertThrows(UnreleasedInstanceIdException.class, () -> context.consumerGroupHeartbeat(
-                new ConsumerGroupHeartbeatRequestData()
-                        .setGroupId(groupId)
-                        .setMemberId(memberId3)
-                        .setInstanceId(memberId2)
-                        .setMemberEpoch(0)
-                        .setRebalanceTimeoutMs(5000)
-                        .setServerAssignor("range")
-                        .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                        .setTopicPartitions(Collections.emptyList())));
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId3)
+                .setInstanceId(memberId2)
+                .setMemberEpoch(0)
+                .setRebalanceTimeoutMs(5000)
+                .setServerAssignor("range")
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList())));
     }
 
     @Test
@@ -2333,75 +2327,75 @@ public class GroupMetadataManagerTest {
 
         MockPartitionAssignor assignor = new MockPartitionAssignor("range");
         ConsumerGroupMember member1 = new ConsumerGroupMember.Builder(memberId1)
-                .setInstanceId(memberId1)
-                .setMemberEpoch(10)
-                .setPreviousMemberEpoch(9)
-                .setTargetMemberEpoch(10)
-                .setClientId("client")
-                .setClientHost("localhost/127.0.0.1")
-                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                .setServerAssignorName("range")
-                .setAssignedPartitions(mkAssignment(
-                        mkTopicAssignment(fooTopicId, 0, 1, 2),
-                        mkTopicAssignment(barTopicId, 0, 1)))
-                .build();
+            .setInstanceId(memberId1)
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setTargetMemberEpoch(10)
+            .setClientId("client")
+            .setClientHost("localhost/127.0.0.1")
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setServerAssignorName("range")
+            .setAssignedPartitions(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2),
+                mkTopicAssignment(barTopicId, 0, 1)))
+            .build();
         ConsumerGroupMember member2 = new ConsumerGroupMember.Builder(memberId2)
-                .setInstanceId(memberId2)
-                .setMemberEpoch(10)
-                .setPreviousMemberEpoch(9)
-                .setTargetMemberEpoch(10)
-                .setClientId("client")
-                .setClientHost("localhost/127.0.0.1")
-                // Use zar only here to ensure that metadata needs to be recomputed.
-                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                .setServerAssignorName("range")
-                .setAssignedPartitions(mkAssignment(
-                        mkTopicAssignment(fooTopicId, 3, 4, 5),
-                        mkTopicAssignment(barTopicId, 2)))
-                .build();
+            .setInstanceId(memberId2)
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(9)
+            .setTargetMemberEpoch(10)
+            .setClientId("client")
+            .setClientHost("localhost/127.0.0.1")
+            // Use zar only here to ensure that metadata needs to be recomputed.
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setServerAssignorName("range")
+            .setAssignedPartitions(mkAssignment(
+                mkTopicAssignment(fooTopicId, 3, 4, 5),
+                mkTopicAssignment(barTopicId, 2)))
+            .build();
 
         // Consumer group with two static members.
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-                .withAssignors(Collections.singletonList(assignor))
-                .withMetadataImage(new MetadataImageBuilder()
-                        .addTopic(fooTopicId, fooTopicName, 6)
-                        .addTopic(barTopicId, barTopicName, 3)
-                        .addRacks()
-                        .build())
-                .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
-                        .withMember(member1)
-                        .withMember(member2)
-                        .withAssignment(memberId1, mkAssignment(
-                                mkTopicAssignment(fooTopicId, 0, 1, 2),
-                                mkTopicAssignment(barTopicId, 0, 1)))
-                        .withAssignment(memberId2, mkAssignment(
-                                mkTopicAssignment(fooTopicId, 3, 4, 5),
-                                mkTopicAssignment(barTopicId, 2)))
-                        .withAssignmentEpoch(10))
-                .build();
+            .withAssignors(Collections.singletonList(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .addRacks()
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(member1)
+                .withMember(member2)
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1)))
+                .withAssignment(memberId2, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 2)))
+                .withAssignmentEpoch(10))
+            .build();
 
         // Member 2 leaves the consumer group.
         CoordinatorResult<ConsumerGroupHeartbeatResponseData, Record> result = context.consumerGroupHeartbeat(
-                new ConsumerGroupHeartbeatRequestData()
-                        .setGroupId(groupId)
-                        .setMemberId(memberId2)
-                        .setInstanceId(memberId2)
-                        .setMemberEpoch(-2)
-                        .setRebalanceTimeoutMs(5000)
-                        .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                        .setTopicPartitions(Collections.emptyList()));
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId2)
+                .setInstanceId(memberId2)
+                .setMemberEpoch(-2)
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList()));
 
         // member epoch of the response would be set to -2
         assertResponseEquals(
-                new ConsumerGroupHeartbeatResponseData()
-                        .setMemberId(memberId2)
-                        .setMemberEpoch(-2),
-                result.response()
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId2)
+                .setMemberEpoch(-2),
+            result.response()
         );
 
         ConsumerGroupMember member2UpdatedEpoch = new ConsumerGroupMember.Builder(member2).setMemberEpoch(-2).build();
         List<Record> expectedRecords = Collections.singletonList(
-                RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch)
+            RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch)
         );
 
         assertEquals(result.records(), expectedRecords);
@@ -2425,59 +2419,59 @@ public class GroupMetadataManagerTest {
 
         // Consumer group with two static members.
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-                .withAssignors(Collections.singletonList(assignor))
-                .withMetadataImage(new MetadataImageBuilder()
-                        .addTopic(fooTopicId, fooTopicName, 6)
-                        .addTopic(barTopicId, barTopicName, 3)
-                        .addTopic(zarTopicId, zarTopicName, 1)
-                        .addRacks()
-                        .build())
-                .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
-                        .withMember(new ConsumerGroupMember.Builder(memberId1)
-                                .setInstanceId(memberId1)
-                                .setMemberEpoch(10)
-                                .setPreviousMemberEpoch(9)
-                                .setTargetMemberEpoch(10)
-                                .setClientId("client")
-                                .setClientHost("localhost/127.0.0.1")
-                                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                                .setServerAssignorName("range")
-                                .setAssignedPartitions(mkAssignment(
-                                        mkTopicAssignment(fooTopicId, 0, 1, 2),
-                                        mkTopicAssignment(barTopicId, 0, 1)))
-                                .build())
-                        .withMember(new ConsumerGroupMember.Builder(memberId2)
-                                .setInstanceId(memberId2)
-                                .setMemberEpoch(10)
-                                .setPreviousMemberEpoch(9)
-                                .setTargetMemberEpoch(10)
-                                .setClientId("client")
-                                .setClientHost("localhost/127.0.0.1")
-                                // Use zar only here to ensure that metadata needs to be recomputed.
-                                .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
-                                .setServerAssignorName("range")
-                                .setAssignedPartitions(mkAssignment(
-                                        mkTopicAssignment(fooTopicId, 3, 4, 5),
-                                        mkTopicAssignment(barTopicId, 2)))
-                                .build())
-                        .withAssignment(memberId1, mkAssignment(
-                                mkTopicAssignment(fooTopicId, 0, 1, 2),
-                                mkTopicAssignment(barTopicId, 0, 1)))
-                        .withAssignment(memberId2, mkAssignment(
-                                mkTopicAssignment(fooTopicId, 3, 4, 5),
-                                mkTopicAssignment(barTopicId, 2)))
-                        .withAssignmentEpoch(10))
-                .build();
+            .withAssignors(Collections.singletonList(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .addTopic(zarTopicId, zarTopicName, 1)
+                .addRacks()
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setInstanceId(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setTargetMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssignedPartitions(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                        mkTopicAssignment(barTopicId, 0, 1)))
+                    .build())
+                .withMember(new ConsumerGroupMember.Builder(memberId2)
+                    .setInstanceId(memberId2)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setTargetMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    // Use zar only here to ensure that metadata needs to be recomputed.
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
+                    .setServerAssignorName("range")
+                    .setAssignedPartitions(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                        mkTopicAssignment(barTopicId, 2)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1)))
+                .withAssignment(memberId2, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 2)))
+                .withAssignmentEpoch(10))
+            .build();
 
         assertThrows(UnknownMemberIdException.class, () -> context.consumerGroupHeartbeat(
-                new ConsumerGroupHeartbeatRequestData()
-                        .setGroupId(groupId)
-                        .setMemberId(memberId2)
-                        .setInstanceId("unknown-" + memberId2)
-                        .setMemberEpoch(-2)
-                        .setRebalanceTimeoutMs(5000)
-                        .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                        .setTopicPartitions(Collections.emptyList())));
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId2)
+                .setInstanceId("unknown-" + memberId2)
+                .setMemberEpoch(-2)
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList())));
     }
 
     @Test
@@ -2498,59 +2492,59 @@ public class GroupMetadataManagerTest {
 
         // Consumer group with two static members.
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-                .withAssignors(Collections.singletonList(assignor))
-                .withMetadataImage(new MetadataImageBuilder()
-                        .addTopic(fooTopicId, fooTopicName, 6)
-                        .addTopic(barTopicId, barTopicName, 3)
-                        .addTopic(zarTopicId, zarTopicName, 1)
-                        .addRacks()
-                        .build())
-                .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
-                        .withMember(new ConsumerGroupMember.Builder(memberId1)
-                                .setInstanceId(memberId1)
-                                .setMemberEpoch(10)
-                                .setPreviousMemberEpoch(9)
-                                .setTargetMemberEpoch(10)
-                                .setClientId("client")
-                                .setClientHost("localhost/127.0.0.1")
-                                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                                .setServerAssignorName("range")
-                                .setAssignedPartitions(mkAssignment(
-                                        mkTopicAssignment(fooTopicId, 0, 1, 2),
-                                        mkTopicAssignment(barTopicId, 0, 1)))
-                                .build())
-                        .withMember(new ConsumerGroupMember.Builder(memberId2)
-                                .setInstanceId(memberId2)
-                                .setMemberEpoch(10)
-                                .setPreviousMemberEpoch(9)
-                                .setTargetMemberEpoch(10)
-                                .setClientId("client")
-                                .setClientHost("localhost/127.0.0.1")
-                                // Use zar only here to ensure that metadata needs to be recomputed.
-                                .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
-                                .setServerAssignorName("range")
-                                .setAssignedPartitions(mkAssignment(
-                                        mkTopicAssignment(fooTopicId, 3, 4, 5),
-                                        mkTopicAssignment(barTopicId, 2)))
-                                .build())
-                        .withAssignment(memberId1, mkAssignment(
-                                mkTopicAssignment(fooTopicId, 0, 1, 2),
-                                mkTopicAssignment(barTopicId, 0, 1)))
-                        .withAssignment(memberId2, mkAssignment(
-                                mkTopicAssignment(fooTopicId, 3, 4, 5),
-                                mkTopicAssignment(barTopicId, 2)))
-                        .withAssignmentEpoch(10))
-                .build();
+            .withAssignors(Collections.singletonList(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .addTopic(zarTopicId, zarTopicName, 1)
+                .addRacks()
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setInstanceId(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setTargetMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssignedPartitions(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                        mkTopicAssignment(barTopicId, 0, 1)))
+                    .build())
+                .withMember(new ConsumerGroupMember.Builder(memberId2)
+                    .setInstanceId(memberId2)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setTargetMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    // Use zar only here to ensure that metadata needs to be recomputed.
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
+                    .setServerAssignorName("range")
+                    .setAssignedPartitions(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                        mkTopicAssignment(barTopicId, 2)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1)))
+                .withAssignment(memberId2, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 2)))
+                .withAssignmentEpoch(10))
+            .build();
 
         assertThrows(FencedInstanceIdException.class, () -> context.consumerGroupHeartbeat(
-                new ConsumerGroupHeartbeatRequestData()
-                        .setGroupId(groupId)
-                        .setMemberId("unknown-" + memberId2)
-                        .setInstanceId(memberId2)
-                        .setMemberEpoch(-2)
-                        .setRebalanceTimeoutMs(5000)
-                        .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                        .setTopicPartitions(Collections.emptyList())));
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId("unknown-" + memberId2)
+                .setInstanceId(memberId2)
+                .setMemberEpoch(-2)
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList())));
     }
 
     @Test
@@ -2571,59 +2565,59 @@ public class GroupMetadataManagerTest {
         MockPartitionAssignor assignor = new MockPartitionAssignor("range");
 
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-                .withAssignors(Collections.singletonList(assignor))
-                .withMetadataImage(new MetadataImageBuilder()
-                        .addTopic(fooTopicId, fooTopicName, 6)
-                        .addTopic(barTopicId, barTopicName, 3)
-                        .addTopic(zarTopicId, zarTopicName, 1)
-                        .addRacks()
-                        .build())
-                .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
-                        .withMember(new ConsumerGroupMember.Builder(memberId1)
-                                .setInstanceId(memberId1)
-                                .setMemberEpoch(10)
-                                .setPreviousMemberEpoch(9)
-                                .setTargetMemberEpoch(10)
-                                .setClientId("client")
-                                .setClientHost("localhost/127.0.0.1")
-                                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                                .setServerAssignorName("range")
-                                .setAssignedPartitions(mkAssignment(
-                                        mkTopicAssignment(fooTopicId, 0, 1, 2),
-                                        mkTopicAssignment(barTopicId, 0, 1)))
-                                .build())
-                        .withMember(new ConsumerGroupMember.Builder(memberId2)
-                                .setInstanceId(memberId2)
-                                .setMemberEpoch(10)
-                                .setPreviousMemberEpoch(9)
-                                .setTargetMemberEpoch(10)
-                                .setClientId("client")
-                                .setClientHost("localhost/127.0.0.1")
-                                // Use zar only here to ensure that metadata needs to be recomputed.
-                                .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
-                                .setServerAssignorName("range")
-                                .setAssignedPartitions(mkAssignment(
-                                        mkTopicAssignment(fooTopicId, 3, 4, 5),
-                                        mkTopicAssignment(barTopicId, 2)))
-                                .build())
-                        .withAssignment(memberId1, mkAssignment(
-                                mkTopicAssignment(fooTopicId, 0, 1, 2),
-                                mkTopicAssignment(barTopicId, 0, 1)))
-                        .withAssignment(memberId2, mkAssignment(
-                                mkTopicAssignment(fooTopicId, 3, 4, 5),
-                                mkTopicAssignment(barTopicId, 2)))
-                        .withAssignmentEpoch(10))
-                .build();
+            .withAssignors(Collections.singletonList(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addTopic(barTopicId, barTopicName, 3)
+                .addTopic(zarTopicId, zarTopicName, 1)
+                .addRacks()
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setInstanceId(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setTargetMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssignedPartitions(mkAssignment(
+                            mkTopicAssignment(fooTopicId, 0, 1, 2),
+                            mkTopicAssignment(barTopicId, 0, 1)))
+                    .build())
+                .withMember(new ConsumerGroupMember.Builder(memberId2)
+                    .setInstanceId(memberId2)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setTargetMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    // Use zar only here to ensure that metadata needs to be recomputed.
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
+                    .setServerAssignorName("range")
+                    .setAssignedPartitions(mkAssignment(
+                            mkTopicAssignment(fooTopicId, 3, 4, 5),
+                            mkTopicAssignment(barTopicId, 2)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1)))
+                .withAssignment(memberId2, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 2)))
+                .withAssignmentEpoch(10))
+            .build();
 
 
         assertThrows(InvalidRequestException.class, () -> context.consumerGroupHeartbeat(
-                new ConsumerGroupHeartbeatRequestData()
-                        .setGroupId(groupId)
-                        .setMemberId(memberId2)
-                        .setMemberEpoch(-2)
-                        .setRebalanceTimeoutMs(5000)
-                        .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                        .setTopicPartitions(Collections.emptyList())));
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId2)
+                .setMemberEpoch(-2)
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList())));
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -1316,17 +1316,16 @@ public class GroupMetadataManagerTest {
                 .setServerAssignor("bar")));
         assertEquals("ServerAssignor bar is not supported. Supported assignors: range.", ex.getMessage());
 
-        String memberId = Uuid.randomUuid().toString();
         ex = assertThrows(InvalidRequestException.class, () -> context.consumerGroupHeartbeat(
             new ConsumerGroupHeartbeatRequestData()
                 .setGroupId("foo")
-                .setMemberId(memberId)
+                .setMemberId(Uuid.randomUuid().toString())
                 .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH)
                 .setRebalanceTimeoutMs(5000)
                 .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                 .setTopicPartitions(Collections.emptyList())));
 
-        assertEquals("InstanceId can't be null. GroupId: foo, MemberId: " + memberId, ex.getMessage());
+        assertEquals("InstanceId can't be null.", ex.getMessage());
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -1909,6 +1909,90 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
+    public void testNoGroupEpochBumpWhenStaticMemberLeaves() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId1 = Uuid.randomUuid().toString();
+        String memberId2 = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+        Uuid zarTopicId = Uuid.randomUuid();
+        String zarTopicName = "zar";
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+
+        // Consumer group with two members.
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+                .withAssignors(Collections.singletonList(assignor))
+                .withMetadataImage(new MetadataImageBuilder()
+                        .addTopic(fooTopicId, fooTopicName, 6)
+                        .addTopic(barTopicId, barTopicName, 3)
+                        .addTopic(zarTopicId, zarTopicName, 1)
+                        .addRacks()
+                        .build())
+                .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                        .withMember(new ConsumerGroupMember.Builder(memberId1)
+                                .setInstanceId(memberId1)
+                                .setMemberEpoch(10)
+                                .setPreviousMemberEpoch(9)
+                                .setTargetMemberEpoch(10)
+                                .setClientId("client")
+                                .setClientHost("localhost/127.0.0.1")
+                                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                                .setServerAssignorName("range")
+                                .setAssignedPartitions(mkAssignment(
+                                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                                        mkTopicAssignment(barTopicId, 0, 1)))
+                                .build())
+                        .withMember(new ConsumerGroupMember.Builder(memberId2)
+                                .setInstanceId(memberId2)
+                                .setMemberEpoch(10)
+                                .setPreviousMemberEpoch(9)
+                                .setTargetMemberEpoch(10)
+                                .setClientId("client")
+                                .setClientHost("localhost/127.0.0.1")
+                                // Use zar only here to ensure that metadata needs to be recomputed.
+                                .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
+                                .setServerAssignorName("range")
+                                .setAssignedPartitions(mkAssignment(
+                                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                                        mkTopicAssignment(barTopicId, 2)))
+                                .build())
+                        .withAssignment(memberId1, mkAssignment(
+                                mkTopicAssignment(fooTopicId, 0, 1, 2),
+                                mkTopicAssignment(barTopicId, 0, 1)))
+                        .withAssignment(memberId2, mkAssignment(
+                                mkTopicAssignment(fooTopicId, 3, 4, 5),
+                                mkTopicAssignment(barTopicId, 2)))
+                        .withAssignmentEpoch(10))
+                .build();
+
+        // Member 2 leaves the consumer group.
+        // Note that it is not necessary to set instance id in this case since the lookup for an existing
+        // member happens using member id.
+        CoordinatorResult<ConsumerGroupHeartbeatResponseData, Record> result = context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                        .setGroupId(groupId)
+                        .setMemberId(memberId2)
+                        .setInstanceId(memberId2)
+                        .setMemberEpoch(-1)
+                        .setRebalanceTimeoutMs(5000)
+                        .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                        .setTopicPartitions(Collections.emptyList()));
+
+        assertResponseEquals(
+                new ConsumerGroupHeartbeatResponseData()
+                        .setMemberId(memberId2)
+                        .setMemberEpoch(-1),
+                result.response()
+        );
+        assertTrue(result.records().isEmpty());
+    }
+
+    @Test
     public void testReconciliationProcess() {
         String groupId = "fooup";
         // Use a static member id as it makes the test easier.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -2113,7 +2113,13 @@ public class GroupMetadataManagerTest {
                 .withAssignment(memberId2, mkAssignment(
                     mkTopicAssignment(fooTopicId, 3, 4, 5),
                     mkTopicAssignment(barTopicId, 2)))
-                .withAssignmentEpoch(10))
+                .withAssignmentEpoch(10)
+                .withSubscriptionMetadata(new HashMap<String, TopicMetadata>() {
+                    {
+                        put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 6, mkMapOfPartitionRacks(6)));
+                        put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 3, mkMapOfPartitionRacks(3)));
+                    }
+                }))
             .build();
 
         assignor.prepareGroupAssignment(new GroupAssignment(
@@ -2183,29 +2189,21 @@ public class GroupMetadataManagerTest {
                 .setMemberId(member2RejoinId)
                 .setMemberEpoch(10)
                 .setHeartbeatIntervalMs(5000)
-                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
-                    .setTopicPartitions(Arrays.asList(
-                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
-                            .setTopicId(fooTopicId)
-                            .setPartitions(Arrays.asList(3, 4, 5)),
-                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
-                            .setTopicId(barTopicId)
-                            .setPartitions(Collections.singletonList(2))
-                    ))),
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()),
                 rejoinResult.response()
         );
 
         ConsumerGroupMember expectedRejoinedMember = new ConsumerGroupMember.Builder(member2RejoinId)
             .setMemberEpoch(10)
             .setInstanceId(memberId2)
-            .setPreviousMemberEpoch(9)
+            .setPreviousMemberEpoch(0)
             .setTargetMemberEpoch(10)
             .setClientId("client")
             .setClientHost("localhost/127.0.0.1")
             .setRebalanceTimeoutMs(5000)
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
-            .setAssignedPartitions(mkAssignment(
+            .setPartitionsPendingAssignment(mkAssignment(
                     mkTopicAssignment(fooTopicId, 3, 4, 5),
                     mkTopicAssignment(barTopicId, 2)))
             .build();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -2189,7 +2189,15 @@ public class GroupMetadataManagerTest {
                 .setMemberId(member2RejoinId)
                 .setMemberEpoch(10)
                 .setHeartbeatIntervalMs(5000)
-                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()),
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setTopicPartitions(Arrays.asList(
+                    new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                        .setTopicId(fooTopicId)
+                        .setPartitions(Arrays.asList(3, 4, 5)),
+                    new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                        .setTopicId(barTopicId)
+                        .setPartitions(Collections.singletonList(2))
+                ))),
                 rejoinResult.response()
         );
 
@@ -2203,7 +2211,7 @@ public class GroupMetadataManagerTest {
             .setRebalanceTimeoutMs(5000)
             .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
             .setServerAssignorName("range")
-            .setPartitionsPendingAssignment(mkAssignment(
+            .setAssignedPartitions(mkAssignment(
                     mkTopicAssignment(fooTopicId, 3, 4, 5),
                     mkTopicAssignment(barTopicId, 2)))
             .build();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -2129,10 +2129,6 @@ public class GroupMetadataManagerTest {
                         mkTopicAssignment(fooTopicId, 0, 1, 2),
                         mkTopicAssignment(barTopicId, 0, 1)
                     )));
-                    put(memberId2, new MemberAssignment(mkAssignment(
-                        mkTopicAssignment(fooTopicId, 3, 4, 5),
-                        mkTopicAssignment(barTopicId, 2)
-                    )));
                     // When the member rejoins, it gets the same assignments.
                     put(member2RejoinId, new MemberAssignment(mkAssignment(
                         mkTopicAssignment(fooTopicId, 3, 4, 5),
@@ -2152,7 +2148,7 @@ public class GroupMetadataManagerTest {
                 .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                 .setTopicPartitions(Collections.emptyList()));
 
-        // member epoch of the response would be set to -2
+        // Member epoch of the response would be set to -2.
         assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId2)
@@ -2160,19 +2156,18 @@ public class GroupMetadataManagerTest {
             result.response()
         );
 
+        // The departing static member will have it's epoch set to -2.
         ConsumerGroupMember member2UpdatedEpoch = new ConsumerGroupMember.Builder(member2)
             .setMemberEpoch(-2)
             .build();
-        // The departing static member will have it's epoch set to -2.
+
         List<Record> expectedRecords = Collections.singletonList(
             RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch)
         );
 
         assertEquals(result.records(), expectedRecords);
-        // Replay the updated record with -2 epoch so that the group can update itself.
-        context.replay(RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch));
 
-        // member 2 rejoins the group with the same instance id
+        // Member 2 rejoins the group with the same instance id.
         CoordinatorResult<ConsumerGroupHeartbeatResponseData, Record> rejoinResult = context.consumerGroupHeartbeat(
             new ConsumerGroupHeartbeatRequestData()
                 .setMemberId(member2RejoinId)
@@ -2229,94 +2224,9 @@ public class GroupMetadataManagerTest {
         );
 
         assertRecordsEquals(expectedRecordsAfterRejoin, rejoinResult.records());
-    }
-
-    @Test
-    public void testShouldThrownUnreleasedInstanceIdExceptionWhenMemberJoinsWithInUseInstanceId() {
-        String groupId = "fooup";
-        // Use a static member id as it makes the test easier.
-        String memberId1 = Uuid.randomUuid().toString();
-        String memberId2 = Uuid.randomUuid().toString();
-        String memberId3 = Uuid.randomUuid().toString();
-
-        Uuid fooTopicId = Uuid.randomUuid();
-        String fooTopicName = "foo";
-        Uuid barTopicId = Uuid.randomUuid();
-        String barTopicName = "bar";
-
-        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
-
-        // Consumer group with two static members.
-        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-            .withAssignors(Collections.singletonList(assignor))
-            .withMetadataImage(new MetadataImageBuilder()
-                .addTopic(fooTopicId, fooTopicName, 6)
-                .addTopic(barTopicId, barTopicName, 3)
-                .addRacks()
-                .build())
-            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
-                .withMember(new ConsumerGroupMember.Builder(memberId1)
-                    .setInstanceId(memberId1)
-                    .setMemberEpoch(10)
-                    .setPreviousMemberEpoch(9)
-                    .setTargetMemberEpoch(10)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
-                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                    .setServerAssignorName("range")
-                    .setAssignedPartitions(mkAssignment(
-                        mkTopicAssignment(fooTopicId, 0, 1, 2),
-                        mkTopicAssignment(barTopicId, 0, 1)))
-                    .build())
-                .withMember(new ConsumerGroupMember.Builder(memberId2)
-                    .setInstanceId(memberId2)
-                    .setMemberEpoch(10)
-                    .setPreviousMemberEpoch(9)
-                    .setTargetMemberEpoch(10)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
-                    // Use zar only here to ensure that metadata needs to be recomputed.
-                    .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
-                    .setServerAssignorName("range")
-                    .setAssignedPartitions(mkAssignment(
-                        mkTopicAssignment(fooTopicId, 3, 4, 5),
-                        mkTopicAssignment(barTopicId, 2)))
-                    .build())
-                .withAssignment(memberId1, mkAssignment(
-                    mkTopicAssignment(fooTopicId, 0, 1, 2),
-                    mkTopicAssignment(barTopicId, 0, 1)))
-                .withAssignment(memberId2, mkAssignment(
-                    mkTopicAssignment(fooTopicId, 3, 4, 5),
-                    mkTopicAssignment(barTopicId, 2)))
-                .withAssignmentEpoch(10))
-            .build();
-
-        assignor.prepareGroupAssignment(new GroupAssignment(
-            new HashMap<String, MemberAssignment>() {
-                {
-                    put(memberId1, new MemberAssignment(mkAssignment(
-                        mkTopicAssignment(fooTopicId, 0, 1),
-                        mkTopicAssignment(barTopicId, 0)
-                    )));
-                    put(memberId2, new MemberAssignment(mkAssignment(
-                        mkTopicAssignment(fooTopicId, 2, 3),
-                        mkTopicAssignment(barTopicId, 1)
-                    )));
-                }
-            }
-            ));
-
-        // Member 3 joins the consumer group with an in-use instance id.
-        assertThrows(UnreleasedInstanceIdException.class, () -> context.consumerGroupHeartbeat(
-            new ConsumerGroupHeartbeatRequestData()
-                .setGroupId(groupId)
-                .setMemberId(memberId3)
-                .setInstanceId(memberId2)
-                .setMemberEpoch(0)
-                .setRebalanceTimeoutMs(5000)
-                .setServerAssignor("range")
-                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
-                .setTopicPartitions(Collections.emptyList())));
+        // Verify that there are no timers.
+        context.assertNoSessionTimeout(groupId, memberId2);
+        context.assertNoRevocationTimeout(groupId, memberId2);
     }
 
     @Test
@@ -2408,7 +2318,7 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
-    public void testShouldThrowUnknownMemberIdExceptionWhenUnknownStaticMemberLeaves() {
+    public void testLeavingStaticMemberBumpsGroupEpoch() {
         String groupId = "fooup";
         // Use a static member id as it makes the test easier.
         String memberId1 = Uuid.randomUuid().toString();
@@ -2469,11 +2379,313 @@ public class GroupMetadataManagerTest {
                 .withAssignmentEpoch(10))
             .build();
 
+        // Member 2 leaves the consumer group.
+        CoordinatorResult<ConsumerGroupHeartbeatResponseData, Record> result = context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setInstanceId(memberId2)
+                .setMemberId(memberId2)
+                .setMemberEpoch(LEAVE_GROUP_MEMBER_EPOCH)
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList()));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId2)
+                .setMemberEpoch(LEAVE_GROUP_MEMBER_EPOCH),
+            result.response()
+        );
+
+        List<Record> expectedRecords = Arrays.asList(
+            RecordHelpers.newCurrentAssignmentTombstoneRecord(groupId, memberId2),
+            RecordHelpers.newTargetAssignmentTombstoneRecord(groupId, memberId2),
+            RecordHelpers.newMemberSubscriptionTombstoneRecord(groupId, memberId2),
+            // Subscription metadata is recomputed because zar is no longer there.
+            RecordHelpers.newGroupSubscriptionMetadataRecord(groupId, new HashMap<String, TopicMetadata>() {
+                {
+                    put(fooTopicName, new TopicMetadata(fooTopicId, fooTopicName, 6, mkMapOfPartitionRacks(6)));
+                    put(barTopicName, new TopicMetadata(barTopicId, barTopicName, 3, mkMapOfPartitionRacks(3)));
+                }
+            }),
+            RecordHelpers.newGroupEpochRecord(groupId, 11)
+        );
+
+        assertRecordsEquals(expectedRecords, result.records());
+    }
+
+    @Test
+    public void testShouldThrownUnreleasedInstanceIdExceptionWhenNewMemberJoinsWithInUseInstanceId() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId1 = Uuid.randomUuid().toString();
+        String memberId2 = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+
+        // Consumer group with one static member.
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addRacks()
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setInstanceId(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setTargetMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssignedPartitions(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        // Member 2 joins the consumer group with an in-use instance id.
+        assertThrows(UnreleasedInstanceIdException.class, () -> context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId2)
+                .setInstanceId(memberId1)
+                .setMemberEpoch(0)
+                .setRebalanceTimeoutMs(5000)
+                .setServerAssignor("range")
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList())));
+    }
+
+    @Test
+    public void testShouldThrownUnknownMemberIdExceptionWhenUnknownStaticMemberJoins() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId1 = Uuid.randomUuid().toString();
+        String memberId2 = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+
+        // Consumer group with one static member.
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setInstanceId(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setTargetMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssignedPartitions(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        // Member 2 joins the consumer group with a non-zero epoch
         assertThrows(UnknownMemberIdException.class, () -> context.consumerGroupHeartbeat(
             new ConsumerGroupHeartbeatRequestData()
                 .setGroupId(groupId)
                 .setMemberId(memberId2)
-                .setInstanceId("unknown-" + memberId2)
+                .setInstanceId(memberId2)
+                .setMemberEpoch(10)
+                .setRebalanceTimeoutMs(5000)
+                .setServerAssignor("range")
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList())));
+    }
+
+    @Test
+    public void testShouldThrowFencedInstanceIdExceptionWhenStaticMemberWithDifferentMemberIdJoins() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId1 = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+
+        // Consumer group with one static member.
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setInstanceId(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setTargetMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssignedPartitions(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        assertThrows(FencedInstanceIdException.class, () -> context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId("unknown-" + memberId1)
+                .setInstanceId(memberId1)
+                .setMemberEpoch(11)
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.emptyList())));
+    }
+
+    @Test
+    public void testConsumerGroupMemberEpochValidationForStaticMember() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId = Uuid.randomUuid().toString();
+        Uuid fooTopicId = Uuid.randomUuid();
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .build();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder(memberId)
+            .setInstanceId(memberId)
+            .setMemberEpoch(100)
+            .setPreviousMemberEpoch(99)
+            .setTargetMemberEpoch(100)
+            .setRebalanceTimeoutMs(5000)
+            .setClientId("client")
+            .setClientHost("localhost/127.0.0.1")
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setServerAssignorName("range")
+            .setAssignedPartitions(mkAssignment(mkTopicAssignment(fooTopicId, 1, 2, 3)))
+            .build();
+
+        context.replay(RecordHelpers.newMemberSubscriptionRecord(groupId, member));
+
+        context.replay(RecordHelpers.newGroupEpochRecord(groupId, 100));
+
+        context.replay(RecordHelpers.newTargetAssignmentRecord(groupId, memberId, mkAssignment(
+            mkTopicAssignment(fooTopicId, 1, 2, 3)
+        )));
+
+        context.replay(RecordHelpers.newTargetAssignmentEpochRecord(groupId, 100));
+
+        context.replay(RecordHelpers.newCurrentAssignmentRecord(groupId, member));
+
+        // Member epoch is greater than the expected epoch.
+        assertThrows(FencedMemberEpochException.class, () ->
+            context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId)
+                    .setInstanceId(memberId)
+                    .setMemberEpoch(200)
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))));
+
+        // Member epoch is smaller than the expected epoch.
+        assertThrows(FencedMemberEpochException.class, () ->
+            context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId)
+                    .setInstanceId(memberId)
+                    .setMemberEpoch(50)
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))));
+
+        // Member joins with previous epoch but without providing partitions.
+        assertThrows(FencedMemberEpochException.class, () ->
+            context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId)
+                    .setInstanceId(memberId)
+                    .setMemberEpoch(99)
+                    .setRebalanceTimeoutMs(5000)
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))));
+
+        // Member joins with previous epoch and has a subset of the owned partitions. This
+        // is accepted as the response with the bumped epoch may have been lost. In this
+        // case, we provide back the correct epoch to the member.
+        CoordinatorResult<ConsumerGroupHeartbeatResponseData, Record> result = context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setInstanceId(memberId)
+                .setMemberEpoch(99)
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                .setTopicPartitions(Collections.singletonList(new ConsumerGroupHeartbeatRequestData.TopicPartitions()
+                    .setTopicId(fooTopicId)
+                    .setPartitions(Arrays.asList(1, 2)))));
+        assertEquals(100, result.response().memberEpoch());
+    }
+
+    @Test
+    public void testShouldThrowUnknownMemberIdExceptionWhenUnknownStaticMemberLeaves() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId1 = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+
+        // Consumer group with one static member.
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .build())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId1)
+                    .setInstanceId(memberId1)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(9)
+                    .setTargetMemberEpoch(10)
+                    .setClientId("client")
+                    .setClientHost("localhost/127.0.0.1")
+                    .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+                    .setServerAssignorName("range")
+                    .setAssignedPartitions(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2)))
+                    .build())
+                .withAssignment(memberId1, mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        assertThrows(UnknownMemberIdException.class, () -> context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId1)
+                .setInstanceId("unknown-" + memberId1)
                 .setMemberEpoch(-2)
                 .setRebalanceTimeoutMs(5000)
                 .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
@@ -2485,25 +2697,17 @@ public class GroupMetadataManagerTest {
         String groupId = "fooup";
         // Use a static member id as it makes the test easier.
         String memberId1 = Uuid.randomUuid().toString();
-        String memberId2 = Uuid.randomUuid().toString();
 
         Uuid fooTopicId = Uuid.randomUuid();
         String fooTopicName = "foo";
-        Uuid barTopicId = Uuid.randomUuid();
-        String barTopicName = "bar";
-        Uuid zarTopicId = Uuid.randomUuid();
-        String zarTopicName = "zar";
 
         MockPartitionAssignor assignor = new MockPartitionAssignor("range");
 
-        // Consumer group with two static members.
+        // Consumer group with one static member.
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .withAssignors(Collections.singletonList(assignor))
             .withMetadataImage(new MetadataImageBuilder()
                 .addTopic(fooTopicId, fooTopicName, 6)
-                .addTopic(barTopicId, barTopicName, 3)
-                .addTopic(zarTopicId, zarTopicName, 1)
-                .addRacks()
                 .build())
             .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
                 .withMember(new ConsumerGroupMember.Builder(memberId1)
@@ -2516,37 +2720,18 @@ public class GroupMetadataManagerTest {
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
                     .setAssignedPartitions(mkAssignment(
-                        mkTopicAssignment(fooTopicId, 0, 1, 2),
-                        mkTopicAssignment(barTopicId, 0, 1)))
-                    .build())
-                .withMember(new ConsumerGroupMember.Builder(memberId2)
-                    .setInstanceId(memberId2)
-                    .setMemberEpoch(10)
-                    .setPreviousMemberEpoch(9)
-                    .setTargetMemberEpoch(10)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
-                    // Use zar only here to ensure that metadata needs to be recomputed.
-                    .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
-                    .setServerAssignorName("range")
-                    .setAssignedPartitions(mkAssignment(
-                        mkTopicAssignment(fooTopicId, 3, 4, 5),
-                        mkTopicAssignment(barTopicId, 2)))
+                        mkTopicAssignment(fooTopicId, 0, 1, 2)))
                     .build())
                 .withAssignment(memberId1, mkAssignment(
-                    mkTopicAssignment(fooTopicId, 0, 1, 2),
-                    mkTopicAssignment(barTopicId, 0, 1)))
-                .withAssignment(memberId2, mkAssignment(
-                    mkTopicAssignment(fooTopicId, 3, 4, 5),
-                    mkTopicAssignment(barTopicId, 2)))
+                    mkTopicAssignment(fooTopicId, 0, 1, 2)))
                 .withAssignmentEpoch(10))
             .build();
 
         assertThrows(FencedInstanceIdException.class, () -> context.consumerGroupHeartbeat(
             new ConsumerGroupHeartbeatRequestData()
                 .setGroupId(groupId)
-                .setMemberId("unknown-" + memberId2)
-                .setInstanceId(memberId2)
+                .setMemberId("unknown-" + memberId1)
+                .setInstanceId(memberId1)
                 .setMemberEpoch(-2)
                 .setRebalanceTimeoutMs(5000)
                 .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
@@ -2555,18 +2740,12 @@ public class GroupMetadataManagerTest {
 
     @Test
     public void testShouldThrowInvalidRequestExceptionWhenInstanceIdIsNullForStaticMember() {
-
         String groupId = "fooup";
         // Use a static member id as it makes the test easier.
         String memberId1 = Uuid.randomUuid().toString();
-        String memberId2 = Uuid.randomUuid().toString();
 
         Uuid fooTopicId = Uuid.randomUuid();
         String fooTopicName = "foo";
-        Uuid barTopicId = Uuid.randomUuid();
-        String barTopicName = "bar";
-        Uuid zarTopicId = Uuid.randomUuid();
-        String zarTopicName = "zar";
 
         MockPartitionAssignor assignor = new MockPartitionAssignor("range");
 
@@ -2574,9 +2753,6 @@ public class GroupMetadataManagerTest {
             .withAssignors(Collections.singletonList(assignor))
             .withMetadataImage(new MetadataImageBuilder()
                 .addTopic(fooTopicId, fooTopicName, 6)
-                .addTopic(barTopicId, barTopicName, 3)
-                .addTopic(zarTopicId, zarTopicName, 1)
-                .addRacks()
                 .build())
             .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
                 .withMember(new ConsumerGroupMember.Builder(memberId1)
@@ -2589,37 +2765,17 @@ public class GroupMetadataManagerTest {
                     .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                     .setServerAssignorName("range")
                     .setAssignedPartitions(mkAssignment(
-                            mkTopicAssignment(fooTopicId, 0, 1, 2),
-                            mkTopicAssignment(barTopicId, 0, 1)))
-                    .build())
-                .withMember(new ConsumerGroupMember.Builder(memberId2)
-                    .setInstanceId(memberId2)
-                    .setMemberEpoch(10)
-                    .setPreviousMemberEpoch(9)
-                    .setTargetMemberEpoch(10)
-                    .setClientId("client")
-                    .setClientHost("localhost/127.0.0.1")
-                    // Use zar only here to ensure that metadata needs to be recomputed.
-                    .setSubscribedTopicNames(Arrays.asList("foo", "bar", "zar"))
-                    .setServerAssignorName("range")
-                    .setAssignedPartitions(mkAssignment(
-                            mkTopicAssignment(fooTopicId, 3, 4, 5),
-                            mkTopicAssignment(barTopicId, 2)))
+                            mkTopicAssignment(fooTopicId, 0, 1, 2)))
                     .build())
                 .withAssignment(memberId1, mkAssignment(
-                    mkTopicAssignment(fooTopicId, 0, 1, 2),
-                    mkTopicAssignment(barTopicId, 0, 1)))
-                .withAssignment(memberId2, mkAssignment(
-                    mkTopicAssignment(fooTopicId, 3, 4, 5),
-                    mkTopicAssignment(barTopicId, 2)))
+                    mkTopicAssignment(fooTopicId, 0, 1, 2)))
                 .withAssignmentEpoch(10))
             .build();
-
 
         assertThrows(InvalidRequestException.class, () -> context.consumerGroupHeartbeat(
             new ConsumerGroupHeartbeatRequestData()
                 .setGroupId(groupId)
-                .setMemberId(memberId2)
+                .setMemberId(memberId1)
                 .setMemberEpoch(-2)
                 .setRebalanceTimeoutMs(5000)
                 .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
@@ -4011,6 +4167,87 @@ public class GroupMetadataManagerTest {
         context.assertSessionTimeout(groupId, memberId, 45000);
 
         // Advance time past the session timeout.
+        List<ExpiredTimeout<Void, Record>> timeouts = context.sleep(45000 + 1);
+
+        // Verify the expired timeout.
+        assertEquals(
+            Collections.singletonList(new ExpiredTimeout<Void, Record>(
+                consumerGroupSessionTimeoutKey(groupId, memberId),
+                new CoordinatorResult<>(
+                    Arrays.asList(
+                        RecordHelpers.newCurrentAssignmentTombstoneRecord(groupId, memberId),
+                        RecordHelpers.newTargetAssignmentTombstoneRecord(groupId, memberId),
+                        RecordHelpers.newMemberSubscriptionTombstoneRecord(groupId, memberId),
+                        RecordHelpers.newGroupSubscriptionMetadataRecord(groupId, Collections.emptyMap()),
+                        RecordHelpers.newGroupEpochRecord(groupId, 2)
+                    )
+                )
+            )),
+            timeouts
+        );
+
+        // Verify that there are no timers.
+        context.assertNoSessionTimeout(groupId, memberId);
+        context.assertNoRevocationTimeout(groupId, memberId);
+    }
+
+    @Test
+    public void testSessionTimeoutExpirationStaticMember() {
+        String groupId = "fooup";
+        // Use a static member id as it makes the test easier.
+        String memberId = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withAssignors(Collections.singletonList(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 6)
+                .addRacks()
+                .build())
+            .build();
+
+        assignor.prepareGroupAssignment(new GroupAssignment(
+            Collections.singletonMap(memberId, new MemberAssignment(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5)
+            )))
+        ));
+
+        // Session timer is scheduled on first heartbeat.
+        CoordinatorResult<ConsumerGroupHeartbeatResponseData, Record> result =
+            context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId)
+                    .setInstanceId(memberId)
+                    .setMemberEpoch(0)
+                    .setRebalanceTimeoutMs(90000)
+                    .setSubscribedTopicNames(Collections.singletonList("foo"))
+                    .setTopicPartitions(Collections.emptyList()));
+        assertEquals(1, result.response().memberEpoch());
+
+        // Verify that there is a session time.
+        context.assertSessionTimeout(groupId, memberId, 45000);
+
+        // Static member sends a temporary leave group request
+        result = context.consumerGroupHeartbeat(
+                new ConsumerGroupHeartbeatRequestData()
+                    .setGroupId(groupId)
+                    .setMemberId(memberId)
+                    .setInstanceId(memberId)
+                    .setMemberEpoch(-2)
+                    .setRebalanceTimeoutMs(90000)
+                    .setSubscribedTopicNames(Collections.singletonList("foo"))
+                    .setTopicPartitions(Collections.emptyList()));
+
+        assertEquals(-2, result.response().memberEpoch());
+
+        // Verify that there is still a session time.
+        context.assertSessionTimeout(groupId, memberId, 45000);
+
+        // Advance time past the session timeout. No static member joined back as a replacement
         List<ExpiredTimeout<Void, Record>> timeouts = context.sleep(45000 + 1);
 
         // Verify the expired timeout.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
@@ -46,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ConsumerGroupTest {
 
@@ -88,6 +89,34 @@ public class ConsumerGroupTest {
     }
 
     @Test
+    public void testNoStaticMember() {
+        ConsumerGroup consumerGroup = createConsumerGroup("foo");
+
+        // Create a new member which is not static
+        consumerGroup.getOrMaybeCreateMember("member", true);
+        assertNull(consumerGroup.staticMember("instance-id"));
+    }
+
+    @Test
+    public void testGetStaticMemberByInstanceId() {
+        ConsumerGroup consumerGroup = createConsumerGroup("foo");
+        ConsumerGroupMember member;
+
+        member = consumerGroup.getOrMaybeCreateMember("member", true);
+
+        member = new ConsumerGroupMember.Builder(member)
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setInstanceId("instance")
+            .build();
+
+        consumerGroup.updateMember(member);
+
+        assertEquals(member, consumerGroup.staticMember("instance"));
+        assertEquals(member, consumerGroup.getOrMaybeCreateMember("member", false));
+        assertEquals(member.memberId(), consumerGroup.staticMemberId("instance"));
+    }
+
+    @Test
     public void testRemoveMember() {
         ConsumerGroup consumerGroup = createConsumerGroup("foo");
 
@@ -96,6 +125,28 @@ public class ConsumerGroupTest {
 
         consumerGroup.removeMember("member");
         assertFalse(consumerGroup.hasMember("member"));
+
+    }
+
+    @Test
+    public void testRemoveStaticMember() {
+        ConsumerGroup consumerGroup = createConsumerGroup("foo");
+
+        ConsumerGroupMember member;
+        member = consumerGroup.getOrMaybeCreateMember("member", true);
+        assertTrue(consumerGroup.hasMember("member"));
+
+        member = new ConsumerGroupMember.Builder(member)
+            .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
+            .setInstanceId("instance")
+            .build();
+
+        consumerGroup.updateMember(member);
+
+        consumerGroup.removeMember("member");
+        assertFalse(consumerGroup.hasMember("member"));
+        assertNull(consumerGroup.staticMember("instance"));
+        assertNull(consumerGroup.staticMemberId("instance"));
 
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
@@ -147,7 +147,6 @@ public class ConsumerGroupTest {
         assertFalse(consumerGroup.hasMember("member"));
         assertNull(consumerGroup.staticMember("instance"));
         assertNull(consumerGroup.staticMemberId("instance"));
-
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
@@ -753,7 +753,7 @@ public class TargetAssignmentBuilderTest {
         context.removeMemberSubscription("member-3", "member-3");
 
         // Another static member joins with the same instance id as the departed one
-        context.addGroupMember("member-3-a", "member-3", Arrays.asList("foo", "bar", "zar"), new HashMap<>());
+        context.updateMemberSubscription("member-3-a", Arrays.asList("foo", "bar", "zar"), Optional.of("member-3"), Optional.empty());
 
         context.prepareMemberAssignment("member-1", mkAssignment(
             mkTopicAssignment(fooTopicId, 1, 2),


### PR DESCRIPTION
This is the first PR which aims at adding static membership to the new consumer group protocol. It aims at a static member joining, re-joining and leaving a consumer group using the new ConsumerGroupHeartbeat API in group coordinator. Note that the rejoining case is within the session timeout and kicking out a static member if no static member joins within session timeout is not part of this PR.