### PR TITLE
KAFKA-15485: Support building with Java 21 (3/3)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,10 +156,10 @@ pipeline {
           }
         }
 
-        stage('JDK 20 and Scala 2.13') {
+        stage('JDK 21 and Scala 2.13') {
           agent { label 'ubuntu' }
           tools {
-            jdk 'jdk_20_latest'
+            jdk 'jdk_21_latest'
           }
           options {
             timeout(time: 8, unit: 'HOURS')
@@ -171,7 +171,7 @@ pipeline {
           steps {
             doValidation()
             doTest(env)
-            echo 'Skipping Kafka Streams archetype test for Java 20'
+            echo 'Skipping Kafka Streams archetype test for Java 21'
           }
         }
       }

--- a/build.gradle
+++ b/build.gradle
@@ -232,7 +232,10 @@ subprojects {
 
   apply plugin: 'java-library'
   apply plugin: 'checkstyle'
-  apply plugin: "com.github.spotbugs"
+
+  // spotbugs doesn't support Java 21 yet
+  if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21))
+    apply plugin: "com.github.spotbugs"
 
   // We use the shadow plugin for the jmh-benchmarks module and the `-all` jar can get pretty large, so
   // don't publish it
@@ -702,12 +705,15 @@ subprojects {
 
   test.dependsOn('checkstyleMain', 'checkstyleTest')
 
-  spotbugs {
-    toolVersion = versions.spotbugs
-    excludeFilter = file("$rootDir/gradle/spotbugs-exclude.xml")
-    ignoreFailures = false
+  // spotbugs doesn't support Java 21 yet
+  if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
+    spotbugs {
+      toolVersion = versions.spotbugs
+      excludeFilter = file("$rootDir/gradle/spotbugs-exclude.xml")
+      ignoreFailures = false
+    }
+    test.dependsOn('spotbugsMain')
   }
-  test.dependsOn('spotbugsMain')
 
   tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
     reports {

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -195,7 +195,7 @@ public class SslTransportLayerTest {
      */
     @ParameterizedTest
     @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
-    @DisabledOnJre(value = JRE.JAVA_20, disabledReason = "KAFKA-15117")
+    @DisabledOnJre(value = {JRE.JAVA_20, JRE.JAVA_21}, disabledReason = "KAFKA-15117")
     public void testValidEndpointIdentificationCN(Args args) throws Exception {
         args.serverCertStores = certBuilder(true, "localhost", args.useInlinePem).build();
         args.clientCertStores = certBuilder(false, "localhost", args.useInlinePem).build();


### PR DESCRIPTION
* Update CI to build with Java 21 instead of Java 20
* Disable spotbugs when building with Java 21 as it doesn't support it yet (filed KAFKA-15492 for addressing this)
* Disable SslTransportLayerTest.testValidEndpointIdentificationCN with Java 21 (same as Java 20)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
