### PR TITLE
MINOR: Logging fix in StreamsPartitionAssignor

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -640,7 +640,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         log.info("Assigning stateful tasks: {}\n"
                      + "and stateless tasks: {}",
                  statefulTasks,
-                 allTasks.stream().filter(t -> !statefulTasks.contains(t)));
+                 allTasks.stream().filter(t -> !statefulTasks.contains(t)).collect(Collectors.toSet()));
         log.debug("Assigning tasks and {} standby replicas to client nodes {}",
                   numStandbyReplicas(), clientStates);
 


### PR DESCRIPTION
Seeing `'Assigning stateful tasks: [0_0]
and stateless tasks: java.util.stream.ReferencePipeline$2@4b0f4416 (org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor:640)'` in the logs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
