### PR TITLE
[KAFKA-15117] In TestSslUtils set SubjectAlternativeNames to null if there are no hostnames

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -36,8 +36,6 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.condition.DisabledOnJre;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -195,7 +193,6 @@ public class SslTransportLayerTest {
      */
     @ParameterizedTest
     @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
-    @DisabledOnJre(value = JRE.JAVA_20, disabledReason = "KAFKA-15117")
     public void testValidEndpointIdentificationCN(Args args) throws Exception {
         args.serverCertStores = certBuilder(true, "localhost", args.useInlinePem).build();
         args.clientCertStores = certBuilder(false, "localhost", args.useInlinePem).build();

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -404,6 +404,8 @@ public class TestSslUtils {
                 for (int i = 0; i < hostNames.length; i++)
                     altNames[i] = new GeneralName(GeneralName.dNSName, hostNames[i]);
                 subjectAltName = GeneralNames.getInstance(new DERSequence(altNames)).getEncoded();
+            } else {
+                subjectAltName = null;
             }
             return this;
         }

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -399,10 +399,12 @@ public class TestSslUtils {
         }
 
         public CertificateBuilder sanDnsNames(String... hostNames) throws IOException {
-            GeneralName[] altNames = new GeneralName[hostNames.length];
-            for (int i = 0; i < hostNames.length; i++)
-                altNames[i] = new GeneralName(GeneralName.dNSName, hostNames[i]);
-            subjectAltName = GeneralNames.getInstance(new DERSequence(altNames)).getEncoded();
+            if (hostNames.length > 0) {
+                GeneralName[] altNames = new GeneralName[hostNames.length];
+                for (int i = 0; i < hostNames.length; i++)
+                    altNames[i] = new GeneralName(GeneralName.dNSName, hostNames[i]);
+                subjectAltName = GeneralNames.getInstance(new DERSequence(altNames)).getEncoded();
+            }
             return this;
         }
 


### PR DESCRIPTION
We are currently encoding an empty hostNames array to `subjectAltName` in the keystore. While parsing the certificates in the test this causes the issue - `Unparseable SubjectAlternativeName extension due to
java.io.IOException: No data available in passed DER encoded value`.
Up to Java 17, this parsing error was ignored. This PR assigns `subjectAltName` to `null` if hostnames are empty.
