### PR TITLE
KIP-759: new DSL operation on KStreams interface

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -686,6 +686,47 @@ public interface KStream<K, V> {
                                       final Named named);
 
     /**
+     * Marking the {@code KStream} as partitioned signals the stream is partitioned as intended,
+     * and does not require further repartitioning in downstream key changing operations.
+     *
+     * <p><em>
+     *     Note that {@link KStream#markAsPartitioned()} SHOULD NOT be used with interactive query(IQ) or {@link KStream#join}.
+     *     For reasons that when repartitions happen, records are physically shuffled by a composite key defined in the stateful operation.
+     *     However, if the repartitions were cancelled, records stayed in their original partition by its original key. IQ or joins
+     *     assumes and uses the composite key instead of the original key.
+     * </p></em>
+     *
+     *
+     * This method will overwrite a default behavior as described below.
+     * <p>
+     *     By default, Kafka Streams always automatically repartition the records to prepare for a stateful operation,
+     *     however, it is not always required when input stream is partitioned as intended. As an example,
+     *     if a input stream is partitioned by a String key1, calling the below function will trigger a repartition:
+     *     <pre>{@code
+     *     KStream<String, String> inputStream = builder.stream("topic");
+     *     stream
+     *       .selectKey( ... => (key1, metric))
+     *       .groupByKey()
+     *       .aggregate()
+     *     }</pre>
+     * </p>
+     *
+     * <p>
+     *     You can then overwrite the default behavior by calling this method:
+     *     <pre>{@code
+     *     stream
+     *       .selectKey( ... => (key1, metric))
+     *       .markAsPartitioned()
+     *       .groupByKey()
+     *       .aggregate()
+     *     }</pre>
+     * </p>
+     *
+     * @return a new {@code KStream} instance that will not repartition in subsequent operations: {@link KStream#selectKey(KeyValueMapper)}, {@link KStream#map(KeyValueMapper)}, {@link KStream#flatTransform(TransformerSupplier, String...)}.
+     */
+    KStream<K, V> markAsPartitioned();
+
+    /**
      * Print the records of this KStream using the options provided by {@link Printed}
      * Note that this is mainly for debugging/testing purposes, and it will try to flush on each record print.
      * It <em>SHOULD NOT</em> be used for production usage if performance requirements are concerned.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -48,6 +48,7 @@ import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
 import org.apache.kafka.streams.kstream.internals.graph.BaseRepartitionNode;
 import org.apache.kafka.streams.kstream.internals.graph.BaseRepartitionNode.BaseRepartitionNodeBuilder;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.PartitionPreservingNode;
 import org.apache.kafka.streams.kstream.internals.graph.OptimizableRepartitionNode;
 import org.apache.kafka.streams.kstream.internals.graph.OptimizableRepartitionNode.OptimizableRepartitionNodeBuilder;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorGraphNode;
@@ -74,6 +75,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+
 import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.RocksDBTimeOrderedKeyValueBuffer;
 
@@ -138,6 +140,8 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     private static final String TO_KTABLE_NAME = "KSTREAM-TOTABLE-";
 
     private static final String REPARTITION_NAME = "KSTREAM-REPARTITION-";
+
+    private static final String PARTITION_PRESERVE_NAME = "KSTREAM-PARTITION-PRESERVE";
 
     private final boolean repartitionRequired;
 
@@ -222,21 +226,21 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                          final Named named) {
         Objects.requireNonNull(mapper, "mapper can't be null");
         Objects.requireNonNull(named, "named can't be null");
-
+        final boolean repartitionRequired = !(graphNode instanceof PartitionPreservingNode);
         final ProcessorGraphNode<K, V> selectKeyProcessorNode = internalSelectKey(mapper, new NamedInternal(named));
-        selectKeyProcessorNode.keyChangingOperation(true);
+        selectKeyProcessorNode.keyChangingOperation(repartitionRequired);
 
         builder.addGraphNode(graphNode, selectKeyProcessorNode);
 
         // key serde cannot be preserved
         return new KStreamImpl<>(
-            selectKeyProcessorNode.nodeName(),
-            null,
-            valueSerde,
-            subTopologySourceNodes,
-            true,
-            selectKeyProcessorNode,
-            builder);
+                selectKeyProcessorNode.nodeName(),
+                null,
+                valueSerde,
+                subTopologySourceNodes,
+                repartitionRequired,
+                selectKeyProcessorNode,
+                builder);
     }
 
     private <KR> ProcessorGraphNode<K, V> internalSelectKey(final KeyValueMapper<? super K, ? super V, ? extends KR> mapper,
@@ -262,22 +266,23 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
         final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, MAP_NAME);
         final ProcessorParameters<? super K, ? super V, ?, ?> processorParameters =
-            new ProcessorParameters<>(new KStreamMap<>(mapper), name);
+                new ProcessorParameters<>(new KStreamMap<>(mapper), name);
         final ProcessorGraphNode<? super K, ? super V> mapProcessorNode =
-            new ProcessorGraphNode<>(name, processorParameters);
-        mapProcessorNode.keyChangingOperation(true);
+                new ProcessorGraphNode<>(name, processorParameters);
+        final boolean repartitionRequired = !(graphNode instanceof PartitionPreservingNode);
+        mapProcessorNode.keyChangingOperation(repartitionRequired);
 
         builder.addGraphNode(graphNode, mapProcessorNode);
 
         // key and value serde cannot be preserved
         return new KStreamImpl<>(
-            name,
-            null,
-            null,
-            subTopologySourceNodes,
-            true,
-            mapProcessorNode,
-            builder);
+                name,
+                null,
+                null,
+                subTopologySourceNodes,
+                repartitionRequired,
+                mapProcessorNode,
+                builder);
     }
 
     @Override
@@ -333,17 +338,18 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         Objects.requireNonNull(mapper, "mapper can't be null");
         Objects.requireNonNull(named, "named can't be null");
 
+        final boolean repartitionRequired = !(graphNode instanceof PartitionPreservingNode);
         final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, FLATMAP_NAME);
         final ProcessorParameters<? super K, ? super V, ?, ?> processorParameters =
-            new ProcessorParameters<>(new KStreamFlatMap<>(mapper), name);
+                new ProcessorParameters<>(new KStreamFlatMap<>(mapper), name);
         final ProcessorGraphNode<? super K, ? super V> flatMapNode =
-            new ProcessorGraphNode<>(name, processorParameters);
-        flatMapNode.keyChangingOperation(true);
+                new ProcessorGraphNode<>(name, processorParameters);
+        flatMapNode.keyChangingOperation(repartitionRequired);
 
         builder.addGraphNode(graphNode, flatMapNode);
 
         // key and value serde cannot be preserved
-        return new KStreamImpl<>(name, null, null, subTopologySourceNodes, true, flatMapNode, builder);
+        return new KStreamImpl<>(name, null, null, subTopologySourceNodes, repartitionRequired, flatMapNode, builder);
     }
 
     @Override
@@ -725,14 +731,14 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final String name = namedInternal.orElseGenerateWithPrefix(builder, TO_KTABLE_NAME);
 
         final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materializedInternal =
-            new MaterializedInternal<>(materialized, builder, TO_KTABLE_NAME);
+                new MaterializedInternal<>(materialized, builder, TO_KTABLE_NAME);
 
         final Serde<K> keySerdeOverride = materializedInternal.keySerde() == null
-            ? keySerde
-            : materializedInternal.keySerde();
+                ? keySerde
+                : materializedInternal.keySerde();
         final Serde<V> valueSerdeOverride = materializedInternal.valueSerde() == null
-            ? valueSerde
-            : materializedInternal.valueSerde();
+                ? valueSerde
+                : materializedInternal.valueSerde();
 
         final Set<String> subTopologySourceNodes;
         final GraphNode tableParentNode;
@@ -740,12 +746,12 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         if (repartitionRequired) {
             final OptimizableRepartitionNodeBuilder<K, V> repartitionNodeBuilder = optimizableRepartitionNodeBuilder();
             final String sourceName = createRepartitionedSource(
-                builder,
-                keySerdeOverride,
-                valueSerdeOverride,
-                name,
-                null,
-                repartitionNodeBuilder
+                    builder,
+                    keySerdeOverride,
+                    valueSerdeOverride,
+                    name,
+                    null,
+                    repartitionNodeBuilder
             );
 
             tableParentNode = repartitionNodeBuilder.build();
@@ -757,28 +763,28 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         }
 
         final KTableSource<K, V> tableSource = new KTableSource<>(
-            materializedInternal.storeName(),
-            materializedInternal.queryableStoreName()
+                materializedInternal.storeName(),
+                materializedInternal.queryableStoreName()
         );
         final ProcessorParameters<K, V, ?, ?> processorParameters = new ProcessorParameters<>(tableSource, name);
         final GraphNode tableNode = new StreamToTableNode<>(
-            name,
-            processorParameters,
-            materializedInternal
+                name,
+                processorParameters,
+                materializedInternal
         );
         tableNode.setOutputVersioned(materializedInternal.storeSupplier() instanceof VersionedBytesStoreSupplier);
 
         builder.addGraphNode(tableParentNode, tableNode);
 
         return new KTableImpl<K, V, V>(
-            name,
-            keySerdeOverride,
-            valueSerdeOverride,
-            subTopologySourceNodes,
-            materializedInternal.queryableStoreName(),
-            tableSource,
-            tableNode,
-            builder
+                name,
+                keySerdeOverride,
+                valueSerdeOverride,
+                subTopologySourceNodes,
+                materializedInternal.queryableStoreName(),
+                tableSource,
+                tableNode,
+                builder
         );
     }
 
@@ -793,19 +799,20 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         Objects.requireNonNull(keySelector, "keySelector can't be null");
         Objects.requireNonNull(grouped, "grouped can't be null");
 
+        final boolean repartitionRequired = !(graphNode instanceof PartitionPreservingNode);
         final GroupedInternal<KR, V> groupedInternal = new GroupedInternal<>(grouped);
         final ProcessorGraphNode<K, V> selectKeyMapNode = internalSelectKey(keySelector, new NamedInternal(groupedInternal.name()));
-        selectKeyMapNode.keyChangingOperation(true);
+        selectKeyMapNode.keyChangingOperation(repartitionRequired);
 
         builder.addGraphNode(graphNode, selectKeyMapNode);
 
         return new KGroupedStreamImpl<>(
-            selectKeyMapNode.nodeName(),
-            subTopologySourceNodes,
-            groupedInternal,
-            true,
-            selectKeyMapNode,
-            builder);
+                selectKeyMapNode.nodeName(),
+                subTopologySourceNodes,
+                groupedInternal,
+                repartitionRequired,
+                selectKeyMapNode,
+                builder);
     }
 
     @Override
@@ -984,7 +991,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final Serde<K> repartitionKeySerde = keySerdeOverride != null ? keySerdeOverride : keySerde;
         final Serde<V> repartitionValueSerde = valueSerdeOverride != null ? valueSerdeOverride : valueSerde;
         final OptimizableRepartitionNodeBuilder<K, V> optimizableRepartitionNodeBuilder =
-            OptimizableRepartitionNode.optimizableRepartitionNodeBuilder();
+                OptimizableRepartitionNode.optimizableRepartitionNodeBuilder();
         // we still need to create the repartitioned source each time
         // as it increments the counter which
         // is needed to maintain topology compatibility
@@ -1338,25 +1345,25 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         for (final String stateStoreName : stateStoreNames) {
             Objects.requireNonNull(stateStoreName, "stateStoreNames can't contain `null` as store name");
         }
-
+        final boolean repartitionRequired = !(graphNode instanceof PartitionPreservingNode);
         final String name = new NamedInternal(named).name();
         final StatefulProcessorNode<? super K, ? super V> transformNode = new StatefulProcessorNode<>(
-            name,
-            new ProcessorParameters<>(new KStreamFlatTransform<>(transformerSupplier), name),
-            stateStoreNames);
-        transformNode.keyChangingOperation(true);
+                name,
+                new ProcessorParameters<>(new KStreamFlatTransform<>(transformerSupplier), name),
+                stateStoreNames);
+        transformNode.keyChangingOperation(repartitionRequired);
 
         builder.addGraphNode(graphNode, transformNode);
 
         // cannot inherit key and value serde
         return new KStreamImpl<>(
-            name,
-            null,
-            null,
-            subTopologySourceNodes,
-            true,
-            transformNode,
-            builder);
+                name,
+                null,
+                null,
+                subTopologySourceNodes,
+                repartitionRequired,
+                transformNode,
+                builder);
     }
 
     @Override
@@ -1436,9 +1443,9 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                                    final String... stateStoreNames) {
         Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
         return doFlatTransformValues(
-            toValueTransformerWithKeySupplier(valueTransformerSupplier),
-            NamedInternal.empty(),
-            stateStoreNames);
+                toValueTransformerWithKeySupplier(valueTransformerSupplier),
+                NamedInternal.empty(),
+                stateStoreNames);
     }
 
     @Override
@@ -1448,9 +1455,9 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                                    final String... stateStoreNames) {
         Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
         return doFlatTransformValues(
-            toValueTransformerWithKeySupplier(valueTransformerSupplier),
-            named,
-            stateStoreNames);
+                toValueTransformerWithKeySupplier(valueTransformerSupplier),
+                named,
+                stateStoreNames);
     }
 
     @Override
@@ -1481,22 +1488,22 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
         final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, TRANSFORMVALUES_NAME);
         final StatefulProcessorNode<? super K, ? super V> transformNode = new StatefulProcessorNode<>(
-            name,
-            new ProcessorParameters<>(new KStreamFlatTransformValues<>(valueTransformerWithKeySupplier), name),
-            stateStoreNames);
+                name,
+                new ProcessorParameters<>(new KStreamFlatTransformValues<>(valueTransformerWithKeySupplier), name),
+                stateStoreNames);
         transformNode.setValueChangingOperation(true);
 
         builder.addGraphNode(graphNode, transformNode);
 
         // cannot inherit value serde
         return new KStreamImpl<>(
-            name,
-            keySerde,
-            null,
-            subTopologySourceNodes,
-            repartitionRequired,
-            transformNode,
-            builder);
+                name,
+                keySerde,
+                null,
+                subTopologySourceNodes,
+                repartitionRequired,
+                transformNode,
+                builder);
     }
 
     @Override
@@ -1564,13 +1571,13 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
         // cannot inherit key and value serde
         return new KStreamImpl<>(
-            name,
-            null,
-            null,
-            subTopologySourceNodes,
-            true,
-            processNode,
-            builder);
+                name,
+                null,
+                null,
+                subTopologySourceNodes,
+                !(graphNode instanceof PartitionPreservingNode),
+                processNode,
+                builder);
     }
 
     @Override
@@ -1615,5 +1622,26 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             repartitionRequired,
             processNode,
             builder);
+    }
+
+    @Override
+    public KStream<K, V> markAsPartitioned() {
+        final ProcessorParameters<? super K, ? super V, ?, ?> processorParameters =
+                new ProcessorParameters<>(new PassThrough<>(), PARTITION_PRESERVE_NAME + name);
+
+        final PartitionPreservingNode<? super K, ? super V> partitionPreservingNode = new PartitionPreservingNode<>(
+                processorParameters,
+                PARTITION_PRESERVE_NAME + name);
+
+        builder.addGraphNode(graphNode, partitionPreservingNode);
+        return new KStreamImpl<>(
+                partitionPreservingNode.nodeName(),
+                keySerde,
+                valueSerde,
+                subTopologySourceNodes,
+                false,
+                partitionPreservingNode,
+                builder
+        );
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/PartitionPreservingNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/PartitionPreservingNode.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream.internals.graph;
+
+/**
+ * Inform downstream operations to preserve the partition, i.e. does not trigger repartition.
+ */
+public class PartitionPreservingNode<K, V> extends ProcessorGraphNode<K, V> {
+
+    private String nodeName;
+
+    public PartitionPreservingNode(final ProcessorParameters<K, V, ?, ?> processorParameters, final String nodeName) {
+        super(processorParameters);
+        this.nodeName = nodeName;
+    }
+
+    @Override
+    public boolean isKeyChangingOperation() {
+        return false;
+    }
+
+    @Override
+    public void keyChangingOperation(final boolean keyChangingOperation) {
+        // can not change this to a key changing operation
+        if (keyChangingOperation) {
+            throw new IllegalArgumentException("Cannot set a PartitionPreservingNode to key changing");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "PartitionPreservingNode{" +
+                "nodeName='" + nodeName + '}';
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
@@ -450,6 +450,85 @@ public class KStreamRepartitionIntegrationTest {
     }
 
     @Test
+    public void shouldNotRepartitionWithMarkAsPartitionedFollowingSelectKey() throws Exception {
+        final long timestamp = System.currentTimeMillis();
+
+        sendEvents(
+                timestamp,
+                Arrays.asList(
+                        new KeyValue<>(1, "10"),
+                        new KeyValue<>(2, "20")
+                )
+        );
+
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        builder.stream(inputTopic, Consumed.with(Serdes.Integer(), Serdes.String()))
+                .selectKey((key, value) -> Integer.valueOf(value))
+                .markAsPartitioned()
+                .groupByKey()
+                .count()
+                .toStream()
+                .to(outputTopic);
+
+
+        startStreams(builder);
+
+        validateReceivedMessages(
+                new IntegerDeserializer(),
+                new LongDeserializer(),
+                Arrays.asList(
+                        new KeyValue<>(10, 1L),
+                        new KeyValue<>(20, 1L)
+                )
+        );
+
+        final String topology = builder.build().describe().toString();
+
+        assertEquals(0, countOccurrencesInTopology(topology, "Sink: .*-repartition.*"));
+    }
+
+    @Test
+    public void shouldNotRepartitionWithMarkAsPartitionedFollowingMap() throws Exception {
+        final String topicBMapperName = "topic-b-mapper";
+        final long timestamp = System.currentTimeMillis();
+
+        sendEvents(
+                timestamp,
+                Arrays.asList(
+                        new KeyValue<>(1, "10"),
+                        new KeyValue<>(2, "20")
+                )
+        );
+
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        builder.stream(inputTopic, Consumed.with(Serdes.Integer(), Serdes.String()))
+                .map(KeyValue::new, Named.as(topicBMapperName))
+                .markAsPartitioned()
+                .groupByKey()
+                .count()
+                .toStream()
+                .to(outputTopic);
+
+
+        startStreams(builder);
+
+        validateReceivedMessages(
+                new IntegerDeserializer(),
+                new LongDeserializer(),
+                Arrays.asList(
+                        new KeyValue<>(1, 1L),
+                        new KeyValue<>(2, 1L)
+                )
+        );
+
+        final String topology = builder.build().describe().toString();
+
+        assertEquals(0, countOccurrencesInTopology(topology, "Sink: .*-repartition.*"));
+    }
+
+    @Test
     public void shouldCreateRepartitionTopicIfKeyChangingOperationWasNotPerformed() throws Exception {
         final String repartitionName = "dummy";
         final long timestamp = System.currentTimeMillis();


### PR DESCRIPTION
Implement the KStreams DSL operation proposed in [KIP-759](https://cwiki.apache.org/confluence/display/KAFKA/KIP-759%3A+Unneeded+repartition+canceling), which was voted and approved. 

Create PartitionPreservingNode to signal downstream processing nodes to skip repartition work as indicated by the user. Same as mentioned in the KIP that the DSL should not be used with joins, or IQ, and nor is it applicable to KTable. 

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
