### PR TITLE
MINOR: Upgrade version of zstd-jni to the latest stable version 1.5.5-6

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -318,7 +318,7 @@ pcollections-4.0.1, see: licenses/pcollections-MIT
 ---------------------------------------
 BSD 2-Clause
 
-zstd-jni-1.5.5-1 see: licenses/zstd-jni-BSD-2-clause
+zstd-jni-1.5.5-5 see: licenses/zstd-jni-BSD-2-clause
 
 ---------------------------------------
 BSD 3-Clause

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -318,7 +318,7 @@ pcollections-4.0.1, see: licenses/pcollections-MIT
 ---------------------------------------
 BSD 2-Clause
 
-zstd-jni-1.5.5-5 see: licenses/zstd-jni-BSD-2-clause
+zstd-jni-1.5.5-6 see: licenses/zstd-jni-BSD-2-clause
 
 ---------------------------------------
 BSD 3-Clause

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -163,7 +163,7 @@ versions += [
   swaggerJaxrs2: "2.2.8",
   zinc: "1.9.2",
   zookeeper: "3.8.2",
-  zstd: "1.5.5-1"
+  zstd: "1.5.5-5"
 ]
 
 libs += [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -163,7 +163,7 @@ versions += [
   swaggerJaxrs2: "2.2.8",
   zinc: "1.9.2",
   zookeeper: "3.8.2",
-  zstd: "1.5.5-5"
+  zstd: "1.5.5-6"
 ]
 
 libs += [


### PR DESCRIPTION
Upgrading zstd-jni library to the version 1.5.5-5 can bring much bug fixes, there is no clear release notes on the official repository we can see the changed that are made since the current stable version and how much bugs fixed and improvements made 

For more details about the great job done on the library to bring those enhancements please refer to 
https://github.com/luben/zstd-jni/compare/v1.5.5-1...v.1.5.5-6



### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
