### PR TITLE
KAFKA-15504: Upgrade snappy java to version 1.1.10.4

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -259,7 +259,7 @@ scala-library-2.13.12
 scala-logging_2.13-3.9.4
 scala-reflect-2.13.12
 scala-java8-compat_2.13-1.0.2
-snappy-java-1.1.10.3
+snappy-java-1.1.10.4
 swagger-annotations-2.2.8
 zookeeper-3.8.2
 zookeeper-jute-3.8.2

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -156,7 +156,7 @@ versions += [
   scalaJava8Compat : "1.0.2",
   scoverage: "1.9.3",
   slf4j: "1.7.36",
-  snappy: "1.1.10.3",
+  snappy: "1.1.10.4",
   spotbugs: "4.7.3",
   // New version of Swagger 2.2.14 requires minimum JDK 11.
   swaggerAnnotations: "2.2.8",


### PR DESCRIPTION
The version 1.1.10.4 contains a Fix of [CVE-2023-43642](https://github.com/xerial/snappy-java/security/advisories/GHSA-55g7-9cwv-5qfv)
 
and As mentioned on the release notes of the library https://github.com/xerial/snappy-java/releases/tag/v1.1.10.4  Fixed SnappyInputStream so as not to allocate too large memory when decompressing data with an extremely large chunk size 

and much dependencies updates


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
