### PR TITLE
MINOR: Replace Java 20 with Java 21 in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ See our [web site](https://kafka.apache.org) for details on the project.
 
 You need to have [Java](http://www.oracle.com/technetwork/java/javase/downloads/index.html) installed.
 
-We build and test Apache Kafka with Java 8, 11, 17 and 20. We set the `release` parameter in javac and scalac
+We build and test Apache Kafka with Java 8, 11, 17 and 21. We set the `release` parameter in javac and scalac
 to `8` to ensure the generated binaries are compatible with Java 8 or higher (independently of the Java version
 used for compilation). Java 8 support has been deprecated since Apache Kafka 3.0 and will be removed in Apache
 Kafka 4.0 (see [KIP-750](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181308223) for more details).


### PR DESCRIPTION
I intended to include this in 99e6f12dd099, but somehow missed it.

I will wait for KAFKA-15493 before updating the site docs with Java 21 (we never added Java 20 there).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
