### PR TITLE
KAFKA-15498: bump snappy-java version to 1.1.10.5

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -259,7 +259,7 @@ scala-library-2.13.12
 scala-logging_2.13-3.9.4
 scala-reflect-2.13.12
 scala-java8-compat_2.13-1.0.2
-snappy-java-1.1.10.4
+snappy-java-1.1.10.5
 swagger-annotations-2.2.8
 zookeeper-3.8.2
 zookeeper-jute-3.8.2

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -156,7 +156,7 @@ versions += [
   scalaJava8Compat : "1.0.2",
   scoverage: "1.9.3",
   slf4j: "1.7.36",
-  snappy: "1.1.10.4",
+  snappy: "1.1.10.5",
   spotbugs: "4.7.3",
   // New version of Swagger 2.2.14 requires minimum JDK 11.
   swaggerAnnotations: "2.2.8",


### PR DESCRIPTION
Release notes - https://github.com/xerial/snappy-java/releases/tag/v1.1.10.5 

This release contains adds support for Windows ARM and fixes some dependencies associated with Linux ppc64. The complete list of commits can be found at https://github.com/xerial/snappy-java/compare/v1.1.10.4...v1.1.10.5

