### PR TITLE
MINOR: Fix build failure in genConnectOpenAPIDocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
   id 'java-library'
   id 'org.owasp.dependencycheck' version '8.2.1'
   id 'org.nosphere.apache.rat' version "0.8.1"
-  id "io.swagger.core.v3.swagger-gradle-plugin" version "2.2.16"
+  id "io.swagger.core.v3.swagger-gradle-plugin" version "2.2.8" // keep aligned with the swagger version used in gradle/dependencies.gradle
 
   id "com.github.spotbugs" version '5.1.3' apply false
   id 'org.scoverage' version '7.0.1' apply false


### PR DESCRIPTION
We bumped the `swagger-gradle-plugin` version in https://github.com/apache/kafka/commit/d1ad1d7b7013ea2c24a3f71c485a2a914adf1348

This breaks the `genConnectOpenAPIDocs` task:
```
> Task :connect:runtime:genConnectOpenAPIDocs FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':connect:runtime:genConnectOpenAPIDocs'.
> io.swagger.v3.jaxrs2.integration.SwaggerLoader.setSkipResolveAppPath(java.lang.Boolean)
```

We've had a similar [breakage](https://github.com/apache/kafka/pull/13387) in the past when `swagger-gradle-plugin` and `swaggerAnnotations`/`swaggerJaxrs2` used different versions. 

As far as I can tell `swaggerAnnotations` and `swaggerJaxrs2` are stuck with 2.2.8 as it's the last version that supports Java 8. I get the build working using `swagger-gradle-plugin` 2.2.10 but it's probably safer, at least for now, to keep these versions aligned.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
