### PR TITLE
KAFKA-15527: Add reverseRange and reverseAll query over kv-store in IQv2

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/query/RangeQuery.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/RangeQuery.java
@@ -40,10 +40,12 @@ public final class RangeQuery<K, V> implements Query<KeyValueIterator<K, V>> {
     private final Optional<K> lower;
     private final Optional<K> upper;
 
+    private final boolean isKeyAscending;
 
-    private RangeQuery(final Optional<K> lower, final Optional<K> upper) {
+    private RangeQuery(final Optional<K> lower, final Optional<K> upper, final boolean isKeyAscending) {
         this.lower = lower;
         this.upper = upper;
+        this.isKeyAscending = isKeyAscending;
     }
 
     /**
@@ -54,7 +56,23 @@ public final class RangeQuery<K, V> implements Query<KeyValueIterator<K, V>> {
      * @param <V> The value type
      */
     public static <K, V> RangeQuery<K, V> withRange(final K lower, final K upper) {
-        return new RangeQuery<>(Optional.ofNullable(lower), Optional.ofNullable(upper));
+        return new RangeQuery<>(Optional.ofNullable(lower), Optional.ofNullable(upper), true);
+    }
+
+    /**
+     * Determines if the query keys are in ascending order.
+     * @return true if ascending, false otherwise.
+     */
+    public boolean isKeyAscending() {
+        return isKeyAscending;
+    }
+
+    /**
+     * Set the query to return keys in descending order.
+     * @return a new RangeQuery instance with descending flag set.
+     */
+    public RangeQuery<K, V> withDescendingKeys() {
+        return new RangeQuery<>(this.lower, this.upper, false);
     }
 
     /**
@@ -65,7 +83,7 @@ public final class RangeQuery<K, V> implements Query<KeyValueIterator<K, V>> {
      * @param <V> The value type
      */
     public static <K, V> RangeQuery<K, V> withUpperBound(final K upper) {
-        return new RangeQuery<>(Optional.empty(), Optional.of(upper));
+        return new RangeQuery<>(Optional.empty(), Optional.of(upper), true);
     }
 
     /**
@@ -75,7 +93,7 @@ public final class RangeQuery<K, V> implements Query<KeyValueIterator<K, V>> {
      * @param <V> The value type
      */
     public static <K, V> RangeQuery<K, V> withLowerBound(final K lower) {
-        return new RangeQuery<>(Optional.of(lower), Optional.empty());
+        return new RangeQuery<>(Optional.of(lower), Optional.empty(), true);
     }
 
     /**
@@ -84,7 +102,7 @@ public final class RangeQuery<K, V> implements Query<KeyValueIterator<K, V>> {
      * @param <V> The value type
      */
     public static <K, V> RangeQuery<K, V> withNoBounds() {
-        return new RangeQuery<>(Optional.empty(), Optional.empty());
+        return new RangeQuery<>(Optional.empty(), Optional.empty(), true);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -253,7 +253,8 @@ public class MeteredKeyValueStore<K, V>
 
         final QueryResult<R> result;
         final RangeQuery<K, V> typedQuery = (RangeQuery<K, V>) query;
-        final RangeQuery<Bytes, byte[]> rawRangeQuery;
+        RangeQuery<Bytes, byte[]> rawRangeQuery;
+        final boolean isKeyAscending = typedQuery.isKeyAscending();
         if (typedQuery.getLowerBound().isPresent() && typedQuery.getUpperBound().isPresent()) {
             rawRangeQuery = RangeQuery.withRange(
                 keyBytes(typedQuery.getLowerBound().get()),
@@ -265,6 +266,9 @@ public class MeteredKeyValueStore<K, V>
             rawRangeQuery = RangeQuery.withUpperBound(keyBytes(typedQuery.getUpperBound().get()));
         } else {
             rawRangeQuery = RangeQuery.withNoBounds();
+        }
+        if (!isKeyAscending) {
+            rawRangeQuery = rawRangeQuery.withDescendingKeys();
         }
         final QueryResult<KeyValueIterator<Bytes, byte[]>> rawResult =
             wrapped().query(rawRangeQuery, positionBound, config);
@@ -287,7 +291,6 @@ public class MeteredKeyValueStore<K, V>
         }
         return result;
     }
-
 
     @SuppressWarnings("unchecked")
     protected <R> QueryResult<R> runKeyQuery(final Query<R> query,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
@@ -186,12 +186,17 @@ public final class StoreQueryUtils {
         final RangeQuery<Bytes, byte[]> rangeQuery = (RangeQuery<Bytes, byte[]>) query;
         final Optional<Bytes> lowerRange = rangeQuery.getLowerBound();
         final Optional<Bytes> upperRange = rangeQuery.getUpperBound();
+        final boolean isKeyAscending = rangeQuery.isKeyAscending();
         final KeyValueIterator<Bytes, byte[]> iterator;
         try {
-            if (!lowerRange.isPresent() && !upperRange.isPresent()) {
+            if (!lowerRange.isPresent() && !upperRange.isPresent() && isKeyAscending) {
                 iterator = kvStore.all();
-            } else {
+            } else if (isKeyAscending) {
                 iterator = kvStore.range(lowerRange.orElse(null), upperRange.orElse(null));
+            } else if (!lowerRange.isPresent() && !upperRange.isPresent()) {
+                iterator = kvStore.reverseAll();
+            } else {
+                iterator = kvStore.reverseRange(lowerRange.orElse(null), upperRange.orElse(null));
             }
             final R result = (R) iterator;
             return QueryResult.forResult(result);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -1595,7 +1595,7 @@ public class IQv2StoreIntegrationTest {
         final Optional<Integer> upper,
         final boolean isKeyAscending,
         final Function<V, Integer> valueExtactor,
-        final List<Integer> expectedValue) {
+        final List<Integer> expectedValues) {
 
         RangeQuery<Integer, V> query;
         query = RangeQuery.withRange(lower.orElse(null), upper.orElse(null));
@@ -1614,7 +1614,7 @@ public class IQv2StoreIntegrationTest {
         if (result.getGlobalResult() != null) {
             fail("global tables aren't implemented");
         } else {
-            final List<Integer> actualValue = new ArrayList<>();
+            final List<Integer> actualValues = new ArrayList<>();
             final Map<Integer, QueryResult<KeyValueIterator<Integer, V>>> queryResult = result.getPartitionResults();
             final TreeSet<Integer> partitions = new TreeSet<>(queryResult.keySet());
             for (final int partition : partitions) {
@@ -1635,12 +1635,12 @@ public class IQv2StoreIntegrationTest {
 
                 try (final KeyValueIterator<Integer, V> iterator = queryResult.get(partition).getResult()) {
                     while (iterator.hasNext()) {
-                        actualValue.add(valueExtactor.apply(iterator.next().value));
+                        actualValues.add(valueExtactor.apply(iterator.next().value));
                     }
                 }
                 assertThat(queryResult.get(partition).getExecutionInfo(), is(empty()));
             }
-            assertThat("Result:" + result, actualValue, is(expectedValue));
+            assertThat("Result:" + result, actualValues, is(expectedValues));
             assertThat("Result:" + result, result.getPosition(), is(INPUT_POSITION));
         }
     }
@@ -1650,7 +1650,7 @@ public class IQv2StoreIntegrationTest {
         final Instant timeFrom,
         final Instant timeTo,
         final Function<V, Integer> valueExtactor,
-        final Set<Integer> expectedValue) {
+        final Set<Integer> expectedValues) {
 
         final WindowKeyQuery<Integer, V> query = WindowKeyQuery.withKeyAndWindowStartRange(
             key,
@@ -1670,7 +1670,7 @@ public class IQv2StoreIntegrationTest {
         if (result.getGlobalResult() != null) {
             fail("global tables aren't implemented");
         } else {
-            final Set<Integer> actualValue = new HashSet<>();
+            final Set<Integer> actualValues = new HashSet<>();
             final Map<Integer, QueryResult<WindowStoreIterator<V>>> queryResult = result.getPartitionResults();
             for (final int partition : queryResult.keySet()) {
                 final boolean failure = queryResult.get(partition).isFailure();
@@ -1690,12 +1690,12 @@ public class IQv2StoreIntegrationTest {
 
                 try (final WindowStoreIterator<V> iterator = queryResult.get(partition).getResult()) {
                     while (iterator.hasNext()) {
-                        actualValue.add(valueExtactor.apply(iterator.next().value));
+                        actualValues.add(valueExtactor.apply(iterator.next().value));
                     }
                 }
                 assertThat(queryResult.get(partition).getExecutionInfo(), is(empty()));
             }
-            assertThat("Result:" + result, actualValue, is(expectedValue));
+            assertThat("Result:" + result, actualValues, is(expectedValues));
             assertThat("Result:" + result, result.getPosition(), is(INPUT_POSITION));
         }
     }
@@ -1704,7 +1704,7 @@ public class IQv2StoreIntegrationTest {
         final Instant timeFrom,
         final Instant timeTo,
         final Function<V, Integer> valueExtactor,
-        final Set<Integer> expectedValue) {
+        final Set<Integer> expectedValues) {
 
         final WindowRangeQuery<Integer, V> query = WindowRangeQuery.withWindowStartRange(timeFrom, timeTo);
 
@@ -1720,7 +1720,7 @@ public class IQv2StoreIntegrationTest {
         if (result.getGlobalResult() != null) {
             fail("global tables aren't implemented");
         } else {
-            final Set<Integer> actualValue = new HashSet<>();
+            final Set<Integer> actualValues = new HashSet<>();
             final Map<Integer, QueryResult<KeyValueIterator<Windowed<Integer>, V>>> queryResult = result.getPartitionResults();
             for (final int partition : queryResult.keySet()) {
                 final boolean failure = queryResult.get(partition).isFailure();
@@ -1740,19 +1740,19 @@ public class IQv2StoreIntegrationTest {
 
                 try (final KeyValueIterator<Windowed<Integer>, V> iterator = queryResult.get(partition).getResult()) {
                     while (iterator.hasNext()) {
-                        actualValue.add(valueExtactor.apply(iterator.next().value));
+                        actualValues.add(valueExtactor.apply(iterator.next().value));
                     }
                 }
                 assertThat(queryResult.get(partition).getExecutionInfo(), is(empty()));
             }
-            assertThat("Result:" + result, actualValue, is(expectedValue));
+            assertThat("Result:" + result, actualValues, is(expectedValues));
             assertThat("Result:" + result, result.getPosition(), is(INPUT_POSITION));
         }
     }
 
     public <V> void shouldHandleSessionRangeQuery(
         final Integer key,
-        final Set<Integer> expectedValue) {
+        final Set<Integer> expectedValues) {
 
         final WindowRangeQuery<Integer, V> query = WindowRangeQuery.withKey(key);
 
@@ -1767,7 +1767,7 @@ public class IQv2StoreIntegrationTest {
         if (result.getGlobalResult() != null) {
             fail("global tables aren't implemented");
         } else {
-            final Set<Integer> actualValue = new HashSet<>();
+            final Set<Integer> actualValues = new HashSet<>();
             final Map<Integer, QueryResult<KeyValueIterator<Windowed<Integer>, V>>> queryResult = result.getPartitionResults();
             for (final int partition : queryResult.keySet()) {
                 final boolean failure = queryResult.get(partition).isFailure();
@@ -1787,12 +1787,12 @@ public class IQv2StoreIntegrationTest {
 
                 try (final KeyValueIterator<Windowed<Integer>, V> iterator = queryResult.get(partition).getResult()) {
                     while (iterator.hasNext()) {
-                        actualValue.add((Integer) iterator.next().value);
+                        actualValues.add((Integer) iterator.next().value);
                     }
                 }
                 assertThat(queryResult.get(partition).getExecutionInfo(), is(empty()));
             }
-            assertThat("Result:" + result, actualValue, is(expectedValue));
+            assertThat("Result:" + result, actualValues, is(expectedValues));
             assertThat("Result:" + result, result.getPosition(), is(INPUT_POSITION));
         }
     }


### PR DESCRIPTION
### Summary
Update an implementation of the Query interface, introduced in [KIP-796: Interactive Query v2](https://cwiki.apache.org/confluence/display/KAFKA/KIP-796%3A+Interactive+Query+v2) , to support reverseRange and reverseAll. Use bounded query to achieve reverseRange and use unbounded query to achieve reverseAll. 
To achieve reverseRange and reverseAll, we add new flag variable reverse in RangeQuery class, to help us to do the rangeQuery or reverseQuery.


### Test plan
This time, we aim to implement reverseRange and reverseAll. To ensure the accuracy of the results for both, modifications to IQv2StoreIntegrationTest  are necessary. Previously, we stored query results in a set, which doesn't retain order. I've since switched to using a list to store the query results. This allows us to discern the differences between rangeQuery and reverseQuery.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
