### PR TITLE
KAFKA-15330: Add missing documentation of metrics introduced as part of KAFKA-15028

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1792,12 +1792,12 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Rate of transactional verification errors</td>
         <td>kafka.server:type=AddPartitionsToTxnManager,name=VerificationFailureRate</td>
-        <td>in steady state 0, but transient errors are expected during rolls and reassignments of the transactional state partition</td>
+        <td>Rate of verifications that returned in failure either from the AddPartitionsToTxn API response or through errors in the AddPartitionsToTxnManager. In steady state 0, but transient errors are expected during rolls and reassignments of the transactional state partition.</td>
       </tr>
       <tr>
         <td>Time to verify a transactional request</td>
         <td>kafka.server:type=AddPartitionsToTxnManager,name=VerificationTimeMs</td>
-        <td>the amount of time queueing while a possible previous request is in-flight plus the round trip to the transaction coordinator to verify (or not verify)</td>
+        <td>The amount of time queueing while a possible previous request is in-flight plus the round trip to the transaction coordinator to verify (or not verify)</td>
       </tr>
       <tr>
         <td>Consumer Group Offset Count</td>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1790,6 +1790,16 @@ $ bin/kafka-acls.sh \
         <td>average time, in milliseconds, it took to load transaction metadata from the consumer offset partitions loaded in the last 30 seconds (including time spent waiting for the loading task to be scheduled)</td>
       </tr>
       <tr>
+        <td>Rate of transactional verification errors</td>
+        <td>kafka.server:type=AddPartitionsToTxnManager,name=VerificationFailureRate</td>
+        <td>in steady state 0, but transient errors are expected during rolls and reassignments of the transactional state partition</td>
+      </tr>
+      <tr>
+        <td>Time to verify a transactional request</td>
+        <td>kafka.server:type=AddPartitionsToTxnManager,name=VerificationTimeMs</td>
+        <td>the amount of time queueing while a possible previous request is in-flight plus the round trip to the transaction coordinator to verify (or not verify)</td>
+      </tr>
+      <tr>
         <td>Consumer Group Offset Count</td>
         <td>kafka.server:type=GroupMetadataManager,name=NumOffsets</td>
         <td>Total number of committed offsets for Consumer Groups</td>


### PR DESCRIPTION
I've added details for VerificationFailureRate and VerificationTimeMs. 

I considered adding the documentation for the AddPartitionsToTxnVerification metrics, but I noticed that all the request metrics simply listed Produce|FetchConsumer|FetchFollower. If we don't already report the AddPartitionsToTxn request metrics in this file, it doesn't make sense to add the verification variant. (As well as all the other APIs we report)

We can file a followup jira if we want to redo that whole section.

Once we have alignment here, I will cherrypick to 3.6 branch as well as the kafka-site repo.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
