### PR TITLE
KAFKA-15169: Added TestCase in RemoteIndexCache

### DIFF
--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -561,7 +561,7 @@ class RemoteIndexCacheTest {
   @EnumSource(value = classOf[IndexType], names = Array("OFFSET", "TIMESTAMP", "TRANSACTION"))
   def testCorruptCacheIndexFileExistsButNotInCache(indexType: IndexType): Unit = {
     // create Corrupted Index File in remote index cache
-    createCorruptedIndexFile(indexType,cache.cacheDir())
+    createCorruptedIndexFile(indexType, cache.cacheDir())
     val entry = cache.getIndexEntry(rlsMetadata)
     // Test would fail if it throws corrupt Exception
     val offsetIndexFile = entry.offsetIndex.file().toPath
@@ -711,7 +711,7 @@ class RemoteIndexCacheTest {
         val txnIdx = createTxIndexForSegmentMetadata(metadata)
         maybeAppendIndexEntries(offsetIdx, timeIdx)
         // Create corrupt index file return from RSM
-        createCorruptedIndexFile(testIndexType,tpDir)
+        createCorruptedIndexFile(testIndexType, tpDir)
         indexType match {
           case IndexType.OFFSET => new FileInputStream(offsetIdx.file)
           case IndexType.TIMESTAMP => new FileInputStream(timeIdx.file)
@@ -912,6 +912,7 @@ class RemoteIndexCacheTest {
     // but it should be multiple of Time Index EntrySIZE which is equal to 12.
     pw.close()
   }
+
   private def createCorruptedIndexFile(indexType: IndexType, dir: File): Unit = {
     if (indexType == IndexType.OFFSET) {
       createCorruptOffsetIndexFile(dir)

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -563,7 +563,7 @@ class RemoteIndexCacheTest {
     // create Corrupted Index File in remote index cache
     createCorruptedIndexFile(indexType, cache.cacheDir())
     val entry = cache.getIndexEntry(rlsMetadata)
-    // Test would fail if it throws corrupt Exception
+    // Test would fail if it throws Exception other than CorruptIndexException
     val offsetIndexFile = entry.offsetIndex.file().toPath
     val txnIndexFile = entry.txnIndex.file().toPath
     val timeIndexFile = entry.timeIndex.file().toPath
@@ -649,6 +649,8 @@ class RemoteIndexCacheTest {
     // rsm should not be called to fetch offset Index
     verifyFetchIndexInvocation(0, Seq(IndexType.OFFSET))
     verifyFetchIndexInvocation(1, Seq(IndexType.TIMESTAMP))
+    // Transaction index would be fetched again
+    // as previous getIndexEntry failed before fetchTransactionIndex
     verifyFetchIndexInvocation(1, Seq(IndexType.TRANSACTION))
   }
 

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -623,12 +623,12 @@ class RemoteIndexCacheTest {
     verifyFetchIndexInvocation(1, Seq(IndexType.OFFSET, IndexType.TIMESTAMP))
     verifyFetchIndexInvocation(0, Seq(IndexType.TRANSACTION))
     // However cache fetch failed
-    // but it has  already created offset and time index file in remote cache dir.
+    // but it has already created offset and time index file in remote cache dir.
     // Current status
-    // ( cache  is null)
+    // (cache is null)
     // RemoteCacheDir contain
-    // 1. Offset Index File which is fine and not corrupted
-    // 2. Time Index File which is corrupted
+    // 1. Offset Index File is fine and not corrupted
+    // 2. Time Index File is corrupted
     // What should be the code flow in next execution
     // 1. No rsm call for fetching OffSet Index File.
     // 2. Time index file should be fetched from remote storage again as it is corrupted in the first execution.
@@ -656,7 +656,7 @@ class RemoteIndexCacheTest {
       })
     cache.getIndexEntry(rlsMetadata)
     // No exception should occur
-    // Offset rsm 0,TimeIndex 1 , TxnIndex 1
+    // rsm should not be called for offset Index
     verifyFetchIndexInvocation(0, Seq(IndexType.OFFSET))
     verifyFetchIndexInvocation(1, Seq(IndexType.TIMESTAMP))
     verifyFetchIndexInvocation(1, Seq(IndexType.TRANSACTION))
@@ -700,10 +700,8 @@ class RemoteIndexCacheTest {
     // validate cache entry for the above key should be null
     assertNull(cache.internalCache().getIfPresent(rlsMetadata.remoteLogSegmentId().id()))
     cache.getIndexEntry(rlsMetadata)
-    // Index  Files already exist
-    // rsm should not be called again
-    // instead files exist on disk
-    // should be used
+    // Index  Files already exist ,rsm should not be called again
+    // instead files exist on disk should be used
     verifyFetchIndexInvocation(count = 1)
     // verify index files on disk
     assertTrue(getRemoteCacheIndexFileFromDisk(LogFileUtils.INDEX_FILE_SUFFIX).isPresent, s"Offset index file should be present on disk at ${remoteIndexCacheDir.toPath}")

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -279,6 +279,8 @@ class RemoteIndexCacheTest {
       "Failed to mark cache entry for cleanup after invalidation")
     TestUtils.waitUntilTrue(() => cacheEntry.isCleanStarted,
       "Failed to cleanup cache entry after invalidation")
+    TestUtils.waitUntilTrue(() => cacheEntry.isCleanFinished,
+      "Failed to finish cleanup cache entry after invalidation")
 
     // first it will be marked for cleanup, second time markForCleanup is called when cleanup() is called
     verify(cacheEntry, times(2)).markForCleanup()
@@ -543,6 +545,8 @@ class RemoteIndexCacheTest {
       "Failed to mark cache entry for cleanup after resizing cache.")
     TestUtils.waitUntilTrue(() => cacheEntry.isCleanStarted,
       "Failed to cleanup cache entry after resizing cache.")
+    TestUtils.waitUntilTrue(() => cacheEntry.isCleanFinished,
+      "Failed to finish cleanup cache entry after resizing cache.")
 
     // verify no index files on remote cache dir
     TestUtils.waitUntilTrue(() => !getIndexFileFromRemoteCacheDir(LogFileUtils.INDEX_FILE_SUFFIX).isPresent,
@@ -687,6 +691,8 @@ class RemoteIndexCacheTest {
       "Failed to mark cache entry for cleanup after invalidation")
     TestUtils.waitUntilTrue(() => entry.isCleanStarted,
       "Failed to cleanup cache entry after invalidation")
+    TestUtils.waitUntilTrue(() => entry.isCleanFinished,
+      "Failed to finish cleanup cache entry after invalidation")
 
     // restore index files
     renameRemoteCacheIndexFileFromDisk(tempSuffix)
@@ -762,6 +768,8 @@ class RemoteIndexCacheTest {
       "Failed to mark cache entry for cleanup after invalidation")
     TestUtils.waitUntilTrue(() => entry.isCleanStarted,
       "Failed to cleanup cache entry after invalidation")
+    TestUtils.waitUntilTrue(() => entry.isCleanFinished,
+      "Failed to finish cleanup cache entry after invalidation")
 
     // verify no index files on disk
     waitUntilTrue(() => !getRemoteCacheIndexFileFromDisk(LogFileUtils.INDEX_FILE_SUFFIX).isPresent,

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -489,8 +489,6 @@ public class RemoteIndexCache implements Closeable {
 
         private boolean cleanStarted = false;
 
-        private boolean cleanFinished = false;
-
         private boolean markedForCleanup = false;
 
         private final long entrySizeBytes;
@@ -520,11 +518,6 @@ public class RemoteIndexCache implements Closeable {
         // Visible for testing
         public boolean isCleanStarted() {
             return cleanStarted;
-        }
-
-        // Visible for testing
-        public boolean isCleanFinished() {
-            return cleanFinished;
         }
 
         // Visible for testing
@@ -604,7 +597,6 @@ public class RemoteIndexCache implements Closeable {
                     });
 
                     tryAll(actions);
-                    cleanFinished = true;
                 }
             } finally {
                 lock.writeLock().unlock();

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -186,8 +186,8 @@ public class RemoteIndexCache implements Closeable {
     }
 
     // Visible for testing
-    public Path cacheDir() {
-        return cacheDir.toPath();
+    public File cacheDir () {
+        return cacheDir;
     }
 
     public void remove(Uuid key) {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -489,6 +489,8 @@ public class RemoteIndexCache implements Closeable {
 
         private boolean cleanStarted = false;
 
+        private boolean cleanFinished = false;
+
         private boolean markedForCleanup = false;
 
         private final long entrySizeBytes;
@@ -518,6 +520,11 @@ public class RemoteIndexCache implements Closeable {
         // Visible for testing
         public boolean isCleanStarted() {
             return cleanStarted;
+        }
+
+        // Visible for testing
+        public boolean isCleanFinished() {
+            return cleanFinished;
         }
 
         // Visible for testing
@@ -597,6 +604,7 @@ public class RemoteIndexCache implements Closeable {
                     });
 
                     tryAll(actions);
+                    cleanFinished = true;
                 }
             } finally {
                 lock.writeLock().unlock();

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -186,7 +186,7 @@ public class RemoteIndexCache implements Closeable {
     }
 
     // Visible for testing
-    public File cacheDir () {
+    public File cacheDir() {
         return cacheDir;
     }
 


### PR DESCRIPTION
### **Test Cases Covered** 

1. **Index Files already exist on disk but not in Cache** i.e. RemoteIndexCache should not call  remoteStorageManager to fetch it instead cache it from the local index file present.
2. **RSM returns CorruptedIndex File**  i.e. RemoteIndexCache should throw CorruptedIndexException instead of successfull execution. 
3. **Deleted Suffix Indexes file already present on disk**  i.e. If cleaner thread is slow , then there is a chance of deleted index files present on the disk while in parallel same index Entry is invalidated. To understand more refer https://issues.apache.org/jira/browse/KAFKA-15169

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
