### PR TITLE
MINOR: Update the list of collaborators

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,28 +25,28 @@ notifications:
 # https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features#Git.asf.yamlfeatures-JenkinsPRwhitelisting
 jenkins:
   github_whitelist:
-    - gharris1727
     - vcrfxia
-    - divijvaidya
-    - lucasbru
-    - yashmayya
-    - philipnee
-    - vamossagar12
     - clolov
     - fvaleri
-    - andymg3
+    - philipnee
+    - vamossagar12
+    - kamalcph
+    - hudeqi
+    - lihaosky
+    - jeffkbkim
+    - tinaselenge
 
 # This list allows you to triage pull requests. It can have a maximum of 10 people.
 # https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features#Git.asf.yamlfeatures-AssigningexternalcollaboratorswiththetriageroleonGitHub
 github:
   collaborators:
-    - gharris1727
     - vcrfxia
-    - divijvaidya
-    - lucasbru
-    - yashmayya
-    - philipnee
-    - vamossagar12
     - clolov
     - fvaleri
-    - andymg3
+    - philipnee
+    - vamossagar12
+    - kamalcph
+    - hudeqi
+    - lihaosky
+    - jeffkbkim
+    - tinaselenge


### PR DESCRIPTION
- The collaborators list was initially added in https://github.com/apache/kafka/pull/13713 (following the policy specified here - https://github.com/apache/kafka-site/pull/510).
- The list is currently outdated since 4 of the 10 collaborators are now committers.
- Until https://issues.apache.org/jira/browse/KAFKA-14995 is resolved, this list needs to be maintained manually.
- The list has been updated here following the same methodology outlined [originally](https://github.com/apache/kafka/pull/13713#issuecomment-1545913632):

```
> git shortlog --numbered --summary --since="1 year ago"

    76	David Jacot
    62	Greg Harris
    47	David Arthur
    46	Yash Mayya
    44	Ismael Juma
    43	Luke Chen
    41	Lucas Brutschy
    37	Colin Patrick McCabe
    35	Victoria Xia
    34	José Armando García Sancio
    33	Chris Egerton
    30	Mickael Maison
    29	Christo Lolov
    29	Divij Vaidya
    27	Federico Valeri
    27	Philip Nee
    26	vamossagar12
    24	Chia-Ping Tsai
    23	Kamal Chandraprakash
    20	Justine Olshan
    20	Matthias J. Sax
    20	Satish Duggana
    19	hudeqi
    17	A. Sophie Blee-Goldman
    15	Hao Li
    15	Jeff Kim
    14	Gantigmaa Selenge
    14	Jason Gustafson
    13	Bruno Cadonna
    13	Kirk True
    12	Ron Dagostino
    11	Guozhang Wang
    11	Manyanda Chitimbo
    11	Proven Provenzano
    11	andymg3
    10	Said Boudjelda
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
