### PR TITLE
KAFKA-15547 fixes thread leak in MirrorMakerConfigTest

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorMakerConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorMakerConfigTest.java
@@ -108,8 +108,10 @@ public class MirrorMakerConfigTest {
             "replication.policy.separator is honored");
         assertEquals(clusterABootstrap, aClientConfig.adminConfig().get("bootstrap.servers"),
             "client configs include bootstrap.servers");
-        assertEquals(ForwardingAdmin.class.getName(), aClientConfig.forwardingAdmin(aClientConfig.adminConfig()).getClass().getName(),
-                "Cluster a uses the default ForwardingAdmin");
+        try (ForwardingAdmin forwardingAdmin = aClientConfig.forwardingAdmin(aClientConfig.adminConfig())) {
+            assertEquals(ForwardingAdmin.class.getName(), forwardingAdmin.getClass().getName(),
+                    "Cluster a uses the default ForwardingAdmin");
+        }
         assertEquals("PLAINTEXT", aClientConfig.adminConfig().get("security.protocol"),
             "client configs include security.protocol");
         assertEquals("SSL", aClientConfig.producerConfig().get("security.protocol"),
@@ -126,8 +128,10 @@ public class MirrorMakerConfigTest {
             "client configs should not include metrics reporter");
         assertFalse(bClientConfig.adminConfig().containsKey("metrics.reporter"),
             "client configs should not include metrics reporter");
-        assertEquals(FakeForwardingAdmin.class.getName(), bClientConfig.forwardingAdmin(bClientConfig.adminConfig()).getClass().getName(),
-                "Cluster b should use the FakeForwardingAdmin");
+        try (ForwardingAdmin forwardingAdmin = bClientConfig.forwardingAdmin(bClientConfig.adminConfig())) {
+            assertEquals(FakeForwardingAdmin.class.getName(), forwardingAdmin.getClass().getName(),
+                    "Cluster b should use the FakeForwardingAdmin");
+        }
     }
 
     @Test


### PR DESCRIPTION
The test `MirrorMakerConfigTest#testClientConfigProperties` creates a `ForwardingAdmin` but needs to use `try-with-resources` statement to ensure the Admin client is closed 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
