### PR TITLE
KAFKA-15468: Prevent transaction coordinator reloads on already loaded leaders

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -452,8 +452,8 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
     txnMarkerChannelManager.removeMarkersForTxnTopicPartition(txnTopicPartitionId)
 
     // Now load the partition.
-    txnManager.loadTransactionsForTxnTopicPartition(txnTopicPartitionId, coordinatorEpoch,
-      txnMarkerChannelManager.addTxnMarkersToSend, txnManager.hasTxnStateLoaded(txnTopicPartitionId))
+    txnManager.maybeLoadTransactionsAndBumpEpochForTxnTopicPartition(txnTopicPartitionId, coordinatorEpoch,
+      txnMarkerChannelManager.addTxnMarkersToSend, txnManager.txnStateLoaded(txnTopicPartitionId))
   }
 
   /**

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -449,11 +449,11 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
     // left off during the unloading phase. Ensure we remove all associated state for this partition before we continue
     // loading it. In the case where the state partition is already loaded, we want to remove inflight markers with the
     // old epoch.
-      txnMarkerChannelManager.removeMarkersForTxnTopicPartition(txnTopicPartitionId)
+    txnMarkerChannelManager.removeMarkersForTxnTopicPartition(txnTopicPartitionId)
 
-      // Now load the partition.
-      txnManager.loadTransactionsForTxnTopicPartition(txnTopicPartitionId, coordinatorEpoch,
-        txnMarkerChannelManager.addTxnMarkersToSend, txnManager.hasTxnStateLoaded(txnTopicPartitionId))
+    // Now load the partition.
+    txnManager.loadTransactionsForTxnTopicPartition(txnTopicPartitionId, coordinatorEpoch,
+      txnMarkerChannelManager.addTxnMarkersToSend, txnManager.hasTxnStateLoaded(txnTopicPartitionId))
   }
 
   /**

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -375,7 +375,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
                                   newTopicPartitions: immutable.Set[TopicPartition],
                                   newTxnStartTimestamp: Long,
                                   updateTimestamp: Long): TxnTransitMetadata = {
-    if (pendingState.isDefined)
+    if (pendingState.isDefined && pendingState.get != newState)
       throw new IllegalStateException(s"Preparing transaction state transition to $newState " +
         s"while it already a pending state ${pendingState.get}")
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -375,7 +375,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
                                   newTopicPartitions: immutable.Set[TopicPartition],
                                   newTxnStartTimestamp: Long,
                                   updateTimestamp: Long): TxnTransitMetadata = {
-    if (pendingState.isDefined && pendingState.get != newState)
+    if (pendingState.exists(_ != newState))
       throw new IllegalStateException(s"Preparing transaction state transition to $newState " +
         s"while it already a pending state ${pendingState.get}")
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -573,7 +573,7 @@ class TransactionStateManager(brokerId: Int,
                     transactionsPendingForCompletion +=
                       TransactionalIdCoordinatorEpochAndTransitMetadata(transactionalId, coordinatorEpoch, TransactionResult.COMMIT, txnMetadata, txnMetadata.prepareComplete(time.milliseconds()))
                   case _ =>
-                  // nothing needs to be done
+                    // nothing needs to be done
                 }
               }
           }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2483,12 +2483,12 @@ class ReplicaManager(val config: KafkaConfig,
       }
 
       // Handle partitions which we are now the leader or follower for.
-      if (!localChanges.leaders.isEmpty || !localChanges.followers.isEmpty) {
+      if (!localChanges.updatedLeaders.isEmpty || !localChanges.followers.isEmpty) {
         val lazyOffsetCheckpoints = new LazyOffsetCheckpoints(this.highWatermarkCheckpoints)
         val leaderChangedPartitions = new mutable.HashSet[Partition]
         val followerChangedPartitions = new mutable.HashSet[Partition]
-        if (!localChanges.leaders.isEmpty) {
-          applyLocalLeadersDelta(leaderChangedPartitions, delta, lazyOffsetCheckpoints, localChanges.leaders.asScala)
+        if (!localChanges.updatedLeaders.isEmpty) {
+          applyLocalLeadersDelta(leaderChangedPartitions, delta, lazyOffsetCheckpoints, localChanges.updatedLeaders.asScala)
         }
         if (!localChanges.followers.isEmpty) {
           applyLocalFollowersDelta(followerChangedPartitions, newImage, delta, lazyOffsetCheckpoints, localChanges.followers.asScala)

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -301,7 +301,7 @@ class BrokerMetadataPublisher(
       changes.deletes.forEach { topicPartition =>
         resignation(topicPartition.partition, None)
       }
-      changes.leaders.forEach { (topicPartition, partitionInfo) =>
+      changes.electedLeaders.forEach { (topicPartition, partitionInfo) =>
         election(topicPartition.partition, partitionInfo.partition.leaderEpoch)
       }
       changes.followers.forEach { (topicPartition, partitionInfo) =>

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -186,7 +186,7 @@ class TransactionStateManagerTest {
     val partitionAndLeaderEpoch = TransactionPartitionAndLeaderEpoch(partitionId, coordinatorEpoch)
 
     val loadingThread = new Thread(() => {
-      transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch, (_, _, _, _) => (), true)
+      transactionManager.maybeLoadTransactionsAndBumpEpochForTxnTopicPartition(partitionId, coordinatorEpoch, (_, _, _, _) => (), transactionStateLoaded = true)
     })
     loadingThread.start()
     TestUtils.waitUntilTrue(() => transactionManager.loadingPartitions.contains(partitionAndLeaderEpoch),
@@ -264,7 +264,7 @@ class TransactionStateManagerTest {
       _ => fail(transactionalId2 + "'s transaction state is already in the cache")
     )
 
-    transactionManager.loadTransactionsForTxnTopicPartition(partitionId, 0, (_, _, _, _) => (), false)
+    transactionManager.maybeLoadTransactionsAndBumpEpochForTxnTopicPartition(partitionId, 0, (_, _, _, _) => (), transactionStateLoaded = false)
 
     // let the time advance to trigger the background thread loading
     scheduler.tick()
@@ -893,13 +893,13 @@ class TransactionStateManagerTest {
     prepareTxnLog(topicPartition, 0, records)
 
     // immigrate partition at epoch 0
-    transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch = 0, sendMarkers, false)
+    transactionManager.maybeLoadTransactionsAndBumpEpochForTxnTopicPartition(partitionId, coordinatorEpoch = 0, sendMarkers, transactionStateLoaded = false)
     assertEquals(0, transactionManager.loadingPartitions.size)
     assertEquals(0, transactionsWithPendingMarkers.get(transactionalId1).coordinatorEpoch)
 
     // Re-immigrate partition at epoch 1. This should be successful even though we didn't get to emigrate the partition.
     prepareTxnLog(topicPartition, 0, records)
-    transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch = 1, sendMarkers, true)
+    transactionManager.maybeLoadTransactionsAndBumpEpochForTxnTopicPartition(partitionId, coordinatorEpoch = 1, sendMarkers, transactionStateLoaded = true)
     assertEquals(0, transactionManager.loadingPartitions.size)
     assertTrue(transactionManager.transactionMetadataCache.contains(partitionId))
     assertEquals(1, transactionManager.transactionMetadataCache(partitionId).coordinatorEpoch)
@@ -924,7 +924,7 @@ class TransactionStateManagerTest {
     ).thenReturn(new FetchDataInfo(new LogOffsetMetadata(startOffset), MemoryRecords.EMPTY))
     when(replicaManager.getLogEndOffset(topicPartition)).thenReturn(Some(endOffset))
 
-    transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch = 0, (_, _, _, _) => (), false)
+    transactionManager.maybeLoadTransactionsAndBumpEpochForTxnTopicPartition(partitionId, coordinatorEpoch = 0, (_, _, _, _) => (), transactionStateLoaded = false)
 
     // let the time advance to trigger the background thread loading
     scheduler.tick()
@@ -1066,7 +1066,7 @@ class TransactionStateManagerTest {
       txnId = metadata.transactionalId
     }
 
-    transactionManager.loadTransactionsForTxnTopicPartition(partitionId, 0, rememberTxnMarkers, false)
+    transactionManager.maybeLoadTransactionsAndBumpEpochForTxnTopicPartition(partitionId, 0, rememberTxnMarkers, transactionStateLoaded = false)
     scheduler.tick()
 
     assertEquals(transactionalId1, txnId)
@@ -1165,7 +1165,7 @@ class TransactionStateManagerTest {
     val records = MemoryRecords.withRecords(startOffset, CompressionType.NONE, txnRecords.toArray: _*)
 
     prepareTxnLog(topicPartition, startOffset, records)
-    transactionManager.loadTransactionsForTxnTopicPartition(partitionId, 0, (_, _, _, _) => (), false)
+    transactionManager.maybeLoadTransactionsAndBumpEpochForTxnTopicPartition(partitionId, 0, (_, _, _, _) => (), transactionStateLoaded = false)
     scheduler.tick()
 
     assertTrue(partitionLoadTime("partition-load-time-max") >= 0)
@@ -1190,7 +1190,7 @@ class TransactionStateManagerTest {
 
     prepareTxnLog(topicPartition, 0, records)
 
-    transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch = 1, (_, _, _, _) => (), false)
+    transactionManager.maybeLoadTransactionsAndBumpEpochForTxnTopicPartition(partitionId, coordinatorEpoch = 1, (_, _, _, _) => (), transactionStateLoaded = false)
     assertEquals(0, transactionManager.loadingPartitions.size)
     assertTrue(transactionManager.transactionMetadataCache.contains(partitionId))
     val txnMetadataPool = transactionManager.transactionMetadataCache(partitionId).metadataPerTransactionalId

--- a/metadata/src/main/java/org/apache/kafka/image/LocalReplicaChanges.java
+++ b/metadata/src/main/java/org/apache/kafka/image/LocalReplicaChanges.java
@@ -26,19 +26,22 @@ import java.util.Map;
 
 public final class LocalReplicaChanges {
     private final Set<TopicPartition> deletes;
-    private final Map<TopicPartition, PartitionInfo> leaders;
+    private final Map<TopicPartition, PartitionInfo> electedLeaders;
+    private final Map<TopicPartition, PartitionInfo> updatedLeaders;
     private final Map<TopicPartition, PartitionInfo> followers;
     // The topic name -> topic id map in leaders and followers changes
     private final Map<String, Uuid> topicIds;
 
     LocalReplicaChanges(
         Set<TopicPartition> deletes,
-        Map<TopicPartition, PartitionInfo> leaders,
+        Map<TopicPartition, PartitionInfo> electedLeaders,
+        Map<TopicPartition, PartitionInfo> updatedLeaders,
         Map<TopicPartition, PartitionInfo> followers,
         Map<String, Uuid> topicIds
     ) {
         this.deletes = deletes;
-        this.leaders = leaders;
+        this.electedLeaders = electedLeaders;
+        this.updatedLeaders = updatedLeaders;
         this.followers = followers;
         this.topicIds = topicIds;
     }
@@ -47,8 +50,12 @@ public final class LocalReplicaChanges {
         return deletes;
     }
 
-    public Map<TopicPartition, PartitionInfo> leaders() {
-        return leaders;
+    public Map<TopicPartition, PartitionInfo> electedLeaders() {
+        return electedLeaders;
+    }
+
+    public Map<TopicPartition, PartitionInfo> updatedLeaders() {
+        return updatedLeaders;
     }
 
     public Map<TopicPartition, PartitionInfo> followers() {
@@ -62,9 +69,10 @@ public final class LocalReplicaChanges {
     @Override
     public String toString() {
         return String.format(
-            "LocalReplicaChanges(deletes = %s, leaders = %s, followers = %s)",
+            "LocalReplicaChanges(deletes = %s, newly elected leaders = %s, updated leaders = %s, followers = %s)",
             deletes,
-            leaders,
+            electedLeaders,
+            updatedLeaders,
             followers
         );
     }

--- a/metadata/src/main/java/org/apache/kafka/image/TopicDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicDelta.java
@@ -120,9 +120,9 @@ public final class TopicDelta {
      *
      * The changes identified are:
      *   1. partitions for which the broker is not a replica anymore
-     *   2. partitions for which the broker is now a leader
-     *   3. partitions for which the isr or replicas change if the broker is a leader
-     *   4. partitions for which the broker is now a follower or follower with isr or replica updates
+     *   2. partitions for which the broker is now a leader (leader epoch bump on the leader)
+     *   3. partitions for which the isr or replicas change if the broker is a leader (partition epoch bump on the leader)
+     *   4. partitions for which the broker is now a follower or follower with isr or replica updates (partition epoch bump on follower)
      *
      * @param brokerId the broker id
      * @return the list of partitions which the broker should remove, become leader, become/update leader, or become/update follower.

--- a/metadata/src/main/java/org/apache/kafka/image/TopicDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicDelta.java
@@ -120,15 +120,17 @@ public final class TopicDelta {
      *
      * The changes identified are:
      *   1. partitions for which the broker is not a replica anymore
-     *   2. partitions for which the broker is now the leader
-     *   3. partitions for which the broker is now a follower
+     *   2. partitions for which the broker is now a leader
+     *   3. partitions for which the isr or replicas change if the broker is a leader
+     *   4. partitions for which the broker is now a follower or follower with isr or replica updates
      *
      * @param brokerId the broker id
-     * @return the list of partitions which the broker should remove, become leader or become follower.
+     * @return the list of partitions which the broker should remove, become leader, become/update leader, or become/update follower.
      */
     public LocalReplicaChanges localChanges(int brokerId) {
         Set<TopicPartition> deletes = new HashSet<>();
-        Map<TopicPartition, LocalReplicaChanges.PartitionInfo> leaders = new HashMap<>();
+        Map<TopicPartition, LocalReplicaChanges.PartitionInfo> electedLeaders = new HashMap<>();
+        Map<TopicPartition, LocalReplicaChanges.PartitionInfo> updatedLeaders = new HashMap<>();
         Map<TopicPartition, LocalReplicaChanges.PartitionInfo> followers = new HashMap<>();
         Map<String, Uuid> topicIds = new HashMap<>();
 
@@ -141,10 +143,12 @@ public final class TopicDelta {
             } else if (entry.getValue().leader == brokerId) {
                 PartitionRegistration prevPartition = image.partitions().get(entry.getKey());
                 if (prevPartition == null || prevPartition.partitionEpoch != entry.getValue().partitionEpoch) {
-                    leaders.put(
-                        new TopicPartition(name(), entry.getKey()),
-                        new LocalReplicaChanges.PartitionInfo(id(), entry.getValue())
-                    );
+                    TopicPartition tp = new TopicPartition(name(), entry.getKey());
+                    LocalReplicaChanges.PartitionInfo partitionInfo = new LocalReplicaChanges.PartitionInfo(id(), entry.getValue());
+                    updatedLeaders.put(tp, partitionInfo);
+                    if (prevPartition == null || prevPartition.leaderEpoch != entry.getValue().leaderEpoch) {
+                        electedLeaders.put(tp, partitionInfo);
+                    }
                     topicIds.putIfAbsent(name(), id());
                 }
             } else if (
@@ -162,7 +166,7 @@ public final class TopicDelta {
             }
         }
 
-        return new LocalReplicaChanges(deletes, leaders, followers, topicIds);
+        return new LocalReplicaChanges(deletes, electedLeaders, updatedLeaders, followers, topicIds);
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/image/TopicsDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicsDelta.java
@@ -188,7 +188,8 @@ public final class TopicsDelta {
      */
     public LocalReplicaChanges localChanges(int brokerId) {
         Set<TopicPartition> deletes = new HashSet<>();
-        Map<TopicPartition, LocalReplicaChanges.PartitionInfo> leaders = new HashMap<>();
+        Map<TopicPartition, LocalReplicaChanges.PartitionInfo> electedLeaders = new HashMap<>();
+        Map<TopicPartition, LocalReplicaChanges.PartitionInfo> updatedLeaders = new HashMap<>();
         Map<TopicPartition, LocalReplicaChanges.PartitionInfo> followers = new HashMap<>();
         Map<String, Uuid> topicIds = new HashMap<>();
 
@@ -196,7 +197,8 @@ public final class TopicsDelta {
             LocalReplicaChanges changes = delta.localChanges(brokerId);
 
             deletes.addAll(changes.deletes());
-            leaders.putAll(changes.leaders());
+            electedLeaders.putAll(changes.electedLeaders());
+            updatedLeaders.putAll(changes.updatedLeaders());
             followers.putAll(changes.followers());
             topicIds.putAll(changes.topicIds());
         }
@@ -211,7 +213,7 @@ public final class TopicsDelta {
             });
         });
 
-        return new LocalReplicaChanges(deletes, leaders, followers, topicIds);
+        return new LocalReplicaChanges(deletes, electedLeaders, updatedLeaders, followers, topicIds);
     }
 
     @Override

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -218,11 +218,11 @@ public class TopicsImageTest {
         );
         assertEquals(
             new HashSet<>(Arrays.asList(new TopicPartition("baz", 0))),
-                changes.electedLeaders().keySet()
+            changes.electedLeaders().keySet()
         );
         assertEquals(
             new HashSet<>(Arrays.asList(new TopicPartition("baz", 0))),
-                changes.updatedLeaders().keySet()
+            changes.updatedLeaders().keySet()
         );
         assertEquals(
             new HashSet<>(
@@ -290,21 +290,21 @@ public class TopicsImageTest {
 
         List<TopicImage> topics = new ArrayList<>();
         topics.add(
-                newTopicImage(
-                        "zoo",
-                        zooId,
-                        newPartition(new int[] {localId, 1, 2})
-                )
+            newTopicImage(
+                "zoo",
+                zooId,
+                newPartition(new int[] {localId, 1, 2})
+            )
         );
         TopicsImage image = new TopicsImage(newTopicsByIdMap(topics),
-                newTopicsByNameMap(topics));
+            newTopicsByNameMap(topics));
 
         List<ApiMessageAndVersion> topicRecords = new ArrayList<>();
         topicRecords.add(
-                new ApiMessageAndVersion(
-                        new PartitionChangeRecord().setTopicId(zooId).setPartitionId(0).setIsr(Arrays.asList(localId, 1)),
-                        PARTITION_CHANGE_RECORD.highestSupportedVersion()
-                )
+            new ApiMessageAndVersion(
+                new PartitionChangeRecord().setTopicId(zooId).setPartitionId(0).setIsr(Arrays.asList(localId, 1)),
+                PARTITION_CHANGE_RECORD.highestSupportedVersion()
+            )
         );
 
         TopicsDelta delta = new TopicsDelta(image);
@@ -313,8 +313,10 @@ public class TopicsImageTest {
         LocalReplicaChanges changes = delta.localChanges(localId);
         assertEquals(Collections.emptySet(), changes.deletes());
         assertEquals(Collections.emptyMap(), changes.electedLeaders());
-        assertEquals(new HashSet<>(Arrays.asList(new TopicPartition("zoo", 0))),
-                changes.updatedLeaders().keySet());
+        assertEquals(
+            new HashSet<>(Arrays.asList(new TopicPartition("zoo", 0))),
+            changes.updatedLeaders().keySet()
+        );
         assertEquals(Collections.emptyMap(), changes.followers());
     }
 
@@ -410,11 +412,11 @@ public class TopicsImageTest {
         );
         assertEquals(
             new HashSet<>(Arrays.asList(new TopicPartition("zoo", 0), new TopicPartition("zoo", 4))),
-                changes.electedLeaders().keySet()
+            changes.electedLeaders().keySet()
         );
         assertEquals(
-                new HashSet<>(Arrays.asList(new TopicPartition("zoo", 0), new TopicPartition("zoo", 4))),
-                changes.updatedLeaders().keySet()
+            new HashSet<>(Arrays.asList(new TopicPartition("zoo", 0), new TopicPartition("zoo", 4))),
+            changes.updatedLeaders().keySet()
         );
         assertEquals(
             new HashSet<>(Arrays.asList(new TopicPartition("zoo", 1), new TopicPartition("zoo", 5))),

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -221,7 +221,7 @@ public class TopicsImageTest {
                 changes.electedLeaders().keySet()
         );
         assertEquals(
-                new HashSet<>(Arrays.asList(new TopicPartition("baz", 0))),
+            new HashSet<>(Arrays.asList(new TopicPartition("baz", 0))),
                 changes.updatedLeaders().keySet()
         );
         assertEquals(
@@ -282,6 +282,7 @@ public class TopicsImageTest {
         imageRecords.addAll(topicRecords);
         testToImage(finalImage, Optional.of(imageRecords));
     }
+
     @Test
     public void testUpdatedLeaders() {
         int localId = 3;


### PR DESCRIPTION
This PR has two parts:

1. Redefining the TopicDelta fields to better distinguish when a leader is elected (leader epoch bump) vs when a leader has isr/replica changes (partition epoch bump). There are some cases where we bump the partition epoch but not the leader epoch. We do not need to do operations that only care about the leader epoch bump. (ie -- onElect callbacks)
2. Even in the case of leader epoch bumps, we may be electing the same leader. In that case, we don't need to do some operations (load state from disk that is already loaded). The GroupCoordinator already handles this case, but the transaction coordinator does not. I've updated this code to not read from disk, but to take the existing metadata and update the leader epoch, as well as send markers with the new epoch.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
