### PR TITLE
KAFKA-15452: Access SslPrincipalMapper and kerberosShortNamer in Custom KafkaPrincipalBuilder(KIP-982)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/auth/KerberosPrincipalBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/KerberosPrincipalBuilder.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.auth;
+
+import org.apache.kafka.common.security.kerberos.KerberosShortNamer;
+
+/**
+ * Interface for building Kafka principals with Kerberos authentication.
+ */
+public interface KerberosPrincipalBuilder extends KafkaPrincipalBuilder {
+
+    /**
+     * Set the KerberosShortNamer to be used for building Kafka principals.
+     *
+     * @param kerberosShortNamer The KerberosShortNamer instance.
+     */
+    void buildKerberosPrincipalBuilder(KerberosShortNamer kerberosShortNamer);
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/auth/SSLPrincipalBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/SSLPrincipalBuilder.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.auth;
+
+import org.apache.kafka.common.security.ssl.SslPrincipalMapper;
+
+/**
+ * Interface for building Kafka principals with SSL authentication.
+ */
+public interface SSLPrincipalBuilder extends KafkaPrincipalBuilder {
+
+    /**
+     * Set the SSLPrincipalMapper to be used for building Kafka principals.
+     *
+     * @param sslPrincipalMapper The SSLPrincipalMapper instance.
+     */
+    void buildSSLPrincipalBuilder(SslPrincipalMapper sslPrincipalMapper);
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/DefaultKerberosPrincipalBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/DefaultKerberosPrincipalBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.authenticator;
+
+import org.apache.kafka.common.security.auth.AuthenticationContext;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.KerberosPrincipalBuilder;
+import org.apache.kafka.common.security.kerberos.KerberosShortNamer;
+
+/**
+ * Default implementation of {@link KerberosPrincipalBuilder} for Kerberos authentication.
+ */
+public class DefaultKerberosPrincipalBuilder implements KerberosPrincipalBuilder {
+
+    private DefaultKafkaPrincipalBuilder defaultKafkaPrincipalBuilder;
+
+    /**
+     * Set the KerberosShortNamer for building Kafka principals.
+     *
+     * @param kerberosShortNamer The KerberosShortNamer instance.
+     */
+    @Override
+    public void buildKerberosPrincipalBuilder(KerberosShortNamer kerberosShortNamer) {
+        this.defaultKafkaPrincipalBuilder = new DefaultKafkaPrincipalBuilder(kerberosShortNamer, null);
+    }
+
+    /**
+     * Build the Kafka principal based on the provided AuthenticationContext.
+     *
+     * @param context The AuthenticationContext containing authentication details.
+     * @return The constructed KafkaPrincipal.
+     */
+    @Override
+    public KafkaPrincipal build(AuthenticationContext context) {
+        return defaultKafkaPrincipalBuilder.build(context);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/DefaultSSLPrincipalBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/DefaultSSLPrincipalBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.authenticator;
+
+import org.apache.kafka.common.security.auth.AuthenticationContext;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SSLPrincipalBuilder;
+import org.apache.kafka.common.security.ssl.SslPrincipalMapper;
+
+/**
+ * Default implementation of {@link SSLPrincipalBuilder} for SSL authentication.
+ */
+public class DefaultSSLPrincipalBuilder implements SSLPrincipalBuilder {
+
+    private DefaultKafkaPrincipalBuilder defaultKafkaPrincipalBuilder;
+
+    /**
+     * Set the SSLPrincipalMapper for building Kafka principals.
+     *
+     * @param sslPrincipalMapper The SSLPrincipalMapper instance.
+     */
+    @Override
+    public void buildSSLPrincipalBuilder(SslPrincipalMapper sslPrincipalMapper) {
+        this.defaultKafkaPrincipalBuilder = new DefaultKafkaPrincipalBuilder(null, sslPrincipalMapper);
+    }
+
+    /**
+     * Build the Kafka principal based on the provided AuthenticationContext.
+     *
+     * @param context The AuthenticationContext containing authentication details.
+     * @return The constructed KafkaPrincipal.
+     */
+    @Override
+    public KafkaPrincipal build(AuthenticationContext context) {
+        return defaultKafkaPrincipalBuilder.build(context);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/network/ChannelBuildersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/ChannelBuildersTest.java
@@ -20,14 +20,22 @@ import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.security.TestSecurityConfig;
-import org.apache.kafka.common.security.auth.AuthenticationContext;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.KafkaPrincipalBuilder;
 import org.apache.kafka.common.security.auth.PlaintextAuthenticationContext;
+import org.apache.kafka.common.security.auth.SslAuthenticationContext;
+import org.apache.kafka.common.security.auth.AuthenticationContext;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder;
+import org.apache.kafka.common.security.kerberos.KerberosShortNamer;
+import org.apache.kafka.common.security.ssl.SslPrincipalMapper;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.security.auth.x500.X500Principal;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.security.Principal;
 import java.util.HashMap;
 import java.util.Map;
@@ -38,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ChannelBuildersTest {
 
@@ -66,6 +75,36 @@ public class ChannelBuildersTest {
         KafkaPrincipalBuilder builder = ChannelBuilders.createPrincipalBuilder(configs, null, null, null, null);
         assertTrue(builder instanceof ConfigurableKafkaPrincipalBuilder);
         assertTrue(((ConfigurableKafkaPrincipalBuilder) builder).configured);
+    }
+
+    @Test
+    public void testCreateCustomKafkaPrincipalBuilder() throws UnknownHostException, SSLPeerUnverifiedException {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, CustomKafkaPrincipalBuilder.class);
+        KerberosShortNamer kerberosShortNamer = mock(KerberosShortNamer.class);
+        SslPrincipalMapper sslPrincipalMapper = SslPrincipalMapper.fromRules("DEFAULT");
+
+        KafkaPrincipalBuilder builder = ChannelBuilders.createPrincipalBuilder(configs, null, null, kerberosShortNamer, sslPrincipalMapper);
+        assertTrue(builder instanceof CustomKafkaPrincipalBuilder);
+        assertTrue(((CustomKafkaPrincipalBuilder) builder).configured);
+
+        SSLSession session = mock(SSLSession.class);
+        X500Principal x500Principal = new X500Principal("CN=Wmt, OU=ServiceUsers, O=Org, C=US");
+        when(session.getPeerPrincipal()).thenReturn(x500Principal);
+        SslAuthenticationContext sslContext = new SslAuthenticationContext(session, InetAddress.getLocalHost(), SecurityProtocol.PLAINTEXT.name());
+
+        KafkaPrincipal principal = builder.build(sslContext);
+        assertEquals(x500Principal.getName(), principal.getName());
+        assertEquals(KafkaPrincipal.USER_TYPE, principal.getPrincipalType());
+    }
+
+    @Test
+    public void testCreateCustomKafkaPrincipalBuilderWithDefaultConstructor() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, CustomKafkaPrincipalBuilderWithDefaultConstructor.class);
+        KafkaPrincipalBuilder builder = ChannelBuilders.createPrincipalBuilder(configs, null, null, null, null);
+        assertTrue(builder instanceof CustomKafkaPrincipalBuilderWithDefaultConstructor);
+        assertTrue(((CustomKafkaPrincipalBuilderWithDefaultConstructor) builder).configured);
     }
 
     @Test
@@ -167,4 +206,35 @@ public class ChannelBuildersTest {
             return null;
         }
     }
+
+    public static class CustomKafkaPrincipalBuilder extends DefaultKafkaPrincipalBuilder implements Configurable {
+        private boolean configured = false;
+
+        public CustomKafkaPrincipalBuilder(KerberosShortNamer kerberosShortNamer, SslPrincipalMapper sslPrincipalMapper) {
+            super(kerberosShortNamer, sslPrincipalMapper);
+        }
+
+        public CustomKafkaPrincipalBuilder() {
+            super(null, null);
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs) {
+            configured = true;
+        }
+    }
+
+    public static class CustomKafkaPrincipalBuilderWithDefaultConstructor extends DefaultKafkaPrincipalBuilder implements Configurable {
+        private boolean configured = false;
+
+        public CustomKafkaPrincipalBuilderWithDefaultConstructor() {
+            super(null, null);
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs) {
+            configured = true;
+        }
+    }
+
 }

--- a/clients/src/test/java/org/apache/kafka/common/network/ChannelBuildersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/ChannelBuildersTest.java
@@ -214,10 +214,6 @@ public class ChannelBuildersTest {
             super(kerberosShortNamer, sslPrincipalMapper);
         }
 
-        public CustomKafkaPrincipalBuilder() {
-            super(null, null);
-        }
-
         @Override
         public void configure(Map<String, ?> configs) {
             configured = true;


### PR DESCRIPTION
Made the changes to allow custom KafkaPrincipalBuilder implementations to access SslPrincipalMapper and kerberosShortNamer so that custom KafkaPrincipalBuilders will be able to parse Regex Rules from BrokerSecurityConfigs SSL_PRINCIPAL_MAPPING_RULES_CONFIG

[KIP-982](https://cwiki.apache.org/confluence/display/KAFKA/KIP-982%3A+Access+SslPrincipalMapper+and+kerberosShortNamer+in+Custom+KafkaPrincipalBuilder) have complete details about the change

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
