### PR TITLE
MINOR - KAFKA-15550: Validation for negative target times in offsetsForTimes

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -48,7 +48,7 @@
     <suppress id="dontUseSystemExit"
               files="Exit.java"/>
     <suppress checks="ClassFanOutComplexity"
-              files="(AbstractFetch|Sender|SenderTest|ConsumerCoordinator|KafkaConsumer|KafkaProducer|Utils|TransactionManager|TransactionManagerTest|KafkaAdminClient|NetworkClient|Admin|KafkaRaftClient|KafkaRaftClientTest|RaftClientTestContext).java"/>
+              files="(AbstractFetch|Sender|SenderTest|ConsumerCoordinator|KafkaConsumer|PrototypeAsyncConsumer|KafkaProducer|Utils|TransactionManager|TransactionManagerTest|KafkaAdminClient|NetworkClient|Admin|KafkaRaftClient|KafkaRaftClientTest|RaftClientTestContext).java"/>
     <suppress checks="ClassFanOutComplexity"
               files="(SaslServerAuthenticator|SaslAuthenticatorTest).java"/>
     <suppress checks="NPath"

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -242,11 +242,11 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         eventHandler.add(validatePositionsEvent);
 
         // Reset positions using committed offsets retrieved from the group coordinator, for any
-        // partitions which do  not have a valid position and are not awaiting reset. We
+        // partitions which do not have a valid position and are not awaiting reset. This will
+        // trigger an OffsetFetch request and update positions with the offsets retrieved. This
         // will only do a coordinator lookup if there are partitions which have missing
         // positions, so a consumer with manually assigned partitions can avoid a coordinator
-        // dependence by always ensuring that assigned partitions have an initial position. This
-        // will trigger an OffsetFetch request and update positions with the offsets retrieved.
+        // dependence by always ensuring that assigned partitions have an initial position.
         if (isCommittedOffsetsManagementEnabled() && !refreshCommittedOffsetsIfNeeded(timer))
             return false;
 
@@ -255,7 +255,7 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         // are partitions with a missing position, then we will raise a NoOffsetForPartitionException exception.
         subscriptions.resetInitializingPositions();
 
-        // Reset positions using partitions offsets retrieved from the leader, for any partitions
+        // Reset positions using partition offsets retrieved from the leader, for any partitions
         // which are awaiting reset. This will trigger a ListOffset request, retrieve the
         // partition offsets according to the strategy (ex. earliest, latest), and update the
         // positions.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumer.java
@@ -443,6 +443,13 @@ public class PrototypeAsyncConsumer<K, V> implements Consumer<K, V> {
         // Keeping same argument validation error thrown by the current consumer implementation
         // to avoid API level changes.
         requireNonNull(timestampsToSearch, "Timestamps to search cannot be null");
+        for (Map.Entry<TopicPartition, Long> entry : timestampsToSearch.entrySet()) {
+            // Exclude the earliest and latest offset here so the timestamp in the returned
+            // OffsetAndTimestamp is always positive.
+            if (entry.getValue() < 0)
+                throw new IllegalArgumentException("The target time for partition " + entry.getKey() + " is " +
+                        entry.getValue() + ". The target time cannot be negative.");
+        }
 
         if (timestampsToSearch.isEmpty()) {
             return Collections.emptyMap();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PrototypeAsyncConsumerTest.java
@@ -36,6 +36,7 @@ import org.apache.kafka.common.errors.InvalidGroupIdException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.LogContext;
@@ -320,6 +321,25 @@ public class PrototypeAsyncConsumerTest {
         PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
         assertThrows(NullPointerException.class, () -> consumer.offsetsForTimes(null,
                 Duration.ofMillis(1)));
+    }
+
+    @Test
+    public void testOffsetsForTimesFailsOnNegativeTargetTimes() {
+        PrototypeAsyncConsumer<?, ?> consumer = newConsumer(time, new StringDeserializer(), new StringDeserializer());
+        assertThrows(IllegalArgumentException.class,
+                () -> consumer.offsetsForTimes(Collections.singletonMap(new TopicPartition(
+                                "topic1", 1), ListOffsetsRequest.EARLIEST_TIMESTAMP),
+                        Duration.ofMillis(1)));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> consumer.offsetsForTimes(Collections.singletonMap(new TopicPartition(
+                                "topic1", 1), ListOffsetsRequest.LATEST_TIMESTAMP),
+                        Duration.ofMillis(1)));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> consumer.offsetsForTimes(Collections.singletonMap(new TopicPartition(
+                                "topic1", 1), ListOffsetsRequest.MAX_TIMESTAMP),
+                        Duration.ofMillis(1)));
     }
 
     @Test


### PR DESCRIPTION
The current KafkaConsumer `offsetsForTimes` fails with `IllegalArgumentException` if negative target timestamps are provided as arguments. This PR includes the same validation and tests for the new consumer implementation (and some improved comments for the `updateFetchPositions`)