### PR TITLE
KAFKA-15452: Access SslPrincipalMapper and kerberosShortNamer in Custom KafkaPrincipalBuilder(KIP-982)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java
@@ -36,6 +36,8 @@ import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -224,12 +226,19 @@ public class ChannelBuilders {
                                                                KerberosShortNamer kerberosShortNamer,
                                                                SslPrincipalMapper sslPrincipalMapper) {
         Class<?> principalBuilderClass = (Class<?>) configs.get(BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG);
-        final KafkaPrincipalBuilder builder;
+        KafkaPrincipalBuilder builder;
 
         if (principalBuilderClass == null || principalBuilderClass == DefaultKafkaPrincipalBuilder.class) {
             builder = new DefaultKafkaPrincipalBuilder(kerberosShortNamer, sslPrincipalMapper);
         } else if (KafkaPrincipalBuilder.class.isAssignableFrom(principalBuilderClass)) {
-            builder = (KafkaPrincipalBuilder) Utils.newInstance(principalBuilderClass);
+            try {
+                Constructor<?> constructor = principalBuilderClass.getConstructor(KerberosShortNamer.class, SslPrincipalMapper.class);
+                builder = (KafkaPrincipalBuilder) constructor.newInstance(kerberosShortNamer, sslPrincipalMapper);
+            } catch (NoSuchMethodException e) {
+                builder = (KafkaPrincipalBuilder) Utils.newInstance(principalBuilderClass);
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException("Error instantiating Custom KafkaPrincipalBuilder", e);
+            }
         } else {
             throw new InvalidConfigurationException("Type " + principalBuilderClass.getName() + " is not " +
                     "an instance of " + KafkaPrincipalBuilder.class.getName());

--- a/clients/src/test/java/org/apache/kafka/common/network/ChannelBuildersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/ChannelBuildersTest.java
@@ -22,8 +22,21 @@ import org.apache.kafka.common.security.TestSecurityConfig;
 import org.apache.kafka.common.security.auth.AuthenticationContext;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.KafkaPrincipalBuilder;
+import org.apache.kafka.common.security.auth.PlaintextAuthenticationContext;
+import org.apache.kafka.common.security.auth.SslAuthenticationContext;
+import org.apache.kafka.common.security.auth.AuthenticationContext;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder;
+import org.apache.kafka.common.security.kerberos.KerberosShortNamer;
+import org.apache.kafka.common.security.ssl.SslPrincipalMapper;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.security.auth.x500.X500Principal;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.security.Principal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -32,6 +45,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ChannelBuildersTest {
 
@@ -42,6 +57,36 @@ public class ChannelBuildersTest {
         KafkaPrincipalBuilder builder = ChannelBuilders.createPrincipalBuilder(configs, null, null);
         assertTrue(builder instanceof ConfigurableKafkaPrincipalBuilder);
         assertTrue(((ConfigurableKafkaPrincipalBuilder) builder).configured);
+    }
+
+    @Test
+    public void testCreateCustomKafkaPrincipalBuilder() throws UnknownHostException, SSLPeerUnverifiedException {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, CustomKafkaPrincipalBuilder.class);
+        KerberosShortNamer kerberosShortNamer = mock(KerberosShortNamer.class);
+        SslPrincipalMapper sslPrincipalMapper = SslPrincipalMapper.fromRules("DEFAULT");
+
+        KafkaPrincipalBuilder builder = ChannelBuilders.createPrincipalBuilder(configs, kerberosShortNamer, sslPrincipalMapper);
+        assertTrue(builder instanceof CustomKafkaPrincipalBuilder);
+        assertTrue(((CustomKafkaPrincipalBuilder) builder).configured);
+
+        SSLSession session = mock(SSLSession.class);
+        X500Principal x500Principal = new X500Principal("CN=Wmt, OU=ServiceUsers, O=Org, C=US");
+        when(session.getPeerPrincipal()).thenReturn(x500Principal);
+        SslAuthenticationContext sslContext = new SslAuthenticationContext(session, InetAddress.getLocalHost(), SecurityProtocol.PLAINTEXT.name());
+
+        KafkaPrincipal principal = builder.build(sslContext);
+        assertEquals(x500Principal.getName(), principal.getName());
+        assertEquals(KafkaPrincipal.USER_TYPE, principal.getPrincipalType());
+    }
+
+    @Test
+    public void testCreateCustomKafkaPrincipalBuilderWithDefaultConstructor() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, CustomKafkaPrincipalBuilderWithDefaultConstructor.class);
+        KafkaPrincipalBuilder builder = ChannelBuilders.createPrincipalBuilder(configs, null, null);
+        assertTrue(builder instanceof CustomKafkaPrincipalBuilderWithDefaultConstructor);
+        assertTrue(((CustomKafkaPrincipalBuilderWithDefaultConstructor) builder).configured);
     }
 
     @Test
@@ -117,4 +162,31 @@ public class ChannelBuildersTest {
             return null;
         }
     }
+
+    public static class CustomKafkaPrincipalBuilder extends DefaultKafkaPrincipalBuilder implements Configurable {
+        private boolean configured = false;
+
+        public CustomKafkaPrincipalBuilder(KerberosShortNamer kerberosShortNamer, SslPrincipalMapper sslPrincipalMapper) {
+            super(kerberosShortNamer, sslPrincipalMapper);
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs) {
+            configured = true;
+        }
+    }
+
+    public static class CustomKafkaPrincipalBuilderWithDefaultConstructor extends DefaultKafkaPrincipalBuilder implements Configurable {
+        private boolean configured = false;
+
+        public CustomKafkaPrincipalBuilderWithDefaultConstructor() {
+            super(null, null);
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs) {
+            configured = true;
+        }
+    }
+
 }


### PR DESCRIPTION
Made the changes to allow custom KafkaPrincipalBuilder implementations to access SslPrincipalMapper and kerberosShortNamer so that custom KafkaPrincipalBuilders will be able to parse Regex Rules from BrokerSecurityConfigs SSL_PRINCIPAL_MAPPING_RULES_CONFIG

### [KIP-982](https://cwiki.apache.org/confluence/display/KAFKA/KIP-982%3A+Access+SslPrincipalMapper+and+kerberosShortNamer+in+Custom+KafkaPrincipalBuilder) have complete details about the change

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
