### PR TITLE
KAFKA-15552 Fix Producer ID ZK migration

### DIFF
--- a/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
+++ b/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
@@ -263,7 +263,7 @@ class ZkMigrationClient(
         recordConsumer.accept(List(new ApiMessageAndVersion(new ProducerIdsRecord()
           .setBrokerEpoch(-1)
           .setBrokerId(producerIdBlock.assignedBrokerId)
-          .setNextProducerId(producerIdBlock.firstProducerId()), 0.toShort)).asJava)
+          .setNextProducerId(producerIdBlock.nextBlockFirstId()), 0.toShort)).asJava)
       case None => // Nothing to migrate
     }
   }

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
@@ -213,7 +213,7 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
 
   @Test
   def testReadMigrateAndWriteProducerId(): Unit = {
-    // allocate three blocks like the controller would for three brokers
+    // allocate some producer id blocks
     ZkProducerIdManager.getNewProducerIdBlock(1, zkClient, this)
     ZkProducerIdManager.getNewProducerIdBlock(2, zkClient, this)
     val block = ZkProducerIdManager.getNewProducerIdBlock(3, zkClient, this)

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
@@ -18,7 +18,7 @@ package kafka.zk.migration
 
 import kafka.api.LeaderAndIsr
 import kafka.controller.{LeaderIsrAndControllerEpoch, ReplicaAssignment}
-import kafka.coordinator.transaction.ProducerIdManager
+import kafka.coordinator.transaction.{ProducerIdManager, ZkProducerIdManager}
 import kafka.server.{ConfigType, KafkaConfig}
 import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.errors.ControllerMovedException
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test
 import java.util.Properties
 import scala.collection.Map
 import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success}
 
 /**
  * ZooKeeper integration tests that verify the interoperability of KafkaZkClient and ZkMigrationClient.
@@ -211,30 +212,33 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
   }
 
   @Test
-  def testReadAndWriteProducerId(): Unit = {
-    def generateNextProducerIdWithZkAndRead(): Long = {
-      // Generate a producer ID in ZK
-      val manager = ProducerIdManager.zk(1, zkClient)
-      manager.generateProducerId()
+  def testReadMigrateAndWriteProducerId(): Unit = {
+    // allocate three blocks like the controller would for three brokers
+    ZkProducerIdManager.getNewProducerIdBlock(1, zkClient, this)
+    ZkProducerIdManager.getNewProducerIdBlock(2, zkClient, this)
+    val block = ZkProducerIdManager.getNewProducerIdBlock(3, zkClient, this)
 
-      val records = new java.util.ArrayList[java.util.List[ApiMessageAndVersion]]()
-      migrationClient.migrateProducerId(batch => records.add(batch))
-      assertEquals(1, records.size())
-      assertEquals(1, records.get(0).size())
+    // Migrate the producer ID state to KRaft as a record
+    val records = new java.util.ArrayList[java.util.List[ApiMessageAndVersion]]()
+    migrationClient.migrateProducerId(batch => records.add(batch))
+    assertEquals(1, records.size())
+    assertEquals(1, records.get(0).size())
+    val record = records.get(0).get(0).message().asInstanceOf[ProducerIdsRecord]
 
-      val record = records.get(0).get(0).message().asInstanceOf[ProducerIdsRecord]
-      record.nextProducerId()
-    }
-
-    // Initialize with ZK ProducerIdManager
-    assertEquals(0, generateNextProducerIdWithZkAndRead())
+    // Ensure the block stored in KRaft is the _next_ block since that is what will be served
+    // to the next ALLOCATE_PRODUCER_IDS caller
+    assertEquals(block.nextBlockFirstId(), record.nextProducerId())
 
     // Update next producer ID via migration client
     migrationState = migrationClient.writeProducerId(6000, migrationState)
     assertEquals(1, migrationState.migrationZkVersion())
 
-    // Switch back to ZK, it should provision the next block
-    assertEquals(7000, generateNextProducerIdWithZkAndRead())
+    val manager = ProducerIdManager.zk(1, zkClient)
+    val producerId = manager.generateProducerId() match {
+      case Failure(e) => fail("Encountered error when generating producer id", e)
+      case Success(value) => value
+    }
+    assertEquals(7000, producerId)
   }
 
   @Test


### PR DESCRIPTION
This patch fixes a problem where we migrate the current producer ID batch to KRaft instead of the next producer ID batch. Since KRaft stores the _next_ batch in the log, we end up serving up a duplicate batch to the first caller of AllocateProducerIds once the KRaft controller has taken over.