### PR TITLE
MINOR: Only commit running active and standby tasks when tasks corrupted

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ReadOnlyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ReadOnlyTask.java
@@ -206,7 +206,10 @@ public class ReadOnlyTask implements Task {
 
     @Override
     public boolean commitNeeded() {
-        throw new UnsupportedOperationException("This task is read-only");
+        if (task.isActive()) {
+            throw new UnsupportedOperationException("This task is read-only");
+        }
+        return task.commitNeeded();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -223,10 +223,7 @@ public class TaskManager {
             final Collection<Task> tasksToCommit = allTasks()
                 .values()
                 .stream()
-                // TODO: once we remove state restoration from the stream thread, we can also remove
-                //  the RESTORING state here, since there will not be any restoring tasks managed
-                //  by the stream thread anymore.
-                .filter(t -> t.state() == Task.State.RUNNING || t.state() == Task.State.RESTORING)
+                .filter(t -> t.state() == Task.State.RUNNING)
                 .filter(t -> !corruptedTasks.contains(t.id()))
                 .collect(Collectors.toSet());
             commitTasksAndMaybeUpdateCommittableOffsets(tasksToCommit, new HashMap<>());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ReadOnlyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ReadOnlyTaskTest.java
@@ -28,7 +28,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
 
-import static java.util.Collections.emptySet;
 import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.standbyTask;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statefulTask;
@@ -193,10 +192,10 @@ class ReadOnlyTaskTest {
                     parameters[i] = 0;
                     break;
                 case "java.util.Set":
-                    parameters[i] = emptySet();
+                    parameters[i] = Collections.emptySet();
                     break;
                 case "java.util.Collection":
-                    parameters[i] = emptySet();
+                    parameters[i] = Collections.emptySet();
                     break;
                 case "java.util.Map":
                     parameters[i] = Collections.emptyMap();
@@ -211,7 +210,7 @@ class ReadOnlyTaskTest {
                     parameters[i] = (Consumer) ignored -> { };
                     break;
                 case "java.lang.Iterable":
-                    parameters[i] = emptySet();
+                    parameters[i] = Collections.emptySet();
                     break;
                 case "org.apache.kafka.common.utils.Time":
                     parameters[i] = Time.SYSTEM;


### PR DESCRIPTION
When tasks are found corrupted, Kafka Streams tries to commit the non-corrupted tasks before closing and reviving the corrupted active tasks. Besides active running tasks, Kafka Streams tries to commit restoring active tasks and standby tasks. However, restoring active tasks do not need to be committed since they do not have offsets to commit and the current code does not write a checkpoint. Furthermore, trying to commit restoring active tasks with the state updater enabled results in the following error:

java.lang.UnsupportedOperationException: This task is read-only at org.apache.kafka.streams.processor.internals.ReadOnlyTask.commitNeeded(ReadOnlyTask.java:209) ...

since commitNeeded() is not a read-only method for active tasks.

In future, we can consider writing a checkpoint for active restoring tasks in this situation. Additionally, we should fix commitNeeded() in active tasks to be read-only.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
