### PR TITLE
KAFKA-15567 Fix benchmark code to work

### DIFF
--- a/checkstyle/import-control-jmh-benchmarks.xml
+++ b/checkstyle/import-control-jmh-benchmarks.xml
@@ -40,6 +40,7 @@
     <allow pkg="kafka.network"/>
     <allow pkg="kafka.utils"/>
     <allow pkg="kafka.zk"/>
+    <allow pkg="kafka.zookeeper"/>
     <allow class="kafka.utils.Pool"/>
     <allow class="kafka.utils.KafkaScheduler"/>
     <allow class="org.apache.kafka.clients.FetchSessionHandler"/>

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
@@ -43,6 +43,8 @@ import kafka.server.builders.KafkaApisBuilder;
 import kafka.server.metadata.MockConfigRepository;
 import kafka.server.metadata.ZkMetadataCache;
 import kafka.zk.KafkaZkClient;
+
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.message.ApiMessageType;
 import org.apache.kafka.common.message.UpdateMetadataRequestData.UpdateMetadataBroker;
@@ -77,6 +79,8 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import scala.Option;
+import scala.collection.Seq;
+import scala.collection.Seq$;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -112,8 +116,10 @@ public class MetadataRequestBenchmark {
     private KafkaZkClient kafkaZkClient = Mockito.mock(KafkaZkClient.class);
     private Metrics metrics = new Metrics();
     private int brokerId = 1;
+    @SuppressWarnings("unchecked")
     private ZkMetadataCache metadataCache = MetadataCache.zkMetadataCache(brokerId,
-        MetadataVersion.latest(), BrokerFeatures.createEmpty(), null);
+                                                                          MetadataVersion.latest(), BrokerFeatures.createEmpty(),
+                                                                          (Seq<Node>) Seq$.MODULE$.empty());
     private ClientQuotaManager clientQuotaManager = Mockito.mock(ClientQuotaManager.class);
     private ClientRequestQuotaManager clientRequestQuotaManager = Mockito.mock(ClientRequestQuotaManager.class);
     private ControllerMutationQuotaManager controllerMutationQuotaManager = Mockito.mock(ControllerMutationQuotaManager.class);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
@@ -22,6 +22,8 @@ import kafka.server.AlterPartitionManager;
 import kafka.server.BrokerFeatures;
 import kafka.server.BrokerTopicStats;
 import kafka.server.KafkaConfig;
+
+import org.apache.kafka.common.Node;
 import org.apache.kafka.server.util.MockTime;
 import org.apache.kafka.storage.internals.log.CleanerConfig;
 import org.apache.kafka.storage.internals.log.LogConfig;
@@ -63,6 +65,8 @@ import java.util.stream.Collectors;
 
 import scala.collection.JavaConverters;
 import scala.Option;
+import scala.collection.Seq;
+import scala.collection.Seq$;
 
 @Warmup(iterations = 5)
 @Measurement(iterations = 5)
@@ -112,10 +116,11 @@ public class CheckpointBench {
                         1024 * 1024, 32 * 1024 * 1024, Double.MAX_VALUE, 15 * 1000, true), time, MetadataVersion.latest(), 4, false, Option.empty());
         scheduler.startup();
         final BrokerTopicStats brokerTopicStats = new BrokerTopicStats(Optional.empty());
+        @SuppressWarnings("unchecked")
         final MetadataCache metadataCache =
                 MetadataCache.zkMetadataCache(this.brokerProperties.brokerId(),
-                    this.brokerProperties.interBrokerProtocolVersion(),
-                    BrokerFeatures.createEmpty(), null);
+                                              this.brokerProperties.interBrokerProtocolVersion(),
+                                              BrokerFeatures.createEmpty(), (Seq<Node>) Seq$.MODULE$.empty());
         this.quotaManagers =
                 QuotaFactory.instantiate(this.brokerProperties,
                         this.metrics,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
@@ -119,8 +119,8 @@ public class CheckpointBench {
         @SuppressWarnings("unchecked")
         final MetadataCache metadataCache =
                 MetadataCache.zkMetadataCache(this.brokerProperties.brokerId(),
-                                              this.brokerProperties.interBrokerProtocolVersion(),
-                                              BrokerFeatures.createEmpty(), (Seq<Node>) Seq$.MODULE$.empty());
+                    this.brokerProperties.interBrokerProtocolVersion(),
+                    BrokerFeatures.createEmpty(), (Seq<Node>) Seq$.MODULE$.empty());
         this.quotaManagers =
                 QuotaFactory.instantiate(this.brokerProperties,
                         this.metrics,


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/KAFKA-15567

## Summary

- Currently, ReplicaFetcherThreadBenchmark doesn't run due to 2 reasons:
  * NPE that is introduced by https://github.com/apache/kafka/commit/755e04a41dfd00dd4587b0fe0980befd0ae5c433
      - ZkMetadataCache instantiation causes NPE because we pass `null` for `kraftControllerNodes` but it should be `Seq.empty`
  * NotLeaderOrFollowerException that is introduced by https://github.com/apache/kafka/commit/3467036e017adc3ac0919bbc0c067b1bb1b621f3
      - Even we address above NPE issue, we still get NotLeaderOrFollowerException
      - ```
        org.apache.kafka.common.errors.NotLeaderOrFollowerException: Error while fetching partition state for topic-30
        ```
      - This is because replicaManager doesn't host partitions when RemoteLeaderEndPoint tries to build fetches
- This PR addresses these problems
- NPE issue on ZkMetadataCache instantiation also occurs in other several benchmarks. This PR also fix these benchmarks.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
