### PR TITLE
KAFKA-15514: Metadata records Replicas->Assignment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1758,7 +1758,7 @@ project(':storage') {
   task processMessages(type:JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
-    args = [ "-p", " org.apache.kafka.server.log.remote.metadata.storage.generated",
+    args = [ "-p", "org.apache.kafka.server.log.remote.metadata.storage.generated",
              "-o", "src/generated/java/org/apache/kafka/server/log/remote/metadata/storage/generated",
              "-i", "src/main/resources/message",
              "-m", "MessageDataGenerator", "JsonConverterGenerator",

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -112,7 +112,9 @@
     </module>
 
     <!-- code quality -->
-    <module name="MethodLength"/>
+    <module name="MethodLength">
+      <property name="max" value="170" />
+    </module>
     <module name="ParameterNumber">
       <!-- default is 8 -->
       <property name="max" value="13"/>

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -115,7 +115,8 @@ public enum ApiKeys {
     CONSUMER_GROUP_DESCRIBE(ApiMessageType.CONSUMER_GROUP_DESCRIBE),
     CONTROLLER_REGISTRATION(ApiMessageType.CONTROLLER_REGISTRATION),
     GET_TELEMETRY_SUBSCRIPTIONS(ApiMessageType.GET_TELEMETRY_SUBSCRIPTIONS),
-    PUSH_TELEMETRY(ApiMessageType.PUSH_TELEMETRY);
+    PUSH_TELEMETRY(ApiMessageType.PUSH_TELEMETRY),
+    ASSIGN_REPLICAS_TO_DIRS(ApiMessageType.ASSIGN_REPLICAS_TO_DIRS);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -320,6 +320,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return GetTelemetrySubscriptionsRequest.parse(buffer, apiVersion);
             case PUSH_TELEMETRY:
                 return PushTelemetryRequest.parse(buffer, apiVersion);
+            case ASSIGN_REPLICAS_TO_DIRS:
+                return AssignReplicasToDirsRequest.parse(buffer, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -257,6 +257,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return GetTelemetrySubscriptionsResponse.parse(responseBuffer, version);
             case PUSH_TELEMETRY:
                 return PushTelemetryResponse.parse(responseBuffer, version);
+            case ASSIGN_REPLICAS_TO_DIRS:
+                return AssignReplicasToDirsResponse.parse(responseBuffer, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AssignReplicasToDirsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AssignReplicasToDirsRequest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.AssignReplicasToDirsRequestData;
+import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+
+public class AssignReplicasToDirsRequest extends AbstractRequest {
+
+    public static class Builder extends AbstractRequest.Builder<AssignReplicasToDirsRequest> {
+
+        private final AssignReplicasToDirsRequestData data;
+
+        public Builder(AssignReplicasToDirsRequestData data) {
+            super(ApiKeys.ASSIGN_REPLICAS_TO_DIRS);
+            this.data = data;
+        }
+
+        @Override
+        public AssignReplicasToDirsRequest build(short version) {
+            return new AssignReplicasToDirsRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final AssignReplicasToDirsRequestData data;
+
+    public AssignReplicasToDirsRequest(AssignReplicasToDirsRequestData data, short version) {
+        super(ApiKeys.ASSIGN_REPLICAS_TO_DIRS, version);
+        this.data = data;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        return new AssignReplicasToDirsResponse(
+                new AssignReplicasToDirsResponseData()
+                        .setThrottleTimeMs(throttleTimeMs)
+                        .setErrorCode(Errors.forException(e).code())
+        );
+    }
+
+    @Override
+    public AssignReplicasToDirsRequestData data() {
+        return data;
+    }
+
+    public static AssignReplicasToDirsRequest parse(ByteBuffer buffer, short version) {
+        return new AssignReplicasToDirsRequest(new AssignReplicasToDirsRequestData(
+                new ByteBufferAccessor(buffer), version), version);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/AssignReplicasToDirsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AssignReplicasToDirsResponse.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class AssignReplicasToDirsResponse extends AbstractResponse {
+
+    private final AssignReplicasToDirsResponseData data;
+
+    public AssignReplicasToDirsResponse(AssignReplicasToDirsResponseData data) {
+        super(ApiKeys.ASSIGN_REPLICAS_TO_DIRS);
+        this.data = data;
+    }
+
+    @Override
+    public AssignReplicasToDirsResponseData data() {
+        return data;
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return Collections.singletonMap(Errors.forCode(data.errorCode()), 1);
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        data.setThrottleTimeMs(throttleTimeMs);
+    }
+
+    public static AssignReplicasToDirsResponse parse(ByteBuffer buffer, short version) {
+        return new AssignReplicasToDirsResponse(new AssignReplicasToDirsResponseData(
+                new ByteBufferAccessor(buffer), version));
+    }
+}

--- a/clients/src/main/resources/common/message/AssignReplicasToDirsRequest.json
+++ b/clients/src/main/resources/common/message/AssignReplicasToDirsRequest.json
@@ -14,24 +14,27 @@
 // limitations under the License.
 
 {
-  "apiKey": 63,
+  "apiKey": 73,
   "type": "request",
   "listeners": ["controller"],
-  "name": "BrokerHeartbeatRequest",
-  "validVersions": "0-1",
+  "name": "AssignReplicasToDirsRequest",
+  "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "BrokerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
-      "about": "The broker ID." },
+      "about": "The ID of the requesting broker" },
     { "name": "BrokerEpoch", "type": "int64", "versions": "0+", "default": "-1",
-      "about": "The broker epoch." },
-    { "name": "CurrentMetadataOffset", "type": "int64", "versions": "0+",
-      "about": "The highest metadata offset which the broker has reached." },
-    { "name": "WantFence", "type": "bool", "versions": "0+",
-      "about": "True if the broker wants to be fenced, false otherwise." },
-    { "name": "WantShutDown", "type": "bool", "versions": "0+",
-      "about": "True if the broker wants to be shut down, false otherwise." },
-    { "name": "OfflineLogDirs", "type":  "[]uuid", "versions": "1+", "taggedVersions": "1+", "tag": "0",
-      "about": "Log directories that failed and went offline." }
+      "about": "The epoch of the requesting broker" },
+    { "name": "Directories", "type":  "[]DirectoryData", "versions": "0+", "fields":  [
+      { "name":  "Id", "type": "uuid", "versions": "0+", "about": "The ID of the directory" },
+      { "name": "Topics", "type": "[]TopicData", "versions": "0+", "fields": [
+        { "name":  "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+          "about": "The name of the assigned topic" },
+        { "name": "Partitions", "type": "[]PartitionData", "versions": "0+", "fields": [
+          { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+            "about": "The partition index" }
+        ]}
+      ]}
+    ]}
   ]
 }

--- a/clients/src/main/resources/common/message/AssignReplicasToDirsResponse.json
+++ b/clients/src/main/resources/common/message/AssignReplicasToDirsResponse.json
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 73,
+  "type": "response",
+  "name": "AssignReplicasToDirsResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top level response error code" },
+    { "name": "Directories", "type":  "[]DirectoryData", "versions": "0+", "fields":  [
+      { "name":  "Id", "type": "uuid", "versions": "0+", "about": "The ID of the directory" },
+      { "name": "Topics", "type": "[]TopicData", "versions": "0+", "fields": [
+        { "name":  "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+          "about": "The name of the assigned topic" },
+        { "name": "Partitions", "type": "[]PartitionData", "versions": "0+", "fields": [
+          { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+            "about": "The partition index" },
+          { "name": "ErrorCode", "type": "int16", "versions": "0+",
+            "about": "The partition level error code" }
+        ]}
+      ]}
+    ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/BrokerHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/BrokerHeartbeatResponse.json
@@ -17,7 +17,7 @@
   "apiKey": 63,
   "type": "response",
   "name": "BrokerHeartbeatResponse",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",

--- a/clients/src/main/resources/common/message/BrokerRegistrationRequest.json
+++ b/clients/src/main/resources/common/message/BrokerRegistrationRequest.json
@@ -14,14 +14,16 @@
 // limitations under the License.
 
 // Version 1 adds Zk broker epoch to the request if the broker is migrating from Zk mode to KRaft mode.
-//
+
 // Version 2 adds the PreviousBrokerEpoch for the KIP-966
+
+// Version 3 adds LogDirs for KIP-858
 {
   "apiKey":62,
   "type": "request",
   "listeners": ["controller"],
   "name": "BrokerRegistrationRequest",
-  "validVersions": "0-2",
+  "validVersions": "0-3",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "BrokerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
@@ -57,6 +59,8 @@
     { "name": "IsMigratingZkBroker", "type": "bool", "versions": "1+", "default": "false",
       "about": "If the required configurations for ZK migration are present, this value is set to true" },
     { "name": "PreviousBrokerEpoch", "type": "int64", "versions": "2+", "default": "-1",
-      "about": "The epoch before a clean shutdown." }
+      "about": "The epoch before a clean shutdown." },
+    { "name": "LogDirs", "type":  "[]uuid", "versions":  "3+",
+      "about": "Log directories configured in this broker which are available." }
   ]
 }

--- a/clients/src/main/resources/common/message/BrokerRegistrationResponse.json
+++ b/clients/src/main/resources/common/message/BrokerRegistrationResponse.json
@@ -20,7 +20,7 @@
   "apiKey": 62,
   "type": "response",
   "name": "BrokerRegistrationResponse",
-  "validVersions": "0-2",
+  "validVersions": "0-3",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",

--- a/clients/src/test/java/org/apache/kafka/common/message/ApiMessageTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/ApiMessageTypeTest.java
@@ -105,7 +105,8 @@ public class ApiMessageTypeTest {
         for (ApiMessageType type : ApiMessageType.values()) {
             assertEquals(0, type.lowestSupportedVersion());
 
-            assertEquals(type.requestSchemas().length, type.responseSchemas().length);
+            assertEquals(type.requestSchemas().length, type.responseSchemas().length,
+                    "request and response schemas must be the same length for " + type.name());
             for (Schema schema : type.requestSchemas())
                 assertNotNull(schema);
             for (Schema schema : type.responseSchemas())

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -61,6 +61,8 @@ import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersion;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionCollection;
+import org.apache.kafka.common.message.AssignReplicasToDirsRequestData;
+import org.apache.kafka.common.message.AssignReplicasToDirsResponseData;
 import org.apache.kafka.common.message.BeginQuorumEpochRequestData;
 import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
@@ -1071,6 +1073,7 @@ public class RequestResponseTest {
             case CONTROLLER_REGISTRATION: return createControllerRegistrationRequest(version);
             case GET_TELEMETRY_SUBSCRIPTIONS: return createGetTelemetrySubscriptionsRequest(version);
             case PUSH_TELEMETRY: return createPushTelemetryRequest(version);
+            case ASSIGN_REPLICAS_TO_DIRS: return createAssignReplicasToDirsRequest(version);
             default: throw new IllegalArgumentException("Unknown API key " + apikey);
         }
     }
@@ -1150,6 +1153,7 @@ public class RequestResponseTest {
             case CONTROLLER_REGISTRATION: return createControllerRegistrationResponse();
             case GET_TELEMETRY_SUBSCRIPTIONS: return createGetTelemetrySubscriptionsResponse();
             case PUSH_TELEMETRY: return createPushTelemetryResponse();
+            case ASSIGN_REPLICAS_TO_DIRS: return createAssignReplicasToDirsResponse();
             default: throw new IllegalArgumentException("Unknown API key " + apikey);
         }
     }
@@ -1176,6 +1180,71 @@ public class RequestResponseTest {
             ))
             .setThrottleTimeMs(1000);
         return new ConsumerGroupDescribeResponse(data);
+    }
+
+    private AssignReplicasToDirsRequest createAssignReplicasToDirsRequest(short version) {
+        AssignReplicasToDirsRequestData data = new AssignReplicasToDirsRequestData()
+                .setBrokerId(1)
+                .setBrokerEpoch(123L)
+                .setDirectories(Arrays.asList(
+                        new AssignReplicasToDirsRequestData.DirectoryData()
+                                .setId(Uuid.randomUuid())
+                                .setTopics(Arrays.asList(
+                                        new AssignReplicasToDirsRequestData.TopicData()
+                                                .setName("foo")
+                                                .setPartitions(Arrays.asList(
+                                                        new AssignReplicasToDirsRequestData.PartitionData()
+                                                                .setPartitionIndex(8)
+                                                ))
+                                )),
+                        new AssignReplicasToDirsRequestData.DirectoryData()
+                                .setId(Uuid.randomUuid())
+                                .setTopics(Arrays.asList(
+                                        new AssignReplicasToDirsRequestData.TopicData()
+                                                .setName("bar")
+                                                .setPartitions(Arrays.asList(
+                                                        new AssignReplicasToDirsRequestData.PartitionData()
+                                                                .setPartitionIndex(2),
+                                                        new AssignReplicasToDirsRequestData.PartitionData()
+                                                                .setPartitionIndex(80)
+                                                        ))
+                                ))
+                ));
+        return new AssignReplicasToDirsRequest.Builder(data).build(version);
+    }
+
+    private AssignReplicasToDirsResponse createAssignReplicasToDirsResponse() {
+        AssignReplicasToDirsResponseData data = new AssignReplicasToDirsResponseData()
+                .setErrorCode(Errors.NONE.code())
+                .setThrottleTimeMs(123)
+                .setDirectories(Arrays.asList(
+                        new AssignReplicasToDirsResponseData.DirectoryData()
+                                .setId(Uuid.randomUuid())
+                                .setTopics(Arrays.asList(
+                                        new AssignReplicasToDirsResponseData.TopicData()
+                                                .setName("foo")
+                                                .setPartitions(Arrays.asList(
+                                                        new AssignReplicasToDirsResponseData.PartitionData()
+                                                                .setPartitionIndex(8)
+                                                                .setErrorCode(Errors.NONE.code())
+                                                ))
+                                )),
+                        new AssignReplicasToDirsResponseData.DirectoryData()
+                                .setId(Uuid.randomUuid())
+                                .setTopics(Arrays.asList(
+                                        new AssignReplicasToDirsResponseData.TopicData()
+                                                .setName("bar")
+                                                .setPartitions(Arrays.asList(
+                                                        new AssignReplicasToDirsResponseData.PartitionData()
+                                                                .setPartitionIndex(2)
+                                                                .setErrorCode(Errors.UNKNOWN_TOPIC_OR_PARTITION.code()),
+                                                        new AssignReplicasToDirsResponseData.PartitionData()
+                                                                .setPartitionIndex(8)
+                                                                .setErrorCode(Errors.NONE.code())
+                                                ))
+                                ))
+                ));
+        return new AssignReplicasToDirsResponse(data);
     }
 
     private ConsumerGroupHeartbeatRequest createConsumerGroupHeartbeatRequest(short version) {

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -465,6 +465,7 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
       metadataInstance.partitionLeadershipInfo(partition) match {
         case Some(LeaderIsrAndControllerEpoch(leaderAndIsr, controllerEpoch)) =>
           val replicas = metadataInstance.partitionReplicaAssignment(partition)
+          // TODO KAFKA-15362 offline dirs also need to be considered to determine offlineReplicas
           val offlineReplicas = replicas.filter(!metadataInstance.isReplicaOnline(_, partition))
           val updatedLeaderAndIsr =
             if (beingDeleted) LeaderAndIsr.duringDelete(leaderAndIsr.isr)

--- a/core/src/main/scala/kafka/migration/MigrationControllerChannelContext.scala
+++ b/core/src/main/scala/kafka/migration/MigrationControllerChannelContext.scala
@@ -33,7 +33,7 @@ object MigrationControllerChannelContext {
   def partitionReplicaAssignment(image: MetadataImage, tp: TopicPartition): collection.Seq[Int] = {
     image.topics().topicsByName().asScala.get(tp.topic()) match {
       case Some(topic) => topic.partitions().asScala.get(tp.partition()) match {
-        case Some(partition) => partition.replicas.toSeq
+        case Some(partition) => partition.replicaBrokerIds().toSeq
         case None => collection.Seq.empty
       }
       case None => collection.Seq.empty

--- a/core/src/main/scala/kafka/network/RequestConvertToJson.scala
+++ b/core/src/main/scala/kafka/network/RequestConvertToJson.scala
@@ -100,6 +100,7 @@ object RequestConvertToJson {
       case req: ConsumerGroupHeartbeatRequest => ConsumerGroupHeartbeatRequestDataJsonConverter.write(req.data, request.version)
       case req: ConsumerGroupDescribeRequest => ConsumerGroupDescribeRequestDataJsonConverter.write(req.data, request.version)
       case req: ControllerRegistrationRequest => ControllerRegistrationRequestDataJsonConverter.write(req.data, request.version)
+      case req: AssignReplicasToDirsRequest => AssignReplicasToDirsRequestDataJsonConverter.write(req.data, request.version)
       case _ => throw new IllegalStateException(s"ApiKey ${request.apiKey} is not currently handled in `request`, the " +
         "code should be updated to do so.");
     }
@@ -180,6 +181,7 @@ object RequestConvertToJson {
       case res: ConsumerGroupHeartbeatResponse => ConsumerGroupHeartbeatResponseDataJsonConverter.write(res.data, version)
       case res: ConsumerGroupDescribeResponse => ConsumerGroupDescribeResponseDataJsonConverter.write(res.data, version)
       case req: ControllerRegistrationResponse => ControllerRegistrationResponseDataJsonConverter.write(req.data, version)
+      case res: AssignReplicasToDirsResponse => AssignReplicasToDirsResponseDataJsonConverter.write(res.data, version)
       case _ => throw new IllegalStateException(s"ApiKey ${response.apiKey} is not currently handled in `response`, the " +
         "code should be updated to do so.");
     }

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -128,6 +128,7 @@ class ControllerApis(
         case ApiKeys.UPDATE_FEATURES => handleUpdateFeatures(request)
         case ApiKeys.DESCRIBE_CLUSTER => handleDescribeCluster(request)
         case ApiKeys.CONTROLLER_REGISTRATION => handleControllerRegistration(request)
+        case ApiKeys.ASSIGN_REPLICAS_TO_DIRS => handleAssignReplicasToDirs(request)
         case _ => throw new ApiException(s"Unsupported ApiKey ${request.context.header.apiKey}")
       }
 
@@ -1072,6 +1073,15 @@ class ControllerApis(
     )
     requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
       new DescribeClusterResponse(response.setThrottleTimeMs(requestThrottleMs)))
+    CompletableFuture.completedFuture[Unit](())
+  }
+
+  def handleAssignReplicasToDirs(request: RequestChannel.Request): CompletableFuture[Unit] = {
+    val assignReplicasToDirsRequest = request.body[AssignReplicasToDirsRequest]
+
+    // TODO KAFKA-15426
+    requestHelper.sendMaybeThrottle(request,
+      assignReplicasToDirsRequest.getErrorResponse(Errors.UNSUPPORTED_VERSION.exception))
     CompletableFuture.completedFuture[Unit](())
   }
 }

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -285,7 +285,8 @@ class ControllerServer(
             config.passwordEncoderIterations)
           case None => PasswordEncoder.noop()
         }
-        val migrationClient = ZkMigrationClient(zkClient, zkConfigEncoder)
+        val metadataVersion = controller.asInstanceOf[QuorumController].featureControl().metadataVersion()
+        val migrationClient = ZkMigrationClient(zkClient, zkConfigEncoder, metadataVersion)
         val propagator: LegacyPropagator = new MigrationPropagator(config.nodeId, config)
         val migrationDriver = KRaftMigrationDriver.newBuilder()
           .setNodeId(config.nodeId)

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -79,9 +79,10 @@ object BrokerMetadataPublisher extends Logging {
       val partitionId = log.topicPartition.partition()
       Option(newTopicsImage.getPartition(topicId, partitionId)) match {
         case Some(partition) =>
-          if (!partition.replicas.contains(brokerId)) {
-            info(s"Found stray log dir $log: the current replica assignment ${partition.replicas} " +
-              s"does not contain the local brokerId $brokerId.")
+          val replicas = partition.replicaBrokerIds()
+          if (!replicas.contains(brokerId)) {
+            info(s"Found stray log dir $log: the current replica assignment " +
+              s"${replicas.mkString("(", ", ", ")")} does not contain the local brokerId $brokerId.")
             Some(log.topicPartition)
           } else {
             None

--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -128,7 +128,7 @@ class ZkMigrationIntegrationTest {
 
     val underlying = clusterInstance.asInstanceOf[ZkClusterInstance].getUnderlying()
     val zkClient = underlying.zkClient
-    val migrationClient = ZkMigrationClient(zkClient, PasswordEncoder.noop())
+    val migrationClient = ZkMigrationClient(zkClient, PasswordEncoder.noop(), MetadataVersion.latest())
     val verifier = new MetadataDeltaVerifier()
     migrationClient.readAllMetadata(batch => verifier.accept(batch), _ => { })
     verifier.verify { image =>
@@ -238,7 +238,7 @@ class ZkMigrationIntegrationTest {
       case None => PasswordEncoder.noop()
     }
 
-    val migrationClient = ZkMigrationClient(zkClient, zkConfigEncoder)
+    val migrationClient = ZkMigrationClient(zkClient, zkConfigEncoder, MetadataVersion.latest())
     var migrationState = migrationClient.getOrCreateMigrationRecoveryState(ZkMigrationLeadershipState.EMPTY)
     migrationState = migrationState.withNewKRaftController(3000, 42)
     migrationState = migrationClient.claimControllerLeadership(migrationState)

--- a/core/src/test/scala/unit/kafka/server/AlterUserScramCredentialsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterUserScramCredentialsRequestTest.scala
@@ -404,7 +404,7 @@ class AlterUserScramCredentialsRequestTest extends BaseRequestTest {
     val results = response.data.results
     assertEquals(1, results.size)
     checkAllErrorsAlteringCredentials(results, Errors.UNSUPPORTED_VERSION,
-                                      "when altering the credentials on unsupported IPB version")
+                                      "when altering the credentials on unsupported IBP version")
     assertEquals("The current metadata version does not support SCRAM", results.get(0).errorMessage)
   }
 

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -1095,6 +1095,34 @@ class ControllerApisTest {
     assertEquals(Errors.NOT_CONTROLLER, response.error)
   }
 
+  @Test
+  def testAssignReplicasToDirsReturnsUnsupportedVersion(): Unit = {
+    val controller = mock(classOf[Controller])
+    val controllerApis = createControllerApis(None, controller)
+
+    val request =
+      new AssignReplicasToDirsRequest.Builder(
+        new AssignReplicasToDirsRequestData()
+          .setBrokerId(1)
+          .setBrokerEpoch(123L)
+          .setDirectories(util.Arrays.asList(
+            new AssignReplicasToDirsRequestData.DirectoryData()
+              .setId(Uuid.randomUuid())
+              .setTopics(util.Arrays.asList(
+                new AssignReplicasToDirsRequestData.TopicData()
+                  .setName("foo")
+                  .setPartitions(util.Arrays.asList(
+                    new AssignReplicasToDirsRequestData.PartitionData()
+                      .setPartitionIndex(8)
+                  ))
+              ))
+          ))).build()
+
+    val expectedResponse = new AssignReplicasToDirsResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)
+    val response = handleRequest[AssignReplicasToDirsResponse](request, controllerApis)
+    assertEquals(expectedResponse, response.data)
+  }
+
   private def handleRequest[T <: AbstractResponse](
     request: AbstractRequest,
     controllerApis: ControllerApis

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -437,7 +437,7 @@ class ReplicaManagerConcurrencyTest {
       delta.replay(new PartitionRecord()
         .setTopicId(topic.topicId)
         .setPartitionId(partitionId)
-        .setReplicas(toList(registration.replicas))
+        .setReplicas(toList(registration.replicaBrokerIds()))
         .setIsr(toList(registration.isr))
         .setLeader(registration.leader)
         .setLeaderEpoch(registration.leaderEpoch)
@@ -465,7 +465,7 @@ class ReplicaManagerConcurrencyTest {
     partitionEpoch: Int = 0
   ): PartitionRegistration = {
     new PartitionRegistration.Builder().
-      setReplicas(replicaIds.toArray).
+      setReplicasWithUnknownDirs(replicaIds.toArray).
       setIsr(isr.toArray).
       setLeader(leader).
       setLeaderRecoveryState(leaderRecoveryState).

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -719,6 +719,9 @@ class RequestQuotaTest extends BaseRequestTest {
         case ApiKeys.PUSH_TELEMETRY =>
           new PushTelemetryRequest.Builder(new PushTelemetryRequestData(), true)
 
+        case ApiKeys.ASSIGN_REPLICAS_TO_DIRS =>
+          new AssignReplicasToDirsRequest.Builder(new AssignReplicasToDirsRequestData())
+
         case _ =>
           throw new IllegalArgumentException("Unsupported API key " + apiKey)
     }

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -161,7 +161,7 @@ class BrokerMetadataPublisherTest {
   ): TopicImage = {
     val partitionRegistrations = partitions.map { case (partitionId, replicas) =>
       Int.box(partitionId) -> new PartitionRegistration.Builder().
-        setReplicas(replicas.toArray).
+        setReplicasWithUnknownDirs(replicas.toArray).
         setIsr(replicas.toArray).
         setLeader(replicas.head).
         setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
@@ -79,8 +79,8 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals(0, migrationState.migrationZkVersion())
 
     val partitions = Map(
-      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(1, 2)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(6).setPartitionEpoch(-1).build(),
-      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(3)).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(7).setPartitionEpoch(-1).build()
+      0 -> new PartitionRegistration.Builder().setReplicasWithUnknownDirs(Array(0, 1, 2)).setIsr(Array(1, 2)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(6).setPartitionEpoch(-1).build(),
+      1 -> new PartitionRegistration.Builder().setReplicasWithUnknownDirs(Array(1, 2, 3)).setIsr(Array(3)).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(7).setPartitionEpoch(-1).build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().updateTopicPartitions(Map("test" -> partitions).asJava, migrationState)
     assertEquals(1, migrationState.migrationZkVersion())
@@ -106,8 +106,8 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals(0, migrationState.migrationZkVersion())
 
     val partitions = Map(
-      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
-      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
+      0 -> new PartitionRegistration.Builder().setReplicasWithUnknownDirs(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
+      1 -> new PartitionRegistration.Builder().setReplicasWithUnknownDirs(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().createTopic("test", Uuid.randomUuid(), partitions, migrationState)
     assertEquals(1, migrationState.migrationZkVersion())
@@ -129,8 +129,8 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals(0, migrationState.migrationZkVersion())
 
     val partitions = Map(
-      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
-      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
+      0 -> new PartitionRegistration.Builder().setReplicasWithUnknownDirs(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
+      1 -> new PartitionRegistration.Builder().setReplicasWithUnknownDirs(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     val topicId = Uuid.randomUuid()
     migrationState = migrationClient.topicClient().createTopic("test", topicId, partitions, migrationState)
@@ -375,8 +375,8 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
 
     val topicId = Uuid.randomUuid()
     val partitions = Map(
-      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
-      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
+      0 -> new PartitionRegistration.Builder().setReplicasWithUnknownDirs(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
+      1 -> new PartitionRegistration.Builder().setReplicasWithUnknownDirs(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().createTopic("test", topicId, partitions, migrationState)
     assertEquals(1, migrationState.migrationZkVersion())
@@ -384,8 +384,8 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     // Change assignment in partitions and update the topic assignment. See the change is
     // reflected.
     val changedPartitions = Map(
-      0 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
-      1 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
+      0 -> new PartitionRegistration.Builder().setReplicasWithUnknownDirs(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
+      1 -> new PartitionRegistration.Builder().setReplicasWithUnknownDirs(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().updateTopic("test", topicId, changedPartitions, migrationState)
     assertEquals(2, migrationState.migrationZkVersion())
@@ -406,7 +406,7 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
 
     // Add a new Partition.
     val newPartition = Map(
-      2 -> new PartitionRegistration.Builder().setReplicas(Array(2, 3, 4)).setIsr(Array(2, 3, 4)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
+      2 -> new PartitionRegistration.Builder().setReplicasWithUnknownDirs(Array(2, 3, 4)).setIsr(Array(2, 3, 4)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
     ).map { case (k, v) => int2Integer(k) -> v }.asJava
     migrationState = migrationClient.topicClient().createTopicPartitions(Map("test" -> newPartition).asJava, migrationState)
     assertEquals(3, migrationState.migrationZkVersion())

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationTestHarness.scala
@@ -21,6 +21,7 @@ import kafka.utils.PasswordEncoder
 import kafka.zk.ZkMigrationClient
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
+import org.apache.kafka.server.common.MetadataVersion
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 
 import java.util.Properties
@@ -54,7 +55,7 @@ class ZkMigrationTestHarness extends QuorumTestHarness {
   override def setUp(testInfo: TestInfo): Unit = {
     super.setUp(testInfo)
     zkClient.createControllerEpochRaw(1)
-    migrationClient = ZkMigrationClient(zkClient, encoder)
+    migrationClient = ZkMigrationClient(zkClient, encoder, MetadataVersion.latest())
     migrationState = initialMigrationState
     migrationState = migrationClient.getOrCreateMigrationRecoveryState(migrationState)
   }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -499,7 +499,7 @@ public class ConsumerGroup implements Group {
                 Map<Integer, Set<String>> partitionRacks = new HashMap<>();
                 topicImage.partitions().forEach((partition, partitionRegistration) -> {
                     Set<String> racks = new HashSet<>();
-                    for (int replica : partitionRegistration.replicas) {
+                    for (int replica : partitionRegistration.replicaBrokerIds()) {
                         Optional<String> rackOptional = clusterImage.broker(replica).rack();
                         // Only add the rack if it is available for the broker/replica.
                         rackOptional.ifPresent(racks::add);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/TopicsImageZonalOutageBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/TopicsImageZonalOutageBenchmark.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.image.TopicsDelta;
 import org.apache.kafka.image.TopicsImage;
+import org.apache.kafka.metadata.Replicas;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -80,7 +81,7 @@ public class TopicsImageZonalOutageBenchmark {
                     topicsDelta.replay(new PartitionRecord().
                         setPartitionId(partitionNumber).
                         setTopicId(topicId).
-                        setReplicas(Arrays.stream(partitionRegistration.replicas).boxed().collect(Collectors.toList())).
+                        setAssignment(Replicas.toPartitionRecordReplicaAssignment(partitionRegistration.replicas)).
                         setIsr(newIsr).
                         setRemovingReplicas(Collections.emptyList()).
                         setAddingReplicas(Collections.emptyList()).

--- a/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java
@@ -188,7 +188,7 @@ public class FeatureControlManager {
         }
     }
 
-    MetadataVersion metadataVersion() {
+    public MetadataVersion metadataVersion() {
         return metadataVersion.get();
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionReassignmentReplicas.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionReassignmentReplicas.java
@@ -18,7 +18,6 @@
 package org.apache.kafka.controller;
 
 import org.apache.kafka.metadata.PartitionRegistration;
-import org.apache.kafka.metadata.Replicas;
 import org.apache.kafka.metadata.placement.PartitionAssignment;
 
 import java.util.ArrayList;
@@ -75,25 +74,12 @@ class PartitionReassignmentReplicas {
     }
 
     boolean isReassignmentInProgress() {
-        return isReassignmentInProgress(
-            removing,
-            adding);
+        return removing.size() > 0 || adding.size() > 0;
     }
 
     static boolean isReassignmentInProgress(PartitionRegistration part) {
-        return isReassignmentInProgress(
-            Replicas.toList(part.removingReplicas),
-            Replicas.toList(part.addingReplicas));
+        return part.removingReplicas.length > 0 || part.addingReplicas.length > 0;
     }
-
-    private static boolean isReassignmentInProgress(
-        List<Integer> removingReplicas,
-        List<Integer> addingReplicas
-    ) {
-        return removingReplicas.size() > 0
-            || addingReplicas.size() > 0;
-    }
-
 
     Optional<CompletedReassignment> maybeCompleteReassignment(List<Integer> targetIsr) {
         // Check if there is a reassignment to complete.

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionReassignmentRevert.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionReassignmentRevert.java
@@ -40,7 +40,7 @@ class PartitionReassignmentRevert {
             new PartitionReassignmentReplicas(
                 Replicas.toList(registration.removingReplicas),
                 Replicas.toList(registration.addingReplicas),
-                Replicas.toList(registration.replicas)
+                Replicas.brokerIdsList(registration.replicas)
             );
 
         this.replicas = ongoingReassignment.originalReplicas();

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -657,8 +657,7 @@ public final class QuorumController implements Controller {
         return clusterControl;
     }
 
-    // Visible for testing
-    FeatureControlManager featureControl() {
+    public FeatureControlManager featureControl() {
         return featureControl;
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
@@ -68,7 +68,7 @@ public final class TopicImage {
         for (Entry<Integer, PartitionRegistration> entry : partitions.entrySet()) {
             int partitionId = entry.getKey();
             PartitionRegistration partition = entry.getValue();
-            writer.write(partition.toRecord(id, partitionId, options.metadataVersion().partitionRecordVersion()));
+            writer.write(partition.toRecord(id, partitionId, options));
         }
     }
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/Replica.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/Replica.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata;
+
+import org.apache.kafka.common.Uuid;
+
+import java.util.Objects;
+
+public class Replica {
+
+    final int brokerId;
+    final Uuid directory;
+
+    public Replica(int brokerId, Uuid directory) {
+        this.brokerId = brokerId;
+        this.directory = directory;
+    }
+
+    public int brokerId() {
+        return brokerId;
+    }
+
+    public Uuid directory() {
+        return directory;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Replica that = (Replica) o;
+        return brokerId == that.brokerId && Objects.equals(directory, that.directory);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(brokerId, directory);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%d:%s", brokerId, directory);
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/Replicas.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/Replicas.java
@@ -17,10 +17,17 @@
 
 package org.apache.kafka.metadata;
 
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metadata.PartitionChangeRecord;
+import org.apache.kafka.common.metadata.PartitionRecord;
+
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 
@@ -46,6 +53,17 @@ public class Replicas {
     }
 
     /**
+     * Convert an array of Replicas to a list of Replicas.
+     *
+     * @param array         The input array.
+     * @return              The output list.
+     */
+    public static List<Replica> toList(Replica[] array) {
+        if (array == null) return null;
+        return Arrays.asList(array);
+    }
+
+    /**
      * Convert a list of integers to an array of ints.
      *
      * @param list          The input list.
@@ -54,6 +72,21 @@ public class Replicas {
     public static int[] toArray(List<Integer> list) {
         if (list == null) return null;
         int[] array = new int[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+            array[i] = list.get(i);
+        }
+        return array;
+    }
+
+    /**
+     * Convert a list of Replica to the respective array of broker IDs.
+     *
+     * @param list          The input list.
+     * @return              The output array.
+     */
+    public static Replica[] toReplicaArray(List<Replica> list) {
+        if (list == null) return null;
+        Replica[] array = new Replica[list.size()];
         for (int i = 0; i < list.size(); i++) {
             array[i] = list.get(i);
         }
@@ -73,27 +106,6 @@ public class Replicas {
     }
 
     /**
-     * Check that a replica set is valid.
-     *
-     * @param replicas      The replica set.
-     * @return              True if none of the replicas are negative, and there are no
-     *                      duplicates.
-     */
-    public static boolean validate(int[] replicas) {
-        if (replicas.length == 0) return true;
-        int[] sortedReplicas = clone(replicas);
-        Arrays.sort(sortedReplicas);
-        int prev = sortedReplicas[0];
-        if (prev < 0) return false;
-        for (int i = 1; i < sortedReplicas.length; i++) {
-            int replica = sortedReplicas[i];
-            if (prev == replica) return false;
-            prev = replica;
-        }
-        return true;
-    }
-
-    /**
      * Check that an isr set is valid.
      *
      * @param replicas      The replica set.
@@ -101,11 +113,11 @@ public class Replicas {
      * @return              True if none of the in-sync replicas are negative, there are
      *                      no duplicates, and all in-sync replicas are also replicas.
      */
-    public static boolean validateIsr(int[] replicas, int[] isr) {
+    public static boolean validateIsr(Replica[] replicas, int[] isr) {
         if (isr.length == 0) return true;
         if (replicas.length == 0) return false;
-        int[] sortedReplicas = clone(replicas);
-        Arrays.sort(sortedReplicas);
+        int[] sortedBrokerIds = brokerIds(replicas);
+        Arrays.sort(sortedBrokerIds);
         int[] sortedIsr = clone(isr);
         Arrays.sort(sortedIsr);
         int j = 0;
@@ -116,8 +128,8 @@ public class Replicas {
             if (prevIsr == curIsr) return false;
             prevIsr = curIsr;
             while (true) {
-                if (j == sortedReplicas.length) return false;
-                int curReplica = sortedReplicas[j++];
+                if (j == sortedBrokerIds.length) return false;
+                int curReplica = sortedBrokerIds[j++];
                 if (curReplica == curIsr) break;
             }
         }
@@ -140,7 +152,7 @@ public class Replicas {
     }
 
     /**
-     * Check if the first list of integers contains the second.
+     * Check if the first list of broker IDs contains the second.
      *
      * @param a             The first list
      * @param b             The second list
@@ -162,6 +174,21 @@ public class Replicas {
             }
         }
         return true;
+    }
+
+    /**
+     * Returns true if an array of replicas contains a specific broker ID.
+     *
+     * @param replicas      The replica array.
+     * @param brokerId      The value to look for.
+     *
+     * @return              True only if the value is found in the array.
+     */
+    public static boolean contains(Replica[] replicas, int brokerId) {
+        for (int i = 0; i < replicas.length; i++) {
+            if (replicas[i].brokerId == brokerId) return true;
+        }
+        return false;
     }
 
     /**
@@ -244,5 +271,179 @@ public class Replicas {
             result.add(replica);
         }
         return result;
+    }
+
+    /**
+     * Consolidated replica information by coalescing directory information,
+     * keyed on the broker ID. If the updated replica information does not
+     * specify directory information, the existing directory assignment
+     * is maintained.
+     * @param base the existing replica information
+     * @param update the new replica information
+     * @throws KafkaException if the base replicas contains duplicate broker IDs
+     * @return a copy of the update parameter with coalesced directory information
+     */
+    public static Replica[] update(Replica[] base, Replica[] update) {
+        Map<Integer, Uuid> assignments = new HashMap<>();
+        for (Replica replica : base) {
+            if (assignments.put(replica.brokerId(), replica.directory()) != null) {
+                throw new KafkaException("Duplicate broker ID in assignment");
+            }
+        }
+        Replica[] consolidated = new Replica[update.length];
+        for (int i = 0; i < update.length; i++) {
+            Replica replica = update[i];
+            Uuid existingUuid = assignments.getOrDefault(replica.brokerId(), Uuid.UNKNOWN_DIR);
+            Uuid updatedUuid = replica.directory();
+            Uuid consolidatedUuid = Uuid.UNKNOWN_DIR.equals(updatedUuid) && !Uuid.UNKNOWN_DIR.equals(existingUuid)
+                    ? existingUuid : updatedUuid;
+            consolidated[i] = new Replica(replica.brokerId(), consolidatedUuid);
+        }
+        return consolidated;
+    }
+
+    /**
+     * Extract an array of broker IDs from an array of Replicas.
+     *
+     * @param replicas  the array of replicas
+     * @return          the array of broker IDs
+     */
+    public static int[] brokerIds(Replica[] replicas) {
+        if (replicas == null) return null;
+        int[] brokerIds = new int[replicas.length];
+        for (int i = 0; i < brokerIds.length; i++) {
+            brokerIds[i] = replicas[i].brokerId();
+        }
+        return brokerIds;
+    }
+
+    /**
+     * Extract a list of broker IDs from a list of Replicas.
+     *
+     * @param replicas  the list of replicas
+     * @return          the list of broker IDs
+     */
+    public static List<Integer> brokerIdsList(List<Replica> replicas) {
+        if (replicas == null) return null;
+        ArrayList<Integer> brokerIds = new ArrayList<>(replicas.size());
+        for (Replica replica : replicas) {
+            brokerIds.add(replica.brokerId());
+        }
+        return brokerIds;
+    }
+
+    /**
+     * Extract a list of broker IDs from an array of Replicas.
+     *
+     * @param replicas  the array of replicas
+     * @return          the list of broker IDs
+     */
+    public static List<Integer> brokerIdsList(Replica[] replicas) {
+        if (replicas == null) return null;
+        ArrayList<Integer> list = new ArrayList<>(replicas.length);
+        for (Replica replica : replicas) {
+            list.add(replica.brokerId());
+        }
+        return list;
+    }
+
+    /**
+     * Build an array of Replicas from an array of broker IDs assuming
+     * {@code Uuid.UNKNOWN_DIR} as the directory.
+     * @param brokerIds  the array of broker IDs
+     * @return           the array of Replicas
+     */
+    public static Replica[] withUnknownDirs(int[] brokerIds) {
+        if (brokerIds == null) return null;
+        Replica[] replicas = new Replica[brokerIds.length];
+        for (int i = 0; i < replicas.length; i++) {
+            int brokerId = brokerIds[i];
+            Uuid dir = Uuid.UNKNOWN_DIR;
+            replicas[i] = new Replica(brokerId, dir);
+        }
+        return replicas;
+    }
+
+    /**
+     * Build an array of Replicas from a list of broker IDs assuming
+     * {@code Uuid.UNKNOWN_DIR} as the directory.
+     * @param brokerIds  the list of broker IDs
+     * @return           the array of Replicas
+     */
+    public static Replica[] withUnknownDirs(List<Integer> brokerIds) {
+        if (brokerIds == null) return null;
+        Replica[] replicas = new Replica[brokerIds.size()];
+        for (int i = 0; i < replicas.length; i++) {
+            int brokerId = brokerIds.get(i);
+            Uuid dir = Uuid.UNKNOWN_DIR;
+            replicas[i] = new Replica(brokerId, dir);
+        }
+        return replicas;
+    }
+
+    /**
+     * Build a Replica from a {@link PartitionRecord}.
+     * @param record    the record
+     * @return          the Replica
+     */
+    public static Replica[] fromRecord(PartitionRecord record) {
+        if (!record.assignment().isEmpty()) {
+            return record.assignment().
+                    stream().map(a -> new Replica(a.broker(), a.directory())).
+                    toArray(Replica[]::new);
+        }
+        if (!record.replicas().isEmpty()) {
+            return withUnknownDirs(record.replicas());
+        }
+        return new Replica[0];
+    }
+
+    /**
+     * Build a Replica from a {@link PartitionChangeRecord}.
+     * @param record    the record
+     * @return          the Replica
+     */
+    public static Replica[] fromRecord(PartitionChangeRecord record) {
+        if (record.assignment() != null && !record.assignment().isEmpty()) {
+            return record.assignment().
+                    stream().map(a -> new Replica(a.broker(), a.directory())).
+                    toArray(Replica[]::new);
+        }
+        if (record.replicas() != null && !record.replicas().isEmpty()) {
+            return withUnknownDirs(record.replicas());
+        }
+        return new Replica[0];
+    }
+
+    /**
+     * Build a list of {@link PartitionRecord.ReplicaAssignment} from an array of {@link Replica}.
+     * @param array     the array
+     * @return          the list
+     */
+    public static List<PartitionRecord.ReplicaAssignment> toPartitionRecordReplicaAssignment(Replica[] array) {
+        if (array == null) return null;
+        List<PartitionRecord.ReplicaAssignment> list = new ArrayList<>(array.length);
+        for (Replica replica : array) {
+            list.add(new PartitionRecord.ReplicaAssignment().
+                    setBroker(replica.brokerId()).
+                    setDirectory(replica.directory()));
+        }
+        return list;
+    }
+
+    /**
+     * Build a list of {@link PartitionChangeRecord.ReplicaAssignment} from an array of {@link Replica}.
+     * @param array     the array
+     * @return          the list
+     */
+    public static List<PartitionChangeRecord.ReplicaAssignment> toPartitionChangeRecordReplicaAssignment(Replica[] array) {
+        if (array == null) return null;
+        List<PartitionChangeRecord.ReplicaAssignment> list = new ArrayList<>(array.length);
+        for (Replica replica : array) {
+            list.add(new PartitionChangeRecord.ReplicaAssignment().
+                    setBroker(replica.brokerId()).
+                    setDirectory(replica.directory()));
+        }
+        return list;
     }
 }

--- a/metadata/src/main/resources/common/metadata/BrokerRegistrationChangeRecord.json
+++ b/metadata/src/main/resources/common/metadata/BrokerRegistrationChangeRecord.json
@@ -13,11 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Version 2 adds LogDirs
 {
   "apiKey": 17,
   "type": "metadata",
   "name": "BrokerRegistrationChangeRecord",
-  "validVersions": "0-1",
+  "validVersions": "0-2",
   "flexibleVersions": "0+",
   "fields": [
    { "name": "BrokerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
@@ -27,6 +28,8 @@
    { "name": "Fenced", "type": "int8", "versions": "0+", "taggedVersions": "0+", "tag": 0,
      "about": "-1 if the broker has been unfenced, 0 if no change, 1 if the broker has been fenced." },
    { "name": "InControlledShutdown", "type": "int8", "versions": "1+", "taggedVersions": "1+", "tag": 1,
-     "about": "0 if no change, 1 if the broker is in controlled shutdown." }
+     "about": "0 if no change, 1 if the broker is in controlled shutdown." },
+   { "name": "LogDirs", "type":  "[]uuid", "versions":  "2+", "taggedVersions": "2+", "tag": "2",
+     "about": "Log directories configured in this broker which are available." }
   ]
 }

--- a/metadata/src/main/resources/common/metadata/PartitionChangeRecord.json
+++ b/metadata/src/main/resources/common/metadata/PartitionChangeRecord.json
@@ -17,9 +17,9 @@
   "apiKey": 5,
   "type": "metadata",
   "name": "PartitionChangeRecord",
-  "validVersions": "0-1",
   // Version 1 implements Eligiable Leader Replicas and LastKnownELR as described in KIP-966.
-  //
+  // Version 2 replaces Replicas with Assignment
+  "validVersions": "0-2",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "PartitionId", "type": "int32", "versions": "0+", "default": "-1",
@@ -48,6 +48,14 @@
       "about": "null if the ELR didn't change; the new eligible leader replicas otherwise." },
     { "name": "LastKnownELR", "type": "[]int32", "default": "null", "entityType": "brokerId",
       "versions": "1+", "nullableVersions": "1+", "taggedVersions": "1+", "tag": 7,
-      "about": "null if the LastKnownELR didn't change; the last known eligible leader replicas otherwise." }
+      "about": "null if the LastKnownELR didn't change; the last known eligible leader replicas otherwise." },
+    { "name": "Assignment", "type": "[]ReplicaAssignment", "default": "null",
+      "versions": "2+", "nullableVersions": "2+", "taggedVersions": "2+", "tag": 8,
+      "about": "null if the replica assignment didn't change; the new replica assignment otherwise.", "fields": [
+      { "name": "Broker", "type": "int32", "versions": "2+", "entityType": "brokerId",
+        "about": "The broker ID hosting the replica." },
+      { "name": "Directory", "type": "uuid", "versions": "2+",
+        "about": "The log directory hosting the replica" }
+    ]}
   ]
 }

--- a/metadata/src/main/resources/common/metadata/PartitionRecord.json
+++ b/metadata/src/main/resources/common/metadata/PartitionRecord.json
@@ -17,9 +17,9 @@
   "apiKey": 3,
   "type": "metadata",
   "name": "PartitionRecord",
-  "validVersions": "0-1",
-  // Version 1 implements Eligiable Leader Replicas and LastKnownELR as described in KIP-966.
-  //
+  // Version 1 replaces Replicas with Assignment
+  // Version 2 implements Eligiable Leader Replicas and LastKnownELR as described in KIP-966.
+  "validVersions": "0-2",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "PartitionId", "type": "int32", "versions": "0+", "default": "-1",
@@ -47,6 +47,13 @@
       "about": "The eligible leader replicas of this partition." },
     { "name": "LastKnownELR", "type": "[]int32", "default": "null", "entityType": "brokerId",
       "versions": "1+", "nullableVersions": "1+", "taggedVersions": "1+", "tag": 2,
-      "about": "The last known eligible leader replicas of this partition." }
+      "about": "The last known eligible leader replicas of this partition." },
+    { "name": "Assignment", "type": "[]ReplicaAssignment", "versions": "2+",
+      "about": "The replica assignment for this partition, sorted by preferred order.", "fields": [
+      { "name": "Broker", "type": "int32", "versions": "2+", "entityType": "brokerId",
+        "about": "The broker ID hosting the replica." },
+      { "name": "Directory", "type": "uuid", "versions": "2+",
+        "about": "The log directory hosting the replica" }
+    ]}
   ]
 }

--- a/metadata/src/main/resources/common/metadata/RegisterBrokerRecord.json
+++ b/metadata/src/main/resources/common/metadata/RegisterBrokerRecord.json
@@ -13,11 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Version 3 adds LogDirs
 {
   "apiKey": 0,
   "type": "metadata",
   "name": "RegisterBrokerRecord",
-  "validVersions": "0-2",
+  "validVersions": "0-3",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "BrokerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
@@ -53,6 +54,8 @@
     { "name": "Fenced", "type": "bool", "versions": "0+", "default": "true",
       "about": "True if the broker is fenced." },
     { "name": "InControlledShutdown", "type": "bool", "versions": "1+", "default": "false",
-      "about": "True if the broker is in controlled shutdown." }
+      "about": "True if the broker is in controlled shutdown." },
+    { "name": "LogDirs", "type":  "[]uuid", "versions":  "3+", "taggedVersions": "3+", "tag": "0",
+      "about": "Log directories configured in this broker which are available." }
   ]
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentReplicasTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentReplicasTest.java
@@ -133,7 +133,7 @@ public class PartitionReassignmentReplicasTest {
     public void testIsReassignmentInProgress() {
         assertTrue(PartitionReassignmentReplicas.isReassignmentInProgress(
             new PartitionRegistration.Builder().
-                setReplicas(new int[]{0, 1, 3, 2}).
+                setReplicasWithUnknownDirs(new int[]{0, 1, 3, 2}).
                 setIsr(new int[]{0, 1, 3, 2}).
                 setRemovingReplicas(new int[]{2}).
                 setAddingReplicas(new int[]{3}).
@@ -144,7 +144,7 @@ public class PartitionReassignmentReplicasTest {
                 build()));
         assertTrue(PartitionReassignmentReplicas.isReassignmentInProgress(
             new PartitionRegistration.Builder().
-                setReplicas(new int[]{0, 1, 3, 2}).
+                setReplicasWithUnknownDirs(new int[]{0, 1, 3, 2}).
                 setIsr(new int[]{0, 1, 3, 2}).
                 setRemovingReplicas(new int[]{2}).
                 setLeader(0).
@@ -154,7 +154,7 @@ public class PartitionReassignmentReplicasTest {
                 build()));
         assertTrue(PartitionReassignmentReplicas.isReassignmentInProgress(
             new PartitionRegistration.Builder().
-                setReplicas(new int[]{0, 1, 3, 2}).
+                setReplicasWithUnknownDirs(new int[]{0, 1, 3, 2}).
                 setIsr(new int[]{0, 1, 3, 2}).
                 setAddingReplicas(new int[]{3}).
                 setLeader(0).
@@ -164,7 +164,7 @@ public class PartitionReassignmentReplicasTest {
                 build()));
         assertFalse(PartitionReassignmentReplicas.isReassignmentInProgress(
             new PartitionRegistration.Builder().
-                setReplicas(new int[]{0, 1, 2}).
+                setReplicasWithUnknownDirs(new int[]{0, 1, 2}).
                 setIsr(new int[]{0, 1, 2}).
                 setLeader(0).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentRevertTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentRevertTest.java
@@ -34,7 +34,7 @@ public class PartitionReassignmentRevertTest {
     @Test
     public void testNoneAddedOrRemoved() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
-            setReplicas(new int[] {3, 2, 1}).setIsr(new int[] {3, 2}).
+            setReplicasWithUnknownDirs(new int[] {3, 2, 1}).setIsr(new int[] {3, 2}).
             setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
@@ -45,7 +45,7 @@ public class PartitionReassignmentRevertTest {
     @Test
     public void testSomeRemoving() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
-            setReplicas(new int[] {3, 2, 1}).setIsr(new int[] {3, 2}).
+            setReplicasWithUnknownDirs(new int[] {3, 2, 1}).setIsr(new int[] {3, 2}).
             setRemovingReplicas(new int[]{2, 1}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
@@ -56,7 +56,7 @@ public class PartitionReassignmentRevertTest {
     @Test
     public void testSomeAdding() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
-            setReplicas(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5, 2}).
+            setReplicasWithUnknownDirs(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5, 2}).
             setAddingReplicas(new int[]{4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
@@ -67,7 +67,7 @@ public class PartitionReassignmentRevertTest {
     @Test
     public void testSomeRemovingAndAdding() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
-            setReplicas(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5, 2}).
+            setReplicasWithUnknownDirs(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5, 2}).
             setRemovingReplicas(new int[]{2}).setAddingReplicas(new int[]{4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
@@ -78,7 +78,7 @@ public class PartitionReassignmentRevertTest {
     @Test
     public void testIsrSpecialCase() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
-            setReplicas(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5}).
+            setReplicasWithUnknownDirs(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5}).
             setRemovingReplicas(new int[]{2}).setAddingReplicas(new int[]{4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -548,7 +548,7 @@ public class ReplicationControlManagerTest {
             setTopicId(result3.response().topics().find("foo").topicId()));
         assertEquals(expectedResponse3, result3.response());
         ctx.replay(result3.records());
-        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 0}).
+        assertEquals(new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[] {1, 2, 0}).
             setIsr(new int[] {1, 2, 0}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build(),
             replicationControl.getPartition(
                 ((TopicRecord) result3.records().get(0).message()).topicId(), 0));
@@ -610,7 +610,7 @@ public class ReplicationControlManagerTest {
         // Broker 2 cannot be in the ISR because it is fenced and broker 1
         // cannot be in the ISR because it is in controlled shutdown.
         assertEquals(
-            new PartitionRegistration.Builder().setReplicas(new int[]{1, 0, 2}).
+            new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[]{1, 0, 2}).
                 setIsr(new int[]{0}).
                 setLeader(0).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
@@ -1484,7 +1484,7 @@ public class ReplicationControlManagerTest {
         // Broker 2 cannot be in the ISR because it is fenced and broker 1
         // cannot be in the ISR because it is in controlled shutdown.
         assertEquals(
-            new PartitionRegistration.Builder().setReplicas(new int[]{0, 1, 2}).
+            new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[]{0, 1, 2}).
                 setIsr(new int[]{0}).
                 setLeader(0).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
@@ -1670,7 +1670,7 @@ public class ReplicationControlManagerTest {
 
         assertEquals(
             new PartitionRegistration.Builder().
-                setReplicas(new int[] {1, 2, 3, 4}).
+                    setReplicasWithUnknownDirs(new int[] {1, 2, 3, 4}).
                 setIsr(new int[] {1, 2, 4}).
                 setLeader(1).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
@@ -1812,7 +1812,7 @@ public class ReplicationControlManagerTest {
 
         assertEquals(
             new PartitionRegistration.Builder().
-                setReplicas(new int[] {1, 2, 3, 4}).
+                    setReplicasWithUnknownDirs(new int[] {1, 2, 3, 4}).
                 setIsr(new int[] {1, 2, 3, 4}).
                 setLeader(1).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
@@ -1868,7 +1868,7 @@ public class ReplicationControlManagerTest {
         List<ApiMessageAndVersion> fenceRecords = new ArrayList<>();
         replication.handleBrokerFenced(3, fenceRecords);
         ctx.replay(fenceRecords);
-        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).setIsr(new int[] {1, 2, 4}).
+        assertEquals(new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[] {1, 2, 3, 4}).setIsr(new int[] {1, 2, 4}).
             setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(1).build(), replication.getPartition(fooId, 0));
         ControllerResult<AlterPartitionReassignmentsResponseData> alterResult =
             replication.alterPartitionReassignments(
@@ -1905,11 +1905,11 @@ public class ReplicationControlManagerTest {
                     setErrorMessage(null))))),
             alterResult.response());
         ctx.replay(alterResult.records());
-        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2}).
+        assertEquals(new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[] {1, 2, 3}).setIsr(new int[] {1, 2}).
             setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(2).build(), replication.getPartition(fooId, 0));
-        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 0}).setIsr(new int[] {0, 1, 2}).
+        assertEquals(new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[] {1, 2, 3, 0}).setIsr(new int[] {0, 1, 2}).
             setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(2).build(), replication.getPartition(fooId, 1));
-        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 0}).setIsr(new int[] {4, 2}).
+        assertEquals(new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[] {1, 2, 3, 4, 0}).setIsr(new int[] {4, 2}).
             setAddingReplicas(new int[] {0, 1}).setLeader(4).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(2).build(), replication.getPartition(barId, 0));
         ListPartitionReassignmentsResponseData currentReassigning =
             new ListPartitionReassignmentsResponseData().setErrorMessage(null).
@@ -1968,7 +1968,7 @@ public class ReplicationControlManagerTest {
             cancelResult);
         ctx.replay(cancelResult.records());
         assertEquals(NONE_REASSIGNING, replication.listPartitionReassignments(null, Long.MAX_VALUE));
-        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {2, 3, 4}).setIsr(new int[] {4, 2}).
+        assertEquals(new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[] {2, 3, 4}).setIsr(new int[] {4, 2}).
             setLeader(4).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(3).build(), replication.getPartition(barId, 0));
     }
 
@@ -1989,7 +1989,7 @@ public class ReplicationControlManagerTest {
         ctx.createPartitions(2, "foo", new int[][] {new int[] {3, 4, 5}},
             INVALID_REPLICA_ASSIGNMENT.code());
         ctx.createPartitions(2, "foo", new int[][] {new int[] {2, 4, 5}}, NONE.code());
-        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {2, 4, 5}).
+        assertEquals(new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[] {2, 4, 5}).
                 setIsr(new int[] {2}).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build(),
             ctx.replicationControl.getPartition(fooId, 1));
     }
@@ -2165,15 +2165,15 @@ public class ReplicationControlManagerTest {
         PartitionRegistration partition1 = replication.getPartition(fooId, 1);
         PartitionRegistration partition2 = replication.getPartition(fooId, 2);
 
-        assertArrayEquals(new int[]{1, 2, 3}, partition0.replicas);
+        assertArrayEquals(new int[]{1, 2, 3}, partition0.replicaBrokerIds());
         assertArrayEquals(new int[]{1}, partition0.isr);
         assertEquals(1, partition0.leader);
 
-        assertArrayEquals(new int[]{2, 3, 4}, partition1.replicas);
+        assertArrayEquals(new int[]{2, 3, 4}, partition1.replicaBrokerIds());
         assertArrayEquals(new int[]{4}, partition1.isr);
         assertEquals(4, partition1.leader);
 
-        assertArrayEquals(new int[]{0, 2, 1}, partition2.replicas);
+        assertArrayEquals(new int[]{0, 2, 1}, partition2.replicaBrokerIds());
         assertArrayEquals(new int[]{0, 1}, partition2.isr);
         assertNotEquals(2, partition2.leader);
     }
@@ -2629,7 +2629,7 @@ public class ReplicationControlManagerTest {
         // Make sure the leader is in the replicas still
         partition = replication.getPartition(topicId, 0);
         assertEquals(2, partition.leader);
-        assertTrue(Replicas.toSet(partition.replicas).contains(partition.leader));
+        assertTrue(Replicas.toSet(partition.replicaBrokerIds()).contains(partition.leader));
 
         // Add 3, 4 to the ISR to complete the reassignment
         AlterPartitionRequestData alterPartitionRequestDataTwo = new AlterPartitionRequestData().

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsChangesTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsChangesTest.java
@@ -27,8 +27,10 @@ import org.apache.kafka.common.metadata.PartitionChangeRecord;
 import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.image.TopicDelta;
 import org.apache.kafka.image.TopicImage;
+import org.apache.kafka.image.writer.ImageWriterOptions;
 import org.apache.kafka.metadata.BrokerRegistration;
 import org.apache.kafka.metadata.PartitionRegistration;
+import org.apache.kafka.server.common.MetadataVersion;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.FakePartitionRegistrationType.NORMAL;
@@ -159,16 +161,18 @@ public class ControllerMetricsChangesTest {
 
     static {
         TOPIC_DELTA1 = new TopicDelta(new TopicImage("foo", FOO_ID, Collections.emptyMap()));
+        ImageWriterOptions options = new ImageWriterOptions.Builder()
+                .setMetadataVersion(MetadataVersion.latest()).build();
         TOPIC_DELTA1.replay((PartitionRecord) fakePartitionRegistration(NORMAL).
-                toRecord(FOO_ID, 0, (short) 0).message());
+                toRecord(FOO_ID, 0, options).message());
         TOPIC_DELTA1.replay((PartitionRecord) fakePartitionRegistration(NORMAL).
-                toRecord(FOO_ID, 1, (short) 0).message());
+                toRecord(FOO_ID, 1, options).message());
         TOPIC_DELTA1.replay((PartitionRecord) fakePartitionRegistration(NORMAL).
-                toRecord(FOO_ID, 2, (short) 0).message());
+                toRecord(FOO_ID, 2, options).message());
         TOPIC_DELTA1.replay((PartitionRecord) fakePartitionRegistration(NON_PREFERRED_LEADER).
-                toRecord(FOO_ID, 3, (short) 0).message());
+                toRecord(FOO_ID, 3, options).message());
         TOPIC_DELTA1.replay((PartitionRecord) fakePartitionRegistration(NON_PREFERRED_LEADER).
-                toRecord(FOO_ID, 4, (short) 0).message());
+                toRecord(FOO_ID, 4, options).message());
 
         TOPIC_DELTA2 = new TopicDelta(TOPIC_DELTA1.apply());
         TOPIC_DELTA2.replay(new PartitionChangeRecord().
@@ -176,7 +180,7 @@ public class ControllerMetricsChangesTest {
                 setTopicId(FOO_ID).
                 setLeader(1));
         TOPIC_DELTA2.replay((PartitionRecord) fakePartitionRegistration(NORMAL).
-                toRecord(FOO_ID, 5, (short) 0).message());
+                toRecord(FOO_ID, 5, options).message());
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsTestUtils.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsTestUtils.java
@@ -72,7 +72,7 @@ public class ControllerMetricsTestUtils {
                 break;
         }
         return new PartitionRegistration.Builder().
-            setReplicas(new int[] {0, 1, 2}).
+            setReplicasWithUnknownDirs(new int[] {0, 1, 2}).
             setIsr(new int[] {0, 1, 2}).
             setLeader(leader).
             setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.image.writer.RecordListWriter;
 import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.metadata.RecordTestUtils;
+import org.apache.kafka.metadata.Replicas;
 import org.apache.kafka.server.immutable.ImmutableMap;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.junit.jupiter.api.Test;
@@ -100,14 +101,14 @@ public class TopicsImageTest {
     static {
         TOPIC_IMAGES1 = Arrays.asList(
             newTopicImage("foo", FOO_UUID,
-                new PartitionRegistration.Builder().setReplicas(new int[] {2, 3, 4}).
+                new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[] {2, 3, 4}).
                     setIsr(new int[] {2, 3}).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(345).build(),
-                new PartitionRegistration.Builder().setReplicas(new int[] {3, 4, 5}).
+                new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[] {3, 4, 5}).
                     setIsr(new int[] {3, 4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(4).setPartitionEpoch(684).build(),
-                new PartitionRegistration.Builder().setReplicas(new int[] {2, 4, 5}).
+                new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[] {2, 4, 5}).
                     setIsr(new int[] {2, 4, 5}).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(10).setPartitionEpoch(84).build()),
             newTopicImage("bar", BAR_UUID,
-                new PartitionRegistration.Builder().setReplicas(new int[] {0, 1, 2, 3, 4}).
+                new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[] {0, 1, 2, 3, 4}).
                     setIsr(new int[] {0, 1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {3, 4}).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(345).build()));
 
         IMAGE1 = new TopicsImage(newTopicsByIdMap(TOPIC_IMAGES1), newTopicsByNameMap(TOPIC_IMAGES1));
@@ -126,7 +127,8 @@ public class TopicsImageTest {
         DELTA1_RECORDS.add(new ApiMessageAndVersion(new PartitionRecord().
             setPartitionId(0).
             setTopicId(BAZ_UUID).
-            setReplicas(Arrays.asList(1, 2, 3, 4)).
+            setAssignment(Replicas.toPartitionRecordReplicaAssignment(
+                    Replicas.withUnknownDirs(new int[] {1, 2, 3, 4}))).
             setIsr(Arrays.asList(3, 4)).
             setRemovingReplicas(Collections.singletonList(2)).
             setAddingReplicas(Collections.singletonList(1)).
@@ -139,10 +141,10 @@ public class TopicsImageTest {
 
         List<TopicImage> topics2 = Arrays.asList(
             newTopicImage("bar", BAR_UUID,
-                new PartitionRegistration.Builder().setReplicas(new int[] {0, 1, 2, 3, 4}).
+                new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[] {0, 1, 2, 3, 4}).
                     setIsr(new int[] {0, 1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {3, 4}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(346).build()),
             newTopicImage("baz", BAZ_UUID,
-                new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).
+                new PartitionRegistration.Builder().setReplicasWithUnknownDirs(new int[] {1, 2, 3, 4}).
                     setIsr(new int[] {3, 4}).setRemovingReplicas(new int[] {2}).setAddingReplicas(new int[] {1}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(1).build()));
         IMAGE2 = new TopicsImage(newTopicsByIdMap(topics2), newTopicsByNameMap(topics2));
     }
@@ -163,7 +165,7 @@ public class TopicsImageTest {
 
     private PartitionRegistration newPartition(int[] replicas) {
         return new PartitionRegistration.Builder().
-            setReplicas(replicas).
+            setReplicasWithUnknownDirs(replicas).
             setIsr(replicas).
             setLeader(replicas[0]).
             setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).

--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
@@ -502,7 +502,7 @@ public class KRaftMigrationDriverTest {
                 IMAGE1.topicsByName().forEach((topicName, topicImage) -> {
                     Map<Integer, List<Integer>> assignment = new HashMap<>();
                     topicImage.partitions().forEach((partitionId, partitionRegistration) ->
-                        assignment.put(partitionId, IntStream.of(partitionRegistration.replicas).boxed().collect(Collectors.toList()))
+                        assignment.put(partitionId, IntStream.of(partitionRegistration.replicaBrokerIds()).boxed().collect(Collectors.toList()))
                     );
                     visitor.visitTopic(topicName, topicImage.id(), assignment);
 

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -293,6 +293,10 @@ public enum MetadataVersion {
         return this.isAtLeast(IBP_3_7_IV1);
     }
 
+    public boolean isDirectoryAssignmentSupported() {
+        return false; // TODO: Bump IBP for JBOD support in KRaft
+    }
+
     public boolean isKRaftSupported() {
         return this.featureLevel > 0;
     }
@@ -344,7 +348,9 @@ public enum MetadataVersion {
     }
 
     public short partitionChangeRecordVersion() {
-        if (isElrSupported()) {
+        if (isDirectoryAssignmentSupported()) {
+            return (short) 2;
+        } else if (isElrSupported()) {
             return (short) 1;
         } else {
             return (short) 0;

--- a/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandErrorTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandErrorTest.java
@@ -80,7 +80,7 @@ public class LeaderElectionCommandErrorTest {
     public void testInvalidBroker() {
         Throwable e = assertThrows(AdminCommandFailedException.class, () -> LeaderElectionCommand.run(
             Duration.ofSeconds(1),
-            "--bootstrap-server", "example.com:1234",
+            "--bootstrap-server", "localhost:1234",
             "--election-type", "unclean",
             "--all-topic-partitions"
         ));


### PR DESCRIPTION
The new "Assignments" field replaces the "Replicas" field in PartitionRecord and PartitionChangeRecord.

Depends on #14290 - [KAFKA-15355](https://issues.apache.org/jira/browse/KAFKA-15355)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
