### PR TITLE
KAFKA-15534: Inject request completion time when the request failed

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -195,41 +195,41 @@ public class CommitRequestManager implements RequestManager {
                 OffsetAndMetadata offsetAndMetadata = entry.getValue();
 
                 OffsetCommitRequestData.OffsetCommitRequestTopic topic = requestTopicDataMap
-                        .getOrDefault(topicPartition.topic(),
-                                new OffsetCommitRequestData.OffsetCommitRequestTopic()
-                                        .setName(topicPartition.topic())
-                        );
+                    .getOrDefault(topicPartition.topic(),
+                        new OffsetCommitRequestData.OffsetCommitRequestTopic()
+                            .setName(topicPartition.topic())
+                    );
 
                 topic.partitions().add(new OffsetCommitRequestData.OffsetCommitRequestPartition()
-                        .setPartitionIndex(topicPartition.partition())
-                        .setCommittedOffset(offsetAndMetadata.offset())
-                        .setCommittedLeaderEpoch(offsetAndMetadata.leaderEpoch().orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
-                        .setCommittedMetadata(offsetAndMetadata.metadata())
+                    .setPartitionIndex(topicPartition.partition())
+                    .setCommittedOffset(offsetAndMetadata.offset())
+                    .setCommittedLeaderEpoch(offsetAndMetadata.leaderEpoch().orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
+                    .setCommittedMetadata(offsetAndMetadata.metadata())
                 );
                 requestTopicDataMap.put(topicPartition.topic(), topic);
             }
 
             OffsetCommitRequest.Builder builder = new OffsetCommitRequest.Builder(
-                    new OffsetCommitRequestData()
-                            .setGroupId(this.groupId)
-                            .setGenerationIdOrMemberEpoch(generation.generationId)
-                            .setMemberId(generation.memberId)
-                            .setGroupInstanceId(groupInstanceId)
-                            .setTopics(new ArrayList<>(requestTopicDataMap.values())));
+                new OffsetCommitRequestData()
+                    .setGroupId(this.groupId)
+                    .setGenerationIdOrMemberEpoch(generation.generationId)
+                    .setMemberId(generation.memberId)
+                    .setGroupInstanceId(groupInstanceId)
+                    .setTopics(new ArrayList<>(requestTopicDataMap.values())));
             return new NetworkClientDelegate.UnsentRequest(
-                    builder,
-                    coordinatorRequestManager.coordinator(),
-                    (response, throwable) -> {
-                        if (throwable == null) {
-                            future.complete(null);
-                        } else {
-                            future.completeExceptionally(throwable);
-                        }
-                    });
+                builder,
+                coordinatorRequestManager.coordinator(),
+                (response, throwable) -> {
+                    if (throwable == null) {
+                        future.complete(null);
+                    } else {
+                        future.completeExceptionally(throwable);
+                    }
+                });
         }
     }
 
-    private class OffsetFetchRequestState extends RequestState {
+    class OffsetFetchRequestState extends RequestState {
         public final Set<TopicPartition> requestedPartitions;
         public final GroupState.Generation requestedGeneration;
         private final CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> future;
@@ -254,14 +254,14 @@ public class CommitRequestManager implements RequestManager {
                     new ArrayList<>(this.requestedPartitions),
                     throwOnFetchStableOffsetUnsupported);
             return new NetworkClientDelegate.UnsentRequest(
-                    builder,
-                    coordinatorRequestManager.coordinator(),
-                    (r, t) -> onResponse(r.receivedTimeMs(), (OffsetFetchResponse) r.responseBody()));
+                builder,
+                coordinatorRequestManager.coordinator(),
+                (r, t) -> onResponse(r.receivedTimeMs(), (OffsetFetchResponse) r.responseBody()));
         }
 
         public void onResponse(
-                final long currentTimeMs,
-                final OffsetFetchResponse response) {
+            final long currentTimeMs,
+            final OffsetFetchResponse response) {
             Errors responseError = response.groupLevelError(groupState.groupId);
             if (responseError != Errors.NONE) {
                 onFailure(currentTimeMs, responseError);
@@ -279,7 +279,7 @@ public class CommitRequestManager implements RequestManager {
                 retry(currentTimeMs);
             } else if (responseError == Errors.NOT_COORDINATOR) {
                 // re-discover the coordinator and retry
-                coordinatorRequestManager.markCoordinatorUnknown(responseError.message(), Time.SYSTEM.milliseconds());
+                coordinatorRequestManager.markCoordinatorUnknown(responseError.message(), currentTimeMs);
                 retry(currentTimeMs);
             } else if (responseError == Errors.GROUP_AUTHORIZATION_FAILED) {
                 future.completeExceptionally(GroupAuthorizationException.forGroupId(groupState.groupId));
@@ -290,7 +290,6 @@ public class CommitRequestManager implements RequestManager {
 
         private void retry(final long currentTimeMs) {
             onFailedAttempt(currentTimeMs);
-            onSendAttempt(currentTimeMs);
             pendingRequests.addOffsetFetchRequest(this);
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
@@ -114,7 +114,7 @@ public class CoordinatorRequestManager implements RequestManager {
             Optional.empty()
         );
 
-        unsentRequest.handler().whenComplete((clientResponse, throwable) -> {
+        unsentRequest.future().whenComplete((clientResponse, throwable) -> {
             if (clientResponse != null) {
                 FindCoordinatorResponse response = (FindCoordinatorResponse) clientResponse.responseBody();
                 onResponse(clientResponse.receivedTimeMs(), response);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
@@ -114,13 +114,12 @@ public class CoordinatorRequestManager implements RequestManager {
             Optional.empty()
         );
 
-        unsentRequest.future().whenComplete((clientResponse, throwable) -> {
-            long responseTimeMs = time.milliseconds();
+        unsentRequest.handler().whenComplete((clientResponse, throwable) -> {
             if (clientResponse != null) {
                 FindCoordinatorResponse response = (FindCoordinatorResponse) clientResponse.responseBody();
-                onResponse(responseTimeMs, response);
+                onResponse(clientResponse.receivedTimeMs(), response);
             } else {
-                onFailedResponse(responseTimeMs, throwable);
+                onFailedResponse(unsentRequest.handler().completionTimeMs(), throwable);
             }
         });
 
@@ -165,10 +164,7 @@ public class CoordinatorRequestManager implements RequestManager {
         coordinatorRequestState.onSuccessfulAttempt(currentTimeMs);
     }
 
-    private void onFailedResponse(
-        final long currentTimeMs,
-        final Throwable exception
-    ) {
+    private void onFailedResponse(final long currentTimeMs, final Throwable exception) {
         coordinatorRequestState.onFailedAttempt(currentTimeMs);
         markCoordinatorUnknown("FindCoordinator failed with exception", currentTimeMs);
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -184,13 +184,11 @@ public class HeartbeatRequestManager implements RequestManager {
         NetworkClientDelegate.UnsentRequest request = new NetworkClientDelegate.UnsentRequest(
             new ConsumerGroupHeartbeatRequest.Builder(data),
             coordinatorRequestManager.coordinator());
-        request.future().whenComplete((response, exception) -> {
+        request.handler().whenComplete((response, exception) -> {
             if (response != null) {
                 onResponse((ConsumerGroupHeartbeatResponse) response.responseBody(), response.receivedTimeMs());
             } else {
-                // TODO: Currently, we lack a good way to propage the response time from the network client to the
-                //  request handler. We will need to store the response time in the handler to make it accessible.
-                onFailure(exception, time.milliseconds());
+                onFailure(exception, request.handler().completionTimeMs());
             }
         });
         return request;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -186,7 +186,7 @@ public class HeartbeatRequestManager implements RequestManager {
             coordinatorRequestManager.coordinator());
         request.future().whenComplete((response, exception) -> {
             if (response != null) {
-                onResponse((ConsumerGroupHeartbeatResponse) response.responseBody(), response.receivedTimeMs());
+                onResponse((ConsumerGroupHeartbeatResponse) response.responseBody(), request.handler().completionTimeMs());
             } else {
                 onFailure(exception, request.handler().completionTimeMs());
             }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -184,7 +184,7 @@ public class HeartbeatRequestManager implements RequestManager {
         NetworkClientDelegate.UnsentRequest request = new NetworkClientDelegate.UnsentRequest(
             new ConsumerGroupHeartbeatRequest.Builder(data),
             coordinatorRequestManager.coordinator());
-        request.handler().whenComplete((response, exception) -> {
+        request.future().whenComplete((response, exception) -> {
             if (response != null) {
                 onResponse((ConsumerGroupHeartbeatResponse) response.responseBody(), response.receivedTimeMs());
             } else {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -251,11 +251,7 @@ public class NetworkClientDelegate implements AutoCloseable {
     }
 
     public static class FutureCompletionHandler extends CompletableFuture<ClientResponse> implements RequestCompletionHandler {
-
-        /**
-         * The time when the response is completed. This is used when the response is completed exceptionally because
-         * ClientResponse already contains received time which is injected by the network client.
-         */
+        
         private long responseCompletionTimeMs;
 
         FutureCompletionHandler() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -91,7 +91,7 @@ public class NetworkClientDelegate implements AutoCloseable {
             pollTimeoutMs = Math.min(retryBackoffMs, pollTimeoutMs);
         }
         this.client.poll(pollTimeoutMs, currentTimeMs);
-        checkDisconnects();
+        checkDisconnects(currentTimeMs);
     }
 
     /**
@@ -106,7 +106,7 @@ public class NetworkClientDelegate implements AutoCloseable {
             unsent.timer.update(currentTimeMs);
             if (unsent.timer.isExpired()) {
                 iterator.remove();
-                unsent.handler.onFailure(new TimeoutException(
+                unsent.handler.onFailure(currentTimeMs, new TimeoutException(
                     "Failed to send request after " + unsent.timer.timeoutMs() + " ms."));
                 continue;
             }
@@ -137,7 +137,7 @@ public class NetworkClientDelegate implements AutoCloseable {
         return true;
     }
 
-    private void checkDisconnects() {
+    private void checkDisconnects(final long currentTimeMs) {
         // Check the connection of the unsent request. Disconnect the disconnected node if it is unable to be connected.
         Iterator<UnsentRequest> iter = unsentRequests.iterator();
         while (iter.hasNext()) {
@@ -145,7 +145,7 @@ public class NetworkClientDelegate implements AutoCloseable {
             if (u.node.isPresent() && client.connectionFailed(u.node.get())) {
                 iter.remove();
                 AuthenticationException authenticationException = client.authenticationException(u.node.get());
-                u.handler.onFailure(authenticationException);
+                u.handler.onFailure(currentTimeMs, authenticationException);
             }
         }
     }
@@ -224,18 +224,14 @@ public class NetworkClientDelegate implements AutoCloseable {
                              final Optional<Node> node,
                              final BiConsumer<ClientResponse, Throwable> callback) {
             this(requestBuilder, node);
-            this.handler.future.whenComplete(callback);
+            this.handler.whenComplete(callback);
         }
 
         public void setTimer(final Time time, final long requestTimeoutMs) {
             this.timer = time.timer(requestTimeoutMs);
         }
 
-        CompletableFuture<ClientResponse> future() {
-            return handler.future;
-        }
-
-        RequestCompletionHandler callback() {
+        FutureCompletionHandler handler() {
             return handler;
         }
 
@@ -254,28 +250,38 @@ public class NetworkClientDelegate implements AutoCloseable {
         }
     }
 
-    public static class FutureCompletionHandler implements RequestCompletionHandler {
+    public static class FutureCompletionHandler extends CompletableFuture<ClientResponse> implements RequestCompletionHandler {
 
-        private final CompletableFuture<ClientResponse> future;
+        /**
+         * The time when the response is completed. This is used when the response is completed exceptionally because
+         * ClientResponse already contains received time which is injected by the network client.
+         */
+        private long responseCompletionTimeMs;
 
         FutureCompletionHandler() {
-            this.future = new CompletableFuture<>();
         }
 
-        public void onFailure(final RuntimeException e) {
-            future.completeExceptionally(e);
+        public void onFailure(final long currentTimeMs, final RuntimeException e) {
+            this.responseCompletionTimeMs = currentTimeMs;
+            this.completeExceptionally(e);
+        }
+
+        public long completionTimeMs() {
+            return responseCompletionTimeMs;
         }
 
         @Override
         public void onComplete(final ClientResponse response) {
+            long completionTimeMs = response.receivedTimeMs();
             if (response.authenticationException() != null) {
-                onFailure(response.authenticationException());
+                onFailure(completionTimeMs, response.authenticationException());
             } else if (response.wasDisconnected()) {
-                onFailure(DisconnectException.INSTANCE);
+                onFailure(completionTimeMs, DisconnectException.INSTANCE);
             } else if (response.versionMismatch() != null) {
-                onFailure(response.versionMismatch());
+                onFailure(completionTimeMs, response.versionMismatch());
             } else {
-                future.complete(response);
+                responseCompletionTimeMs = completionTimeMs;
+                this.complete(response);
             }
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -343,7 +343,7 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
                 Optional.ofNullable(node));
         unsentRequests.add(unsentRequest);
         CompletableFuture<ListOffsetResult> result = new CompletableFuture<>();
-        unsentRequest.handler().whenComplete((response, error) -> {
+        unsentRequest.future().whenComplete((response, error) -> {
             if (error != null) {
                 log.debug("Sending ListOffset request {} to broker {} failed",
                         builder,
@@ -492,7 +492,7 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
                 Optional.ofNullable(node));
         unsentRequests.add(unsentRequest);
         CompletableFuture<OffsetsForLeaderEpochUtils.OffsetForEpochResult> result = new CompletableFuture<>();
-        unsentRequest.handler().whenComplete((response, error) -> {
+        unsentRequest.future().whenComplete((response, error) -> {
             if (error != null) {
                 log.debug("Sending OffsetsForLeaderEpoch request {} to broker {} failed",
                         builder,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -343,7 +343,7 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
                 Optional.ofNullable(node));
         unsentRequests.add(unsentRequest);
         CompletableFuture<ListOffsetResult> result = new CompletableFuture<>();
-        unsentRequest.future().whenComplete((response, error) -> {
+        unsentRequest.handler().whenComplete((response, error) -> {
             if (error != null) {
                 log.debug("Sending ListOffset request {} to broker {} failed",
                         builder,
@@ -492,7 +492,7 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
                 Optional.ofNullable(node));
         unsentRequests.add(unsentRequest);
         CompletableFuture<OffsetsForLeaderEpochUtils.OffsetForEpochResult> result = new CompletableFuture<>();
-        unsentRequest.future().whenComplete((response, error) -> {
+        unsentRequest.handler().whenComplete((response, error) -> {
             if (error != null) {
                 log.debug("Sending OffsetsForLeaderEpoch request {} to broker {} failed",
                         builder,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManager.java
@@ -148,30 +148,33 @@ public class TopicMetadataRequestManager implements RequestManager {
 
         private NetworkClientDelegate.UnsentRequest createUnsentRequest(
                 final MetadataRequest.Builder request) {
-            return new NetworkClientDelegate.UnsentRequest(
-                    request,
-                    Optional.empty(),
-                    this::processResponseOrException
-            );
+            NetworkClientDelegate.UnsentRequest unsent = new NetworkClientDelegate.UnsentRequest(
+                request,
+                Optional.empty());
+
+            unsent.handler().whenComplete((response, exception) -> {
+                if (response == null) {
+                    // Backoff if the error is retriable
+                    handleError(exception, unsent.handler().completionTimeMs());
+                } else {
+                    handleResponse(response);
+                }
+            });
+
+            return unsent;
         }
 
-        private void processResponseOrException(final ClientResponse response,
-                                                final Throwable exception) {
-            if (exception == null) {
-                handleResponse(response, response.receivedTimeMs());
-                return;
-            }
-
+        private void handleError(final Throwable exception,
+                                 final long completionTimeMs) {
             if (exception instanceof RetriableException) {
-                // We continue to retry on RetriableException
-                // TODO: TimeoutException will continue to retry despite user API timeout.
-                onFailedAttempt(response.receivedTimeMs());
+                onFailedAttempt(completionTimeMs);
             } else {
-                completeFutureAndRemoveRequest(new KafkaException(exception));
+                completeFutureAndRemoveRequest(exception);
             }
         }
 
-        private void handleResponse(final ClientResponse response, final long responseTimeMs) {
+        private void handleResponse(final ClientResponse response) {
+            long responseTimeMs = response.receivedTimeMs();
             try {
                 Map<String, List<PartitionInfo>> res = handleTopicMetadataResponse((MetadataResponse) response.responseBody());
                 future.complete(res);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManager.java
@@ -152,7 +152,7 @@ public class TopicMetadataRequestManager implements RequestManager {
                 request,
                 Optional.empty());
 
-            unsent.handler().whenComplete((response, exception) -> {
+            unsent.future().whenComplete((response, exception) -> {
                 if (response == null) {
                     // Backoff if the error is retriable
                     handleError(exception, unsent.handler().completionTimeMs());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManager.java
@@ -154,7 +154,6 @@ public class TopicMetadataRequestManager implements RequestManager {
 
             unsent.future().whenComplete((response, exception) -> {
                 if (response == null) {
-                    // Backoff if the error is retriable
                     handleError(exception, unsent.handler().completionTimeMs());
                 } else {
                     handleResponse(response);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -290,7 +290,7 @@ public class CommitRequestManagerTest {
         topicPartitionData.put(tp1, new OffsetFetchResponse.PartitionData(100L, Optional.of(1), "metadata", error));
         topicPartitionData.put(tp2, new OffsetFetchResponse.PartitionData(100L, Optional.of(1), "metadata", Errors.NONE));
 
-        res.unsentRequests.get(0).handler().complete(buildOffsetFetchClientResponse(
+        res.unsentRequests.get(0).future().complete(buildOffsetFetchClientResponse(
                 res.unsentRequests.get(0),
                 topicPartitionData,
                 Errors.NONE));
@@ -328,7 +328,8 @@ public class CommitRequestManagerTest {
 
         NetworkClientDelegate.PollResult res = commitRequestManger.poll(time.milliseconds());
         assertEquals(1, res.unsentRequests.size());
-        res.unsentRequests.get(0).handler().complete(buildOffsetFetchClientResponse(res.unsentRequests.get(0), partitions, error));
+        res.unsentRequests.get(0).future().complete(buildOffsetFetchClientResponse(res.unsentRequests.get(0),
+            partitions, error));
         res = commitRequestManger.poll(time.milliseconds());
         assertEquals(0, res.unsentRequests.size());
         return futures;
@@ -352,7 +353,7 @@ public class CommitRequestManagerTest {
         NetworkClientDelegate.PollResult res = manager.poll(time.milliseconds());
         assertEquals(numRes, res.unsentRequests.size());
 
-        return res.unsentRequests.stream().map(NetworkClientDelegate.UnsentRequest::handler).collect(Collectors.toList());
+        return res.unsentRequests.stream().map(NetworkClientDelegate.UnsentRequest::future).collect(Collectors.toList());
     }
 
     private CommitRequestManager create(final boolean autoCommitEnabled, final long autoCommitInterval) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -290,7 +290,7 @@ public class CommitRequestManagerTest {
         topicPartitionData.put(tp1, new OffsetFetchResponse.PartitionData(100L, Optional.of(1), "metadata", error));
         topicPartitionData.put(tp2, new OffsetFetchResponse.PartitionData(100L, Optional.of(1), "metadata", Errors.NONE));
 
-        res.unsentRequests.get(0).future().complete(buildOffsetFetchClientResponse(
+        res.unsentRequests.get(0).handler().complete(buildOffsetFetchClientResponse(
                 res.unsentRequests.get(0),
                 topicPartitionData,
                 Errors.NONE));
@@ -328,7 +328,7 @@ public class CommitRequestManagerTest {
 
         NetworkClientDelegate.PollResult res = commitRequestManger.poll(time.milliseconds());
         assertEquals(1, res.unsentRequests.size());
-        res.unsentRequests.get(0).future().complete(buildOffsetFetchClientResponse(res.unsentRequests.get(0), partitions, error));
+        res.unsentRequests.get(0).handler().complete(buildOffsetFetchClientResponse(res.unsentRequests.get(0), partitions, error));
         res = commitRequestManger.poll(time.milliseconds());
         assertEquals(0, res.unsentRequests.size());
         return futures;
@@ -352,7 +352,7 @@ public class CommitRequestManagerTest {
         NetworkClientDelegate.PollResult res = manager.poll(time.milliseconds());
         assertEquals(numRes, res.unsentRequests.size());
 
-        return res.unsentRequests.stream().map(NetworkClientDelegate.UnsentRequest::future).collect(Collectors.toList());
+        return res.unsentRequests.stream().map(NetworkClientDelegate.UnsentRequest::handler).collect(Collectors.toList());
     }
 
     private CommitRequestManager create(final boolean autoCommitEnabled, final long autoCommitInterval) {
@@ -391,7 +391,7 @@ public class CommitRequestManagerTest {
                 new OffsetFetchResponse(error, topicPartitionData);
         return new ClientResponse(
                 new RequestHeader(ApiKeys.OFFSET_FETCH, offsetFetchRequest.version(), "", 1),
-                request.callback(),
+                request.handler(),
                 "-1",
                 time.milliseconds(),
                 time.milliseconds(),

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManagerTest.java
@@ -153,7 +153,7 @@ public class CoordinatorRequestManagerTest {
         assertEquals(1, res.unsentRequests.size());
 
         NetworkClientDelegate.UnsentRequest unsentRequest = res.unsentRequests.get(0);
-        unsentRequest.handler().complete(buildResponse(unsentRequest, error));
+        unsentRequest.future().complete(buildResponse(unsentRequest, error));
 
         boolean expectCoordinatorFound = error == Errors.NONE;
         assertEquals(expectCoordinatorFound, coordinatorManager.coordinator().isPresent());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManagerTest.java
@@ -153,7 +153,7 @@ public class CoordinatorRequestManagerTest {
         assertEquals(1, res.unsentRequests.size());
 
         NetworkClientDelegate.UnsentRequest unsentRequest = res.unsentRequests.get(0);
-        unsentRequest.future().complete(buildResponse(unsentRequest, error));
+        unsentRequest.handler().complete(buildResponse(unsentRequest, error));
 
         boolean expectCoordinatorFound = error == Errors.NONE;
         assertEquals(expectCoordinatorFound, coordinatorManager.coordinator().isPresent());
@@ -182,7 +182,7 @@ public class CoordinatorRequestManagerTest {
             FindCoordinatorResponse.prepareResponse(error, GROUP_ID, node);
         return new ClientResponse(
             new RequestHeader(ApiKeys.FIND_COORDINATOR, findCoordinatorRequest.version(), "", 1),
-            request.callback(),
+            request.handler(),
             node.idString(),
             time.milliseconds(),
             time.milliseconds(),

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
@@ -211,7 +211,7 @@ public class HeartbeatRequestManagerTest {
         when(membershipManager.shouldSendHeartbeat()).thenReturn(true);
         NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
         assertEquals(1, result.unsentRequests.size());
-        result.unsentRequests.get(0).handler().completeExceptionally(new KafkaException("fatal"));
+        result.unsentRequests.get(0).future().completeExceptionally(new KafkaException("fatal"));
         verify(membershipManager).transitionToFailed();
         verify(errorEventHandler).handle(any());
     }
@@ -299,7 +299,7 @@ public class HeartbeatRequestManagerTest {
         ClientResponse response = createHeartbeatResponse(
             result.unsentRequests.get(0),
             error);
-        result.unsentRequests.get(0).handler().complete(response);
+        result.unsentRequests.get(0).future().complete(response);
         ConsumerGroupHeartbeatResponse mockResponse = (ConsumerGroupHeartbeatResponse) response.responseBody();
 
         switch (error) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
@@ -184,7 +184,8 @@ public class HeartbeatRequestManagerTest {
         when(membershipManager.shouldSendHeartbeat()).thenReturn(true);
         NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
         assertEquals(1, result.unsentRequests.size());
-        result.unsentRequests.get(0).future().completeExceptionally(new TimeoutException("timeout"));
+        // Mimic network timeout
+        result.unsentRequests.get(0).handler().onFailure(time.milliseconds(), new TimeoutException("timeout"));
 
         // Assure the manager will backoff on timeout
         time.sleep(RETRY_BACKOFF_MS - 1);
@@ -210,7 +211,7 @@ public class HeartbeatRequestManagerTest {
         when(membershipManager.shouldSendHeartbeat()).thenReturn(true);
         NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
         assertEquals(1, result.unsentRequests.size());
-        result.unsentRequests.get(0).future().completeExceptionally(new KafkaException("fatal"));
+        result.unsentRequests.get(0).handler().completeExceptionally(new KafkaException("fatal"));
         verify(membershipManager).transitionToFailed();
         verify(errorEventHandler).handle(any());
     }
@@ -298,7 +299,7 @@ public class HeartbeatRequestManagerTest {
         ClientResponse response = createHeartbeatResponse(
             result.unsentRequests.get(0),
             error);
-        result.unsentRequests.get(0).future().complete(response);
+        result.unsentRequests.get(0).handler().complete(response);
         ConsumerGroupHeartbeatResponse mockResponse = (ConsumerGroupHeartbeatResponse) response.responseBody();
 
         switch (error) {
@@ -385,7 +386,7 @@ public class HeartbeatRequestManagerTest {
         ConsumerGroupHeartbeatResponse response = new ConsumerGroupHeartbeatResponse(data);
         return new ClientResponse(
             new RequestHeader(ApiKeys.CONSUMER_GROUP_HEARTBEAT, ApiKeys.CONSUMER_GROUP_HEARTBEAT.latestVersion(), "client-id", 1),
-            request.callback(),
+            request.handler(),
             "0",
             time.milliseconds(),
             time.milliseconds(),

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
@@ -171,7 +171,7 @@ public class HeartbeatRequestManagerTest {
     }
 
     @Test
-    public void testBackoffOnTimeout() {
+    public void testNetworkTimeout() {
         heartbeatRequestState = new HeartbeatRequestManager.HeartbeatRequestState(
             logContext,
             time,
@@ -299,7 +299,7 @@ public class HeartbeatRequestManagerTest {
         ClientResponse response = createHeartbeatResponse(
             result.unsentRequests.get(0),
             error);
-        result.unsentRequests.get(0).future().complete(response);
+        result.unsentRequests.get(0).handler().onComplete(response);
         ConsumerGroupHeartbeatResponse mockResponse = (ConsumerGroupHeartbeatResponse) response.responseBody();
 
         switch (error) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.MockClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.Node;
@@ -32,7 +33,6 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
@@ -45,6 +45,8 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZE
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class NetworkClientDelegateTest {
     private static final int REQUEST_TIMEOUT_MS = 5000;
@@ -110,14 +112,12 @@ public class NetworkClientDelegateTest {
     }
 
     @Test
-    public void testEnsureCorrectCompletionTimeOnComplete() throws IOException {
+    public void testEnsureCorrectCompletionTimeOnComplete() {
         NetworkClientDelegate.UnsentRequest unsentRequest = newUnsentFindCoordinatorRequest();
-        prepareFindCoordinatorResponse(Errors.NONE);
         long timeMs = time.milliseconds();
-        try (NetworkClientDelegate delegate = newNetworkClientDelegate()) {
-            delegate.send(unsentRequest);
-            delegate.poll(0, timeMs);
-        }
+        final ClientResponse response = mock(ClientResponse.class);
+        when(response.receivedTimeMs()).thenReturn(timeMs);
+        unsentRequest.handler().onComplete(response);
         time.sleep(100);
         assertEquals(timeMs, unsentRequest.handler().completionTimeMs());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
@@ -65,8 +65,8 @@ public class NetworkClientDelegateTest {
             ncd.send(unsentRequest);
             ncd.poll(0, time.milliseconds());
 
-            assertTrue(unsentRequest.future().isDone());
-            assertNotNull(unsentRequest.future().get());
+            assertTrue(unsentRequest.handler().isDone());
+            assertNotNull(unsentRequest.handler().get());
         }
     }
 
@@ -79,8 +79,8 @@ public class NetworkClientDelegateTest {
             ncd.poll(0, time.milliseconds());
             time.sleep(REQUEST_TIMEOUT_MS);
             ncd.poll(0, time.milliseconds());
-            assertTrue(unsentRequest.future().isDone());
-            TestUtils.assertFutureThrows(unsentRequest.future(), TimeoutException.class);
+            assertTrue(unsentRequest.handler().isDone());
+            TestUtils.assertFutureThrows(unsentRequest.handler(), TimeoutException.class);
         }
     }
 
@@ -92,8 +92,8 @@ public class NetworkClientDelegateTest {
             ncd.poll(0, time.milliseconds());
             time.sleep(REQUEST_TIMEOUT_MS);
             ncd.poll(0, time.milliseconds());
-            assertTrue(unsentRequest.future().isDone());
-            TestUtils.assertFutureThrows(unsentRequest.future(), DisconnectException.class);
+            assertTrue(unsentRequest.handler().isDone());
+            TestUtils.assertFutureThrows(unsentRequest.handler(), DisconnectException.class);
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegateTest.java
@@ -65,8 +65,8 @@ public class NetworkClientDelegateTest {
             ncd.send(unsentRequest);
             ncd.poll(0, time.milliseconds());
 
-            assertTrue(unsentRequest.handler().isDone());
-            assertNotNull(unsentRequest.handler().get());
+            assertTrue(unsentRequest.future().isDone());
+            assertNotNull(unsentRequest.future().get());
         }
     }
 
@@ -79,8 +79,8 @@ public class NetworkClientDelegateTest {
             ncd.poll(0, time.milliseconds());
             time.sleep(REQUEST_TIMEOUT_MS);
             ncd.poll(0, time.milliseconds());
-            assertTrue(unsentRequest.handler().isDone());
-            TestUtils.assertFutureThrows(unsentRequest.handler(), TimeoutException.class);
+            assertTrue(unsentRequest.future().isDone());
+            TestUtils.assertFutureThrows(unsentRequest.future(), TimeoutException.class);
         }
     }
 
@@ -92,8 +92,8 @@ public class NetworkClientDelegateTest {
             ncd.poll(0, time.milliseconds());
             time.sleep(REQUEST_TIMEOUT_MS);
             ncd.poll(0, time.milliseconds());
-            assertTrue(unsentRequest.handler().isDone());
-            TestUtils.assertFutureThrows(unsentRequest.handler(), DisconnectException.class);
+            assertTrue(unsentRequest.future().isDone());
+            TestUtils.assertFutureThrows(unsentRequest.future(), DisconnectException.class);
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
@@ -514,8 +514,8 @@ public class OffsetsRequestManagerTest {
                 unsentRequest, Collections.singletonMap(TEST_PARTITION_1, Errors.TOPIC_AUTHORIZATION_FAILED));
         clientResponse.onComplete();
 
-        assertTrue(unsentRequest.handler().isDone());
-        assertFalse(unsentRequest.handler().isCompletedExceptionally());
+        assertTrue(unsentRequest.future().isDone());
+        assertFalse(unsentRequest.future().isCompletedExceptionally());
 
         verify(subscriptionState).requestFailed(any(), anyLong());
         verify(metadata).requestUpdate(false);
@@ -551,8 +551,8 @@ public class OffsetsRequestManagerTest {
         ClientResponse clientResponse = buildOffsetsForLeaderEpochResponse(unsentRequest,
                 Collections.singletonList(tp), expectedEndOffset);
         clientResponse.onComplete();
-        assertTrue(unsentRequest.handler().isDone());
-        assertFalse(unsentRequest.handler().isCompletedExceptionally());
+        assertTrue(unsentRequest.future().isDone());
+        assertFalse(unsentRequest.future().isCompletedExceptionally());
         verify(subscriptionState).maybeCompleteValidation(any(), any(), any());
     }
 
@@ -588,8 +588,8 @@ public class OffsetsRequestManagerTest {
                 buildOffsetsForLeaderEpochResponseWithErrors(unsentRequest, Collections.singletonMap(TEST_PARTITION_1, Errors.TOPIC_AUTHORIZATION_FAILED));
         clientResponse.onComplete();
 
-        assertTrue(unsentRequest.handler().isDone());
-        assertFalse(unsentRequest.handler().isCompletedExceptionally());
+        assertTrue(unsentRequest.future().isDone());
+        assertFalse(unsentRequest.future().isCompletedExceptionally());
 
         // Following validatePositions should raise the previous exception without performing any
         // request
@@ -650,8 +650,8 @@ public class OffsetsRequestManagerTest {
         NetworkClientDelegate.UnsentRequest unsentRequest = pollResult.unsentRequests.get(0);
         ClientResponse clientResponse = buildClientResponse(unsentRequest, expectedOffsets);
         clientResponse.onComplete();
-        assertTrue(unsentRequest.handler().isDone());
-        assertFalse(unsentRequest.handler().isCompletedExceptionally());
+        assertTrue(unsentRequest.future().isDone());
+        assertFalse(unsentRequest.future().isCompletedExceptionally());
     }
 
     private ListOffsetsResponseData.ListOffsetsTopicResponse mockUnknownOffsetResponse(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
@@ -514,8 +514,8 @@ public class OffsetsRequestManagerTest {
                 unsentRequest, Collections.singletonMap(TEST_PARTITION_1, Errors.TOPIC_AUTHORIZATION_FAILED));
         clientResponse.onComplete();
 
-        assertTrue(unsentRequest.future().isDone());
-        assertFalse(unsentRequest.future().isCompletedExceptionally());
+        assertTrue(unsentRequest.handler().isDone());
+        assertFalse(unsentRequest.handler().isCompletedExceptionally());
 
         verify(subscriptionState).requestFailed(any(), anyLong());
         verify(metadata).requestUpdate(false);
@@ -551,8 +551,8 @@ public class OffsetsRequestManagerTest {
         ClientResponse clientResponse = buildOffsetsForLeaderEpochResponse(unsentRequest,
                 Collections.singletonList(tp), expectedEndOffset);
         clientResponse.onComplete();
-        assertTrue(unsentRequest.future().isDone());
-        assertFalse(unsentRequest.future().isCompletedExceptionally());
+        assertTrue(unsentRequest.handler().isDone());
+        assertFalse(unsentRequest.handler().isCompletedExceptionally());
         verify(subscriptionState).maybeCompleteValidation(any(), any(), any());
     }
 
@@ -588,8 +588,8 @@ public class OffsetsRequestManagerTest {
                 buildOffsetsForLeaderEpochResponseWithErrors(unsentRequest, Collections.singletonMap(TEST_PARTITION_1, Errors.TOPIC_AUTHORIZATION_FAILED));
         clientResponse.onComplete();
 
-        assertTrue(unsentRequest.future().isDone());
-        assertFalse(unsentRequest.future().isCompletedExceptionally());
+        assertTrue(unsentRequest.handler().isDone());
+        assertFalse(unsentRequest.handler().isCompletedExceptionally());
 
         // Following validatePositions should raise the previous exception without performing any
         // request
@@ -650,8 +650,8 @@ public class OffsetsRequestManagerTest {
         NetworkClientDelegate.UnsentRequest unsentRequest = pollResult.unsentRequests.get(0);
         ClientResponse clientResponse = buildClientResponse(unsentRequest, expectedOffsets);
         clientResponse.onComplete();
-        assertTrue(unsentRequest.future().isDone());
-        assertFalse(unsentRequest.future().isCompletedExceptionally());
+        assertTrue(unsentRequest.handler().isDone());
+        assertFalse(unsentRequest.handler().isCompletedExceptionally());
     }
 
     private ListOffsetsResponseData.ListOffsetsTopicResponse mockUnknownOffsetResponse(
@@ -820,7 +820,7 @@ public class OffsetsRequestManagerTest {
         OffsetsForLeaderEpochResponse response = new OffsetsForLeaderEpochResponse(data);
         return new ClientResponse(
                 new RequestHeader(ApiKeys.OFFSET_FOR_LEADER_EPOCH, offsetsForLeaderEpochRequest.version(), "", 1),
-                request.callback(),
+                request.handler(),
                 "-1",
                 time.milliseconds(),
                 time.milliseconds(),
@@ -853,7 +853,7 @@ public class OffsetsRequestManagerTest {
         OffsetsForLeaderEpochResponse response = new OffsetsForLeaderEpochResponse(data);
         return new ClientResponse(
                 new RequestHeader(ApiKeys.OFFSET_FOR_LEADER_EPOCH, offsetsForLeaderEpochRequest.version(), "", 1),
-                request.callback(),
+                request.handler(),
                 "-1",
                 time.milliseconds(),
                 time.milliseconds(),
@@ -902,7 +902,7 @@ public class OffsetsRequestManagerTest {
         ListOffsetsResponse response = buildListOffsetsResponse(topicResponses);
         return new ClientResponse(
                 new RequestHeader(ApiKeys.OFFSET_FETCH, offsetFetchRequest.version(), "", 1),
-                request.callback(),
+                request.handler(),
                 "-1",
                 time.milliseconds(),
                 time.milliseconds(),

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/TopicMetadataRequestManagerTest.java
@@ -94,7 +94,7 @@ public class TopicMetadataRequestManagerTest {
         this.topicMetadataRequestManager.requestTopicMetadata(Optional.of("hello"));
         this.time.sleep(100);
         NetworkClientDelegate.PollResult res = this.topicMetadataRequestManager.poll(this.time.milliseconds());
-        res.unsentRequests.get(0).handler().complete(buildTopicMetadataClientResponse(
+        res.unsentRequests.get(0).future().complete(buildTopicMetadataClientResponse(
             res.unsentRequests.get(0),
             Optional.of(topic),
             error));
@@ -118,7 +118,7 @@ public class TopicMetadataRequestManagerTest {
         NetworkClientDelegate.PollResult res = this.topicMetadataRequestManager.poll(this.time.milliseconds());
         assertEquals(1, res.unsentRequests.size());
 
-        res.unsentRequests.get(0).handler().complete(buildTopicMetadataClientResponse(
+        res.unsentRequests.get(0).future().complete(buildTopicMetadataClientResponse(
             res.unsentRequests.get(0),
             topic,
             Errors.NONE));
@@ -143,7 +143,7 @@ public class TopicMetadataRequestManagerTest {
         NetworkClientDelegate.PollResult res = this.topicMetadataRequestManager.poll(this.time.milliseconds());
         assertEquals(1, res.unsentRequests.size());
 
-        res.unsentRequests.get(0).handler().completeExceptionally(exception);
+        res.unsentRequests.get(0).future().completeExceptionally(exception);
 
         if (exception instanceof RetriableException) {
             assertFalse(topicMetadataRequestManager.inflightRequests().isEmpty());
@@ -175,7 +175,7 @@ public class TopicMetadataRequestManagerTest {
         res2 = topicMetadataRequestManager.poll(this.time.milliseconds());
         assertEquals(1, res2.unsentRequests.size());
 
-        res2.unsentRequests.get(0).handler().complete(buildTopicMetadataClientResponse(
+        res2.unsentRequests.get(0).future().complete(buildTopicMetadataClientResponse(
             res2.unsentRequests.get(0),
             topic,
             Errors.NONE));


### PR DESCRIPTION
Currently, we aren't able to access the request completion time if the request is completed exceptionally, which results in many system calls.  This is not ideal because these system calls can add up.  Instead, time is already retrieved on the top of the background thread event loop, which is then propagated into the NetworkClientDelegate.poll.

In this PR - I store the completion time in the handler, so that it becomes accessible in the callbacks.