### PR TITLE
KAFKA-15596: Upgrade ZooKeeper to 3.8.3

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -261,8 +261,8 @@ scala-reflect-2.13.12
 scala-java8-compat_2.13-1.0.2
 snappy-java-1.1.10.5
 swagger-annotations-2.2.8
-zookeeper-3.8.2
-zookeeper-jute-3.8.2
+zookeeper-3.8.3
+zookeeper-jute-3.8.3
 
 ===============================================================================
 This product bundles various third-party components under other open source

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -163,7 +163,7 @@ versions += [
   snappy: "1.1.10.5",
   spotbugs: "4.7.3",
   zinc: "1.9.2",
-  zookeeper: "3.8.2",
+  zookeeper: "3.8.3",
   zstd: "1.5.5-6"
 ]
 


### PR DESCRIPTION
Release notes - https://zookeeper.apache.org/doc/r3.8.3/releasenotes.html 

The diff from 3.8.2 contains dependency upgrades to fix CVEs and an improvement. No backward incompatibility reported.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
