### PR TITLE
KAFKA-15378: fix streams upgrade system test

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1198,7 +1198,7 @@ public class StreamsConfig extends AbstractConfig {
         public static final String STATE_UPDATER_ENABLED = "__state.updater.enabled__";
 
         public static boolean getStateUpdaterEnabled(final Map<String, Object> configs) {
-            return InternalConfig.getBoolean(configs, InternalConfig.STATE_UPDATER_ENABLED, false);
+            return InternalConfig.getBoolean(configs, InternalConfig.STATE_UPDATER_ENABLED, true);
         }
 
         public static boolean getBoolean(final Map<String, Object> configs, final String key, final boolean defaultValue) {

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1198,7 +1198,7 @@ public class StreamsConfig extends AbstractConfig {
         public static final String STATE_UPDATER_ENABLED = "__state.updater.enabled__";
 
         public static boolean getStateUpdaterEnabled(final Map<String, Object> configs) {
-            return InternalConfig.getBoolean(configs, InternalConfig.STATE_UPDATER_ENABLED, true);
+            return InternalConfig.getBoolean(configs, InternalConfig.STATE_UPDATER_ENABLED, false);
         }
 
         public static boolean getBoolean(final Map<String, Object> configs, final String key, final boolean defaultValue) {

--- a/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
@@ -100,7 +100,7 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
         processor_3 = StreamsBrokerDownResilienceService(self.test_context, self.kafka, configs)
         processor_3.start()
 
-        broker_unavailable_message = "Broker may not be available"
+        broker_unavailable_message = "Node may not be available"
 
         # verify streams instances unable to connect to broker, kept trying
         self.wait_for_verification(processor, broker_unavailable_message, processor.LOG_FILE, 10)

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -40,11 +40,13 @@ broker_upgrade_versions = [str(LATEST_0_11_0), str(LATEST_1_0), str(LATEST_1_1),
 metadata_1_versions = [str(LATEST_0_10_0)]
 metadata_2_versions = [str(LATEST_0_10_1), str(LATEST_0_10_2), str(LATEST_0_11_0), str(LATEST_1_0), str(LATEST_1_1),
                        str(LATEST_2_4), str(LATEST_2_5), str(LATEST_2_6), str(LATEST_2_7), str(LATEST_2_8),
-                       str(LATEST_3_0)]
-# upgrading from version (2.4...3.0) is broken and only fixed later in 3.1
-# we cannot test two bounce rolling upgrade because we know it's broken
-# instead we add version 2.4...3.0 to the `metadata_2_versions` upgrade list
-fk_join_versions = [str(LATEST_3_1), str(LATEST_3_2), str(LATEST_3_3)]
+                       str(LATEST_3_0), str(LATEST_3_1), str(LATEST_3_2), str(LATEST_3_3)]
+# upgrading from version (2.4...3.3) is broken and only fixed later in 3.3.3 (unreleased) and 3.4.0
+# -> https://issues.apache.org/jira/browse/KAFKA-14646
+# thus, we cannot test two bounce rolling upgrade because we know it's broken
+# instead we add version 2.4...3.3 to the `metadata_2_versions` upgrade list
+#fk_join_versions = [str(LATEST_3_4)]
+
 
 """
 After each release one should first check that the released version has been uploaded to 
@@ -202,7 +204,7 @@ class StreamsUpgradeTest(Test):
     @cluster(num_nodes=6)
     @matrix(from_version=metadata_1_versions, to_version=[str(DEV_VERSION)])
     @matrix(from_version=metadata_2_versions, to_version=[str(DEV_VERSION)])
-    @matrix(from_version=fk_join_versions, to_version=[str(DEV_VERSION)])
+    #@matrix(from_version=fk_join_versions, to_version=[str(DEV_VERSION)])
     def test_rolling_upgrade_with_2_bounces(self, from_version, to_version):
         """
         This test verifies that the cluster successfully upgrades despite changes in the metadata and FK

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -107,8 +107,10 @@ class KafkaVersion(LooseVersion):
         return self >= V_2_8_0
 
     def supports_fk_joins(self):
-        # while we support FK joins since 2.4, rolling upgrade is broken in older versions and only fixed in 3.1
-        return hasattr(self, "version") and self >= V_3_1_2
+        # while we support FK joins since 2.4, rolling upgrade is broken in older versions
+        # it's only fixed in 3.3.3 (unreleased) and 3.4.0
+        # -> https://issues.apache.org/jira/browse/KAFKA-14646
+        return hasattr(self, "version") and self >= V_3_4_0
 
 def get_version(node=None):
     """Return the version attached to the given node.


### PR DESCRIPTION
Fixing bad test setup. We tried to fix an upgrade bug for FK-joins in 3.1 release, but it later turned out that the PR was not sufficient to fix it. We finally fixed in 3.4 release.

This PR updates the system test matrix to only test working versions with FK-joins. As we don't have added system test to upgrade from 3.4 and 3.5 yet (PR in progress: https://github.com/apache/kafka/pull/13860) we don't have any test run with FK-joins in this PR. PR 13860 will need to add those versions to close the gap.

This PR also disables the new state-updater-thread that still seems to be buggy crashing system tests.

This PR should be cherry-picked to older branches, too.