### PR TITLE
KAFKA-15572: Race condition between log dir roll and log rename dir

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -1008,19 +1008,6 @@ public final class Utils {
     }
 
     /**
-     * Flushes dirty directories to guarantee crash consistency with swallowing {@link NoSuchFileException}
-     *
-     * @throws IOException if flushing the directory fails.
-     */
-    public static void flushDirIfExists(Path path) throws IOException {
-        try {
-            flushDir(path);
-        } catch (NoSuchFileException e) {
-            log.warn("Failed to flush directory {}", path);
-        }
-    }
-
-    /**
      * Closes all the provided closeables.
      * @throws IOException if any of the close methods throws an IOException.
      *         The first IOException is thrown with subsequent exceptions

--- a/core/src/main/scala/kafka/log/LocalLog.scala
+++ b/core/src/main/scala/kafka/log/LocalLog.scala
@@ -174,9 +174,7 @@ class LocalLog(@volatile private var _dir: File,
       segmentsToFlush.foreach(_.flush())
       // If there are any new segments, we need to flush the parent directory for crash consistency.
       if (segmentsToFlush.exists(_.baseOffset >= currentRecoveryPoint)) {
-        // The directory might be renamed concurrently for topic deletion, which may cause NoSuchFileException here.
-        // Since the directory is to be deleted anyways, we just swallow NoSuchFileException and let it go.
-        Utils.flushDirIfExists(dir.toPath)
+        Utils.flushDir(dir.toPath)
       }
     }
   }

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1648,8 +1648,9 @@ class UnifiedLog(@volatile var logStartOffset: Long,
         debug(s"Flushing log up to offset $offset ($includingOffsetStr)" +
           s"with recovery point $newRecoveryPoint, last flushed: $lastFlushTime,  current time: ${time.milliseconds()}," +
           s"unflushed: ${localLog.unflushedMessages}")
-        localLog.flush(flushOffset)
         lock synchronized {
+          // Flushing under lock, as log directory can be concurrently renamed in LocalLog.renameDir
+          localLog.flush(flushOffset)
           localLog.markFlushed(newRecoveryPoint)
         }
       }

--- a/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
@@ -31,9 +31,7 @@ import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.server.util.{MockTime, Scheduler}
 import org.apache.kafka.storage.internals.log.{FetchDataInfo, LogConfig, LogDirFailureChannel, LogFileUtils, LogOffsetMetadata}
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
-import org.mockito.Mockito.{doReturn, spy}
 
 import scala.jdk.CollectionConverters._
 
@@ -701,20 +699,6 @@ class LocalLogTest {
     // expect an error because of attempt to roll to a new offset (1L) that's lower than the
     // base offset (3L) of the active segment
     assertThrows(classOf[KafkaException], () => log.roll())
-  }
-
-  @Test
-  def testFlushingNonExistentDir(): Unit = {
-    val spyLog = spy(log)
-
-    val record = new SimpleRecord(mockTime.milliseconds, "a".getBytes)
-    appendRecords(List(record))
-    mockTime.sleep(1)
-    val newSegment = log.roll()
-
-    // simulate the directory is renamed concurrently
-    doReturn(new File("__NON_EXISTENT__"), Nil: _*).when(spyLog).dir
-    assertDoesNotThrow((() => spyLog.flush(newSegment.baseOffset)): Executable)
   }
 
   private def createLocalLogWithActiveSegment(dir: File = logDir,


### PR DESCRIPTION
## Description

This PR fixes a race condition between:
- the log rename dir logic, which can be called during alter replica log dirs or during log dir delete
- the log flush dir logic, which is called to force fsync when new segments are rolled

This PR overwrites a previous fix in https://github.com/apache/kafka/pull/14280. That PR fixed a similar race condition (only between log flush and log delete) by swallowing `NoSuchFileException`, to avoid the log dir becoming offline. That was a correct fix for the race condition between log flush and log delete, but is not enough to fix the race condition between log flush and log rename ([after dir flush fails, we can lose messages from new segments, if broker fails](https://github.com/apache/kafka/commit/db3e5e2c0de367ffcfe4078359d6d208ba722581)).

Since both log delete and log alter reached the race condition with log flush through log rename dir, this PR fixes the race condition for both, by synchronizing log flush and log rename dir on the same lock in `UnifiedLog`. More detailed:
1. call to `localLog.flush` was moved under the synchronized block
2. call to `Utils.flushDirIfExists` was replaced with call to `Utils.flushDir`, since swallowing `NoSuchFileException` is no longer required if race condition is addressed with 1
3. `Utils.flushDirIfExists` is removed, since it is no longer used
4. Unit test simulating concurrent dir rename is removed, since it can no longer happen after addressing with 1

Decided to lock the entire `localLog.flush` call instead of separating the segment flush part from the dir flush part (in `LocalLog`), and locking only the dir flush (in `UnifiedLog`, if call to segment flush returned a boolean for new segments flushed), as the logic was losing cohesion, without much added benefit.

For details on the race condition, including code references, please see the description of https://issues.apache.org/jira/browse/KAFKA-15572 and comments.

## Testing

This fix was tested by deploying trunk + patch of this PR to one of our staging clusters and running alter replica log dir on 1.5TB of data across 33863 replica log dirs.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
