### PR TITLE
MINOR: Zk to KRaft migration is now production ready

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3736,7 +3736,7 @@ foo
   <h4 class="anchor-heading"><a id="kraft_zk_migration" class="anchor-link"></a><a href="#kraft_zk_migration">ZooKeeper to KRaft Migration</a></h4>
 
   <p>
-    <b>ZooKeeper to KRaft migration is considered an Early Access feature and is not recommended for production clusters.</b>
+    <b>Limitations:</b>
   </p>
 
   <p>The following features are not yet supported for ZK to KRaft migrations:</p>


### PR DESCRIPTION
- As of 3.6.0, ZK to KRaft migration is considered production ready so updating the doc
  * https://kafka.apache.org/blog#apache_kafka_360_release_announcement

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
