### PR TITLE
POC - DO NO MERGE: refactor StreamsConfig

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2151,7 +2151,7 @@ project(':streams') {
 
   task genStreamsConfigDocs(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
-    mainClass = 'org.apache.kafka.streams.StreamsConfig'
+    mainClass = 'org.apache.kafka.streams.internals.InternalStreamsConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "streams_config.html").newOutputStream()
   }

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaClientSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaClientSupplier.java
@@ -43,8 +43,7 @@ public interface KafkaClientSupplier {
     /**
      * Create a {@link Producer} which is used to write records to sink topics.
      *
-     * @param config {@link StreamsConfig#getProducerConfigs(String) producer config} which is supplied by the
-     *               {@link java.util.Properties} given to the {@link KafkaStreams} instance
+     * @param config Supplied by the {@link java.util.Properties} given to the {@link KafkaStreams}
      * @return an instance of Kafka producer
      */
     Producer<byte[], byte[]> getProducer(final Map<String, Object> config);
@@ -52,8 +51,7 @@ public interface KafkaClientSupplier {
     /**
      * Create a {@link Consumer} which is used to read records of source topics.
      *
-     * @param config {@link StreamsConfig#getMainConsumerConfigs(String, String, int) consumer config} which is
-     *               supplied by the {@link java.util.Properties} given to the {@link KafkaStreams} instance
+     * @param config Supplied by the {@link java.util.Properties} given to the {@link KafkaStreams}
      * @return an instance of Kafka consumer
      */
     Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config);
@@ -61,8 +59,7 @@ public interface KafkaClientSupplier {
     /**
      * Create a {@link Consumer} which is used to read records to restore {@link StateStore}s.
      *
-     * @param config {@link StreamsConfig#getRestoreConsumerConfigs(String) restore consumer config} which is supplied
-     *               by the {@link java.util.Properties} given to the {@link KafkaStreams}
+     * @param config Supplied by the {@link java.util.Properties} given to the {@link KafkaStreams}
      * @return an instance of Kafka consumer
      */
     Consumer<byte[], byte[]> getRestoreConsumer(final Map<String, Object> config);
@@ -70,8 +67,7 @@ public interface KafkaClientSupplier {
     /**
      * Create a {@link Consumer} which is used to consume records for {@link GlobalKTable}.
      *
-     * @param config {@link StreamsConfig#getGlobalConsumerConfigs(String) global consumer config} which is supplied
-     *               by the {@link java.util.Properties} given to the {@link KafkaStreams}
+     * @param config Supplied by the {@link java.util.Properties} given to the {@link KafkaStreams}
      * @return an instance of Kafka consumer
      */
     Consumer<byte[], byte[]> getGlobalConsumer(final Map<String, Object> config);

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -158,6 +158,10 @@ public class StreamsConfig extends AbstractConfig {
     protected static final long EOS_DEFAULT_COMMIT_INTERVAL_MS = 100L;
     private static final int DEFAULT_TRANSACTION_TIMEOUT = 10000;
 
+    /**
+     * @deprecated since 3.7.0; do not use (internal)
+     */
+    @Deprecated
     public static final int DUMMY_THREAD_INDEX = 1;
     public static final long MAX_TASK_IDLE_MS_DISABLED = -1;
 

--- a/streams/src/main/java/org/apache/kafka/streams/TopologyConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/TopologyConfig.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.internals.StreamsConfigUtils;
 import org.apache.kafka.streams.processor.TimestampExtractor;
@@ -110,7 +111,7 @@ public class TopologyConfig extends AbstractConfig {
     public final String topologyName;
     public final boolean eosEnabled;
 
-    public final StreamsConfig applicationConfigs;
+    public final InternalStreamsConfig applicationConfigs;
     public final Properties topologyOverrides;
 
     public final int maxBufferedSize;
@@ -121,12 +122,12 @@ public class TopologyConfig extends AbstractConfig {
     public final Supplier<TimestampExtractor> timestampExtractorSupplier;
     public final Supplier<DeserializationExceptionHandler> deserializationExceptionHandlerSupplier;
 
-    public TopologyConfig(final StreamsConfig globalAppConfigs) {
+    public TopologyConfig(final InternalStreamsConfig globalAppConfigs) {
         this(null, globalAppConfigs, new Properties());
     }
 
     @SuppressWarnings("this-escape")
-    public TopologyConfig(final String topologyName, final StreamsConfig globalAppConfigs, final Properties topologyOverrides) {
+    public TopologyConfig(final String topologyName, final InternalStreamsConfig globalAppConfigs, final Properties topologyOverrides) {
         super(CONFIG, topologyOverrides, false);
 
         this.topologyName = topologyName;

--- a/streams/src/main/java/org/apache/kafka/streams/internals/InternalStreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/InternalStreamsConfig.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.internals;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
+import org.apache.kafka.streams.errors.ProductionExceptionHandler;
+import org.apache.kafka.streams.processor.TimestampExtractor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class InternalStreamsConfig extends StreamsConfig {
+    private static final Logger log = LoggerFactory.getLogger(StreamsConfig.class);
+
+    // This is settable in the main Streams config, but it's a private API for now
+    public static final String TASK_ASSIGNOR_CLASS = "__internal.task.assignor.class__";
+    // These are not settable in the main Streams config; they are set by the StreamThread to pass internal
+    // state into the assignor.
+    public static final String REFERENCE_CONTAINER_PARTITION_ASSIGNOR = "__reference.container.instance__";
+    // This is settable in the main Streams config, but it's a private API for testing
+    public static final String ASSIGNMENT_LISTENER = "__assignment.listener__";
+    // Private API used to control the emit latency for left/outer join results (https://issues.apache.org/jira/browse/KAFKA-10847)
+    public static final String EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX = "__emit.interval.ms.kstreams.outer.join.spurious.results.fix__";
+    // Private API used to control the emit latency for windowed aggregation results for ON_WINDOW_CLOSE emit strategy
+    public static final String EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION = "__emit.interval.ms.kstreams.windowed.aggregation__";
+    // Private API used to control the usage of consistency offset vectors
+    public static final String IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED = "__iq.consistency.offset.vector.enabled__";
+    // Private API used to control the prefix of the auto created topics
+    public static final String TOPIC_PREFIX_ALTERNATIVE = "__internal.override.topic.prefix__";
+    // Private API to enable the state updater (i.e. state updating on a dedicated thread)
+    public static final String STATE_UPDATER_ENABLED = "__state.updater.enabled__";
+
+
+
+    public InternalStreamsConfig(final StreamsConfig streamsConfig) {
+        super(streamsConfig.originals(), false);
+    }
+
+    public InternalStreamsConfig(final Map<?, ?> configs) {
+        super(configs, false);
+    }
+
+
+
+    /**
+     * Return a copy of the config definition.
+     *
+     * @return a copy of the config definition
+     */
+    @SuppressWarnings({"deprecation", "unused"})
+    public static ConfigDef configDef() {
+        return new ConfigDef(CONFIG);
+    }
+
+    public static boolean stateUpdaterEnabled(final Map<String, Object> configs) {
+        return getBoolean(configs, STATE_UPDATER_ENABLED, true);
+    }
+
+    public static boolean getBoolean(final Map<String, Object> configs, final String key, final boolean defaultValue) {
+        final Object value = configs.getOrDefault(key, defaultValue);
+        if (value instanceof Boolean) {
+            return (boolean) value;
+        } else if (value instanceof String) {
+            return Boolean.parseBoolean((String) value);
+        } else {
+            log.warn("Invalid value (" + value + ") on internal configuration '" + key + "'. Please specify a true/false value.");
+            return defaultValue;
+        }
+    }
+
+    public static long getLong(final Map<String, Object> configs, final String key, final long defaultValue) {
+        final Object value = configs.getOrDefault(key, defaultValue);
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        } else if (value instanceof String) {
+            return Long.parseLong((String) value);
+        } else {
+            log.warn("Invalid value (" + value + ") on internal configuration '" + key + "'. Please specify a numeric value.");
+            return defaultValue;
+        }
+    }
+
+    public static String getString(final Map<String, Object> configs, final String key, final String defaultValue) {
+        final Object value = configs.getOrDefault(key, defaultValue);
+        if (value instanceof String) {
+            return (String) value;
+        } else {
+            log.warn("Invalid value (" + value + ") on internal configuration '" + key + "'. Please specify a String value.");
+            return defaultValue;
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    public Map<String, Object> mainConsumerConfigs(final String groupId, final String clientId, final int threadIdx) {
+        return super.getMainConsumerConfigs(groupId, clientId, threadIdx);
+    }
+
+    @SuppressWarnings("deprecation")
+    public Map<String, Object> restoreConsumerConfigs(final String clientId) {
+        return super.getRestoreConsumerConfigs(clientId);
+    }
+
+    @SuppressWarnings("deprecation")
+    public Map<String, Object> globalConsumerConfigs(final String clientId) {
+        return super.getGlobalConsumerConfigs(clientId);
+    }
+
+    @SuppressWarnings("deprecation")
+    public Map<String, Object> producerConfigs(final String clientId) {
+        return super.getProducerConfigs(clientId);
+    }
+
+    @SuppressWarnings("deprecation")
+    public Map<String, Object> adminConfigs(final String clientId) {
+        return super.getAdminConfigs(clientId);
+    }
+
+    @SuppressWarnings("deprecation")
+    public Map<String, String> clientTags() {
+        return super.getClientTags();
+    }
+
+    @SuppressWarnings("deprecation")
+    public Serde<?> defaultKeySerde() {
+        return super.defaultKeySerde();
+    }
+
+    @SuppressWarnings("deprecation")
+    public Serde<?> defaultValueSerde() {
+        return super.defaultValueSerde();
+    }
+
+    @SuppressWarnings("deprecation")
+    public TimestampExtractor defaultTimestampExtractor() {
+        return super.defaultTimestampExtractor();
+    }
+
+    @SuppressWarnings("deprecation")
+    public DeserializationExceptionHandler defaultDeserializationExceptionHandler() {
+        return super.defaultDeserializationExceptionHandler();
+    }
+
+    @SuppressWarnings("deprecation")
+    public ProductionExceptionHandler defaultProductionExceptionHandler() {
+        return super.defaultProductionExceptionHandler();
+    }
+
+    @SuppressWarnings("deprecation")
+    public KafkaClientSupplier kafkaClientSupplier() {
+        return super.getKafkaClientSupplier();
+    }
+
+    @Override
+    protected Map<String, Object> postProcessParsedConfig(final Map<String, Object> parsedValues) {
+        final Map<String, Object> configUpdates =
+                CommonClientConfigs.postProcessReconnectBackoffConfigs(this, parsedValues);
+
+        if (StreamsConfigUtils.eosEnabled(this) && !originals().containsKey(COMMIT_INTERVAL_MS_CONFIG)) {
+            log.debug("Using {} default value of {} as exactly once is enabled.",
+                    COMMIT_INTERVAL_MS_CONFIG, EOS_DEFAULT_COMMIT_INTERVAL_MS);
+            configUpdates.put(COMMIT_INTERVAL_MS_CONFIG, EOS_DEFAULT_COMMIT_INTERVAL_MS);
+        }
+
+        validateRackAwarenessConfiguration();
+
+        return configUpdates;
+    }
+
+    private void validateRackAwarenessConfiguration() {
+        final List<String> rackAwareAssignmentTags = getList(RACK_AWARE_ASSIGNMENT_TAGS_CONFIG);
+        final Map<String, String> clientTags = clientTags();
+
+        if (clientTags.size() > MAX_RACK_AWARE_ASSIGNMENT_TAG_LIST_SIZE) {
+            throw new ConfigException("At most " + MAX_RACK_AWARE_ASSIGNMENT_TAG_LIST_SIZE + " client tags " +
+                    "can be specified using " + CLIENT_TAG_PREFIX + " prefix.");
+        }
+
+        for (final String rackAwareAssignmentTag : rackAwareAssignmentTags) {
+            if (!clientTags.containsKey(rackAwareAssignmentTag)) {
+                throw new ConfigException(RACK_AWARE_ASSIGNMENT_TAGS_CONFIG,
+                        rackAwareAssignmentTags,
+                        "Contains invalid value [" + rackAwareAssignmentTag + "] " +
+                                "which doesn't have corresponding tag set via [" + CLIENT_TAG_PREFIX + "] prefix.");
+            }
+        }
+
+        clientTags.forEach((tagKey, tagValue) -> {
+            if (tagKey.length() > MAX_RACK_AWARE_ASSIGNMENT_TAG_KEY_LENGTH) {
+                throw new ConfigException(CLIENT_TAG_PREFIX,
+                        tagKey,
+                        "Tag key exceeds maximum length of " + MAX_RACK_AWARE_ASSIGNMENT_TAG_KEY_LENGTH + ".");
+            }
+            if (tagValue.length() > MAX_RACK_AWARE_ASSIGNMENT_TAG_VALUE_LENGTH) {
+                throw new ConfigException(CLIENT_TAG_PREFIX,
+                        tagValue,
+                        "Tag value exceeds maximum length of " + MAX_RACK_AWARE_ASSIGNMENT_TAG_VALUE_LENGTH + ".");
+            }
+        });
+    }
+
+    @SuppressWarnings({"deprecation"})
+    public static void main(final String[] args) {
+        System.out.println(CONFIG.toHtml(4, config -> "streamsconfigs_" + config));
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/internals/StreamsConfigUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/StreamsConfigUtils.java
@@ -40,7 +40,7 @@ public class StreamsConfigUtils {
             this.name = name;
         }
     }
-    
+
     @SuppressWarnings("deprecation")
     public static ProcessingMode processingMode(final StreamsConfig config) {
         if (StreamsConfig.EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))) {
@@ -75,7 +75,7 @@ public class StreamsConfigUtils {
     }
 
     @SuppressWarnings("deprecation")
-    public static long getTotalCacheSize(final StreamsConfig config) {
+    public static long getTotalCacheSize(final InternalStreamsConfig config) {
         // both deprecated and new config set. Warn and use the new one.
         if (config.originals().containsKey(CACHE_MAX_BYTES_BUFFERING_CONFIG) && config.originals().containsKey(STATESTORE_CACHE_MAX_BYTES_CONFIG)) {
             if (!config.getLong(CACHE_MAX_BYTES_BUFFERING_CONFIG).equals(config.getLong(STATESTORE_CACHE_MAX_BYTES_CONFIG))) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractKStreamTimeWindowAggregateProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractKStreamTimeWindowAggregateProcessor.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import static org.apache.kafka.streams.StreamsConfig.InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION;
+import static org.apache.kafka.streams.internals.InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION;
 import static org.apache.kafka.streams.processor.internals.metrics.ProcessorNodeMetrics.emitFinalLatencySensor;
 import static org.apache.kafka.streams.processor.internals.metrics.ProcessorNodeMetrics.emittedRecordsSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
@@ -25,7 +25,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.EmitStrategy;
 import org.apache.kafka.streams.kstream.EmitStrategy.StrategyType;
 import org.apache.kafka.streams.kstream.Window;
@@ -85,7 +85,7 @@ public abstract class AbstractKStreamTimeWindowAggregateProcessor<KIn, VIn, VAgg
             if (lastEmitWindowCloseTime != null) {
                 this.lastEmitWindowCloseTime = lastEmitWindowCloseTime;
             }
-            final long emitInterval = StreamsConfig.InternalConfig.getLong(
+            final long emitInterval = InternalStreamsConfig.getLong(
                 context.appConfigs(),
                 EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION,
                 1000L

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.GlobalKTable;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KStream;
@@ -331,6 +332,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
      * A user can provide either the config OPTIMIZE which means all optimizations rules will be
      * applied or they can provide a list of optimization rules.
      */
+    @SuppressWarnings("deprecation")
     private void optimizeTopology(final Properties props) {
         final Set<String> optimizationConfigs;
         if (props == null || !props.containsKey(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG)) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.kstream.internals.KStreamImplJoin.TimeTracker;
 import org.apache.kafka.streams.kstream.internals.KStreamImplJoin.TimeTrackerSupplier;
@@ -34,13 +35,12 @@ import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.streams.state.internals.TimestampedKeyAndJoinSide;
 import org.apache.kafka.streams.state.internals.LeftOrRightValue;
-import org.apache.kafka.streams.StreamsConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
-import static org.apache.kafka.streams.StreamsConfig.InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX;
+import static org.apache.kafka.streams.internals.InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX;
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 
 class KStreamKStreamJoin<K, V1, V2, VOut> implements ProcessorSupplier<K, V1, K, VOut> {
@@ -112,7 +112,7 @@ class KStreamKStreamJoin<K, V1, V2, VOut> implements ProcessorSupplier<K, V1, K,
                 outerJoinStore = outerJoinWindowName.map(context::getStateStore);
 
                 sharedTimeTracker.setEmitInterval(
-                    StreamsConfig.InternalConfig.getLong(
+                    InternalStreamsConfig.getLong(
                         context.appConfigs(),
                         EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX,
                         1000L

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
@@ -20,7 +20,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Aggregator;
 import org.apache.kafka.streams.kstream.EmitStrategy;
 import org.apache.kafka.streams.kstream.Initializer;
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.kafka.streams.StreamsConfig.InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION;
+import static org.apache.kafka.streams.internals.InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION;
 import static org.apache.kafka.streams.processor.internals.metrics.ProcessorNodeMetrics.emitFinalLatencySensor;
 import static org.apache.kafka.streams.processor.internals.metrics.ProcessorNodeMetrics.emittedRecordsSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
@@ -122,7 +122,7 @@ public class KStreamSessionWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
                 if (lastEmitWindowCloseTime != null) {
                     this.lastEmitWindowCloseTime = lastEmitWindowCloseTime;
                 }
-                final long emitInterval = StreamsConfig.InternalConfig.getLong(
+                final long emitInterval = InternalStreamsConfig.getLong(
                         context.appConfigs(),
                         EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION,
                         1000L

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.CommitCallback;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
@@ -39,7 +40,7 @@ public abstract class AbstractProcessorContext<KOut, VOut> implements InternalPr
 
     private final TaskId taskId;
     private final String applicationId;
-    private final StreamsConfig config;
+    private final InternalStreamsConfig config;
     private final StreamsMetricsImpl metrics;
     private final Serde<?> keySerde;
     private final Serde<?> valueSerde;
@@ -51,7 +52,7 @@ public abstract class AbstractProcessorContext<KOut, VOut> implements InternalPr
     private ProcessorMetadata processorMetadata;
 
     public AbstractProcessorContext(final TaskId taskId,
-                                    final StreamsConfig config,
+                                    final InternalStreamsConfig config,
                                     final StreamsMetricsImpl metrics,
                                     final ThreadCache cache) {
         this.taskId = taskId;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -24,8 +24,8 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KafkaClientSupplier;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
@@ -52,7 +52,7 @@ import static org.apache.kafka.streams.processor.internals.ClientUtils.getThread
 
 class ActiveTaskCreator {
     private final TopologyMetadata topologyMetadata;
-    private final StreamsConfig applicationConfig;
+    private final InternalStreamsConfig applicationConfig;
     private final StreamsMetricsImpl streamsMetrics;
     private final StateDirectory stateDirectory;
     private final ChangelogReader storeChangelogReader;
@@ -68,7 +68,7 @@ class ActiveTaskCreator {
     private final boolean stateUpdaterEnabled;
 
     ActiveTaskCreator(final TopologyMetadata topologyMetadata,
-                      final StreamsConfig applicationConfig,
+                      final InternalStreamsConfig applicationConfig,
                       final StreamsMetricsImpl streamsMetrics,
                       final StateDirectory stateDirectory,
                       final ChangelogReader storeChangelogReader,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
@@ -33,7 +33,6 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.slf4j.Logger;
@@ -51,12 +50,6 @@ import java.util.stream.Collectors;
 
 public class ClientUtils {
     private static final Logger LOG = LoggerFactory.getLogger(ClientUtils.class);
-
-    public static final class QuietStreamsConfig extends StreamsConfig {
-        public QuietStreamsConfig(final Map<?, ?> props) {
-            super(props, false);
-        }
-    }
 
     public static final class QuietConsumerConfig extends ConsumerConfig {
         public QuietConsumerConfig(final Map<String, Object> props) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task.State;
 import org.apache.kafka.streams.processor.internals.TaskAndAction.Action;
@@ -543,7 +544,7 @@ public class DefaultStateUpdater implements StateUpdater {
 
     public DefaultStateUpdater(final String name,
                                final Metrics metrics,
-                               final StreamsConfig config,
+                               final InternalStreamsConfig config,
                                final ChangelogReader changelogReader,
                                final TopologyMetadata topologyMetadata,
                                final Time time) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
@@ -41,7 +42,7 @@ public class GlobalProcessorContextImpl extends AbstractProcessorContext<Object,
     private final GlobalStateManager stateManager;
     private final Time time;
 
-    public GlobalProcessorContextImpl(final StreamsConfig config,
+    public GlobalProcessorContextImpl(final InternalStreamsConfig config,
                                       final GlobalStateManager stateMgr,
                                       final StreamsMetricsImpl metrics,
                                       final ThreadCache cache,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.CommitCallback;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateRestoreListener;
@@ -86,7 +87,7 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
                                   final Consumer<byte[], byte[]> globalConsumer,
                                   final StateDirectory stateDirectory,
                                   final StateRestoreListener stateRestoreListener,
-                                  final StreamsConfig config) {
+                                  final InternalStreamsConfig config) {
         this.time = time;
         this.topology = topology;
         baseDir = stateDirectory.globalStateDir();
@@ -106,7 +107,7 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
         this.globalConsumer = globalConsumer;
         this.stateRestoreListener = stateRestoreListener;
 
-        final Map<String, Object> consumerProps = config.getGlobalConsumerConfigs("dummy");
+        final Map<String, Object> consumerProps = config.globalConsumerConfigs("dummy");
         // need to add mandatory configs; otherwise `QuietConsumerConfig` throws
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.ThreadCache;
@@ -55,7 +56,7 @@ public class GlobalStreamThread extends Thread {
 
     private final Logger log;
     private final LogContext logContext;
-    private final StreamsConfig config;
+    private final InternalStreamsConfig config;
     private final Consumer<byte[], byte[]> globalConsumer;
     private final StateDirectory stateDirectory;
     private final Time time;
@@ -194,7 +195,7 @@ public class GlobalStreamThread extends Thread {
     }
 
     public GlobalStreamThread(final ProcessorTopology topology,
-                              final StreamsConfig config,
+                              final InternalStreamsConfig config,
                               final Consumer<byte[], byte[]> globalConsumer,
                               final StateDirectory stateDirectory,
                               final long cacheSizeBytes,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -44,6 +44,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.internals.ClientUtils.QuietConsumerConfig;
 import org.slf4j.Logger;
 
@@ -84,7 +85,7 @@ public class InternalTopicManager {
 
     public InternalTopicManager(final Time time,
                                 final Admin adminClient,
-                                final StreamsConfig streamsConfig) {
+                                final InternalStreamsConfig streamsConfig) {
         this.time = time;
         this.adminClient = adminClient;
 
@@ -94,7 +95,7 @@ public class InternalTopicManager {
         replicationFactor = streamsConfig.getInt(StreamsConfig.REPLICATION_FACTOR_CONFIG).shortValue();
         windowChangeLogAdditionalRetention = streamsConfig.getLong(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG);
         retryBackOffMs = streamsConfig.getLong(StreamsConfig.RETRY_BACKOFF_MS_CONFIG);
-        final Map<String, Object> consumerConfig = streamsConfig.getMainConsumerConfigs("dummy", "dummy", -1);
+        final Map<String, Object> consumerConfig = streamsConfig.mainConsumerConfigs("dummy", "dummy", -1);
         // need to add mandatory configs; otherwise `QuietConsumerConfig` throws
         consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
         consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -24,6 +24,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.internals.ApiUtils;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.TimestampExtractor;
@@ -396,7 +397,7 @@ public class InternalTopologyBuilder {
         return this;
     }
 
-    public synchronized final void setStreamsConfig(final StreamsConfig applicationConfig) {
+    public synchronized final void setStreamsConfig(final InternalStreamsConfig applicationConfig) {
         Objects.requireNonNull(applicationConfig, "config can't be null");
         topologyConfigs = new TopologyConfig(applicationConfig);
     }
@@ -417,7 +418,7 @@ public class InternalTopologyBuilder {
         return namedTopology;
     }
 
-    public synchronized final InternalTopologyBuilder rewriteTopology(final StreamsConfig config) {
+    public synchronized final InternalTopologyBuilder rewriteTopology(final InternalStreamsConfig config) {
         Objects.requireNonNull(config, "config can't be null");
 
         setApplicationId(config.getString(StreamsConfig.APPLICATION_ID_CONFIG));

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
@@ -43,7 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
+import static org.apache.kafka.streams.internals.InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 import static org.apache.kafka.streams.internals.ApiUtils.prepareMillisCheckFailMsgPrefix;
 import static org.apache.kafka.streams.internals.ApiUtils.validateMillisecondDuration;
 import static org.apache.kafka.streams.processor.internals.AbstractReadOnlyDecorator.getReadOnlyStore;
@@ -61,13 +62,13 @@ public class ProcessorContextImpl extends AbstractProcessorContext<Object, Objec
 
     @SuppressWarnings("this-escape")
     public ProcessorContextImpl(final TaskId id,
-                                final StreamsConfig config,
+                                final InternalStreamsConfig config,
                                 final ProcessorStateManager stateMgr,
                                 final StreamsMetricsImpl metrics,
                                 final ThreadCache cache) {
         super(id, config, metrics, cache);
         stateManager = stateMgr;
-        consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
+        consistencyEnabled = InternalStreamsConfig.getBoolean(
                 appConfigs(),
                 IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
                 false);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextUtils.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
@@ -74,9 +74,9 @@ public final class ProcessorContextUtils {
         if (configs == null) {
             return applicationId;
         } else {
-            return StreamsConfig.InternalConfig.getString(
+            return InternalStreamsConfig.getString(
                 configs,
-                StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE,
+                InternalStreamsConfig.TOPIC_PREFIX_ALTERNATIVE,
                 applicationId
             );
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
@@ -36,7 +37,7 @@ import static org.apache.kafka.streams.internals.StreamsConfigUtils.eosEnabled;
 
 class StandbyTaskCreator {
     private final TopologyMetadata topologyMetadata;
-    private final StreamsConfig applicationConfig;
+    private final InternalStreamsConfig applicationConfig;
     private final StreamsMetricsImpl streamsMetrics;
     private final StateDirectory stateDirectory;
     private final ChangelogReader storeChangelogReader;
@@ -46,7 +47,7 @@ class StandbyTaskCreator {
     private final boolean stateUpdaterEnabled;
 
     StandbyTaskCreator(final TopologyMetadata topologyMetadata,
-                       final StreamsConfig applicationConfig,
+                       final InternalStreamsConfig applicationConfig,
                        final StreamsMetricsImpl streamsMetrics,
                        final StateDirectory stateDirectory,
                        final ChangelogReader storeChangelogReader,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -112,7 +113,7 @@ public class StateDirectory {
      * @throws ProcessorStateException if the base state directory or application state directory does not exist
      *                                 and could not be created when hasPersistentStores is enabled.
      */
-    public StateDirectory(final StreamsConfig config, final Time time, final boolean hasPersistentStores, final boolean hasNamedTopologies) {
+    public StateDirectory(final InternalStreamsConfig config, final Time time, final boolean hasPersistentStores, final boolean hasNamedTopologies) {
         this.time = time;
         this.hasPersistentStores = hasPersistentStores;
         this.hasNamedTopologies = hasNamedTopologies;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -33,9 +33,9 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager.StateStoreMetadata;
@@ -218,7 +218,7 @@ public class StoreChangelogReader implements ChangelogReader {
     private long lastUpdateOffsetTime;
 
     public StoreChangelogReader(final Time time,
-                                final StreamsConfig config,
+                                final InternalStreamsConfig config,
                                 final LogContext logContext,
                                 final Admin adminClient,
                                 final Consumer<byte[], byte[]> restoreConsumer,
@@ -230,7 +230,7 @@ public class StoreChangelogReader implements ChangelogReader {
         this.restoreConsumer = restoreConsumer;
         this.stateRestoreListener = stateRestoreListener;
 
-        this.stateUpdaterEnabled = InternalConfig.getStateUpdaterEnabled(config.originals());
+        this.stateUpdaterEnabled = InternalStreamsConfig.stateUpdaterEnabled(config.originals());
 
         this.groupId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
         this.pollTime = Duration.ofMillis(config.getLong(StreamsConfig.POLL_MS_CONFIG));

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -41,6 +41,7 @@ import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.internals.StreamsConfigUtils;
 import org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode;
 import org.apache.kafka.streams.processor.TaskId;
@@ -78,7 +79,7 @@ public class StreamsProducer {
     private boolean transactionInitialized = false;
     private double oldProducerTotalBlockedTime = 0;
 
-    public StreamsProducer(final StreamsConfig config,
+    public StreamsProducer(final InternalStreamsConfig config,
                            final String threadId,
                            final KafkaClientSupplier clientSupplier,
                            final TaskId taskId,
@@ -97,13 +98,13 @@ public class StreamsProducer {
         final Map<String, Object> producerConfigs;
         switch (processingMode) {
             case AT_LEAST_ONCE: {
-                producerConfigs = config.getProducerConfigs(getThreadProducerClientId(threadId));
+                producerConfigs = config.producerConfigs(getThreadProducerClientId(threadId));
                 eosV2ProducerConfigs = null;
 
                 break;
             }
             case EXACTLY_ONCE_ALPHA: {
-                producerConfigs = config.getProducerConfigs(
+                producerConfigs = config.producerConfigs(
                     getTaskProducerClientId(
                         threadId,
                         Objects.requireNonNull(taskId, "taskId cannot be null for exactly-once alpha")
@@ -118,7 +119,7 @@ public class StreamsProducer {
                 break;
             }
             case EXACTLY_ONCE_V2: {
-                producerConfigs = config.getProducerConfigs(getThreadProducerClientId(threadId));
+                producerConfigs = config.producerConfigs(getThreadProducerClientId(threadId));
 
                 final String applicationId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
                 producerConfigs.put(

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.errors.UnknownTopologyException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.internals.StreamsConfigUtils;
 import org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode;
 import org.apache.kafka.streams.processor.StateStore;
@@ -69,7 +70,7 @@ public class TopologyMetadata {
     public static final String UNNAMED_TOPOLOGY = "__UNNAMED_TOPOLOGY__";
     private static final Pattern EMPTY_ZERO_LENGTH_PATTERN = Pattern.compile("");
 
-    private final StreamsConfig config;
+    private final InternalStreamsConfig config;
     private final ProcessingMode processingMode;
     private final TopologyVersion version;
     private final TaskExecutionMetadata taskExecutionMetadata;
@@ -100,7 +101,7 @@ public class TopologyMetadata {
     }
 
     public TopologyMetadata(final InternalTopologyBuilder builder,
-                            final StreamsConfig config) {
+                            final InternalStreamsConfig config) {
         this.version = new TopologyVersion();
         this.processingMode = StreamsConfigUtils.processingMode(config);
         this.config = config;
@@ -117,7 +118,7 @@ public class TopologyMetadata {
     }
 
     public TopologyMetadata(final ConcurrentNavigableMap<String, InternalTopologyBuilder> builders,
-                            final StreamsConfig config) {
+                            final InternalStreamsConfig config) {
         this.version = new TopologyVersion();
         this.processingMode = StreamsConfigUtils.processingMode(config);
         this.config = config;
@@ -360,7 +361,7 @@ public class TopologyMetadata {
         allInputTopics.addAll(newInputTopics);
     }
 
-    public int getNumStreamThreads(final StreamsConfig config) {
+    public int getNumStreamThreads(final InternalStreamsConfig config) {
         final int configuredNumStreamThreads = config.getInt(StreamsConfig.NUM_STREAM_THREADS_CONFIG);
 
         // If there are named topologies but some are empty, this indicates a bug in user code

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.errors.GroupSubscribedToTopicException;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyQueryMetadata;
@@ -36,6 +37,7 @@ import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.errors.UnknownStateStoreException;
 import org.apache.kafka.streams.errors.UnknownTopologyException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
@@ -77,15 +79,15 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
      * An empty Kafka Streams application that allows NamedTopologies to be added at a later point
      */
     public KafkaStreamsNamedTopologyWrapper(final Properties props) {
-        this(new StreamsConfig(props), new DefaultKafkaClientSupplier());
+        this(new InternalStreamsConfig(props), new DefaultKafkaClientSupplier());
     }
 
     public KafkaStreamsNamedTopologyWrapper(final Properties props, final KafkaClientSupplier clientSupplier) {
-        this(new StreamsConfig(props), clientSupplier);
+        this(new InternalStreamsConfig(props), clientSupplier);
     }
 
-    private KafkaStreamsNamedTopologyWrapper(final StreamsConfig config, final KafkaClientSupplier clientSupplier) {
-        super(new TopologyMetadata(new ConcurrentSkipListMap<>(), config), config, clientSupplier);
+    private KafkaStreamsNamedTopologyWrapper(final InternalStreamsConfig config, final KafkaClientSupplier clientSupplier) {
+        super(new TopologyMetadata(new ConcurrentSkipListMap<>(), config), config, clientSupplier, Time.SYSTEM);
         final LogContext logContext = new LogContext(String.format("stream-client [%s] ", clientId));
         this.log = logContext.logger(getClass());
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTopologyBuilder.java
@@ -19,13 +19,14 @@ package org.apache.kafka.streams.processor.internals.namedtopology;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 
 import java.util.Properties;
 
 public class NamedTopologyBuilder extends StreamsBuilder {
 
-    NamedTopologyBuilder(final String topologyName, final StreamsConfig applicationConfigs, final Properties topologyOverrides) {
+    NamedTopologyBuilder(final String topologyName, final InternalStreamsConfig applicationConfigs, final Properties topologyOverrides) {
         super(new TopologyConfig(topologyName, applicationConfigs, topologyOverrides));
         internalTopologyBuilder.setNamedTopology((NamedTopology) topology);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
@@ -21,8 +21,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -43,7 +43,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
+import static org.apache.kafka.streams.internals.InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 
 public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Segment> implements SegmentedBytesStore {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractDualSchemaRocksDBSegmentedBytesStore.class);
@@ -269,7 +269,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
 
         open = true;
 
-        consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
+        consistencyEnabled = InternalStreamsConfig.getBoolean(
             context.appConfigs(),
             IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
             false

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -20,8 +20,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -44,7 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
+import static org.apache.kafka.streams.internals.InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 
 public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements SegmentedBytesStore {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractRocksDBSegmentedBytesStore.class);
@@ -322,7 +322,7 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
 
         open = true;
 
-        consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
+        consistencyEnabled = InternalStreamsConfig.getBoolean(
                 context.appConfigs(),
                 IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
                 false);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -20,7 +20,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -44,7 +44,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
+import static org.apache.kafka.streams.internals.InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 
 public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
 
@@ -70,7 +70,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     public void init(final ProcessorContext context,
                      final StateStore root) {
         if (root != null) {
-            final boolean consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
+            final boolean consistencyEnabled = InternalStreamsConfig.getBoolean(
                 context.appConfigs(),
                 IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
                 false

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -20,7 +20,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -52,7 +52,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
-import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
+import static org.apache.kafka.streams.internals.InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 
 public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
 
@@ -116,7 +116,7 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
         }
 
         if (root != null) {
-            final boolean consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
+            final boolean consistencyEnabled = InternalStreamsConfig.getBoolean(
                 context.appConfigs(),
                 IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
                 false

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -20,7 +20,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -53,7 +53,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
-import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
+import static org.apache.kafka.streams.internals.InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 import static org.apache.kafka.streams.state.internals.WindowKeySchema.extractStoreKeyBytes;
 import static org.apache.kafka.streams.state.internals.WindowKeySchema.extractStoreTimestamp;
 
@@ -115,7 +115,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         );
 
         if (root != null) {
-            final boolean consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
+            final boolean consistencyEnabled = InternalStreamsConfig.getBoolean(
                 context.appConfigs(),
                 IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
                 false

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryLRUCache.java
@@ -20,7 +20,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
+import static org.apache.kafka.streams.internals.InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 
 /**
  * An in-memory LRU cache store based on HashSet and HashMap.
@@ -99,7 +99,7 @@ public class MemoryLRUCache implements KeyValueStore<Bytes, byte[]> {
 
     @Override
     public void init(final StateStoreContext context, final StateStore root) {
-        final boolean consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
+        final boolean consistencyEnabled = InternalStreamsConfig.getBoolean(
             context.appConfigs(),
             IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
             false

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -25,6 +25,7 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -74,7 +75,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
+import static org.apache.kafka.streams.internals.InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 import static org.apache.kafka.streams.StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.getMetricsImpl;
 
@@ -177,7 +178,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
             (RecordBatchingStateRestoreCallback) this::restoreBatch,
             () -> StoreQueryUtils.checkpointPosition(positionCheckpoint, position)
         );
-        consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
+        consistencyEnabled = InternalStreamsConfig.getBoolean(
             context.appConfigs(),
             IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
             false);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStore.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
+import static org.apache.kafka.streams.internals.InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 import static org.apache.kafka.streams.state.internals.RocksDBStore.DB_FILE_DIR;
 
 import java.io.File;
@@ -28,9 +28,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -321,7 +321,7 @@ public class RocksDBVersionedStore implements VersionedKeyValueStore<Bytes, byte
 
         open = true;
 
-        consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
+        consistencyEnabled = InternalStreamsConfig.getBoolean(
             context.appConfigs(),
             IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
             false

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingWindowStore.java
@@ -24,7 +24,7 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -121,9 +121,9 @@ class TimeOrderedCachingWindowStore
     }
 
     private void initInternal(final InternalProcessorContext<?, ?> context) {
-        final String prefix = StreamsConfig.InternalConfig.getString(
+        final String prefix = InternalStreamsConfig.getString(
             context.appConfigs(),
-            StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE,
+            InternalStreamsConfig.TOPIC_PREFIX_ALTERNATIVE,
             context.applicationId()
         );
         this.context = context;

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
 import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Branched;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.ForeachAction;
@@ -148,7 +149,7 @@ public class StreamsBuilderTest {
         builder.build();
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+            builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
 
         assertThat(
             topology.stateStores().size(),
@@ -171,7 +172,7 @@ public class StreamsBuilderTest {
         builder.build();
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+            builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
 
         assertThat(
             topology.stateStores().size(),
@@ -195,7 +196,7 @@ public class StreamsBuilderTest {
         builder.build();
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+            builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
 
         assertThat(
             topology.stateStores().size(),
@@ -218,7 +219,7 @@ public class StreamsBuilderTest {
         builder.build();
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+            builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
 
         assertThat(
             topology.stateStores().size(),
@@ -241,7 +242,7 @@ public class StreamsBuilderTest {
         builder.build();
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+            builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
 
         assertThat(
             topology.stateStores().size(),
@@ -265,7 +266,7 @@ public class StreamsBuilderTest {
         builder.build();
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+            builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
 
         assertThat(
             topology.stateStores().size(),
@@ -285,7 +286,7 @@ public class StreamsBuilderTest {
         builder.build();
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+            builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
 
         assertThat(
             topology.stateStores().size(),
@@ -454,7 +455,7 @@ public class StreamsBuilderTest {
         builder.table(topic, Materialized.with(Serdes.Long(), Serdes.String()));
 
         final ProcessorTopology topology =
-            builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+            builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
 
         assertThat(topology.stateStores().size(), equalTo(0));
     }
@@ -468,7 +469,7 @@ public class StreamsBuilderTest {
         final Topology topology = builder.build(props);
 
         final InternalTopologyBuilder internalTopologyBuilder = TopologyWrapper.getInternalTopologyBuilder(topology);
-        internalTopologyBuilder.rewriteTopology(new StreamsConfig(props));
+        internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props));
 
         assertThat(
             internalTopologyBuilder.buildTopology().storeToChangelogTopic(),
@@ -493,7 +494,7 @@ public class StreamsBuilderTest {
         final Topology topology = builder.build(props);
 
         final InternalTopologyBuilder internalTopologyBuilder = TopologyWrapper.getInternalTopologyBuilder(topology);
-        internalTopologyBuilder.rewriteTopology(new StreamsConfig(props));
+        internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props));
 
         assertThat(
             internalTopologyBuilder.buildTopology().storeToChangelogTopic(),
@@ -553,7 +554,7 @@ public class StreamsBuilderTest {
         builder.stream(STREAM_TOPIC, Consumed.as(expected));
         builder.stream(STREAM_TOPIC_TWO);
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, expected, "KSTREAM-SOURCE-0000000001");
     }
 
@@ -564,7 +565,7 @@ public class StreamsBuilderTest {
         builder.table(STREAM_TOPIC_TWO);
         builder.build();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
 
         assertNamesForOperation(
             topology,
@@ -580,7 +581,7 @@ public class StreamsBuilderTest {
         builder.globalTable(STREAM_TOPIC, Consumed.as(expected));
         builder.globalTable(STREAM_TOPIC_TWO);
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
 
         assertNamesForStateStore(
             topology.globalStateStores(),
@@ -596,7 +597,7 @@ public class StreamsBuilderTest {
         stream.to(STREAM_TOPIC_TWO, Produced.as(expected));
         stream.to(STREAM_TOPIC_TWO);
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", expected, "KSTREAM-SINK-0000000002");
     }
 
@@ -604,7 +605,7 @@ public class StreamsBuilderTest {
     public void shouldUseSpecifiedNameForMapOperation() {
         builder.stream(STREAM_TOPIC).map(KeyValue::pair, Named.as(STREAM_OPERATION_NAME));
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -612,7 +613,7 @@ public class StreamsBuilderTest {
     public void shouldUseSpecifiedNameForMapValuesOperation() {
         builder.stream(STREAM_TOPIC).mapValues(v -> v, Named.as(STREAM_OPERATION_NAME));
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -620,7 +621,7 @@ public class StreamsBuilderTest {
     public void shouldUseSpecifiedNameForMapValuesWithKeyOperation() {
         builder.stream(STREAM_TOPIC).mapValues((k, v) -> v, Named.as(STREAM_OPERATION_NAME));
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -628,7 +629,7 @@ public class StreamsBuilderTest {
     public void shouldUseSpecifiedNameForFilterOperation() {
         builder.stream(STREAM_TOPIC).filter((k, v) -> true, Named.as(STREAM_OPERATION_NAME));
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -636,7 +637,7 @@ public class StreamsBuilderTest {
     public void shouldUseSpecifiedNameForForEachOperation() {
         builder.stream(STREAM_TOPIC).foreach((k, v) -> { }, Named.as(STREAM_OPERATION_NAME));
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -645,7 +646,7 @@ public class StreamsBuilderTest {
     public void shouldUseSpecifiedNameForTransform() {
         builder.stream(STREAM_TOPIC).transform(() -> null, Named.as(STREAM_OPERATION_NAME));
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -654,7 +655,7 @@ public class StreamsBuilderTest {
     public void shouldUseSpecifiedNameForTransformValues() {
         builder.stream(STREAM_TOPIC).transformValues(() -> new NoopValueTransformer<>(), Named.as(STREAM_OPERATION_NAME));
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -663,7 +664,7 @@ public class StreamsBuilderTest {
     public void shouldUseSpecifiedNameForTransformValuesWithKey() {
         builder.stream(STREAM_TOPIC).transformValues(() -> new NoopValueTransformerWithKey<>(), Named.as(STREAM_OPERATION_NAME));
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -674,7 +675,7 @@ public class StreamsBuilderTest {
                .branch(Named.as("branch-processor"), (k, v) -> true, (k, v) -> false);
 
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
                                 "KSTREAM-SOURCE-0000000000",
                                 "branch-processor",
@@ -689,7 +690,7 @@ public class StreamsBuilderTest {
                 .branch((k, v) -> true, Branched.as("-1"))
                 .branch((k, v) -> false, Branched.as("-2"));
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
                 "KSTREAM-SOURCE-0000000000",
                 "branch-processor",
@@ -704,7 +705,7 @@ public class StreamsBuilderTest {
         streamOne.join(streamTwo, (value1, value2) -> value1, Joined.as(STREAM_OPERATION_NAME));
         builder.build();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
                                 "KSTREAM-SOURCE-0000000000",
                                 "KSTREAM-SOURCE-0000000002",
@@ -719,7 +720,7 @@ public class StreamsBuilderTest {
         streamOne.leftJoin(streamTwo, (value1, value2) -> value1, Joined.as(STREAM_OPERATION_NAME));
         builder.build();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
                                 "KSTREAM-SOURCE-0000000000",
                                 "KSTREAM-SOURCE-0000000002",
@@ -744,7 +745,7 @@ public class StreamsBuilderTest {
         final Properties properties = new Properties();
         builder.build(properties);
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
                 STREAM_OPERATION_NAME + "-this-join-store",
                 STREAM_OPERATION_NAME + "-outer-other-join-store"
@@ -773,7 +774,7 @@ public class StreamsBuilderTest {
         );
         builder.build();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
             STREAM_OPERATION_NAME + "-this-join-store",
             STREAM_OPERATION_NAME + "-outer-other-join-store",
@@ -803,7 +804,7 @@ public class StreamsBuilderTest {
         );
         builder.build();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
                                  "KSTREAM-JOINTHIS-0000000004-store",
                                  "KSTREAM-OUTEROTHER-0000000005-store",
@@ -831,7 +832,7 @@ public class StreamsBuilderTest {
             StreamJoined.<String, String, String>as(STREAM_OPERATION_NAME).withName(STREAM_OPERATION_NAME));
         builder.build();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
                                  STREAM_OPERATION_NAME + "-this-join-store",
                                  STREAM_OPERATION_NAME + "-other-join-store"
@@ -859,7 +860,7 @@ public class StreamsBuilderTest {
                 .withName(STREAM_OPERATION_NAME));
         builder.build();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
                                  "KSTREAM-JOINTHIS-0000000004-store",
                                  "KSTREAM-JOINOTHER-0000000005-store"
@@ -887,7 +888,7 @@ public class StreamsBuilderTest {
                 .withName(STREAM_OPERATION_NAME)
         );
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
                                  STREAM_OPERATION_NAME + "-outer-this-join-store",
                                  STREAM_OPERATION_NAME + "-outer-other-join-store",
@@ -917,7 +918,7 @@ public class StreamsBuilderTest {
         );
         builder.build();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
                                  "KSTREAM-OUTERTHIS-0000000004-store",
                                  "KSTREAM-OUTEROTHER-0000000005-store",
@@ -943,7 +944,7 @@ public class StreamsBuilderTest {
         final KStream<String, String> source2 = builder.stream(topic2);
         source1.merge(source2, Named.as("merge-processor"));
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", "KSTREAM-SOURCE-0000000001", "merge-processor");
     }
 
@@ -953,7 +954,7 @@ public class StreamsBuilderTest {
                 .process(new MockApiProcessorSupplier<>(), Named.as("test-processor"));
 
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", "test-processor");
     }
 
@@ -961,7 +962,7 @@ public class StreamsBuilderTest {
     public void shouldUseSpecifiedNameForPrintOperation() {
         builder.stream(STREAM_TOPIC).print(Printed.toSysOut().withName("print-processor"));
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", "print-processor");
     }
 
@@ -970,7 +971,7 @@ public class StreamsBuilderTest {
     public void shouldUseSpecifiedNameForFlatTransformValueOperation() {
         builder.stream(STREAM_TOPIC).flatTransformValues(() -> new NoopValueTransformer<>(), Named.as(STREAM_OPERATION_NAME));
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -979,7 +980,7 @@ public class StreamsBuilderTest {
     public void shouldUseSpecifiedNameForFlatTransformValueWithKeyOperation() {
         builder.stream(STREAM_TOPIC).flatTransformValues(() -> new NoopValueTransformerWithKey(), Named.as(STREAM_OPERATION_NAME));
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", STREAM_OPERATION_NAME);
     }
 
@@ -989,7 +990,7 @@ public class StreamsBuilderTest {
                .toStream(Named.as("to-stream"));
 
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
                                 "KSTREAM-SOURCE-0000000001",
                                 "KTABLE-SOURCE-0000000002",
@@ -1002,7 +1003,7 @@ public class StreamsBuilderTest {
                .toStream(KeyValue::pair, Named.as("to-stream"));
 
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForOperation(topology,
                                 "KSTREAM-SOURCE-0000000001",
                                 "KTABLE-SOURCE-0000000002",
@@ -1014,7 +1015,7 @@ public class StreamsBuilderTest {
     public void shouldUseSpecifiedNameForAggregateOperationGivenTable() {
         builder.table(STREAM_TOPIC).groupBy(KeyValue::pair, Grouped.as("group-operation")).count(Named.as(STREAM_OPERATION_NAME));
         builder.build();
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildTopology();
         assertNamesForStateStore(
             topology.stateStores(),
             STREAM_TOPIC + "-STATE-STORE-0000000000",
@@ -1043,7 +1044,7 @@ public class StreamsBuilderTest {
         );
         builder.build();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildGlobalStateTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildGlobalStateTopology();
         assertNamesForOperation(topology, "test-source", "test");
     }
 
@@ -1060,7 +1061,7 @@ public class StreamsBuilderTest {
         );
         builder.build();
 
-        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildGlobalStateTopology();
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(props)).buildGlobalStateTopology();
         assertNamesForOperation(topology, "KSTREAM-SOURCE-0000000000", "KTABLE-SOURCE-0000000001");
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
@@ -2307,7 +2308,7 @@ public class TopologyTest {
         final Properties topologyOverrides = new Properties();
         // change default store as in-memory
         topologyOverrides.put(StreamsConfig.DEFAULT_DSL_STORE_CONFIG, defaultStore);
-        final StreamsConfig config = new StreamsConfig(StreamsTestUtils.getStreamsConfig());
+        final InternalStreamsConfig config = new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig());
 
         return new TopologyConfig(
             "my-topology",

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyWrapper.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyWrapper.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams;
 
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.test.StreamsTestUtils;
 
@@ -26,14 +27,14 @@ import org.apache.kafka.test.StreamsTestUtils;
 public class TopologyWrapper extends Topology {
 
     static public InternalTopologyBuilder getInternalTopologyBuilder(final Topology topology) {
-        return topology.internalTopologyBuilder.rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig()));
+        return topology.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig()));
     }
 
     public InternalTopologyBuilder getInternalBuilder() {
-        return internalTopologyBuilder.rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig()));
+        return internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig()));
     }
 
     public InternalTopologyBuilder getInternalBuilder(final String applicationId) {
-        return internalTopologyBuilder.rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig(applicationId)));
+        return internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig(applicationId)));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ConsistencyVectorIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ConsistencyVectorIntegrationTest.java
@@ -26,9 +26,9 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.query.KeyQuery;
@@ -224,7 +224,7 @@ public class ConsistencyVectorIntegrationTest {
         config.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 200);
         config.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 1000);
         config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
-        config.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        config.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         return config;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosV2UpgradeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosV2UpgradeIntegrationTest.java
@@ -34,11 +34,11 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils.StableAssignmentListener;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.kstream.TransformerSupplier;
@@ -951,7 +951,7 @@ public class EosV2UpgradeIntegrationTest {
         properties.put(StreamsConfig.producerPrefix(ProducerConfig.PARTITIONER_CLASS_CONFIG), KeyPartitioner.class);
         properties.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
         properties.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath() + File.separator + appDir);
-        properties.put(InternalConfig.ASSIGNMENT_LISTENER, assignmentListener);
+        properties.put(InternalStreamsConfig.ASSIGNMENT_LISTENER, assignmentListener);
 
         final Properties config = StreamsTestUtils.getStreamsConfig(
             applicationId,

--- a/streams/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
@@ -37,6 +37,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils;
@@ -324,9 +325,9 @@ public class HighAvailabilityTaskAssignorIntegrationTest {
                 mkEntry(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, "0"), // make the warmup catch up completely
                 mkEntry(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, "2"),
                 mkEntry(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, "60000"),
-                mkEntry(StreamsConfig.InternalConfig.ASSIGNMENT_LISTENER, configuredAssignmentListener),
+                mkEntry(InternalStreamsConfig.ASSIGNMENT_LISTENER, configuredAssignmentListener),
                 mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L),
-                mkEntry(StreamsConfig.InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS, HighAvailabilityTaskAssignor.class.getName()),
+                mkEntry(InternalStreamsConfig.TASK_ASSIGNOR_CLASS, HighAvailabilityTaskAssignor.class.getName()),
                 // Increasing the number of threads to ensure that a rebalance happens each time a consumer sends a rejoin (KAFKA-10455)
                 mkEntry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 40),
                 mkEntry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName()),

--- a/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.processor.StateRestoreListener;
@@ -160,7 +161,7 @@ public class LagFetchIntegrationTest {
             final Properties props = (Properties) streamsConfiguration.clone();
             // this test relies on the second instance getting the standby, so we specify
             // an assignor with this contract.
-            props.put(StreamsConfig.InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS, FallbackPriorTaskAssignor.class.getName());
+            props.put(InternalStreamsConfig.TASK_ASSIGNOR_CLASS, FallbackPriorTaskAssignor.class.getName());
             props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + i);
             props.put(StreamsConfig.CLIENT_ID_CONFIG, "instance-" + i);
             props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, optimization);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -39,6 +39,7 @@ import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
@@ -210,7 +211,7 @@ public class NamedTopologyIntegrationTest {
         streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         streamsConfiguration.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 10 * 1000);
         streamsConfiguration.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
-        streamsConfiguration.put(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE, TOPIC_PREFIX);
+        streamsConfiguration.put(InternalStreamsConfig.TOPIC_PREFIX_ALTERNATIVE, TOPIC_PREFIX);
         return streamsConfiguration;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/PauseResumeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/PauseResumeIntegrationTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
 import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopologyBuilder;
@@ -140,7 +141,7 @@ public class PauseResumeIntegrationTest {
         properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         properties.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
         properties.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 1000);
-        properties.put(StreamsConfig.InternalConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled);
+        properties.put(InternalStreamsConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled);
         return properties;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/PositionRestartIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/PositionRestartIntegrationTest.java
@@ -29,9 +29,9 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.SessionWindows;
@@ -689,7 +689,7 @@ public class PositionRestartIntegrationTest {
         config.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 1000);
         config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         config.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
-        config.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        config.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         return config;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -36,11 +36,11 @@ import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils.TrackingStateRestoreListener;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Materialized;
@@ -140,7 +140,7 @@ public class RestoreIntegrationTest {
     }
 
     private Properties props(final boolean stateUpdaterEnabled) {
-        return props(mkObjectProperties(mkMap(mkEntry(InternalConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled))));
+        return props(mkObjectProperties(mkMap(mkEntry(InternalStreamsConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled))));
     }
 
     private Properties props(final Properties extraProperties) {
@@ -257,7 +257,7 @@ public class RestoreIntegrationTest {
         createStateForRestoration(inputStream, 0);
         setCommittedOffset(inputStream, offsetLimitDelta);
 
-        final StateDirectory stateDirectory = new StateDirectory(new StreamsConfig(props), new MockTime(), true, false);
+        final StateDirectory stateDirectory = new StateDirectory(new InternalStreamsConfig(props), new MockTime(), true, false);
         // note here the checkpointed offset is the last processed record's offset, so without control message we should write this offset - 1
         new OffsetCheckpoint(new File(stateDirectory.getOrCreateDirectoryForTask(new TaskId(0, 0)), ".checkpoint"))
                 .write(Collections.singletonMap(new TopicPartition(inputStream, 0), (long) offsetCheckpointed - 1));
@@ -324,7 +324,7 @@ public class RestoreIntegrationTest {
         createStateForRestoration(changelog, 0);
         createStateForRestoration(inputStream, 10000);
 
-        final StateDirectory stateDirectory = new StateDirectory(new StreamsConfig(props), new MockTime(), true, false);
+        final StateDirectory stateDirectory = new StateDirectory(new InternalStreamsConfig(props), new MockTime(), true, false);
         // note here the checkpointed offset is the last processed record's offset, so without control message we should write this offset - 1
         new OffsetCheckpoint(new File(stateDirectory.getOrCreateDirectoryForTask(new TaskId(0, 0)), ".checkpoint"))
                 .write(Collections.singletonMap(new TopicPartition(changelog, 0), (long) offsetCheckpointed - 1));

--- a/streams/src/test/java/org/apache/kafka/streams/integration/SlidingWindowedKStreamIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/SlidingWindowedKStreamIntegrationTest.java
@@ -30,9 +30,9 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.KeyValueTimestamp;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.EmitStrategy;
 import org.apache.kafka.streams.kstream.EmitStrategy.StrategyType;
@@ -145,7 +145,7 @@ public class SlidingWindowedKStreamIntegrationTest {
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-        streamsConfiguration.put(InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 0); // Always process
+        streamsConfiguration.put(InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 0); // Always process
         streamsConfiguration.put(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG, Long.MAX_VALUE); // Don't expire changelog
 
         emitStrategy = StrategyType.forType(type);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
@@ -20,9 +20,9 @@ import java.util.stream.Stream;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.tests.SmokeTestClient;
 import org.apache.kafka.streams.tests.SmokeTestDriver;
 import org.junit.jupiter.api.AfterAll;
@@ -127,7 +127,7 @@ public class SmokeTestDriverIntegrationTest {
 
         final Properties props = new Properties();
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        props.put(InternalConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled);
+        props.put(InternalStreamsConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled);
         // decrease the session timeout so that we can trigger the rebalance soon after old client left closed
         props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 10000);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -188,7 +189,7 @@ public class StandbyTaskEOSIntegrationTest {
         final Properties props = props(stateDirPath);
 
         final StateDirectory stateDirectory = new StateDirectory(
-            new StreamsConfig(props), new MockTime(), true, false);
+            new InternalStreamsConfig(props), new MockTime(), true, false);
 
         new OffsetCheckpoint(new File(stateDirectory.getOrCreateDirectoryForTask(taskId), ".checkpoint"))
             .write(Collections.singletonMap(new TopicPartition("unknown-topic", 0), 5L));

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskAssignorIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskAssignorIntegrationTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration;
@@ -113,8 +114,8 @@ public class TaskAssignorIntegrationTest {
                 mkEntry(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, "6"),
                 mkEntry(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, "7"),
                 mkEntry(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, "480000"),
-                mkEntry(StreamsConfig.InternalConfig.ASSIGNMENT_LISTENER, configuredAssignmentListener),
-                mkEntry(StreamsConfig.InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS, MyTaskAssignor.class.getName())
+                mkEntry(InternalStreamsConfig.ASSIGNMENT_LISTENER, configuredAssignmentListener),
+                mkEntry(InternalStreamsConfig.TASK_ASSIGNOR_CLASS, MyTaskAssignor.class.getName())
             )
         );
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TimeWindowedKStreamIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TimeWindowedKStreamIntegrationTest.java
@@ -29,9 +29,9 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.KeyValueTimestamp;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.EmitStrategy;
 import org.apache.kafka.streams.kstream.EmitStrategy.StrategyType;
@@ -153,7 +153,7 @@ public class TimeWindowedKStreamIntegrationTest {
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-        streamsConfiguration.put(InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 0); // Always process
+        streamsConfiguration.put(InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 0); // Always process
         streamsConfiguration.put(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG, Long.MAX_VALUE); // Don't expire changelog
 
         emitFinal = emitStrategy.type() == StrategyType.ON_WINDOW_CLOSE;

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.GlobalKTable;
 import org.apache.kafka.streams.kstream.JoinWindows;
@@ -139,7 +140,7 @@ public class InternalStreamsBuilderTest {
 
         builder.buildAndOptimizeTopology();
         final ProcessorTopology topology = builder.internalTopologyBuilder
-            .rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
+            .rewriteTopology(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
             .buildTopology();
 
         assertEquals(0, topology.stateStores().size());
@@ -176,7 +177,7 @@ public class InternalStreamsBuilderTest {
 
         builder.buildAndOptimizeTopology();
         final ProcessorTopology topology = builder.internalTopologyBuilder
-            .rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
+            .rewriteTopology(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
             .buildGlobalStateTopology();
         final List<StateStore> stateStores = topology.globalStateStores();
 
@@ -204,7 +205,7 @@ public class InternalStreamsBuilderTest {
 
     private void doBuildGlobalTopologyWithAllGlobalTables() {
         final ProcessorTopology topology = builder.internalTopologyBuilder
-            .rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
+            .rewriteTopology(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
             .buildGlobalStateTopology();
 
         final List<StateStore> stateStores = topology.globalStateStores();
@@ -281,7 +282,7 @@ public class InternalStreamsBuilderTest {
         final KStream<String, String> mapped = playEvents.map(MockMapper.selectValueKeyValueMapper());
         mapped.leftJoin(table, MockValueJoiner.TOSTRING_JOINER).groupByKey().count(Materialized.as("count"));
         builder.buildAndOptimizeTopology();
-        builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)));
+        builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)));
         assertEquals(Collections.singletonList("table-topic"), builder.internalTopologyBuilder.sourceTopicsForStore("table-store"));
         assertEquals(Collections.singletonList(APP_ID + "-KSTREAM-MAP-0000000003-repartition"), builder.internalTopologyBuilder.sourceTopicsForStore("count"));
     }
@@ -369,7 +370,7 @@ public class InternalStreamsBuilderTest {
     public void shouldHaveNullTimestampExtractorWhenNoneSupplied() {
         builder.stream(Collections.singleton("topic"), consumed);
         builder.buildAndOptimizeTopology();
-        builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)));
+        builder.internalTopologyBuilder.rewriteTopology(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)));
         final ProcessorTopology processorTopology = builder.internalTopologyBuilder.buildTopology();
         assertNull(processorTopology.source("topic").getTimestampExtractor());
     }
@@ -380,7 +381,7 @@ public class InternalStreamsBuilderTest {
         builder.stream(Collections.singleton("topic"), consumed);
         builder.buildAndOptimizeTopology();
         final ProcessorTopology processorTopology = builder.internalTopologyBuilder
-            .rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
+            .rewriteTopology(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
             .buildTopology();
         assertThat(processorTopology.source("topic").getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }
@@ -390,7 +391,7 @@ public class InternalStreamsBuilderTest {
         builder.table("topic", consumed, materialized);
         builder.buildAndOptimizeTopology();
         final ProcessorTopology processorTopology = builder.internalTopologyBuilder
-            .rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
+            .rewriteTopology(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
             .buildTopology();
         assertNull(processorTopology.source("topic").getTimestampExtractor());
     }
@@ -401,7 +402,7 @@ public class InternalStreamsBuilderTest {
         builder.table("topic", consumed, materialized);
         builder.buildAndOptimizeTopology();
         final ProcessorTopology processorTopology = builder.internalTopologyBuilder
-            .rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
+            .rewriteTopology(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig(APP_ID)))
             .buildTopology();
         assertThat(processorTopology.source("topic").getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
@@ -21,9 +21,9 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyWrapper;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KStream;
@@ -60,7 +60,7 @@ public class KStreamKStreamLeftJoinTest {
 
     @BeforeClass
     public static void beforeClass() {
-        PROPS.put(InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX, 0L);
+        PROPS.put(InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX, 0L);
     }
 
     @SuppressWarnings("deprecation") // old join semantics; can be removed when `JoinWindows.of()` is removed

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamOuterJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamOuterJoinTest.java
@@ -24,10 +24,10 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyWrapper;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KStream;
@@ -63,7 +63,7 @@ public class KStreamKStreamOuterJoinTest {
 
     @BeforeClass
     public static void beforeClass() {
-        PROPS.put(InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX, 0L);
+        PROPS.put(InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX, 0L);
     }
 
     @SuppressWarnings("deprecation") // old join semantics; can be removed when `JoinWindows.of()` is removed

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Aggregator;
 import org.apache.kafka.streams.kstream.EmitStrategy;
 import org.apache.kafka.streams.kstream.Initializer;
@@ -118,8 +119,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
     private void setup(final boolean enableCache) {
         // Always process
         final Properties prop = StreamsTestUtils.getStreamsConfig();
-        prop.put(StreamsConfig.InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 0);
-        final StreamsConfig config = new StreamsConfig(prop);
+        prop.put(InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 0);
+        final InternalStreamsConfig config = new InternalStreamsConfig(prop);
 
         context = new InternalMockProcessorContext<Windowed<String>, Change<Long>>(
             TestUtils.tempDirectory(),

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregateTest.java
@@ -26,9 +26,9 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.EmitStrategy;
 import org.apache.kafka.streams.kstream.EmitStrategy.StrategyType;
@@ -127,7 +127,7 @@ public class KStreamSlidingWindowAggregateTest {
         emitFinal = type.equals(StrategyType.ON_WINDOW_CLOSE);
         emitStrategy = StrategyType.forType(type);
         // Set interval to 0 so that it always tries to emit
-        props.setProperty(InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, "0");
+        props.setProperty(InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, "0");
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
@@ -29,9 +29,9 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.EmitStrategy;
 import org.apache.kafka.streams.kstream.EmitStrategy.StrategyType;
@@ -118,7 +118,7 @@ public class KStreamWindowAggregateTest {
         emitFinal = type.equals(StrategyType.ON_WINDOW_CLOSE);
         emitStrategy = StrategyType.forType(type);
         // Set interval to 0 so that it always tries to emit
-        props.setProperty(InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, "0");
+        props.setProperty(InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, "0");
     }
 
     @Test
@@ -636,7 +636,7 @@ public class KStreamWindowAggregateTest {
 
         try {
             // Always process
-            props.put(InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 0);
+            props.put(InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 0);
             final MockInternalNewProcessorContext<Windowed<String>, Change<String>> context = makeContext(stateDir, windowSize);
             final KStreamWindowAggregate<String, String, String, TimeWindow> processorSupplier = new KStreamWindowAggregate<>(
                 windows,
@@ -724,7 +724,7 @@ public class KStreamWindowAggregateTest {
 
         try {
             // Always process
-            props.put(InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 0);
+            props.put(InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 0);
             final MockInternalNewProcessorContext<Windowed<String>, Change<String>> context = makeContext(stateDir, windowSize);
             final KStreamWindowAggregate<String, String, String, TimeWindow> processorSupplier = new KStreamWindowAggregate<>(
                 windows,
@@ -791,7 +791,7 @@ public class KStreamWindowAggregateTest {
 
         try {
             // Emit final every second
-            props.put(InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 1000L);
+            props.put(InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 1000L);
             final MockInternalNewProcessorContext<Windowed<String>, Change<String>> context = makeContext(stateDir, windowSize);
             final KStreamWindowAggregate<String, String, String, TimeWindow> processorSupplier = new KStreamWindowAggregate<>(
                 windows,
@@ -890,7 +890,7 @@ public class KStreamWindowAggregateTest {
 
         try {
             // Always process
-            props.put(InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 0);
+            props.put(InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, 0);
             final MockInternalNewProcessorContext<Windowed<String>, Change<String>> context = makeContext(stateDir, windowSize);
             final KStreamWindowAggregate<String, String, String, TimeWindow> processorSupplier = new KStreamWindowAggregate<>(
                 windows,

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/MaterializedInternalTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/MaterializedInternalTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
@@ -78,7 +79,7 @@ public class MaterializedInternalTest {
     public void shouldUseStoreTypeWhenProvidedViaTopologyConfig() {
         final Properties topologyOverrides = new Properties();
         topologyOverrides.put(StreamsConfig.DEFAULT_DSL_STORE_CONFIG, StreamsConfig.IN_MEMORY);
-        final StreamsConfig config = new StreamsConfig(StreamsTestUtils.getStreamsConfig());
+        final InternalStreamsConfig config = new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig());
 
         final InternalTopologyBuilder topologyBuilder = new InternalTopologyBuilder(
             new TopologyConfig("my-topology", config, topologyOverrides));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImplTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.EmitStrategy;
 import org.apache.kafka.streams.kstream.Grouped;
@@ -94,7 +95,7 @@ public class SessionWindowedKStreamImplTest {
         emitFinal = type.equals(EmitStrategy.StrategyType.ON_WINDOW_CLOSE);
 
         // Set interval to 0 so that it always tries to emit
-        props.setProperty(StreamsConfig.InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, "0");
+        props.setProperty(InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, "0");
 
         final KStream<String, String> stream = builder.stream(TOPIC, Consumed.with(Serdes.String(), Serdes.String()));
         this.stream = stream.groupByKey(Grouped.with(Serdes.String(), Serdes.String()))

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImplTest.java
@@ -25,8 +25,8 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.EmitStrategy;
 import org.apache.kafka.streams.kstream.EmitStrategy.StrategyType;
@@ -100,7 +100,7 @@ public class TimeWindowedKStreamImplTest {
         emitFinal = type.equals(StrategyType.ON_WINDOW_CLOSE);
         emitStrategy = StrategyType.forType(type);
         // Set interval to 0 so that it always tries to emit
-        props.setProperty(InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, "0");
+        props.setProperty(InternalStreamsConfig.EMIT_INTERVAL_MS_KSTREAMS_WINDOWED_AGGREGATION, "0");
         final KStream<String, String> stream = builder.stream(TOPIC, Consumed.with(Serdes.String(), Serdes.String()));
         windowedStream = stream.groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
             .windowedBy(TimeWindows.ofSizeWithNoGrace(ofMillis(500L)));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
@@ -196,11 +197,11 @@ public class AbstractProcessorContextTest {
         }
 
         TestProcessorContext(final MockStreamsMetrics metrics) {
-            super(new TaskId(0, 0), new StreamsConfig(config), metrics, new ThreadCache(new LogContext("name "), 0, metrics));
+            super(new TaskId(0, 0), new InternalStreamsConfig(config), metrics, new ThreadCache(new LogContext("name "), 0, metrics));
         }
 
         TestProcessorContext(final MockStreamsMetrics metrics, final Properties config) {
-            super(new TaskId(0, 0), new StreamsConfig(config), metrics, new ThreadCache(new LogContext("name "), 0, metrics));
+            super(new TaskId(0, 0), new InternalStreamsConfig(config), metrics, new ThreadCache(new LogContext("name "), 0, metrics));
         }
 
         @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
@@ -473,7 +474,7 @@ public class ActiveTaskCreatorTest {
         final ProcessorTopology topology = mock(ProcessorTopology.class);
         final SourceNode sourceNode = mock(SourceNode.class);
 
-        when(builder.topologyConfigs()).thenReturn(new TopologyConfig(new StreamsConfig(properties)));
+        when(builder.topologyConfigs()).thenReturn(new TopologyConfig(new InternalStreamsConfig(properties)));
         when(builder.buildSubtopology(0)).thenReturn(topology);
         when(topology.sinkTopics()).thenReturn(emptySet());
         when(stateDirectory.getOrCreateDirectoryForTask(task00)).thenReturn(mock(File.class));
@@ -484,7 +485,7 @@ public class ActiveTaskCreatorTest {
         when(sourceNode.getTimestampExtractor()).thenReturn(mock(TimestampExtractor.class));
         when(topology.sources()).thenReturn(Collections.singleton(sourceNode));
 
-        final StreamsConfig config = new StreamsConfig(properties);
+        final InternalStreamsConfig config = new InternalStreamsConfig(properties);
         activeTaskCreator = new ActiveTaskCreator(
             new TopologyMetadata(builder, config),
             config,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.StateUpdater.ExceptionAndTasks;
 import org.apache.kafka.streams.processor.internals.Task.State;
@@ -100,7 +101,7 @@ class DefaultStateUpdaterTest {
     // need an auto-tick timer to work for draining with timeout
     private final Time time = new MockTime(1L);
     private final Metrics metrics = new Metrics(time);
-    private final StreamsConfig config = new StreamsConfig(configProps(COMMIT_INTERVAL));
+    private final InternalStreamsConfig config = new InternalStreamsConfig(configProps(COMMIT_INTERVAL));
     private final ChangelogReader changelogReader = mock(ChangelogReader.class);
     private final TopologyMetadata topologyMetadata = unnamedTopology().build();
     private DefaultStateUpdater stateUpdater =
@@ -162,7 +163,7 @@ class DefaultStateUpdaterTest {
     @Test
     public void shouldRemoveUpdatingTasksOnShutdown() throws Exception {
         stateUpdater.shutdown(Duration.ofMillis(Long.MAX_VALUE));
-        stateUpdater = new DefaultStateUpdater("test-state-updater", metrics, new StreamsConfig(configProps(Integer.MAX_VALUE)), changelogReader, topologyMetadata, time);
+        stateUpdater = new DefaultStateUpdater("test-state-updater", metrics, new InternalStreamsConfig(configProps(Integer.MAX_VALUE)), changelogReader, topologyMetadata, time);
         final StreamTask activeTask = statefulTask(TASK_0_0, mkSet(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
         final StandbyTask standbyTask = standbyTask(TASK_0_2, mkSet(TOPIC_PARTITION_C_0)).inState(State.RUNNING).build();
         when(changelogReader.completedChangelogs()).thenReturn(Collections.emptySet());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImplTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.To;
@@ -63,7 +64,7 @@ public class GlobalProcessorContextImplTest {
 
     @Before
     public void setup() {
-        final StreamsConfig streamsConfig = mock(StreamsConfig.class);
+        final InternalStreamsConfig streamsConfig = mock(InternalStreamsConfig.class);
         when(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).thenReturn("dummy-id");
 
         globalContext = new GlobalProcessorContextImpl(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.TimestampedBytesStore;
@@ -92,7 +93,7 @@ public class GlobalStateManagerImplTest {
     private final TopicPartition t4 = new TopicPartition("t4", 1);
     private GlobalStateManagerImpl stateManager;
     private StateDirectory stateDirectory;
-    private StreamsConfig streamsConfig;
+    private InternalStreamsConfig streamsConfig;
     private NoOpReadOnlyStore<Object, Object> store1, store2, store3, store4;
     private MockConsumer<byte[], byte[]> consumer;
     private File checkpointFile;
@@ -126,7 +127,7 @@ public class GlobalStateManagerImplTest {
 
         topology = withGlobalStores(asList(store1, store2, store3, store4), storeToTopic);
 
-        streamsConfig = new StreamsConfig(new Properties() {
+        streamsConfig = new InternalStreamsConfig(new Properties() {
             {
                 put(StreamsConfig.APPLICATION_ID_CONFIG, "appId");
                 put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
@@ -561,7 +562,7 @@ public class GlobalStateManagerImplTest {
         };
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
-        streamsConfig = new StreamsConfig(mkMap(
+        streamsConfig = new InternalStreamsConfig(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
@@ -604,7 +605,7 @@ public class GlobalStateManagerImplTest {
         };
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
-        streamsConfig = new StreamsConfig(mkMap(
+        streamsConfig = new InternalStreamsConfig(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
@@ -645,7 +646,7 @@ public class GlobalStateManagerImplTest {
         };
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
-        streamsConfig = new StreamsConfig(mkMap(
+        streamsConfig = new InternalStreamsConfig(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
@@ -693,7 +694,7 @@ public class GlobalStateManagerImplTest {
         };
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
-        streamsConfig = new StreamsConfig(mkMap(
+        streamsConfig = new InternalStreamsConfig(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
@@ -727,7 +728,7 @@ public class GlobalStateManagerImplTest {
         };
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
-        streamsConfig = new StreamsConfig(mkMap(
+        streamsConfig = new InternalStreamsConfig(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
@@ -770,7 +771,7 @@ public class GlobalStateManagerImplTest {
         };
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
-        streamsConfig = new StreamsConfig(mkMap(
+        streamsConfig = new InternalStreamsConfig(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
@@ -811,7 +812,7 @@ public class GlobalStateManagerImplTest {
         };
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
-        streamsConfig = new StreamsConfig(mkMap(
+        streamsConfig = new InternalStreamsConfig(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
@@ -859,7 +860,7 @@ public class GlobalStateManagerImplTest {
         };
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
-        streamsConfig = new StreamsConfig(mkMap(
+        streamsConfig = new InternalStreamsConfig(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
@@ -893,7 +894,7 @@ public class GlobalStateManagerImplTest {
         };
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
-        streamsConfig = new StreamsConfig(mkMap(
+        streamsConfig = new InternalStreamsConfig(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
@@ -936,7 +937,7 @@ public class GlobalStateManagerImplTest {
         };
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
-        streamsConfig = new StreamsConfig(mkMap(
+        streamsConfig = new InternalStreamsConfig(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
@@ -977,7 +978,7 @@ public class GlobalStateManagerImplTest {
         };
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
-        streamsConfig = new StreamsConfig(mkMap(
+        streamsConfig = new InternalStreamsConfig(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
@@ -1020,7 +1021,7 @@ public class GlobalStateManagerImplTest {
         };
         initializeConsumer(0, 0, t1, t2, t3, t4);
 
-        streamsConfig = new StreamsConfig(mkMap(
+        streamsConfig = new InternalStreamsConfig(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
@@ -1061,7 +1062,7 @@ public class GlobalStateManagerImplTest {
         consumer.updateBeginningOffsets(startOffsets);
         consumer.updateEndOffsets(endOffsets);
 
-        streamsConfig = new StreamsConfig(mkMap(
+        streamsConfig = new InternalStreamsConfig(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.internals.InternalNameProvider;
 import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
@@ -67,7 +68,7 @@ public class GlobalStreamThreadTest {
     private final MockTime time = new MockTime();
     private final MockStateRestoreListener stateRestoreListener = new MockStateRestoreListener();
     private GlobalStreamThread globalStreamThread;
-    private StreamsConfig config;
+    private InternalStreamsConfig config;
     private String baseDirectoryName;
 
     private final static String GLOBAL_STORE_TOPIC_NAME = "foo";
@@ -116,7 +117,7 @@ public class GlobalStreamThreadTest {
         properties.put(StreamsConfig.STATE_DIR_CONFIG, baseDirectoryName);
         properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArraySerde.class.getName());
         properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.ByteArraySerde.class.getName());
-        config = new StreamsConfig(properties);
+        config = new InternalStreamsConfig(properties);
         globalStreamThread = new GlobalStreamThread(
             builder.rewriteTopology(config).buildGlobalStateTopology(),
             config,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/HighAvailabilityStreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/HighAvailabilityStreamsPartitionAssignorTest.java
@@ -27,8 +27,8 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
@@ -107,7 +107,7 @@ public class HighAvailabilityStreamsPartitionAssignorTest {
     private TaskManager taskManager;
     @Mock
     private Admin adminClient;
-    private StreamsConfig streamsConfig = new StreamsConfig(configProps());
+    private InternalStreamsConfig streamsConfig = new InternalStreamsConfig(configProps());
     private final InternalTopologyBuilder builder = new InternalTopologyBuilder();
     private TopologyMetadata topologyMetadata = new TopologyMetadata(builder, streamsConfig);
     @Mock
@@ -129,7 +129,7 @@ public class HighAvailabilityStreamsPartitionAssignorTest {
         referenceContainer.taskManager = taskManager;
         referenceContainer.streamsMetadataState = streamsMetadataState;
         referenceContainer.time = time;
-        configurationMap.put(InternalConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, referenceContainer);
+        configurationMap.put(InternalStreamsConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, referenceContainer);
         return configurationMap;
     }
 
@@ -138,7 +138,7 @@ public class HighAvailabilityStreamsPartitionAssignorTest {
         final Map<String, Object> configMap = configProps();
         configMap.putAll(props);
 
-        streamsConfig = new StreamsConfig(configMap);
+        streamsConfig = new InternalStreamsConfig(configMap);
         topologyMetadata = new TopologyMetadata(builder, streamsConfig);
         partitionAssignor.configure(configMap);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -50,6 +50,7 @@ import org.apache.kafka.common.requests.CreateTopicsRequest;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.internals.InternalTopicManager.ValidationResult;
 import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.junit.After;
@@ -130,7 +131,7 @@ public class InternalTopicManagerTest {
         internalTopicManager = new InternalTopicManager(
             time,
             mockAdminClient,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
     }
 
@@ -167,7 +168,7 @@ public class InternalTopicManagerTest {
     @Test
     public void shouldOnlyRetryNotSuccessfulFuturesDuringSetup() {
         final AdminClient admin = mock(AdminClient.class);
-        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(config);
         final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
         final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFailFuture = new KafkaFutureImpl<>();
         createTopicFailFuture.completeExceptionally(new TopicExistsException("exists"));
@@ -207,7 +208,7 @@ public class InternalTopicManagerTest {
 
     private void shouldRetryCreateTopicWhenRetriableExceptionIsThrown(final Exception retriableException) {
         final AdminClient admin = mock(AdminClient.class);
-        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(config);
         final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
         final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFailFuture = new KafkaFutureImpl<>();
         createTopicFailFuture.completeExceptionally(retriableException);
@@ -263,7 +264,7 @@ public class InternalTopicManagerTest {
             }
         };
 
-        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(config);
         final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
 
         final InternalTopicConfig topicConfig = new RepartitionTopicConfig(topic1, Collections.emptyMap());
@@ -286,7 +287,7 @@ public class InternalTopicManagerTest {
         mockAdminClient.timeoutNextRequest(Integer.MAX_VALUE);
 
         final InternalTopicManager internalTopicManager =
-            new InternalTopicManager(time, mockAdminClient, new StreamsConfig(config));
+            new InternalTopicManager(time, mockAdminClient, new InternalStreamsConfig(config));
 
         final TimeoutException exception = assertThrows(
             TimeoutException.class,
@@ -306,7 +307,7 @@ public class InternalTopicManagerTest {
             (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 15
         );
         final InternalTopicManager internalTopicManager =
-            new InternalTopicManager(time, mockAdminClient, new StreamsConfig(config));
+            new InternalTopicManager(time, mockAdminClient, new InternalStreamsConfig(config));
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
 
         final TimeoutException exception = assertThrows(
@@ -330,7 +331,7 @@ public class InternalTopicManagerTest {
         mockAdminClient.timeoutNextRequest(1);
 
         final InternalTopicManager internalTopicManager =
-                new InternalTopicManager(time, mockAdminClient, new StreamsConfig(config));
+                new InternalTopicManager(time, mockAdminClient, new InternalStreamsConfig(config));
         try {
             final Set<String> topic1set = new HashSet<>(Collections.singletonList(topic1));
             internalTopicManager.getTopicPartitionInfo(topic1set, null);
@@ -355,7 +356,7 @@ public class InternalTopicManagerTest {
         mockAdminClient.timeoutNextRequest(1);
 
         final InternalTopicManager internalTopicManager =
-                new InternalTopicManager(time, mockAdminClient, new StreamsConfig(config));
+                new InternalTopicManager(time, mockAdminClient, new InternalStreamsConfig(config));
         try {
             final Set<String> topic1set = new HashSet<String>(Arrays.asList(topic1));
             final Set<String> topic2set = new HashSet<String>(Arrays.asList(topic2));
@@ -382,7 +383,7 @@ public class InternalTopicManagerTest {
     @Test
     public void shouldThrowWhenCreateTopicsThrowsUnexpectedException() {
         final AdminClient admin = mock(AdminClient.class);
-        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(config);
         final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
         final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFailFuture = new KafkaFutureImpl<>();
@@ -401,7 +402,7 @@ public class InternalTopicManagerTest {
     @Test
     public void shouldThrowWhenCreateTopicsResultsDoNotContainTopic() {
         final AdminClient admin = mock(AdminClient.class);
-        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(config);
         final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
         final NewTopic newTopic = newTopic(topic1, internalTopicConfig, streamsConfig);
@@ -420,7 +421,7 @@ public class InternalTopicManagerTest {
         final MockTime time = new MockTime(
             (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 3
         );
-        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(config);
         final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
         final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFailFuture = new KafkaFutureImpl<>();
         createTopicFailFuture.completeExceptionally(new TimeoutException());
@@ -441,7 +442,7 @@ public class InternalTopicManagerTest {
         final MockTime time = new MockTime(
             (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 3
         );
-        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(config);
         final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
         final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFutureThatNeverCompletes = new KafkaFutureImpl<>();
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
@@ -458,7 +459,7 @@ public class InternalTopicManagerTest {
     @Test
     public void shouldCleanUpWhenUnexpectedExceptionIsThrownDuringSetup() {
         final AdminClient admin = mock(AdminClient.class);
-        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(config);
         final MockTime time = new MockTime(
             (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 3
         );
@@ -483,7 +484,7 @@ public class InternalTopicManagerTest {
     @Test
     public void shouldCleanUpWhenCreateTopicsResultsDoNotContainTopic() {
         final AdminClient admin = mock(AdminClient.class);
-        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(config);
         final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
         final InternalTopicConfig internalTopicConfig1 = setupRepartitionTopicConfig(topic1, 1);
         final InternalTopicConfig internalTopicConfig2 = setupRepartitionTopicConfig(topic2, 1);
@@ -521,7 +522,7 @@ public class InternalTopicManagerTest {
     @Test
     public void shouldCleanUpWhenCreateTopicsTimesOut() {
         final AdminClient admin = mock(AdminClient.class);
-        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(config);
         final MockTime time = new MockTime(
             (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 3
         );
@@ -575,7 +576,7 @@ public class InternalTopicManagerTest {
 
     private void shouldRetryDeleteTopicWhenRetriableException(final Exception retriableException) {
         final AdminClient admin = mock(AdminClient.class);
-        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(config);
         final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
         final InternalTopicConfig internalTopicConfig1 = setupRepartitionTopicConfig(topic1, 1);
         final InternalTopicConfig internalTopicConfig2 = setupRepartitionTopicConfig(topic2, 1);
@@ -600,7 +601,7 @@ public class InternalTopicManagerTest {
     @Test
     public void shouldThrowTimeoutExceptionWhenFuturesNeverCompleteDuringCleanUp() {
         final AdminClient admin = mock(AdminClient.class);
-        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(config);
         final MockTime time = new MockTime(
             (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 3
         );
@@ -624,7 +625,7 @@ public class InternalTopicManagerTest {
     @Test
     public void shouldThrowWhenDeleteTopicsThrowsUnexpectedException() {
         final AdminClient admin = mock(AdminClient.class);
-        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(config);
         final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
         final InternalTopicConfig internalTopicConfig1 = setupRepartitionTopicConfig(topic1, 1);
         final InternalTopicConfig internalTopicConfig2 = setupRepartitionTopicConfig(topic2, 1);
@@ -643,7 +644,7 @@ public class InternalTopicManagerTest {
         );
     }
 
-    private void setupCleanUpScenario(final AdminClient admin, final StreamsConfig streamsConfig, final InternalTopicConfig internalTopicConfig1, final InternalTopicConfig internalTopicConfig2) {
+    private void setupCleanUpScenario(final AdminClient admin, final InternalStreamsConfig streamsConfig, final InternalTopicConfig internalTopicConfig1, final InternalTopicConfig internalTopicConfig2) {
         final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFailFuture1 = new KafkaFutureImpl<>();
         createTopicFailFuture1.completeExceptionally(new TopicExistsException("exists"));
         final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFailFuture2 = new KafkaFutureImpl<>();
@@ -756,7 +757,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
             time,
             admin,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
         final TopicPartitionInfo partitionInfo = new TopicPartitionInfo(0, broker1,
             Collections.singletonList(broker1), Collections.singletonList(broker1));
@@ -828,7 +829,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager internalTopicManager2 = new InternalTopicManager(
             time,
             mockAdminClient,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
 
         final InternalTopicConfig internalTopicConfig = new RepartitionTopicConfig(topic1, Collections.emptyMap());
@@ -848,7 +849,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
                 new AutoAdvanceMockTime(time),
                 mockAdminClient,
-                new StreamsConfig(config)
+                new InternalStreamsConfig(config)
         );
 
         final InternalTopicConfig internalTopicConfig = new RepartitionTopicConfig(topic1, Collections.emptyMap());
@@ -898,7 +899,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
             time,
             admin,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
 
         final KafkaFutureImpl<TopicDescription> topicDescriptionLeaderNotAvailableFuture = new KafkaFutureImpl<>();
@@ -934,7 +935,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
             time,
             admin,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
         final TopicPartitionInfo partitionInfo = new TopicPartitionInfo(0, broker1,
                 Collections.singletonList(broker1), Collections.singletonList(broker1));
@@ -967,7 +968,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
             time,
             admin,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
 
         final KafkaFutureImpl<TopicDescription> topicDescriptionFailFuture = new KafkaFutureImpl<>();
@@ -1006,7 +1007,7 @@ public class InternalTopicManagerTest {
         );
 
         final InternalTopicManager internalTopicManager =
-            new InternalTopicManager(time, mockAdminClient, new StreamsConfig(config));
+            new InternalTopicManager(time, mockAdminClient, new InternalStreamsConfig(config));
         final InternalTopicConfig internalTopicConfig = new RepartitionTopicConfig(topic1, Collections.emptyMap());
         internalTopicConfig.setNumberOfPartitions(1);
 
@@ -1370,7 +1371,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager internalTopicManager2 = new InternalTopicManager(
             time,
             mockAdminClient,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
 
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
@@ -1399,7 +1400,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
             time,
             admin,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
         final KafkaFutureImpl<TopicDescription> topicDescriptionFailFuture = new KafkaFutureImpl<>();
         topicDescriptionFailFuture.completeExceptionally(new LeaderNotAvailableException("Leader Not Available!"));
@@ -1434,7 +1435,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
             time,
             admin,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
         final KafkaFutureImpl<TopicDescription> topicDescriptionSuccessfulFuture = new KafkaFutureImpl<>();
         topicDescriptionSuccessfulFuture.complete(new TopicDescription(
@@ -1469,7 +1470,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
             time,
             admin,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
         final KafkaFutureImpl<TopicDescription> topicDescriptionFailFuture = new KafkaFutureImpl<>();
         topicDescriptionFailFuture.completeExceptionally(new LeaderNotAvailableException("Leader Not Available!"));
@@ -1524,7 +1525,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
             time,
             admin,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
         final KafkaFutureImpl<TopicDescription> topicDescriptionFailFuture = new KafkaFutureImpl<>();
         topicDescriptionFailFuture.completeExceptionally(new IllegalStateException("Nobody expects the Spanish inquisition"));
@@ -1541,7 +1542,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
             time,
             admin,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
         when(admin.describeTopics(Collections.singleton(topic1)))
             .thenAnswer(answer -> new MockDescribeTopicsResult(mkMap()));
@@ -1561,7 +1562,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
             time,
             admin,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
         final KafkaFutureImpl<TopicDescription> topicDescriptionSuccessfulFuture = new KafkaFutureImpl<>();
         topicDescriptionSuccessfulFuture.complete(new TopicDescription(
@@ -1590,7 +1591,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
             time,
             admin,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
         final KafkaFutureImpl<TopicDescription> topicDescriptionSuccessfulFuture = new KafkaFutureImpl<>();
         topicDescriptionSuccessfulFuture.complete(new TopicDescription(
@@ -1686,7 +1687,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
             time,
             admin,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
         final KafkaFutureImpl<TopicDescription> topicDescriptionSuccessfulFuture = new KafkaFutureImpl<>();
         topicDescriptionSuccessfulFuture.complete(new TopicDescription(
@@ -1717,7 +1718,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
             time,
             admin,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
         final KafkaFutureImpl<TopicDescription> topicDescriptionFailFuture = new KafkaFutureImpl<>();
         topicDescriptionFailFuture.completeExceptionally(new TimeoutException());
@@ -1748,7 +1749,7 @@ public class InternalTopicManagerTest {
         final InternalTopicManager topicManager = new InternalTopicManager(
             time,
             admin,
-            new StreamsConfig(config)
+            new InternalStreamsConfig(config)
         );
         final KafkaFutureImpl<TopicDescription> topicDescriptionFutureThatNeverCompletes = new KafkaFutureImpl<>();
         when(admin.describeTopics(Collections.singleton(topic1)))
@@ -1771,7 +1772,7 @@ public class InternalTopicManagerTest {
 
     private NewTopic newTopic(final String topicName,
                               final InternalTopicConfig topicConfig,
-                              final StreamsConfig streamsConfig) {
+                              final InternalStreamsConfig streamsConfig) {
         return new NewTopic(
             topicName,
             topicConfig.numberOfPartitions(),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;
 import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TopicNameExtractor;
@@ -985,7 +986,7 @@ public class InternalTopologyBuilderTest {
     public void shouldSetTopologyConfigOnRewriteTopology() {
         final Properties globalProps = StreamsTestUtils.getStreamsConfig();
         globalProps.put(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG, 100L);
-        final StreamsConfig globalStreamsConfig = new StreamsConfig(globalProps);
+        final InternalStreamsConfig globalStreamsConfig = new InternalStreamsConfig(globalProps);
         final InternalTopologyBuilder topologyBuilder = builder.rewriteTopology(globalStreamsConfig);
         assertThat(topologyBuilder.topologyConfigs(), equalTo(new TopologyConfig(null, globalStreamsConfig, new Properties())));
         assertThat(topologyBuilder.topologyConfigs().getTaskConfig().maxTaskIdleMs, equalTo(100L));
@@ -997,7 +998,7 @@ public class InternalTopologyBuilderTest {
         final Properties globalProps = StreamsTestUtils.getStreamsConfig();
         globalProps.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 200L);
         globalProps.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 100L);
-        final StreamsConfig globalStreamsConfig = new StreamsConfig(globalProps);
+        final InternalStreamsConfig globalStreamsConfig = new InternalStreamsConfig(globalProps);
         final InternalTopologyBuilder topologyBuilder = builder.rewriteTopology(globalStreamsConfig);
         assertThat(topologyBuilder.topologyConfigs(), equalTo(new TopologyConfig(null, globalStreamsConfig, new Properties())));
         assertThat(topologyBuilder.topologyConfigs().cacheSize, equalTo(200L));
@@ -1014,7 +1015,7 @@ public class InternalTopologyBuilderTest {
         topologyOverrides.put(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, LogAndContinueExceptionHandler.class);
         topologyOverrides.put(StreamsConfig.DEFAULT_DSL_STORE_CONFIG, StreamsConfig.IN_MEMORY);
 
-        final StreamsConfig config = new StreamsConfig(StreamsTestUtils.getStreamsConfig());
+        final InternalStreamsConfig config = new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig());
         final InternalTopologyBuilder topologyBuilder = new InternalTopologyBuilder(
             new TopologyConfig(
                 "my-topology",
@@ -1041,7 +1042,7 @@ public class InternalTopologyBuilderTest {
         streamsProps.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockTimestampExtractor.class);
         streamsProps.put(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, LogAndContinueExceptionHandler.class);
 
-        final StreamsConfig config = new StreamsConfig(streamsProps);
+        final InternalStreamsConfig config = new InternalStreamsConfig(streamsProps);
         final InternalTopologyBuilder topologyBuilder = new InternalTopologyBuilder(
             new TopologyConfig(
                 "my-topology",
@@ -1059,7 +1060,7 @@ public class InternalTopologyBuilderTest {
     @Test
     public void shouldAddTimestampExtractorPerSource() {
         builder.addSource(null, "source", new MockTimestampExtractor(), null, null, "topic");
-        final ProcessorTopology processorTopology = builder.rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig())).buildTopology();
+        final ProcessorTopology processorTopology = builder.rewriteTopology(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig())).buildTopology();
         assertThat(processorTopology.source("topic").getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }
 
@@ -1067,7 +1068,7 @@ public class InternalTopologyBuilderTest {
     public void shouldAddTimestampExtractorWithPatternPerSource() {
         final Pattern pattern = Pattern.compile("t.*");
         builder.addSource(null, "source", new MockTimestampExtractor(), null, null, pattern);
-        final ProcessorTopology processorTopology = builder.rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig())).buildTopology();
+        final ProcessorTopology processorTopology = builder.rewriteTopology(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig())).buildTopology();
         assertThat(processorTopology.source(pattern.pattern()).getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }
 
@@ -1299,7 +1300,7 @@ public class InternalTopologyBuilderTest {
         );
         builder.initializeSubscription();
 
-        builder.rewriteTopology(new StreamsConfig(mkProperties(mkMap(
+        builder.rewriteTopology(new InternalStreamsConfig(mkProperties(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "asdf"),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "asdf")
         ))));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.PunctuationType;
@@ -80,7 +80,7 @@ import static org.mockito.Mockito.when;
 public class ProcessorContextImplTest {
     private ProcessorContextImpl context;
 
-    private final StreamsConfig streamsConfig = streamsConfigMock();
+    private final InternalStreamsConfig streamsConfig = streamsConfigMock();
 
     @Mock
     private RecordCollector recordCollector;
@@ -734,19 +734,19 @@ public class ProcessorContextImplTest {
         return sessionStore;
     }
 
-    private StreamsConfig streamsConfigMock() {
-        final StreamsConfig streamsConfig = mock(StreamsConfig.class);
+    private InternalStreamsConfig streamsConfigMock() {
+        final InternalStreamsConfig streamsConfig = mock(InternalStreamsConfig.class);
         when(streamsConfig.originals()).thenReturn(Collections.emptyMap());
         when(streamsConfig.values()).thenReturn(Collections.emptyMap());
         when(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).thenReturn("add-id");
         return streamsConfig;
     }
 
-    private StreamsConfig streamsConfigWithConsistencyMock() {
-        final StreamsConfig streamsConfig = mock(StreamsConfig.class);
+    private InternalStreamsConfig streamsConfigWithConsistencyMock() {
+        final InternalStreamsConfig streamsConfig = mock(InternalStreamsConfig.class);
 
         final Map<String, Object> myValues = new HashMap<>();
-        myValues.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        myValues.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         when(streamsConfig.originals()).thenReturn(myValues);
         when(streamsConfig.values()).thenReturn(Collections.emptyMap());
         when(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).thenReturn("add-id");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task.TaskType;
@@ -39,7 +40,7 @@ public class ProcessorContextTest {
 
     @Before
     public void prepare() {
-        final StreamsConfig streamsConfig = mock(StreamsConfig.class);
+        final InternalStreamsConfig streamsConfig = mock(InternalStreamsConfig.class);
         doReturn("add-id").when(streamsConfig).getString(StreamsConfig.APPLICATION_ID_CONFIG);
         doReturn(Serdes.ByteArray()).when(streamsConfig).defaultValueSerde();
         doReturn(Serdes.ByteArray()).when(streamsConfig).defaultKeySerde();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.CommitCallback;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
@@ -136,7 +137,7 @@ public class ProcessorStateManagerTest {
     public void setup() {
         baseDir = TestUtils.tempDirectory();
 
-        stateDirectory = new StateDirectory(new StreamsConfig(new Properties() {
+        stateDirectory = new StateDirectory(new InternalStreamsConfig(new Properties() {
             {
                 put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
                 put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RackAwarenessStreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RackAwarenessStreamsPartitionAssignorTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.processor.internals.assignment.ReferenceContainer;
@@ -122,7 +123,7 @@ public class RackAwarenessStreamsPartitionAssignorTest {
 
     private TaskManager taskManager;
     private Admin adminClient;
-    private StreamsConfig streamsConfig = new StreamsConfig(configProps());
+    private InternalStreamsConfig streamsConfig = new InternalStreamsConfig(configProps());
     private final InternalTopologyBuilder builder = new InternalTopologyBuilder();
     private TopologyMetadata topologyMetadata = new TopologyMetadata(builder, streamsConfig);
     private final StreamsMetadataState streamsMetadataState = mock(StreamsMetadataState.class);
@@ -140,7 +141,7 @@ public class RackAwarenessStreamsPartitionAssignorTest {
         referenceContainer.taskManager = taskManager;
         referenceContainer.streamsMetadataState = streamsMetadataState;
         referenceContainer.time = time;
-        configurationMap.put(StreamsConfig.InternalConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, referenceContainer);
+        configurationMap.put(InternalStreamsConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, referenceContainer);
         configurationMap.put(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG, String.join(",", ALL_TAG_KEYS));
         ALL_TAG_KEYS.forEach(key -> configurationMap.put(StreamsConfig.clientTagPrefix(key), "dummy"));
         return configurationMap;
@@ -151,7 +152,7 @@ public class RackAwarenessStreamsPartitionAssignorTest {
         final Map<String, Object> configMap = configProps();
         configMap.putAll(props);
 
-        streamsConfig = new StreamsConfig(configMap);
+        streamsConfig = new InternalStreamsConfig(configMap);
         topologyMetadata = new TopologyMetadata(builder, streamsConfig);
         partitionAssignor.configure(configMap);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -51,6 +51,7 @@ import org.apache.kafka.streams.errors.DefaultProductionExceptionHandler;
 import org.apache.kafka.streams.errors.ProductionExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
@@ -101,11 +102,11 @@ public class RecordCollectorTest {
     private final TaskId taskId = new TaskId(0, 0);
     private final ProductionExceptionHandler productionExceptionHandler = new DefaultProductionExceptionHandler();
     private final StreamsMetricsImpl streamsMetrics = new MockStreamsMetrics(new Metrics());
-    private final StreamsConfig config = new StreamsConfig(mkMap(
+    private final InternalStreamsConfig config = new InternalStreamsConfig(mkMap(
         mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
         mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234")
     ));
-    private final StreamsConfig eosConfig = new StreamsConfig(mkMap(
+    private final InternalStreamsConfig eosConfig = new InternalStreamsConfig(mkMap(
         mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
         mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
         mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2)

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RepartitionTopicsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RepartitionTopicsTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskAssignmentException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder.TopicsInfo;
 import org.apache.kafka.streams.processor.internals.assignment.CopartitionedTopicsEnforcer;
@@ -94,7 +95,7 @@ public class RepartitionTopicsTest {
         mkMap(mkEntry(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_CONFIG1)),
         Collections.emptyMap()
     );
-    final  StreamsConfig config = new DummyStreamsConfig();
+    final InternalStreamsConfig config = new DummyStreamsConfig();
 
     @Mock
     InternalTopologyBuilder internalTopologyBuilder;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task.TaskType;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
@@ -107,12 +108,12 @@ public class StandbyTaskTest {
     private final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, threadName, StreamsConfig.METRICS_LATEST, time);
 
     private File baseDir;
-    private StreamsConfig config;
+    private InternalStreamsConfig config;
     private StateDirectory stateDirectory;
     private StandbyTask task;
 
-    private StreamsConfig createConfig(final File baseDir) throws IOException {
-        return new StreamsConfig(mkProperties(mkMap(
+    private InternalStreamsConfig createConfig(final File baseDir) throws IOException {
+        return new InternalStreamsConfig(mkProperties(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
             mkEntry(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, DEBUG.name),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
@@ -523,7 +524,7 @@ public class StandbyTaskTest {
 
         final MetricName metricName = setupCloseTaskMetric();
 
-        config = new StreamsConfig(mkProperties(mkMap(
+        config = new InternalStreamsConfig(mkProperties(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
             mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE)
@@ -553,7 +554,7 @@ public class StandbyTaskTest {
 
         final MetricName metricName = setupCloseTaskMetric();
 
-        config = new StreamsConfig(mkProperties(mkMap(
+        config = new InternalStreamsConfig(mkProperties(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, applicationId),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
             mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2)

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.StateDirectory.TaskDirectory;
 import org.apache.kafka.common.utils.LogCaptureAppender;
@@ -97,7 +98,7 @@ public class StateDirectoryTest {
             cleanup();
         }
         directory = new StateDirectory(
-            new StreamsConfig(new Properties() {
+            new InternalStreamsConfig(new Properties() {
                 {
                     put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
                     put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
@@ -377,7 +378,7 @@ public class StateDirectoryTest {
     public void shouldReturnEmptyArrayIfListFilesReturnsNull() throws IOException {
         stateDir = new File(TestUtils.IO_TMP_DIR, "kafka-" + TestUtils.randomString(5));
         directory = new StateDirectory(
-            new StreamsConfig(new Properties() {
+            new InternalStreamsConfig(new Properties() {
                 {
                     put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
                     put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
@@ -420,7 +421,7 @@ public class StateDirectoryTest {
         final File tempDir = TestUtils.tempDirectory();
         final File stateDir = new File(new File(tempDir, "foo"), "state-dir");
         final StateDirectory stateDirectory = new StateDirectory(
-            new StreamsConfig(new Properties() {
+            new InternalStreamsConfig(new Properties() {
                 {
                     put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
                     put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
@@ -620,7 +621,7 @@ public class StateDirectoryTest {
     public void shouldLogTempDirMessage() {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StateDirectory.class)) {
             new StateDirectory(
-                new StreamsConfig(
+                new InternalStreamsConfig(
                     mkMap(
                         mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, ""),
                         mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "")

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -35,8 +35,8 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager.StateStoreMetadata;
@@ -126,7 +126,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
     private final TopicPartition tp = new TopicPartition(topicName, 0);
     private final TopicPartition tp1 = new TopicPartition("one", 0);
     private final TopicPartition tp2 = new TopicPartition("two", 0);
-    private final StreamsConfig config = new StreamsConfig(StreamsTestUtils.getStreamsConfig("test-reader"));
+    private final InternalStreamsConfig config = new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig("test-reader"));
     private final MockTime time = new MockTime();
     private final MockStateRestoreListener callback = new MockStateRestoreListener();
     private final KafkaException kaboom = new KafkaException("KABOOM!");
@@ -401,7 +401,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
 
     private void shouldPollWithRightTimeout(final boolean stateUpdaterEnabled) {
         final Properties properties = new Properties();
-        properties.put(InternalConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled);
+        properties.put(InternalStreamsConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled);
         shouldPollWithRightTimeout(properties);
     }
 
@@ -422,7 +422,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
         consumer.updateBeginningOffsets(Collections.singletonMap(tp, 5L));
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 11L));
 
-        final StreamsConfig config = new StreamsConfig(StreamsTestUtils.getStreamsConfig("test-reader", properties));
+        final InternalStreamsConfig config = new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig("test-reader", properties));
 
         final StoreChangelogReader changelogReader =
                 new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback);
@@ -437,8 +437,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
         if (type == ACTIVE) {
             assertEquals(Duration.ofMillis(config.getLong(StreamsConfig.POLL_MS_CONFIG)), consumer.lastPollTimeout());
         } else {
-            if (!properties.containsKey(InternalConfig.STATE_UPDATER_ENABLED)
-                    || (boolean) properties.get(InternalConfig.STATE_UPDATER_ENABLED)) {
+            if (!properties.containsKey(InternalStreamsConfig.STATE_UPDATER_ENABLED)
+                    || (boolean) properties.get(InternalStreamsConfig.STATE_UPDATER_ENABLED)) {
                 assertEquals(Duration.ofMillis(config.getLong(StreamsConfig.POLL_MS_CONFIG)), consumer.lastPollTimeout());
             } else {
                 assertEquals(Duration.ZERO, consumer.lastPollTimeout());
@@ -967,7 +967,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
 
         final Properties properties = new Properties();
         properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
-        final StreamsConfig config = new StreamsConfig(StreamsTestUtils.getStreamsConfig("test-reader", properties));
+        final InternalStreamsConfig config = new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig("test-reader", properties));
         final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback);
         changelogReader.transitToUpdateStandby();
 
@@ -1015,7 +1015,7 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
         final long now = time.milliseconds();
         final Properties properties = new Properties();
         properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
-        final StreamsConfig config = new StreamsConfig(StreamsTestUtils.getStreamsConfig("test-reader", properties));
+        final InternalStreamsConfig config = new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig("test-reader", properties));
         final StoreChangelogReader changelogReader = new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback);
         changelogReader.transitToUpdateStandby();
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -53,6 +53,7 @@ import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
 import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
 import org.apache.kafka.streams.processor.StateStore;
@@ -225,19 +226,19 @@ public class StreamTaskTest {
                                      Collections.emptySet());
     }
 
-    private static StreamsConfig createConfig() {
+    private static InternalStreamsConfig createConfig() {
         return createConfig("0");
     }
 
-    private static StreamsConfig createConfig(final String enforcedProcessingValue) {
+    private static InternalStreamsConfig createConfig(final String enforcedProcessingValue) {
         return createConfig(AT_LEAST_ONCE, enforcedProcessingValue);
     }
 
-    private static StreamsConfig createConfig(final String eosConfig, final String enforcedProcessingValue) {
+    private static InternalStreamsConfig createConfig(final String eosConfig, final String enforcedProcessingValue) {
         return createConfig(eosConfig, enforcedProcessingValue, LogAndFailExceptionHandler.class.getName());
     }
 
-    private static StreamsConfig createConfig(
+    private static InternalStreamsConfig createConfig(
         final String eosConfig,
         final String enforcedProcessingValue,
         final String deserializationExceptionHandler) {
@@ -247,7 +248,7 @@ public class StreamTaskTest {
         } catch (final IOException e) {
             throw new RuntimeException(e);
         }
-        return new StreamsConfig(mkProperties(mkMap(
+        return new InternalStreamsConfig(mkProperties(mkMap(
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID),
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171"),
             mkEntry(StreamsConfig.BUFFERED_RECORDS_PER_PARTITION_CONFIG, "3"),
@@ -1819,7 +1820,7 @@ public class StreamTaskTest {
         EasyMock.expect(recordCollector.offsets()).andReturn(emptyMap()).anyTimes();
         EasyMock.replay(stateManager, recordCollector);
 
-        final StreamsConfig config = createConfig();
+        final InternalStreamsConfig config = createConfig();
         final InternalProcessorContext context = new ProcessorContextImpl(
             taskId,
             config,
@@ -2670,7 +2671,7 @@ public class StreamTaskTest {
         return metrics.metrics().keySet().stream().filter(m -> m.tags().containsKey("task-id")).collect(Collectors.toList());
     }
 
-    private StreamTask createOptimizedStatefulTask(final StreamsConfig config, final Consumer<byte[], byte[]> consumer) {
+    private StreamTask createOptimizedStatefulTask(final InternalStreamsConfig config, final Consumer<byte[], byte[]> consumer) {
         final StateStore stateStore = new MockKeyValueStore(storeName, true);
 
         final ProcessorTopology topology = ProcessorTopologyFactories.with(
@@ -2704,7 +2705,7 @@ public class StreamTaskTest {
         );
     }
 
-    private StreamTask createDisconnectedTask(final StreamsConfig config) {
+    private StreamTask createDisconnectedTask(final InternalStreamsConfig config) {
         final MockKeyValueStore stateStore = new MockKeyValueStore(storeName, false);
 
         final ProcessorTopology topology = ProcessorTopologyFactories.with(
@@ -2745,7 +2746,7 @@ public class StreamTaskTest {
         );
     }
 
-    private StreamTask createFaultyStatefulTask(final StreamsConfig config) {
+    private StreamTask createFaultyStatefulTask(final InternalStreamsConfig config) {
         final ProcessorTopology topology = ProcessorTopologyFactories.with(
             asList(source1, source3),
             mkMap(mkEntry(topic1, source1), mkEntry(topic2, source3)),
@@ -2778,11 +2779,11 @@ public class StreamTaskTest {
         );
     }
 
-    private StreamTask createStatefulTask(final StreamsConfig config, final boolean logged) {
+    private StreamTask createStatefulTask(final InternalStreamsConfig config, final boolean logged) {
         return createStatefulTask(config, logged, stateManager);
     }
 
-    private StreamTask createStatefulTask(final StreamsConfig config, final boolean logged, final ProcessorStateManager stateManager) {
+    private StreamTask createStatefulTask(final InternalStreamsConfig config, final boolean logged, final ProcessorStateManager stateManager) {
         final MockKeyValueStore stateStore = new MockKeyValueStore(storeName, logged);
 
         final ProcessorTopology topology = ProcessorTopologyFactories.with(
@@ -2816,7 +2817,7 @@ public class StreamTaskTest {
         );
     }
 
-    private StreamTask createSingleSourceStateless(final StreamsConfig config,
+    private StreamTask createSingleSourceStateless(final InternalStreamsConfig config,
                                                    final String builtInMetricsVersion) {
         final ProcessorTopology topology = withSources(
             asList(source1, processorStreamTime, processorSystemTime),
@@ -2856,7 +2857,7 @@ public class StreamTaskTest {
         );
     }
 
-    private StreamTask createStatelessTask(final StreamsConfig config) {
+    private StreamTask createStatelessTask(final InternalStreamsConfig config) {
         final ProcessorTopology topology = withSources(
             asList(source1, source2, processorStreamTime, processorSystemTime),
             mkMap(mkEntry(topic1, source1), mkEntry(topic2, source2))
@@ -2909,7 +2910,7 @@ public class StreamTaskTest {
         EasyMock.expect(recordCollector.offsets()).andReturn(Collections.emptyMap()).anyTimes();
         EasyMock.replay(stateManager, recordCollector);
 
-        final StreamsConfig config = createConfig();
+        final InternalStreamsConfig config = createConfig();
 
         final InternalProcessorContext context = new ProcessorContextImpl(
             taskId,
@@ -2944,7 +2945,7 @@ public class StreamTaskTest {
             mkMap(mkEntry(topic1, timeoutSource))
         );
 
-        final StreamsConfig config = createConfig(eosConfig, "0");
+        final InternalStreamsConfig config = createConfig(eosConfig, "0");
         final InternalProcessorContext context = new ProcessorContextImpl(
             taskId,
             config,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -54,12 +54,12 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.ThreadMetadata;
 import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 import org.apache.kafka.streams.kstream.internals.InternalStreamsBuilder;
@@ -170,8 +170,8 @@ public class StreamThreadTest {
     private final MockTime mockTime = new MockTime();
     private final String stateDir = TestUtils.tempDirectory().getPath();
     private final MockClientSupplier clientSupplier = new MockClientSupplier();
-    private final StreamsConfig config = new StreamsConfig(configProps(false));
-    private final StreamsConfig eosEnabledConfig = new StreamsConfig(configProps(true));
+    private final InternalStreamsConfig config = new InternalStreamsConfig(configProps(false));
+    private final InternalStreamsConfig eosEnabledConfig = new InternalStreamsConfig(configProps(true));
     private final ConsumedInternal<Object, Object> consumed = new ConsumedInternal<>();
     private final ChangelogReader changelogReader = new MockChangelogReader();
     private final StateDirectory stateDirectory = new StateDirectory(config, mockTime, true, false);
@@ -241,13 +241,13 @@ public class StreamThreadTest {
     }
 
     private StreamThread createStreamThread(@SuppressWarnings("SameParameterValue") final String clientId,
-                                            final StreamsConfig config,
+                                            final InternalStreamsConfig config,
                                             final boolean eosEnabled) {
         return createStreamThread(clientId, config, mockTime, eosEnabled);
     }
 
     private StreamThread createStreamThread(@SuppressWarnings("SameParameterValue") final String clientId,
-                                            final StreamsConfig config,
+                                            final InternalStreamsConfig config,
                                             final Time time,
                                             final boolean eosEnabled) {
         if (eosEnabled) {
@@ -270,7 +270,7 @@ public class StreamThreadTest {
             topologyMetadata,
             config,
             clientSupplier,
-            clientSupplier.getAdmin(config.getAdminConfigs(clientId)),
+            clientSupplier.getAdmin(config.adminConfigs(clientId)),
             PROCESS_ID,
             clientId,
             streamsMetrics,
@@ -470,7 +470,7 @@ public class StreamThreadTest {
         props.setProperty(StreamsConfig.STATE_DIR_CONFIG, stateDir);
         props.setProperty(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, Long.toString(commitInterval));
 
-        final StreamsConfig config = new StreamsConfig(props);
+        final InternalStreamsConfig config = new InternalStreamsConfig(props);
         final Consumer<byte[], byte[]> consumer = EasyMock.createNiceMock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         expect(consumer.groupMetadata()).andStubReturn(consumerGroupMetadata);
@@ -499,7 +499,7 @@ public class StreamThreadTest {
         props.setProperty(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, Long.toString(commitInterval));
         props.setProperty(StreamsConfig.REPARTITION_PURGE_INTERVAL_MS_CONFIG, Long.toString(purgeInterval));
 
-        final StreamsConfig config = new StreamsConfig(props);
+        final InternalStreamsConfig config = new InternalStreamsConfig(props);
         final Consumer<byte[], byte[]> consumer = EasyMock.createNiceMock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         expect(consumer.groupMetadata()).andStubReturn(consumerGroupMetadata);
@@ -528,7 +528,7 @@ public class StreamThreadTest {
         props.setProperty(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, Long.toString(purgeInterval));
         props.setProperty(StreamsConfig.REPARTITION_PURGE_INTERVAL_MS_CONFIG, Long.toString(purgeInterval));
 
-        final StreamsConfig config = new StreamsConfig(props);
+        final InternalStreamsConfig config = new InternalStreamsConfig(props);
         final Consumer<byte[], byte[]> consumer = EasyMock.createNiceMock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         expect(consumer.groupMetadata()).andStubReturn(consumerGroupMetadata);
@@ -556,7 +556,7 @@ public class StreamThreadTest {
     public void shouldNotProcessWhenPartitionRevoked() {
         final Properties props = configProps(false);
 
-        final StreamsConfig config = new StreamsConfig(props);
+        final InternalStreamsConfig config = new InternalStreamsConfig(props);
         when(mainConsumer.poll(Mockito.any())).thenReturn(ConsumerRecords.empty());
         final ConsumerGroupMetadata consumerGroupMetadata = Mockito.mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -577,7 +577,7 @@ public class StreamThreadTest {
     public void shouldProcessWhenRunning() {
         final Properties props = configProps(false);
 
-        final StreamsConfig config = new StreamsConfig(props);
+        final InternalStreamsConfig config = new InternalStreamsConfig(props);
         when(mainConsumer.poll(Mockito.any())).thenReturn(ConsumerRecords.empty());
         final ConsumerGroupMetadata consumerGroupMetadata = Mockito.mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -599,9 +599,9 @@ public class StreamThreadTest {
     @Test
     public void shouldProcessWhenPartitionAssigned() {
         final Properties props = configProps(false);
-        props.setProperty(InternalConfig.STATE_UPDATER_ENABLED, Boolean.toString(true));
+        props.setProperty(InternalStreamsConfig.STATE_UPDATER_ENABLED, Boolean.toString(true));
 
-        final StreamsConfig config = new StreamsConfig(props);
+        final InternalStreamsConfig config = new InternalStreamsConfig(props);
         when(mainConsumer.poll(Mockito.any())).thenReturn(ConsumerRecords.empty());
         final ConsumerGroupMetadata consumerGroupMetadata = Mockito.mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -622,9 +622,9 @@ public class StreamThreadTest {
     @Test
     public void shouldProcessWhenStarting() {
         final Properties props = configProps(false);
-        props.setProperty(InternalConfig.STATE_UPDATER_ENABLED, Boolean.toString(true));
+        props.setProperty(InternalStreamsConfig.STATE_UPDATER_ENABLED, Boolean.toString(true));
 
-        final StreamsConfig config = new StreamsConfig(props);
+        final InternalStreamsConfig config = new InternalStreamsConfig(props);
         when(mainConsumer.poll(Mockito.any())).thenReturn(ConsumerRecords.empty());
         final ConsumerGroupMetadata consumerGroupMetadata = Mockito.mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -644,7 +644,7 @@ public class StreamThreadTest {
     @Test
     public void shouldEnforceRebalanceWhenScheduledAndNotCurrentlyRebalancing() throws InterruptedException {
         final Time mockTime = new MockTime(1);
-        final StreamsConfig config = new StreamsConfig(configProps(false));
+        final InternalStreamsConfig config = new InternalStreamsConfig(configProps(false));
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(
             metrics,
             APPLICATION_ID,
@@ -667,7 +667,7 @@ public class StreamThreadTest {
             topologyMetadata,
             config,
             mockClientSupplier,
-            mockClientSupplier.getAdmin(config.getAdminConfigs(CLIENT_ID)),
+            mockClientSupplier.getAdmin(config.adminConfigs(CLIENT_ID)),
             PROCESS_ID,
             CLIENT_ID,
             streamsMetrics,
@@ -705,7 +705,7 @@ public class StreamThreadTest {
     @Test
     public void shouldNotEnforceRebalanceWhenCurrentlyRebalancing() throws InterruptedException {
         final Time mockTime = new MockTime(1);
-        final StreamsConfig config = new StreamsConfig(configProps(false));
+        final InternalStreamsConfig config = new InternalStreamsConfig(configProps(false));
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(
             metrics,
             APPLICATION_ID,
@@ -729,7 +729,7 @@ public class StreamThreadTest {
             topologyMetadata,
             config,
             mockClientSupplier,
-            mockClientSupplier.getAdmin(config.getAdminConfigs(CLIENT_ID)),
+            mockClientSupplier.getAdmin(config.adminConfigs(CLIENT_ID)),
             PROCESS_ID,
             CLIENT_ID,
             streamsMetrics,
@@ -788,7 +788,7 @@ public class StreamThreadTest {
 
         AtomicLong nextRebalanceMs() {
             return ((ReferenceContainer) consumerConfigs.get(
-                    StreamsConfig.InternalConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR)
+                    InternalStreamsConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR)
                 ).nextScheduledRebalanceMs;
         }
     }
@@ -814,7 +814,7 @@ public class StreamThreadTest {
 
         final Properties properties = new Properties();
         properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
-        final StreamsConfig config = new StreamsConfig(StreamsTestUtils.getStreamsConfig(APPLICATION_ID,
+        final InternalStreamsConfig config = new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig(APPLICATION_ID,
                                                                                          "localhost:2171",
                                                                                          Serdes.ByteArraySerde.class.getName(),
                                                                                          Serdes.ByteArraySerde.class.getName(),
@@ -922,7 +922,7 @@ public class StreamThreadTest {
         props.setProperty(StreamsConfig.STATE_DIR_CONFIG, stateDir);
         props.setProperty(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, Long.toString(commitInterval));
 
-        final StreamsConfig config = new StreamsConfig(props);
+        final InternalStreamsConfig config = new InternalStreamsConfig(props);
         final Consumer<byte[], byte[]> consumer = EasyMock.createNiceMock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         expect(consumer.groupMetadata()).andStubReturn(consumerGroupMetadata);
@@ -952,7 +952,7 @@ public class StreamThreadTest {
         props.setProperty(StreamsConfig.STATE_DIR_CONFIG, stateDir);
         props.setProperty(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, Long.toString(commitInterval));
 
-        final StreamsConfig config = new StreamsConfig(props);
+        final InternalStreamsConfig config = new InternalStreamsConfig(props);
         final Consumer<byte[], byte[]> consumer = EasyMock.createNiceMock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         expect(consumer.groupMetadata()).andStubReturn(consumerGroupMetadata);
@@ -1014,7 +1014,7 @@ public class StreamThreadTest {
         props.setProperty(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, Long.toString(commitInterval));
         props.setProperty(StreamsConfig.REPARTITION_PURGE_INTERVAL_MS_CONFIG, Long.toString(purgeInterval));
 
-        final StreamsConfig config = new StreamsConfig(props);
+        final InternalStreamsConfig config = new InternalStreamsConfig(props);
         final Consumer<byte[], byte[]> consumer = EasyMock.createNiceMock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         expect(consumer.groupMetadata()).andStubReturn(consumerGroupMetadata);
@@ -1190,7 +1190,7 @@ public class StreamThreadTest {
 
         final Properties props = configProps(true);
         props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
-        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(props), true);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new InternalStreamsConfig(props), true);
 
         thread.setState(StreamThread.State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptyList());
@@ -1226,7 +1226,7 @@ public class StreamThreadTest {
         internalTopologyBuilder.addSource(null, "source1", null, null, null, topic1);
 
         final Properties props = configProps(true);
-        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(props), true);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new InternalStreamsConfig(props), true);
 
         thread.setState(StreamThread.State.STARTING);
         thread.rebalanceListener().onPartitionsRevoked(Collections.emptyList());
@@ -1269,9 +1269,9 @@ public class StreamThreadTest {
         // Since this tests verifies an aspect that is independent from the state updater, it is OK to disable
         // the state updater and leave the rewriting of the test to later, when the code path for disabled state updater
         // is removed.
-        props.put(InternalConfig.STATE_UPDATER_ENABLED, false);
+        props.put(InternalStreamsConfig.STATE_UPDATER_ENABLED, false);
         final StreamThread thread =
-            createStreamThread(CLIENT_ID, new StreamsConfig(props), new MockTime(1), true);
+            createStreamThread(CLIENT_ID, new InternalStreamsConfig(props), new MockTime(1), true);
 
         thread.taskManager().handleRebalanceStart(Collections.singleton(topic1));
 
@@ -1317,7 +1317,7 @@ public class StreamThreadTest {
 
         final StreamThread thread = createStreamThread(
             CLIENT_ID,
-            new StreamsConfig(configProps(true)),
+            new InternalStreamsConfig(configProps(true)),
             new MockTime(1),
             true
         );
@@ -1437,8 +1437,8 @@ public class StreamThreadTest {
             new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST, mockTime);
 
         final Properties props = configProps(false);
-        props.put(InternalConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled);
-        final StreamsConfig config = new StreamsConfig(props);
+        props.put(InternalStreamsConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled);
+        final InternalStreamsConfig config = new InternalStreamsConfig(props);
         final StreamThread thread = new StreamThread(
             new MockTime(1),
             config,
@@ -1543,7 +1543,7 @@ public class StreamThreadTest {
         internalTopologyBuilder.addSource(null, "source", null, null, null, topic1);
         internalTopologyBuilder.addSink("sink", "dummyTopic", null, null, null, "source");
 
-        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(configProps(true)), true);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new InternalStreamsConfig(configProps(true)), true);
 
         final MockConsumer<byte[], byte[]> consumer = clientSupplier.consumer;
 
@@ -1602,7 +1602,7 @@ public class StreamThreadTest {
 
     @Test
     public void shouldNotCloseTaskAndRemoveFromTaskManagerIfProducerGotFencedInCommitTransactionWhenSuspendingTasks() {
-        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(configProps(true)), true);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new InternalStreamsConfig(configProps(true)), true);
 
         internalTopologyBuilder.addSource(null, "name", null, null, null, topic1);
         internalTopologyBuilder.addSink("out", "output", null, null, null, "name");
@@ -1651,8 +1651,8 @@ public class StreamThreadTest {
 
     private void shouldReinitializeRevivedTasksInAnyState(final boolean stateUpdaterEnabled) throws Exception {
         final Properties streamsConfigProps = configProps(false);
-        streamsConfigProps.put(InternalConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled);
-        final StreamsConfig config = new StreamsConfig(streamsConfigProps);
+        streamsConfigProps.put(InternalStreamsConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled);
+        final InternalStreamsConfig config = new InternalStreamsConfig(streamsConfigProps);
         final StreamThread thread = createStreamThread(CLIENT_ID, config, new MockTime(1), false);
 
         final String storeName = "store";
@@ -1763,7 +1763,7 @@ public class StreamThreadTest {
         // only have source but no sink so that we would not get fenced in producer.send
         internalTopologyBuilder.addSource(null, "source", null, null, null, topic1);
 
-        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(configProps(true)), true);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new InternalStreamsConfig(configProps(true)), true);
 
         final MockConsumer<byte[], byte[]> consumer = clientSupplier.consumer;
 
@@ -1812,7 +1812,7 @@ public class StreamThreadTest {
 
     @Test
     public void shouldNotCloseTaskProducerWhenSuspending() {
-        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(configProps(true)), true);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new InternalStreamsConfig(configProps(true)), true);
 
         internalTopologyBuilder.addSource(null, "name", null, null, null, topic1);
         internalTopologyBuilder.addSink("out", "output", null, null, null, "name");
@@ -1868,7 +1868,7 @@ public class StreamThreadTest {
             topologyMetadata,
             config,
             clientSupplier,
-            clientSupplier.getAdmin(config.getAdminConfigs(CLIENT_ID)),
+            clientSupplier.getAdmin(config.adminConfigs(CLIENT_ID)),
             PROCESS_ID,
             CLIENT_ID,
             streamsMetrics,
@@ -1971,8 +1971,8 @@ public class StreamThreadTest {
         final String changelogName2 = APPLICATION_ID + "-" + storeName2 + "-changelog";
         final Properties props = configProps(false);
         // Updating standby tasks on the stream thread only happens when the state updater is disabled
-        props.put(InternalConfig.STATE_UPDATER_ENABLED, false);
-        final StreamsConfig config = new StreamsConfig(props);
+        props.put(InternalStreamsConfig.STATE_UPDATER_ENABLED, false);
+        final InternalStreamsConfig config = new InternalStreamsConfig(props);
         final StreamThread thread = createStreamThread(CLIENT_ID, config, false);
         final MockConsumer<byte[], byte[]> restoreConsumer = clientSupplier.restoreConsumer;
 
@@ -2096,8 +2096,8 @@ public class StreamThreadTest {
         final String changelogName2 = APPLICATION_ID + "-" + storeName2 + "-changelog";
         final Properties props = configProps(false);
         // Updating standby tasks on the stream thread only happens when the state updater is disabled
-        props.put(InternalConfig.STATE_UPDATER_ENABLED, false);
-        final StreamsConfig config = new StreamsConfig(props);
+        props.put(InternalStreamsConfig.STATE_UPDATER_ENABLED, false);
+        final InternalStreamsConfig config = new InternalStreamsConfig(props);
         final StreamThread thread = createStreamThread(CLIENT_ID, config, false);
         final MockConsumer<byte[], byte[]> restoreConsumer = clientSupplier.restoreConsumer;
 
@@ -2353,8 +2353,8 @@ public class StreamThreadTest {
         internalStreamsBuilder.buildAndOptimizeTopology();
 
         final Properties props = configProps(false);
-        props.put(InternalConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled);
-        final StreamsConfig config = new StreamsConfig(props);
+        props.put(InternalStreamsConfig.STATE_UPDATER_ENABLED, stateUpdaterEnabled);
+        final InternalStreamsConfig config = new InternalStreamsConfig(props);
         final StreamThread thread = createStreamThread("clientId", config, new MockTime(1), false);
         final MockConsumer<byte[], byte[]> mockConsumer = (MockConsumer<byte[], byte[]>) thread.mainConsumer();
         final MockConsumer<byte[], byte[]> mockRestoreConsumer = (MockConsumer<byte[], byte[]>) thread.restoreConsumer();
@@ -2486,7 +2486,7 @@ public class StreamThreadTest {
             LogAndContinueExceptionHandler.class.getName()
         );
         config.setProperty(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass().getName());
-        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(config), false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new InternalStreamsConfig(config), false);
 
         thread.setState(StreamThread.State.STARTING);
         thread.setState(StreamThread.State.PARTITIONS_REVOKED);
@@ -3009,7 +3009,7 @@ public class StreamThreadTest {
             StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
             LogAndSkipOnInvalidTimestamp.class.getName()
         );
-        final StreamThread thread = createStreamThread(CLIENT_ID, new StreamsConfig(config), false);
+        final StreamThread thread = createStreamThread(CLIENT_ID, new InternalStreamsConfig(config), false);
 
         thread.setState(StreamThread.State.STARTING);
         thread.setState(StreamThread.State.PARTITIONS_REVOKED);
@@ -3238,7 +3238,7 @@ public class StreamThreadTest {
     @Test
     public void shouldCheckStateUpdater() {
         final Properties streamsConfigProps = StreamsTestUtils.getStreamsConfig();
-        streamsConfigProps.put(InternalConfig.STATE_UPDATER_ENABLED, true);
+        streamsConfigProps.put(InternalStreamsConfig.STATE_UPDATER_ENABLED, true);
         final StreamThread streamThread = setUpThread(streamsConfigProps);
         final TaskManager taskManager = streamThread.taskManager();
         streamThread.setState(State.STARTING);
@@ -3252,7 +3252,7 @@ public class StreamThreadTest {
     @Test
     public void shouldCheckStateUpdaterInBetweenProcessCalls() {
         final Properties streamsConfigProps = StreamsTestUtils.getStreamsConfig();
-        streamsConfigProps.put(InternalConfig.STATE_UPDATER_ENABLED, true);
+        streamsConfigProps.put(InternalStreamsConfig.STATE_UPDATER_ENABLED, true);
         final StreamThread streamThread = setUpThread(streamsConfigProps);
         final TaskManager taskManager = streamThread.taskManager();
         streamThread.setState(State.STARTING);
@@ -3296,7 +3296,7 @@ public class StreamThreadTest {
     @Test
     public void shouldRespectPollTimeInPartitionsAssignedStateWithStateUpdater() {
         final Properties streamsConfigProps = StreamsTestUtils.getStreamsConfig();
-        streamsConfigProps.put(InternalConfig.STATE_UPDATER_ENABLED, true);
+        streamsConfigProps.put(InternalStreamsConfig.STATE_UPDATER_ENABLED, true);
         final Duration pollTime = Duration.ofMillis(config.getLong(StreamsConfig.POLL_MS_CONFIG));
         final StreamThread streamThread = setUpThread(streamsConfigProps);
         streamThread.setState(State.STARTING);
@@ -3310,7 +3310,7 @@ public class StreamThreadTest {
     @Test
     public void shouldNotBlockWhenPollingInPartitionsAssignedStateWithoutStateUpdater() {
         final Properties streamsConfigProps = StreamsTestUtils.getStreamsConfig();
-        streamsConfigProps.put(InternalConfig.STATE_UPDATER_ENABLED, false);
+        streamsConfigProps.put(InternalStreamsConfig.STATE_UPDATER_ENABLED, false);
         final StreamThread streamThread = setUpThread(streamsConfigProps);
         streamThread.setState(State.STARTING);
         streamThread.setState(State.PARTITIONS_ASSIGNED);
@@ -3330,7 +3330,7 @@ public class StreamThreadTest {
         topologyMetadata.buildAndRewriteTopology();
         return new StreamThread(
             mockTime,
-            new StreamsConfig(streamsConfigProps.entrySet().stream()
+            new InternalStreamsConfig(streamsConfigProps.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))),
             null,
             mainConsumer,
@@ -3452,7 +3452,7 @@ public class StreamThreadTest {
 
     private StreamThread buildStreamThread(final Consumer<byte[], byte[]> consumer,
                                            final TaskManager taskManager,
-                                           final StreamsConfig config,
+                                           final InternalStreamsConfig config,
                                            final TopologyMetadata topologyMetadata) {
         final StreamsMetricsImpl streamsMetrics =
             new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST, mockTime);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsAssignmentScaleTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsAssignmentScaleTest.java
@@ -27,7 +27,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.processor.internals.assignment.FallbackPriorTaskAssignor;
 import org.apache.kafka.streams.processor.internals.assignment.HighAvailabilityTaskAssignor;
@@ -170,7 +170,7 @@ public class StreamsAssignmentScaleTest {
         builder.addSource(null, "source", null, null, null, "topic");
         builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source");
         builder.addStateStore(new MockKeyValueStoreBuilder("store", false), "processor");
-        final TopologyMetadata topologyMetadata = new TopologyMetadata(builder, new StreamsConfig(configMap));
+        final TopologyMetadata topologyMetadata = new TopologyMetadata(builder, new InternalStreamsConfig(configMap));
         topologyMetadata.buildAndRewriteTopology();
 
         @SuppressWarnings("unchecked")
@@ -186,13 +186,13 @@ public class StreamsAssignmentScaleTest {
         referenceContainer.taskManager = taskManager;
         referenceContainer.streamsMetadataState = mock(StreamsMetadataState.class);
         referenceContainer.time = new MockTime();
-        configMap.put(InternalConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, referenceContainer);
-        configMap.put(InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS, taskAssignor.getName());
+        configMap.put(InternalStreamsConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, referenceContainer);
+        configMap.put(InternalStreamsConfig.TASK_ASSIGNOR_CLASS, taskAssignor.getName());
         configMap.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, numStandbys);
 
         final MockInternalTopicManager mockInternalTopicManager = new MockInternalTopicManager(
             new MockTime(),
-            new StreamsConfig(configMap),
+            new InternalStreamsConfig(configMap),
             new MockClientSupplier().restoreConsumer,
             false
         );

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -40,6 +40,7 @@ import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.test.MockClientSupplier;
 import org.junit.Before;
@@ -88,19 +89,19 @@ public class StreamsProducerTest {
         Collections.emptySet()
     );
 
-    private final StreamsConfig nonEosConfig = new StreamsConfig(mkMap(
+    private final InternalStreamsConfig nonEosConfig = new InternalStreamsConfig(mkMap(
         mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
         mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"))
     );
 
     @SuppressWarnings("deprecation")
-    private final StreamsConfig eosAlphaConfig = new StreamsConfig(mkMap(
+    private final InternalStreamsConfig eosAlphaConfig = new InternalStreamsConfig(mkMap(
         mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
         mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
         mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE))
     );
 
-    private final StreamsConfig eosBetaConfig = new StreamsConfig(mkMap(
+    private final InternalStreamsConfig eosBetaConfig = new InternalStreamsConfig(mkMap(
         mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "appId"),
         mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
         mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2))
@@ -384,8 +385,8 @@ public class StreamsProducerTest {
 
     @Test
     public void shouldNotSetTransactionIdIfEosDisabled() {
-        final StreamsConfig mockConfig = mock(StreamsConfig.class);
-        expect(mockConfig.getProducerConfigs("threadId-producer")).andReturn(mock(Map.class));
+        final InternalStreamsConfig mockConfig = mock(InternalStreamsConfig.class);
+        expect(mockConfig.producerConfigs("threadId-producer")).andReturn(mock(Map.class));
         expect(mockConfig.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)).andReturn(StreamsConfig.AT_LEAST_ONCE).anyTimes();
         replay(mockConfig);
 
@@ -502,8 +503,8 @@ public class StreamsProducerTest {
         expect(mockMap.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "appId-0_0")).andReturn(null);
         expect(mockMap.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG)).andReturn("appId-0_0");
 
-        final StreamsConfig mockConfig = mock(StreamsConfig.class);
-        expect(mockConfig.getProducerConfigs("threadId-0_0-producer")).andReturn(mockMap);
+        final InternalStreamsConfig mockConfig = mock(InternalStreamsConfig.class);
+        expect(mockConfig.producerConfigs("threadId-0_0-producer")).andReturn(mockMap);
         expect(mockConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andReturn("appId");
         expect(mockConfig.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)).andReturn(StreamsConfig.EXACTLY_ONCE);
 
@@ -530,8 +531,8 @@ public class StreamsProducerTest {
         expect(mockMap.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "appId-" + processId + "-0")).andReturn(null);
         expect(mockMap.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG)).andReturn("appId-" + processId);
 
-        final StreamsConfig mockConfig = mock(StreamsConfig.class);
-        expect(mockConfig.getProducerConfigs("threadId-StreamThread-0-producer")).andReturn(mockMap);
+        final InternalStreamsConfig mockConfig = mock(InternalStreamsConfig.class);
+        expect(mockConfig.producerConfigs("threadId-StreamThread-0-producer")).andReturn(mockMap);
         expect(mockConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).andReturn("appId");
         expect(mockConfig.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)).andReturn(StreamsConfig.EXACTLY_ONCE_V2).anyTimes();
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TopologyMetadataTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TopologyMetadataTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.internals.testutil.DummyStreamsConfig;
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,7 +31,7 @@ public class TopologyMetadataTest {
     @Test
     public void testPauseResume() {
         final InternalTopologyBuilder internalTopologyBuilder = mock(InternalTopologyBuilder.class);
-        final StreamsConfig config = new DummyStreamsConfig();
+        final InternalStreamsConfig config = new DummyStreamsConfig();
 
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder,
             config);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/WriteConsistencyVectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/WriteConsistencyVectorTest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task.TaskType;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.when;
 public class WriteConsistencyVectorTest {
 
     @Mock
-    private StreamsConfig streamsConfig;
+    private InternalStreamsConfig streamsConfig;
     @Mock
     private ProcessorStateManager stateManager;
     @Mock
@@ -77,7 +77,7 @@ public class WriteConsistencyVectorTest {
 
     @Before
     public void setup() {
-        when(streamsConfig.originals()).thenReturn(Collections.singletonMap(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true));
+        when(streamsConfig.originals()).thenReturn(Collections.singletonMap(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true));
         when(streamsConfig.values()).thenReturn(Collections.emptyMap());
         when(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).thenReturn("add-id");
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -37,7 +37,7 @@ import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.InternalTopicManager;
 import org.apache.kafka.streams.processor.internals.Task;
@@ -690,13 +690,13 @@ public final class AssignmentTestUtils {
         }
 
         final ReferenceContainer referenceContainer = new ReferenceContainer();
-        configurationMap.put(InternalConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, referenceContainer);
+        configurationMap.put(InternalStreamsConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, referenceContainer);
         return configurationMap;
     }
 
     static InternalTopicManager mockInternalTopicManagerForRandomChangelog(final int nodeSize, final int tpSize, final int partitionSize) {
         final MockTime time = new MockTime();
-        final StreamsConfig streamsConfig = new StreamsConfig(configProps(true));
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(configProps(true));
         final MockClientSupplier mockClientSupplier = new MockClientSupplier();
         final MockInternalTopicManager mockInternalTopicManager = new MockInternalTopicManager(
             time,
@@ -871,7 +871,7 @@ public final class AssignmentTestUtils {
 
     static InternalTopicManager mockInternalTopicManagerForChangelog() {
         final MockTime time = new MockTime();
-        final StreamsConfig streamsConfig = new StreamsConfig(configProps(true));
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(configProps(true));
         final MockClientSupplier mockClientSupplier = new MockClientSupplier();
         final MockInternalTopicManager mockInternalTopicManager = new MockInternalTopicManager(
             time,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfigurationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfigurationTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.internals.assignment;
 
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.internals.UpgradeFromValues;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,7 +39,7 @@ public class AssignorConfigurationTest {
     public void setup() {
         config.put(StreamsConfig.APPLICATION_ID_CONFIG, "app.id");
         config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy");
-        config.put(StreamsConfig.InternalConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, mock(ReferenceContainer.class));
+        config.put(InternalStreamsConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, mock(ReferenceContainer.class));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
@@ -104,6 +104,7 @@ import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration.AssignmentConfigs;
 import org.apache.kafka.test.MockClientSupplier;
@@ -120,7 +121,7 @@ import org.mockito.Mockito;
 public class RackAwareTaskAssignorTest {
 
     private final MockTime time = new MockTime();
-    private final StreamsConfig streamsConfig = new StreamsConfig(configProps(true));
+    private final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(configProps(true));
     private final MockClientSupplier mockClientSupplier = new MockClientSupplier();
 
     private int trafficCost;
@@ -157,17 +158,17 @@ public class RackAwareTaskAssignorTest {
 
     private AssignmentConfigs getRackAwareEnabledConfig() {
         return new AssignorConfiguration(
-            new StreamsConfig(configProps(true)).originals()).assignmentConfigs();
+            new InternalStreamsConfig(configProps(true)).originals()).assignmentConfigs();
     }
 
     private AssignmentConfigs getRackAwareEnabledConfigWithStandby(final int replicaNum) {
         return new AssignorConfiguration(
-            new StreamsConfig(configProps(true, replicaNum)).originals()).assignmentConfigs();
+            new InternalStreamsConfig(configProps(true, replicaNum)).originals()).assignmentConfigs();
     }
 
     private AssignmentConfigs getRackAwareDisabledConfig() {
         return new AssignorConfiguration(
-            new StreamsConfig(configProps(false)).originals()).assignmentConfigs();
+            new InternalStreamsConfig(configProps(false)).originals()).assignmentConfigs();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignorConvergenceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignorConvergenceTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.InternalTopicManager;
 import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
@@ -164,7 +165,7 @@ public class TaskAssignorConvergenceTest {
             }
 
             final MockTime time = new MockTime();
-            final StreamsConfig streamsConfig = new StreamsConfig(configProps(true));
+            final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(configProps(true));
             final MockClientSupplier mockClientSupplier = new MockClientSupplier();
             final MockInternalTopicManager mockInternalTopicManager = new MockInternalTopicManager(
                 time,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/testutil/DummyStreamsConfig.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/testutil/DummyStreamsConfig.java
@@ -17,12 +17,13 @@
 package org.apache.kafka.streams.processor.internals.testutil;
 
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.internals.StreamsConfigUtils;
 import org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode;
 
 import java.util.Properties;
 
-public class DummyStreamsConfig extends StreamsConfig {
+public class DummyStreamsConfig extends InternalStreamsConfig {
 
 
     public DummyStreamsConfig() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.DefaultProductionExceptionHandler;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
@@ -213,7 +214,7 @@ public class KeyValueStoreTestDriver<K, V> {
             logContext,
             new TaskId(0, 0),
             new StreamsProducer(
-                new StreamsConfig(props),
+                new InternalStreamsConfig(props),
                 "threadId",
                 new MockClientSupplier(),
                 null,
@@ -276,12 +277,12 @@ public class KeyValueStoreTestDriver<K, V> {
 
             @Override
             public Map<String, Object> appConfigs() {
-                return new StreamsConfig(props).originals();
+                return new InternalStreamsConfig(props).originals();
             }
 
             @Override
             public Map<String, Object> appConfigsWithPrefix(final String prefix) {
-                return new StreamsConfig(props).originalsWithPrefix(prefix);
+                return new InternalStreamsConfig(props).originalsWithPrefix(prefix);
             }
         };
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
@@ -34,7 +34,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
@@ -1342,14 +1342,14 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
     @Test
     public void shouldRestoreRecordsAndConsistencyVectorSingleTopic() {
         final Properties props = StreamsTestUtils.getStreamsConfig();
-        props.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        props.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         final File dir = TestUtils.tempDirectory();
         context = new InternalMockProcessorContext<>(
                 dir,
                 Serdes.String(),
                 Serdes.String(),
                 new StreamsMetricsImpl(new Metrics(), "mock", StreamsConfig.METRICS_LATEST, new MockTime()),
-                new StreamsConfig(props),
+                new InternalStreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
                 Time.SYSTEM
@@ -1378,14 +1378,14 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
     @Test
     public void shouldRestoreRecordsAndConsistencyVectorMultipleTopics() {
         final Properties props = StreamsTestUtils.getStreamsConfig();
-        props.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        props.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         final File dir = TestUtils.tempDirectory();
         context = new InternalMockProcessorContext<>(
                 dir,
                 Serdes.String(),
                 Serdes.String(),
                 new StreamsMetricsImpl(new Metrics(), "mock", StreamsConfig.METRICS_LATEST, new MockTime()),
-                new StreamsConfig(props),
+                new InternalStreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
                 Time.SYSTEM
@@ -1417,14 +1417,14 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
     @Test
     public void shouldHandleTombstoneRecords() {
         final Properties props = StreamsTestUtils.getStreamsConfig();
-        props.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        props.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         final File dir = TestUtils.tempDirectory();
         context = new InternalMockProcessorContext<>(
                 dir,
                 Serdes.String(),
                 Serdes.String(),
                 new StreamsMetricsImpl(new Metrics(), "mock", StreamsConfig.METRICS_LATEST, new MockTime()),
-                new StreamsConfig(props),
+                new InternalStreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
                 Time.SYSTEM
@@ -1458,14 +1458,14 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
     @Test
     public void shouldNotThrowWhenRestoringOnMissingHeaders() {
         final Properties props = StreamsTestUtils.getStreamsConfig();
-        props.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        props.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         final File dir = TestUtils.tempDirectory();
         context = new InternalMockProcessorContext<>(
                 dir,
                 Serdes.String(),
                 Serdes.String(),
                 new StreamsMetricsImpl(new Metrics(), "mock", StreamsConfig.METRICS_LATEST, new MockTime()),
-                new StreamsConfig(props),
+                new InternalStreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
                 Time.SYSTEM
@@ -1584,7 +1584,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest<S extends
         final AbstractDualSchemaRocksDBSegmentedBytesStore<S> bytesStore = getBytesStore();
         final InternalMockProcessorContext context = new InternalMockProcessorContext(
             TestUtils.tempDirectory(),
-            new StreamsConfig(streamsConfig)
+            new InternalStreamsConfig(streamsConfig)
         );
         final Time time = new SystemTime();
         context.setSystemTimeMs(time.milliseconds());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -35,7 +35,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
@@ -543,14 +543,14 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
     @Test
     public void shouldRestoreRecordsAndConsistencyVectorSingleTopic() {
         final Properties props = StreamsTestUtils.getStreamsConfig();
-        props.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        props.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         final File dir = TestUtils.tempDirectory();
         context = new InternalMockProcessorContext<>(
                 dir,
                 Serdes.String(),
                 Serdes.String(),
                 new StreamsMetricsImpl(new Metrics(), "mock", StreamsConfig.METRICS_LATEST, new MockTime()),
-                new StreamsConfig(props),
+                new InternalStreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
                 Time.SYSTEM
@@ -581,14 +581,14 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
     @Test
     public void shouldRestoreRecordsAndConsistencyVectorMultipleTopics() {
         final Properties props = StreamsTestUtils.getStreamsConfig();
-        props.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        props.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         final File dir = TestUtils.tempDirectory();
         context = new InternalMockProcessorContext<>(
                 dir,
                 Serdes.String(),
                 Serdes.String(),
                 new StreamsMetricsImpl(new Metrics(), "mock", StreamsConfig.METRICS_LATEST, new MockTime()),
-                new StreamsConfig(props),
+                new InternalStreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
                 Time.SYSTEM
@@ -621,14 +621,14 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
     @Test
     public void shouldHandleTombstoneRecords() {
         final Properties props = StreamsTestUtils.getStreamsConfig();
-        props.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        props.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         final File dir = TestUtils.tempDirectory();
         context = new InternalMockProcessorContext<>(
                 dir,
                 Serdes.String(),
                 Serdes.String(),
                 new StreamsMetricsImpl(new Metrics(), "mock", StreamsConfig.METRICS_LATEST, new MockTime()),
-                new StreamsConfig(props),
+                new InternalStreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
                 Time.SYSTEM
@@ -663,14 +663,14 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
     @Test
     public void shouldNotThrowWhenRestoringOnMissingHeaders() {
         final Properties props = StreamsTestUtils.getStreamsConfig();
-        props.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        props.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         final File dir = TestUtils.tempDirectory();
         context = new InternalMockProcessorContext<>(
                 dir,
                 Serdes.String(),
                 Serdes.String(),
                 new StreamsMetricsImpl(new Metrics(), "mock", StreamsConfig.METRICS_LATEST, new MockTime()),
-                new StreamsConfig(props),
+                new InternalStreamsConfig(props),
                 MockRecordCollector::new,
                 new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())),
                 Time.SYSTEM
@@ -789,7 +789,7 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         final AbstractRocksDBSegmentedBytesStore<S> bytesStore = getBytesStore();
         final InternalMockProcessorContext context = new InternalMockProcessorContext(
             TestUtils.tempDirectory(),
-            new StreamsConfig(streamsConfig)
+            new InternalStreamsConfig(streamsConfig)
         );
         final Time time = new SystemTime();
         context.setSystemTimeMs(time.milliseconds());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -798,7 +799,7 @@ public abstract class AbstractSessionBytesStoreTest {
         final SessionStore<String, Long> sessionStore = buildSessionStore(RETENTION_PERIOD, Serdes.String(), Serdes.Long());
         final InternalMockProcessorContext context = new InternalMockProcessorContext(
             TestUtils.tempDirectory(),
-            new StreamsConfig(streamsConfig),
+            new InternalStreamsConfig(streamsConfig),
             recordCollector
         );
         final Time time = new SystemTime();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
@@ -990,7 +991,7 @@ public abstract class AbstractWindowBytesStoreTest {
             buildWindowStore(RETENTION_PERIOD, WINDOW_SIZE, false, Serdes.Integer(), Serdes.String());
         final InternalMockProcessorContext context = new InternalMockProcessorContext(
             TestUtils.tempDirectory(),
-            new StreamsConfig(streamsConfig),
+            new InternalStreamsConfig(streamsConfig),
             recordCollector
         );
         final Time time = new SystemTime();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
@@ -27,7 +27,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -73,7 +73,7 @@ public class ChangeLoggingKeyValueBytesStoreTest {
     private final InMemoryKeyValueStore inner = new InMemoryKeyValueStore("kv");
     private final ChangeLoggingKeyValueBytesStore store = new ChangeLoggingKeyValueBytesStore(inner);
     private InternalMockProcessorContext context;
-    private final StreamsConfig streamsConfig = streamsConfigMock();
+    private final InternalStreamsConfig streamsConfig = streamsConfigMock();
     private final Bytes hi = Bytes.wrap("hi".getBytes());
     private final Bytes hello = Bytes.wrap("hello".getBytes());
     private final byte[] there = "there".getBytes();
@@ -271,11 +271,11 @@ public class ChangeLoggingKeyValueBytesStoreTest {
 
     }
 
-    private StreamsConfig streamsConfigMock() {
-        final StreamsConfig streamsConfig = mock(StreamsConfig.class);
+    private InternalStreamsConfig streamsConfigMock() {
+        final InternalStreamsConfig streamsConfig = mock(InternalStreamsConfig.class);
 
         final Map<String, Object> myValues = new HashMap<>();
-        myValues.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        myValues.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         when(streamsConfig.originals()).thenReturn(myValues);
         when(streamsConfig.values()).thenReturn(Collections.emptyMap());
         when(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)).thenReturn("add-id");

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProviderTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.TaskId;
@@ -60,7 +61,7 @@ import static org.junit.Assert.assertTrue;
 
 public class GlobalStateStoreProviderTest {
     private final Map<String, StateStore> stores = new HashMap<>();
-    private final static Map<String, Object> CONFIGS =  mkMap(mkEntry(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE, "appId"));
+    private final static Map<String, Object> CONFIGS =  mkMap(mkEntry(InternalStreamsConfig.TOPIC_PREFIX_ALTERNATIVE, "appId"));
 
     @Before
     public void before() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
@@ -67,7 +68,7 @@ public class LogicalKeyValueSegmentTest {
             TestUtils.tempDirectory(),
             Serdes.String(),
             Serdes.String(),
-            new StreamsConfig(StreamsTestUtils.getStreamsConfig())
+            new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig())
         ), physicalStore);
 
         segment0 = new LogicalKeyValueSegment(0, "segment-0", physicalStore);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.TaskId;
@@ -94,7 +95,7 @@ public class MeteredTimestampedKeyValueStoreTest {
     @Mock
     private InternalProcessorContext context;
 
-    private final static Map<String, Object> CONFIGS =  mkMap(mkEntry(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE, APPLICATION_ID));
+    private final static Map<String, Object> CONFIGS =  mkMap(mkEntry(InternalStreamsConfig.TOPIC_PREFIX_ALTERNATIVE, APPLICATION_ID));
 
     private MeteredTimestampedKeyValueStore<String, String> metered;
     private final KeyValue<Bytes, byte[]> byteKeyValueTimestampPair = KeyValue.pair(KEY_BYTES,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.TaskId;
@@ -84,7 +85,7 @@ public class MeteredTimestampedWindowStoreTest {
             Serdes.String(),
             Serdes.Long(),
             streamsMetrics,
-            new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
+            new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig()),
             MockRecordCollector::new,
             new ThreadCache(new LogContext("testCache "), 0, streamsMetrics),
             Time.SYSTEM,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
@@ -114,7 +115,7 @@ public class MeteredWindowStoreTest {
             Serdes.String(),
             Serdes.Long(),
             streamsMetrics,
-            new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
+            new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig()),
             MockRecordCollector::new,
             new ThreadCache(new LogContext("testCache "), 0, streamsMetrics),
             Time.SYSTEM

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -42,9 +42,9 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.ChangelogRecordDeserializationHelper;
@@ -142,7 +142,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
             dir,
             Serdes.String(),
             Serdes.String(),
-            new StreamsConfig(props)
+            new InternalStreamsConfig(props)
         );
         rocksDBStore = getRocksDBStore();
     }
@@ -179,7 +179,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
     private InternalMockProcessorContext getProcessorContext(final Properties streamsProps) {
         return new InternalMockProcessorContext(
             TestUtils.tempDirectory(),
-            new StreamsConfig(streamsProps)
+            new InternalStreamsConfig(streamsProps)
         );
     }
 
@@ -390,7 +390,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
             dir,
             Serdes.String(),
             Serdes.String(),
-            new StreamsConfig(props)
+            new InternalStreamsConfig(props)
         );
 
         rocksDBStore.init((StateStoreContext) context, rocksDBStore);
@@ -402,7 +402,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
     @Test
     public void shouldThrowProcessorStateExceptionOnOpeningReadOnlyDir() {
         final File tmpDir = TestUtils.tempDirectory();
-        final InternalMockProcessorContext tmpContext = new InternalMockProcessorContext(tmpDir, new StreamsConfig(StreamsTestUtils.getStreamsConfig()));
+        final InternalMockProcessorContext tmpContext = new InternalMockProcessorContext(tmpDir, new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig()));
 
         assertTrue(tmpDir.setReadOnly());
 
@@ -873,7 +873,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         context = new InternalMockProcessorContext(dir,
             Serdes.String(),
             Serdes.String(),
-            new StreamsConfig(props));
+            new InternalStreamsConfig(props));
 
         enableBloomFilters = false;
         rocksDBStore.init((StateStoreContext) context, rocksDBStore);
@@ -923,7 +923,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         when(context.metrics()).thenReturn(streamsMetrics);
         when(context.taskId()).thenReturn(taskId);
         when(context.appConfigs())
-            .thenReturn(new StreamsConfig(StreamsTestUtils.getStreamsConfig()).originals());
+            .thenReturn(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig()).originals());
         when(context.stateDir()).thenReturn(dir);
         final MonotonicProcessorRecordContext processorRecordContext = new MonotonicProcessorRecordContext("test", 0);
         when(context.recordMetadata()).thenReturn(Optional.of(processorRecordContext));
@@ -956,7 +956,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         when(context.metrics()).thenReturn(streamsMetrics);
         when(context.taskId()).thenReturn(taskId);
         when(context.appConfigs())
-                .thenReturn(new StreamsConfig(StreamsTestUtils.getStreamsConfig()).originals());
+                .thenReturn(new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig()).originals());
         when(context.stateDir()).thenReturn(dir);
         final MonotonicProcessorRecordContext processorRecordContext = new MonotonicProcessorRecordContext("test", 0);
         when(context.recordMetadata()).thenReturn(Optional.of(processorRecordContext));
@@ -988,7 +988,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         context = mock(InternalMockProcessorContext.class);
         when(context.metrics()).thenReturn(streamsMetrics);
         when(context.taskId()).thenReturn(taskId);
-        when(context.appConfigs()).thenReturn(new StreamsConfig(props).originals());
+        when(context.appConfigs()).thenReturn(new InternalStreamsConfig(props).originals());
         when(context.stateDir()).thenReturn(dir);
 
         rocksDBStore.init((StateStoreContext) context, rocksDBStore);
@@ -1078,13 +1078,13 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         final List<ConsumerRecord<byte[], byte[]>> entries = getChangelogRecords();
         final Properties props = StreamsTestUtils.getStreamsConfig();
         props.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, MockRocksDbConfigSetter.class);
-        props.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        props.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         dir = TestUtils.tempDirectory();
         context = new InternalMockProcessorContext<>(
                 dir,
                 Serdes.String(),
                 Serdes.String(),
-                new StreamsConfig(props)
+                new InternalStreamsConfig(props)
         );
         rocksDBStore.init((StateStoreContext) context, rocksDBStore);
         context.restoreWithHeaders(rocksDBStore.name(), entries);
@@ -1115,13 +1115,13 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         final List<ConsumerRecord<byte[], byte[]>> entries = getChangelogRecordsMultipleTopics();
         final Properties props = StreamsTestUtils.getStreamsConfig();
         props.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, MockRocksDbConfigSetter.class);
-        props.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        props.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         dir = TestUtils.tempDirectory();
         context = new InternalMockProcessorContext<>(
                 dir,
                 Serdes.String(),
                 Serdes.String(),
-                new StreamsConfig(props)
+                new InternalStreamsConfig(props)
         );
         rocksDBStore.init((StateStoreContext) context, rocksDBStore);
         context.restoreWithHeaders(rocksDBStore.name(), entries);
@@ -1154,13 +1154,13 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         final List<ConsumerRecord<byte[], byte[]>> entries = getChangelogRecordsWithTombstones();
         final Properties props = StreamsTestUtils.getStreamsConfig();
         props.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, MockRocksDbConfigSetter.class);
-        props.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        props.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         dir = TestUtils.tempDirectory();
         context = new InternalMockProcessorContext<>(
                 dir,
                 Serdes.String(),
                 Serdes.String(),
-                new StreamsConfig(props)
+                new InternalStreamsConfig(props)
         );
         rocksDBStore.init((StateStoreContext) context, rocksDBStore);
         context.restoreWithHeaders(rocksDBStore.name(), entries);
@@ -1178,13 +1178,13 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         final List<KeyValue<byte[], byte[]>> entries = getChangelogRecordsWithoutHeaders();
         final Properties props = StreamsTestUtils.getStreamsConfig();
         props.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, MockRocksDbConfigSetter.class);
-        props.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        props.put(InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
         dir = TestUtils.tempDirectory();
         context = new InternalMockProcessorContext<>(
                 dir,
                 Serdes.String(),
                 Serdes.String(),
-                new StreamsConfig(props)
+                new InternalStreamsConfig(props)
         );
         rocksDBStore.init((StateStoreContext) context, rocksDBStore);
         context.restore(rocksDBStore.name(), entries);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreTest.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.state.VersionedRecord;
 import org.apache.kafka.test.InternalMockProcessorContext;
@@ -74,7 +75,7 @@ public class RocksDBVersionedStoreTest {
             TestUtils.tempDirectory(),
             Serdes.String(),
             Serdes.String(),
-            new StreamsConfig(StreamsTestUtils.getStreamsConfig())
+            new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig())
         );
         context.setTime(BASE_TIMESTAMP);
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyWrapper;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.internals.StreamsConfigUtils;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
@@ -153,7 +154,7 @@ public class StreamThreadStateStoreProviderTest {
         stateDir = TestUtils.tempDirectory();
         properties.put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
 
-        final StreamsConfig streamsConfig = new StreamsConfig(properties);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(properties);
         final MockClientSupplier clientSupplier = new MockClientSupplier();
         configureClients(clientSupplier, "applicationId-kv-store-changelog");
         configureClients(clientSupplier, "applicationId-window-store-changelog");
@@ -401,7 +402,7 @@ public class StreamThreadStateStoreProviderTest {
                 QueryableStoreTypes.keyValueStore())));
     }
 
-    private StreamTask createStreamsTask(final StreamsConfig streamsConfig,
+    private StreamTask createStreamsTask(final InternalStreamsConfig streamsConfig,
                                          final MockClientSupplier clientSupplier,
                                          final ProcessorTopology topology,
                                          final TaskId taskId) {

--- a/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.CommitCallback;
 import org.apache.kafka.streams.processor.PunctuationType;
@@ -63,7 +64,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
+import static org.apache.kafka.streams.internals.InternalStreamsConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 import static org.apache.kafka.streams.processor.internals.StateRestoreCallbackAdapter.adapt;
 
 public class InternalMockProcessorContext<KOut, VOut>
@@ -90,7 +91,7 @@ public class InternalMockProcessorContext<KOut, VOut>
             null,
             null,
             new StreamsMetricsImpl(new Metrics(), "mock", StreamsConfig.METRICS_LATEST, new MockTime()),
-            new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
+            new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig()),
             null,
             null,
             Time.SYSTEM
@@ -98,7 +99,7 @@ public class InternalMockProcessorContext<KOut, VOut>
     }
 
     public InternalMockProcessorContext(final File stateDir,
-                                        final StreamsConfig config) {
+                                        final InternalStreamsConfig config) {
         this(
             stateDir,
             null,
@@ -122,7 +123,7 @@ public class InternalMockProcessorContext<KOut, VOut>
             null,
             null,
             streamsMetrics,
-            new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
+            new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig()),
             null,
             null,
             Time.SYSTEM
@@ -130,7 +131,7 @@ public class InternalMockProcessorContext<KOut, VOut>
     }
 
     public InternalMockProcessorContext(final File stateDir,
-                                        final StreamsConfig config,
+                                        final InternalStreamsConfig config,
                                         final RecordCollector collector) {
         this(
             stateDir,
@@ -152,7 +153,7 @@ public class InternalMockProcessorContext<KOut, VOut>
     public InternalMockProcessorContext(final File stateDir,
                                         final Serde<?> keySerde,
                                         final Serde<?> valueSerde,
-                                        final StreamsConfig config) {
+                                        final InternalStreamsConfig config) {
         this(
             stateDir,
             keySerde,
@@ -178,7 +179,7 @@ public class InternalMockProcessorContext<KOut, VOut>
             serdes.keySerde(),
             serdes.valueSerde(),
             new StreamsMetricsImpl(metrics, "mock", StreamsConfig.METRICS_LATEST, new MockTime()),
-            new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
+            new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig()),
             () -> collector,
             null,
             Time.SYSTEM
@@ -195,7 +196,7 @@ public class InternalMockProcessorContext<KOut, VOut>
             keySerde,
             valueSerde,
             new StreamsMetricsImpl(new Metrics(), "mock", StreamsConfig.METRICS_LATEST, new MockTime()),
-            new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
+            new InternalStreamsConfig(StreamsTestUtils.getStreamsConfig()),
             () -> collector,
             cache,
             Time.SYSTEM
@@ -206,7 +207,7 @@ public class InternalMockProcessorContext<KOut, VOut>
                                         final Serde<?> keySerde,
                                         final Serde<?> valueSerde,
                                         final StreamsMetricsImpl metrics,
-                                        final StreamsConfig config,
+                                        final InternalStreamsConfig config,
                                         final RecordCollector.Supplier collectorSupplier,
                                         final ThreadCache cache,
                                         final Time time) {
@@ -218,7 +219,7 @@ public class InternalMockProcessorContext<KOut, VOut>
                                         final Serde<?> keySerde,
                                         final Serde<?> valueSerde,
                                         final StreamsMetricsImpl metrics,
-                                        final StreamsConfig config,
+                                        final InternalStreamsConfig config,
                                         final RecordCollector.Supplier collectorSupplier,
                                         final ThreadCache cache,
                                         final Time time,
@@ -235,7 +236,7 @@ public class InternalMockProcessorContext<KOut, VOut>
         this.valueSerde = valueSerde;
         this.recordCollectorSupplier = collectorSupplier;
         this.time = time;
-        consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
+        consistencyEnabled = InternalStreamsConfig.getBoolean(
                 appConfigs(),
                 IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
                 false);

--- a/streams/src/test/java/org/apache/kafka/test/MockClientSupplier.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockClientSupplier.java
@@ -39,6 +39,8 @@ import static org.junit.Assert.assertFalse;
 public class MockClientSupplier implements KafkaClientSupplier {
     private static final ByteArraySerializer BYTE_ARRAY_SERIALIZER = new ByteArraySerializer();
 
+    public static int adminCount = 0;
+
     private Cluster cluster;
     private String applicationId;
 
@@ -58,6 +60,7 @@ public class MockClientSupplier implements KafkaClientSupplier {
 
     @Override
     public Admin getAdmin(final Map<String, Object> config) {
+        ++adminCount;
         return adminClient;
     }
 

--- a/streams/src/test/java/org/apache/kafka/test/MockInternalTopicManager.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockInternalTopicManager.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.internals.InternalTopicConfig;
 import org.apache.kafka.streams.processor.internals.InternalTopicManager;
 
@@ -37,7 +38,7 @@ public class MockInternalTopicManager extends InternalTopicManager {
     private final boolean mockCreateInternalTopics;
 
     public MockInternalTopicManager(final Time time,
-                                    final StreamsConfig streamsConfig,
+                                    final InternalStreamsConfig streamsConfig,
                                     final MockConsumer<byte[], byte[]> restoreConsumer,
                                     final boolean mockCreateInternalTopics) {
         super(time, new MockClientSupplier().getAdmin(streamsConfig.originals()), streamsConfig);

--- a/streams/src/test/java/org/apache/kafka/test/NoOpProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/NoOpProcessorContext.java
@@ -19,6 +19,7 @@ package org.apache.kafka.test;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.CommitCallback;
 import org.apache.kafka.streams.processor.PunctuationType;
@@ -55,11 +56,11 @@ public class NoOpProcessorContext extends AbstractProcessorContext<Object, Objec
         super(new TaskId(1, 1), streamsConfig(), new MockStreamsMetrics(new Metrics()), null);
     }
 
-    private static StreamsConfig streamsConfig() {
+    private static InternalStreamsConfig streamsConfig() {
         final Properties props = new Properties();
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "appId");
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "boot");
-        return new StreamsConfig(props);
+        return new InternalStreamsConfig(props);
     }
 
     @Override

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -42,6 +42,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.internals.StreamsConfigUtils;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -318,7 +319,7 @@ public class TopologyTestDriver implements Closeable {
         configCopy.putIfAbsent(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy-bootstrap-host:0");
         // provide randomized dummy app-id if it's not specified
         configCopy.putIfAbsent(StreamsConfig.APPLICATION_ID_CONFIG,  "dummy-topology-test-driver-app-id-" + ThreadLocalRandom.current().nextInt());
-        final StreamsConfig streamsConfig = new ClientUtils.QuietStreamsConfig(configCopy);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(configCopy);
         logIfTaskIdleEnabled(streamsConfig);
 
         logContext = new LogContext("topology-test-driver ");
@@ -373,7 +374,7 @@ public class TopologyTestDriver implements Closeable {
         setupTask(streamsConfig, streamsMetrics, cache, internalTopologyBuilder.topologyConfigs().getTaskConfig());
     }
 
-    private static void logIfTaskIdleEnabled(final StreamsConfig streamsConfig) {
+    private static void logIfTaskIdleEnabled(final InternalStreamsConfig streamsConfig) {
         final Long taskIdleTime = streamsConfig.getLong(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG);
         if (taskIdleTime > 0) {
             log.info("Detected {} config in use with TopologyTestDriver (set to {}ms)." +
@@ -387,7 +388,7 @@ public class TopologyTestDriver implements Closeable {
         }
     }
 
-    private StreamsMetricsImpl setupMetrics(final StreamsConfig streamsConfig) {
+    private StreamsMetricsImpl setupMetrics(final InternalStreamsConfig streamsConfig) {
         final String threadId = Thread.currentThread().getName();
 
         final MetricConfig metricConfig = new MetricConfig()
@@ -408,7 +409,7 @@ public class TopologyTestDriver implements Closeable {
     }
 
     private void setupTopology(final InternalTopologyBuilder builder,
-                               final StreamsConfig streamsConfig) {
+                               final InternalStreamsConfig streamsConfig) {
         internalTopologyBuilder = builder;
         internalTopologyBuilder.rewriteTopology(streamsConfig);
 
@@ -425,7 +426,7 @@ public class TopologyTestDriver implements Closeable {
     }
 
     private void setupGlobalTask(final Time mockWallClockTime,
-                                 final StreamsConfig streamsConfig,
+                                 final InternalStreamsConfig streamsConfig,
                                  final StreamsMetricsImpl streamsMetrics,
                                  final ThreadCache cache) {
         if (globalTopology != null) {
@@ -470,7 +471,7 @@ public class TopologyTestDriver implements Closeable {
     }
 
     @SuppressWarnings("deprecation")
-    private void setupTask(final StreamsConfig streamsConfig,
+    private void setupTask(final InternalStreamsConfig streamsConfig,
                            final StreamsMetricsImpl streamsMetrics,
                            final ThreadCache cache,
                            final TaskConfig taskConfig) {
@@ -1391,7 +1392,7 @@ public class TopologyTestDriver implements Closeable {
 
     private static class TestDriverProducer extends StreamsProducer {
 
-        public TestDriverProducer(final StreamsConfig config,
+        public TestDriverProducer(final InternalStreamsConfig config,
                                   final KafkaClientSupplier clientSupplier,
                                   final LogContext logContext,
                                   final Time time) {

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -28,6 +28,7 @@ import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.internals.ApiUtils;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.kstream.ValueTransformer;
 import org.apache.kafka.streams.processor.internals.ClientUtils;
@@ -61,7 +62,7 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
     // Immutable fields ================================================
     private final StreamsMetricsImpl metrics;
     private final TaskId taskId;
-    private final StreamsConfig config;
+    private final InternalStreamsConfig config;
     private final File stateDir;
 
     // settable record metadata ================================================
@@ -231,7 +232,7 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
         configCopy.putAll(config);
         configCopy.putIfAbsent(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy-bootstrap-host:0");
         configCopy.putIfAbsent(StreamsConfig.APPLICATION_ID_CONFIG, "dummy-mock-app-id");
-        final StreamsConfig streamsConfig = new ClientUtils.QuietStreamsConfig(configCopy);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(configCopy);
         this.taskId = taskId;
         this.config = streamsConfig;
         this.stateDir = stateDir;

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/api/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/api/MockProcessorContext.java
@@ -25,6 +25,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.internals.InternalStreamsConfig;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.kstream.ValueTransformer;
 import org.apache.kafka.streams.processor.Cancellable;
@@ -71,7 +72,7 @@ public class MockProcessorContext<KForward, VForward> implements ProcessorContex
     // Immutable fields ================================================
     private final StreamsMetricsImpl metrics;
     private final TaskId taskId;
-    private final StreamsConfig config;
+    private final InternalStreamsConfig config;
     private final File stateDir;
 
     // settable record metadata ================================================
@@ -247,7 +248,7 @@ public class MockProcessorContext<KForward, VForward> implements ProcessorContex
         configCopy.putAll(config);
         configCopy.putIfAbsent(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy-bootstrap-host:0");
         configCopy.putIfAbsent(StreamsConfig.APPLICATION_ID_CONFIG, "dummy-mock-app-id");
-        final StreamsConfig streamsConfig = new ClientUtils.QuietStreamsConfig(configCopy);
+        final InternalStreamsConfig streamsConfig = new InternalStreamsConfig(configCopy);
         this.taskId = taskId;
         this.config = streamsConfig;
         this.stateDir = stateDir;


### PR DESCRIPTION
This is a POC to refactor `StreamsConfig` to move "leaking" internal methods into a newly added subclass `InternalStreamsConfig`, following an already established pattern using for DSL config objects (like `Consumed`, `Produced`, `Materialized` etc). This change requires a KIP.

We would deprecate the following methods on `StreamsConfig` to be able to remove them w/o replacement in a future release, as we should consider them internal:
- `confgDef`
- `getMainConsumerConfig`
- `getRestoreConsumeConfig`
- `getGlobalConsumerConfig`
- `getProducerConfig`
- `getAdminConfig`
- `getClientTag`
- `getKafkaClientSupplier`
- `defaultKeySerde`
- `defaultValueSerde`
- `defaultTimestampExtractor`
- `defaultDeserializationHandler`
- `defaultProductionExceptionHandler`
- `main`
- `DUMMY_THREAD_INDEX`

In addition, this PR changes all internal usage from `StreamsConfig` to `InternalStreamsConfig`.

If we believe this is a reasonable change, I can prepare a KIP for it.