### PR TITLE
KAFKA-15563: Provide informative error messages when Connect REST requests time out

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -157,7 +157,7 @@
               files="(KafkaConfigBackingStore|Values|ConnectMetricsRegistry).java"/>
 
     <suppress checks="NPathComplexity"
-              files="(DistributedHerder|RestClient|RestServer|JsonConverter|KafkaConfigBackingStore|FileStreamSourceTask|WorkerSourceTask|TopicAdmin).java"/>
+              files="(DistributedHerder|AbstractHerder|RestClient|RestServer|JsonConverter|KafkaConfigBackingStore|FileStreamSourceTask|WorkerSourceTask|TopicAdmin).java"/>
 
     <!-- connect tests-->
     <suppress checks="ClassDataAbstractionCoupling"

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -59,6 +59,8 @@ import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.log4j.Level;
+import org.apache.kafka.connect.util.Stage;
+import org.apache.kafka.connect.util.TemporaryStage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,6 +85,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -124,6 +127,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
     private final ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy;
     protected volatile boolean running = false;
     private final ExecutorService connectorExecutor;
+    private final Time time;
     protected final Loggers loggers;
 
     private final ConcurrentMap<String, Connector> tempConnectors = new ConcurrentHashMap<>();
@@ -143,6 +147,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         this.configBackingStore = configBackingStore;
         this.connectorClientConfigOverridePolicy = connectorClientConfigOverridePolicy;
         this.connectorExecutor = Executors.newCachedThreadPool();
+        this.time = time;
         this.loggers = new Loggers(time);
     }
 
@@ -394,9 +399,16 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
     @Override
     public void validateConnectorConfig(Map<String, String> connectorProps, Callback<ConfigInfos> callback, boolean doLog) {
+        callback.recordStage(new Stage(
+                "waiting for a new thread to become available for connector validation",
+                time.milliseconds()
+        ));
         connectorExecutor.submit(() -> {
+            callback.recordStage(null);
             try {
-                ConfigInfos result = validateConnectorConfig(connectorProps, doLog);
+                Function<String, TemporaryStage> reportStage = description ->
+                        new TemporaryStage(description, time.milliseconds(), callback);
+                ConfigInfos result = validateConnectorConfig(connectorProps, reportStage, doLog);
                 callback.onCompletion(null, result);
             } catch (Throwable t) {
                 callback.onCompletion(t, null);
@@ -468,9 +480,17 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
             || SinkConnectorConfig.hasDlqTopicConfig(connProps);
     }
 
-    ConfigInfos validateConnectorConfig(Map<String, String> connectorProps, boolean doLog) {
+    ConfigInfos validateConnectorConfig(
+            Map<String, String> connectorProps,
+            Function<String, TemporaryStage> reportStage,
+            boolean doLog
+    ) {
+        String stageDescription;
         if (worker.configTransformer() != null) {
-            connectorProps = worker.configTransformer().transform(connectorProps);
+            stageDescription = "resolving transformed configuration properties for the connector";
+            try (TemporaryStage stage = reportStage.apply(stageDescription)) {
+                connectorProps = worker.configTransformer().transform(connectorProps);
+            }
         }
         String connType = connectorProps.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
         if (connType == null)
@@ -485,11 +505,17 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
             if (connector instanceof SourceConnector) {
                 connectorType = org.apache.kafka.connect.health.ConnectorType.SOURCE;
                 enrichedConfigDef = ConnectorConfig.enrich(plugins(), SourceConnectorConfig.configDef(), connectorProps, false);
-                validatedConnectorConfig = validateSourceConnectorConfig((SourceConnector) connector, enrichedConfigDef, connectorProps);
+                stageDescription = "validating source connector-specific properties for the connector";
+                try (TemporaryStage stage = reportStage.apply(stageDescription)) {
+                    validatedConnectorConfig = validateSourceConnectorConfig((SourceConnector) connector, enrichedConfigDef, connectorProps);
+                }
             } else {
                 connectorType = org.apache.kafka.connect.health.ConnectorType.SINK;
                 enrichedConfigDef = ConnectorConfig.enrich(plugins(), SinkConnectorConfig.configDef(), connectorProps, false);
-                validatedConnectorConfig = validateSinkConnectorConfig((SinkConnector) connector, enrichedConfigDef, connectorProps);
+                stageDescription = "validating sink connector-specific properties for the connector";
+                try (TemporaryStage stage = reportStage.apply(stageDescription)) {
+                    validatedConnectorConfig = validateSinkConnectorConfig((SinkConnector) connector, enrichedConfigDef, connectorProps);
+                }
             }
 
             connectorProps.entrySet().stream()
@@ -505,7 +531,11 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
             Set<String> allGroups = new LinkedHashSet<>(enrichedConfigDef.groups());
 
             // do custom connector-specific validation
-            ConfigDef configDef = connector.config();
+            ConfigDef configDef;
+            stageDescription = "retrieving the configuration definition from the connector";
+            try (TemporaryStage stage = reportStage.apply(stageDescription)) {
+                configDef = connector.config();
+            }
             if (null == configDef) {
                 throw new BadRequestException(
                         String.format(
@@ -514,7 +544,12 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                         )
                 );
             }
-            Config config = connector.validate(connectorProps);
+
+            Config config;
+            stageDescription = "performing multi-property validation for the connector";
+            try (TemporaryStage stage = reportStage.apply(stageDescription)) {
+                config = connector.validate(connectorProps);
+            }
             if (null == config) {
                 throw new BadRequestException(
                         String.format(
@@ -535,37 +570,46 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
             ConfigInfos adminConfigInfos = null;
 
             if (connectorUsesProducer(connectorType, connectorProps)) {
-                producerConfigInfos = validateClientOverrides(
-                    connName,
-                    ConnectorConfig.CONNECTOR_CLIENT_PRODUCER_OVERRIDES_PREFIX,
-                    connectorConfig,
-                    ProducerConfig.configDef(),
-                    connector.getClass(),
-                    connectorType,
-                    ConnectorClientConfigRequest.ClientType.PRODUCER,
-                    connectorClientConfigOverridePolicy);
+                stageDescription = "validating producer config overrides for the connector";
+                try (TemporaryStage stage = reportStage.apply(stageDescription)) {
+                    producerConfigInfos = validateClientOverrides(
+                            connName,
+                            ConnectorConfig.CONNECTOR_CLIENT_PRODUCER_OVERRIDES_PREFIX,
+                            connectorConfig,
+                            ProducerConfig.configDef(),
+                            connector.getClass(),
+                            connectorType,
+                            ConnectorClientConfigRequest.ClientType.PRODUCER,
+                            connectorClientConfigOverridePolicy);
+                }
             }
             if (connectorUsesAdmin(connectorType, connectorProps)) {
-                adminConfigInfos = validateClientOverrides(
-                    connName,
-                    ConnectorConfig.CONNECTOR_CLIENT_ADMIN_OVERRIDES_PREFIX,
-                    connectorConfig,
-                    AdminClientConfig.configDef(),
-                    connector.getClass(),
-                    connectorType,
-                    ConnectorClientConfigRequest.ClientType.ADMIN,
-                    connectorClientConfigOverridePolicy);
+                stageDescription = "validating admin config overrides for the connector";
+                try (TemporaryStage stage = reportStage.apply(stageDescription)) {
+                    adminConfigInfos = validateClientOverrides(
+                            connName,
+                            ConnectorConfig.CONNECTOR_CLIENT_ADMIN_OVERRIDES_PREFIX,
+                            connectorConfig,
+                            AdminClientConfig.configDef(),
+                            connector.getClass(),
+                            connectorType,
+                            ConnectorClientConfigRequest.ClientType.ADMIN,
+                            connectorClientConfigOverridePolicy);
+                }
             }
             if (connectorUsesConsumer(connectorType, connectorProps)) {
-                consumerConfigInfos = validateClientOverrides(
-                    connName,
-                    ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX,
-                    connectorConfig,
-                    ConsumerConfig.configDef(),
-                    connector.getClass(),
-                    connectorType,
-                    ConnectorClientConfigRequest.ClientType.CONSUMER,
-                    connectorClientConfigOverridePolicy);
+                stageDescription = "validating consumer config overrides for the connector";
+                try (TemporaryStage stage = reportStage.apply(stageDescription)) {
+                    consumerConfigInfos = validateClientOverrides(
+                            connName,
+                            ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX,
+                            connectorConfig,
+                            ConsumerConfig.configDef(),
+                            connector.getClass(),
+                            connectorType,
+                            ConnectorClientConfigRequest.ClientType.CONSUMER,
+                            connectorClientConfigOverridePolicy);
+                }
             }
             return mergeConfigInfos(connType, configInfos, producerConfigInfos, consumerConfigInfos, adminConfigInfos);
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -399,12 +399,13 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
     @Override
     public void validateConnectorConfig(Map<String, String> connectorProps, Callback<ConfigInfos> callback, boolean doLog) {
-        callback.recordStage(new Stage(
+        Stage waitingForThread = new Stage(
                 "waiting for a new thread to become available for connector validation",
                 time.milliseconds()
-        ));
+        );
+        callback.recordStage(waitingForThread);
         connectorExecutor.submit(() -> {
-            callback.recordStage(null);
+            waitingForThread.complete(time.milliseconds());
             try {
                 Function<String, TemporaryStage> reportStage = description ->
                         new TemporaryStage(description, callback, time);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -407,7 +407,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
             callback.recordStage(null);
             try {
                 Function<String, TemporaryStage> reportStage = description ->
-                        new TemporaryStage(description, time.milliseconds(), callback);
+                        new TemporaryStage(description, callback, time);
                 ConfigInfos result = validateConnectorConfig(connectorProps, reportStage, doLog);
                 callback.onCompletion(null, result);
             } catch (Throwable t) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1388,6 +1388,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     try (TickThreadStage stage = new TickThreadStage("restarting connector " + connName)) {
                         worker.stopAndAwaitConnector(connName);
                         startConnector(connName, callback);
+                        currentRequest = null;
                     } catch (Throwable t) {
                         callback.onCompletion(t, null);
                     }
@@ -2039,6 +2040,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 callback.onCompletion(null, null);
             }
         };
+        callback.recordStage(new Stage("starting the connector", time.milliseconds()));
         worker.startConnector(connectorName, configProps, ctx, this, initialState, onInitialStateChange);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1389,10 +1389,11 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 }
 
                 if (assignment.connectors().contains(connName)) {
-                    try (TickThreadStage stage = new TickThreadStage("restarting connector " + connName)) {
-                        worker.stopAndAwaitConnector(connName);
+                    try {
+                        try (TickThreadStage stage = new TickThreadStage("stopping restarted connector " + connName)) {
+                            worker.stopAndAwaitConnector(connName);
+                        }
                         startConnector(connName, callback);
-                        currentRequest = null;
                     } catch (Throwable t) {
                         callback.onCompletion(t, null);
                     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -75,6 +75,8 @@ import org.apache.kafka.connect.util.ConnectUtils;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.FutureCallback;
 import org.apache.kafka.connect.util.SinkUtils;
+import org.apache.kafka.connect.util.Stage;
+import org.apache.kafka.connect.util.TemporaryStage;
 import org.slf4j.Logger;
 
 import javax.crypto.KeyGenerator;
@@ -213,6 +215,8 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     private volatile long keyExpiration;
     private short currentProtocolVersion;
     private short backoffRetries;
+    private volatile DistributedHerderRequest currentRequest;
+    private volatile Stage tickThreadStage;
 
     // visible for testing
     // The latest pending restart request for each named connector
@@ -333,6 +337,8 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         keyExpiration = Long.MAX_VALUE;
         sessionKey = null;
         backoffRetries = BACKOFF_RETRIES;
+        currentRequest = null;
+        tickThreadStage = new Stage("awaiting startup", time.milliseconds());
 
         currentProtocolVersion = ConnectProtocolCompatibility.compatibility(
             config.getString(DistributedConfig.CONNECT_PROTOCOL_CONFIG)
@@ -362,7 +368,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             log.info("Herder starting");
             herderThread = Thread.currentThread();
 
-            startServices();
+            try (TickThreadStage stage = new TickThreadStage("reading to the end of internal topics")) {
+                startServices();
+            }
 
             log.info("Herder started");
             running = true;
@@ -371,6 +379,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 tick();
             }
 
+            recordTickThreadStage("beginning shutdown");
             halt();
 
             log.info("Herder stopped");
@@ -402,7 +411,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             }
 
             log.debug("Ensuring group membership is still active");
-            member.ensureActive();
+            try (TickThreadStage stage = new TickThreadStage("ensuring membership in the cluster")) {
+                member.ensureActive();
+            }
             // Ensure we're in a good state in our group. If not restart and everything should be setup to rejoin
             if (!handleRebalanceCompleted()) return;
         } catch (WakeupException e) {
@@ -418,7 +429,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 // We were accidentally fenced out, possibly by a zombie leader
                 try {
                     log.debug("Reclaiming write privileges for config topic after being fenced out");
-                    configBackingStore.claimWritePrivileges();
+                    try (TickThreadStage stage = new TickThreadStage("reclaiming write privileges for the config topic")) {
+                        configBackingStore.claimWritePrivileges();
+                    }
                     fencedFromConfigTopic = false;
                     log.debug("Successfully reclaimed write privileges for config topic after being fenced out");
                 } catch (Exception e) {
@@ -440,7 +453,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             keyExpiration = Long.MAX_VALUE;
             try {
                 SessionKey newSessionKey = new SessionKey(keyGenerator.generateKey(), now);
-                writeToConfigTopicAsLeader(() -> configBackingStore.putSessionKey(newSessionKey));
+                writeToConfigTopicAsLeader(
+                        "writing a new session key to the config topic",
+                        () -> configBackingStore.putSessionKey(newSessionKey)
+                );
             } catch (Exception e) {
                 log.info("Failed to write new session key to config topic; forcing a read to the end of the config topic before possibly retrying", e);
                 canReadConfigs = false;
@@ -461,7 +477,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             if (next == null) {
                 break;
             } else if (now >= next.at) {
-                requests.pollFirst();
+                currentRequest = requests.pollFirst();
             } else {
                 scheduledTick = next.at;
                 break;
@@ -534,7 +550,11 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             log.trace("Polling for group activity; will wait for {}ms or until poll is interrupted by "
                     + "either config backing store updates or a new external request",
                     nextRequestTimeoutMs);
-            member.poll(nextRequestTimeoutMs);
+            String pollDurationDescription = scheduledTick != null ? "for up to " + nextRequestTimeoutMs + "ms or " : "";
+            String stageDescription = "polling the group coordinator " + pollDurationDescription + "until interrupted";
+            try (TickThreadStage stage = new TickThreadStage(stageDescription)) {
+                member.poll(nextRequestTimeoutMs);
+            }
             // Ensure we're in a good state in our group. If not restart and everything should be setup to rejoin
             handleRebalanceCompleted();
         } catch (WakeupException e) { // FIXME should not be WakeupException
@@ -824,7 +844,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     callback.onCompletion(null, configState.connectors());
                 return null;
             },
-            forwardErrorCallback(callback)
+            forwardErrorAndTickThreadStages(callback)
         );
     }
 
@@ -845,7 +865,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 }
                 return null;
             },
-            forwardErrorCallback(callback)
+            forwardErrorAndTickThreadStages(callback)
         );
     }
 
@@ -865,7 +885,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 }
                 return null;
             },
-            forwardErrorCallback(callback)
+            forwardErrorAndTickThreadStages(callback)
         );
     }
 
@@ -894,12 +914,15 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     callback.onCompletion(new NotFoundException("Connector " + connName + " not found"), null);
                 } else {
                     log.trace("Removing connector config {} {}", connName, configState.connectors());
-                    writeToConfigTopicAsLeader(() -> configBackingStore.removeConnectorConfig(connName));
+                    writeToConfigTopicAsLeader(
+                            "removing the config for connector " + connName + " from the config topic",
+                            () -> configBackingStore.removeConnectorConfig(connName)
+                    );
                     callback.onCompletion(null, new Created<>(false, null));
                 }
                 return null;
             },
-            forwardErrorCallback(callback)
+            forwardErrorAndTickThreadStages(callback)
         );
     }
 
@@ -1058,7 +1081,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         log.trace("Submitting connector config write request {}", connName);
         addRequest(
             () -> {
-                validateConnectorConfig(config, (error, configInfos) -> {
+                validateConnectorConfig(config, callback.chainStaging((error, configInfos) -> {
                     if (error != null) {
                         callback.onCompletion(error, null);
                         return;
@@ -1085,7 +1108,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                             }
 
                             log.trace("Submitting connector config {} {} {}", connName, allowReplace, configState.connectors());
-                            writeToConfigTopicAsLeader(() -> configBackingStore.putConnectorConfig(connName, config, targetState));
+                            writeToConfigTopicAsLeader(
+                                    "writing a config for connector " + connName + " to the config topic",
+                                    () -> configBackingStore.putConnectorConfig(connName, config, targetState)
+                            );
 
                             // Note that we use the updated connector config despite the fact that we don't have an updated
                             // snapshot yet. The existing task info should still be accurate.
@@ -1094,12 +1120,12 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                             callback.onCompletion(null, new Created<>(!exists, info));
                             return null;
                         },
-                        forwardErrorCallback(callback)
+                        forwardErrorAndTickThreadStages(callback)
                     );
-                });
+                }));
                 return null;
             },
-            forwardErrorCallback(callback)
+            forwardErrorAndTickThreadStages(callback)
         );
     }
 
@@ -1124,7 +1150,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     // a non-empty set of task configs). A STOPPED connector with a non-empty set of tasks is less acceptable
                     // and likely to confuse users.
                     writeTaskConfigs(connName, Collections.emptyList());
-                    configBackingStore.putTargetState(connName, TargetState.STOPPED);
+                    String stageDescription = "writing the STOPPED target stage for connector " + connName + " to the config topic";
+                    try (TickThreadStage stage = new TickThreadStage(stageDescription)) {
+                        configBackingStore.putTargetState(connName, TargetState.STOPPED);
+                    }
                     // Force a read of the new target state for the connector
                     if (!refreshConfigSnapshot(workerSyncTimeoutMs)) {
                         log.warn("Failed to read to end of config topic after writing the STOPPED target state for connector {}", connName);
@@ -1133,7 +1162,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     callback.onCompletion(null, null);
                     return null;
                 },
-                forwardErrorCallback(callback)
+                forwardErrorAndTickThreadStages(callback)
         );
     }
 
@@ -1176,7 +1205,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 }
                 return null;
             },
-            forwardErrorCallback(callback)
+            forwardErrorAndTickThreadStages(callback)
         );
     }
 
@@ -1199,7 +1228,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 }
                 return null;
             },
-            forwardErrorCallback(callback)
+            forwardErrorAndTickThreadStages(callback)
         );
     }
 
@@ -1232,7 +1261,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     log.trace("Forwarding zombie fencing request for connector {} to leader at {}", id.connector(), fenceUrl);
                     forwardRequestExecutor.execute(() -> {
                         try {
-                            restClient.httpRequest(fenceUrl, "PUT", null, null, null, sessionKey, requestSignatureAlgorithm);
+                            String stageDescription = "Forwarding zombie fencing request to the leader at " + workerUrl;
+                            try (TemporaryStage stage = new TemporaryStage(stageDescription, time.milliseconds(), callback)) {
+                                restClient.httpRequest(fenceUrl, "PUT", null, null, null, sessionKey, requestSignatureAlgorithm);
+                            }
                             callback.onCompletion(null, null);
                         } catch (Throwable t) {
                             callback.onCompletion(t, null);
@@ -1261,7 +1293,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         addRequest(() -> {
             doFenceZombieSourceTasks(connName, callback);
             return null;
-        }, forwardErrorCallback(callback));
+        }, forwardErrorAndTickThreadStages(callback));
     }
 
     private void doFenceZombieSourceTasks(String connName, Callback<Void> callback) {
@@ -1325,7 +1357,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     log.debug("Skipping zombie fencing round but writing task count record for connector {} "
                             + "as both the most recent and the current generation of task configs only contain one task", connName);
                 }
-                writeToConfigTopicAsLeader(() -> configBackingStore.putTaskCountRecord(connName, taskCount));
+                writeToConfigTopicAsLeader(
+                        "writing a task count record for connector " + connName + " to the config topic",
+                        () -> configBackingStore.putTaskCountRecord(connName, taskCount)
+                );
             }
             callback.onCompletion(null, null);
         }
@@ -1350,7 +1385,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 }
 
                 if (assignment.connectors().contains(connName)) {
-                    try {
+                    try (TickThreadStage stage = new TickThreadStage("restarting connector " + connName)) {
                         worker.stopAndAwaitConnector(connName);
                         startConnector(connName, callback);
                     } catch (Throwable t) {
@@ -1363,7 +1398,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 }
                 return null;
             },
-            forwardErrorCallback(callback));
+            forwardErrorAndTickThreadStages(callback));
     }
 
     @Override
@@ -1384,7 +1419,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 }
 
                 if (assignment.tasks().contains(id)) {
-                    try {
+                    try (TickThreadStage stage = new TickThreadStage("restarting task " + id)) {
                         worker.stopAndAwaitTask(id);
                         if (startTask(id))
                             callback.onCompletion(null, null);
@@ -1400,7 +1435,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 }
                 return null;
             },
-            forwardErrorCallback(callback));
+            forwardErrorAndTickThreadStages(callback));
     }
 
     @Override
@@ -1422,7 +1457,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     }
                     if (isLeader()) {
                         // Write a restart request to the config backing store, to be executed asynchronously in tick()
-                        configBackingStore.putRestartRequest(request);
+                        String stageDescription = "writing restart request for connector " + request.connectorName() + " to the config topic";
+                        try (TickThreadStage stage = new TickThreadStage(stageDescription)) {
+                            configBackingStore.putRestartRequest(request);
+                        }
                         // Compute and send the response that this was accepted
                         Optional<RestartPlan> plan = buildRestartPlan(request);
                         if (!plan.isPresent()) {
@@ -1435,7 +1473,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     }
                     return null;
                 },
-                forwardErrorCallback(callback)
+                forwardErrorAndTickThreadStages(callback)
         );
     }
 
@@ -1455,7 +1493,8 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             pendingRestartRequests.clear();
         }
         restartRequests.forEach(restartRequest -> {
-            try {
+            String stageDescription = "handling restart request for connector " + restartRequest.connectorName();
+            try (TickThreadStage stage = new TickThreadStage(stageDescription)) {
                 doRestartConnectorAndTasks(restartRequest);
             } catch (Exception e) {
                 log.warn("Unexpected error while trying to process " + restartRequest + ", the restart request will be skipped.", e);
@@ -1538,7 +1577,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     super.connectorOffsets(connName, cb);
                     return null;
                 },
-                forwardErrorCallback(cb)
+                forwardErrorAndTickThreadStages(cb)
         );
     }
 
@@ -1567,14 +1606,14 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                                 worker.modifyConnectorOffsets(connName, configState.connectorConfig(connName), offsets, callback);
                             }
                             return null;
-                        }, forwardErrorCallback(callback));
+                        }, forwardErrorAndTickThreadStages(callback));
                     }
                 });
             } else {
                 worker.modifyConnectorOffsets(connName, configState.connectorConfig(connName), offsets, callback);
             }
             return null;
-        }, forwardErrorCallback(callback));
+        }, forwardErrorAndTickThreadStages(callback));
     }
 
     /**
@@ -1641,11 +1680,12 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
      * Note that it is not necessary to wrap every write to the config topic in this method, only the writes that should be performed
      * exclusively by the leader. For example, {@link ConfigBackingStore#putTargetState(String, TargetState)} does not require this
      * method, as it can be invoked by any worker in the cluster.
+     * @param description a description of the action; e.g., "writing 5 task configs for connector file-source"
      * @param write the action that writes to the config topic, such as {@link ConfigBackingStore#putSessionKey(SessionKey)} or
      *              {@link ConfigBackingStore#putConnectorConfig(String, Map, TargetState)}.
      */
-    private void writeToConfigTopicAsLeader(Runnable write) {
-        try {
+    private void writeToConfigTopicAsLeader(String description, Runnable write) {
+        try (TickThreadStage stage = new TickThreadStage(description)) {
             write.run();
         } catch (PrivilegedWriteException e) {
             log.warn("Failed to write to config topic as leader; will rejoin group if necessary and, if still leader, attempt to reclaim write privileges for the config topic", e);
@@ -1782,7 +1822,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
      * @return true if successful; false if timed out
      */
     private boolean refreshConfigSnapshot(long timeoutMs) {
-        try {
+        try (TickThreadStage stage = new TickThreadStage("reading to the end of the config topic")) {
             configBackingStore.refresh(timeoutMs, TimeUnit.MILLISECONDS);
             configState = configBackingStore.snapshot();
             log.info("Finished reading to end of log and updated config snapshot, new config log offset: {}", configState.offset());
@@ -1796,14 +1836,20 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
     private void backoff(long ms) {
         if (ConnectProtocolCompatibility.fromProtocolVersion(currentProtocolVersion) == EAGER) {
-            time.sleep(ms);
+            String stageDescription = "sleeping for a backoff duration of " + ms + "ms";
+            try (TickThreadStage stage = new TickThreadStage(stageDescription)) {
+                time.sleep(ms);
+            }
             return;
         }
 
         if (backoffRetries > 0) {
             int rebalanceDelayFraction =
                     config.getInt(DistributedConfig.SCHEDULED_REBALANCE_MAX_DELAY_MS_CONFIG) / 10 / backoffRetries;
-            time.sleep(rebalanceDelayFraction);
+            String stageDescription = "sleeping for a backoff duration of " + rebalanceDelayFraction + "ms";
+            try (TickThreadStage stage = new TickThreadStage(stageDescription)) {
+                time.sleep(rebalanceDelayFraction);
+            }
             --backoffRetries;
             return;
         }
@@ -1864,7 +1910,12 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             }
         }
 
-        startAndStop(callables);
+        if (!callables.isEmpty()) {
+            String stageDescription = "starting " + callables.size() + " connectors and tasks after a rebalance";
+            try (TickThreadStage stage = new TickThreadStage(stageDescription)) {
+                startAndStop(callables);
+            }
+        }
 
         synchronized (this) {
             runningAssignment = member.currentProtocolVersion() == CONNECT_PROTOCOL_V0
@@ -1982,7 +2033,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                         callback.onCompletion(null, null);
                         return null;
                     },
-                    forwardErrorCallback(callback)
+                    forwardErrorAndTickThreadStages(callback)
                 );
             } else {
                 callback.onCompletion(null, null);
@@ -2144,7 +2195,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                             .build()
                             .toString();
                     log.trace("Forwarding task configurations for connector {} to leader", connName);
-                    restClient.httpRequest(reconfigUrl, "POST", null, rawTaskProps, null, sessionKey, requestSignatureAlgorithm);
+                    String stageDescription = "Forwarding task configurations to the leader at " + leaderUrl;
+                    try (TemporaryStage stage = new TemporaryStage(stageDescription, time.milliseconds(), cb)) {
+                        restClient.httpRequest(reconfigUrl, "POST", null, rawTaskProps, null, sessionKey, requestSignatureAlgorithm);
+                    }
                     cb.onCompletion(null, null);
                 } catch (ConnectException e) {
                     log.error("Request to leader to reconfigure connector tasks failed", e);
@@ -2160,7 +2214,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 throw new BadRequestException("Cannot submit non-empty set of task configs for stopped connector " + connName);
         }
 
-        writeToConfigTopicAsLeader(() -> configBackingStore.putTaskConfigs(connName, taskConfigs));
+        writeToConfigTopicAsLeader(
+                "writing " + taskConfigs.size() + " task configs for connector " + connName + " to the config topic",
+                () -> configBackingStore.putTaskConfigs(connName, taskConfigs)
+        );
     }
 
     // Invoked by exactly-once worker source tasks after they have successfully initialized their transactional
@@ -2175,7 +2232,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
         addRequest(
             () -> verifyTaskGenerationAndOwnership(id, initialTaskGen, verifyCallback),
-            forwardErrorCallback(verifyCallback)
+            forwardErrorAndTickThreadStages(verifyCallback)
         );
 
         try {
@@ -2248,6 +2305,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         // queue was added
         if (peekWithoutException() == req)
             member.wakeup();
+        callback.recordStage(tickThreadStage);
         return req;
     }
 
@@ -2257,6 +2315,8 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             callback.onCompletion(null, null);
         } catch (Throwable t) {
             callback.onCompletion(t, null);
+        } finally {
+            currentRequest = null;
         }
     }
 
@@ -2439,11 +2499,12 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         }
     }
 
-    private static Callback<Void> forwardErrorCallback(final Callback<?> callback) {
-        return (error, result) -> {
+    private static Callback<Void> forwardErrorAndTickThreadStages(final Callback<?> callback) {
+        Callback<Void> cb = callback.chainStaging((error, result) -> {
             if (error != null)
                 callback.onCompletion(error, null);
-        };
+        });
+        return cb;
     }
 
     private void updateDeletedConnectorStatus() {
@@ -2666,6 +2727,39 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         return result;
     }
 
+    private synchronized void recordTickThreadStage(String description) {
+        log.trace("Recording new tick thread stage: {}", description);
+        // Preserve the current stage to report to requests submitted after this method is invoked
+        setTickThreadStage(new Stage(description, time.milliseconds()));
+    }
+
+    private synchronized void wipeTickThreadStage() {
+        log.trace("Wiping current tick thread stage; was {}", tickThreadStage);
+        setTickThreadStage(null);
+    }
+
+    private synchronized void setTickThreadStage(Stage stage) {
+        // Preserve the current stage to report to requests submitted after this method is invoked
+        this.tickThreadStage = stage;
+        // Report the current stage to all pending requests
+        requests.forEach(request -> request.callback().recordStage(tickThreadStage));
+        // And, if there is an in-progress request, report the stage to it as well
+        Optional.ofNullable(currentRequest).map(DistributedHerderRequest::callback)
+                .ifPresent(callback -> callback.recordStage(tickThreadStage));
+    }
+
+    private class TickThreadStage implements AutoCloseable {
+        public TickThreadStage(String description) {
+            if (description != null)
+                recordTickThreadStage(description);
+        }
+
+        @Override
+        public void close() {
+            wipeTickThreadStage();
+        }
+    }
+
     /**
      * Represents an active zombie fencing: that is, an in-progress attempt to invoke
      * {@link Worker#fenceZombies(String, int, Map)} and then, if successful, write a new task count
@@ -2699,18 +2793,21 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             if (fencingFuture != null) {
                 throw new IllegalStateException("Cannot invoke start() multiple times");
             }
-            fencingFuture = worker.fenceZombies(connName, tasksToFence, configState.connectorConfig(connName)).thenApply(ignored -> {
-                // This callback will be called on the same thread that invokes KafkaFuture::thenApply if
-                // the future is already completed. Since that thread is the herder tick thread, we don't need
-                // to perform follow-up logic through an additional herder request (and if we tried, it would lead
-                // to deadlock)
-                runOnTickThread(
-                        this::onZombieFencingSuccess,
-                        fencingFollowup
-                );
-                awaitFollowup();
-                return null;
-            });
+            String stageDescription = "initiating a round of zombie fencing for connector " + connName;
+            try (TickThreadStage stage = new TickThreadStage(stageDescription)) {
+                fencingFuture = worker.fenceZombies(connName, tasksToFence, configState.connectorConfig(connName)).thenApply(ignored -> {
+                    // This callback will be called on the same thread that invokes KafkaFuture::thenApply if
+                    // the future is already completed. Since that thread is the herder tick thread, we don't need
+                    // to perform follow-up logic through an additional herder request (and if we tried, it would lead
+                    // to deadlock)
+                    runOnTickThread(
+                            this::onZombieFencingSuccess,
+                            fencingFollowup
+                    );
+                    awaitFollowup();
+                    return null;
+                });
+            }
             // Immediately after the fencing and necessary followup work (i.e., writing the task count record to the config topic)
             // is complete, remove this from the list of active fencings
             addCallback((ignored, error) -> {
@@ -2736,7 +2833,10 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             if (fencingFollowup.isDone()) {
                 return null;
             }
-            writeToConfigTopicAsLeader(() -> configBackingStore.putTaskCountRecord(connName, tasksToRecord));
+            writeToConfigTopicAsLeader(
+                    "writing a task count record for connector " + connName + " to the config topic",
+                    () -> configBackingStore.putTaskCountRecord(connName, tasksToRecord)
+            );
             return null;
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -42,10 +42,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocolCollection;
 import static org.apache.kafka.common.message.JoinGroupResponseData.JoinGroupResponseMember;
+import static org.apache.kafka.common.utils.Utils.UncheckedCloseable;
 import static org.apache.kafka.connect.runtime.distributed.ConnectProtocolCompatibility.EAGER;
+
 
 /**
  * This class manages the coordination process with the Kafka group coordinator on the broker for managing assignments
@@ -120,7 +123,7 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
         return super.ensureCoordinatorReady(timer);
     }
 
-    public void poll(long timeout, Runnable onPoll) {
+    public void poll(long timeout, Supplier<UncheckedCloseable> onPoll) {
         // poll for io until the timeout expires
         final long start = time.milliseconds();
         long now = start;
@@ -130,8 +133,11 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
             if (coordinatorUnknown()) {
                 log.debug("Broker coordinator is marked unknown. Attempting discovery with a timeout of {}ms",
                         coordinatorDiscoveryTimeoutMs);
-                onPoll.run();
-                if (ensureCoordinatorReady(time.timer(coordinatorDiscoveryTimeoutMs))) {
+                boolean coordinatorReady;
+                try (UncheckedCloseable polling = onPoll.get()) {
+                    coordinatorReady = ensureCoordinatorReady(time.timer(coordinatorDiscoveryTimeoutMs));
+                }
+                if (coordinatorReady) {
                     log.debug("Broker coordinator is ready");
                 } else {
                     log.debug("Can not connect to broker coordinator");
@@ -147,8 +153,9 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
             }
 
             if (rejoinNeededOrPending()) {
-                onPoll.run();
-                ensureActiveGroup();
+                try (UncheckedCloseable polling = onPoll.get()) {
+                    ensureActiveGroup();
+                }
                 now = time.milliseconds();
             }
 
@@ -160,8 +167,9 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
             // Note that because the network client is shared with the background heartbeat thread,
             // we do not want to block in poll longer than the time to the next heartbeat.
             long pollTimeout = Math.min(Math.max(0, remaining), timeToNextHeartbeat(now));
-            onPoll.run();
-            client.poll(time.timer(pollTimeout));
+            try (UncheckedCloseable polling = onPoll.get()) {
+                client.poll(time.timer(pollTimeout));
+            }
 
             now = time.milliseconds();
             elapsed = now - start;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -48,6 +48,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.apache.kafka.common.utils.Utils.UncheckedCloseable;
 
 /**
  * This class manages the coordination process with brokers for the Connect cluster group membership. It ties together
@@ -158,11 +161,11 @@ public class WorkerGroupMember {
      * Ensure that the connection to the broker coordinator is up and that the worker is an
      * active member of the group.
      */
-    public void ensureActive(Runnable onPoll) {
+    public void ensureActive(Supplier<UncheckedCloseable> onPoll) {
         coordinator.poll(0, onPoll);
     }
 
-    public void poll(long timeout, Runnable onPoll) {
+    public void poll(long timeout, Supplier<UncheckedCloseable> onPoll) {
         if (timeout < 0)
             throw new IllegalArgumentException("Timeout must not be negative");
         coordinator.poll(timeout, onPoll);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -158,14 +158,14 @@ public class WorkerGroupMember {
      * Ensure that the connection to the broker coordinator is up and that the worker is an
      * active member of the group.
      */
-    public void ensureActive() {
-        coordinator.poll(0);
+    public void ensureActive(Runnable onPoll) {
+        coordinator.poll(0, onPoll);
     }
 
-    public void poll(long timeout) {
+    public void poll(long timeout, Runnable onPoll) {
         if (timeout < 0)
             throw new IllegalArgumentException("Timeout must not be negative");
-        coordinator.poll(timeout);
+        coordinator.poll(timeout, onPoll);
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/HerderRequestHandler.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/HerderRequestHandler.java
@@ -40,7 +40,7 @@ public class HerderRequestHandler {
 
     private final RestClient restClient;
 
-    private long requestTimeoutMs;
+    private volatile long requestTimeoutMs;
 
     public HerderRequestHandler(RestClient restClient, long requestTimeoutMs) {
         this.restClient = restClient;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/HerderRequestHandler.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/HerderRequestHandler.java
@@ -21,12 +21,14 @@ import org.apache.kafka.connect.runtime.distributed.RebalanceNeededException;
 import org.apache.kafka.connect.runtime.distributed.RequestTargetException;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
 import org.apache.kafka.connect.util.FutureCallback;
+import org.apache.kafka.connect.util.StagedTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
+import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -64,6 +66,13 @@ public class HerderRequestHandler {
             return cb.get(requestTimeoutMs, TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {
             throw e.getCause();
+        } catch (StagedTimeoutException e) {
+            String message = "Request timed out. The worker is currently " +
+                    e.stage().description + ", which began at " +
+                    Instant.ofEpochMilli(e.stage().started);
+            // This timeout is for the operation itself. None of the timeout error codes are relevant, so internal server
+            // error is the best option
+            throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), message);
         } catch (TimeoutException e) {
             // This timeout is for the operation itself. None of the timeout error codes are relevant, so internal server
             // error is the best option

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/HerderRequestHandler.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/HerderRequestHandler.java
@@ -21,6 +21,7 @@ import org.apache.kafka.connect.runtime.distributed.RebalanceNeededException;
 import org.apache.kafka.connect.runtime.distributed.RequestTargetException;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
 import org.apache.kafka.connect.util.FutureCallback;
+import org.apache.kafka.connect.util.Stage;
 import org.apache.kafka.connect.util.StagedTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,9 +68,18 @@ public class HerderRequestHandler {
         } catch (ExecutionException e) {
             throw e.getCause();
         } catch (StagedTimeoutException e) {
-            String message = "Request timed out. The worker is currently " +
-                    e.stage().description + ", which began at " +
-                    Instant.ofEpochMilli(e.stage().started);
+            String message;
+            Stage stage = e.stage();
+            if (stage.completed() != null) {
+                message = "Request timed out. The last operation the worker completed was "
+                        + stage.description() + ", which began at "
+                        + Instant.ofEpochMilli(stage.started()) + " and completed at "
+                        + Instant.ofEpochMilli(stage.completed());
+            } else {
+                message = "Request timed out. The worker is currently "
+                        + stage.description() + ", which began at "
+                        + Instant.ofEpochMilli(stage.started());
+            }
             // This timeout is for the operation itself. None of the timeout error codes are relevant, so internal server
             // error is the best option
             throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), message);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
@@ -27,6 +27,7 @@ import org.apache.kafka.connect.runtime.rest.entities.ConfigKeyInfo;
 import org.apache.kafka.connect.runtime.rest.entities.PluginInfo;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
 import org.apache.kafka.connect.util.FutureCallback;
+import org.apache.kafka.connect.util.Stage;
 import org.apache.kafka.connect.util.StagedTimeoutException;
 
 import javax.ws.rs.BadRequestException;
@@ -110,9 +111,18 @@ public class ConnectorPluginsResource implements ConnectResource {
         try {
             return validationCallback.get(requestTimeoutMs, TimeUnit.MILLISECONDS);
         } catch (StagedTimeoutException e) {
-            String message = "Request timed out. The worker is currently " +
-                    e.stage().description + ", which began at " +
-                    Instant.ofEpochMilli(e.stage().started);
+            Stage stage = e.stage();
+            String message;
+            if (stage.completed() != null) {
+                message = "Request timed out. The last operation the worker completed was "
+                        + stage.description() + ", which began at "
+                        + Instant.ofEpochMilli(stage.started()) + " and completed at "
+                        + Instant.ofEpochMilli(stage.completed());
+            } else {
+                message = "Request timed out. The worker is currently "
+                        + stage.description() + ", which began at "
+                        + Instant.ofEpochMilli(stage.started());
+            }
             // This timeout is for the operation itself. None of the timeout error codes are relevant, so internal server
             // error is the best option
             throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), message);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/Stage.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/Stage.java
@@ -16,17 +16,52 @@
  */
 package org.apache.kafka.connect.util;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 public class Stage {
-    public final String description;
-    public final long started;
+    private final String description;
+    private final long started;
+    private final AtomicLong completed;
 
     public Stage(String description, long started) {
+        if (started < 0)
+            throw new IllegalArgumentException("Invalid start timestamp " + started + "; cannot be negative");
+
         this.description = description;
         this.started = started;
+        this.completed = new AtomicLong(-1);
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public long started() {
+        return started;
+    }
+
+    public Long completed() {
+        long result = completed.get();
+        return result >= 0 ? result : null;
+    }
+
+    public synchronized void complete(long time) {
+        if (time < 0)
+            throw new IllegalArgumentException("Cannot complete stage with negative timestamp " + time);
+        if (time < started)
+            throw new IllegalArgumentException("Cannot complete stage with timestamp " + time + " before its start time " + started);
+
+        this.completed.updateAndGet(l -> {
+            if (l >= 0)
+                throw new IllegalStateException("Stage is already completed");
+
+            return time;
+        });
     }
 
     @Override
     public String toString() {
-        return description + "(started " + started + ")";
+        return description + "(started " + started + ", completed=" + completed() + ")";
     }
+
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/Stage.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/Stage.java
@@ -16,33 +16,17 @@
  */
 package org.apache.kafka.connect.util;
 
-/**
- * Generic interface for callbacks
- */
-public interface Callback<V> {
-    /**
-     * Invoked upon completion of the operation.
-     *
-     * @param error the error that caused the operation to fail, or null if no error occurred
-     * @param result the return value, or null if the operation failed
-     */
-    void onCompletion(Throwable error, V result);
+public class Stage {
+    public final String description;
+    public final long started;
 
-    default void recordStage(Stage stage) {
+    public Stage(String description, long started) {
+        this.description = description;
+        this.started = started;
     }
 
-    default <V2> Callback<V2> chainStaging(Callback<V2> chained) {
-        return new Callback<V2>() {
-            @Override
-            public void recordStage(Stage stage) {
-                Callback.this.recordStage(stage);
-            }
-
-            @Override
-            public void onCompletion(Throwable error, V2 result) {
-                chained.onCompletion(error, result);
-            }
-        };
+    @Override
+    public String toString() {
+        return description + "(started " + started + ")";
     }
-
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/StagedTimeoutException.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/StagedTimeoutException.java
@@ -16,33 +16,20 @@
  */
 package org.apache.kafka.connect.util;
 
-/**
- * Generic interface for callbacks
- */
-public interface Callback<V> {
-    /**
-     * Invoked upon completion of the operation.
-     *
-     * @param error the error that caused the operation to fail, or null if no error occurred
-     * @param result the return value, or null if the operation failed
-     */
-    void onCompletion(Throwable error, V result);
+import java.util.Objects;
+import java.util.concurrent.TimeoutException;
 
-    default void recordStage(Stage stage) {
+public class StagedTimeoutException extends TimeoutException {
+
+    private final Stage stage;
+
+    public StagedTimeoutException(Stage stage) {
+        super();
+        this.stage = Objects.requireNonNull(stage, "Stage may not be null");
     }
 
-    default <V2> Callback<V2> chainStaging(Callback<V2> chained) {
-        return new Callback<V2>() {
-            @Override
-            public void recordStage(Stage stage) {
-                Callback.this.recordStage(stage);
-            }
-
-            @Override
-            public void onCompletion(Throwable error, V2 result) {
-                chained.onCompletion(error, result);
-            }
-        };
+    public Stage stage() {
+        return stage;
     }
 
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TemporaryStage.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TemporaryStage.java
@@ -16,33 +16,18 @@
  */
 package org.apache.kafka.connect.util;
 
-/**
- * Generic interface for callbacks
- */
-public interface Callback<V> {
-    /**
-     * Invoked upon completion of the operation.
-     *
-     * @param error the error that caused the operation to fail, or null if no error occurred
-     * @param result the return value, or null if the operation failed
-     */
-    void onCompletion(Throwable error, V result);
+public class TemporaryStage implements AutoCloseable {
 
-    default void recordStage(Stage stage) {
+    private final Callback<?> callback;
+
+    public TemporaryStage(String description, long started, Callback<?> callback) {
+        this.callback = callback;
+        callback.recordStage(new Stage(description, started));
     }
 
-    default <V2> Callback<V2> chainStaging(Callback<V2> chained) {
-        return new Callback<V2>() {
-            @Override
-            public void recordStage(Stage stage) {
-                Callback.this.recordStage(stage);
-            }
-
-            @Override
-            public void onCompletion(Throwable error, V2 result) {
-                chained.onCompletion(error, result);
-            }
-        };
+    @Override
+    public void close() {
+        callback.recordStage(null);
     }
 
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TemporaryStage.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TemporaryStage.java
@@ -16,18 +16,22 @@
  */
 package org.apache.kafka.connect.util;
 
+import org.apache.kafka.common.utils.Time;
+
 public class TemporaryStage implements AutoCloseable {
 
-    private final Callback<?> callback;
+    private final Stage stage;
+    private final Time time;
 
-    public TemporaryStage(String description, long started, Callback<?> callback) {
-        this.callback = callback;
-        callback.recordStage(new Stage(description, started));
+    public TemporaryStage(String description, Callback<?> callback, Time time) {
+        this.stage = new Stage(description, time.milliseconds());
+        this.time = time;
+        callback.recordStage(stage);
     }
 
     @Override
     public void close() {
-        callback.recordStage(null);
+        stage.complete(time.milliseconds());
     }
 
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -191,6 +191,13 @@ public class BlockingConnectorTest {
 
         createNormalConnector();
         verifyNormalConnector();
+
+        // Try to restart the connector
+        assertRequestTimesOut(
+                "restart connector that blocks during initialize",
+                () -> connect.restartConnector(BLOCKING_CONNECTOR_NAME),
+                "The worker is currently starting the connector"
+        );
     }
 
     @Test
@@ -201,6 +208,13 @@ public class BlockingConnectorTest {
 
         createNormalConnector();
         verifyNormalConnector();
+
+        // Try to restart the connector
+        assertRequestTimesOut(
+                "restart connector that blocks during start",
+                () -> connect.restartConnector(BLOCKING_CONNECTOR_NAME),
+                "The worker is currently starting the connector"
+        );
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -133,6 +133,11 @@ public class BlockingConnectorTest {
                 NUM_WORKERS,
                 "Initial group of workers did not start in time"
         );
+
+        try (Response response = connect.requestGet(connect.endpointForResource("connectors/nonexistent"))) {
+            // hack: make sure the worker is actually up (has joined the cluster, created and read to the end of internal topics, etc.)
+            assertEquals(404, response.getStatus());
+        }
     }
 
     @After

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -784,6 +784,9 @@ public class ConnectWorkerIntegrationTest {
         workerProps.put(CONFIG_TOPIC_CONFIG, configTopic);
         // Workaround for KAFKA-15676, which can cause the scheduled rebalance delay to
         // be spuriously triggered after the group coordinator for a Connect cluster is bounced
+        // Set to 1 instead of 0 as another workaround for KAFKA-15693, which can cause
+        // connectors and tasks to be unassigned indefinitely if the scheduled rebalance delay
+        // is set to 0
         workerProps.put(SCHEDULED_REBALANCE_MAX_DELAY_MS_CONFIG, "1");
         connect = connectBuilder
                 .numBrokers(1)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -790,7 +790,6 @@ public class ConnectWorkerIntegrationTest {
                 .numWorkers(1)
                 .build();
         connect.start();
-
         connect.assertions().assertAtLeastNumWorkersAreUp(1,
                 "Worker did not start in time");
 
@@ -801,7 +800,6 @@ public class ConnectWorkerIntegrationTest {
         // Create a connector to ensure that the worker has completed startup
         log.info("Creating initial connector");
         connect.configureConnector(CONNECTOR_NAME, connectorConfig1);
-
         connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(
                 CONNECTOR_NAME, NUM_TASKS, "connector and tasks did not start in time"
         );
@@ -824,7 +822,7 @@ public class ConnectWorkerIntegrationTest {
         assertNotNull(e.getMessage());
         assertTrue(
                 "Message '" + e.getMessage() + "' does not match expected format",
-                e.getMessage().contains("Request timed out. The worker is currently polling the group coordinator")
+                e.getMessage().contains("Request timed out. The worker is currently flushing updates to the status topic")
         );
         log.info("Restarting Kafka cluster");
         connect.kafka().startOnlyKafkaOnSamePorts();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -61,6 +61,7 @@ import static org.apache.kafka.connect.runtime.TopicCreationConfig.REPLICATION_F
 import static org.apache.kafka.connect.runtime.WorkerConfig.CONNECTOR_CLIENT_POLICY_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG;
 import static org.apache.kafka.connect.runtime.distributed.DistributedConfig.CONFIG_TOPIC_CONFIG;
+import static org.apache.kafka.connect.runtime.distributed.DistributedConfig.SCHEDULED_REBALANCE_MAX_DELAY_MS_CONFIG;
 import static org.apache.kafka.connect.runtime.rest.resources.ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS;
 import static org.apache.kafka.connect.util.clusters.ConnectAssertions.CONNECTOR_SETUP_DURATION_MS;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -781,6 +782,9 @@ public class ConnectWorkerIntegrationTest {
     public void testRequestTimeouts() throws Exception {
         final String configTopic = "test-request-timeout-configs";
         workerProps.put(CONFIG_TOPIC_CONFIG, configTopic);
+        // Workaround for KAFKA-15676, which can cause the scheduled rebalance delay to
+        // be spuriously triggered after the group coordinator for a Connect cluster is bounced
+        workerProps.put(SCHEDULED_REBALANCE_MAX_DELAY_MS_CONFIG, "0");
         connect = connectBuilder
                 .numBrokers(1)
                 .numWorkers(1)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -784,7 +784,7 @@ public class ConnectWorkerIntegrationTest {
         workerProps.put(CONFIG_TOPIC_CONFIG, configTopic);
         // Workaround for KAFKA-15676, which can cause the scheduled rebalance delay to
         // be spuriously triggered after the group coordinator for a Connect cluster is bounced
-        workerProps.put(SCHEDULED_REBALANCE_MAX_DELAY_MS_CONFIG, "0");
+        workerProps.put(SCHEDULED_REBALANCE_MAX_DELAY_MS_CONFIG, "1");
         connect = connectBuilder
                 .numBrokers(1)
                 .numWorkers(1)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -785,10 +785,7 @@ public class ConnectWorkerIntegrationTest {
         workerProps.put(CONFIG_TOPIC_CONFIG, configTopic);
         // Workaround for KAFKA-15676, which can cause the scheduled rebalance delay to
         // be spuriously triggered after the group coordinator for a Connect cluster is bounced
-        // Set to 1 instead of 0 as another workaround for KAFKA-15693, which can cause
-        // connectors and tasks to be unassigned indefinitely if the scheduled rebalance delay
-        // is set to 0
-        workerProps.put(SCHEDULED_REBALANCE_MAX_DELAY_MS_CONFIG, "1");
+        workerProps.put(SCHEDULED_REBALANCE_MAX_DELAY_MS_CONFIG, "0");
         connect = connectBuilder
                 .numBrokers(1)
                 .numWorkers(1)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -820,6 +820,7 @@ public class ConnectWorkerIntegrationTest {
                 e.getMessage().contains("Request timed out. The worker is currently polling the group coordinator")
         );
         connect.kafka().startOnlyKafkaOnSamePorts();
+        connect.assertions().assertExactlyNumBrokersAreUp(1, "Broker did not complete startup in time");
 
         connect.requestTimeout(DEFAULT_REST_REQUEST_TIMEOUT_MS);
         // Reconfigure the connector to ensure that the broker has completed startup

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.rest.entities.CreateConnectorRequest;
 import org.apache.kafka.connect.runtime.rest.resources.ConnectorsResource;
+import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
 import org.apache.kafka.connect.util.clusters.WorkerHandle;
@@ -45,6 +46,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.connect.integration.MonitorableSourceConnector.TOPIC_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
@@ -58,12 +60,16 @@ import static org.apache.kafka.connect.runtime.TopicCreationConfig.PARTITIONS_CO
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.REPLICATION_FACTOR_CONFIG;
 import static org.apache.kafka.connect.runtime.WorkerConfig.CONNECTOR_CLIENT_POLICY_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG;
+import static org.apache.kafka.connect.runtime.distributed.DistributedConfig.CONFIG_TOPIC_CONFIG;
+import static org.apache.kafka.connect.runtime.rest.resources.ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS;
 import static org.apache.kafka.connect.util.clusters.ConnectAssertions.CONNECTOR_SETUP_DURATION_MS;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test simple operations on the workers of a Connect cluster.
@@ -769,6 +775,90 @@ public class ConnectWorkerIntegrationTest {
         props.put(TOPICS_CONFIG, topics);
 
         return props;
+    }
+
+    @Test
+    public void testRequestTimeouts() throws Exception {
+        final String configTopic = "test-request-timeout-configs";
+        workerProps.put(CONFIG_TOPIC_CONFIG, configTopic);
+        connect = connectBuilder
+                .numBrokers(1)
+                .numWorkers(1)
+                .build();
+        connect.start();
+
+        connect.assertions().assertAtLeastNumWorkersAreUp(1,
+                "Worker did not start in time");
+
+        Map<String, String> connectorConfig1 = defaultSourceConnectorProps(TOPIC_NAME);
+        Map<String, String> connectorConfig2 = new HashMap<>(connectorConfig1);
+        connectorConfig2.put(TASKS_MAX_CONFIG, Integer.toString(NUM_TASKS + 1));
+
+        // Create a connector to ensure that the worker has completed startup
+        connect.configureConnector(CONNECTOR_NAME, connectorConfig1);
+
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(
+                CONNECTOR_NAME, NUM_TASKS, "connector and tasks did not start in time"
+        );
+
+        // Bring down Kafka, which should cause some REST requests to fail
+        connect.kafka().stopOnlyKafka();
+        // Allow for the workers to discover that the coordinator is unavailable, wait is
+        // heartbeat timeout * 2 + 4sec
+        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+
+        connect.requestTimeout(5_000);
+        // Try to reconfigure the connector, which should fail with a timeout error
+        ConnectRestException e = assertThrows(
+                ConnectRestException.class,
+                () -> connect.configureConnector(CONNECTOR_NAME, connectorConfig2)
+        );
+        assertEquals(INTERNAL_SERVER_ERROR.getStatusCode(), e.statusCode());
+        assertNotNull(e.getMessage());
+        assertTrue(
+                "Message '" + e.getMessage() + "' does not match expected format",
+                e.getMessage().contains("Request timed out. The worker is currently polling the group coordinator")
+        );
+        connect.kafka().startOnlyKafkaOnSamePorts();
+
+        connect.requestTimeout(DEFAULT_REST_REQUEST_TIMEOUT_MS);
+        // Reconfigure the connector to ensure that the broker has completed startup
+        connect.configureConnector(CONNECTOR_NAME, connectorConfig2);
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(
+                CONNECTOR_NAME, NUM_TASKS + 1, "connector and tasks did not start in time"
+        );
+
+        // Delete the config topic--WCGW?
+        connect.kafka().deleteTopic(configTopic);
+
+        connect.requestTimeout(5_000);
+        // Try to delete the connector, which should fail with a slightly-different timeout error
+        e = assertThrows(
+                ConnectRestException.class,
+                () -> connect.deleteConnector(CONNECTOR_NAME)
+        );
+        assertEquals(INTERNAL_SERVER_ERROR.getStatusCode(), e.statusCode());
+        assertTrue(
+                "Message '" + e.getMessage() + "' does not match the expected format",
+                e.getMessage().contains(
+                        "Request timed out. The worker is currently removing the config for connector " +
+                                CONNECTOR_NAME + " from the config topic"
+                )
+        );
+
+        // The worker should still be blocked on the same operation
+        e = assertThrows(
+                ConnectRestException.class,
+                () -> connect.configureConnector(CONNECTOR_NAME, connectorConfig1)
+        );
+        assertEquals(INTERNAL_SERVER_ERROR.getStatusCode(), e.statusCode());
+        assertTrue(
+                "Message '" + e.getMessage() + "' does not match the expected format",
+                e.getMessage().contains(
+                        "Request timed out. The worker is currently removing the config for connector " +
+                                CONNECTOR_NAME + " from the config topic"
+                )
+        );
     }
 
     private Map<String, String> defaultSourceConnectorProps(String topic) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.policy.AllConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
+import org.apache.kafka.connect.connector.policy.NoneConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.connector.policy.PrincipalConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.NotFoundException;
@@ -164,7 +165,7 @@ public class AbstractHerderTest {
     private final String kafkaClusterId = "I4ZmrWqfT2e-upky_4fdPA";
     private final int generation = 5;
     private final String connectorName = "connector";
-    private final SampleConnectorClientConfigOverridePolicy noneConnectorClientConfigOverridePolicy = new SampleConnectorClientConfigOverridePolicy();
+    private final ConnectorClientConfigOverridePolicy noneConnectorClientConfigOverridePolicy = new NoneConnectorClientConfigOverridePolicy();
 
     @Mock private Worker worker;
     @Mock private WorkerConfigTransformer transformer;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -28,7 +28,6 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.policy.AllConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
-import org.apache.kafka.connect.connector.policy.NoneConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.connector.policy.PrincipalConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.NotFoundException;
@@ -165,7 +164,7 @@ public class AbstractHerderTest {
     private final String kafkaClusterId = "I4ZmrWqfT2e-upky_4fdPA";
     private final int generation = 5;
     private final String connectorName = "connector";
-    private final ConnectorClientConfigOverridePolicy noneConnectorClientConfigOverridePolicy = new NoneConnectorClientConfigOverridePolicy();
+    private final SampleConnectorClientConfigOverridePolicy noneConnectorClientConfigOverridePolicy = new SampleConnectorClientConfigOverridePolicy();
 
     @Mock private Worker worker;
     @Mock private WorkerConfigTransformer transformer;
@@ -360,7 +359,7 @@ public class AbstractHerderTest {
         config.put("required", "value");
         config.put("testKey", null);
 
-        final ConfigInfos configInfos = herder.validateConnectorConfig(config, false);
+        final ConfigInfos configInfos = herder.validateConnectorConfig(config, s -> null, false);
 
         assertEquals(1, configInfos.errorCount());
         assertErrorForKey(configInfos, "testKey");
@@ -378,7 +377,7 @@ public class AbstractHerderTest {
         config.put("testKey", null);
         config.put("secondTestKey", null);
 
-        final ConfigInfos configInfos = herder.validateConnectorConfig(config, false);
+        final ConfigInfos configInfos = herder.validateConnectorConfig(config, s -> null, false);
 
         assertEquals(2, configInfos.errorCount());
         assertErrorForKey(configInfos, "testKey");
@@ -448,7 +447,7 @@ public class AbstractHerderTest {
     public void testConfigValidationEmptyConfig() {
         AbstractHerder herder = createConfigValidationHerder(SampleSourceConnector.class, noneConnectorClientConfigOverridePolicy, 0);
 
-        assertThrows(BadRequestException.class, () -> herder.validateConnectorConfig(Collections.emptyMap(), false));
+        assertThrows(BadRequestException.class, () -> herder.validateConnectorConfig(Collections.emptyMap(), s -> null, false));
         verify(transformer).transform(Collections.emptyMap());
     }
 
@@ -458,7 +457,7 @@ public class AbstractHerderTest {
         AbstractHerder herder = createConfigValidationHerder(connectorClass, noneConnectorClientConfigOverridePolicy);
 
         Map<String, String> config = Collections.singletonMap(ConnectorConfig.CONNECTOR_CLASS_CONFIG, connectorClass.getName());
-        ConfigInfos result = herder.validateConnectorConfig(config, false);
+        ConfigInfos result = herder.validateConnectorConfig(config, s -> null, false);
 
         // We expect there to be errors due to the missing name and .... Note that these assertions depend heavily on
         // the config fields for SourceConnectorConfig, but we expect these to change rarely.
@@ -493,7 +492,7 @@ public class AbstractHerderTest {
         config.put(SinkConnectorConfig.TOPICS_CONFIG, "topic1,topic2");
         config.put(SinkConnectorConfig.TOPICS_REGEX_CONFIG, "topic.*");
 
-        ConfigInfos validation = herder.validateConnectorConfig(config, false);
+        ConfigInfos validation = herder.validateConnectorConfig(config, s -> null, false);
 
         ConfigInfo topicsListInfo = findInfo(validation, SinkConnectorConfig.TOPICS_CONFIG);
         assertNotNull(topicsListInfo);
@@ -516,7 +515,7 @@ public class AbstractHerderTest {
         config.put(SinkConnectorConfig.TOPICS_CONFIG, "topic1");
         config.put(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, "topic1");
 
-        ConfigInfos validation = herder.validateConnectorConfig(config, false);
+        ConfigInfos validation = herder.validateConnectorConfig(config, s -> null, false);
 
         ConfigInfo topicsListInfo = findInfo(validation, SinkConnectorConfig.TOPICS_CONFIG);
         assertNotNull(topicsListInfo);
@@ -535,7 +534,7 @@ public class AbstractHerderTest {
         config.put(SinkConnectorConfig.TOPICS_REGEX_CONFIG, "topic.*");
         config.put(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, "topic1");
 
-        ConfigInfos validation = herder.validateConnectorConfig(config, false);
+        ConfigInfos validation = herder.validateConnectorConfig(config, s -> null, false);
 
         ConfigInfo topicsRegexInfo = findInfo(validation, SinkConnectorConfig.TOPICS_REGEX_CONFIG);
         assertNotNull(topicsRegexInfo);
@@ -560,7 +559,7 @@ public class AbstractHerderTest {
         config.put(ConnectorConfig.TRANSFORMS_CONFIG, "xformA,xformB");
         config.put(ConnectorConfig.TRANSFORMS_CONFIG + ".xformA.type", SampleTransformation.class.getName());
         config.put("required", "value"); // connector required config
-        ConfigInfos result = herder.validateConnectorConfig(config, false);
+        ConfigInfos result = herder.validateConnectorConfig(config, s -> null, false);
         assertEquals(herder.connectorType(config), ConnectorType.SOURCE);
 
         // We expect there to be errors due to the missing name and .... Note that these assertions depend heavily on
@@ -616,7 +615,7 @@ public class AbstractHerderTest {
         config.put(ConnectorConfig.PREDICATES_CONFIG + ".predX.type", SamplePredicate.class.getName());
         config.put("required", "value"); // connector required config
 
-        ConfigInfos result = herder.validateConnectorConfig(config, false);
+        ConfigInfos result = herder.validateConnectorConfig(config, s -> null, false);
         assertEquals(ConnectorType.SOURCE, herder.connectorType(config));
 
         // We expect there to be errors due to the missing name and .... Note that these assertions depend heavily on
@@ -682,7 +681,7 @@ public class AbstractHerderTest {
         config.put(ackConfigKey, "none");
         config.put(saslConfigKey, "jaas_config");
 
-        ConfigInfos result = herder.validateConnectorConfig(config, false);
+        ConfigInfos result = herder.validateConnectorConfig(config, s -> null, false);
         assertEquals(herder.connectorType(config), ConnectorType.SOURCE);
 
         // We expect there to be errors due to now allowed override policy for ACKS.... Note that these assertions depend heavily on
@@ -741,7 +740,7 @@ public class AbstractHerderTest {
         overriddenClientConfigs.add(bootstrapServersConfigKey);
         overriddenClientConfigs.add(loginCallbackHandlerConfigKey);
 
-        ConfigInfos result = herder.validateConnectorConfig(config, false);
+        ConfigInfos result = herder.validateConnectorConfig(config, s -> null, false);
         assertEquals(herder.connectorType(config), ConnectorType.SOURCE);
 
         Map<String, String> validatedOverriddenClientConfigs = new HashMap<>();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -733,7 +733,7 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         // Initial rebalance where this member becomes the leader
         herder.tick();
@@ -750,7 +750,7 @@ public class DistributedHerderTest {
         doNothing().when(configBackingStore).putConnectorConfig(eq(CONN2), eq(CONN2_CONFIG), eq(TargetState.STOPPED));
 
         // This will occur just before/during the second tick
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
 
         // No immediate action besides this -- change will be picked up via the config log
         List<String> stages = expectRecordStages(putConnectorCallback);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -339,7 +339,7 @@ public class DistributedHerderTest {
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, invocation -> TASK_CONFIGS);
         when(worker.startSourceTask(eq(TASK1), any(), any(), any(), eq(herder), eq(TargetState.STARTED))).thenReturn(true);
 
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
         time.sleep(1000L);
@@ -363,7 +363,7 @@ public class DistributedHerderTest {
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, invocation -> TASK_CONFIGS);
         when(worker.startSourceTask(eq(TASK1), any(), any(), any(), eq(herder), eq(TargetState.STARTED))).thenReturn(true);
 
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         time.sleep(1000L);
         assertStatistics(0, 0, 0, Double.POSITIVE_INFINITY);
@@ -401,7 +401,7 @@ public class DistributedHerderTest {
         expectRebalance(1, Collections.emptyList(), Collections.emptyList());
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         time.sleep(1000L);
         assertStatistics(0, 0, 0, Double.POSITIVE_INFINITY);
@@ -446,7 +446,7 @@ public class DistributedHerderTest {
                 ConnectProtocol.Assignment.NO_ERROR, 1,
                 Collections.emptyList(), Collections.emptyList(), 0);
         doNothing().when(member).requestRejoin();
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.configState = SNAPSHOT;
         time.sleep(1000L);
@@ -487,7 +487,7 @@ public class DistributedHerderTest {
         doAnswer(invocation -> {
             time.sleep(9900L);
             return null;
-        }).when(member).poll(anyLong());
+        }).when(member).poll(anyLong(), any());
 
         // Request to re-join expected because the scheduled rebalance delay has been reached
         doNothing().when(member).requestRejoin();
@@ -511,7 +511,7 @@ public class DistributedHerderTest {
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, invocation -> TASK_CONFIGS);
         when(worker.startSourceTask(eq(TASK1), any(), any(), any(), eq(herder), eq(TargetState.STARTED))).thenReturn(true);
 
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
         time.sleep(2000L);
@@ -536,7 +536,7 @@ public class DistributedHerderTest {
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, invocation -> TASK_CONFIGS);
         when(worker.startSourceTask(eq(TASK1), any(), any(), any(), eq(herder), eq(TargetState.STARTED))).thenReturn(true);
 
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
         time.sleep(1000L);
@@ -593,7 +593,7 @@ public class DistributedHerderTest {
         when(worker.startSourceTask(eq(TASK1), any(), any(), any(), eq(herder), eq(TargetState.STARTED))).thenReturn(true);
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, invocation -> TASK_CONFIGS);
 
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
@@ -651,7 +651,7 @@ public class DistributedHerderTest {
 
         // The tick loop where the revoke happens returns early (because there's a subsequent rebalance) and doesn't result in a poll at
         // the end of the method
-        verify(member, times(2)).poll(anyLong());
+        verify(member, times(2)).poll(anyLong(), any());
 
         verifyNoMoreInteractions(member, statusBackingStore, configBackingStore, worker);
     }
@@ -678,7 +678,7 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         // Initial rebalance where this member becomes the leader
         herder.tick();
@@ -695,7 +695,7 @@ public class DistributedHerderTest {
         doNothing().when(configBackingStore).putConnectorConfig(eq(CONN2), eq(CONN2_CONFIG), isNull());
 
         // This will occur just before/during the second tick
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
 
         // No immediate action besides this -- change will be picked up via the config log
 
@@ -787,7 +787,7 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         // Initial rebalance where this member becomes the leader
         herder.tick();
@@ -804,7 +804,7 @@ public class DistributedHerderTest {
                 .when(configBackingStore).putConnectorConfig(eq(CONN2), eq(CONN2_CONFIG), isNull());
 
         // This will occur just before/during the second tick
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
 
         List<String> stages = expectRecordStages(putConnectorCallback);
 
@@ -840,7 +840,7 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         HashMap<String, String> config = new HashMap<>(CONN2_CONFIG);
         config.remove(ConnectorConfig.NAME_CONFIG);
@@ -859,7 +859,7 @@ public class DistributedHerderTest {
         herder.tick();
 
         // We don't need another rebalance to occur
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         herder.tick();
         time.sleep(1000L);
         assertStatistics(3, 1, 100, 1000L);
@@ -930,7 +930,7 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         // mock the actual validation since its asynchronous nature is difficult to test and should
         // be covered sufficiently by the unit tests for the AbstractHerder class
@@ -946,7 +946,7 @@ public class DistributedHerderTest {
         herder.tick();
 
         // We don't need another rebalance to occur
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         herder.tick();
         time.sleep(1000L);
         assertStatistics(3, 1, 100, 1000L);
@@ -981,7 +981,7 @@ public class DistributedHerderTest {
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, invocation -> TASK_CONFIGS);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         // And delete the connector
         doNothing().when(configBackingStore).removeConnectorConfig(CONN1);
@@ -1022,7 +1022,7 @@ public class DistributedHerderTest {
                         "awaiting startup",
                         "ensuring membership in the cluster",
                         "reading to the end of the config topic",
-                        "starting 1 connectors and tasks after a rebalance",
+                        "starting 1 connector(s) and task(s) after a rebalance",
                         "removing the config for connector sourceA from the config topic"
                 ),
                 stages
@@ -1039,7 +1039,7 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         ArgumentCaptor<Callback<TargetState>> onStart = ArgumentCaptor.forClass(Callback.class);
         doAnswer(invocation -> {
@@ -1051,7 +1051,7 @@ public class DistributedHerderTest {
         // Initial rebalance where this member becomes the leader
         herder.tick();
 
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
 
         doNothing().when(worker).stopAndAwaitConnector(CONN1);
 
@@ -1075,12 +1075,12 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
         // now handle the connector restart
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         FutureCallback<Void> callback = new FutureCallback<>();
         herder.restartConnector(CONN2, callback);
         herder.tick();
@@ -1098,12 +1098,12 @@ public class DistributedHerderTest {
         expectRebalance(1, Collections.emptyList(), Collections.emptyList());
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
         // now handle the connector restart
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
 
         FutureCallback<Void> callback = new FutureCallback<>();
         herder.restartConnector(CONN1, callback);
@@ -1123,12 +1123,12 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
         // now handle the connector restart
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         String ownerUrl = "ownerUrl";
         when(member.ownerUrl(CONN1)).thenReturn(ownerUrl);
 
@@ -1161,12 +1161,12 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
         // now handle the connector restart
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         herder.tick();
         FutureCallback<ConnectorStateInfo> callback = new FutureCallback<>();
         herder.restartConnectorAndTasks(restartRequest, callback);
@@ -1185,12 +1185,12 @@ public class DistributedHerderTest {
         when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);
         expectRebalance(1, Collections.emptyList(), Collections.emptyList());
         expectConfigRefreshAndSnapshot(SNAPSHOT);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
         // now handle the connector restart
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
 
         herder.tick();
         FutureCallback<ConnectorStateInfo> callback = new FutureCallback<>();
@@ -1212,12 +1212,12 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
         // now handle the connector restart
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         when(statusBackingStore.get(CONN1)).thenReturn(null);
         RestartRequest restartRequest = new RestartRequest(CONN1, false, true);
         doNothing().when(configBackingStore).putRestartRequest(restartRequest);
@@ -1241,12 +1241,12 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
         // now handle the connector restart
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
 
         RestartPlan restartPlan = mock(RestartPlan.class);
         ConnectorStateInfo connectorStateInfo = mock(ConnectorStateInfo.class);
@@ -1399,14 +1399,14 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         when(worker.startSourceTask(eq(TASK0), any(), any(), any(), eq(herder), any())).thenReturn(true);
 
         herder.tick();
 
         // now handle the task restart
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         doNothing().when(worker).stopAndAwaitTask(TASK0);
         FutureCallback<Void> callback = new FutureCallback<>();
         herder.restartTask(TASK0, callback);
@@ -1425,11 +1425,11 @@ public class DistributedHerderTest {
         when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);
         expectRebalance(1, Collections.emptyList(), Collections.emptyList());
         expectConfigRefreshAndSnapshot(SNAPSHOT);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         FutureCallback<Void> callback = new FutureCallback<>();
         herder.restartTask(new ConnectorTaskId("blah", 0), callback);
         herder.tick();
@@ -1447,12 +1447,12 @@ public class DistributedHerderTest {
         when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);
         expectRebalance(1, Collections.emptyList(), Collections.emptyList());
         expectConfigRefreshAndSnapshot(SNAPSHOT);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
         // now handle the task restart
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         FutureCallback<Void> callback = new FutureCallback<>();
         herder.restartTask(TASK0, callback);
         herder.tick();
@@ -1472,14 +1472,14 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
         // now handle the task restart
         String ownerUrl = "ownerUrl";
         when(member.ownerUrl(TASK0)).thenReturn(ownerUrl);
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
 
         FutureCallback<Void> callback = new FutureCallback<>();
         herder.restartTask(TASK0, callback);
@@ -1516,7 +1516,7 @@ public class DistributedHerderTest {
 
         // join, no configs so no need to catch up on config topic
         expectRebalance(-1, Collections.emptyList(), Collections.emptyList());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick(); // join
 
@@ -1555,7 +1555,7 @@ public class DistributedHerderTest {
         // join
         expectRebalance(1, Arrays.asList(CONN1), Collections.emptyList());
         expectConfigRefreshAndSnapshot(SNAPSHOT);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         ArgumentCaptor<Callback<TargetState>> onStart = ArgumentCaptor.forClass(Callback.class);
         doAnswer(invocation -> {
@@ -1567,7 +1567,7 @@ public class DistributedHerderTest {
         herder.tick();
 
         // apply config
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         when(configBackingStore.snapshot()).thenReturn(SNAPSHOT); // for this test, it doesn't matter if we use the same config snapshot
         doNothing().when(worker).stopAndAwaitConnector(CONN1);
 
@@ -1590,7 +1590,7 @@ public class DistributedHerderTest {
         // join
         expectRebalance(1, Arrays.asList(CONN1), Collections.emptyList());
         expectConfigRefreshAndSnapshot(SNAPSHOT);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         ArgumentCaptor<Callback<TargetState>> onStart = ArgumentCaptor.forClass(Callback.class);
         doAnswer(invocation -> {
@@ -1602,7 +1602,7 @@ public class DistributedHerderTest {
         herder.tick();
 
         // apply config
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         // During the next tick, throw an error from the transformer
         ClusterConfigState snapshotWithTransform = new ClusterConfigState(
                 1,
@@ -1645,7 +1645,7 @@ public class DistributedHerderTest {
         // join
         expectRebalance(1, Arrays.asList(CONN1), Collections.emptyList());
         expectConfigRefreshAndSnapshot(SNAPSHOT);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         ArgumentCaptor<Callback<TargetState>> onStart = ArgumentCaptor.forClass(Callback.class);
         doAnswer(invocation -> {
@@ -1657,7 +1657,7 @@ public class DistributedHerderTest {
         herder.tick(); // join
 
         // handle the state change
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         when(configBackingStore.snapshot()).thenReturn(SNAPSHOT_PAUSED_CONN1);
 
         ArgumentCaptor<Callback<TargetState>> onPause = ArgumentCaptor.forClass(Callback.class);
@@ -1682,7 +1682,7 @@ public class DistributedHerderTest {
         // start with the connector paused
         expectRebalance(1, Arrays.asList(CONN1), Collections.emptyList());
         expectConfigRefreshAndSnapshot(SNAPSHOT_PAUSED_CONN1);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         ArgumentCaptor<Callback<TargetState>> onStart = ArgumentCaptor.forClass(Callback.class);
         doAnswer(invocation -> {
@@ -1693,7 +1693,7 @@ public class DistributedHerderTest {
         herder.tick(); // join
 
         // handle the state change
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         when(configBackingStore.snapshot()).thenReturn(SNAPSHOT);
 
         ArgumentCaptor<Callback<TargetState>> onResume = ArgumentCaptor.forClass(Callback.class);
@@ -1722,7 +1722,7 @@ public class DistributedHerderTest {
         // join
         expectRebalance(1, Arrays.asList(CONN1), Collections.emptyList());
         expectConfigRefreshAndSnapshot(SNAPSHOT);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         ArgumentCaptor<Callback<TargetState>> onStart = ArgumentCaptor.forClass(Callback.class);
         doAnswer(invocation -> {
@@ -1734,7 +1734,7 @@ public class DistributedHerderTest {
         herder.tick(); // join
 
         // handle the state change
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         when(configBackingStore.snapshot()).thenReturn(SNAPSHOT_STOPPED_CONN1);
 
         ArgumentCaptor<Callback<TargetState>> onStop = ArgumentCaptor.forClass(Callback.class);
@@ -1759,14 +1759,14 @@ public class DistributedHerderTest {
         // join
         expectRebalance(1, Collections.emptyList(), singletonList(TASK0));
         expectConfigRefreshAndSnapshot(SNAPSHOT);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         when(worker.startSourceTask(eq(TASK0), any(), any(), any(), eq(herder), eq(TargetState.STARTED))).thenReturn(true);
 
         herder.tick(); // join
 
         // state change is ignored since we have no target state
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         when(configBackingStore.snapshot()).thenReturn(SNAPSHOT);
 
         configUpdateListener.onConnectorTargetStateChange("unknown-connector");
@@ -1785,14 +1785,14 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         when(worker.startSourceTask(eq(TASK0), any(), any(), any(), eq(herder), eq(TargetState.STARTED))).thenReturn(true);
 
         herder.tick(); // join
 
         // handle stop request
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         expectConfigRefreshAndSnapshot(SNAPSHOT);
         doNothing().when(configBackingStore).putTaskConfigs(CONN1, Collections.emptyList());
         doNothing().when(configBackingStore).putTargetState(CONN1, TargetState.STOPPED);
@@ -1816,14 +1816,14 @@ public class DistributedHerderTest {
         // join as member (non-leader)
         expectRebalance(1, Collections.emptyList(), singletonList(TASK0));
         expectConfigRefreshAndSnapshot(SNAPSHOT);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         when(worker.startSourceTask(eq(TASK0), any(), any(), any(), eq(herder), eq(TargetState.STARTED))).thenReturn(true);
 
         herder.tick();
 
         // handle stop request
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         FutureCallback<Void> cb = new FutureCallback<>();
 
         herder.stopConnector(CONN1, cb); // external request
@@ -1850,7 +1850,7 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         when(worker.startSourceTask(eq(TASK0), any(), any(), any(), eq(herder), eq(TargetState.STARTED))).thenReturn(true);
 
@@ -1858,7 +1858,7 @@ public class DistributedHerderTest {
 
         ConnectException taskConfigsWriteException = new ConnectException("Could not write task configs to config topic");
         // handle stop request
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         doThrow(taskConfigsWriteException).when(configBackingStore).putTaskConfigs(CONN1, Collections.emptyList());
         // We do not expect configBackingStore::putTargetState to be invoked, which
         // is intentional since that call should only take place if we are first able to
@@ -1891,14 +1891,14 @@ public class DistributedHerderTest {
         // join
         expectRebalance(1, Collections.emptyList(), singletonList(TASK0));
         expectConfigRefreshAndSnapshot(SNAPSHOT);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         when(worker.startSourceTask(eq(TASK0), any(), any(), any(), eq(herder), eq(TargetState.STARTED))).thenReturn(true);
 
         herder.tick(); // join
 
         // handle the state change
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         when(configBackingStore.snapshot()).thenReturn(SNAPSHOT_PAUSED_CONN1);
 
         ArgumentCaptor<Callback<TargetState>> onPause = ArgumentCaptor.forClass(Callback.class);
@@ -1925,14 +1925,14 @@ public class DistributedHerderTest {
         // join
         expectRebalance(1, Collections.emptyList(), singletonList(TASK0));
         expectConfigRefreshAndSnapshot(SNAPSHOT_PAUSED_CONN1);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         when(worker.startSourceTask(eq(TASK0), any(), any(), any(), eq(herder), eq(TargetState.PAUSED))).thenReturn(true);
 
         herder.tick(); // join
 
         // handle the state change
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         when(configBackingStore.snapshot()).thenReturn(SNAPSHOT);
 
         ArgumentCaptor<Callback<TargetState>> onStart = ArgumentCaptor.forClass(Callback.class);
@@ -1958,7 +1958,7 @@ public class DistributedHerderTest {
 
         // join
         expectRebalance(-1, Collections.emptyList(), Collections.emptyList());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick(); // join
 
@@ -2022,7 +2022,7 @@ public class DistributedHerderTest {
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, invocation -> TASK_CONFIGS);
 
         when(worker.startSourceTask(eq(TASK1), any(), any(), any(), eq(herder), eq(TargetState.STARTED))).thenReturn(true);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
         assertEquals(before + coordinatorDiscoveryTimeoutMs, time.milliseconds());
@@ -2051,7 +2051,7 @@ public class DistributedHerderTest {
         expectRebalance(1, Arrays.asList(CONN1), Arrays.asList(TASK1), true);
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         ArgumentCaptor<Callback<TargetState>> onStart = ArgumentCaptor.forClass(Callback.class);
         doAnswer(invocation -> {
@@ -2125,7 +2125,7 @@ public class DistributedHerderTest {
         expectRebalance(1, Arrays.asList(CONN1), Arrays.asList(TASK1), true);
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         ArgumentCaptor<Callback<TargetState>> onStart = ArgumentCaptor.forClass(Callback.class);
         doAnswer(invocation -> {
@@ -2204,7 +2204,7 @@ public class DistributedHerderTest {
 
         expectRebalance(1, Collections.emptyList(), Collections.emptyList(), true);
 
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         WorkerConfigTransformer configTransformer = mock(WorkerConfigTransformer.class);
 
@@ -2276,7 +2276,7 @@ public class DistributedHerderTest {
         }).when(worker).startConnector(eq(CONN1), eq(CONN1_CONFIG), any(), eq(herder), eq(TargetState.STARTED), onStart.capture());
         expectExecuteTaskReconfiguration(true, conn1SinkConfig, invocation -> TASK_CONFIGS);
 
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         // Should pick up original config
         FutureCallback<Map<String, String>> connectorConfigCb = new FutureCallback<>();
@@ -2286,7 +2286,7 @@ public class DistributedHerderTest {
         assertEquals(CONN1_CONFIG, connectorConfigCb.get());
 
         // Poll loop for second round of calls
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
 
         ArgumentCaptor<Callback<ConfigInfos>> validateCallback = ArgumentCaptor.forClass(Callback.class);
         doAnswer(invocation -> {
@@ -2342,12 +2342,12 @@ public class DistributedHerderTest {
         expectRebalance(1, Collections.emptyList(), Collections.emptyList());
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
         // First rebalance: poll indefinitely as no key has been read yet, so expiration doesn't come into play
-        verify(member).poll(eq(Long.MAX_VALUE));
+        verify(member).poll(eq(Long.MAX_VALUE), any());
 
         expectRebalance(2, Collections.emptyList(), Collections.emptyList());
         SessionKey initialKey = new SessionKey(mock(SecretKey.class), 0);
@@ -2368,7 +2368,7 @@ public class DistributedHerderTest {
         herder.tick();
 
         // Second rebalance: poll indefinitely as worker is follower, so expiration still doesn't come into play
-        verify(member, times(2)).poll(eq(Long.MAX_VALUE));
+        verify(member, times(2)).poll(eq(Long.MAX_VALUE), any());
 
         expectRebalance(2, Collections.emptyList(), Collections.emptyList(), "member", MEMBER_URL, true);
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
@@ -2381,7 +2381,7 @@ public class DistributedHerderTest {
         herder.tick();
 
         // Third rebalance: poll for a limited time as worker has become leader and must wake up for key expiration
-        verify(member).poll(eq(rotationTtlDelay));
+        verify(member).poll(eq(rotationTtlDelay), any());
         verifyNoMoreInteractions(worker, member, configBackingStore, statusBackingStore);
     }
 
@@ -2409,19 +2409,19 @@ public class DistributedHerderTest {
                 Collections.emptySet(),
                 Collections.emptySet());
         expectConfigRefreshAndSnapshot(snapshotWithKey);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         configUpdateListener.onSessionKeyUpdate(initialKey);
         herder.tick();
 
         // First rebalance: poll for a limited time as worker is leader and must wake up for key expiration
-        verify(member).poll(leq(rotationTtlDelay));
+        verify(member).poll(leq(rotationTtlDelay), any());
 
         expectRebalance(1, Collections.emptyList(), Collections.emptyList());
         herder.tick();
 
         // Second rebalance: poll indefinitely as worker is no longer leader, so key expiration doesn't come into play
-        verify(member).poll(eq(Long.MAX_VALUE));
+        verify(member).poll(eq(Long.MAX_VALUE), any());
         verifyNoMoreInteractions(worker, member, configBackingStore, statusBackingStore);
     }
 
@@ -2587,8 +2587,8 @@ public class DistributedHerderTest {
 
         herder.tick();
 
-        verify(member, times(2)).ensureActive();
-        verify(member, times(1)).poll(anyLong());
+        verify(member, times(2)).ensureActive(any());
+        verify(member, times(1)).poll(anyLong(), any());
         verify(configBackingStore, times(2)).putSessionKey(any(SessionKey.class));
     }
 
@@ -2636,8 +2636,8 @@ public class DistributedHerderTest {
 
         herder.tick();
 
-        verify(member, times(2)).ensureActive();
-        verify(member, times(1)).poll(anyLong());
+        verify(member, times(2)).ensureActive(any());
+        verify(member, times(1)).poll(anyLong(), any());
         verify(configBackingStore, times(1)).putSessionKey(any(SessionKey.class));
     }
 
@@ -2691,7 +2691,7 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         expectRebalance(1, Collections.emptyList(), Collections.emptyList());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         OngoingStubbing<RestClient.HttpResponse<Object>> expectRequest = when(restClient.httpRequest(
                 any(), eq("PUT"), isNull(), isNull(), isNull(), any(), any()
@@ -2780,7 +2780,7 @@ public class DistributedHerderTest {
         expectRebalance(1, Collections.emptyList(), Collections.emptyList(), true);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         if (expectTaskCountRecord) {
             doNothing().when(configBackingStore).putTaskCountRecord(CONN1, 1);
@@ -2824,7 +2824,7 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(configState);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         // The future returned by Worker::fenceZombies
         KafkaFuture<Void> workerFencingFuture = mock(KafkaFuture.class);
@@ -2883,7 +2883,7 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(configState);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         Exception fencingException = new KafkaException("whoops!");
         when(worker.fenceZombies(eq(CONN1), eq(2), eq(CONN1_CONFIG))).thenThrow(fencingException);
@@ -2926,7 +2926,7 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(configState);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         // The future returned by Worker::fenceZombies
         KafkaFuture<Void> workerFencingFuture = mock(KafkaFuture.class);
@@ -3005,7 +3005,7 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(configState);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         // The callbacks that the herder has accrued for outstanding fencing futures, which will be completed after
         // a successful round of fencing and a task record write to the config topic
@@ -3231,7 +3231,7 @@ public class DistributedHerderTest {
 
         // We should poll for less than the delay - time to start the connector, meaning that a long connector start
         // does not delay the poll timeout
-        verify(member, times(3)).poll(leq(maxPollWaitMs));
+        verify(member, times(3)).poll(leq(maxPollWaitMs), any());
         verify(worker, times(2)).startConnector(eq(CONN1), any(), any(), eq(herder), eq(TargetState.STARTED), any());
         verifyNoMoreInteractions(member, worker, configBackingStore);
     }
@@ -3313,13 +3313,13 @@ public class DistributedHerderTest {
         // 1. end of initial tick when no request has been added to the herder queue yet
         // 2. the third task reconfiguration request is expected to pass; so expect no more retries (a Long.MAX_VALUE poll
         //    timeout indicates that there is no herder request currently in the queue)
-        verify(member, times(2)).poll(eq(Long.MAX_VALUE));
+        verify(member, times(2)).poll(eq(Long.MAX_VALUE), any());
 
         // task reconfiguration herder request with initial retry backoff
-        verify(member).poll(eq(250L));
+        verify(member).poll(eq(250L), any());
 
         // task reconfiguration herder request with double the initial retry backoff
-        verify(member).poll(eq(500L));
+        verify(member).poll(eq(500L), any());
 
         verifyNoMoreInteractions(member, worker, restClient);
     }
@@ -3577,7 +3577,7 @@ public class DistributedHerderTest {
         expectConfigRefreshAndSnapshot(SNAPSHOT);
 
         when(statusBackingStore.connectors()).thenReturn(Collections.emptySet());
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
@@ -3718,12 +3718,12 @@ public class DistributedHerderTest {
         when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);
         expectRebalance(1, Collections.emptyList(), Collections.emptyList(), true);
         expectConfigRefreshAndSnapshot(SNAPSHOT_STOPPED_CONN1);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
         // Now handle the alter connector offsets request
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         when(herder.connectorType(any())).thenReturn(ConnectorType.SOURCE);
 
         // Expect a round of zombie fencing to occur
@@ -3784,12 +3784,12 @@ public class DistributedHerderTest {
         when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);
         expectRebalance(1, Collections.emptyList(), Collections.emptyList(), true);
         expectConfigRefreshAndSnapshot(SNAPSHOT_STOPPED_CONN1);
-        doNothing().when(member).poll(anyLong());
+        expectMemberPoll();
 
         herder.tick();
 
         // Now handle the reset connector offsets request
-        doNothing().when(member).ensureActive();
+        expectMemberEnsureActive();
         when(herder.connectorType(any())).thenReturn(ConnectorType.SOURCE);
 
         // Expect a round of zombie fencing to occur
@@ -3818,6 +3818,22 @@ public class DistributedHerderTest {
         // queue up the actual reset offsets request if the zombie fencing succeeds.
         verify(herderFencingFuture, times(2)).whenComplete(any());
         verifyNoMoreInteractions(workerFencingFuture, herderFencingFuture, member, worker);
+    }
+
+    private void expectMemberPoll() {
+        ArgumentCaptor<Runnable> onPoll = ArgumentCaptor.forClass(Runnable.class);
+        doAnswer(invocation -> {
+            onPoll.getValue().run();
+            return null;
+        }).when(member).poll(anyLong(), onPoll.capture());
+    }
+
+    private void expectMemberEnsureActive() {
+        ArgumentCaptor<Runnable> onPoll = ArgumentCaptor.forClass(Runnable.class);
+        doAnswer(invocation -> {
+            onPoll.getValue().run();
+            return null;
+        }).when(member).ensureActive(onPoll.capture());
     }
 
     private void expectRebalance(final long offset,
@@ -3873,7 +3889,9 @@ public class DistributedHerderTest {
                                  final List<ConnectorTaskId> assignedTasks,
                                  int delay,
                                  boolean isLeader) {
+        ArgumentCaptor<Runnable> onPoll = ArgumentCaptor.forClass(Runnable.class);
         doAnswer(invocation -> {
+            onPoll.getValue().run();
             ExtendedAssignment assignment;
             if (!revokedConnectors.isEmpty() || !revokedTasks.isEmpty()) {
                 rebalanceListener.onRevoked(leader, revokedConnectors, revokedTasks);
@@ -3893,7 +3911,7 @@ public class DistributedHerderTest {
             rebalanceListener.onAssigned(assignment, 3);
             time.sleep(100L);
             return null;
-        }).when(member).ensureActive();
+        }).when(member).ensureActive(onPoll.capture());
 
         if (isLeader) {
             doNothing().when(configBackingStore).claimWritePrivileges();
@@ -4101,20 +4119,6 @@ public class DistributedHerderTest {
         @Override
         public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
             return false;
-        }
-    }
-
-    private static class RecordingFutureCallback<T> extends FutureCallback<T> {
-        private final List<String> stageDescriptions = Collections.synchronizedList(new ArrayList<>());
-
-        @Override
-        public void recordStage(Stage stage) {
-            stageDescriptions.add(stage.description());
-            super.recordStage(stage);
-        }
-
-        public List<String> allStages() {
-            return stageDescriptions;
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -4053,7 +4053,7 @@ public class DistributedHerderTest {
         doAnswer(invocation -> {
             Stage stage = invocation.getArgument(0);
             if (stage != null)
-                result.add(stage.description);
+                result.add(stage.description());
             return null;
         }).when(callback).recordStage(any());
 
@@ -4109,7 +4109,7 @@ public class DistributedHerderTest {
 
         @Override
         public void recordStage(Stage stage) {
-            stageDescriptions.add(stage.description);
+            stageDescriptions.add(stage.description());
             super.recordStage(stage);
         }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -1494,8 +1494,8 @@ public class DistributedHerderTest {
 
     @Test
     public void testRequestProcessingOrder() {
-        Callable<Void> action = mock();
-        Callback<Void> callback = mock();
+        Callable<Void> action = mock(Callable.class);
+        Callback<Void> callback = mock(Callback.class);
 
         final DistributedHerder.DistributedHerderRequest req1 = herder.addRequest(100, action, callback);
         final DistributedHerder.DistributedHerderRequest req2 = herder.addRequest(10, action, callback);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/ConnectAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/ConnectAssertions.java
@@ -536,9 +536,9 @@ public class ConnectAssertions {
                     () -> {
                         String result = conditionMessage;
                         if (lastInfo.get() != null) {
-                            return result + ". When last checked, " + stateSummary(lastInfo.get());
+                            return result + " When last checked, " + stateSummary(lastInfo.get());
                         } else if (lastInfoError.get() != null) {
-                            result +=  ". The last attempt to check the connector state failed: " + lastInfoError.get().getClass();
+                            result +=  " The last attempt to check the connector state failed: " + lastInfoError.get().getClass();
                             String exceptionMessage = lastInfoError.get().getMessage();
                             if (exceptionMessage != null) {
                                 result += ": " + exceptionMessage;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/ConnectAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/ConnectAssertions.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.test.TestUtils.waitForCondition;
@@ -302,20 +303,16 @@ public class ConnectAssertions {
      */
     public void assertConnectorAndAtLeastNumTasksAreRunning(String connectorName, int numTasks, String detailMessage)
             throws InterruptedException {
-        try {
-            waitForCondition(
-                () -> checkConnectorState(
-                    connectorName,
-                    AbstractStatus.State.RUNNING,
-                    numTasks,
-                    AbstractStatus.State.RUNNING,
-                    (actual, expected) -> actual >= expected
-                ).orElse(false),
-                CONNECTOR_SETUP_DURATION_MS,
-                "The connector or at least " + numTasks + " of tasks are not running.");
-        } catch (AssertionError e) {
-            throw new AssertionError(detailMessage, e);
-        }
+        waitForConnectorState(
+                connectorName,
+                AbstractStatus.State.RUNNING,
+                atLeast(numTasks),
+                null,
+                AbstractStatus.State.RUNNING,
+                "The connector or at least " + numTasks + " of tasks are not running.",
+                detailMessage,
+                CONNECTOR_SETUP_DURATION_MS
+        );
     }
 
     /**
@@ -329,20 +326,16 @@ public class ConnectAssertions {
      */
     public void assertConnectorAndExactlyNumTasksAreRunning(String connectorName, int numTasks, String detailMessage)
             throws InterruptedException {
-        try {
-            waitForCondition(
-                () -> checkConnectorState(
-                    connectorName,
-                    AbstractStatus.State.RUNNING,
-                    numTasks,
-                    AbstractStatus.State.RUNNING,
-                    (actual, expected) -> actual == expected
-                ).orElse(false),
-                CONNECTOR_SETUP_DURATION_MS,
-                "The connector or exactly " + numTasks + " tasks are not running.");
-        } catch (AssertionError e) {
-            throw new AssertionError(detailMessage, e);
-        }
+        waitForConnectorState(
+                connectorName,
+                AbstractStatus.State.RUNNING,
+                exactly(numTasks),
+                null,
+                AbstractStatus.State.RUNNING,
+                "The connector or exactly " + numTasks + " tasks are not running.",
+                detailMessage,
+                CONNECTOR_SETUP_DURATION_MS
+        );
     }
 
     /**
@@ -356,20 +349,16 @@ public class ConnectAssertions {
      */
     public void assertConnectorAndExactlyNumTasksArePaused(String connectorName, int numTasks, String detailMessage)
             throws InterruptedException {
-        try {
-            waitForCondition(
-                    () -> checkConnectorState(
-                            connectorName,
-                            AbstractStatus.State.PAUSED,
-                            numTasks,
-                            AbstractStatus.State.PAUSED,
-                            Integer::equals
-                    ).orElse(false),
-                    CONNECTOR_SHUTDOWN_DURATION_MS,
-                    "The connector or exactly " + numTasks + " tasks are not paused.");
-        } catch (AssertionError e) {
-            throw new AssertionError(detailMessage, e);
-        }
+        waitForConnectorState(
+                connectorName,
+                AbstractStatus.State.PAUSED,
+                exactly(numTasks),
+                null,
+                AbstractStatus.State.PAUSED,
+                "The connector or exactly " + numTasks + " tasks are not paused.",
+                detailMessage,
+                CONNECTOR_SHUTDOWN_DURATION_MS
+        );
     }
 
     /**
@@ -383,24 +372,20 @@ public class ConnectAssertions {
      */
     public void assertConnectorIsRunningAndTasksHaveFailed(String connectorName, int numTasks, String detailMessage)
             throws InterruptedException {
-        try {
-            waitForCondition(
-                () -> checkConnectorState(
-                    connectorName,
-                    AbstractStatus.State.RUNNING,
-                    numTasks,
-                    AbstractStatus.State.FAILED,
-                    (actual, expected) -> actual >= expected
-                ).orElse(false),
-                CONNECTOR_SETUP_DURATION_MS,
-                "Either the connector is not running or not all the " + numTasks + " tasks have failed.");
-        } catch (AssertionError e) {
-            throw new AssertionError(detailMessage, e);
-        }
+        waitForConnectorState(
+                connectorName,
+                AbstractStatus.State.RUNNING,
+                exactly(numTasks),
+                null,
+                AbstractStatus.State.FAILED,
+                "Either the connector is not running or not all the " + numTasks + " tasks have failed.",
+                detailMessage,
+                CONNECTOR_SETUP_DURATION_MS
+        );
     }
 
     /**
-     * Assert that a connector is running, that it has a specific number of tasks out of that numFailedTasks are in the FAILED state.
+     * Assert that a connector is running, that it has a specific number of tasks, and out of those, numFailedTasks are in the FAILED state.
      *
      * @param connectorName the connector name
      * @param numTasks the number of tasks
@@ -410,21 +395,16 @@ public class ConnectAssertions {
      */
     public void assertConnectorIsRunningAndNumTasksHaveFailed(String connectorName, int numTasks, int numFailedTasks, String detailMessage)
             throws InterruptedException {
-        try {
-            waitForCondition(
-                    () -> checkConnectorState(
-                            connectorName,
-                            AbstractStatus.State.RUNNING,
-                            numTasks,
-                            numFailedTasks,
-                            AbstractStatus.State.FAILED,
-                            (actual, expected) -> actual >= expected
-                    ).orElse(false),
-                    CONNECTOR_SETUP_DURATION_MS,
-                    "Either the connector is not running or not all the " + numTasks + " tasks have failed.");
-        } catch (AssertionError e) {
-            throw new AssertionError(detailMessage, e);
-        }
+        waitForConnectorState(
+                connectorName,
+                AbstractStatus.State.RUNNING,
+                exactly(numTasks),
+                numFailedTasks,
+                AbstractStatus.State.FAILED,
+                "Either the connector is not running or not all the " + numTasks + " tasks have failed.",
+                detailMessage,
+                CONNECTOR_SETUP_DURATION_MS
+        );
     }
 
     /**
@@ -438,20 +418,16 @@ public class ConnectAssertions {
      */
     public void assertConnectorIsFailedAndTasksHaveFailed(String connectorName, int numTasks, String detailMessage)
             throws InterruptedException {
-        try {
-            waitForCondition(
-                    () -> checkConnectorState(
-                            connectorName,
-                            AbstractStatus.State.FAILED,
-                            numTasks,
-                            AbstractStatus.State.FAILED,
-                            (actual, expected) -> actual >= expected
-                    ).orElse(false),
-                    CONNECTOR_SETUP_DURATION_MS,
-                    "Either the connector is running or not all the " + numTasks + " tasks have failed.");
-        } catch (AssertionError e) {
-            throw new AssertionError(detailMessage, e);
-        }
+        waitForConnectorState(
+                connectorName,
+                AbstractStatus.State.FAILED,
+                exactly(numTasks),
+                null,
+                AbstractStatus.State.FAILED,
+                "Either the connector is running or not all the " + numTasks + " tasks have failed.",
+                detailMessage,
+                CONNECTOR_SETUP_DURATION_MS
+        );
     }
 
     /**
@@ -500,82 +476,84 @@ public class ConnectAssertions {
      */
     public void assertConnectorIsStopped(String connectorName, String detailMessage)
             throws InterruptedException {
+        waitForConnectorState(
+                connectorName,
+                AbstractStatus.State.STOPPED,
+                exactly(0),
+                null,
+                null,
+                "At least the connector or one of its tasks is still running",
+                detailMessage,
+                CONNECTOR_SHUTDOWN_DURATION_MS
+        );
+    }
+
+    /**
+     * Check whether the given connector state matches the current state of the connector and
+     * whether it has at least the given number of tasks, with some number of tasks matching the given
+     * task state.
+     * @param connectorName the connector
+     * @param connectorState
+     * @param expectedNumTasks the expected number of tasks
+     * @param tasksState
+     */
+    protected void waitForConnectorState(
+            String connectorName,
+            AbstractStatus.State connectorState,
+            Predicate<Integer> expectedNumTasks,
+            Integer numTasksInTasksState,
+            AbstractStatus.State tasksState,
+            String conditionMessage,
+            String detailMessage,
+            long maxWaitMs
+    ) throws InterruptedException {
+        AtomicReference<ConnectorStateInfo> lastInfo = new AtomicReference<>();
+        AtomicReference<Exception> lastInfoError = new AtomicReference<>();
         try {
             waitForCondition(
-                    () -> checkConnectorState(
-                            connectorName,
-                            AbstractStatus.State.STOPPED,
-                            0,
-                            null,
-                            Integer::equals
-                    ).orElse(false),
-                    CONNECTOR_SHUTDOWN_DURATION_MS,
-                    "At least the connector or one of its tasks is still running");
+                    () -> {
+                        try {
+                            ConnectorStateInfo info = connect.connectorStatus(connectorName);
+                            lastInfo.set(info);
+                            lastInfoError.set(null);
+
+                            if (info == null)
+                                return false;
+
+                            int numTasks = info.tasks().size();
+                            int expectedTasksInState = Optional.of(numTasksInTasksState).orElse(numTasks);
+                            return expectedNumTasks.test(info.tasks().size())
+                                    && info.connector().state().equals(connectorState.toString())
+                                    && info.tasks().stream().filter(s -> s.state().equals(tasksState.toString())).count() == expectedTasksInState;
+                        } catch (Exception e) {
+                            log.error("Could not check connector state info.", e);
+                            lastInfo.set(null);
+                            lastInfoError.set(e);
+                            return false;
+                        }
+                    },
+                    maxWaitMs,
+                    () -> {
+                        String result = conditionMessage;
+                        if (lastInfo.get() != null) {
+                            return result + ". When last checked, " + stateSummary(lastInfo.get());
+                        } else if (lastInfoError.get() != null) {
+                            result +=  ". The last attempt to check the connector state failed: " + lastInfoError.get().getClass();
+                            String exceptionMessage = lastInfoError.get().getMessage();
+                            if (exceptionMessage != null) {
+                                result += ": " + exceptionMessage;
+                            }
+                            return result;
+                        } else {
+                            return result;
+                        }
+                    }
+            );
         } catch (AssertionError e) {
             throw new AssertionError(detailMessage, e);
         }
     }
 
-    /**
-     * Check whether the given connector state matches the current state of the connector and
-     * whether it has at least the given number of tasks, with all the tasks matching the given
-     * task state.
-     * @param connectorName the connector
-     * @param connectorState
-     * @param numTasks the expected number of tasks
-     * @param tasksState
-     * @return true if the connector and tasks are in the expected state; false otherwise
-     */
-    protected Optional<Boolean> checkConnectorState(
-            String connectorName,
-            AbstractStatus.State connectorState,
-            int numTasks,
-            AbstractStatus.State tasksState,
-            BiFunction<Integer, Integer, Boolean> comp
-    ) {
-        try {
-            ConnectorStateInfo info = connect.connectorStatus(connectorName);
-            boolean result = info != null
-                    && comp.apply(info.tasks().size(), numTasks)
-                    && info.connector().state().equals(connectorState.toString())
-                    && info.tasks().stream().allMatch(s -> s.state().equals(tasksState.toString()));
-            return Optional.of(result);
-        } catch (Exception e) {
-            log.error("Could not check connector state info.", e);
-            return Optional.empty();
-        }
-    }
-
-    /**
-     * Check whether the given connector state matches the current state of the connector and
-     * whether it has at least the given number of tasks, with numTasksInTasksState matching the given
-     * task state.
-     * @param connectorName the connector
-     * @param connectorState
-     * @param numTasks the expected number of tasks
-     * @param tasksState
-     * @return true if the connector and tasks are in the expected state; false otherwise
-     */
-    protected Optional<Boolean> checkConnectorState(
-            String connectorName,
-            AbstractStatus.State connectorState,
-            int numTasks,
-            int numTasksInTasksState,
-            AbstractStatus.State tasksState,
-            BiFunction<Integer, Integer, Boolean> comp
-    ) {
-        try {
-            ConnectorStateInfo info = connect.connectorStatus(connectorName);
-            boolean result = info != null
-                    && comp.apply(info.tasks().size(), numTasks)
-                    && info.connector().state().equals(connectorState.toString())
-                    && info.tasks().stream().filter(s -> s.state().equals(tasksState.toString())).count() == numTasksInTasksState;
-            return Optional.of(result);
-        } catch (Exception e) {
-            log.error("Could not check connector state info.", e);
-            return Optional.empty();
-        }
-    }
     /**
      * Assert that a connector's set of active topics matches the given collection of topic names.
      *
@@ -614,5 +592,25 @@ public class ConnectAssertions {
             log.error("Could not check connector {} state info.", connectorName, e);
             return Optional.empty();
         }
+    }
+
+    private static String stateSummary(ConnectorStateInfo info) {
+        String result = "the connector was " + info.connector().state();
+        if (info.tasks().isEmpty()) {
+            return result + " and no tasks were running";
+        } else {
+            String taskStates = info.tasks().stream()
+                    .map(ConnectorStateInfo.TaskState::state)
+                    .collect(Collectors.joining(", "));
+            return result + " and its tasks were in these states: " + taskStates;
+        }
+    }
+
+    private static Predicate<Integer> exactly(int expected) {
+        return actual -> actual == expected;
+    }
+
+    private static Predicate<Integer> atLeast(int expected) {
+        return actual -> actual >= expected;
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/ConnectAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/ConnectAssertions.java
@@ -521,7 +521,7 @@ public class ConnectAssertions {
                                 return false;
 
                             int numTasks = info.tasks().size();
-                            int expectedTasksInState = Optional.of(numTasksInTasksState).orElse(numTasks);
+                            int expectedTasksInState = Optional.ofNullable(numTasksInTasksState).orElse(numTasks);
                             return expectedNumTasks.test(info.tasks().size())
                                     && info.connector().state().equals(connectorState.toString())
                                     && info.tasks().stream().filter(s -> s.state().equals(tasksState.toString())).count() == expectedTasksInState;


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-15563)

There are three common scenarios when Kafka Connect REST requests time out:

1. A connector operation (such as a call to `Connector::validate`) has blocked
2. A distributed worker's herder tick thread is blocked (which can be for a variety of reasons, including failure to reach the group coordinator, failure to complete startup, and failure to reach the config topic)
3. A distributed worker has to issue its own request to another worker, and that request blocks (note that this does not include transparently-forwarded requests, and currently only includes requests to submit task configurations and perform zombie fencing)

This PR adds error messages to REST requests that help capture which operations are causing the worker to be unable to respond in time. The error messages include a description of the action the worker is blocked on, and a human-readable timestamp of when that action began.

Some rejected alternatives:
- One or more new JMX metrics (harder for users to access, would require a KIP, and would likely be just as difficult to implement, especially when trying to accommodate blocks in both connector interactions, which can take place on an isolated per-request basis, and in a distributed worker's herder tick thread, which can affect multiple REST requests)
- Exposing the stack trace of the distributed worker's herder tick thread as part of the error message for timeouts (does not help with requests that are not blocked because of the herder tick thread, and may present a security risk by including source code for user-provided plugins such as `ConfigProvider` instances)

During review, it may be helpful to focus on these files first (as they contain the internal API for recording and reporting callback stages):
- `HerderRequestHandler` and `ConnectorPluginsResource` (same change applied across both files)
- `Callback`
- `ConvertingFutureCallback`
- `Stage`
- `StagedTimeoutException`
- `TemporaryStage`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
