### PR TITLE
KAFKA-15566: Fix test FetchRequestTest.testLastFetchedEpochValidation for KRaft mode

### DIFF
--- a/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
@@ -196,13 +196,13 @@ class FetchRequestTest extends BaseFetchRequestTest {
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk", "kraft"))
   def testLastFetchedEpochValidation(quorum: String): Unit = {
     checkLastFetchedEpochValidation(ApiKeys.FETCH.latestVersion())
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk", "kraft"))
   def testLastFetchedEpochValidationV12(quorum: String): Unit = {
     checkLastFetchedEpochValidation(12)
   }
@@ -211,6 +211,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
     val topic = "topic"
     val topicPartition = new TopicPartition(topic, 0)
     val partitionToLeader = createTopic(topic, replicationFactor = 3)
+    TestUtils.waitUntilLeaderIsKnown(brokers, topicPartition)
     val firstLeaderId = partitionToLeader(topicPartition.partition)
     val firstLeaderEpoch = TestUtils.findLeaderEpoch(firstLeaderId, topicPartition, brokers)
 


### PR DESCRIPTION
- Fix test FetchRequestTest.testLastFetchedEpochValidation for KRaft mode

The test fails due to unexpected error (`OFFSET_OUT_OF_RANGE`) when enabled with KRaft mode:
```
org.opentest4j.AssertionFailedError: expected: <0> but was: <1>
	at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at app//org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:134)
	at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:129)
	at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:325)
	at app//kafka.server.FetchRequestTest.checkLastFetchedEpochValidation(FetchRequestTest.scala:243)
	at app//kafka.server.FetchRequestTest.testLastFetchedEpochValidation(FetchRequestTest.scala:201)
```
The test retrieves the leader epoch for a topic partition right after creating it. It then uses this epoch to set `lastFetchedEpoch` in the fetch request for offset greater than log end offset. When running KRaft mode, the test retrieves the leader epoch a few milliseconds before the leader epoch gets set on the broker and ends up retrieving value of `-1`. Sending fetch request with non valid/empty `lastFetchedEpoch` results in an attempt to read log which throws OFFSET_OUT_OF_RANGE exception if the offset is out of range (https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/log/LocalLog.scala#L400). The expected path is to return `LogReadInfo` [here](https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/cluster/Partition.scala#L1461) without attempting to read the log therefore no exception. 

The reason it takes longer to set the leader epoch in KRaft mode is because of the way the topic partitions are created differently than Zookeeper. In Zookeeper mode, we create the topic partitions directly with Zookeeper therefore seem to take less time to create the logs and set leader epoch on broker. In KRaft mode, we use Admin client to create topic partitions. Even though the test waits for topic partitions to get created and appear in metadata cache, it doesn’t seem to be sufficient time for leader epoch to get set on the brokers.

Logs for KRaft mode with extra debug lines:
```
[2023-10-19 12:53:26,510] DEBUG First leader epoch to be used for lastFetchedEpoch in the fetch request is -1 (kafka.server.FetchRequestTest:62)
[2023-10-19 12:53:26,533] DEBUG [Partition topic-0 broker=1] Setting leaderEpoch to 0 from the partitionsState (kafka.cluster.Partition:62)
[2023-10-19 12:53:36,532] DEBUG [Partition topic-0 broker=2] Reading records for fetch request with lastFetchedEpoch Optional.empty fetchOffset 250 currentLeaderEpoch Optional[1] (kafka.cluster.Partition:62)
[2023-10-19 12:53:36,533] DEBUG [ReplicaManager broker=2] Throwing OffsetOutOfRangeException for fetching offset 250 (kafka.server.ReplicaManager:62)
```
Logs for ZK mode in comparison:
```
[2023-10-19 13:00:36,474] DEBUG [Partition topic-0 broker=0] Setting leaderEpoch to 0 from the partitionsState which is used for lastFetchedEpoch (kafka.cluster.Partition:62)
[2023-10-19 13:00:36,546] DEBUG First leader epoch to be used for lastFetchedEpoch in the fetch request is 0 (kafka.server.FetchRequestTest:62)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
