### PR TITLE
KAFKA-13988: Enable replicating from latest offset with MirrorMaker 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3010,7 +3010,6 @@ project(':connect:mirror') {
     testImplementation libs.junitJupiter
     testImplementation libs.log4j
     testImplementation libs.mockitoCore
-    testImplementation libs.mockitoInline // supports mocking static methods, final classes, etc.
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':connect:runtime').sourceSets.test.output
     testImplementation project(':core')

--- a/build.gradle
+++ b/build.gradle
@@ -3010,6 +3010,7 @@ project(':connect:mirror') {
     testImplementation libs.junitJupiter
     testImplementation libs.log4j
     testImplementation libs.mockitoCore
+    testImplementation libs.mockitoInline // supports mocking static methods, final classes, etc.
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':connect:runtime').sourceSets.test.output
     testImplementation project(':core')

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -272,9 +272,6 @@ public class MirrorSourceTask extends SourceTask {
         log.info("Starting with {} previously uncommitted partitions.", topicPartitionOffsets.values().stream()
                 .filter(this::isUncommitted).count());
 
-        log.trace("Seeking offsets: {}", topicPartitionOffsets.entrySet().stream()
-                .filter(tpo -> !isUncommitted(tpo.getValue())));
-
         topicPartitionOffsets.forEach((topicPartition, offset) -> {
             // Do not call seek on partitions that don't have an existing offset committed.
             if (isUncommitted(offset)) {


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-13988)

Based off of https://github.com/apache/kafka/pull/13905, which itself appears to be based off of https://github.com/apache/kafka/pull/12358. The only changes applied here are the ones proposed during review of https://github.com/apache/kafka/pull/13905.

This PR tweaks how the `MirrorSourceTask` class interacts with its consumer on startup. With this change, instead of manually seeking to offset 0 when no committed offset for a topic partition is found, no seek is performed at all. This allows users to configure MM2 to begin replicating from the ends of topics (as opposed to the beginning, which is and remains the default behavior) by configuring its consumer with `auto.offset.reset` set to `latest`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
