### PR TITLE
KAFKA-15626: Replace verification guard object with an specific type

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1302,7 +1302,7 @@ class Partition(val topicPartition: TopicPartition,
   }
 
   def appendRecordsToLeader(records: MemoryRecords, origin: AppendOrigin, requiredAcks: Int,
-                            requestLocal: RequestLocal, verificationGuard: VerificationGuard = VerificationGuard.SENTINEL_VERIFICATION_GUARD): LogAppendInfo = {
+                            requestLocal: RequestLocal, verificationGuard: VerificationGuard = VerificationGuard.SENTINEL): LogAppendInfo = {
     val (info, leaderHWIncremented) = inReadLock(leaderIsrUpdateLock) {
       leaderLogIfLocal match {
         case Some(leaderLog) =>

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -582,7 +582,7 @@ class Partition(val topicPartition: TopicPartition,
   }
 
   // Returns a VerificationGuard if we need to verify. This starts or continues the verification process. Otherwise return the
-  // sentinel verification guard.
+  // sentinel VerificationGuard.
   def maybeStartTransactionVerification(producerId: Long, sequence: Int, epoch: Short): VerificationGuard = {
     leaderLogIfLocal match {
       case Some(log) => log.maybeStartTransactionVerification(producerId, sequence, epoch)

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -45,7 +45,7 @@ import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.{IsolationLevel, TopicPartition, Uuid}
 import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.server.common.MetadataVersion
-import org.apache.kafka.storage.internals.log.{AppendOrigin, FetchDataInfo, FetchIsolation, FetchParams, LeaderHwChange, LogAppendInfo, LogOffsetMetadata, LogOffsetSnapshot, LogOffsetsListener, LogReadInfo, LogStartOffsetIncrementReason}
+import org.apache.kafka.storage.internals.log.{AppendOrigin, FetchDataInfo, FetchIsolation, FetchParams, LeaderHwChange, LogAppendInfo, LogOffsetMetadata, LogOffsetSnapshot, LogOffsetsListener, LogReadInfo, LogStartOffsetIncrementReason, VerificationGuard}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 
 import scala.collection.{Map, Seq}
@@ -581,8 +581,8 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
-  // Returns a verification guard object if we need to verify. This starts or continues the verification process. Otherwise return null.
-  def maybeStartTransactionVerification(producerId: Long, sequence: Int, epoch: Short): Object = {
+  // Returns a VerificationGuard if we need to verify. This starts or continues the verification process. Otherwise return null.
+  def maybeStartTransactionVerification(producerId: Long, sequence: Int, epoch: Short): VerificationGuard = {
     leaderLogIfLocal match {
       case Some(log) => log.maybeStartTransactionVerification(producerId, sequence, epoch)
       case None => throw new NotLeaderOrFollowerException();
@@ -1301,7 +1301,7 @@ class Partition(val topicPartition: TopicPartition,
   }
 
   def appendRecordsToLeader(records: MemoryRecords, origin: AppendOrigin, requiredAcks: Int,
-                            requestLocal: RequestLocal, verificationGuard: Object = null): LogAppendInfo = {
+                            requestLocal: RequestLocal, verificationGuard: VerificationGuard = null): LogAppendInfo = {
     val (info, leaderHWIncremented) = inReadLock(leaderIsrUpdateLock) {
       leaderLogIfLocal match {
         case Some(leaderLog) =>

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -581,7 +581,8 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
-  // Returns a VerificationGuard if we need to verify. This starts or continues the verification process. Otherwise return null.
+  // Returns a VerificationGuard if we need to verify. This starts or continues the verification process. Otherwise return the
+  // sentinel verification guard.
   def maybeStartTransactionVerification(producerId: Long, sequence: Int, epoch: Short): VerificationGuard = {
     leaderLogIfLocal match {
       case Some(log) => log.maybeStartTransactionVerification(producerId, sequence, epoch)
@@ -1301,7 +1302,7 @@ class Partition(val topicPartition: TopicPartition,
   }
 
   def appendRecordsToLeader(records: MemoryRecords, origin: AppendOrigin, requiredAcks: Int,
-                            requestLocal: RequestLocal, verificationGuard: VerificationGuard = null): LogAppendInfo = {
+                            requestLocal: RequestLocal, verificationGuard: VerificationGuard = VerificationGuard.SENTINEL_VERIFICATION_GUARD): LogAppendInfo = {
     val (info, leaderHWIncremented) = inReadLock(leaderIsrUpdateLock) {
       leaderLogIfLocal match {
         case Some(leaderLog) =>

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1083,7 +1083,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 
   private def batchMissingRequiredVerification(batch: MutableRecordBatch, requestVerificationGuard: VerificationGuard): Boolean = {
     producerStateManager.producerStateManagerConfig().transactionVerificationEnabled() && !batch.isControlBatch &&
-      !verificationGuard(batch.producerId).verifiedBy(requestVerificationGuard)
+      !verificationGuard(batch.producerId).verifies(requestVerificationGuard)
   }
 
   /**

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1083,7 +1083,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 
   private def batchMissingRequiredVerification(batch: MutableRecordBatch, requestVerificationGuard: VerificationGuard): Boolean = {
     producerStateManager.producerStateManagerConfig().transactionVerificationEnabled() && !batch.isControlBatch &&
-      !verificationGuard(batch.producerId).verifies(requestVerificationGuard)
+      !verificationGuard(batch.producerId).verify(requestVerificationGuard)
   }
 
   /**

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -604,7 +604,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
    */
   def maybeStartTransactionVerification(producerId: Long, sequence: Int, epoch: Short): VerificationGuard = lock synchronized {
     if (hasOngoingTransaction(producerId))
-      VerificationGuard.SENTINEL_VERIFICATION_GUARD
+      VerificationGuard.SENTINEL
     else
       maybeCreateVerificationGuard(producerId, sequence, epoch)
   }
@@ -624,7 +624,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
    */
   def verificationGuard(producerId: Long): VerificationGuard = lock synchronized {
     val entry = producerStateManager.verificationStateEntry(producerId)
-    if (entry != null) entry.verificationGuard else VerificationGuard.SENTINEL_VERIFICATION_GUARD
+    if (entry != null) entry.verificationGuard else VerificationGuard.SENTINEL
   }
 
   /**
@@ -716,7 +716,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
                      origin: AppendOrigin = AppendOrigin.CLIENT,
                      interBrokerProtocolVersion: MetadataVersion = MetadataVersion.latest,
                      requestLocal: RequestLocal = RequestLocal.NoCaching,
-                     verificationGuard: VerificationGuard = VerificationGuard.SENTINEL_VERIFICATION_GUARD): LogAppendInfo = {
+                     verificationGuard: VerificationGuard = VerificationGuard.SENTINEL): LogAppendInfo = {
     val validateAndAssignOffsets = origin != AppendOrigin.RAFT_LEADER
     append(records, origin, interBrokerProtocolVersion, validateAndAssignOffsets, leaderEpoch, Some(requestLocal), verificationGuard, ignoreRecordSize = false)
   }
@@ -735,7 +735,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
       validateAndAssignOffsets = false,
       leaderEpoch = -1,
       requestLocal = None,
-      verificationGuard = VerificationGuard.SENTINEL_VERIFICATION_GUARD,
+      verificationGuard = VerificationGuard.SENTINEL,
       // disable to check the validation of record size since the record is already accepted by leader.
       ignoreRecordSize = true)
   }

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -600,7 +600,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 
   /**
    * Maybe create and return the VerificationGuard for the given producer ID if the transaction is not yet ongoing.
-   * Creation starts the verification process. Otherwise return the Sentinel VerificationGuard.
+   * Creation starts the verification process. Otherwise return the sentinel VerificationGuard.
    */
   def maybeStartTransactionVerification(producerId: Long, sequence: Int, epoch: Short): VerificationGuard = lock synchronized {
     if (hasOngoingTransaction(producerId))

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -877,7 +877,7 @@ class ReplicaManager(val config: KafkaConfig,
         transactionalBatches.foreach(batch => transactionalProducerIds.add(batch.producerId))
 
         if (transactionalBatches.nonEmpty) {
-          // We return verification guard if the partition needs to be verified. If no state is present, no need to verify.
+          // We return VerificationGuard if the partition needs to be verified. If no state is present, no need to verify.
           val firstBatch = records.firstBatch
           val verificationGuard = getPartitionOrException(topicPartition).maybeStartTransactionVerification(firstBatch.producerId, firstBatch.baseSequence, firstBatch.producerEpoch)
           if (verificationGuard != null) {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -58,7 +58,7 @@ import org.apache.kafka.metadata.LeaderConstants.NO_LEADER
 import org.apache.kafka.server.common.MetadataVersion._
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.{Scheduler, ShutdownableThread}
-import org.apache.kafka.storage.internals.log.{AppendOrigin, FetchDataInfo, FetchParams, FetchPartitionData, LeaderHwChange, LogAppendInfo, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogReadInfo, RecordValidationException, RemoteLogReadResult, RemoteStorageFetchInfo}
+import org.apache.kafka.storage.internals.log.{AppendOrigin, FetchDataInfo, FetchParams, FetchPartitionData, LeaderHwChange, LogAppendInfo, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogReadInfo, RecordValidationException, RemoteLogReadResult, RemoteStorageFetchInfo, VerificationGuard}
 
 import java.io.File
 import java.nio.file.{Files, Paths}
@@ -735,7 +735,7 @@ class ReplicaManager(val config: KafkaConfig,
     if (isValidRequiredAcks(requiredAcks)) {
       val sTime = time.milliseconds
 
-      val verificationGuards: mutable.Map[TopicPartition, Object] = mutable.Map[TopicPartition, Object]()
+      val verificationGuards: mutable.Map[TopicPartition, VerificationGuard] = mutable.Map[TopicPartition, VerificationGuard]()
       val (verifiedEntriesPerPartition, notYetVerifiedEntriesPerPartition, errorsPerPartition) =
         if (transactionalId == null || !config.transactionPartitionVerificationEnable)
           (entriesPerPartition, Map.empty[TopicPartition, MemoryRecords], Map.empty[TopicPartition, Errors])
@@ -864,7 +864,7 @@ class ReplicaManager(val config: KafkaConfig,
     }
   }
 
-  private def partitionEntriesForVerification(verificationGuards: mutable.Map[TopicPartition, Object],
+  private def partitionEntriesForVerification(verificationGuards: mutable.Map[TopicPartition, VerificationGuard],
                                               entriesPerPartition: Map[TopicPartition, MemoryRecords],
                                               verifiedEntries: mutable.Map[TopicPartition, MemoryRecords],
                                               unverifiedEntries: mutable.Map[TopicPartition, MemoryRecords],
@@ -1156,7 +1156,7 @@ class ReplicaManager(val config: KafkaConfig,
                                entriesPerPartition: Map[TopicPartition, MemoryRecords],
                                requiredAcks: Short,
                                requestLocal: RequestLocal,
-                               verificationGuards: Map[TopicPartition, Object]): Map[TopicPartition, LogAppendResult] = {
+                               verificationGuards: Map[TopicPartition, VerificationGuard]): Map[TopicPartition, LogAppendResult] = {
     val traceEnabled = isTraceEnabled
     def processFailedRecord(topicPartition: TopicPartition, t: Throwable) = {
       val logStartOffset = onlinePartition(topicPartition).map(_.logStartOffset).getOrElse(-1L)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -880,7 +880,7 @@ class ReplicaManager(val config: KafkaConfig,
           // We return VerificationGuard if the partition needs to be verified. If no state is present, no need to verify.
           val firstBatch = records.firstBatch
           val verificationGuard = getPartitionOrException(topicPartition).maybeStartTransactionVerification(firstBatch.producerId, firstBatch.baseSequence, firstBatch.producerEpoch)
-          if (verificationGuard != null) {
+          if (verificationGuard != VerificationGuard.SENTINEL_VERIFICATION_GUARD) {
             verificationGuards.put(topicPartition, verificationGuard)
             unverifiedEntries.put(topicPartition, records)
           } else
@@ -1183,7 +1183,8 @@ class ReplicaManager(val config: KafkaConfig,
       } else {
         try {
           val partition = getPartitionOrException(topicPartition)
-          val info = partition.appendRecordsToLeader(records, origin, requiredAcks, requestLocal, verificationGuards.getOrElse(topicPartition, null))
+          val info = partition.appendRecordsToLeader(records, origin, requiredAcks, requestLocal,
+            verificationGuards.getOrElse(topicPartition, VerificationGuard.SENTINEL_VERIFICATION_GUARD))
           val numAppendedMessages = info.numMessages
 
           // update stats for successfully appended bytes and messages as bytesInRate and messageInRate

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -880,7 +880,7 @@ class ReplicaManager(val config: KafkaConfig,
           // We return VerificationGuard if the partition needs to be verified. If no state is present, no need to verify.
           val firstBatch = records.firstBatch
           val verificationGuard = getPartitionOrException(topicPartition).maybeStartTransactionVerification(firstBatch.producerId, firstBatch.baseSequence, firstBatch.producerEpoch)
-          if (verificationGuard != VerificationGuard.SENTINEL_VERIFICATION_GUARD) {
+          if (verificationGuard != VerificationGuard.SENTINEL) {
             verificationGuards.put(topicPartition, verificationGuard)
             unverifiedEntries.put(topicPartition, records)
           } else
@@ -1184,7 +1184,7 @@ class ReplicaManager(val config: KafkaConfig,
         try {
           val partition = getPartitionOrException(topicPartition)
           val info = partition.appendRecordsToLeader(records, origin, requiredAcks, requestLocal,
-            verificationGuards.getOrElse(topicPartition, VerificationGuard.SENTINEL_VERIFICATION_GUARD))
+            verificationGuards.getOrElse(topicPartition, VerificationGuard.SENTINEL))
           val numAppendedMessages = info.numMessages
 
           // update stats for successfully appended bytes and messages as bytesInRate and messageInRate

--- a/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
@@ -37,7 +37,7 @@ import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.util.MockTime
 import org.apache.kafka.storage.internals.epoch.LeaderEpochFileCache
-import org.apache.kafka.storage.internals.log.{AppendOrigin, CleanerConfig, FetchIsolation, FetchParams, LogAppendInfo, LogConfig, LogDirFailureChannel, LogSegments, ProducerStateManager, ProducerStateManagerConfig}
+import org.apache.kafka.storage.internals.log.{AppendOrigin, CleanerConfig, FetchIsolation, FetchParams, LogAppendInfo, LogConfig, LogDirFailureChannel, LogSegments, ProducerStateManager, ProducerStateManagerConfig, VerificationGuard}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.mockito.ArgumentMatchers
@@ -450,7 +450,7 @@ class PartitionLockTest extends Logging {
     keepPartitionMetadataFile = true) {
 
     override def appendAsLeader(records: MemoryRecords, leaderEpoch: Int, origin: AppendOrigin,
-                                interBrokerProtocolVersion: MetadataVersion, requestLocal: RequestLocal, verificationGuard: Object): LogAppendInfo = {
+                                interBrokerProtocolVersion: MetadataVersion, requestLocal: RequestLocal, verificationGuard: VerificationGuard): LogAppendInfo = {
       val appendInfo = super.appendAsLeader(records, leaderEpoch, origin, interBrokerProtocolVersion, requestLocal, verificationGuard)
       appendSemaphore.acquire()
       appendInfo

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -3551,7 +3551,7 @@ class PartitionTest extends AbstractPartitionTest {
 
     // Before appendRecordsToLeader is called, ReplicaManager will call maybeStartTransactionVerification. We should get a non-sentinel VerificationGuard.
     val verificationGuard = partition.maybeStartTransactionVerification(producerId, 3, 0)
-    assertNotEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, verificationGuard)
+    assertNotEquals(VerificationGuard.SENTINEL, verificationGuard)
 
     // With the wrong VerificationGuard, append should fail.
     assertThrows(classOf[InvalidTxnStateException], () => partition.appendRecordsToLeader(transactionRecords(),
@@ -3564,7 +3564,7 @@ class PartitionTest extends AbstractPartitionTest {
 
     // We should no longer need a VerificationGuard. Future appends without VerificationGuard will also succeed.
     val verificationGuard3 = partition.maybeStartTransactionVerification(producerId, 3, 0)
-    assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, verificationGuard3)
+    assertEquals(VerificationGuard.SENTINEL, verificationGuard3)
     partition.appendRecordsToLeader(transactionRecords(), origin = AppendOrigin.CLIENT, requiredAcks = 1, RequestLocal.withThreadConfinedCaching)
   }
 

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -3549,9 +3549,9 @@ class PartitionTest extends AbstractPartitionTest {
     // When VerificationGuard is not there, we should not be able to append.
     assertThrows(classOf[InvalidTxnStateException], () => partition.appendRecordsToLeader(transactionRecords(), origin = AppendOrigin.CLIENT, requiredAcks = 1, RequestLocal.withThreadConfinedCaching))
 
-    // Before appendRecordsToLeader is called, ReplicaManager will call maybeStartTransactionVerification. We should get a non-null VerificationGuard.
+    // Before appendRecordsToLeader is called, ReplicaManager will call maybeStartTransactionVerification. We should get a non-sentinel VerificationGuard.
     val verificationGuard = partition.maybeStartTransactionVerification(producerId, 3, 0)
-    assertNotNull(verificationGuard)
+    assertNotEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, verificationGuard)
 
     // With the wrong VerificationGuard, append should fail.
     assertThrows(classOf[InvalidTxnStateException], () => partition.appendRecordsToLeader(transactionRecords(),
@@ -3564,7 +3564,7 @@ class PartitionTest extends AbstractPartitionTest {
 
     // We should no longer need a VerificationGuard. Future appends without VerificationGuard will also succeed.
     val verificationGuard3 = partition.maybeStartTransactionVerification(producerId, 3, 0)
-    assertNull(verificationGuard3)
+    assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, verificationGuard3)
     partition.appendRecordsToLeader(transactionRecords(), origin = AppendOrigin.CLIENT, requiredAcks = 1, RequestLocal.withThreadConfinedCaching)
   }
 

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -56,7 +56,7 @@ import org.apache.kafka.server.common.MetadataVersion.IBP_2_6_IV0
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.util.{KafkaScheduler, MockTime}
 import org.apache.kafka.storage.internals.epoch.LeaderEpochFileCache
-import org.apache.kafka.storage.internals.log.{AppendOrigin, CleanerConfig, EpochEntry, FetchIsolation, FetchParams, LogAppendInfo, LogDirFailureChannel, LogOffsetMetadata, LogReadInfo, LogSegments, LogStartOffsetIncrementReason, ProducerStateManager, ProducerStateManagerConfig}
+import org.apache.kafka.storage.internals.log.{AppendOrigin, CleanerConfig, EpochEntry, FetchIsolation, FetchParams, LogAppendInfo, LogDirFailureChannel, LogOffsetMetadata, LogReadInfo, LogSegments, LogStartOffsetIncrementReason, ProducerStateManager, ProducerStateManagerConfig, VerificationGuard}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
@@ -3555,7 +3555,7 @@ class PartitionTest extends AbstractPartitionTest {
 
     // With the wrong verification guard, append should fail.
     assertThrows(classOf[InvalidTxnStateException], () => partition.appendRecordsToLeader(transactionRecords(),
-      origin = AppendOrigin.CLIENT, requiredAcks = 1, RequestLocal.withThreadConfinedCaching, Optional.of(new Object)))
+      origin = AppendOrigin.CLIENT, requiredAcks = 1, RequestLocal.withThreadConfinedCaching, new VerificationGuard()))
 
     // We should return the same verification object when we still need to verify. Append should proceed.
     val verificationGuard2 = partition.maybeStartTransactionVerification(producerId, 3, 0)

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -3546,23 +3546,23 @@ class PartitionTest extends AbstractPartitionTest {
       baseSequence = 3,
       producerId = producerId)
 
-    // When verification guard is not there, we should not be able to append.
+    // When VerificationGuard is not there, we should not be able to append.
     assertThrows(classOf[InvalidTxnStateException], () => partition.appendRecordsToLeader(transactionRecords(), origin = AppendOrigin.CLIENT, requiredAcks = 1, RequestLocal.withThreadConfinedCaching))
 
-    // Before appendRecordsToLeader is called, ReplicaManager will call maybeStartTransactionVerification. We should get a non-null verification object.
+    // Before appendRecordsToLeader is called, ReplicaManager will call maybeStartTransactionVerification. We should get a non-null VerificationGuard.
     val verificationGuard = partition.maybeStartTransactionVerification(producerId, 3, 0)
     assertNotNull(verificationGuard)
 
-    // With the wrong verification guard, append should fail.
+    // With the wrong VerificationGuard, append should fail.
     assertThrows(classOf[InvalidTxnStateException], () => partition.appendRecordsToLeader(transactionRecords(),
       origin = AppendOrigin.CLIENT, requiredAcks = 1, RequestLocal.withThreadConfinedCaching, new VerificationGuard()))
 
-    // We should return the same verification object when we still need to verify. Append should proceed.
+    // We should return the same VerificationGuard when we still need to verify. Append should proceed.
     val verificationGuard2 = partition.maybeStartTransactionVerification(producerId, 3, 0)
     assertEquals(verificationGuard, verificationGuard2)
     partition.appendRecordsToLeader(transactionRecords(), origin = AppendOrigin.CLIENT, requiredAcks = 1, RequestLocal.withThreadConfinedCaching, verificationGuard)
 
-    // We should no longer need a verification object. Future appends without verification guard will also succeed.
+    // We should no longer need a VerificationGuard. Future appends without VerificationGuard will also succeed.
     val verificationGuard3 = partition.maybeStartTransactionVerification(producerId, 3, 0)
     assertNull(verificationGuard3)
     partition.appendRecordsToLeader(transactionRecords(), origin = AppendOrigin.CLIENT, requiredAcks = 1, RequestLocal.withThreadConfinedCaching)

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -3768,13 +3768,13 @@ class UnifiedLogTest {
     log.appendAsLeader(idempotentRecords, origin = appendOrigin, leaderEpoch = 0)
     assertFalse(log.hasOngoingTransaction(producerId))
 
-    // Since we wrote idempotent records, we keep verification guard.
+    // Since we wrote idempotent records, we keep VerificationGuard.
     assertEquals(verificationGuard, log.verificationGuard(producerId))
 
     // Now write the transactional records
     log.appendAsLeader(transactionalRecords, origin = appendOrigin, leaderEpoch = 0, verificationGuard = verificationGuard)
     assertTrue(log.hasOngoingTransaction(producerId))
-    // Verification guard should be cleared now.
+    // VerificationGuard should be cleared now.
     assertNull(log.verificationGuard(producerId))
 
     // A subsequent maybeStartTransactionVerification will be empty since we are already verified.

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -3738,8 +3738,8 @@ class UnifiedLogTest {
     val logConfig = LogTestUtils.createLogConfig(segmentBytes = 2048 * 5)
     val log = createLog(logDir, logConfig, producerStateManagerConfig = producerStateManagerConfig)
     assertFalse(log.hasOngoingTransaction(producerId))
-    assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, log.verificationGuard(producerId))
-    assertFalse(log.verificationGuard(producerId).verifiedBy(VerificationGuard.SENTINEL_VERIFICATION_GUARD))
+    assertEquals(VerificationGuard.SENTINEL, log.verificationGuard(producerId))
+    assertFalse(log.verificationGuard(producerId).verifiedBy(VerificationGuard.SENTINEL))
 
     val idempotentRecords = MemoryRecords.withIdempotentRecords(
       CompressionType.NONE,
@@ -3764,7 +3764,7 @@ class UnifiedLogTest {
     )
 
     val verificationGuard = log.maybeStartTransactionVerification(producerId, sequence, producerEpoch)
-    assertNotEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, verificationGuard)
+    assertNotEquals(VerificationGuard.SENTINEL, verificationGuard)
 
     log.appendAsLeader(idempotentRecords, origin = appendOrigin, leaderEpoch = 0)
     assertFalse(log.hasOngoingTransaction(producerId))
@@ -3777,10 +3777,10 @@ class UnifiedLogTest {
     log.appendAsLeader(transactionalRecords, origin = appendOrigin, leaderEpoch = 0, verificationGuard = verificationGuard)
     assertTrue(log.hasOngoingTransaction(producerId))
     // VerificationGuard should be cleared now.
-    assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, log.verificationGuard(producerId))
+    assertEquals(VerificationGuard.SENTINEL, log.verificationGuard(producerId))
 
     // A subsequent maybeStartTransactionVerification will be empty since we are already verified.
-    assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, log.maybeStartTransactionVerification(producerId, sequence, producerEpoch))
+    assertEquals(VerificationGuard.SENTINEL, log.maybeStartTransactionVerification(producerId, sequence, producerEpoch))
 
     val endTransactionMarkerRecord = MemoryRecords.withEndTransactionMarker(
       producerId,
@@ -3790,14 +3790,14 @@ class UnifiedLogTest {
 
     log.appendAsLeader(endTransactionMarkerRecord, origin = AppendOrigin.COORDINATOR, leaderEpoch = 0)
     assertFalse(log.hasOngoingTransaction(producerId))
-    assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, log.verificationGuard(producerId))
+    assertEquals(VerificationGuard.SENTINEL, log.verificationGuard(producerId))
 
     if (appendOrigin == AppendOrigin.CLIENT)
       sequence = sequence + 1
 
     // A new maybeStartTransactionVerification will not be empty, as we need to verify the next transaction.
     val newVerificationGuard = log.maybeStartTransactionVerification(producerId, sequence, producerEpoch)
-    assertNotEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, newVerificationGuard)
+    assertNotEquals(VerificationGuard.SENTINEL, newVerificationGuard)
     assertNotEquals(verificationGuard, newVerificationGuard)
     assertFalse(verificationGuard.verifiedBy(newVerificationGuard))
   }
@@ -3812,7 +3812,7 @@ class UnifiedLogTest {
     val log = createLog(logDir, logConfig, producerStateManagerConfig = producerStateManagerConfig)
 
     val verificationGuard = log.maybeStartTransactionVerification(producerId, 0, producerEpoch)
-    assertNotEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, verificationGuard)
+    assertNotEquals(VerificationGuard.SENTINEL, verificationGuard)
 
     val endTransactionMarkerRecord = MemoryRecords.withEndTransactionMarker(
       producerId,
@@ -3822,7 +3822,7 @@ class UnifiedLogTest {
 
     log.appendAsLeader(endTransactionMarkerRecord, origin = AppendOrigin.COORDINATOR, leaderEpoch = 0)
     assertFalse(log.hasOngoingTransaction(producerId))
-    assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, log.verificationGuard(producerId))
+    assertEquals(VerificationGuard.SENTINEL, log.verificationGuard(producerId))
   }
 
   @Test
@@ -3835,7 +3835,7 @@ class UnifiedLogTest {
     val log = createLog(logDir, logConfig, producerStateManagerConfig = producerStateManagerConfig)
 
     val verificationGuard = log.maybeStartTransactionVerification(producerId, 0, producerEpoch)
-    assertNotEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, verificationGuard)
+    assertNotEquals(VerificationGuard.SENTINEL, verificationGuard)
 
     producerStateManagerConfig.setTransactionVerificationEnabled(false)
 
@@ -3850,7 +3850,7 @@ class UnifiedLogTest {
     log.appendAsLeader(transactionalRecords, leaderEpoch = 0)
 
     assertTrue(log.hasOngoingTransaction(producerId))
-    assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, log.verificationGuard(producerId))
+    assertEquals(VerificationGuard.SENTINEL, log.verificationGuard(producerId))
   }
 
   @Test
@@ -3875,14 +3875,14 @@ class UnifiedLogTest {
     )
     assertThrows(classOf[InvalidTxnStateException], () => log.appendAsLeader(transactionalRecords, leaderEpoch = 0))
     assertFalse(log.hasOngoingTransaction(producerId))
-    assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, log.verificationGuard(producerId))
+    assertEquals(VerificationGuard.SENTINEL, log.verificationGuard(producerId))
 
     val verificationGuard = log.maybeStartTransactionVerification(producerId, sequence, producerEpoch)
-    assertNotEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, verificationGuard)
+    assertNotEquals(VerificationGuard.SENTINEL, verificationGuard)
 
     log.appendAsLeader(transactionalRecords, leaderEpoch = 0, verificationGuard = verificationGuard)
     assertTrue(log.hasOngoingTransaction(producerId))
-    assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, log.verificationGuard(producerId))
+    assertEquals(VerificationGuard.SENTINEL, log.verificationGuard(producerId))
   }
 
   @Test
@@ -3895,7 +3895,7 @@ class UnifiedLogTest {
     val logConfig = LogTestUtils.createLogConfig(segmentBytes = 2048 * 5)
     val log = createLog(logDir, logConfig, producerStateManagerConfig = producerStateManagerConfig)
     assertFalse(log.hasOngoingTransaction(producerId))
-    assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, log.verificationGuard(producerId))
+    assertEquals(VerificationGuard.SENTINEL, log.verificationGuard(producerId))
 
     val transactionalRecords = MemoryRecords.withTransactionalRecords(
       CompressionType.NONE,

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -3739,7 +3739,7 @@ class UnifiedLogTest {
     val log = createLog(logDir, logConfig, producerStateManagerConfig = producerStateManagerConfig)
     assertFalse(log.hasOngoingTransaction(producerId))
     assertEquals(VerificationGuard.SENTINEL, log.verificationGuard(producerId))
-    assertFalse(log.verificationGuard(producerId).verifies(VerificationGuard.SENTINEL))
+    assertFalse(log.verificationGuard(producerId).verify(VerificationGuard.SENTINEL))
 
     val idempotentRecords = MemoryRecords.withIdempotentRecords(
       CompressionType.NONE,
@@ -3773,7 +3773,7 @@ class UnifiedLogTest {
     assertEquals(verificationGuard, log.verificationGuard(producerId))
 
     // Now write the transactional records
-    assertTrue(log.verificationGuard(producerId).verifies(verificationGuard))
+    assertTrue(log.verificationGuard(producerId).verify(verificationGuard))
     log.appendAsLeader(transactionalRecords, origin = appendOrigin, leaderEpoch = 0, verificationGuard = verificationGuard)
     assertTrue(log.hasOngoingTransaction(producerId))
     // VerificationGuard should be cleared now.
@@ -3799,7 +3799,7 @@ class UnifiedLogTest {
     val newVerificationGuard = log.maybeStartTransactionVerification(producerId, sequence, producerEpoch)
     assertNotEquals(VerificationGuard.SENTINEL, newVerificationGuard)
     assertNotEquals(verificationGuard, newVerificationGuard)
-    assertFalse(verificationGuard.verifies(newVerificationGuard))
+    assertFalse(verificationGuard.verify(newVerificationGuard))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -3739,7 +3739,7 @@ class UnifiedLogTest {
     val log = createLog(logDir, logConfig, producerStateManagerConfig = producerStateManagerConfig)
     assertFalse(log.hasOngoingTransaction(producerId))
     assertEquals(VerificationGuard.SENTINEL, log.verificationGuard(producerId))
-    assertFalse(log.verificationGuard(producerId).verifiedBy(VerificationGuard.SENTINEL))
+    assertFalse(log.verificationGuard(producerId).verifies(VerificationGuard.SENTINEL))
 
     val idempotentRecords = MemoryRecords.withIdempotentRecords(
       CompressionType.NONE,
@@ -3773,7 +3773,7 @@ class UnifiedLogTest {
     assertEquals(verificationGuard, log.verificationGuard(producerId))
 
     // Now write the transactional records
-    assertTrue(log.verificationGuard(producerId).verifiedBy(verificationGuard))
+    assertTrue(log.verificationGuard(producerId).verifies(verificationGuard))
     log.appendAsLeader(transactionalRecords, origin = appendOrigin, leaderEpoch = 0, verificationGuard = verificationGuard)
     assertTrue(log.hasOngoingTransaction(producerId))
     // VerificationGuard should be cleared now.
@@ -3799,7 +3799,7 @@ class UnifiedLogTest {
     val newVerificationGuard = log.maybeStartTransactionVerification(producerId, sequence, producerEpoch)
     assertNotEquals(VerificationGuard.SENTINEL, newVerificationGuard)
     assertNotEquals(verificationGuard, newVerificationGuard)
-    assertFalse(verificationGuard.verifiedBy(newVerificationGuard))
+    assertFalse(verificationGuard.verifies(newVerificationGuard))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/VerificationGuardTest.scala
+++ b/core/src/test/scala/unit/kafka/log/VerificationGuardTest.scala
@@ -1,0 +1,36 @@
+package unit.kafka.log
+
+import org.apache.kafka.storage.internals.log.VerificationGuard
+import org.apache.kafka.storage.internals.log.VerificationGuard.SENTINEL_VERIFICATION_GUARD
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotEquals, assertTrue}
+import org.junit.jupiter.api.Test
+
+class VerificationGuardTest {
+
+  @Test
+  def testEqualsAndHashCode(): Unit = {
+    val verificationGuard1 = new VerificationGuard
+    val verificationGuard2 = new VerificationGuard
+
+    assertNotEquals(verificationGuard1, verificationGuard2)
+    assertNotEquals(SENTINEL_VERIFICATION_GUARD, verificationGuard1)
+    assertEquals(SENTINEL_VERIFICATION_GUARD, SENTINEL_VERIFICATION_GUARD)
+
+    assertNotEquals(verificationGuard1.hashCode, verificationGuard2.hashCode)
+    assertNotEquals(SENTINEL_VERIFICATION_GUARD.hashCode, verificationGuard1.hashCode)
+    assertEquals(SENTINEL_VERIFICATION_GUARD.hashCode, SENTINEL_VERIFICATION_GUARD.hashCode)
+  }
+
+  @Test
+  def testVerifiedBy(): Unit = {
+    val verificationGuard1 = new VerificationGuard
+    val verificationGuard2 = new VerificationGuard
+
+    assertFalse(verificationGuard1.verifiedBy(verificationGuard2))
+    assertFalse(verificationGuard1.verifiedBy(SENTINEL_VERIFICATION_GUARD))
+    assertFalse(SENTINEL_VERIFICATION_GUARD.verifiedBy(verificationGuard1))
+    assertFalse(SENTINEL_VERIFICATION_GUARD.verifiedBy(SENTINEL_VERIFICATION_GUARD))
+    assertTrue(verificationGuard1.verifiedBy(verificationGuard1))
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/log/VerificationGuardTest.scala
+++ b/core/src/test/scala/unit/kafka/log/VerificationGuardTest.scala
@@ -1,7 +1,24 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
 package unit.kafka.log
 
 import org.apache.kafka.storage.internals.log.VerificationGuard
-import org.apache.kafka.storage.internals.log.VerificationGuard.SENTINEL_VERIFICATION_GUARD
+import org.apache.kafka.storage.internals.log.VerificationGuard.SENTINEL
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotEquals, assertTrue}
 import org.junit.jupiter.api.Test
 
@@ -13,12 +30,12 @@ class VerificationGuardTest {
     val verificationGuard2 = new VerificationGuard
 
     assertNotEquals(verificationGuard1, verificationGuard2)
-    assertNotEquals(SENTINEL_VERIFICATION_GUARD, verificationGuard1)
-    assertEquals(SENTINEL_VERIFICATION_GUARD, SENTINEL_VERIFICATION_GUARD)
+    assertNotEquals(SENTINEL, verificationGuard1)
+    assertEquals(SENTINEL, SENTINEL)
 
     assertNotEquals(verificationGuard1.hashCode, verificationGuard2.hashCode)
-    assertNotEquals(SENTINEL_VERIFICATION_GUARD.hashCode, verificationGuard1.hashCode)
-    assertEquals(SENTINEL_VERIFICATION_GUARD.hashCode, SENTINEL_VERIFICATION_GUARD.hashCode)
+    assertNotEquals(SENTINEL.hashCode, verificationGuard1.hashCode)
+    assertEquals(SENTINEL.hashCode, SENTINEL.hashCode)
   }
 
   @Test
@@ -27,9 +44,9 @@ class VerificationGuardTest {
     val verificationGuard2 = new VerificationGuard
 
     assertFalse(verificationGuard1.verifiedBy(verificationGuard2))
-    assertFalse(verificationGuard1.verifiedBy(SENTINEL_VERIFICATION_GUARD))
-    assertFalse(SENTINEL_VERIFICATION_GUARD.verifiedBy(verificationGuard1))
-    assertFalse(SENTINEL_VERIFICATION_GUARD.verifiedBy(SENTINEL_VERIFICATION_GUARD))
+    assertFalse(verificationGuard1.verifiedBy(SENTINEL))
+    assertFalse(SENTINEL.verifiedBy(verificationGuard1))
+    assertFalse(SENTINEL.verifiedBy(SENTINEL))
     assertTrue(verificationGuard1.verifiedBy(verificationGuard1))
   }
 

--- a/core/src/test/scala/unit/kafka/log/VerificationGuardTest.scala
+++ b/core/src/test/scala/unit/kafka/log/VerificationGuardTest.scala
@@ -43,11 +43,11 @@ class VerificationGuardTest {
     val verificationGuard1 = new VerificationGuard
     val verificationGuard2 = new VerificationGuard
 
-    assertFalse(verificationGuard1.verifies(verificationGuard2))
-    assertFalse(verificationGuard1.verifies(SENTINEL))
-    assertFalse(SENTINEL.verifies(verificationGuard1))
-    assertFalse(SENTINEL.verifies(SENTINEL))
-    assertTrue(verificationGuard1.verifies(verificationGuard1))
+    assertFalse(verificationGuard1.verify(verificationGuard2))
+    assertFalse(verificationGuard1.verify(SENTINEL))
+    assertFalse(SENTINEL.verify(verificationGuard1))
+    assertFalse(SENTINEL.verify(SENTINEL))
+    assertTrue(verificationGuard1.verify(verificationGuard1))
   }
 
 }

--- a/core/src/test/scala/unit/kafka/log/VerificationGuardTest.scala
+++ b/core/src/test/scala/unit/kafka/log/VerificationGuardTest.scala
@@ -43,11 +43,11 @@ class VerificationGuardTest {
     val verificationGuard1 = new VerificationGuard
     val verificationGuard2 = new VerificationGuard
 
-    assertFalse(verificationGuard1.verifiedBy(verificationGuard2))
-    assertFalse(verificationGuard1.verifiedBy(SENTINEL))
-    assertFalse(SENTINEL.verifiedBy(verificationGuard1))
-    assertFalse(SENTINEL.verifiedBy(SENTINEL))
-    assertTrue(verificationGuard1.verifiedBy(verificationGuard1))
+    assertFalse(verificationGuard1.verifies(verificationGuard2))
+    assertFalse(verificationGuard1.verifies(SENTINEL))
+    assertFalse(SENTINEL.verifies(verificationGuard1))
+    assertFalse(SENTINEL.verifies(SENTINEL))
+    assertTrue(verificationGuard1.verifies(verificationGuard1))
   }
 
 }

--- a/core/src/test/scala/unit/kafka/log/VerificationGuardTest.scala
+++ b/core/src/test/scala/unit/kafka/log/VerificationGuardTest.scala
@@ -39,7 +39,7 @@ class VerificationGuardTest {
   }
 
   @Test
-  def testVerifiedBy(): Unit = {
+  def testVerify(): Unit = {
     val verificationGuard1 = new VerificationGuard
     val verificationGuard2 = new VerificationGuard
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -60,7 +60,7 @@ import org.apache.kafka.server.common.OffsetAndEpoch
 import org.apache.kafka.server.common.MetadataVersion.IBP_2_6_IV0
 import org.apache.kafka.server.metrics.{KafkaMetricsGroup, KafkaYammerMetrics}
 import org.apache.kafka.server.util.{MockScheduler, MockTime}
-import org.apache.kafka.storage.internals.log.{AppendOrigin, FetchDataInfo, FetchIsolation, FetchParams, FetchPartitionData, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogSegments, LogStartOffsetIncrementReason, ProducerStateManager, ProducerStateManagerConfig, RemoteStorageFetchInfo}
+import org.apache.kafka.storage.internals.log.{AppendOrigin, FetchDataInfo, FetchIsolation, FetchParams, FetchPartitionData, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogSegments, LogStartOffsetIncrementReason, ProducerStateManager, ProducerStateManagerConfig, RemoteStorageFetchInfo, VerificationGuard}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
@@ -2163,7 +2163,7 @@ class ReplicaManagerTest {
         new SimpleRecord("message".getBytes))
       appendRecords(replicaManager, tp0, idempotentRecords)
       verify(addPartitionsToTxnManager, times(0)).verifyTransaction(any(), any(), any(), any(), any[AddPartitionsToTxnManager.AppendCallback]())
-      assertNull(getVerificationGuard(replicaManager, tp0, producerId))
+      assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, getVerificationGuard(replicaManager, tp0, producerId))
 
       // If we supply a transactional ID and some transactional and some idempotent records, we should only verify the topic partition with transactional records.
       val transactionalRecords = MemoryRecords.withTransactionalRecords(CompressionType.NONE, producerId, producerEpoch, sequence + 1,
@@ -2179,8 +2179,8 @@ class ReplicaManagerTest {
         ArgumentMatchers.eq(Seq(tp0)),
         any[AddPartitionsToTxnManager.AppendCallback]()
       )
-      assertNotNull(getVerificationGuard(replicaManager, tp0, producerId))
-      assertNull(getVerificationGuard(replicaManager, tp1, producerId))
+      assertNotEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, getVerificationGuard(replicaManager, tp0, producerId))
+      assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, getVerificationGuard(replicaManager, tp1, producerId))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }
@@ -2238,7 +2238,7 @@ class ReplicaManagerTest {
 
       val callback2: AddPartitionsToTxnManager.AppendCallback = appendCallback2.getValue()
       callback2(Map.empty[TopicPartition, Errors].toMap)
-      assertEquals(null, getVerificationGuard(replicaManager, tp0, producerId))
+      assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, getVerificationGuard(replicaManager, tp0, producerId))
       assertTrue(replicaManager.localLog(tp0).get.hasOngoingTransaction(producerId))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
@@ -2424,7 +2424,7 @@ class ReplicaManagerTest {
       val transactionalRecords = MemoryRecords.withTransactionalRecords(CompressionType.NONE, producerId, producerEpoch, sequence,
         new SimpleRecord(s"message $sequence".getBytes))
       appendRecords(replicaManager, tp, transactionalRecords, transactionalId = transactionalId)
-      assertNull(getVerificationGuard(replicaManager, tp, producerId))
+      assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, getVerificationGuard(replicaManager, tp, producerId))
 
       // We should not add these partitions to the manager to verify.
       verify(addPartitionsToTxnManager, times(0)).verifyTransaction(any(), any(), any(), any(), any())
@@ -2442,7 +2442,7 @@ class ReplicaManagerTest {
 
       appendRecords(replicaManager, tp, moreTransactionalRecords, transactionalId = transactionalId)
       verify(addPartitionsToTxnManager, times(0)).verifyTransaction(any(), any(), any(), any(), any())
-      assertEquals(null, getVerificationGuard(replicaManager, tp, producerId))
+      assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, getVerificationGuard(replicaManager, tp, producerId))
       assertTrue(replicaManager.localLog(tp).get.hasOngoingTransaction(producerId))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
@@ -2496,7 +2496,7 @@ class ReplicaManagerTest {
       // This time we do not verify
       appendRecords(replicaManager, tp0, transactionalRecords, transactionalId = transactionalId)
       verify(addPartitionsToTxnManager, times(1)).verifyTransaction(any(), any(), any(), any(), any())
-      assertEquals(null, getVerificationGuard(replicaManager, tp0, producerId))
+      assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, getVerificationGuard(replicaManager, tp0, producerId))
       assertTrue(replicaManager.localLog(tp0).get.hasOngoingTransaction(producerId))
     } finally {
       replicaManager.shutdown(checkpointHW = false)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -2297,7 +2297,7 @@ class ReplicaManagerTest {
       )
       assertEquals(verificationGuard, getVerificationGuard(replicaManager, tp0, producerId))
 
-      // Verification should succeed, but we expect to fail with OutOfOrderSequence and for the verification guard to remain.
+      // Verification should succeed, but we expect to fail with OutOfOrderSequence and for the VerificationGuard to remain.
       val callback2: AddPartitionsToTxnManager.AppendCallback = appendCallback2.getValue()
       callback2(Map.empty[TopicPartition, Errors].toMap)
       assertEquals(verificationGuard, getVerificationGuard(replicaManager, tp0, producerId))

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -2163,7 +2163,7 @@ class ReplicaManagerTest {
         new SimpleRecord("message".getBytes))
       appendRecords(replicaManager, tp0, idempotentRecords)
       verify(addPartitionsToTxnManager, times(0)).verifyTransaction(any(), any(), any(), any(), any[AddPartitionsToTxnManager.AppendCallback]())
-      assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, getVerificationGuard(replicaManager, tp0, producerId))
+      assertEquals(VerificationGuard.SENTINEL, getVerificationGuard(replicaManager, tp0, producerId))
 
       // If we supply a transactional ID and some transactional and some idempotent records, we should only verify the topic partition with transactional records.
       val transactionalRecords = MemoryRecords.withTransactionalRecords(CompressionType.NONE, producerId, producerEpoch, sequence + 1,
@@ -2179,8 +2179,8 @@ class ReplicaManagerTest {
         ArgumentMatchers.eq(Seq(tp0)),
         any[AddPartitionsToTxnManager.AppendCallback]()
       )
-      assertNotEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, getVerificationGuard(replicaManager, tp0, producerId))
-      assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, getVerificationGuard(replicaManager, tp1, producerId))
+      assertNotEquals(VerificationGuard.SENTINEL, getVerificationGuard(replicaManager, tp0, producerId))
+      assertEquals(VerificationGuard.SENTINEL, getVerificationGuard(replicaManager, tp1, producerId))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }
@@ -2238,7 +2238,7 @@ class ReplicaManagerTest {
 
       val callback2: AddPartitionsToTxnManager.AppendCallback = appendCallback2.getValue()
       callback2(Map.empty[TopicPartition, Errors].toMap)
-      assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, getVerificationGuard(replicaManager, tp0, producerId))
+      assertEquals(VerificationGuard.SENTINEL, getVerificationGuard(replicaManager, tp0, producerId))
       assertTrue(replicaManager.localLog(tp0).get.hasOngoingTransaction(producerId))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
@@ -2424,7 +2424,7 @@ class ReplicaManagerTest {
       val transactionalRecords = MemoryRecords.withTransactionalRecords(CompressionType.NONE, producerId, producerEpoch, sequence,
         new SimpleRecord(s"message $sequence".getBytes))
       appendRecords(replicaManager, tp, transactionalRecords, transactionalId = transactionalId)
-      assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, getVerificationGuard(replicaManager, tp, producerId))
+      assertEquals(VerificationGuard.SENTINEL, getVerificationGuard(replicaManager, tp, producerId))
 
       // We should not add these partitions to the manager to verify.
       verify(addPartitionsToTxnManager, times(0)).verifyTransaction(any(), any(), any(), any(), any())
@@ -2442,7 +2442,7 @@ class ReplicaManagerTest {
 
       appendRecords(replicaManager, tp, moreTransactionalRecords, transactionalId = transactionalId)
       verify(addPartitionsToTxnManager, times(0)).verifyTransaction(any(), any(), any(), any(), any())
-      assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, getVerificationGuard(replicaManager, tp, producerId))
+      assertEquals(VerificationGuard.SENTINEL, getVerificationGuard(replicaManager, tp, producerId))
       assertTrue(replicaManager.localLog(tp).get.hasOngoingTransaction(producerId))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
@@ -2496,7 +2496,7 @@ class ReplicaManagerTest {
       // This time we do not verify
       appendRecords(replicaManager, tp0, transactionalRecords, transactionalId = transactionalId)
       verify(addPartitionsToTxnManager, times(1)).verifyTransaction(any(), any(), any(), any(), any())
-      assertEquals(VerificationGuard.SENTINEL_VERIFICATION_GUARD, getVerificationGuard(replicaManager, tp0, producerId))
+      assertEquals(VerificationGuard.SENTINEL, getVerificationGuard(replicaManager, tp0, producerId))
       assertTrue(replicaManager.localLog(tp0).get.hasOngoingTransaction(producerId))
     } finally {
       replicaManager.shutdown(checkpointHW = false)

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
@@ -1,13 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.storage.internals.log;
 
 import java.util.concurrent.atomic.AtomicLong;
 
 public class VerificationGuard {
-    private static final AtomicLong incrementingId = new AtomicLong(0L);
+    private static final AtomicLong INCREMENTING_ID = new AtomicLong(0L);
     private final long verificationGuardValue;
 
     public VerificationGuard() {
-        verificationGuardValue = incrementingId.incrementAndGet();
+        verificationGuardValue = INCREMENTING_ID.incrementAndGet();
     }
 
     @Override
@@ -17,16 +33,16 @@ public class VerificationGuard {
 
     @Override
     public boolean equals(Object obj) {
-    if ((null == obj) || (obj.getClass() != this.getClass()))
-        return false;
-    VerificationGuard guard = (VerificationGuard) obj;
-    return verificationGuardValue == guard.verificationGuardValue();
+        if ((null == obj) || (obj.getClass() != this.getClass()))
+            return false;
+        VerificationGuard guard = (VerificationGuard) obj;
+        return verificationGuardValue == guard.verificationGuardValue();
     }
 
     @Override
     public int hashCode() {
         long value = verificationGuardValue;
-        return (int)(value ^ (value >>> 32));
+        return (int) (value ^ (value >>> 32));
     }
 
     public long verificationGuardValue() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
@@ -1,0 +1,35 @@
+package org.apache.kafka.storage.internals.log;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class VerificationGuard {
+    private static final AtomicLong incrementingId = new AtomicLong(0L);
+    private final long verificationGuardValue;
+
+    public VerificationGuard() {
+        verificationGuardValue = incrementingId.incrementAndGet();
+    }
+
+    @Override
+    public String toString() {
+        return "VerificationGuard: " + verificationGuardValue;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+    if ((null == obj) || (obj.getClass() != this.getClass()))
+        return false;
+    VerificationGuard guard = (VerificationGuard) obj;
+    return verificationGuardValue == guard.verificationGuardValue();
+    }
+
+    @Override
+    public int hashCode() {
+        long value = verificationGuardValue;
+        return (int)(value ^ (value >>> 32));
+    }
+
+    public long verificationGuardValue() {
+        return verificationGuardValue;
+    }
+}

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
@@ -49,8 +49,7 @@ public class VerificationGuard {
 
     @Override
     public int hashCode() {
-        long value = verificationGuardValue;
-        return (int) (value ^ (value >>> 32));
+        return Long.hashCode(verificationGuardValue);
     }
 
     private long verificationGuardValue() {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
@@ -56,7 +56,7 @@ public final class VerificationGuard {
         return value;
     }
 
-    public boolean verifies(VerificationGuard verifyingGuard) {
+    public boolean verify(VerificationGuard verifyingGuard) {
         return verifyingGuard != SENTINEL && verifyingGuard.equals(this);
     }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
@@ -19,11 +19,19 @@ package org.apache.kafka.storage.internals.log;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class VerificationGuard {
+
+    // The sentinel verification guard will be used as a default when no verification guard is provided.
+    // It can not be used to verify a transaction is ongoing and its verificationGuardValue is always 0.
+    public static final VerificationGuard SENTINEL_VERIFICATION_GUARD = new VerificationGuard(0);
     private static final AtomicLong INCREMENTING_ID = new AtomicLong(0L);
     private final long verificationGuardValue;
 
     public VerificationGuard() {
         verificationGuardValue = INCREMENTING_ID.incrementAndGet();
+    }
+
+    private VerificationGuard(long value) {
+        verificationGuardValue = value;
     }
 
     @Override
@@ -45,7 +53,11 @@ public class VerificationGuard {
         return (int) (value ^ (value >>> 32));
     }
 
-    public long verificationGuardValue() {
+    private long verificationGuardValue() {
         return verificationGuardValue;
+    }
+
+    public boolean verifiedBy(VerificationGuard verifyingGuard) {
+        return verifyingGuard != SENTINEL_VERIFICATION_GUARD && verifyingGuard.equals(this);
     }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
@@ -21,22 +21,22 @@ import java.util.concurrent.atomic.AtomicLong;
 public class VerificationGuard {
 
     // The sentinel VerificationGuard will be used as a default when no verification guard is provided.
-    // It can not be used to verify a transaction is ongoing and its verificationGuardValue is always 0.
-    public static final VerificationGuard SENTINEL_VERIFICATION_GUARD = new VerificationGuard(0);
+    // It can not be used to verify a transaction is ongoing and its value is always 0.
+    public static final VerificationGuard SENTINEL = new VerificationGuard(0);
     private static final AtomicLong INCREMENTING_ID = new AtomicLong(0L);
-    private final long verificationGuardValue;
+    private final long value;
 
     public VerificationGuard() {
-        verificationGuardValue = INCREMENTING_ID.incrementAndGet();
+        value = INCREMENTING_ID.incrementAndGet();
     }
 
     private VerificationGuard(long value) {
-        verificationGuardValue = value;
+        this.value = value;
     }
 
     @Override
     public String toString() {
-        return "VerificationGuard: " + verificationGuardValue;
+        return "VerificationGuard: " + value;
     }
 
     @Override
@@ -44,19 +44,19 @@ public class VerificationGuard {
         if ((null == obj) || (obj.getClass() != this.getClass()))
             return false;
         VerificationGuard guard = (VerificationGuard) obj;
-        return verificationGuardValue == guard.verificationGuardValue();
+        return value == guard.value();
     }
 
     @Override
     public int hashCode() {
-        return Long.hashCode(verificationGuardValue);
+        return Long.hashCode(value);
     }
 
-    private long verificationGuardValue() {
-        return verificationGuardValue;
+    private long value() {
+        return value;
     }
 
     public boolean verifiedBy(VerificationGuard verifyingGuard) {
-        return verifyingGuard != SENTINEL_VERIFICATION_GUARD && verifyingGuard.equals(this);
+        return verifyingGuard != SENTINEL && verifyingGuard.equals(this);
     }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class VerificationGuard {
 
-    // The sentinel verification guard will be used as a default when no verification guard is provided.
+    // The sentinel VerificationGuard will be used as a default when no verification guard is provided.
     // It can not be used to verify a transaction is ongoing and its verificationGuardValue is always 0.
     public static final VerificationGuard SENTINEL_VERIFICATION_GUARD = new VerificationGuard(0);
     private static final AtomicLong INCREMENTING_ID = new AtomicLong(0L);

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationGuard.java
@@ -18,7 +18,7 @@ package org.apache.kafka.storage.internals.log;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-public class VerificationGuard {
+public final class VerificationGuard {
 
     // The sentinel VerificationGuard will be used as a default when no verification guard is provided.
     // It can not be used to verify a transaction is ongoing and its value is always 0.
@@ -36,7 +36,7 @@ public class VerificationGuard {
 
     @Override
     public String toString() {
-        return "VerificationGuard: " + value;
+        return "VerificationGuard(value=" + value + ")";
     }
 
     @Override
@@ -56,7 +56,7 @@ public class VerificationGuard {
         return value;
     }
 
-    public boolean verifiedBy(VerificationGuard verifyingGuard) {
+    public boolean verifies(VerificationGuard verifyingGuard) {
         return verifyingGuard != SENTINEL && verifyingGuard.equals(this);
     }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationStateEntry.java
@@ -30,13 +30,13 @@ package org.apache.kafka.storage.internals.log;
 public class VerificationStateEntry {
 
     final private long timestamp;
-    final private Object verificationGuard;
+    final private VerificationGuard verificationGuard;
     private int lowestSequence;
     private short epoch;
 
     public VerificationStateEntry(long timestamp, int sequence, short epoch) {
         this.timestamp = timestamp;
-        this.verificationGuard = new Object();
+        this.verificationGuard = new VerificationGuard();
         this.lowestSequence = sequence;
         this.epoch = epoch;
     }
@@ -45,7 +45,7 @@ public class VerificationStateEntry {
         return timestamp;
     }
 
-    public Object verificationGuard() {
+    public VerificationGuard verificationGuard() {
         return verificationGuard;
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationStateEntry.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/VerificationStateEntry.java
@@ -18,10 +18,10 @@ package org.apache.kafka.storage.internals.log;
 
 /**
  * This class represents the verification state of a specific producer id.
- * It contains a verification guard object that is used to uniquely identify the transaction we want to verify.
+ * It contains a VerificationGuard that is used to uniquely identify the transaction we want to verify.
  * After verifying, we retain this object until we append to the log. This prevents any race conditions where the transaction
  * may end via a control marker before we write to the log. This mechanism is used to prevent hanging transactions.
- * We remove the verification guard object whenever we write data to the transaction or write an end marker for the transaction.
+ * We remove the VerificationGuard whenever we write data to the transaction or write an end marker for the transaction.
  *
  * We also store the lowest seen sequence to block a higher sequence from being written in the case of the lower sequence needing retries.
  *


### PR DESCRIPTION
I've added a new class with an incrementing atomic long to represent the verification guard. Upon creation of verification guard, we will increment this value and assign it to the guard. 

The expected behavior is the same as the object guard, but with better debuggability with the string value and type safety (I found a type safety issue in the current code when implementing this)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
