### PR TITLE
KAFKA-15566: Fix flaky tests in FetchRequestTest.scala in KRaft mode

### DIFF
--- a/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
@@ -43,7 +43,7 @@ import scala.util.Random
 class FetchRequestTest extends BaseFetchRequestTest {
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk","kraft"))
   def testBrokerRespectsPartitionsOrderAndSizeLimits(quorum: String): Unit = {
     initProducer()
 
@@ -146,7 +146,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk","kraft"))
   def testFetchRequestV4WithReadCommitted(quorum: String): Unit = {
     initProducer()
     val maxPartitionBytes = 200
@@ -165,7 +165,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk","kraft"))
   def testFetchRequestToNonReplica(quorum: String): Unit = {
     val topic = "topic"
     val partition = 0
@@ -250,13 +250,13 @@ class FetchRequestTest extends BaseFetchRequestTest {
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk","kraft"))
   def testCurrentEpochValidation(quorum: String): Unit = {
     checkCurrentEpochValidation(ApiKeys.FETCH.latestVersion())
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk","kraft"))
   def testCurrentEpochValidationV12(quorum: String): Unit = {
     checkCurrentEpochValidation(12)
   }
@@ -300,13 +300,13 @@ class FetchRequestTest extends BaseFetchRequestTest {
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk","kraft"))
   def testEpochValidationWithinFetchSession(quorum: String): Unit = {
     checkEpochValidationWithinFetchSession(ApiKeys.FETCH.latestVersion())
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk","kraft"))
   def testEpochValidationWithinFetchSessionV12(quorum: String): Unit = {
     checkEpochValidationWithinFetchSession(12)
   }
@@ -368,7 +368,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
    * channel is muted in the server. If buffers are not released this will result in OOM.
    */
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk","kraft"))
   def testDownConversionWithConnectionFailure(quorum: String): Unit = {
     val (topicPartition, leaderId) = createTopics(numTopics = 1, numPartitions = 1).head
     val topicIds = getTopicIds().asJava
@@ -436,7 +436,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
     * some records have to be dropped during the conversion.
     */
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk","kraft"))
   def testDownConversionFromBatchedToUnbatchedRespectsOffset(quorum: String): Unit = {
     // Increase linger so that we have control over the batches created
     producer = TestUtils.createProducer(bootstrapServers(),
@@ -518,7 +518,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
    * This tests using FetchRequests that don't use topic IDs
    */
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk","kraft"))
   def testCreateIncrementalFetchWithPartitionsInErrorV12(quorum: String): Unit = {
     def createConsumerFetchRequest(topicPartitions: Seq[TopicPartition],
                            metadata: JFetchMetadata,
@@ -533,6 +533,8 @@ class FetchRequestTest extends BaseFetchRequestTest {
     // topicNames can be empty because we are using old requests
     val topicNames = Map[Uuid, String]().asJava
     createTopicWithAssignment("foo", Map(0 -> List(0, 1), 1 -> List(0, 2)))
+    TestUtils.waitUntilLeaderIsKnown(brokers, foo0)
+    TestUtils.waitUntilLeaderIsKnown(brokers, foo1)
     val bar0 = new TopicPartition("bar", 0)
     val req1 = createConsumerFetchRequest(List(foo0, foo1, bar0), JFetchMetadata.INITIAL, Nil)
     val resp1 = sendFetchRequest(0, req1)
@@ -557,6 +559,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
     assertTrue(responseData2.containsKey(bar0))
     assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code, responseData2.get(bar0).errorCode)
     createTopicWithAssignment("bar", Map(0 -> List(0, 1)))
+    TestUtils.waitUntilLeaderIsKnown(brokers, bar0)
     val req3 = createConsumerFetchRequest(Nil, new JFetchMetadata(resp1.sessionId(), 2), Nil)
     val resp3 = sendFetchRequest(0, req3)
     assertEquals(Errors.NONE, resp3.error())
@@ -578,7 +581,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
    * Test that when a Fetch Request receives an unknown topic ID, it returns a top level error.
    */
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk","kraft"))
   def testFetchWithPartitionsWithIdError(quorum: String): Unit = {
     def createConsumerFetchRequest(fetchData: util.LinkedHashMap[TopicPartition, FetchRequest.PartitionData],
                            metadata: JFetchMetadata,
@@ -592,6 +595,8 @@ class FetchRequestTest extends BaseFetchRequestTest {
     val foo0 = new TopicPartition("foo", 0)
     val foo1 = new TopicPartition("foo", 1)
     createTopicWithAssignment("foo", Map(0 -> List(0, 1), 1 -> List(0, 2)))
+    TestUtils.waitUntilLeaderIsKnown(brokers, foo0)
+    TestUtils.waitUntilLeaderIsKnown(brokers, foo1)
     val topicIds = getTopicIds()
     val topicIdsWithUnknown = topicIds ++ Map("bar" -> Uuid.randomUuid())
     val bar0 = new TopicPartition("bar", 0)
@@ -621,7 +626,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk","kraft"))
   def testZStdCompressedTopic(quorum: String): Unit = {
     // ZSTD compressed topic
     val topicConfig = Map(TopicConfig.COMPRESSION_TYPE_CONFIG -> BrokerCompressionType.ZSTD.name)
@@ -669,7 +674,7 @@ class FetchRequestTest extends BaseFetchRequestTest {
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk"))
+  @ValueSource(strings = Array("zk","kraft"))
   def testZStdCompressedRecords(quorum: String): Unit = {
     // Producer compressed topic
     val topicConfig = Map(TopicConfig.COMPRESSION_TYPE_CONFIG -> BrokerCompressionType.PRODUCER.name)


### PR DESCRIPTION
- Fixed some of the failing tests in FetchRequestTest. 

  `testFetchWithPartitionsWithIdError` and `testCreateIncrementalFetchWithPartitionsInErrorV12` fail with the following error when enabled with KRaft mode. These tests only fail sometimes when running locally but consistently failed when running in the Jenkins Pipeline. 
  ```
  expected: <0> but was: <6>
  Expected :0
  Actual   :6
  <Click to see difference>
  
  org.opentest4j.AssertionFailedError: expected: <0> but was: <6>
	  at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	  at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	  at app//org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	  at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:134)
	  at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:129)
	  at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:325)
	  at app//kafka.server.FetchRequestTest.testCreateIncrementalFetchWithPartitionsInErrorV12(FetchRequestTest.scala:547)
  ...
  ```
  
  The tests create topic partitions and send fetch requests for them. The expected error code to be returned is 0 however they get `NOT_LEADER_OR_FOLLOWER` exception.  We throw this exception when trying to read records from a log that doesn’t exist (https://github.com/apache/kafka/blob/dc6a53e19606674bd1276bf05d3ae7a3a2115523/core/src/main/scala/kafka/cluster/Partition.scala#L504). The issue seems to be due to receiving fetch requests before logs being created on the broker.  The following test logs with extra debug lines show that we attempted to read records from the log for topic patition foo-1, a few milliseconds before it was created. 
  ```
  [2023-10-18 12:44:18,200] DEBUG [Partition foo-1 broker=0] Getting log for topic with id foo-1 to read its records (kafka.cluster.Partition:62)
  [2023-10-18 12:44:18,200] DEBUG [Partition foo-1 broker=0] NOT_LEADER_OR_FOLLOWER foo-1 because log is empty (kafka.cluster.Partition:62)
  [2023-10-18 12:44:18,205] INFO Created log for partition foo-1 in /var/folders/fm/65mtddt52vjf8hycyj0rn64r0000gn/T/kafka-6502713585191291330/foo-1 with properties {} (kafka.log.LogManager:66)
  [2023-10-18 12:44:18,212] DEBUG [KafkaApi-0] Fetch request with correlation id 1 from client client-id on partition AAAAAAAAAAAAAAAAAAAAAA:foo-1 failed due to org.apache.kafka.common.errors.NotLeaderOrFollowerException (kafka.server.KafkaApis:62)
  ```
  In Zookeeper case, the log was created much earlier than attempting to read records from it therefore no error was returned for the fetch requests. 
  ```
  [2023-10-18 12:38:31,252] INFO Created log for partition foo-1 in /var/folders/fm/65mtddt52vjf8hycyj0rn64r0000gn/T/kafka-1270567419648769103/foo-1 with properties {} (kafka.log.LogManager:66)
  [2023-10-18 12:38:31,455] DEBUG [Partition foo-1 broker=0] Getting log for topic with id foo-1 to read its records (kafka.cluster.Partition:62)
  ```
  
  The only difference between Zookeeper and KRaft mode in these tests is the way the topic partitions are created. In Zookeeper mode, we create the topic partitions directly with Zookeeper therefore seem to take less time to create the logs. In KRaft mode, we use Admin client to create topic partitions. Even though the test waits for topic partitions to get created and appear in metadata cache before sending fetch requests, it doesn’t seem to be sufficient time for the logs to be created on the brokers.  
  
  Tests will call the utility function `TestUtils.waitUntilLeaderIsKnown` after creating the topic partitions so that they wait for the logs to be created on the leader before sending fetch requests.

- Enabled all tests except `checkLastFetchedEpochValidation` with KRaft mode.
  Looking at the build history in Jenkins, all the other tests except these 2 tests and checkLastFetchedEpochValidation were passing when they were enabled with KRaft mode. Therefore enabled them with KRaft mode again but left `checkLastFetchedEpochValidation` to be investigated further. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
