### PR TITLE
KAFKA-15632: Drop the invalid remote log metadata events

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -80,7 +80,7 @@ public class TopicConfig {
             "You can not disable this config once it is enabled. It will be provided in future versions.";
 
     public static final String LOCAL_LOG_RETENTION_MS_CONFIG = "local.retention.ms";
-    public static final String LOCAL_LOG_RETENTION_MS_DOC = "The number of milli seconds to keep the local log segment before it gets deleted. " +
+    public static final String LOCAL_LOG_RETENTION_MS_DOC = "The number of milliseconds to keep the local log segment before it gets deleted. " +
             "Default value is -2, it represents `retention.ms` value is to be used. The effective value should always be less than or equal " +
             "to `retention.ms` value.";
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCache.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCache.java
@@ -157,13 +157,20 @@ public class RemoteLogMetadataCache {
         RemoteLogSegmentState targetState = metadataUpdate.state();
         RemoteLogSegmentId remoteLogSegmentId = metadataUpdate.remoteLogSegmentId();
         RemoteLogSegmentMetadata existingMetadata = idToSegmentMetadata.get(remoteLogSegmentId);
+        if (!isInitialized() && existingMetadata == null) {
+            log.debug("Dropping the event: {} as the base-metadata about the segment was already removed", metadataUpdate);
+            return;
+        }
         if (existingMetadata == null) {
             throw new RemoteResourceNotFoundException("No remote log segment metadata found for :" +
                                                       remoteLogSegmentId);
         }
 
         // Check the state transition.
-        checkStateTransition(existingMetadata.state(), targetState);
+        boolean isValid = checkStateTransition(existingMetadata.state(), targetState, metadataUpdate.remoteLogSegmentId());
+        if (!isValid) {
+            return;
+        }
 
         switch (targetState) {
             case COPY_SEGMENT_STARTED:
@@ -187,13 +194,11 @@ public class RemoteLogMetadataCache {
 
     protected final void handleSegmentWithCopySegmentFinishedState(RemoteLogSegmentMetadata remoteLogSegmentMetadata) {
         doHandleSegmentStateTransitionForLeaderEpochs(remoteLogSegmentMetadata,
-                                                      (leaderEpoch, remoteLogLeaderEpochState, startOffset, segmentId) -> {
-                                                          long leaderEpochEndOffset = highestOffsetForEpoch(leaderEpoch,
-                                                                                                            remoteLogSegmentMetadata);
-                                                          remoteLogLeaderEpochState.handleSegmentWithCopySegmentFinishedState(startOffset,
-                                                                                                                              segmentId,
-                                                                                                                              leaderEpochEndOffset);
-                                                      });
+            (leaderEpoch, remoteLogLeaderEpochState, startOffset, segmentId) -> {
+                long leaderEpochEndOffset = highestOffsetForEpoch(leaderEpoch, remoteLogSegmentMetadata);
+                remoteLogLeaderEpochState
+                        .handleSegmentWithCopySegmentFinishedState(startOffset, segmentId, leaderEpochEndOffset);
+            });
 
         // Put the entry with the updated metadata.
         idToSegmentMetadata.put(remoteLogSegmentMetadata.remoteLogSegmentId(), remoteLogSegmentMetadata);
@@ -203,8 +208,8 @@ public class RemoteLogMetadataCache {
         log.debug("Cleaning up the state for : [{}]", remoteLogSegmentMetadata);
 
         doHandleSegmentStateTransitionForLeaderEpochs(remoteLogSegmentMetadata,
-                                                      (leaderEpoch, remoteLogLeaderEpochState, startOffset, segmentId) ->
-                                                              remoteLogLeaderEpochState.handleSegmentWithDeleteSegmentStartedState(startOffset, segmentId));
+            (leaderEpoch, remoteLogLeaderEpochState, startOffset, segmentId) ->
+                    remoteLogLeaderEpochState.handleSegmentWithDeleteSegmentStartedState(startOffset, segmentId));
 
         // Put the entry with the updated metadata.
         idToSegmentMetadata.put(remoteLogSegmentMetadata.remoteLogSegmentId(), remoteLogSegmentMetadata);
@@ -214,10 +219,10 @@ public class RemoteLogMetadataCache {
         log.debug("Removing the entry as it reached the terminal state: [{}]", remoteLogSegmentMetadata);
 
         doHandleSegmentStateTransitionForLeaderEpochs(remoteLogSegmentMetadata,
-                                                      (leaderEpoch, remoteLogLeaderEpochState, startOffset, segmentId) ->
-                                                              remoteLogLeaderEpochState.handleSegmentWithDeleteSegmentFinishedState(segmentId));
+            (leaderEpoch, remoteLogLeaderEpochState, startOffset, segmentId) ->
+                    remoteLogLeaderEpochState.handleSegmentWithDeleteSegmentFinishedState(segmentId));
 
-        // Remove the segment's id to metadata mapping because this segment is considered as deleted, and it cleared all
+        // Remove the segment's id to metadata mapping because this segment is considered as deleted and it cleared all
         // the state of this segment in the cache.
         idToSegmentMetadata.remove(remoteLogSegmentMetadata.remoteLogSegmentId());
     }
@@ -302,22 +307,26 @@ public class RemoteLogMetadataCache {
 
         RemoteLogSegmentId remoteLogSegmentId = remoteLogSegmentMetadata.remoteLogSegmentId();
         RemoteLogSegmentMetadata existingMetadata = idToSegmentMetadata.get(remoteLogSegmentId);
-        checkStateTransition(existingMetadata != null ? existingMetadata.state() : null,
-                remoteLogSegmentMetadata.state());
-
+        boolean isValid = checkStateTransition(existingMetadata != null ? existingMetadata.state() : null,
+                remoteLogSegmentMetadata.state(), remoteLogSegmentMetadata.remoteLogSegmentId());
+        if (!isValid) {
+            return;
+        }
         for (Integer epoch : remoteLogSegmentMetadata.segmentLeaderEpochs().keySet()) {
             leaderEpochEntries.computeIfAbsent(epoch, leaderEpoch -> new RemoteLogLeaderEpochState())
                     .handleSegmentWithCopySegmentStartedState(remoteLogSegmentId);
         }
-
         idToSegmentMetadata.put(remoteLogSegmentId, remoteLogSegmentMetadata);
     }
 
-    private void checkStateTransition(RemoteLogSegmentState existingState, RemoteLogSegmentState targetState) {
-        if (!RemoteLogSegmentState.isValidTransition(existingState, targetState)) {
-            throw new IllegalStateException(
-                    "Current state: " + existingState + " can not be transitioned to target state: " + targetState);
+    private boolean checkStateTransition(RemoteLogSegmentState existingState,
+                                         RemoteLogSegmentState targetState,
+                                         RemoteLogSegmentId segmentId) {
+        boolean isValid = RemoteLogSegmentState.isValidTransition(existingState, targetState);
+        if (!isValid) {
+            log.error("Current state: {} can not be transitioned to target state: {}, segmentId: {}. Dropping the event",
+                    existingState, targetState, segmentId);
         }
+        return isValid;
     }
-
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
@@ -433,7 +433,6 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
                     log.info("Initialized topic-based RLMM resources successfully");
                 } catch (Exception e) {
                     log.error("Encountered error while initializing producer/consumer", e);
-                    initializationFailed = true;
                     return;
                 } finally {
                     lock.writeLock().unlock();

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
@@ -433,6 +433,7 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
                     log.info("Initialized topic-based RLMM resources successfully");
                 } catch (Exception e) {
                     log.error("Encountered error while initializing producer/consumer", e);
+                    initializationFailed = true;
                     return;
                 } finally {
                     lock.writeLock().unlock();

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
@@ -207,7 +207,6 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
 
     private Map<String, Object> createConsumerProps(HashMap<String, Object> allConsumerConfigs) {
         Map<String, Object> props = new HashMap<>(allConsumerConfigs);
-
         props.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientIdPrefix + "_consumer");
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
@@ -219,13 +218,11 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
 
     private Map<String, Object> createProducerProps(HashMap<String, Object> allProducerConfigs) {
         Map<String, Object> props = new HashMap<>(allProducerConfigs);
-
         props.put(ProducerConfig.CLIENT_ID_CONFIG, clientIdPrefix + "_producer");
         props.put(ProducerConfig.ACKS_CONFIG, "all");
-        props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+        props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
-
         return Collections.unmodifiableMap(props);
     }
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
@@ -111,14 +111,11 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
 
     public TopicBasedRemoteLogMetadataManagerConfig(Map<String, ?> props) {
         Objects.requireNonNull(props, "props can not be null");
-
         Map<String, Object> parsedConfigs = CONFIG.parse(props);
-
         logDir = (String) props.get(LOG_DIR);
         if (logDir == null || logDir.isEmpty()) {
             throw new IllegalArgumentException(LOG_DIR + " config must not be null or empty.");
         }
-
         metadataTopicPartitionsCount = (int) parsedConfigs.get(REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP);
         metadataTopicReplicationFactor = (short) parsedConfigs.get(REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_PROP);
         metadataTopicRetentionMs = (long) parsedConfigs.get(REMOTE_LOG_METADATA_TOPIC_RETENTION_MS_PROP);
@@ -128,9 +125,7 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
         consumeWaitMs = (long) parsedConfigs.get(REMOTE_LOG_METADATA_CONSUME_WAIT_MS_PROP);
         initializationRetryIntervalMs = (long) parsedConfigs.get(REMOTE_LOG_METADATA_INITIALIZATION_RETRY_INTERVAL_MS_PROP);
         initializationRetryMaxTimeoutMs = (long) parsedConfigs.get(REMOTE_LOG_METADATA_INITIALIZATION_RETRY_MAX_TIMEOUT_MS_PROP);
-
         clientIdPrefix = REMOTE_LOG_METADATA_CLIENT_PREFIX + "_" + props.get(BROKER_ID);
-
         initializeProducerConsumerProperties(props);
     }
 
@@ -138,7 +133,6 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
         Map<String, Object> commonClientConfigs = new HashMap<>();
         Map<String, Object> producerOnlyConfigs = new HashMap<>();
         Map<String, Object> consumerOnlyConfigs = new HashMap<>();
-
         for (Map.Entry<String, ?> entry : configs.entrySet()) {
             String key = entry.getKey();
             if (key.startsWith(REMOTE_LOG_METADATA_COMMON_CLIENT_PREFIX)) {
@@ -149,14 +143,11 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
                 consumerOnlyConfigs.put(key.substring(REMOTE_LOG_METADATA_CONSUMER_PREFIX.length()), entry.getValue());
             }
         }
-
         commonProps = new HashMap<>(commonClientConfigs);
-
-        HashMap<String, Object> allProducerConfigs = new HashMap<>(commonClientConfigs);
+        Map<String, Object> allProducerConfigs = new HashMap<>(commonClientConfigs);
         allProducerConfigs.putAll(producerOnlyConfigs);
         producerProps = createProducerProps(allProducerConfigs);
-
-        HashMap<String, Object> allConsumerConfigs = new HashMap<>(commonClientConfigs);
+        Map<String, Object> allConsumerConfigs = new HashMap<>(commonClientConfigs);
         allConsumerConfigs.putAll(consumerOnlyConfigs);
         consumerProps = createConsumerProps(allConsumerConfigs);
     }
@@ -205,7 +196,7 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
         return producerProps;
     }
 
-    private Map<String, Object> createConsumerProps(HashMap<String, Object> allConsumerConfigs) {
+    private Map<String, Object> createConsumerProps(Map<String, Object> allConsumerConfigs) {
         Map<String, Object> props = new HashMap<>(allConsumerConfigs);
         props.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientIdPrefix + "_consumer");
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
@@ -216,11 +207,11 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
         return props;
     }
 
-    private Map<String, Object> createProducerProps(HashMap<String, Object> allProducerConfigs) {
+    private Map<String, Object> createProducerProps(Map<String, Object> allProducerConfigs) {
         Map<String, Object> props = new HashMap<>(allProducerConfigs);
         props.put(ProducerConfig.CLIENT_ID_CONFIG, clientIdPrefix + "_producer");
         props.put(ProducerConfig.ACKS_CONFIG, "all");
-        props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         return Collections.unmodifiableMap(props);

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCacheTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCacheTest.java
@@ -26,83 +26,136 @@ import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadataUpdate;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentState;
 import org.apache.kafka.server.log.remote.storage.RemoteResourceNotFoundException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RemoteLogMetadataCacheTest {
 
-    private static final TopicIdPartition TP0 = new TopicIdPartition(Uuid.randomUuid(),
-            new TopicPartition("foo", 0));
-    private static final int SEG_SIZE = 1024 * 1024;
-    private static final int BROKER_ID_0 = 0;
-    private static final int BROKER_ID_1 = 1;
-
+    private final TopicPartition tp0 = new TopicPartition("foo", 0);
+    private final TopicIdPartition tpId0 = new TopicIdPartition(Uuid.randomUuid(), tp0);
+    private final int segmentSize = 1048576;
+    private final int brokerId0 = 0;
+    private final int brokerId1 = 1;
     private final Time time = new MockTime(1);
+    private final RemoteLogMetadataCache cache = new RemoteLogMetadataCache();
 
     @Test
-    public void testAPIsWithInvalidArgs() {
-        RemoteLogMetadataCache cache = new RemoteLogMetadataCache();
-
-        Assertions.assertThrows(NullPointerException.class, () -> cache.addCopyInProgressSegment(null));
-        Assertions.assertThrows(NullPointerException.class, () -> cache.updateRemoteLogSegmentMetadata(null));
-
+    public void testCacheAddMetadataOnInvalidArgs() {
+        cache.markInitialized();
+        assertThrows(NullPointerException.class, () -> cache.addCopyInProgressSegment(null));
         // Check for invalid state updates to addCopyInProgressSegment method.
         for (RemoteLogSegmentState state : RemoteLogSegmentState.values()) {
             if (state != RemoteLogSegmentState.COPY_SEGMENT_STARTED) {
-                RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(
-                        new RemoteLogSegmentId(TP0, Uuid.randomUuid()), 0, 100L,
-                        -1L, BROKER_ID_0, time.milliseconds(), SEG_SIZE, Collections.singletonMap(0, 0L));
-                RemoteLogSegmentMetadata updatedMetadata = segmentMetadata
-                        .createWithUpdates(new RemoteLogSegmentMetadataUpdate(segmentMetadata.remoteLogSegmentId(),
-                                time.milliseconds(), Optional.empty(), state, BROKER_ID_1));
-                Assertions.assertThrows(IllegalArgumentException.class, () ->
-                        cache.addCopyInProgressSegment(updatedMetadata));
+                RemoteLogSegmentId segmentId = new RemoteLogSegmentId(tpId0, Uuid.randomUuid());
+                RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(segmentId, 0, 100L,
+                        -1L, brokerId0, time.milliseconds(), segmentSize, Collections.singletonMap(0, 0L));
+                RemoteLogSegmentMetadata updatedMetadata = segmentMetadata.createWithUpdates(
+                        new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(), Optional.empty(),
+                                state, brokerId1));
+                assertThrows(IllegalArgumentException.class, () -> cache.addCopyInProgressSegment(updatedMetadata));
             }
         }
-
-        // Check for updating non existing segment-id.
-        Assertions.assertThrows(RemoteResourceNotFoundException.class, () -> {
-            RemoteLogSegmentId nonExistingId = new RemoteLogSegmentId(TP0, Uuid.randomUuid());
-            cache.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(nonExistingId,
-                    time.milliseconds(),
-                    Optional.empty(),
-                    RemoteLogSegmentState.DELETE_SEGMENT_STARTED, BROKER_ID_1));
-        });
-
-        // Check for invalid state transition.
-        Assertions.assertThrows(IllegalStateException.class, () -> {
-            RemoteLogSegmentMetadata segmentMetadata = createSegmentUpdateWithState(cache, Collections.singletonMap(0, 0L), 0,
-                    100, RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
-            cache.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(segmentMetadata.remoteLogSegmentId(),
-                    time.milliseconds(),
-                    Optional.empty(),
-                    RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, BROKER_ID_1));
-        });
     }
 
-    private RemoteLogSegmentMetadata createSegmentUpdateWithState(RemoteLogMetadataCache cache,
-                                                                  Map<Integer, Long> segmentLeaderEpochs,
-                                                                  long startOffset,
-                                                                  long endOffset,
-                                                                  RemoteLogSegmentState state)
-            throws RemoteResourceNotFoundException {
-        RemoteLogSegmentId segmentId = new RemoteLogSegmentId(TP0, Uuid.randomUuid());
-        RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(segmentId, startOffset, endOffset, -1L,
-                                                                                BROKER_ID_0, time.milliseconds(), SEG_SIZE, segmentLeaderEpochs);
+    @ParameterizedTest(name = "isInitialized={0}")
+    @ValueSource(booleans = {true, false})
+    public void testCacheUpdateMetadataOnInvalidArgs(boolean isInitialized) {
+        if (isInitialized) {
+            cache.markInitialized();
+        }
+        assertThrows(NullPointerException.class, () -> cache.updateRemoteLogSegmentMetadata(null));
+        for (RemoteLogSegmentState state : RemoteLogSegmentState.values()) {
+            if (state != RemoteLogSegmentState.COPY_SEGMENT_STARTED) {
+                RemoteLogSegmentId segmentId = new RemoteLogSegmentId(tpId0, Uuid.randomUuid());
+                RemoteLogSegmentMetadataUpdate updatedMetadata = new RemoteLogSegmentMetadataUpdate(
+                        segmentId, time.milliseconds(), Optional.empty(), state, brokerId1);
+                try {
+                    cache.updateRemoteLogSegmentMetadata(updatedMetadata);
+                    if (isInitialized) {
+                        fail("Should throw RemoteResourceNotFoundException when cache is initialized");
+                    }
+                } catch (RemoteResourceNotFoundException ex) {
+                    if (!isInitialized) {
+                        fail("Should not throw RemoteResourceNotFoundException when cache is not initialized");
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testDropEventOnInvalidStateTransition() throws RemoteResourceNotFoundException {
+        cache.markInitialized();
+        int leaderEpoch = 5;
+        long offset = 10L;
+        RemoteLogSegmentId segmentId = new RemoteLogSegmentId(tpId0, Uuid.randomUuid());
+        RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(segmentId, offset, 100L,
+                -1L, brokerId0, time.milliseconds(), segmentSize, Collections.singletonMap(leaderEpoch, offset));
         cache.addCopyInProgressSegment(segmentMetadata);
 
-        RemoteLogSegmentMetadataUpdate segMetadataUpdate = new RemoteLogSegmentMetadataUpdate(
-                segmentId,
-                time.milliseconds(),
-                Optional.empty(),
-                state, BROKER_ID_1);
-        cache.updateRemoteLogSegmentMetadata(segMetadataUpdate);
+        // invalid-transition-1. COPY_SEGMENT_STARTED -> DELETE_SEGMENT_FINISHED
+        RemoteLogSegmentMetadataUpdate updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
+                Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId1);
+        updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.COPY_SEGMENT_STARTED, leaderEpoch);
 
-        return segmentMetadata.createWithUpdates(segMetadataUpdate);
+        // valid-transition-2: COPY_SEGMENT_STARTED -> COPY_SEGMENT_FINISHED
+        updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
+                Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId1);
+        updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.COPY_SEGMENT_FINISHED, leaderEpoch);
+
+        // invalid-transition-3: COPY_SEGMENT_FINISHED -> DELETE_SEGMENT_FINISHED
+        updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
+                Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId1);
+        updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.COPY_SEGMENT_FINISHED, leaderEpoch);
+
+        // invalid-transition-4: COPY_SEGMENT_FINISHED -> COPY_SEGMENT_STARTED
+        updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
+                Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_STARTED, brokerId1);
+        updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.COPY_SEGMENT_FINISHED, leaderEpoch);
+
+        // valid-transition-5: COPY_SEGMENT_FINISHED -> DELETE_SEGMENT_STARTED
+        updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
+                Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_STARTED, brokerId1);
+        updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.DELETE_SEGMENT_STARTED, leaderEpoch);
+
+        // invalid-transition-6: DELETE_SEGMENT_STARTED -> COPY_SEGMENT_FINISHED
+        updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
+                Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId1);
+        updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.DELETE_SEGMENT_STARTED, leaderEpoch);
+
+        // invalid-transition-7: DELETE_SEGMENT_STARTED -> COPY_SEGMENT_STARTED
+        updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
+                Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_STARTED, brokerId1);
+        updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.DELETE_SEGMENT_STARTED, leaderEpoch);
+
+        // valid-transition-8: DELETE_SEGMENT_STARTED -> DELETE_SEGMENT_FINISHED
+        updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
+                Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId1);
+        updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, leaderEpoch);
     }
 
+    private void updateAndVerifyCacheContents(RemoteLogSegmentMetadataUpdate updatedMetadata,
+                                              RemoteLogSegmentState expectedSegmentState,
+                                              int leaderEpoch) throws RemoteResourceNotFoundException {
+        cache.updateRemoteLogSegmentMetadata(updatedMetadata);
+        List<RemoteLogSegmentMetadata> metadataList = new ArrayList<>();
+        cache.listRemoteLogSegments(leaderEpoch).forEachRemaining(metadataList::add);
+        if (expectedSegmentState != RemoteLogSegmentState.DELETE_SEGMENT_FINISHED) {
+            assertEquals(1, metadataList.size());
+            assertEquals(expectedSegmentState, metadataList.get(0).state());
+        } else {
+            assertTrue(metadataList.isEmpty());
+        }
+    }
 }


### PR DESCRIPTION
__remote_log_metadata topic cleanup policy is set to DELETE and default retention is set to unlimited.

The expectation is that the user will configure the maximum retention time for this internal topic compared to all the other user created topics in the cluster. We cannot keep it to unlimited as the contents of this internal topic need to be in the local storage.

RemoteLogMetadata cache expect the events to be in the order of valid transition as defined in 
[RemoteLogSegmentState#isValidTransition](https://github.com/apache/kafka/blob/trunk/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentState.java#L93)

Once the retention got expired for this topic say after 30 days due to breach by size/time, then there can be partial metadata events and the [RemoteLogMetadataCache](https://github.com/apache/kafka/blob/trunk/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCache.java#L160) starts to throw remote-resource-not-found-error and being logged as warn statement while starting up the broker. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
