### PR TITLE
KAFKA-15633: Fix overwrite of meta.properties at startup to handle JBOD.

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -276,6 +276,7 @@ class LogManager(logDirs: Seq[File],
    * The ID will be written when the new meta.properties file is first written.
    */
   private def directoryIds(dirs: Seq[File]): Map[String, Uuid] = {
+    val s = scala.collection.mutable.Set[Uuid]()
     dirs.flatMap { dir =>
       try {
         val metadataCheckpoint = new BrokerMetadataCheckpoint(new File(dir, KafkaServer.brokerMetaPropsFile))
@@ -296,6 +297,10 @@ class LogManager(logDirs: Seq[File],
             Uuid.randomUuid()
           }
         }
+        if (s.contains(uuid)) {
+            throw new RuntimeException(s"Found duplicate directory.ids ${uuid.toString}")
+        }
+        s += uuid
         Seq(dir.getAbsolutePath -> uuid)
       } catch {
         case e: IOException =>

--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -166,7 +166,7 @@ case class MetaProperties(
   }
 }
 
-// Return only the RawMetaProperties that are the same across all directoris.
+// Return only the RawMetaProperties that are the same across all directories.
 object BrokerMetadataCheckpoint extends Logging {
   def getBrokerMetadataAndOfflineDirs(
     logDirs: collection.Seq[String],

--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -166,6 +166,7 @@ case class MetaProperties(
   }
 }
 
+// Return only the RawMetaProperties that are the same across all directoris.
 object BrokerMetadataCheckpoint extends Logging {
   def getBrokerMetadataAndOfflineDirs(
     logDirs: collection.Seq[String],
@@ -184,6 +185,8 @@ object BrokerMetadataCheckpoint extends Logging {
       try {
         brokerCheckpoint.read() match {
           case Some(properties) =>
+            // XXX Should we check for duplicates here
+            properties.remove(DirectoryIdKey)
             brokerMetadataMap += logDir -> properties
           case None =>
             if (!ignoreMissing) {

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -45,7 +45,7 @@ import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
 import org.apache.kafka.common.security.{JaasContext, JaasUtils}
 import org.apache.kafka.common.utils.{AppInfoParser, LogContext, Time, Utils}
-import org.apache.kafka.common.{Endpoint, KafkaException, Node, TopicPartition, Uuid}
+import org.apache.kafka.common.{Endpoint, KafkaException, Node, TopicPartition}
 import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.metadata.{BrokerState, MetadataRecordSerde, VersionRange}
 import org.apache.kafka.raft.RaftConfig
@@ -1027,9 +1027,7 @@ class KafkaServer(
   private def checkpointBrokerMetadata(brokerMetadata: ZkMetaProperties) = {
     for (logDir <- config.logDirs if logManager.isLogDirOnline(new File(logDir).getAbsolutePath)) {
       val props = brokerMetadata.toProperties.clone().asInstanceOf[Properties]
-      // If the Uuid is not set then we set it here because originally we ignored
-      // directories with no meta.properties file and we are creating it here.
-      props.setProperty("directory.id", logManager.directoryId(logDir).getOrElse(Uuid.randomUuid()).toString)
+      props.setProperty("directory.id", logManager.directoryId(logDir).get.toString)
       val checkpoint = brokerMetadataCheckpoints(logDir)
       try {
         checkpoint.write(props)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -45,7 +45,7 @@ import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
 import org.apache.kafka.common.security.{JaasContext, JaasUtils}
 import org.apache.kafka.common.utils.{AppInfoParser, LogContext, Time, Utils}
-import org.apache.kafka.common.{Endpoint, KafkaException, Node, TopicPartition}
+import org.apache.kafka.common.{Endpoint, KafkaException, Node, TopicPartition, Uuid}
 import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.metadata.{BrokerState, MetadataRecordSerde, VersionRange}
 import org.apache.kafka.raft.RaftConfig
@@ -1027,7 +1027,9 @@ class KafkaServer(
   private def checkpointBrokerMetadata(brokerMetadata: ZkMetaProperties) = {
     for (logDir <- config.logDirs if logManager.isLogDirOnline(new File(logDir).getAbsolutePath)) {
       val props = brokerMetadata.toProperties.clone().asInstanceOf[Properties]
-      props.setProperty("directory.id", logManager.directoryId(logDir).get.toString)
+      // If the Uuid is not set then we set it here because originally we ignored
+      // directories with no meta.properties file and we are creating it here.
+      props.setProperty("directory.id", logManager.directoryId(logDir).getOrElse(Uuid.randomUuid()).toString)
       val checkpoint = brokerMetadataCheckpoints(logDir)
       try {
         checkpoint.write(props)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -63,6 +63,7 @@ import java.io.{File, IOException}
 import java.net.{InetAddress, SocketTimeoutException}
 import java.util.concurrent._
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.Properties
 import scala.collection.{Map, Seq}
 import scala.compat.java8.OptionConverters.RichOptionForJava8
 import scala.jdk.CollectionConverters._
@@ -1025,9 +1026,11 @@ class KafkaServer(
    */
   private def checkpointBrokerMetadata(brokerMetadata: ZkMetaProperties) = {
     for (logDir <- config.logDirs if logManager.isLogDirOnline(new File(logDir).getAbsolutePath)) {
+      val props = brokerMetadata.toProperties.clone().asInstanceOf[Properties]
+      props.setProperty("directory.id", logManager.directoryId(logDir).get.toString)
       val checkpoint = brokerMetadataCheckpoints(logDir)
       try {
-        checkpoint.write(brokerMetadata.toProperties)
+        checkpoint.write(props)
       } catch {
         case e: IOException =>
           val dirPath = checkpoint.file.getAbsolutePath


### PR DESCRIPTION
Fix startup to write back the updated meta.properties file with the new directory.id.
Fix reading of the meta.properties file to ignore the directory.id when validating that all the meta.properties files belong to the same cluster.

