### PR TITLE
MINOR: Don't log missing partitions at ERROR level

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2410,7 +2410,7 @@ class ReplicaManager(val config: KafkaConfig,
         Some(partition, false)
 
       case HostedPartition.None =>
-        if (delta.image().topicsById().containsKey(topicId)) {
+        if (delta.image().topicsById().containsKey(topicId) && !delta.changedTopics().containsKey(topicId)) {
           stateChangeLogger.error(s"Expected partition $tp with topic id " +
             s"$topicId to exist, but it was missing. Creating...")
         } else {


### PR DESCRIPTION
### What
We are logging missing partitions as errors in the `state.change.logger` which may be a bit alarming. There are valid cases where the partition may not exist, eg: partition reassignment.

### Testing
Verified that ReassignPartitionsIntegrationTest logs partition reassignments at error without the patch and doesn't with the patch.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
