### PR TITLE
KAFKA-15610: Fix `CoreUtils.swallow()` test gaps

### DIFF
--- a/core/src/test/scala/unit/kafka/utils/CoreUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/CoreUtilsTest.scala
@@ -44,6 +44,18 @@ class CoreUtilsTest extends Logging {
   }
 
   @Test
+  def testSwallowLogging(): Unit = {
+    var loggedMessage: Option[String] = None
+    val testLogging: Logging = new Logging {
+      override def info(msg: => String, e: => Throwable): Unit = {
+        loggedMessage = Some(msg)
+      }
+    }
+    CoreUtils.swallow(throw new KafkaException("test"), testLogging, Level.INFO)
+    assertEquals(Some("test"), loggedMessage)
+  }
+
+  @Test
   def testReadBytes(): Unit = {
     for(testCase <- List("", "a", "abcd")) {
       val bytes = testCase.getBytes


### PR DESCRIPTION
Adding test to check that the passed in `logging` is used in case of an exception for CoreUtils.swallow.

https://github.com/apache/kafka/pull/14529#discussion_r1355277747.


