### PR TITLE
MINOR: Fix Gradle when git refs are packed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,12 @@ def determineCommitId() {
       headRef = headRef.replaceAll('ref: ', '').trim()
       if (file("$rootDir/.git/$headRef").exists()) {
         file("$rootDir/.git/$headRef").text.trim().take(takeFromHash)
+      } else if (file("$rootDir/.git/packed-refs").exists()) {
+        file("$rootDir/.git/packed-refs").text.lines()
+          .filter { it.endsWith(headRef) }
+          .map { it.replaceAll(headRef, '').trim().take(takeFromHash) }
+          .findFirst()
+          .orElseGet { "unknown" }
       }
     } else {
       headRef.trim().take(takeFromHash)


### PR DESCRIPTION
When `git gc` runs, which can run automatically on large repos like Kafka, it packs all refs under `.git/refs/heads` into a single `.git/packed-refs` file.

When this happens, the Gradle build can no longer locate the ref in `.git/refs/heads` that it expects.

We fix this by having Gradle also search for the `.git/packed-refs` file if it cannot find the ref in `.git/refs/heads`.