### PR TITLE
KAFKA-15584: Leader election with ELR

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -311,7 +311,7 @@
               files="(QuorumController|QuorumControllerTest|ReplicationControlManager|ReplicationControlManagerTest).java"/>
     <suppress checks="(ParameterNumber|ClassDataAbstractionCoupling)"
               files="(QuorumController).java"/>
-    <suppress checks="NPathComplexity"
+    <suppress checks="(CyclomaticComplexity|NPathComplexity)"
               files="(PartitionRegistration|PartitionChangeBuilder).java"/>
     <suppress checks="CyclomaticComplexity"
               files="(ClientQuotasImage|KafkaEventQueue|MetadataDelta|QuorumController|ReplicationControlManager|KRaftMigrationDriver|ClusterControlManager).java"/>

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -273,11 +273,14 @@ public class PartitionChangeBuilder {
 
     private boolean canElectLastKnownLeader() {
         if (!eligibleLeaderReplicasEnabled || !useLastKnownLeaderInBalancedRecovery) {
-            log.debug("Try to elect last known leader for " + topicId + "-" + partitionId + " but elrEnabled=" + eligibleLeaderReplicasEnabled + ", useLastKnownLeaderInBalancedRecovery=" + useLastKnownLeaderInBalancedRecovery);
+            log.trace("Try to elect last known leader for " + topicId + "-" + partitionId +
+                " but elrEnabled=" + eligibleLeaderReplicasEnabled + ", useLastKnownLeaderInBalancedRecovery=" +
+                useLastKnownLeaderInBalancedRecovery);
             return false;
         }
         if (!targetElr.isEmpty() || !targetIsr.isEmpty()) {
-            log.debug("Try to elect last known leader for " + topicId + "-" + partitionId + " but ELR/ISR is not empty. ISR=" + targetIsr + ", ELR=" + targetElr);
+            log.trace("Try to elect last known leader for " + topicId + "-" + partitionId +
+                " but ELR/ISR is not empty. ISR=" + targetIsr + ", ELR=" + targetElr);
             return false;
         }
 
@@ -289,11 +292,13 @@ public class PartitionChangeBuilder {
         //    field even if useLastKnownLeaderInBalancedRecovery is set to true again. In this case, we can't refer to the
         //    lastKnownElr.
         if (partition.lastKnownElr.length != 1) {
-            log.debug("Try to elect last known leader for " + topicId + "-" + partitionId + " but lastKnownElr does not only have 1 member. lastKnownElr=" + Arrays.toString(partition.lastKnownElr));
+            log.trace("Try to elect last known leader for " + topicId + "-" + partitionId +
+                " but lastKnownElr does not only have 1 member. lastKnownElr=" + Arrays.toString(partition.lastKnownElr));
             return false;
         }
         if (isAcceptableLeader.test(partition.lastKnownElr[0])) {
-            log.debug("Try to elect last known leader for " + topicId + "-" + partitionId + " but last known leader is not alive. last known leader=" + partition.lastKnownElr[0]);
+            log.trace("Try to elect last known leader for " + topicId + "-" + partitionId +
+                " but last known leader is not alive. last known leader=" + partition.lastKnownElr[0]);
         }
         return true;
     }
@@ -416,7 +421,7 @@ public class PartitionChangeBuilder {
         if (record.isr() == null && (!targetIsr.isEmpty() || eligibleLeaderReplicasEnabled) && !targetIsr.equals(Replicas.toList(partition.isr))) {
             // Set the new ISR if it is different from the current ISR and unclean leader election didn't already set it.
             if (targetIsr.isEmpty()) {
-                log.info("A partition will have an empty ISR. " + this);
+                log.debug("A partition will have an empty ISR. " + this);
             }
             record.setIsr(targetIsr);
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -483,7 +483,7 @@ public class PartitionChangeBuilder {
             record.setEligibleLeaderReplicas(targetElr);
         }
 
-        if (!targetLastKnownElr.equals(Replicas.toList(partition.lastKnownElr))) {
+        if (!useLastKnownLeaderInBalancedRecovery && !targetLastKnownElr.equals(Replicas.toList(partition.lastKnownElr))) {
             record.setLastKnownELR(targetLastKnownElr);
         }
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -483,7 +483,14 @@ public class PartitionChangeBuilder {
             record.setEligibleLeaderReplicas(targetElr);
         }
 
-        if (!useLastKnownLeaderInBalancedRecovery && !targetLastKnownElr.equals(Replicas.toList(partition.lastKnownElr))) {
+        if (useLastKnownLeaderInBalancedRecovery && partition.lastKnownElr.length == 1 &&
+                (record.leader() == NO_LEADER || record.leader() == NO_LEADER_CHANGE && partition.leader == NO_LEADER)) {
+            // If the last known leader is stored in the lastKnownElr, the last known elr should not be updated when
+            // the partition does not have a leader.
+            targetLastKnownElr = Replicas.toList(partition.lastKnownElr);
+        }
+
+        if (!targetLastKnownElr.equals(Replicas.toList(partition.lastKnownElr))) {
             record.setLastKnownELR(targetLastKnownElr);
         }
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1257,7 +1257,7 @@ public class ReplicationControlManager {
     /**
      * Generate the appropriate records to handle a broker being fenced.
      *
-     * First, we remove this broker from any non-singleton ISR. Then we generate a
+     * First, we remove this broker from any ISR. Then we generate a
      * FenceBrokerRecord.
      *
      * @param brokerId      The broker id.
@@ -1285,7 +1285,7 @@ public class ReplicationControlManager {
     /**
      * Generate the appropriate records to handle a broker being unregistered.
      *
-     * First, we remove this broker from any non-singleton ISR. Then we generate an
+     * First, we remove this broker from any ISR. Then we generate an
      * UnregisterBrokerRecord.
      *
      * @param brokerId      The broker id.
@@ -1330,7 +1330,7 @@ public class ReplicationControlManager {
      * Generate the appropriate records to handle a broker starting a controlled shutdown.
      *
      * First, we create an BrokerRegistrationChangeRecord. Then, we remove this broker
-     * from any non-singleton ISR and elect new leaders for partitions led by this
+     * from any ISR and elect new leaders for partitions led by this
      * broker.
      *
      * @param brokerId      The broker id.

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -350,8 +350,10 @@ public class PartitionRegistration {
             setLeaderEpoch(leaderEpoch).
             setPartitionEpoch(partitionEpoch);
         if (options.metadataVersion().isElrSupported()) {
-            record.setEligibleLeaderReplicas(Replicas.toList(elr)).
-                setLastKnownELR(Replicas.toList(lastKnownElr));
+            // The following are tagged fields, we should only set them when there are some contents, in order to save
+            // spaces.
+            if (elr.length > 0) record.setEligibleLeaderReplicas(Replicas.toList(elr));
+            if (lastKnownElr.length > 0) record.setLastKnownELR(Replicas.toList(lastKnownElr));
         }
         if (options.metadataVersion().isDirectoryAssignmentSupported()) {
             record.setDirectories(Uuid.toList(directories));

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -34,11 +34,8 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-<<<<<<< HEAD
 import org.mockito.Mockito;
-=======
 import org.junit.jupiter.params.provider.ValueSource;
->>>>>>> 6a120de966 (Leader election with ELR)
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -920,24 +917,13 @@ public class PartitionChangeBuilderTest {
     @MethodSource("partitionChangeRecordVersions")
     public void testEligibleLeaderReplicas_RemoveUncleanShutdownReplicasFromElr(short version) {
         PartitionRegistration partition = new PartitionRegistration.Builder()
-<<<<<<< HEAD
-                .setReplicas(new int[] {1, 2, 3, 4})
-                .setDirectories(new Uuid[] {
-                        Uuid.fromString("keB9ssIPRlibyVJT5FcBVA"),
-                        Uuid.fromString("FhezfoReTSmHoKxi8wOIOg"),
-                        Uuid.fromString("QHtFxu8LShm6RiyAP6PxYg"),
-                        Uuid.fromString("tUJOMtvMQkGga30ydluvbQ")
-                })
-                .setIsr(new int[] {1})
-                .setElr(new int[] {2, 3})
-                .setLastKnownElr(new int[] {})
-                .setLeader(1)
-                .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
-                .setLeaderEpoch(100)
-                .setPartitionEpoch(200)
-                .build();
-=======
             .setReplicas(new int[] {1, 2, 3, 4})
+            .setDirectories(new Uuid[] {
+                Uuid.fromString("keB9ssIPRlibyVJT5FcBVA"),
+                Uuid.fromString("FhezfoReTSmHoKxi8wOIOg"),
+                Uuid.fromString("QHtFxu8LShm6RiyAP6PxYg"),
+                Uuid.fromString("tUJOMtvMQkGga30ydluvbQ")
+            })
             .setIsr(new int[] {1})
             .setElr(new int[] {2, 3})
             .setLastKnownElr(new int[] {})
@@ -946,7 +932,6 @@ public class PartitionChangeBuilderTest {
             .setLeaderEpoch(100)
             .setPartitionEpoch(200)
             .build();
->>>>>>> 6a120de966 (Leader election with ELR)
         Uuid topicId = Uuid.fromString("FbrrdcfiR-KC2CPSTHaJrg");
         // Min ISR is 3.
         PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> r != 3, metadataVersionForPartitionChangeRecordVersion(version), 3)
@@ -1015,7 +1000,7 @@ public class PartitionChangeBuilderTest {
         ));
         assertEquals(expected, built);
     }
-    
+
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testEligibleLeaderReplicas_ElrCanBeElected(boolean lastKnownLeaderEnabled) {

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -1087,6 +1087,13 @@ public class PartitionChangeBuilderTest {
         assertTrue(Arrays.equals(new int[]{1, 2, 3, 4}, partition.elr), partition.toString());
         if (lastKnownLeaderEnabled) {
             assertTrue(Arrays.equals(new int[]{1}, partition.lastKnownElr), partition.toString());
+            builder = new PartitionChangeBuilder(partition, topicId, 0, r -> false, metadataVersionForPartitionChangeRecordVersion(version), 3)
+                .setElection(Election.PREFERRED)
+                .setEligibleLeaderReplicasEnabled(true)
+                .setUncleanShutdownReplicas(Arrays.asList(2))
+                .setUseLastKnownLeaderInBalancedRecovery(lastKnownLeaderEnabled);
+            PartitionChangeRecord changeRecord = (PartitionChangeRecord) builder.build().get().message();
+            assertTrue(changeRecord.lastKnownELR() == null, changeRecord.toString());
         } else {
             assertTrue(Arrays.equals(new int[]{}, partition.lastKnownElr), partition.toString());
         }

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -34,7 +34,11 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+<<<<<<< HEAD
 import org.mockito.Mockito;
+=======
+import org.junit.jupiter.params.provider.ValueSource;
+>>>>>>> 6a120de966 (Leader election with ELR)
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -185,7 +189,7 @@ public class PartitionChangeBuilderTest {
         return new PartitionChangeBuilder(BAZ, BAZ_ID, 0, __ -> true, metadataVersionForPartitionChangeRecordVersion(version), 2).setEligibleLeaderReplicasEnabled(isElrEnabled(version));
     }
 
-    private static final PartitionRegistration OFFLINE = new PartitionRegistration.Builder().
+    private static final PartitionRegistration OFFLINE_WITHOUT_ELR = new PartitionRegistration.Builder().
         setReplicas(new int[] {2, 1, 3}).
         setDirectories(new Uuid[]{
            Uuid.fromString("iYGgiDV5Sb2EtH6hbgYnCA"),
@@ -199,10 +203,22 @@ public class PartitionChangeBuilderTest {
         setPartitionEpoch(200).
         build();
 
+    private static final PartitionRegistration OFFLINE_WITH_ELR = new PartitionRegistration.Builder().
+            setReplicas(new int[] {2, 1, 3}).
+            setElr(new int[] {3}).
+            setIsr(new int[] {}).
+            setLastKnownElr(new int[] {2}).
+            setLeader(-1).
+            setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(100).
+            setPartitionEpoch(200).
+            build();
+
     private final static Uuid OFFLINE_ID = Uuid.fromString("LKfUsCBnQKekvL9O5dY9nw");
 
     private static PartitionChangeBuilder createOfflineBuilder(short version) {
-        return new PartitionChangeBuilder(OFFLINE, OFFLINE_ID, 0, r -> r == 1, metadataVersionForPartitionChangeRecordVersion(version), 2).setEligibleLeaderReplicasEnabled(isElrEnabled(version));
+        return version > 0 ? new PartitionChangeBuilder(OFFLINE_WITH_ELR, OFFLINE_ID, 0, r -> r == 1, metadataVersionForPartitionChangeRecordVersion(version), 2).setEligibleLeaderReplicasEnabled(isElrEnabled(version)) :
+            new PartitionChangeBuilder(OFFLINE_WITHOUT_ELR, OFFLINE_ID, 0, r -> r == 1, metadataVersionForPartitionChangeRecordVersion(version), 2).setEligibleLeaderReplicasEnabled(isElrEnabled(version));
     }
 
     private static void assertElectLeaderEquals(PartitionChangeBuilder builder,
@@ -509,13 +525,21 @@ public class PartitionChangeBuilderTest {
                 .setTargetIsrWithBrokerStates(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(Arrays.asList(3))).build()
         );
 
+        PartitionChangeRecord record = new PartitionChangeRecord()
+            .setTopicId(OFFLINE_ID)
+            .setPartitionId(0)
+            .setIsr(Arrays.asList(1))
+            .setLeader(1)
+            .setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value());
+
+        if (version > 0) {
+            // The test partition has ELR, so unclean election will clear these fiedls.
+            record.setEligibleLeaderReplicas(Collections.emptyList())
+                .setLastKnownELR(Collections.emptyList());
+        }
+
         expectedRecord = new ApiMessageAndVersion(
-            new PartitionChangeRecord()
-                .setTopicId(OFFLINE_ID)
-                .setPartitionId(0)
-                .setIsr(Arrays.asList(1))
-                .setLeader(1)
-                .setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value()),
+            record,
             version
         );
         assertEquals(
@@ -762,7 +786,8 @@ public class PartitionChangeBuilderTest {
         Uuid topicId = Uuid.fromString("FbrrdcfiR-KC2CPSTHaJrg");
         PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> r != 3, metadataVersionForPartitionChangeRecordVersion(version), 3)
             .setElection(Election.PREFERRED)
-            .setEligibleLeaderReplicasEnabled(isElrEnabled(version));
+            .setEligibleLeaderReplicasEnabled(isElrEnabled(version))
+            .setLastKnownLeaderEnabled(false);
 
         // Update ISR to {1, 2}
         builder.setTargetIsrWithBrokerStates(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(Arrays.asList(1, 2)));
@@ -814,7 +839,8 @@ public class PartitionChangeBuilderTest {
         // Min ISR is 3.
         PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> r != 3, metadataVersionForPartitionChangeRecordVersion(version), 3)
             .setElection(Election.PREFERRED)
-            .setEligibleLeaderReplicasEnabled(isElrEnabled(version));
+            .setEligibleLeaderReplicasEnabled(isElrEnabled(version))
+            .setLastKnownLeaderEnabled(false);
 
         builder.setTargetIsrWithBrokerStates(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(Arrays.asList(1, 2, 3)));
         PartitionChangeRecord record = new PartitionChangeRecord()
@@ -860,7 +886,8 @@ public class PartitionChangeBuilderTest {
         // Min ISR is 3.
         PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> r != 3, metadataVersionForPartitionChangeRecordVersion(version), 3)
             .setElection(Election.PREFERRED)
-            .setEligibleLeaderReplicasEnabled(isElrEnabled(version));
+            .setEligibleLeaderReplicasEnabled(isElrEnabled(version))
+            .setLastKnownLeaderEnabled(false);
 
         builder.setTargetIsrWithBrokerStates(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(Arrays.asList(1, 4)));
         PartitionChangeRecord record = new PartitionChangeRecord()
@@ -893,6 +920,7 @@ public class PartitionChangeBuilderTest {
     @MethodSource("partitionChangeRecordVersions")
     public void testEligibleLeaderReplicas_RemoveUncleanShutdownReplicasFromElr(short version) {
         PartitionRegistration partition = new PartitionRegistration.Builder()
+<<<<<<< HEAD
                 .setReplicas(new int[] {1, 2, 3, 4})
                 .setDirectories(new Uuid[] {
                         Uuid.fromString("keB9ssIPRlibyVJT5FcBVA"),
@@ -908,19 +936,31 @@ public class PartitionChangeBuilderTest {
                 .setLeaderEpoch(100)
                 .setPartitionEpoch(200)
                 .build();
+=======
+            .setReplicas(new int[] {1, 2, 3, 4})
+            .setIsr(new int[] {1})
+            .setElr(new int[] {2, 3})
+            .setLastKnownElr(new int[] {})
+            .setLeader(1)
+            .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+            .setLeaderEpoch(100)
+            .setPartitionEpoch(200)
+            .build();
+>>>>>>> 6a120de966 (Leader election with ELR)
         Uuid topicId = Uuid.fromString("FbrrdcfiR-KC2CPSTHaJrg");
         // Min ISR is 3.
         PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> r != 3, metadataVersionForPartitionChangeRecordVersion(version), 3)
             .setElection(Election.PREFERRED)
-            .setEligibleLeaderReplicasEnabled(isElrEnabled(version));
+            .setEligibleLeaderReplicasEnabled(isElrEnabled(version))
+            .setLastKnownLeaderEnabled(false);
 
         builder.setUncleanShutdownReplicas(Arrays.asList(3));
 
         PartitionChangeRecord record = new PartitionChangeRecord()
-                .setTopicId(topicId)
-                .setPartitionId(0)
-                .setLeader(-2)
-                .setLeaderRecoveryState(LeaderRecoveryState.NO_CHANGE);
+            .setTopicId(topicId)
+            .setPartitionId(0)
+            .setLeader(-2)
+            .setLeaderRecoveryState(LeaderRecoveryState.NO_CHANGE);
         if (version > 0) {
             record.setEligibleLeaderReplicas(Arrays.asList(2))
                 .setLastKnownELR(Arrays.asList(3));
@@ -945,13 +985,13 @@ public class PartitionChangeBuilderTest {
     @Test
     void testKeepsDirectoriesAfterReassignment() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
-                setReplicas(new int[] {2, 1, 3}).
-                setDirectories(new Uuid[] {
+                setReplicas(new int[]{2, 1, 3}).
+                setDirectories(new Uuid[]{
                         Uuid.fromString("v1PVrX6uS5m8CByXlLfmWg"),
                         Uuid.fromString("iU2znv45Q9yQkOpkTSy3jA"),
                         Uuid.fromString("fM5NKyWTQHqEihjIkUl99Q")
                 }).
-                setIsr(new int[] {2, 1, 3}).
+                setIsr(new int[]{2, 1, 3}).
                 setLeader(1).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
                 setLeaderEpoch(100).
@@ -967,12 +1007,169 @@ public class PartitionChangeBuilderTest {
                         setLeader(1).
                         setReplicas(Arrays.asList(3, 1, 4)).
                         setDirectories(Arrays.asList(
-                            Uuid.fromString("fM5NKyWTQHqEihjIkUl99Q"),
-                            Uuid.fromString("iU2znv45Q9yQkOpkTSy3jA"),
-                            DirectoryId.UNASSIGNED
+                                Uuid.fromString("fM5NKyWTQHqEihjIkUl99Q"),
+                                Uuid.fromString("iU2znv45Q9yQkOpkTSy3jA"),
+                                DirectoryId.UNASSIGNED
                         )),
                 (short) 2
         ));
         assertEquals(expected, built);
+    }
+    
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testEligibleLeaderReplicas_ElrCanBeElected(boolean lastKnownLeaderEnabled) {
+        short version = 1;
+        PartitionRegistration partition = new PartitionRegistration.Builder()
+            .setReplicas(new int[] {1, 2, 3, 4})
+            .setIsr(new int[] {1})
+            .setElr(new int[] {3})
+            .setLastKnownElr(lastKnownLeaderEnabled ? new int[] {} : new int[] {2})
+            .setLeader(1)
+            .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+            .setLeaderEpoch(100)
+            .setPartitionEpoch(200)
+            .build();
+        Uuid topicId = Uuid.fromString("FbrrdcfiR-KC2CPSTHaJrg");
+
+        // Make replica 1 offline.
+        PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> r != 1, metadataVersionForPartitionChangeRecordVersion(version), 3)
+            .setElection(Election.PREFERRED)
+            .setEligibleLeaderReplicasEnabled(isElrEnabled(version))
+            .setLastKnownLeaderEnabled(lastKnownLeaderEnabled);
+
+        builder.setTargetIsr(Collections.emptyList());
+
+        ApiMessageAndVersion expectedRecord = new ApiMessageAndVersion(
+            new PartitionChangeRecord()
+                .setTopicId(topicId)
+                .setPartitionId(0)
+                .setIsr(Arrays.asList(3))
+                .setEligibleLeaderReplicas(Arrays.asList(1))
+                .setLeader(3)
+                .setLeaderRecoveryState(LeaderRecoveryState.NO_CHANGE),
+            version
+        );
+        assertEquals(Optional.of(expectedRecord), builder.build());
+        partition = partition.merge((PartitionChangeRecord) builder.build().get().message());
+        assertTrue(Arrays.equals(new int[]{1}, partition.elr), partition.toString());
+        assertTrue(Arrays.equals(lastKnownLeaderEnabled ? new int[]{} : new int[]{2}, partition.lastKnownElr), partition.toString());
+        assertTrue(Arrays.equals(new int[]{3}, partition.isr), partition.toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testEligibleLeaderReplicas_IsrCanShrinkToZero(boolean lastKnownLeaderEnabled) {
+        short version = 1;
+        PartitionRegistration partition = new PartitionRegistration.Builder()
+            .setReplicas(new int[] {1, 2, 3, 4})
+            .setIsr(new int[] {1, 2, 3, 4})
+            .setElr(new int[] {})
+            .setLastKnownElr(new int[] {})
+            .setLeader(1)
+            .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+            .setLeaderEpoch(100)
+            .setPartitionEpoch(200)
+            .build();
+        Uuid topicId = Uuid.fromString("FbrrdcfiR-KC2CPSTHaJrg");
+
+        // Mark all the replicas offline.
+        PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> false, metadataVersionForPartitionChangeRecordVersion(version), 3)
+            .setElection(Election.PREFERRED)
+            .setEligibleLeaderReplicasEnabled(true)
+            .setLastKnownLeaderEnabled(lastKnownLeaderEnabled);
+
+        builder.setTargetIsr(Collections.emptyList());
+
+        PartitionChangeRecord record = new PartitionChangeRecord()
+            .setTopicId(topicId)
+            .setPartitionId(0)
+            .setIsr(Collections.emptyList())
+            .setLeader(-1)
+            .setLeaderRecoveryState(LeaderRecoveryState.NO_CHANGE)
+            .setEligibleLeaderReplicas(Arrays.asList(1, 2, 3, 4));
+
+        if (lastKnownLeaderEnabled) {
+            record.setLastKnownELR(Arrays.asList(1));
+        }
+
+        ApiMessageAndVersion expectedRecord = new ApiMessageAndVersion(
+            record,
+            version
+        );
+        assertEquals(Optional.of(expectedRecord), builder.build());
+        partition = partition.merge((PartitionChangeRecord) builder.build().get().message());
+        assertTrue(Arrays.equals(new int[]{1, 2, 3, 4}, partition.elr), partition.toString());
+        if (lastKnownLeaderEnabled) {
+            assertTrue(Arrays.equals(new int[]{1}, partition.lastKnownElr), partition.toString());
+        } else {
+            assertTrue(Arrays.equals(new int[]{}, partition.lastKnownElr), partition.toString());
+        }
+        assertTrue(Arrays.equals(new int[]{}, partition.isr), partition.toString());
+    }
+
+    @Test
+    public void testEligibleLeaderReplicas_ElectLastKnownLeader() {
+        short version = 1;
+        PartitionRegistration partition = new PartitionRegistration.Builder()
+                .setReplicas(new int[] {1, 2, 3, 4})
+                .setIsr(new int[] {})
+                .setElr(new int[] {})
+                .setLastKnownElr(new int[] {1})
+                .setLeader(-1)
+                .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+                .setLeaderEpoch(100)
+                .setPartitionEpoch(200)
+                .build();
+        Uuid topicId = Uuid.fromString("FbrrdcfiR-KC2CPSTHaJrg");
+
+        PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> true, metadataVersionForPartitionChangeRecordVersion(version), 3)
+            .setElection(Election.PREFERRED)
+            .setLastKnownLeaderEnabled(true)
+            .setEligibleLeaderReplicasEnabled(true);
+
+        builder.setTargetIsr(Collections.emptyList());
+
+        ApiMessageAndVersion expectedRecord = new ApiMessageAndVersion(
+            new PartitionChangeRecord()
+                .setTopicId(topicId)
+                .setPartitionId(0)
+                .setIsr(Arrays.asList(1))
+                .setLeader(1)
+                .setLeaderRecoveryState(LeaderRecoveryState.RECOVERING.value())
+                .setLastKnownELR(Collections.emptyList()),
+            version
+        );
+        assertEquals(Optional.of(expectedRecord), builder.build());
+        partition = partition.merge((PartitionChangeRecord) builder.build().get().message());
+        assertTrue(Arrays.equals(new int[]{}, partition.elr), partition.toString());
+        assertTrue(Arrays.equals(new int[]{}, partition.lastKnownElr), partition.toString());
+        assertTrue(Arrays.equals(new int[]{1}, partition.isr), partition.toString());
+    }
+
+    @Test
+    public void testEligibleLeaderReplicas_ElectLastKnownLeaderShouldFail() {
+        short version = 1;
+        PartitionRegistration partition = new PartitionRegistration.Builder()
+                .setReplicas(new int[] {1, 2, 3, 4})
+                .setIsr(new int[] {})
+                .setElr(new int[] {3})
+                .setLastKnownElr(new int[] {1})
+                .setLeader(-1)
+                .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+                .setLeaderEpoch(100)
+                .setPartitionEpoch(200)
+                .build();
+        Uuid topicId = Uuid.fromString("FbrrdcfiR-KC2CPSTHaJrg");
+
+        PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> r != 3, metadataVersionForPartitionChangeRecordVersion(version), 3)
+            .setElection(Election.PREFERRED)
+            .setEligibleLeaderReplicasEnabled(true)
+            .setLastKnownLeaderEnabled(true);
+
+        builder.setTargetIsr(Collections.emptyList());
+
+        // No change to the partition.
+        assertEquals(Optional.empty(), builder.build());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -784,7 +784,7 @@ public class PartitionChangeBuilderTest {
         PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> r != 3, metadataVersionForPartitionChangeRecordVersion(version), 3)
             .setElection(Election.PREFERRED)
             .setEligibleLeaderReplicasEnabled(isElrEnabled(version))
-            .setLastKnownLeaderEnabled(false);
+            .setUseLastKnownLeaderInBalancedRecovery(false);
 
         // Update ISR to {1, 2}
         builder.setTargetIsrWithBrokerStates(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(Arrays.asList(1, 2)));
@@ -837,7 +837,7 @@ public class PartitionChangeBuilderTest {
         PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> r != 3, metadataVersionForPartitionChangeRecordVersion(version), 3)
             .setElection(Election.PREFERRED)
             .setEligibleLeaderReplicasEnabled(isElrEnabled(version))
-            .setLastKnownLeaderEnabled(false);
+            .setUseLastKnownLeaderInBalancedRecovery(false);
 
         builder.setTargetIsrWithBrokerStates(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(Arrays.asList(1, 2, 3)));
         PartitionChangeRecord record = new PartitionChangeRecord()
@@ -884,7 +884,7 @@ public class PartitionChangeBuilderTest {
         PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> r != 3, metadataVersionForPartitionChangeRecordVersion(version), 3)
             .setElection(Election.PREFERRED)
             .setEligibleLeaderReplicasEnabled(isElrEnabled(version))
-            .setLastKnownLeaderEnabled(false);
+            .setUseLastKnownLeaderInBalancedRecovery(false);
 
         builder.setTargetIsrWithBrokerStates(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(Arrays.asList(1, 4)));
         PartitionChangeRecord record = new PartitionChangeRecord()
@@ -937,7 +937,7 @@ public class PartitionChangeBuilderTest {
         PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> r != 3, metadataVersionForPartitionChangeRecordVersion(version), 3)
             .setElection(Election.PREFERRED)
             .setEligibleLeaderReplicasEnabled(isElrEnabled(version))
-            .setLastKnownLeaderEnabled(false);
+            .setUseLastKnownLeaderInBalancedRecovery(false);
 
         builder.setUncleanShutdownReplicas(Arrays.asList(3));
 
@@ -1021,7 +1021,7 @@ public class PartitionChangeBuilderTest {
         PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> r != 1, metadataVersionForPartitionChangeRecordVersion(version), 3)
             .setElection(Election.PREFERRED)
             .setEligibleLeaderReplicasEnabled(isElrEnabled(version))
-            .setLastKnownLeaderEnabled(lastKnownLeaderEnabled);
+            .setUseLastKnownLeaderInBalancedRecovery(lastKnownLeaderEnabled);
 
         builder.setTargetIsr(Collections.emptyList());
 
@@ -1062,7 +1062,7 @@ public class PartitionChangeBuilderTest {
         PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> false, metadataVersionForPartitionChangeRecordVersion(version), 3)
             .setElection(Election.PREFERRED)
             .setEligibleLeaderReplicasEnabled(true)
-            .setLastKnownLeaderEnabled(lastKnownLeaderEnabled);
+            .setUseLastKnownLeaderInBalancedRecovery(lastKnownLeaderEnabled);
 
         builder.setTargetIsr(Collections.emptyList());
 
@@ -1110,7 +1110,7 @@ public class PartitionChangeBuilderTest {
 
         PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> true, metadataVersionForPartitionChangeRecordVersion(version), 3)
             .setElection(Election.PREFERRED)
-            .setLastKnownLeaderEnabled(true)
+            .setUseLastKnownLeaderInBalancedRecovery(true)
             .setEligibleLeaderReplicasEnabled(true);
 
         builder.setTargetIsr(Collections.emptyList());
@@ -1150,7 +1150,7 @@ public class PartitionChangeBuilderTest {
         PartitionChangeBuilder builder = new PartitionChangeBuilder(partition, topicId, 0, r -> r != 3, metadataVersionForPartitionChangeRecordVersion(version), 3)
             .setElection(Election.PREFERRED)
             .setEligibleLeaderReplicasEnabled(true)
-            .setLastKnownLeaderEnabled(true);
+            .setUseLastKnownLeaderInBalancedRecovery(true);
 
         builder.setTargetIsr(Collections.emptyList());
 

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -318,6 +318,31 @@ public class PartitionRegistrationTest {
         assertEquals(Replicas.toList(Replicas.NONE), Replicas.toList(partitionRegistration.addingReplicas));
     }
 
+    @ParameterizedTest
+    @MethodSource("partitionRecordVersions")
+    public void testPartitionRegistrationToRecord_ElrShouldBeNullIfEmpty(short version) {
+        PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
+                setReplicas(new int[]{0, 1, 2, 3, 4}).
+                setIsr(new int[]{0, 1}).
+                setLeader(0).
+                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+                setLeaderEpoch(0).
+                setPartitionEpoch(0);
+        PartitionRegistration partitionRegistration = builder.build();
+        Uuid topicID = Uuid.randomUuid();
+        PartitionRecord expectRecord = new PartitionRecord().
+                setTopicId(topicID).
+                setPartitionId(0).
+                setReplicas(Arrays.asList(new Integer[]{0, 1, 2, 3, 4})).
+                setIsr(Arrays.asList(new Integer[]{0, 1})).
+                setLeader(0).
+                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED.value()).
+                setLeaderEpoch(0).
+                setPartitionEpoch(0);
+        assertEquals(new ApiMessageAndVersion(expectRecord, version), partitionRegistration.toRecord(topicID, 0, version));
+        assertEquals(Replicas.toList(Replicas.NONE), Replicas.toList(partitionRegistration.addingReplicas));
+    }
+
     @Property
     public void testConsistentEqualsAndHashCode(
         @ForAll("uniqueSamples") PartitionRegistration a,

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -318,28 +318,31 @@ public class PartitionRegistrationTest {
         assertEquals(Replicas.toList(Replicas.NONE), Replicas.toList(partitionRegistration.addingReplicas));
     }
 
-    @ParameterizedTest
-    @MethodSource("partitionRecordVersions")
-    public void testPartitionRegistrationToRecord_ElrShouldBeNullIfEmpty(short version) {
+    public void testPartitionRegistrationToRecord_ElrShouldBeNullIfEmpty() {
         PartitionRegistration.Builder builder = new PartitionRegistration.Builder().
-                setReplicas(new int[]{0, 1, 2, 3, 4}).
-                setIsr(new int[]{0, 1}).
-                setLeader(0).
-                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
-                setLeaderEpoch(0).
-                setPartitionEpoch(0);
+            setReplicas(new int[]{0, 1, 2, 3, 4}).
+            setIsr(new int[]{0, 1}).
+            setLeader(0).
+            setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(0).
+            setPartitionEpoch(0);
         PartitionRegistration partitionRegistration = builder.build();
         Uuid topicID = Uuid.randomUuid();
         PartitionRecord expectRecord = new PartitionRecord().
-                setTopicId(topicID).
-                setPartitionId(0).
-                setReplicas(Arrays.asList(new Integer[]{0, 1, 2, 3, 4})).
-                setIsr(Arrays.asList(new Integer[]{0, 1})).
-                setLeader(0).
-                setLeaderRecoveryState(LeaderRecoveryState.RECOVERED.value()).
-                setLeaderEpoch(0).
-                setPartitionEpoch(0);
-        assertEquals(new ApiMessageAndVersion(expectRecord, version), partitionRegistration.toRecord(topicID, 0, version));
+            setTopicId(topicID).
+            setPartitionId(0).
+            setReplicas(Arrays.asList(new Integer[]{0, 1, 2, 3, 4})).
+            setIsr(Arrays.asList(new Integer[]{0, 1})).
+            setLeader(0).
+            setLeaderRecoveryState(LeaderRecoveryState.RECOVERED.value()).
+            setLeaderEpoch(0).
+            setPartitionEpoch(0);
+        List<UnwritableMetadataException> exceptions = new ArrayList<>();
+        ImageWriterOptions options = new ImageWriterOptions.Builder().
+            setMetadataVersion(MetadataVersion.latest()).
+            setLossHandler(exceptions::add).
+            build();
+        assertEquals(new ApiMessageAndVersion(expectRecord, (short) 2), partitionRegistration.toRecord(topicID, 0, options));
         assertEquals(Replicas.toList(Replicas.NONE), Replicas.toList(partitionRegistration.addingReplicas));
     }
 


### PR DESCRIPTION
The PR includes the following changes
1. Allow ISR shrink to empty.
2. Allow leader election with ELR members.
3. Allow electing the last known leader.

https://issues.apache.org/jira/browse/KAFKA-15584
