### PR TITLE
KAFKA-15556: Remove NetworkClientDelegate methods isUnavailable, maybeThrowAuthFailure, and tryConnect

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java
@@ -447,7 +447,6 @@ public class OffsetsRequestManager implements RequestManager, ClusterResourceLis
 
             NodeApiVersions nodeApiVersions = apiVersions.get(node.idString());
             if (nodeApiVersions == null) {
-                networkClientDelegate.tryConnect(node);
                 return;
             }
 


### PR DESCRIPTION
it is jira link
https://issues.apache.org/jira/browse/KAFKA-15556
I check the methods: isUnavailable,maybeThrowAuthFailure is not existed
remove the method tryConnect

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
