### PR TITLE
MINOR: Polishing RoundRobinPartitioner

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
@@ -51,8 +51,6 @@ public class RoundRobinPartitioner implements Partitioner {
      */
     @Override
     public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
-        List<PartitionInfo> partitions = cluster.partitionsForTopic(topic);
-        int numPartitions = partitions.size();
         int nextValue = nextValue(topic);
         List<PartitionInfo> availablePartitions = cluster.availablePartitionsForTopic(topic);
         if (!availablePartitions.isEmpty()) {
@@ -60,6 +58,7 @@ public class RoundRobinPartitioner implements Partitioner {
             return availablePartitions.get(part).partition();
         } else {
             // no partitions are available, give a non-available partition
+            int numPartitions = cluster.partitionsForTopic(topic).size();
             return Utils.toPositive(nextValue) % numPartitions;
         }
     }


### PR DESCRIPTION
Avoid calling `cluster.partitionsForTopic(topic)` if `cluster.availablePartitionsForTopic(topic)` is not empty
