### PR TITLE
MINOR: Fix NPE during fetchSnapshot

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -595,7 +595,7 @@ public class ProducerStateManager {
     }
 
     public Optional<File> fetchSnapshot(long offset) {
-        return Optional.of(snapshots.get(offset)).map(x -> x.file());
+        return Optional.ofNullable(snapshots.get(offset)).map(x -> x.file());
     }
 
     private Optional<SnapshotFile> oldestSnapshotFile() {


### PR DESCRIPTION
The remote log manager performs an explicit null check in the case no snapshot file is found at the given index.

Missing snapshot files can happen Kafka is upgraded from any version prior to 2.8.0. When this is the case, the remote log manager takes an empty snapshot.