### PR TITLE
MINOR: Fix flaky testFollowerCompleteDelayedFetchesOnReplication

### DIFF
--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -67,6 +67,7 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
       brokers,
       replicaAssignment = Map(0 -> Seq(leaderBrokerId, followerBrokerId))
     )
+    TestUtils.waitUntilLeaderIsKnown(brokers, new TopicPartition(topic, 0))
     assertTrue(partitionLeaders.values.forall(_ == leaderBrokerId))
 
     val version = ApiKeys.FETCH.latestVersion()


### PR DESCRIPTION
*More detailed description of your change*
The error msg is "org.opentest4j.AssertionFailedError: expected: <{NONE=2}> but was: <{NONE=1, NOT_LEADER_OR_FOLLOWER=1}>
", the reason is similar to #14563 , use `TestUtils.waitUntilLeaderIsKnown` to avoid a corner case.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
