### PR TITLE
KAFKA-15670: add "inter.broker.listener.name" config in KRaft controller config

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3822,6 +3822,9 @@ zookeeper.connect=localhost:2181
 # The inter broker listener in brokers to allow KRaft controller send RPCs to brokers
 inter.broker.listener.name=PLAINTEXT
 
+# Maps listener names to security protocols. Please add the inter broker listener protocol mapping
+listener.security.protocol.map=PLAINTEXT:PLAINTEXT
+
 # Other configs ...</pre>
 
   <p><em>Note: The KRaft cluster <code>node.id</code> values must be different from any existing ZK broker <code>broker.id</code>.
@@ -3903,6 +3906,9 @@ listener.security.protocol.map=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
 
 # Remove the inter broker listener in brokers to allow KRaft controller send RPCs to brokers
 # inter.broker.listener.name=PLAINTEXT
+
+# Maps listener names to security protocols. Please add the inter broker listener protocol mapping
+# listener.security.protocol.map=PLAINTEXT:PLAINTEXT
 
 # Keep the KRaft controller quorum configuration
 controller.quorum.voters=3000@localhost:9093

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3823,7 +3823,7 @@ zookeeper.connect=localhost:2181
 inter.broker.listener.name=PLAINTEXT
 
 # Maps listener names to security protocols. Please add the inter broker listener protocol mapping
-listener.security.protocol.map=PLAINTEXT:PLAINTEXT
+listener.security.protocol.map=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
 
 # Other configs ...</pre>
 
@@ -3908,7 +3908,7 @@ listener.security.protocol.map=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
 # inter.broker.listener.name=PLAINTEXT
 
 # Maps listener names to security protocols. Please add the inter broker listener protocol mapping
-# listener.security.protocol.map=PLAINTEXT:PLAINTEXT
+# listener.security.protocol.map=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
 
 # Keep the KRaft controller quorum configuration
 controller.quorum.voters=3000@localhost:9093

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3819,6 +3819,9 @@ zookeeper.metadata.migration.enable=true
 # ZooKeeper client configuration
 zookeeper.connect=localhost:2181
 
+# The inter broker listener in brokers to allow KRaft controller send RPCs to brokers
+inter.broker.listener.name=PLAINTEXT
+
 # Other configs ...</pre>
 
   <p><em>Note: The KRaft cluster <code>node.id</code> values must be different from any existing ZK broker <code>broker.id</code>.
@@ -3897,6 +3900,9 @@ listener.security.protocol.map=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
 
 # Remove ZooKeeper client configuration
 # zookeeper.connect=localhost:2181
+
+# Remove the inter broker listener in brokers to allow KRaft controller send RPCs to brokers
+# inter.broker.listener.name=PLAINTEXT
 
 # Keep the KRaft controller quorum configuration
 controller.quorum.voters=3000@localhost:9093

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3822,9 +3822,6 @@ zookeeper.connect=localhost:2181
 # The inter broker listener in brokers to allow KRaft controller send RPCs to brokers
 inter.broker.listener.name=PLAINTEXT
 
-# Maps listener names to security protocols. Please add the inter broker listener protocol mapping
-listener.security.protocol.map=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
-
 # Other configs ...</pre>
 
   <p><em>Note: The KRaft cluster <code>node.id</code> values must be different from any existing ZK broker <code>broker.id</code>.
@@ -3903,12 +3900,6 @@ listener.security.protocol.map=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
 
 # Remove ZooKeeper client configuration
 # zookeeper.connect=localhost:2181
-
-# Remove the inter broker listener in brokers to allow KRaft controller send RPCs to brokers
-# inter.broker.listener.name=PLAINTEXT
-
-# Maps listener names to security protocols. Please add the inter broker listener protocol mapping
-# listener.security.protocol.map=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
 
 # Keep the KRaft controller quorum configuration
 controller.quorum.voters=3000@localhost:9093


### PR DESCRIPTION
During ZK migrating to KRaft, before entering dual-write mode, the KRaft controller will send RPCs (i.e. UpdateMetadataRequest, LeaderAndIsrRequest, and StopReplicaRequest) to the brokers. Currently, we use the inter broker listener to send the RPC to brokers from the controller. But in the doc, we didn't provide this info to users because the normal KRaft controller won't use `inter.broker.listener.names`.

This PR adds the missing config in the ZK migrating to KRaft doc.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
