### PR TITLE
Add explicit exit call to each shell command

### DIFF
--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -75,6 +75,7 @@ object AclCommand extends Logging {
         aclCommandService.removeAcls()
       else if (opts.options.has(opts.listOpt))
         aclCommandService.listAcls()
+      Exit.exit(0)
     } catch {
       case e: Throwable =>
         println(s"Error while executing ACL command: ${e.getMessage}")

--- a/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
@@ -23,7 +23,7 @@ import java.util.Properties
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{ConcurrentLinkedQueue, TimeUnit}
 import kafka.utils.Implicits._
-import kafka.utils.Logging
+import kafka.utils.{Exit, Logging}
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.clients.{ApiVersions, ClientDnsLookup, ClientResponse, ClientUtils, CommonClientConfigs, Metadata, NetworkClient, NodeApiVersions}
 import org.apache.kafka.clients.consumer.internals.{ConsumerNetworkClient, RequestFuture}
@@ -52,6 +52,7 @@ object BrokerApiVersionsCommand {
 
   def main(args: Array[String]): Unit = {
     execute(args, System.out)
+    Exit.exit(0)
   }
 
   def execute(args: Array[String], out: PrintStream): Unit = {

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -95,6 +95,7 @@ object ConfigCommand extends Logging {
       } else {
         processCommand(opts)
       }
+      Exit.exit(0)
     } catch {
       case e @ (_: IllegalArgumentException | _: InvalidConfigurationException | _: OptionException) =>
         logger.debug(s"Failed config command with args '${args.mkString(" ")}'", e)

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -57,6 +57,7 @@ object ConsumerGroupCommand extends Logging {
         CommandLineUtils.printUsageAndExit(opts.parser, "Command must include exactly one action: --list, --describe, --delete, --reset-offsets, --delete-offsets")
 
       run(opts)
+      Exit.exit(0)
     } catch {
       case e: OptionException =>
         CommandLineUtils.printUsageAndExit(opts.parser, e.getMessage)

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -221,6 +221,8 @@ object ReassignPartitionsCommand extends Logging {
     // If the command failed, exit with a non-zero exit code.
     if (failed) {
       Exit.exit(1)
+    } else {
+      Exit.exit(0)
     }
   }
 

--- a/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
+++ b/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
@@ -115,6 +115,7 @@ object ZkSecurityMigrator extends Logging {
   def main(args: Array[String]): Unit = {
     try {
       run(args)
+      Exit.exit(0)
     } catch {
         case e: Exception => {
           e.printStackTrace()

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -52,6 +52,7 @@ object ConsoleConsumer extends Logging {
     val conf = new ConsumerConfig(args)
     try {
       run(conf)
+      Exit.exit(0)
     } catch {
       case e: AuthenticationException =>
         error("Authentication failed: terminating consumer process", e)

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -92,6 +92,7 @@ object DumpLogSegments {
         System.err.println(s"  $first is followed by $second")
       }
     }
+    Exit.exit(0)
   }
 
   private def dumpTxnIndex(file: File): Unit = {

--- a/tools/src/main/java/org/apache/kafka/tools/ConsumerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConsumerPerformance.java
@@ -102,6 +102,8 @@ public class ConsumerPerformance {
 
             if (metrics != null)
                 ToolsUtils.printMetrics(metrics);
+
+            Exit.exit(0);
         } catch (Throwable e) {
             System.err.println(e.getMessage());
             System.err.println(Utils.stackTrace(e));

--- a/tools/src/main/java/org/apache/kafka/tools/DeleteRecordsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/DeleteRecordsCommand.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DeleteRecordsResult;
 import org.apache.kafka.clients.admin.RecordsToDelete;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.common.AdminCommandFailedException;
 import org.apache.kafka.server.common.AdminOperationException;
@@ -62,6 +63,7 @@ public class DeleteRecordsCommand {
 
     public static void main(String[] args) throws Exception {
         execute(args, System.out);
+        Exit.exit(0);
     }
 
     static Map<TopicPartition, List<Long>> parseOffsetJsonStringWithoutDedup(String jsonData) throws JsonProcessingException {

--- a/tools/src/main/java/org/apache/kafka/tools/LeaderElectionCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/LeaderElectionCommand.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.ElectionNotNeededException;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.common.AdminCommandFailedException;
 import org.apache.kafka.server.common.AdminOperationException;
@@ -62,11 +63,15 @@ public class LeaderElectionCommand {
     private static final DecodeJson.DecodeInteger INT = new DecodeJson.DecodeInteger();
 
     public static void main(String... args) {
+        int exitCode = 0;
         try {
             run(Duration.ofMillis(30000), args);
         } catch (Exception e) {
             System.err.println(e.getMessage());
             System.err.println(Utils.stackTrace(e));
+            exitCode = 1;
+        } finally {
+            Exit.exit(exitCode);
         }
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -55,6 +55,7 @@ public class ProducerPerformance {
     void start(String[] args) throws IOException {
         ArgumentParser parser = argParser();
 
+        int exitCode = 0;
         try {
             Namespace res = parser.parseArgs(args);
 
@@ -152,11 +153,12 @@ public class ProducerPerformance {
         } catch (ArgumentParserException e) {
             if (args.length == 0) {
                 parser.printHelp();
-                Exit.exit(0);
             } else {
                 parser.handleError(e);
-                Exit.exit(1);
+                exitCode = 1;
             }
+        } finally {
+            Exit.exit(exitCode);
         }
 
     }

--- a/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
@@ -108,6 +108,7 @@ public class ReplicaVerificationTool {
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
 
     public static void main(String[] args) {
+        int exitCode = 0;
         try {
             ReplicaVerificationToolOptions options = new ReplicaVerificationToolOptions(args);
             // getting topic metadata
@@ -210,7 +211,9 @@ public class ReplicaVerificationTool {
         } catch (Throwable e) {
             System.err.println(e.getMessage());
             System.err.println(Utils.stackTrace(e));
-            Exit.exit(1);
+            exitCode = 1;
+        } finally {
+            Exit.exit(exitCode);
         }
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -666,6 +666,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
             // Can't use `Exit.exit` here because it didn't exist until 0.11.0.0.
             System.exit(0);
         }
+        int exitCode = 0;
         try {
             final VerifiableConsumer consumer = createFromArgs(parser, args);
             // Can't use `Exit.addShutdownHook` here because it didn't exist until 2.5.0.
@@ -674,8 +675,10 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
             consumer.run();
         } catch (ArgumentParserException e) {
             parser.handleError(e);
+            exitCode = 1;
+        } finally {
             // Can't use `Exit.exit` here because it didn't exist until 0.11.0.0.
-            System.exit(1);
+            System.exit(exitCode);
         }
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -533,6 +533,7 @@ public class VerifiableProducer implements AutoCloseable {
             System.exit(0);
         }
 
+        int exitCode = 0;
         try {
             final VerifiableProducer producer = createFromArgs(parser, args);
 
@@ -557,8 +558,10 @@ public class VerifiableProducer implements AutoCloseable {
             producer.run(throttler);
         } catch (ArgumentParserException e) {
             parser.handleError(e);
+            exitCode = 1;
+        } finally {
             // Can't use `Exit.exit` here because it didn't exist until 0.11.0.0.
-            System.exit(1);
+            System.exit(exitCode);
         }
     }
 


### PR DESCRIPTION
Using a custom security.provider may keep shell commands running indefinitely if System.exit() is not called explicitly. This behaviour is due to the reason that a security.provider implementation might run background tasks on its own thread, that is never cancelled unless the whole process is terminated.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
