### PR TITLE
KAFKA-15562: ensure commit request manager handles errors correctly

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -342,15 +342,7 @@ public class CommitRequestManager implements RequestManager {
                         continue;
                     }
 
-                    if (error.exception() instanceof RetriableException) {
-                        log.warn("OffsetCommit failed on partition {} at offset {}: {}", tp, offset, error.message());
-                    } else {
-                        log.error("OffsetCommit failed on partition {} at offset {}: {}", tp, offset, error.message());
-                    }
-
-                    if (error == Errors.NONE) {
-                        log.debug("OffsetCommit {} for partition {}", offset, tp);
-                    } else if (error == Errors.TOPIC_AUTHORIZATION_FAILED) {
+                    if (error == Errors.TOPIC_AUTHORIZATION_FAILED) {
                         // Collect all unauthorized topics before failing
                         unauthorizedTopics.add(tp.topic());
                     } else if (error.exception() instanceof RetriableException) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -133,7 +133,7 @@ public class ApplicationEventProcessor extends EventProcessor<ApplicationEvent> 
         }
 
         CommitRequestManager manager = requestManagers.commitRequestManager.get();
-        event.chain(manager.addOffsetCommitRequest(event.offsets()));
+        event.chain(manager.addOffsetCommitRequest(event.offsets()).future());
     }
 
     private void process(final OffsetFetchApplicationEvent event) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -133,7 +133,7 @@ public class ApplicationEventProcessor extends EventProcessor<ApplicationEvent> 
         }
 
         CommitRequestManager manager = requestManagers.commitRequestManager.get();
-        event.chain(manager.addOffsetCommitRequest(event.offsets()).future());
+        event.chain(manager.addOffsetCommitRequest(event.offsets()));
     }
 
     private void process(final OffsetFetchApplicationEvent event) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -328,7 +328,8 @@ public class CommitRequestManagerTest {
                 assertPollDoesNotReturn(commitRequestManger, Long.MAX_VALUE);
                 break;
             case FENCED_INSTANCE_ID:
-                // what should we do
+                // This is a fatal failure, so we should not retry
+                assertPollDoesNotReturn(commitRequestManger, Long.MAX_VALUE);
                 break;
             default:
                 assertPollDoesNotReturn(commitRequestManger, Long.MAX_VALUE);


### PR DESCRIPTION
The current commitRequestManager lacks logic handling various failures.  In the patch I addressed the following gap:
1. Network disconnection should disconnect the coordinator node
2. Handling and testing various of fatal and retriable errors scenarios
3. Ensure the time returned in the poll results is Long.MAX or the minimum of all the inflight request's remainingBackoffMs.  Because we need to respect the backoff.