### PR TITLE
KAFKA-15679: Consumer configurations for group protocol

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -110,7 +110,7 @@ public class ConsumerConfig extends AbstractConfig {
      */
     public static final String GROUP_PROTOCOL_CONFIG = "group.protocol";
     public static final String DEFAULT_GROUP_PROTOCOL = GroupProtocol.GENERIC.name().toLowerCase();
-    public static final String GROUP_PROTOCOL_DOC = "The rebalance protocol consumer should use.  We currently " +
+    public static final String GROUP_PROTOCOL_DOC = "The group protocol consumer should use.  We currently " +
         "support \"generic\" or \"consumer\". If \"consumer\" is specified, then the consumer group protocol will be " +
         "used.  Otherwise, the generic group protocol will be used.";
 
@@ -120,7 +120,8 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String REMOTE_ASSIGNOR_CONFIG = "group.remote.assignor";
     public static final String DEFAULT_REMOTE_ASSIGNOR = null;
     public static final String REMOTE_ASSIGNOR_DOC = "The server-side assignor to use. If no assignor is specified, " +
-        "the group coordinator will pick one.";
+        "the group coordinator will pick one. This configuration is applied only if <code>group.protocol</code> is " +
+        "set to \"consumer\".";
 
     /**
      * <code>bootstrap.servers</code>
@@ -628,16 +629,16 @@ public class ConsumerConfig extends AbstractConfig {
                                         Importance.MEDIUM,
                                         ALLOW_AUTO_CREATE_TOPICS_DOC)
                                 .define(GROUP_PROTOCOL_CONFIG,
-                                    Type.STRING,
-                                    DEFAULT_GROUP_PROTOCOL,
-                                    ConfigDef.CaseInsensitiveValidString.in(Utils.enumOptions(GroupProtocol.class)),
-                                    Importance.HIGH,
-                                    GROUP_PROTOCOL_DOC)
+                                        Type.STRING,
+                                        DEFAULT_GROUP_PROTOCOL,
+                                        ConfigDef.CaseInsensitiveValidString.in(Utils.enumOptions(GroupProtocol.class)),
+                                        Importance.HIGH,
+                                        GROUP_PROTOCOL_DOC)
                                 .define(REMOTE_ASSIGNOR_CONFIG,
-                                    Type.STRING,
-                                    DEFAULT_REMOTE_ASSIGNOR,
-                                    Importance.MEDIUM,
-                                    REMOTE_ASSIGNOR_DOC)
+                                        Type.STRING,
+                                        DEFAULT_REMOTE_ASSIGNOR,
+                                        Importance.MEDIUM,
+                                        REMOTE_ASSIGNOR_DOC)
                                 // security support
                                 .define(SECURITY_PROVIDERS_CONFIG,
                                         Type.STRING,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -109,7 +109,7 @@ public class ConsumerConfig extends AbstractConfig {
      * <code>group.protocol</code>
      */
     public static final String GROUP_PROTOCOL_CONFIG = "group.protocol";
-    public static final String DEFAULT_GROUP_PROTOCOL = GroupProtocol.GENERIC.name().toLowerCase();
+    public static final String DEFAULT_GROUP_PROTOCOL = GroupProtocol.GENERIC.name().toLowerCase(Locale.ROOT);
     public static final String GROUP_PROTOCOL_DOC = "The group protocol consumer should use.  We currently " +
         "support \"generic\" or \"consumer\". If \"consumer\" is specified, then the consumer group protocol will be " +
         "used.  Otherwise, the generic group protocol will be used.";

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -109,19 +109,18 @@ public class ConsumerConfig extends AbstractConfig {
      * <code>group.protocol</code>
      */
     public static final String GROUP_PROTOCOL_CONFIG = "group.protocol";
-    public static final String DEFAULT_GROUP_PROTOCOL = "generic";
+    public static final String DEFAULT_GROUP_PROTOCOL = GroupProtocol.GENERIC.name().toLowerCase();
     public static final String GROUP_PROTOCOL_DOC = "The rebalance protocol consumer should use.  We currently " +
-        "support GENERIC or CONSUMER. If CONSUMER is specified, then the consumer group protocol will be used.  " +
-        "Otherwise, the generic group protocol will be used.";
+        "support \"generic\" or \"consumer\". If \"consumer\" is specified, then the consumer group protocol will be " +
+        "used.  Otherwise, the generic group protocol will be used.";
 
     /**
     * <code>group.remote.assignor</code>
     */
     public static final String REMOTE_ASSIGNOR_CONFIG = "group.remote.assignor";
     public static final String DEFAULT_REMOTE_ASSIGNOR = null;
-    public static final String REMOTE_ASSIGNOR_DOC = "The server side assignor to use. It cannot be used in " +
-        "conjunction with <code>group.local.assignor</code>. The group coordinator will choose the assignor if no " +
-        "assignor is specified.";
+    public static final String REMOTE_ASSIGNOR_DOC = "The server-side assignor to use. If no assignor is specified, " +
+        "the group coordinator will pick one.";
 
     /**
      * <code>bootstrap.servers</code>
@@ -631,8 +630,7 @@ public class ConsumerConfig extends AbstractConfig {
                                 .define(GROUP_PROTOCOL_CONFIG,
                                     Type.STRING,
                                     DEFAULT_GROUP_PROTOCOL,
-                                    ConfigDef.CaseInsensitiveValidString
-                                        .in(Utils.enumOptions(GroupProtocol.class)),
+                                    ConfigDef.CaseInsensitiveValidString.in(Utils.enumOptions(GroupProtocol.class)),
                                     Importance.HIGH,
                                     GROUP_PROTOCOL_DOC)
                                 .define(REMOTE_ASSIGNOR_CONFIG,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -110,7 +110,7 @@ public class ConsumerConfig extends AbstractConfig {
      */
     public static final String GROUP_PROTOCOL_CONFIG = "group.protocol";
     public static final String DEFAULT_GROUP_PROTOCOL = "generic";
-    public static final String GROUP_PROTOCOL_DOC = "The rebalance protocol consumer shoudl use.  We currently " +
+    public static final String GROUP_PROTOCOL_DOC = "The rebalance protocol consumer should use.  We currently " +
         "support GENERIC or CONSUMER. If CONSUMER is specified, then the consumer group protocol will be used.  " +
         "Otherwise, the generic group protocol will be used.";
 
@@ -120,16 +120,16 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String REMOTE_ASSIGNOR_CONFIG = "group.remote.assignor";
     public static final String DEFAULT_REMOTE_ASSIGNOR = null;
     public static final String REMOTE_ASSIGNOR_DOC = "The server side assignor to use. It cannot be used in " +
-        "conjunction with group.local.assignor. The group coordinator will choose the assignor if <code>null</code> " +
-        "is provided.";
+        "conjunction with <code>group.local.assignor</code>. The group coordinator will choose the assignor if no " +
+        "assignor is specified.";
 
     /**
      * <code>group.local.assignor</code>
      */
     public static final String LOCAL_ASSIGNOR_CONFIG = "group.local.assignor";
     public static final List<String> DEFAULT_LOCAL_ASSIGNOR = Collections.emptyList();
-    public static final String LOCAL_ASSIGNOR_DOC = "The list of client side (local) assignors as a list of full " +
-        "class names. It cannot be used in conjunction with group.remote.assignor.";
+    public static final String LOCAL_ASSIGNOR_DOC = "The list of client side assignors in full class names. It cannot" +
+        " be used in conjunction with <code>group.remote.assignor</code>.";
 
     /**
      * <code>bootstrap.servers</code>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -117,9 +117,9 @@ public class ConsumerConfig extends AbstractConfig {
     /**
     * <code>group.remote.assignor</code>
     */
-    public static final String REMOTE_ASSIGNOR_CONFIG = "group.remote.assignor";
-    public static final String DEFAULT_REMOTE_ASSIGNOR = null;
-    public static final String REMOTE_ASSIGNOR_DOC = "The server-side assignor to use. If no assignor is specified, " +
+    public static final String GROUP_REMOTE_ASSIGNOR_CONFIG = "group.remote.assignor";
+    public static final String DEFAULT_GROUP_REMOTE_ASSIGNOR = null;
+    public static final String GROUP_REMOTE_ASSIGNOR_DOC = "The server-side assignor to use. If no assignor is specified, " +
         "the group coordinator will pick one. This configuration is applied only if <code>group.protocol</code> is " +
         "set to \"consumer\".";
 
@@ -634,11 +634,11 @@ public class ConsumerConfig extends AbstractConfig {
                                         ConfigDef.CaseInsensitiveValidString.in(Utils.enumOptions(GroupProtocol.class)),
                                         Importance.HIGH,
                                         GROUP_PROTOCOL_DOC)
-                                .define(REMOTE_ASSIGNOR_CONFIG,
+                                .define(GROUP_REMOTE_ASSIGNOR_CONFIG,
                                         Type.STRING,
-                                        DEFAULT_REMOTE_ASSIGNOR,
+                                        DEFAULT_GROUP_REMOTE_ASSIGNOR,
                                         Importance.MEDIUM,
-                                        REMOTE_ASSIGNOR_DOC)
+                                        GROUP_REMOTE_ASSIGNOR_DOC)
                                 // security support
                                 .define(SECURITY_PROVIDERS_CONFIG,
                                         Type.STRING,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -106,6 +106,32 @@ public class ConsumerConfig extends AbstractConfig {
     private static final String HEARTBEAT_INTERVAL_MS_DOC = CommonClientConfigs.HEARTBEAT_INTERVAL_MS_DOC;
 
     /**
+     * <code>group.protocol</code>
+     */
+    public static final String GROUP_PROTOCOL_CONFIG = "group.protocol";
+    public static final String DEFAULT_GROUP_PROTOCOL = "generic";
+    public static final String GROUP_PROTOCOL_DOC = "The rebalance protocol consumer shoudl use.  We currently " +
+        "support GENERIC or CONSUMER. If CONSUMER is specified, then the consumer group protocol will be used.  " +
+        "Otherwise, the generic group protocol will be used.";
+
+    /**
+    * <code>group.remote.assignor</code>
+    */
+    public static final String REMOTE_ASSIGNOR_CONFIG = "group.remote.assignor";
+    public static final String DEFAULT_REMOTE_ASSIGNOR = null;
+    public static final String REMOTE_ASSIGNOR_DOC = "The server side assignor to use. It cannot be used in " +
+        "conjunction with group.local.assignor. The group coordinator will choose the assignor if <code>null</code> " +
+        "is provided.";
+
+    /**
+     * <code>group.local.assignor</code>
+     */
+    public static final String LOCAL_ASSIGNOR_CONFIG = "group.local.assignor";
+    public static final List<String> DEFAULT_LOCAL_ASSIGNOR = Collections.emptyList();
+    public static final String LOCAL_ASSIGNOR_DOC = "The list of client side (local) assignors as a list of full " +
+        "class names. It cannot be used in conjunction with group.remote.assignor.";
+
+    /**
      * <code>bootstrap.servers</code>
      */
     public static final String BOOTSTRAP_SERVERS_CONFIG = CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
@@ -610,6 +636,24 @@ public class ConsumerConfig extends AbstractConfig {
                                         DEFAULT_ALLOW_AUTO_CREATE_TOPICS,
                                         Importance.MEDIUM,
                                         ALLOW_AUTO_CREATE_TOPICS_DOC)
+                                .define(GROUP_PROTOCOL_CONFIG,
+                                    Type.STRING,
+                                    DEFAULT_GROUP_PROTOCOL,
+                                    ConfigDef.CaseInsensitiveValidString
+                                        .in(Utils.enumOptions(GroupProtocol.class)),
+                                    Importance.HIGH,
+                                    GROUP_PROTOCOL_DOC)
+                                .define(LOCAL_ASSIGNOR_CONFIG,
+                                    Type.LIST,
+                                    DEFAULT_LOCAL_ASSIGNOR,
+                                    new ConfigDef.NonNullValidator(),
+                                    Importance.MEDIUM,
+                                    LOCAL_ASSIGNOR_DOC)
+                                .define(REMOTE_ASSIGNOR_CONFIG,
+                                    Type.STRING,
+                                    DEFAULT_REMOTE_ASSIGNOR,
+                                    Importance.MEDIUM,
+                                    REMOTE_ASSIGNOR_DOC)
                                 // security support
                                 .define(SECURITY_PROVIDERS_CONFIG,
                                         Type.STRING,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -124,14 +124,6 @@ public class ConsumerConfig extends AbstractConfig {
         "assignor is specified.";
 
     /**
-     * <code>group.local.assignor</code>
-     */
-    public static final String LOCAL_ASSIGNOR_CONFIG = "group.local.assignor";
-    public static final List<String> DEFAULT_LOCAL_ASSIGNOR = Collections.emptyList();
-    public static final String LOCAL_ASSIGNOR_DOC = "The list of client side assignors in full class names. It cannot" +
-        " be used in conjunction with <code>group.remote.assignor</code>.";
-
-    /**
      * <code>bootstrap.servers</code>
      */
     public static final String BOOTSTRAP_SERVERS_CONFIG = CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
@@ -643,12 +635,6 @@ public class ConsumerConfig extends AbstractConfig {
                                         .in(Utils.enumOptions(GroupProtocol.class)),
                                     Importance.HIGH,
                                     GROUP_PROTOCOL_DOC)
-                                .define(LOCAL_ASSIGNOR_CONFIG,
-                                    Type.LIST,
-                                    DEFAULT_LOCAL_ASSIGNOR,
-                                    new ConfigDef.NonNullValidator(),
-                                    Importance.MEDIUM,
-                                    LOCAL_ASSIGNOR_DOC)
                                 .define(REMOTE_ASSIGNOR_CONFIG,
                                     Type.STRING,
                                     DEFAULT_REMOTE_ASSIGNOR,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -110,9 +110,9 @@ public class ConsumerConfig extends AbstractConfig {
      */
     public static final String GROUP_PROTOCOL_CONFIG = "group.protocol";
     public static final String DEFAULT_GROUP_PROTOCOL = GroupProtocol.GENERIC.name().toLowerCase(Locale.ROOT);
-    public static final String GROUP_PROTOCOL_DOC = "The group protocol consumer should use.  We currently " +
+    public static final String GROUP_PROTOCOL_DOC = "The group protocol consumer should use. We currently " +
         "support \"generic\" or \"consumer\". If \"consumer\" is specified, then the consumer group protocol will be " +
-        "used.  Otherwise, the generic group protocol will be used.";
+        "used. Otherwise, the generic group protocol will be used.";
 
     /**
     * <code>group.remote.assignor</code>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/GroupProtocol.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/GroupProtocol.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer;
+
+import java.util.Locale;
+
+public enum GroupProtocol {
+    /** Generic group protocol.  */
+    GENERIC("GENERIC"),
+
+    /** Consumer group protocol */
+    CONSUMER("CONSUMER");
+
+    /**
+     * String representation of the group protocol.
+     */
+    public final String name;
+
+    GroupProtocol(final String name) {
+        this.name = name;
+    }
+
+    /**
+     * Case-insensitive group protocol lookup by string name.
+     */
+    public static GroupProtocol of(final String name) {
+        return GroupProtocol.valueOf(name.toUpperCase(Locale.ROOT));
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -167,7 +166,6 @@ public class ConsumerConfigTest {
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass);
         final ConsumerConfig consumerConfig = new ConsumerConfig(configs);
         assertEquals("generic", consumerConfig.getString(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
-        assertEquals(Collections.EMPTY_LIST, consumerConfig.getList(ConsumerConfig.LOCAL_ASSIGNOR_CONFIG));
         assertEquals(null, consumerConfig.getString(ConsumerConfig.REMOTE_ASSIGNOR_CONFIG));
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
@@ -169,7 +169,7 @@ public class ConsumerConfigTest {
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass);
         final ConsumerConfig consumerConfig = new ConsumerConfig(configs);
         assertEquals("generic", consumerConfig.getString(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
-        assertNull(consumerConfig.getString(ConsumerConfig.REMOTE_ASSIGNOR_CONFIG));
+        assertNull(consumerConfig.getString(ConsumerConfig.GROUP_REMOTE_ASSIGNOR_CONFIG));
     }
 
     @Test
@@ -179,11 +179,11 @@ public class ConsumerConfigTest {
         final Map<String, Object> configs = new HashMap<>();
         configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClass);
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass);
-        configs.put(ConsumerConfig.REMOTE_ASSIGNOR_CONFIG, remoteAssignorName);
+        configs.put(ConsumerConfig.GROUP_REMOTE_ASSIGNOR_CONFIG, remoteAssignorName);
         configs.put(ConsumerConfig.GROUP_PROTOCOL_CONFIG, protocol);
         final ConsumerConfig consumerConfig = new ConsumerConfig(configs);
         assertEquals(protocol, consumerConfig.getString(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
-        assertEquals(remoteAssignorName, consumerConfig.getString(ConsumerConfig.REMOTE_ASSIGNOR_CONFIG));
+        assertEquals(remoteAssignorName, consumerConfig.getString(ConsumerConfig.GROUP_REMOTE_ASSIGNOR_CONFIG));
     }
 
     @ParameterizedTest

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -170,7 +171,7 @@ public class ConsumerConfigTest {
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass);
         final ConsumerConfig consumerConfig = new ConsumerConfig(configs);
         assertEquals("generic", consumerConfig.getString(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
-        assertEquals(null, consumerConfig.getString(ConsumerConfig.REMOTE_ASSIGNOR_CONFIG));
+        assertNull(consumerConfig.getString(ConsumerConfig.REMOTE_ASSIGNOR_CONFIG));
     }
 
     @Test
@@ -180,6 +181,7 @@ public class ConsumerConfigTest {
         final Map<String, Object> configs = new HashMap<>();
         configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClass);
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass);
+        configs.put(ConsumerConfig.REMOTE_ASSIGNOR_CONFIG, remoteAssignorName);
         configs.put(ConsumerConfig.GROUP_PROTOCOL_CONFIG, protocol);
         final ConsumerConfig consumerConfig = new ConsumerConfig(configs);
         assertEquals(protocol, consumerConfig.getString(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
@@ -188,7 +190,7 @@ public class ConsumerConfigTest {
 
     @ParameterizedTest
     @MethodSource("protocolNameSupplier")
-    public void testConfigurationValidation(String protocol, boolean isValid) {
+    public void testProtocolConfigValidation(String protocol, boolean isValid) {
         final Map<String, Object> configs = new HashMap<>();
         configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClass);
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
@@ -26,15 +26,13 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -189,28 +187,17 @@ public class ConsumerConfigTest {
     }
 
     @ParameterizedTest
-    @MethodSource("protocolNameSupplier")
+    @CsvSource({"consumer, true", "generic, true", "Consumer, true", "Generic, true", "invalid, false"})
     public void testProtocolConfigValidation(String protocol, boolean isValid) {
         final Map<String, Object> configs = new HashMap<>();
         configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClass);
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass);
         configs.put(ConsumerConfig.GROUP_PROTOCOL_CONFIG, protocol);
-        try {
+        if (isValid) {
             ConsumerConfig config = new ConsumerConfig(configs);
             assertEquals(protocol, config.getString(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
-        } catch (ConfigException e) {
-            if (isValid)
-                fail("Should not have thrown an exception");
+        } else {
+            assertThrows(ConfigException.class, () -> new ConsumerConfig(configs));
         }
-    }
-
-    // Supplies (name, isValid)
-    private static Stream<Arguments> protocolNameSupplier() {
-        return Stream.of(
-            Arguments.of("consumer", true),
-            Arguments.of("generic", true),
-            Arguments.of("Consumer", true),
-            Arguments.of("Generic", true),
-            Arguments.of("invalid", false));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
@@ -27,13 +27,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -157,5 +158,29 @@ public class ConsumerConfigTest {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, saslSslLowerCase);
         final ConsumerConfig consumerConfig = new ConsumerConfig(configs);
         assertEquals(saslSslLowerCase, consumerConfig.originals().get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+    }
+
+    @Test
+    public void testDefaultConsumerGroupConfig() {
+        final Map<String, Object> configs = new HashMap<>();
+        configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClass);
+        configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass);
+        final ConsumerConfig consumerConfig = new ConsumerConfig(configs);
+        assertEquals("generic", consumerConfig.getString(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
+        assertEquals(Collections.EMPTY_LIST, consumerConfig.getList(ConsumerConfig.LOCAL_ASSIGNOR_CONFIG));
+        assertEquals(null, consumerConfig.getString(ConsumerConfig.REMOTE_ASSIGNOR_CONFIG));
+    }
+
+    @Test
+    public void testValidConsumerGroupConfig() {
+        String remoteAssignorName = "org.apache.kafka.clients.group.someAssignor";
+        final Map<String, Object> configs = new HashMap<>();
+        configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClass);
+        configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass);
+        configs.put(ConsumerConfig.GROUP_PROTOCOL_CONFIG, "consumer");
+        configs.put(ConsumerConfig.REMOTE_ASSIGNOR_CONFIG, "org.apache.kafka.clients.group.someAssignor");
+        final ConsumerConfig consumerConfig = new ConsumerConfig(configs);
+        assertEquals("consumer", consumerConfig.getString(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
+        assertEquals(remoteAssignorName, consumerConfig.getString(ConsumerConfig.REMOTE_ASSIGNOR_CONFIG));
     }
 }


### PR DESCRIPTION
Protocol Name | Type | Default | Description
------- | ------ | ------ | --
group.protocol | &nbsp;enum&nbsp;&nbsp;&nbsp; | generic | A flag which indicates if the new protocol should be used or not. It could be: generic or consumer.
group.remote.assignor | &nbsp;string&nbsp; | null | The server side assignor to use. It cannot be used in conjunction with group.local.assignor. null means that the choice of the assignor is left to the group coordinator.

Three new configurations were added.

Note: group.local.assignor will be added later.