### PR TITLE
MINOR: Fix misleading log in streams restoration

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1030,8 +1030,8 @@ public class StreamThread extends Thread {
             log.debug("State is {}; initializing tasks if necessary", stateSnapshot);
 
             if (taskManager.tryToCompleteRestoration(now, offsetResetter)) {
-                log.info("Restoration took {} ms for all tasks {}", time.milliseconds() - lastPartitionAssignedMs,
-                    taskManager.allTasks().keySet());
+                log.info("Restoration took {} ms for all active tasks {}", time.milliseconds() - lastPartitionAssignedMs,
+                    taskManager.activeTaskIds());
                 setState(State.RUNNING);
             }
 


### PR DESCRIPTION
This line seems to indicate that stand-by tasks have caught up to the end of the changelog, as they are logged as part of `allTasks`.  But in fact, only active tasks have caught up to the end of the changelog here, so we should not include the stand-by tasks in the list.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
