### PR TITLE
MINOR: fix typo and comment

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -291,8 +291,8 @@ public class QuorumState {
     }
 
     /**
-     * Transition to the "unattached" state. This means we have found an epoch greater than
-     * or equal to the current epoch, but we do not yet know of the elected leader.
+     * Transition to the "unattached" state. This means we have found an epoch greater than the current epoch,
+     * but we do not yet know of the elected leader.
      */
     public void transitionToUnattached(int epoch) {
         int currentEpoch = state.epoch();

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -292,7 +292,7 @@ public class QuorumState {
 
     /**
      * Transition to the "unattached" state. This means we have found an epoch greater than
-     * or equal to the current epoch, but wo do not yet know of the elected leader.
+     * or equal to the current epoch, but we do not yet know of the elected leader.
      */
     public void transitionToUnattached(int epoch) {
         int currentEpoch = state.epoch();


### PR DESCRIPTION
An epoch can't be equal to the current epoch because of the following code.

```
 if (epoch <= currentEpoch) {
            throw new IllegalStateException("Cannot transition to Unattached with epoch= " + epoch +
                " from current state " + state);
 }
```