### PR TITLE
MINOR: Using INFO level for logging the state transition during the ZooKeeper to KRaft migration

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/migration/KRaftMigrationDriver.java
@@ -316,7 +316,7 @@ public class KRaftMigrationDriver implements MetadataPublisher {
         }
 
         if (newState != migrationState) {
-            log.debug("{} transitioning from {} to {} state", nodeId, migrationState, newState);
+            log.info("{} transitioning from {} to {} state", nodeId, migrationState, newState);
             pollTimeSupplier.reset();
             wakeup();
         } else {


### PR DESCRIPTION
Trivial PR to use the INFO level (instead of DEBUG) for logging the state transition during the ZooKeeper to KRaft migration.
I think it's a useful information to be logged without the need for the user to increase the logging level itself.