### PR TITLE
KAFKA-15703: Update Highwatermark while building the remote log auxiliary state

### DIFF
--- a/core/src/main/java/kafka/server/ReplicaFetcherTierStateMachine.java
+++ b/core/src/main/java/kafka/server/ReplicaFetcherTierStateMachine.java
@@ -231,6 +231,7 @@ public class ReplicaFetcherTierStateMachine implements TierStateMachine {
 
                 // Build leader epoch cache.
                 unifiedLog.maybeIncrementLogStartOffset(leaderLogStartOffset, LeaderOffsetIncremented);
+                unifiedLog.updateHighWatermark(leaderLocalLogStartOffset);
                 List<EpochEntry> epochs = readLeaderEpochCheckpoint(rlm, remoteLogSegmentMetadata);
                 if (unifiedLog.leaderEpochCache().isDefined()) {
                     unifiedLog.leaderEpochCache().get().assign(epochs);

--- a/core/src/main/java/kafka/server/ReplicaFetcherTierStateMachine.java
+++ b/core/src/main/java/kafka/server/ReplicaFetcherTierStateMachine.java
@@ -231,7 +231,6 @@ public class ReplicaFetcherTierStateMachine implements TierStateMachine {
 
                 // Build leader epoch cache.
                 unifiedLog.maybeIncrementLogStartOffset(leaderLogStartOffset, LeaderOffsetIncremented);
-                unifiedLog.updateHighWatermark(leaderLocalLogStartOffset);
                 List<EpochEntry> epochs = readLeaderEpochCheckpoint(rlm, remoteLogSegmentMetadata);
                 if (unifiedLog.leaderEpochCache().isDefined()) {
                     unifiedLog.leaderEpochCache().get().assign(epochs);
@@ -246,6 +245,10 @@ public class ReplicaFetcherTierStateMachine implements TierStateMachine {
                 // Reload producer snapshots.
                 unifiedLog.producerStateManager().truncateFullyAndReloadSnapshots();
                 unifiedLog.loadProducerState(nextOffset);
+                if (log.isTraceEnabled()) {
+                    log.trace("{} Update the follower high watermark to offset: {}", partition, leaderLocalLogStartOffset);
+                }
+                unifiedLog.updateHighWatermark(leaderLocalLogStartOffset);
                 log.debug("Built the leader epoch cache and producer snapshots from remote tier for {}, " +
                                 "with active producers size: {}, leaderLogStartOffset: {}, and logEndOffset: {}",
                         partition, unifiedLog.producerStateManager().activeProducers().size(), leaderLogStartOffset, nextOffset);


### PR DESCRIPTION
While building the remote log auxiliary state for the follower, we have to update the high-watermark to the offset where the local-log starts from. 

If there are no messages in the local log, then the high-watermark won't be updated. The stale high-watermark will cause issues while reassigning/moving the partition from one node to another. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
