### PR TITLE
KAFKA-15704: Set missing ZkMigrationReady field on ControllerRegistrationRequest

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerRegistrationManager.scala
+++ b/core/src/main/scala/kafka/server/ControllerRegistrationManager.scala
@@ -49,6 +49,7 @@ class ControllerRegistrationManager(
   val time: Time,
   val threadNamePrefix: String,
   val supportedFeatures: util.Map[String, VersionRange],
+  val zkMigrationEnabled: Boolean,
   val incarnationId: Uuid,
   val listenerInfo: ListenerInfo,
   val resendExponentialBackoff: ExponentialBackoff = new ExponentialBackoff(100, 2, 120000L, 0.02)
@@ -224,7 +225,9 @@ class ControllerRegistrationManager(
       setControllerId(nodeId).
       setFeatures(features).
       setIncarnationId(incarnationId).
-      setListeners(listenerInfo.toControllerRegistrationRequest)
+      setListeners(listenerInfo.toControllerRegistrationRequest).
+      setZkMigrationReady(zkMigrationEnabled)
+
     info(s"sendControllerRegistration: attempting to send $data")
     _channelManager.sendRequest(new ControllerRegistrationRequest.Builder(data),
       new RegistrationResponseHandler())

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -347,6 +347,7 @@ class ControllerServer(
         time,
         s"controller-${config.nodeId}-",
         QuorumFeatures.defaultFeatureMap(),
+        config.migrationEnabled,
         incarnationId,
         listenerInfo)
 

--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -66,7 +66,12 @@ object ZkMigrationIntegrationTest {
   }
 
   def zkClustersForAllMigrationVersions(clusterGenerator: ClusterGenerator): Unit = {
-    Seq(MetadataVersion.IBP_3_4_IV0, MetadataVersion.IBP_3_5_IV2, MetadataVersion.IBP_3_6_IV2).foreach { mv =>
+    Seq(
+      MetadataVersion.IBP_3_4_IV0,
+      MetadataVersion.IBP_3_5_IV2,
+      MetadataVersion.IBP_3_6_IV2,
+      MetadataVersion.latest()
+    ).foreach { mv =>
       val clusterConfig = ClusterConfig.defaultClusterBuilder()
         .metadataVersion(mv)
         .brokers(3)

--- a/core/src/test/scala/unit/kafka/server/ControllerRegistrationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerRegistrationManagerTest.scala
@@ -73,6 +73,7 @@ class ControllerRegistrationManagerTest {
       Time.SYSTEM,
       "controller-registration-manager-test-",
       createSupportedFeatures(MetadataVersion.IBP_3_7_IV0),
+      false,
       RecordTestUtils.createTestControllerRegistration(1, false).incarnationId(),
       ListenerInfo.create(context.config.controllerListeners.map(_.toJava).asJava),
       new ExponentialBackoff(1, 2, 100, 0.02))

--- a/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
@@ -183,6 +183,7 @@ public class ActivationRecordsGenerator {
                             .append("'zookeeper.metadata.migration.enable' set to 'false'. ");
                         records.add(ZkMigrationState.POST_MIGRATION.toRecord());
                     } else {
+                        // This log message is used in zookeeper_migration_test.py
                         logMessageBuilder
                             .append("Staying in ZK migration mode since 'zookeeper.metadata.migration.enable' ")
                             .append("is still 'true'. ");

--- a/tests/kafkatest/tests/core/zookeeper_migration_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_migration_test.py
@@ -22,7 +22,7 @@ from ducktape.errors import TimeoutError
 
 from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.services.kafka import KafkaService
-from kafkatest.services.kafka.config_property import CLUSTER_ID
+from kafkatest.services.kafka.config_property import CLUSTER_ID, LOG_DIRS
 from kafkatest.services.kafka.quorum import isolated_kraft, ServiceQuorumInfo, zk
 from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.zookeeper import ZookeeperService
@@ -57,7 +57,8 @@ class TestMigration(ProduceConsumeValidateTest):
                                   allow_zk_with_kraft=True,
                                   isolated_kafka=self.kafka,
                                   server_prop_overrides=[["zookeeper.connect", self.zk.connect_setting()],
-                                                         ["zookeeper.metadata.migration.enable", "true"]],
+                                                         ["zookeeper.metadata.migration.enable", "true"],
+                                                         [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]],
                                   quorum_info_provider=remote_quorum)
         controller.start()
 
@@ -95,7 +96,10 @@ class TestMigration(ProduceConsumeValidateTest):
                                   version=DEV_BRANCH,
                                   quorum_info_provider=zk_quorum,
                                   allow_zk_with_kraft=True,
-                                  server_prop_overrides=[["zookeeper.metadata.migration.enable", "false"]])
+                                  server_prop_overrides=[
+                                      ["zookeeper.metadata.migration.enable", "false"],
+                                      [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]
+                                  ])
         self.kafka.security_protocol = "PLAINTEXT"
         self.kafka.interbroker_security_protocol = "PLAINTEXT"
         self.zk.start()
@@ -148,7 +152,10 @@ class TestMigration(ProduceConsumeValidateTest):
                                   zk=self.zk,
                                   allow_zk_with_kraft=True,
                                   version=LATEST_3_4,
-                                  server_prop_overrides=[["zookeeper.metadata.migration.enable", "false"]],
+                                  server_prop_overrides=[
+                                      ["zookeeper.metadata.migration.enable", "false"],
+                                      [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]
+                                  ],
                                   topics={self.topic: {"partitions": self.partitions,
                                                        "replication-factor": self.replication_factor,
                                                        'configs': {"min.insync.replicas": 2}}})
@@ -209,14 +216,18 @@ class TestMigration(ProduceConsumeValidateTest):
                                   version=LATEST_3_4,
                                   quorum_info_provider=zk_quorum,
                                   allow_zk_with_kraft=True,
-                                  server_prop_overrides=[["zookeeper.metadata.migration.enable", "true"]])
+                                  server_prop_overrides=[
+                                      ["zookeeper.metadata.migration.enable", "true"],
+                                      [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]
+                                  ])
 
         remote_quorum = partial(ServiceQuorumInfo, isolated_kraft)
         controller = KafkaService(self.test_context, num_nodes=1, zk=self.zk, version=LATEST_3_4,
                                   allow_zk_with_kraft=True,
                                   isolated_kafka=self.kafka,
                                   server_prop_overrides=[["zookeeper.connect", self.zk.connect_setting()],
-                                                         ["zookeeper.metadata.migration.enable", "true"]],
+                                                         ["zookeeper.metadata.migration.enable", "true"],
+                                                         [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]],
                                   quorum_info_provider=remote_quorum)
 
         self.kafka.security_protocol = "PLAINTEXT"
@@ -259,7 +270,7 @@ class TestMigration(ProduceConsumeValidateTest):
                 try:
                     # Shouldn't have to wait too long to see this log message after startup
                     monitor.wait_until(
-                        "Staying in the ZK migration",
+                        "Staying in ZK migration",
                         timeout_sec=10.0, backoff_sec=.25,
                         err_msg=""
                     )
@@ -284,14 +295,17 @@ class TestMigration(ProduceConsumeValidateTest):
                                   version=DEV_BRANCH,
                                   quorum_info_provider=zk_quorum,
                                   allow_zk_with_kraft=True,
-                                  server_prop_overrides=[["zookeeper.metadata.migration.enable", "false"]])
+                                  server_prop_overrides=[
+                                      ["zookeeper.metadata.migration.enable", "false"],
+                                      [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]])
 
         remote_quorum = partial(ServiceQuorumInfo, isolated_kraft)
         controller = KafkaService(self.test_context, num_nodes=1, zk=self.zk, version=DEV_BRANCH,
                                   allow_zk_with_kraft=True,
                                   isolated_kafka=self.kafka,
                                   server_prop_overrides=[["zookeeper.connect", self.zk.connect_setting()],
-                                                         ["zookeeper.metadata.migration.enable", "true"]],
+                                                         ["zookeeper.metadata.migration.enable", "true"],
+                                                         [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]],
                                   quorum_info_provider=remote_quorum)
 
         self.kafka.security_protocol = "PLAINTEXT"


### PR DESCRIPTION
This field was missed by the initial KIP-919 PR(s). The result is that migrations can't begin since the controllers will never become ready. This patch fixes that as well as pulls over some fixes from the 3.6 branch.