### PR TITLE
Change `CreateTopicPolicy.RequestMetadata` to always provide partitions, replication factor and replica assignments.

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -771,15 +771,22 @@ public class ReplicationControlManagerTest {
 
     @Test
     public void testCreateTopicsWithPolicy() throws Exception {
+        Map<Integer, List<Integer>> fooTopicPartitionToReplicas = new HashMap<>();
+        fooTopicPartitionToReplicas.put(0, asList(1, 2));
+        fooTopicPartitionToReplicas.put(1, asList(2, 0));
+
+        Map<Integer, List<Integer>> barTopicPartitionToReplicas = new HashMap<>();
+        barTopicPartitionToReplicas.put(0, asList(0, 1, 2));
+        barTopicPartitionToReplicas.put(1, asList(2, 0, 1));
+        barTopicPartitionToReplicas.put(2, asList(0, 1, 2));
+
         MockCreateTopicPolicy createTopicPolicy = new MockCreateTopicPolicy(asList(
-            new CreateTopicPolicy.RequestMetadata("foo", 2, (short) 2,
-                null, Collections.emptyMap()),
-            new CreateTopicPolicy.RequestMetadata("bar", 3, (short) 2,
-                null, Collections.emptyMap()),
-            new CreateTopicPolicy.RequestMetadata("baz", null, null,
+            new CreateTopicPolicy.RequestMetadata("foo", fooTopicPartitionToReplicas, Collections.emptyMap()),
+            new CreateTopicPolicy.RequestMetadata("bar", barTopicPartitionToReplicas, Collections.emptyMap()),
+            new CreateTopicPolicy.RequestMetadata("baz",
                 Collections.singletonMap(0, asList(2, 1, 0)),
                 Collections.singletonMap(SEGMENT_BYTES_CONFIG, "12300000")),
-            new CreateTopicPolicy.RequestMetadata("quux", null, null,
+            new CreateTopicPolicy.RequestMetadata("quux",
                 Collections.singletonMap(0, asList(2, 1, 0)), Collections.emptyMap())));
         ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().
                 setCreateTopicPolicy(createTopicPolicy).


### PR DESCRIPTION
For replica assignments, the interface would change to be the actual assignments that will be used, whether it's user provided or Kafka determined it.

This way, implementations can use it to determine per broker limits or to only decide to use number of partitions in the policy. I think this should be backwards compatible because `replicaAssignments` will always provide the same information as `numPartitions` and `replicationFactor` did.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)