### PR TITLE
KAFKA-15643: Fix error logged when unload is called on a broker that was never a coordinator.

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -1359,7 +1359,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         log.info("Scheduling unloading of metadata for {} with epoch {}", tp, partitionEpoch);
 
         scheduleInternalOperation("UnloadCoordinator(tp=" + tp + ", epoch=" + partitionEpoch + ")", tp, () -> {
-            withContextOrThrow(tp, context -> {
+            CoordinatorContext context = coordinators.get(tp);
+            if (context != null) {
                 if (context.epoch < partitionEpoch) {
                     log.info("Started unloading metadata for {} with epoch {}.", tp, partitionEpoch);
                     context.transitionTo(CoordinatorState.CLOSED);
@@ -1370,7 +1371,9 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         tp, partitionEpoch, context.epoch
                     );
                 }
-            });
+            } else {
+                log.info("No unload required since broker was not a coordinator for the given partition " + tp);
+            }
         });
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -1377,7 +1377,9 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     context.lock.unlock();
                 }
             } else {
-                log.debug("No unloading was required since broker was not a coordinator for {} with epoch {}", tp, partitionEpoch);
+                log.debug("Ignored unloading metadata for {} in epoch {} since metadata was never loaded ",
+                    tp, partitionEpoch
+                );
             }
         });
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -1377,7 +1377,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     context.lock.unlock();
                 }
             } else {
-                log.debug("Ignored unloading metadata for {} in epoch {} since metadata was never loaded ",
+                log.info("Ignored unloading metadata for {} in epoch {} since metadata was never loaded.",
                     tp, partitionEpoch
                 );
             }


### PR DESCRIPTION
**Problem Statement:**
When a new leader is elected for a __consumer_offset partition, the followers are notified to unload the state. However, only the former leader is aware of it. The remaining follower prints out the following error:
`ERROR [GroupCoordinator id=1] Execution of UnloadCoordinator(tp=__consumer_offsets-1, epoch=0) failed due to This is not the correct coordinator.. (org.apache.kafka.coordinator.group.runtime.CoordinatorRuntime)`
The error is actually correct and expected when in the remaining follower case, however this could be misleading.

**Solution:**
1.  When scheduleInternalOperation is called, inside the lambda function that is executed at the event runtime, the existence of the context is checked. 
2. If the context doesn't exist, previously the exception would be thrown, now we just skip any operations and log an info message.

Test was added to check the same, all other tests are still passing as expected.
