### PR TITLE
KAFKA-15774: introduce internal StoreFactory

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -38,6 +38,7 @@ import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.processor.internals.ProcessorAdapter;
 import org.apache.kafka.streams.processor.internals.ProcessorNode;
 import org.apache.kafka.streams.processor.internals.SourceNode;
+import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
@@ -520,7 +521,7 @@ public class StreamsBuilder {
      */
     public synchronized StreamsBuilder addStateStore(final StoreBuilder<?> builder) {
         Objects.requireNonNull(builder, "builder can't be null");
-        internalStreamsBuilder.addStateStore(builder);
+        internalStreamsBuilder.addStateStore(new StoreBuilderWrapper<>(builder));
         return this;
     }
 
@@ -563,7 +564,7 @@ public class StreamsBuilder {
         Objects.requireNonNull(storeBuilder, "storeBuilder can't be null");
         Objects.requireNonNull(consumed, "consumed can't be null");
         internalStreamsBuilder.addGlobalStore(
-            storeBuilder,
+            new StoreBuilderWrapper<>(storeBuilder),
             topic,
             new ConsumedInternal<>(consumed),
             () -> ProcessorAdapter.adapt(stateUpdateSupplier.get())
@@ -607,7 +608,7 @@ public class StreamsBuilder {
         Objects.requireNonNull(storeBuilder, "storeBuilder can't be null");
         Objects.requireNonNull(consumed, "consumed can't be null");
         internalStreamsBuilder.addGlobalStore(
-            storeBuilder,
+            new StoreBuilderWrapper<>(storeBuilder),
             topic,
             new ConsumedInternal<>(consumed),
             stateUpdateSupplier

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -521,7 +521,7 @@ public class StreamsBuilder {
      */
     public synchronized StreamsBuilder addStateStore(final StoreBuilder<?> builder) {
         Objects.requireNonNull(builder, "builder can't be null");
-        internalStreamsBuilder.addStateStore(new StoreBuilderWrapper<>(builder));
+        internalStreamsBuilder.addStateStore(new StoreBuilderWrapper(builder));
         return this;
     }
 
@@ -564,7 +564,7 @@ public class StreamsBuilder {
         Objects.requireNonNull(storeBuilder, "storeBuilder can't be null");
         Objects.requireNonNull(consumed, "consumed can't be null");
         internalStreamsBuilder.addGlobalStore(
-            new StoreBuilderWrapper<>(storeBuilder),
+            new StoreBuilderWrapper(storeBuilder),
             topic,
             new ConsumedInternal<>(consumed),
             () -> ProcessorAdapter.adapt(stateUpdateSupplier.get())
@@ -608,7 +608,7 @@ public class StreamsBuilder {
         Objects.requireNonNull(storeBuilder, "storeBuilder can't be null");
         Objects.requireNonNull(consumed, "consumed can't be null");
         internalStreamsBuilder.addGlobalStore(
-            new StoreBuilderWrapper<>(storeBuilder),
+            new StoreBuilderWrapper(storeBuilder),
             topic,
             new ConsumedInternal<>(consumed),
             stateUpdateSupplier

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -535,6 +535,7 @@ public class StreamsConfig extends AbstractConfig {
 
     public static final String ROCKS_DB = "rocksDB";
     public static final String IN_MEMORY = "in_memory";
+    public static final String DEFAULT_DSL_STORE_DEFAULT = ROCKS_DB;
 
     /** {@code default.windowed.key.serde.inner} */
     @SuppressWarnings("WeakerAccess")
@@ -1000,7 +1001,7 @@ public class StreamsConfig extends AbstractConfig {
                     CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_DOC)
             .define(DEFAULT_DSL_STORE_CONFIG,
                     Type.STRING,
-                    ROCKS_DB,
+                    DEFAULT_DSL_STORE_DEFAULT,
                     in(ROCKS_DB, IN_MEMORY),
                     Importance.LOW,
                     DEFAULT_DSL_STORE_DOC)

--- a/streams/src/main/java/org/apache/kafka/streams/Topology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/Topology.java
@@ -776,7 +776,7 @@ public class Topology {
                                                        final String processorName,
                                                        final org.apache.kafka.streams.processor.ProcessorSupplier<K, V> stateUpdateSupplier) {
         internalTopologyBuilder.addGlobalStore(
-            new StoreBuilderWrapper<>(storeBuilder),
+            new StoreBuilderWrapper(storeBuilder),
             sourceName,
             null,
             keyDeserializer,
@@ -828,7 +828,7 @@ public class Topology {
                                                        final String processorName,
                                                        final org.apache.kafka.streams.processor.ProcessorSupplier<K, V> stateUpdateSupplier) {
         internalTopologyBuilder.addGlobalStore(
-            new StoreBuilderWrapper<>(storeBuilder),
+            new StoreBuilderWrapper(storeBuilder),
             sourceName,
             timestampExtractor,
             keyDeserializer,
@@ -871,7 +871,7 @@ public class Topology {
                                                            final String processorName,
                                                            final ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier) {
         internalTopologyBuilder.addGlobalStore(
-            new StoreBuilderWrapper<>(storeBuilder),
+            new StoreBuilderWrapper(storeBuilder),
             sourceName,
             null,
             keyDeserializer,
@@ -916,7 +916,7 @@ public class Topology {
                                                            final String processorName,
                                                            final ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier) {
         internalTopologyBuilder.addGlobalStore(
-            new StoreBuilderWrapper<>(storeBuilder),
+            new StoreBuilderWrapper(storeBuilder),
             sourceName,
             timestampExtractor,
             keyDeserializer,

--- a/streams/src/main/java/org/apache/kafka/streams/Topology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/Topology.java
@@ -34,6 +34,7 @@ import org.apache.kafka.streams.processor.internals.ProcessorNode;
 import org.apache.kafka.streams.processor.internals.ProcessorTopology;
 import org.apache.kafka.streams.processor.internals.SinkNode;
 import org.apache.kafka.streams.processor.internals.SourceNode;
+import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
 import org.apache.kafka.streams.state.StoreBuilder;
 
 import java.util.Set;
@@ -775,7 +776,7 @@ public class Topology {
                                                        final String processorName,
                                                        final org.apache.kafka.streams.processor.ProcessorSupplier<K, V> stateUpdateSupplier) {
         internalTopologyBuilder.addGlobalStore(
-            storeBuilder,
+            new StoreBuilderWrapper<>(storeBuilder),
             sourceName,
             null,
             keyDeserializer,
@@ -827,7 +828,7 @@ public class Topology {
                                                        final String processorName,
                                                        final org.apache.kafka.streams.processor.ProcessorSupplier<K, V> stateUpdateSupplier) {
         internalTopologyBuilder.addGlobalStore(
-            storeBuilder,
+            new StoreBuilderWrapper<>(storeBuilder),
             sourceName,
             timestampExtractor,
             keyDeserializer,
@@ -870,7 +871,7 @@ public class Topology {
                                                            final String processorName,
                                                            final ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier) {
         internalTopologyBuilder.addGlobalStore(
-            storeBuilder,
+            new StoreBuilderWrapper<>(storeBuilder),
             sourceName,
             null,
             keyDeserializer,
@@ -915,7 +916,7 @@ public class Topology {
                                                            final String processorName,
                                                            final ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier) {
         internalTopologyBuilder.addGlobalStore(
-            storeBuilder,
+            new StoreBuilderWrapper<>(storeBuilder),
             sourceName,
             timestampExtractor,
             keyDeserializer,

--- a/streams/src/main/java/org/apache/kafka/streams/TopologyConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/TopologyConfig.java
@@ -218,10 +218,7 @@ public class TopologyConfig extends AbstractConfig {
     }
 
     public Materialized.StoreType parseStoreType() {
-        if (storeType.equals(IN_MEMORY)) {
-            return Materialized.StoreType.IN_MEMORY;
-        }
-        return Materialized.StoreType.ROCKS_DB;
+        return Materialized.StoreType.parse(storeType);
     }
 
     public boolean isNamedTopology() {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.kstream;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -69,7 +70,21 @@ public class Materialized<K, V, S extends StateStore> {
     // the built-in state store types
     public enum StoreType {
         ROCKS_DB,
-        IN_MEMORY
+        IN_MEMORY;
+
+        public static StoreType parse(final String storeType) {
+            switch (storeType) {
+                case StreamsConfig.IN_MEMORY:
+                    return StoreType.IN_MEMORY;
+                case StreamsConfig.ROCKS_DB:
+                default:
+                    // for backwards compatibility, we ignore invalid store
+                    // types as this is how the code was originally, consider
+                    // cleaning this up and throwing an exception for invalid
+                    // store types
+                    return StoreType.ROCKS_DB;
+            }
+        }
     }
 
     private Materialized(final StoreSupplier<S> storeSupplier) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
@@ -77,12 +77,9 @@ public class Materialized<K, V, S extends StateStore> {
                 case StreamsConfig.IN_MEMORY:
                     return StoreType.IN_MEMORY;
                 case StreamsConfig.ROCKS_DB:
-                default:
-                    // for backwards compatibility, we ignore invalid store
-                    // types as this is how the code was originally, consider
-                    // cleaning this up and throwing an exception for invalid
-                    // store types
                     return StoreType.ROCKS_DB;
+                default:
+                    throw new IllegalStateException("Unexpected storeType: " + storeType);
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
@@ -141,7 +141,7 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
             groupPatterns,
             initializer,
             named,
-            new KeyValueStoreMaterializer<>(materializedInternal).materialize(),
+            new KeyValueStoreMaterializer<>(materializedInternal),
             materializedInternal.keySerde(),
             materializedInternal.valueSerde(),
             materializedInternal.queryableStoreName(),

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -52,19 +52,19 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                 final Initializer<VOut> initializer,
                                 final NamedInternal named,
-                                final StoreFactory<?> storeBuilder,
+                                final StoreFactory<?> storeFactory,
                                 final Serde<KR> keySerde,
                                 final Serde<VOut> valueSerde,
                                 final String queryableName,
                                 final boolean isOutputVersioned) {
-        processRepartitions(groupPatterns, storeBuilder);
+        processRepartitions(groupPatterns, storeFactory);
         final Collection<GraphNode> processors = new ArrayList<>();
         final Collection<KStreamAggProcessorSupplier> parentProcessors = new ArrayList<>();
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
             final KStreamAggProcessorSupplier<K, ?, K, ?> parentProcessor =
-                new KStreamAggregate<>(storeBuilder.name(), initializer, kGroupedStream.getValue());
+                new KStreamAggregate<>(storeFactory.name(), initializer, kGroupedStream.getValue());
             parentProcessors.add(parentProcessor);
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
                 named.suffixWithOrElseGet(
@@ -72,26 +72,26 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                     builder,
                     CogroupedKStreamImpl.AGGREGATE_NAME),
                 stateCreated,
-                storeBuilder,
+                storeFactory,
                 parentProcessor);
             statefulProcessorNode.setOutputVersioned(isOutputVersioned);
             stateCreated = true;
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName, storeBuilder.name());
+        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName, storeFactory.name());
     }
 
     @SuppressWarnings("unchecked")
     <KR, W extends Window> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                                   final Initializer<VOut> initializer,
                                                   final NamedInternal named,
-                                                  final StoreFactory<?> storeBuilder,
+                                                  final StoreFactory<?> storeFactory,
                                                   final Serde<KR> keySerde,
                                                   final Serde<VOut> valueSerde,
                                                   final String queryableName,
                                                   final Windows<W> windows) {
-        processRepartitions(groupPatterns, storeBuilder);
+        processRepartitions(groupPatterns, storeFactory);
 
         final Collection<GraphNode> processors = new ArrayList<>();
         final Collection<KStreamAggProcessorSupplier> parentProcessors = new ArrayList<>();
@@ -101,7 +101,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             final KStreamAggProcessorSupplier<K, ?, K, ?>  parentProcessor =
                 (KStreamAggProcessorSupplier<K, ?, K, ?>) new KStreamWindowAggregate<K, K, VOut, W>(
                     windows,
-                    storeBuilder.name(),
+                    storeFactory.name(),
                     EmitStrategy.onWindowUpdate(),
                     initializer,
                     kGroupedStream.getValue());
@@ -112,26 +112,26 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                     builder,
                     CogroupedKStreamImpl.AGGREGATE_NAME),
                 stateCreated,
-                storeBuilder,
+                storeFactory,
                 parentProcessor);
             stateCreated = true;
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName, storeBuilder.name());
+        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName, storeFactory.name());
     }
 
     @SuppressWarnings("unchecked")
     <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                 final Initializer<VOut> initializer,
                                 final NamedInternal named,
-                                final StoreFactory<?> storeBuilder,
+                                final StoreFactory<?> storeFactory,
                                 final Serde<KR> keySerde,
                                 final Serde<VOut> valueSerde,
                                 final String queryableName,
                                 final SessionWindows sessionWindows,
                                 final Merger<? super K, VOut> sessionMerger) {
-        processRepartitions(groupPatterns, storeBuilder);
+        processRepartitions(groupPatterns, storeFactory);
         final Collection<GraphNode> processors = new ArrayList<>();
         final Collection<KStreamAggProcessorSupplier> parentProcessors = new ArrayList<>();
         boolean stateCreated = false;
@@ -140,7 +140,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             final KStreamAggProcessorSupplier<K, ?, K, ?> parentProcessor =
                 (KStreamAggProcessorSupplier<K, ?, K, ?>) new KStreamSessionWindowAggregate<K, K, VOut>(
                     sessionWindows,
-                    storeBuilder.name(),
+                    storeFactory.name(),
                     EmitStrategy.onWindowUpdate(),
                     initializer,
                     kGroupedStream.getValue(),
@@ -152,25 +152,25 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                     builder,
                     CogroupedKStreamImpl.AGGREGATE_NAME),
                 stateCreated,
-                storeBuilder,
+                storeFactory,
                 parentProcessor);
             stateCreated = true;
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName, storeBuilder.name());
+        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName, storeFactory.name());
     }
 
     @SuppressWarnings("unchecked")
     <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                 final Initializer<VOut> initializer,
                                 final NamedInternal named,
-                                final StoreFactory<?> storeBuilder,
+                                final StoreFactory<?> storeFactory,
                                 final Serde<KR> keySerde,
                                 final Serde<VOut> valueSerde,
                                 final String queryableName,
                                 final SlidingWindows slidingWindows) {
-        processRepartitions(groupPatterns, storeBuilder);
+        processRepartitions(groupPatterns, storeFactory);
         final Collection<KStreamAggProcessorSupplier> parentProcessors = new ArrayList<>();
         final Collection<GraphNode> processors = new ArrayList<>();
         boolean stateCreated = false;
@@ -179,7 +179,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             final KStreamAggProcessorSupplier<K, ?, K, ?> parentProcessor =
                 (KStreamAggProcessorSupplier<K, ?, K, ?>) new KStreamSlidingWindowAggregate<K, K, VOut>(
                     slidingWindows,
-                    storeBuilder.name(),
+                    storeFactory.name(),
                     // TODO: We do not have other emit policies for co-group yet
                     EmitStrategy.onWindowUpdate(),
                     initializer,
@@ -191,17 +191,17 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                     builder,
                     CogroupedKStreamImpl.AGGREGATE_NAME),
                 stateCreated,
-                storeBuilder,
+                storeFactory,
                 parentProcessor);
             stateCreated = true;
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName, storeBuilder.name());
+        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName, storeFactory.name());
     }
 
     private void processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
-                                     final StoreFactory<?> storeBuilder) {
+                                     final StoreFactory<?> storeFactory) {
         for (final KGroupedStreamImpl<K, ?> repartitionReqs : groupPatterns.keySet()) {
 
             if (repartitionReqs.repartitionRequired) {
@@ -209,7 +209,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                 final OptimizableRepartitionNodeBuilder<K, ?> repartitionNodeBuilder = optimizableRepartitionNodeBuilder();
 
                 final String repartitionNamePrefix = repartitionReqs.userProvidedRepartitionTopicName != null ?
-                    repartitionReqs.userProvidedRepartitionTopicName : storeBuilder.name();
+                    repartitionReqs.userProvidedRepartitionTopicName : storeFactory.name();
 
                 createRepartitionSource(repartitionNamePrefix, repartitionNodeBuilder, repartitionReqs.keySerde, repartitionReqs.valueSerde);
 
@@ -263,7 +263,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
 
     private StatefulProcessorNode<K, ?> getStatefulProcessorNode(final String processorName,
                                                                  final boolean stateCreated,
-                                                                 final StoreFactory<?> storeBuilder,
+                                                                 final StoreFactory<?> storeFactory,
                                                                  final ProcessorSupplier<K, ?, K, ?> kStreamAggregate) {
         final StatefulProcessorNode<K, ?> statefulProcessorNode;
         if (!stateCreated) {
@@ -271,14 +271,14 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                 new StatefulProcessorNode<>(
                     processorName,
                     new ProcessorParameters<>(kStreamAggregate, processorName),
-                    storeBuilder
+                    storeFactory
                 );
         } else {
             statefulProcessorNode =
                 new StatefulProcessorNode<>(
                     processorName,
                     new ProcessorParameters<>(kStreamAggregate, processorName),
-                    new String[]{storeBuilder.name()}
+                    new String[]{storeFactory.name()}
                 );
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -52,7 +52,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                 final Initializer<VOut> initializer,
                                 final NamedInternal named,
-                                final StoreFactory<?> storeFactory,
+                                final StoreFactory storeFactory,
                                 final Serde<KR> keySerde,
                                 final Serde<VOut> valueSerde,
                                 final String queryableName,
@@ -86,7 +86,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     <KR, W extends Window> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                                   final Initializer<VOut> initializer,
                                                   final NamedInternal named,
-                                                  final StoreFactory<?> storeFactory,
+                                                  final StoreFactory storeFactory,
                                                   final Serde<KR> keySerde,
                                                   final Serde<VOut> valueSerde,
                                                   final String queryableName,
@@ -125,7 +125,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                 final Initializer<VOut> initializer,
                                 final NamedInternal named,
-                                final StoreFactory<?> storeFactory,
+                                final StoreFactory storeFactory,
                                 final Serde<KR> keySerde,
                                 final Serde<VOut> valueSerde,
                                 final String queryableName,
@@ -165,7 +165,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                 final Initializer<VOut> initializer,
                                 final NamedInternal named,
-                                final StoreFactory<?> storeFactory,
+                                final StoreFactory storeFactory,
                                 final Serde<KR> keySerde,
                                 final Serde<VOut> valueSerde,
                                 final String queryableName,
@@ -201,7 +201,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     }
 
     private void processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
-                                     final StoreFactory<?> storeFactory) {
+                                     final StoreFactory storeFactory) {
         for (final KGroupedStreamImpl<K, ?> repartitionReqs : groupPatterns.keySet()) {
 
             if (repartitionReqs.repartitionRequired) {
@@ -263,7 +263,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
 
     private StatefulProcessorNode<K, ?> getStatefulProcessorNode(final String processorName,
                                                                  final boolean stateCreated,
-                                                                 final StoreFactory<?> storeFactory,
+                                                                 final StoreFactory storeFactory,
                                                                  final ProcessorSupplier<K, ?, K, ?> kStreamAggregate) {
         final StatefulProcessorNode<K, ?> statefulProcessorNode;
         if (!stateCreated) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -40,7 +40,7 @@ import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StatefulProcessorNode;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
-import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 
 class CogroupedStreamAggregateBuilder<K, VOut> {
     private final InternalStreamsBuilder builder;
@@ -52,7 +52,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                 final Initializer<VOut> initializer,
                                 final NamedInternal named,
-                                final StoreBuilder<?> storeBuilder,
+                                final StoreFactory<?> storeBuilder,
                                 final Serde<KR> keySerde,
                                 final Serde<VOut> valueSerde,
                                 final String queryableName,
@@ -86,7 +86,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     <KR, W extends Window> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                                   final Initializer<VOut> initializer,
                                                   final NamedInternal named,
-                                                  final StoreBuilder<?> storeBuilder,
+                                                  final StoreFactory<?> storeBuilder,
                                                   final Serde<KR> keySerde,
                                                   final Serde<VOut> valueSerde,
                                                   final String queryableName,
@@ -125,7 +125,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                 final Initializer<VOut> initializer,
                                 final NamedInternal named,
-                                final StoreBuilder<?> storeBuilder,
+                                final StoreFactory<?> storeBuilder,
                                 final Serde<KR> keySerde,
                                 final Serde<VOut> valueSerde,
                                 final String queryableName,
@@ -165,7 +165,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                 final Initializer<VOut> initializer,
                                 final NamedInternal named,
-                                final StoreBuilder<?> storeBuilder,
+                                final StoreFactory<?> storeBuilder,
                                 final Serde<KR> keySerde,
                                 final Serde<VOut> valueSerde,
                                 final String queryableName,
@@ -201,7 +201,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     }
 
     private void processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
-                                     final StoreBuilder<?> storeBuilder) {
+                                     final StoreFactory<?> storeBuilder) {
         for (final KGroupedStreamImpl<K, ?> repartitionReqs : groupPatterns.keySet()) {
 
             if (repartitionReqs.repartitionRequired) {
@@ -263,7 +263,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
 
     private StatefulProcessorNode<K, ?> getStatefulProcessorNode(final String processorName,
                                                                  final boolean stateCreated,
-                                                                 final StoreBuilder<?> storeBuilder,
+                                                                 final StoreFactory<?> storeBuilder,
                                                                  final ProcessorSupplier<K, ?, K, ?> kStreamAggregate) {
         final StatefulProcessorNode<K, ?> statefulProcessorNode;
         if (!stateCreated) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
@@ -67,13 +67,13 @@ class GroupedStreamAggregateBuilder<K, V> {
     }
 
     <KR, VR> KTable<KR, VR> build(final NamedInternal functionName,
-                                  final StoreFactory<?> storeBuilder,
+                                  final StoreFactory<?> storeFactory,
                                   final KStreamAggProcessorSupplier<K, V, KR, VR> aggregateSupplier,
                                   final String queryableStoreName,
                                   final Serde<KR> keySerde,
                                   final Serde<VR> valueSerde,
                                   final boolean isOutputVersioned) {
-        assert queryableStoreName == null || queryableStoreName.equals(storeBuilder.name());
+        assert queryableStoreName == null || queryableStoreName.equals(storeFactory.name());
 
         final String aggFunctionName = functionName.name();
 
@@ -82,7 +82,7 @@ class GroupedStreamAggregateBuilder<K, V> {
 
         if (repartitionRequired) {
             final OptimizableRepartitionNodeBuilder<K, V> repartitionNodeBuilder = optimizableRepartitionNodeBuilder();
-            final String repartitionTopicPrefix = userProvidedRepartitionTopicName != null ? userProvidedRepartitionTopicName : storeBuilder.name();
+            final String repartitionTopicPrefix = userProvidedRepartitionTopicName != null ? userProvidedRepartitionTopicName : storeFactory.name();
             sourceName = createRepartitionSource(repartitionTopicPrefix, repartitionNodeBuilder);
 
             // First time through we need to create a repartition node.
@@ -101,7 +101,7 @@ class GroupedStreamAggregateBuilder<K, V> {
             new StatefulProcessorNode<>(
                 aggFunctionName,
                 new ProcessorParameters<>(aggregateSupplier, aggFunctionName),
-                storeBuilder
+                storeFactory
             );
         statefulProcessorNode.setOutputVersioned(isOutputVersioned);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
@@ -67,7 +67,7 @@ class GroupedStreamAggregateBuilder<K, V> {
     }
 
     <KR, VR> KTable<KR, VR> build(final NamedInternal functionName,
-                                  final StoreFactory<?> storeFactory,
+                                  final StoreFactory storeFactory,
                                   final KStreamAggProcessorSupplier<K, V, KR, VR> aggregateSupplier,
                                   final String queryableStoreName,
                                   final Serde<KR> keySerde,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
@@ -23,7 +23,7 @@ import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StatefulProcessorNode;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
-import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 
 import java.util.Collections;
 import java.util.Set;
@@ -67,7 +67,7 @@ class GroupedStreamAggregateBuilder<K, V> {
     }
 
     <KR, VR> KTable<KR, VR> build(final NamedInternal functionName,
-                                  final StoreBuilder<?> storeBuilder,
+                                  final StoreFactory<?> storeBuilder,
                                   final KStreamAggProcessorSupplier<K, V, KR, VR> aggregateSupplier,
                                   final String queryableStoreName,
                                   final Serde<KR> keySerde,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -212,11 +212,11 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         return prefix + String.format(KTableImpl.STATE_STORE_NAME + "%010d", index.getAndIncrement());
     }
 
-    public synchronized void addStateStore(final StoreFactory<?> builder) {
+    public synchronized void addStateStore(final StoreFactory builder) {
         addGraphNode(root, new StateStoreNode<>(builder));
     }
 
-    public synchronized <KIn, VIn> void addGlobalStore(final StoreFactory<?> storeFactory,
+    public synchronized <KIn, VIn> void addGlobalStore(final StoreFactory storeFactory,
                                                        final String topic,
                                                        final ConsumedInternal<KIn, VIn> consumed,
                                                        final org.apache.kafka.streams.processor.api.ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -40,8 +40,8 @@ import org.apache.kafka.streams.kstream.internals.graph.TableSourceNode;
 import org.apache.kafka.streams.kstream.internals.graph.VersionedSemanticsGraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.WindowedStreamProcessorNode;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -212,11 +212,11 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         return prefix + String.format(KTableImpl.STATE_STORE_NAME + "%010d", index.getAndIncrement());
     }
 
-    public synchronized void addStateStore(final StoreBuilder<?> builder) {
+    public synchronized void addStateStore(final StoreFactory<?> builder) {
         addGraphNode(root, new StateStoreNode<>(builder));
     }
 
-    public synchronized <KIn, VIn> void addGlobalStore(final StoreBuilder<?> storeBuilder,
+    public synchronized <KIn, VIn> void addGlobalStore(final StoreFactory<?> storeBuilder,
                                                        final String topic,
                                                        final ConsumedInternal<KIn, VIn> consumed,
                                                        final org.apache.kafka.streams.processor.api.ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -216,19 +216,19 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         addGraphNode(root, new StateStoreNode<>(builder));
     }
 
-    public synchronized <KIn, VIn> void addGlobalStore(final StoreFactory<?> storeBuilder,
+    public synchronized <KIn, VIn> void addGlobalStore(final StoreFactory<?> storeFactory,
                                                        final String topic,
                                                        final ConsumedInternal<KIn, VIn> consumed,
                                                        final org.apache.kafka.streams.processor.api.ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier) {
         // explicitly disable logging for global stores
-        storeBuilder.withLoggingDisabled();
+        storeFactory.withLoggingDisabled();
 
         final NamedInternal named = new NamedInternal(consumed.name());
         final String sourceName = named.suffixWithOrElseGet(TABLE_SOURCE_SUFFIX, this, KStreamImpl.SOURCE_NAME);
         final String processorName = named.orElseGenerateWithPrefix(this, KTableImpl.SOURCE_NAME);
 
         final GraphNode globalStoreNode = new GlobalStoreNode<>(
-            storeBuilder,
+            storeFactory,
             sourceName,
             topic,
             consumed,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
@@ -239,7 +239,7 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedS
                                          final MaterializedInternal<K, T, KeyValueStore<Bytes, byte[]>> materializedInternal) {
         return aggregateBuilder.build(
             new NamedInternal(functionName),
-            new KeyValueStoreMaterializer<>(materializedInternal).materialize(),
+            new KeyValueStoreMaterializer<>(materializedInternal),
             aggregateSupplier,
             materializedInternal.queryableStoreName(),
             materializedInternal.keySerde(),

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImpl.java
@@ -91,7 +91,7 @@ public class KGroupedTableImpl<K, V> extends AbstractStream<K, V> implements KGr
         final StatefulProcessorNode statefulProcessorNode = new StatefulProcessorNode<>(
             funcName,
             new ProcessorParameters<>(aggregateSupplier, funcName),
-            new KeyValueStoreMaterializer<>(materialized).materialize()
+            new KeyValueStoreMaterializer<>(materialized)
         );
         statefulProcessorNode.setOutputVersioned(materialized.storeSupplier() instanceof VersionedBytesStoreSupplier);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -65,6 +65,7 @@ import org.apache.kafka.streams.processor.api.FixedKeyProcessorSupplier;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.InternalTopicProperties;
 import org.apache.kafka.streams.processor.internals.StaticTopicNameExtractor;
+import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
 import org.apache.kafka.streams.state.KeyValueStore;
 
 import java.lang.reflect.Array;
@@ -1266,7 +1267,9 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                 throw new IllegalArgumentException("KTable must be versioned to use a grace period in a stream table join.");
             }
             bufferStoreName = Optional.of(name + "-Buffer");
-            builder.addStateStore(new RocksDBTimeOrderedKeyValueBuffer.Builder<>(bufferStoreName.get(), joined.gracePeriod(), name));
+            final RocksDBTimeOrderedKeyValueBuffer.Builder<Object, Object> storeBuilder =
+                    new RocksDBTimeOrderedKeyValueBuffer.Builder<>(bufferStoreName.get(), joined.gracePeriod(), name);
+            builder.addStateStore(new StoreBuilderWrapper<>(storeBuilder));
         }
 
         final ProcessorSupplier<K, V, K, ? extends VR> processorSupplier = new KStreamKTableJoin<>(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -1269,7 +1269,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             bufferStoreName = Optional.of(name + "-Buffer");
             final RocksDBTimeOrderedKeyValueBuffer.Builder<Object, Object> storeBuilder =
                     new RocksDBTimeOrderedKeyValueBuffer.Builder<>(bufferStoreName.get(), joined.gracePeriod(), name);
-            builder.addStateStore(new StoreBuilderWrapper<>(storeBuilder));
+            builder.addStateStore(new StoreBuilderWrapper(storeBuilder));
         }
 
         final ProcessorSupplier<K, V, K, ? extends VR> processorSupplier = new KStreamKTableJoin<>(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -184,7 +184,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final Serde<K> keySerde;
         final Serde<V> valueSerde;
         final String queryableStoreName;
-        final StoreFactory<?> storeFactory;
+        final StoreFactory storeFactory;
 
         if (materializedInternal != null) {
             // we actually do not need to generate store names at all since if it is not specified, we will not
@@ -300,7 +300,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final Serde<K> keySerde;
         final Serde<VR> valueSerde;
         final String queryableStoreName;
-        final StoreFactory<?> storeFactory;
+        final StoreFactory storeFactory;
 
         if (materializedInternal != null) {
             // we actually do not need to generate store names at all since if it is not specified, we will not
@@ -456,7 +456,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final Serde<K> keySerde;
         final Serde<VR> valueSerde;
         final String queryableStoreName;
-        final StoreFactory<?> storeFactory;
+        final StoreFactory storeFactory;
 
         if (materializedInternal != null) {
             // don't inherit parent value serde, since this operation may change the value type, more specifically:
@@ -592,7 +592,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final ProcessorGraphNode<K, Change<V>> node = new TableSuppressNode<>(
             name,
             new ProcessorParameters<>(suppressionSupplier, name),
-            new StoreBuilderWrapper<>(storeBuilder)
+            new StoreBuilderWrapper(storeBuilder)
         );
         node.setOutputVersioned(false);
 
@@ -771,7 +771,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final Serde<K> keySerde;
         final Serde<VR> valueSerde;
         final String queryableStoreName;
-        final StoreFactory<?> storeFactory;
+        final StoreFactory storeFactory;
 
         if (materializedInternal != null) {
             if (materializedInternal.keySerde() == null) {
@@ -1193,7 +1193,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
                 new Serdes.BytesSerde(),
                 subscriptionWrapperSerde
             );
-        builder.addStateStore(new StoreBuilderWrapper<>(subscriptionStore));
+        builder.addStateStore(new StoreBuilderWrapper(subscriptionStore));
 
         final StatefulProcessorNode<KO, SubscriptionWrapper<K>> subscriptionReceiveNode =
             new StatefulProcessorNode<>(
@@ -1297,7 +1297,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             materializedInternal.queryableStoreName()
         );
 
-        final StoreFactory<?> resultStore =
+        final StoreFactory resultStore =
             new KeyValueStoreMaterializer<>(materializedInternal);
 
         final TableProcessorNode<K, VR> resultNode = new TableProcessorNode<>(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -184,7 +184,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final Serde<K> keySerde;
         final Serde<V> valueSerde;
         final String queryableStoreName;
-        final StoreFactory<?> storeBuilder;
+        final StoreFactory<?> storeFactory;
 
         if (materializedInternal != null) {
             // we actually do not need to generate store names at all since if it is not specified, we will not
@@ -199,12 +199,12 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             valueSerde = materializedInternal.valueSerde() != null ? materializedInternal.valueSerde() : this.valueSerde;
             queryableStoreName = materializedInternal.queryableStoreName();
             // only materialize if materialized is specified and it has queryable name
-            storeBuilder = queryableStoreName != null ? (new KeyValueStoreMaterializer<>(materializedInternal)).materialize() : null;
+            storeFactory = queryableStoreName != null ? (new KeyValueStoreMaterializer<>(materializedInternal)) : null;
         } else {
             keySerde = this.keySerde;
             valueSerde = this.valueSerde;
             queryableStoreName = null;
-            storeBuilder = null;
+            storeFactory = null;
         }
         final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, FILTER_NAME);
 
@@ -218,7 +218,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final GraphNode tableNode = new TableFilterNode<>(
             name,
             processorParameters,
-            storeBuilder
+            storeFactory
         );
         maybeSetOutputVersioned(tableNode, materializedInternal);
 
@@ -300,7 +300,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final Serde<K> keySerde;
         final Serde<VR> valueSerde;
         final String queryableStoreName;
-        final StoreFactory<?> storeBuilder;
+        final StoreFactory<?> storeFactory;
 
         if (materializedInternal != null) {
             // we actually do not need to generate store names at all since if it is not specified, we will not
@@ -312,12 +312,12 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             valueSerde = materializedInternal.valueSerde();
             queryableStoreName = materializedInternal.queryableStoreName();
             // only materialize if materialized is specified and it has queryable name
-            storeBuilder = queryableStoreName != null ? (new KeyValueStoreMaterializer<>(materializedInternal)).materialize() : null;
+            storeFactory = queryableStoreName != null ? (new KeyValueStoreMaterializer<>(materializedInternal)) : null;
         } else {
             keySerde = this.keySerde;
             valueSerde = null;
             queryableStoreName = null;
-            storeBuilder = null;
+            storeFactory = null;
         }
 
         final String name = new NamedInternal(named).orElseGenerateWithPrefix(builder, MAPVALUES_NAME);
@@ -332,7 +332,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final GraphNode tableNode = new TableProcessorNode<>(
             name,
             processorParameters,
-            storeBuilder
+            storeFactory
         );
         maybeSetOutputVersioned(tableNode, materializedInternal);
 
@@ -456,7 +456,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final Serde<K> keySerde;
         final Serde<VR> valueSerde;
         final String queryableStoreName;
-        final StoreFactory<?> storeBuilder;
+        final StoreFactory<?> storeFactory;
 
         if (materializedInternal != null) {
             // don't inherit parent value serde, since this operation may change the value type, more specifically:
@@ -466,12 +466,12 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             valueSerde = materializedInternal.valueSerde();
             queryableStoreName = materializedInternal.queryableStoreName();
             // only materialize if materialized is specified and it has queryable name
-            storeBuilder = queryableStoreName != null ? (new KeyValueStoreMaterializer<>(materializedInternal)).materialize() : null;
+            storeFactory = queryableStoreName != null ? (new KeyValueStoreMaterializer<>(materializedInternal)) : null;
         } else {
             keySerde = this.keySerde;
             valueSerde = null;
             queryableStoreName = null;
-            storeBuilder = null;
+            storeFactory = null;
         }
 
         final String name = namedInternal.orElseGenerateWithPrefix(builder, TRANSFORMVALUES_NAME);
@@ -488,7 +488,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final GraphNode tableNode = new TableProcessorNode<>(
             name,
             processorParameters,
-            storeBuilder,
+            storeFactory,
             stateStoreNames
         );
         maybeSetOutputVersioned(tableNode, materializedInternal);
@@ -771,7 +771,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final Serde<K> keySerde;
         final Serde<VR> valueSerde;
         final String queryableStoreName;
-        final StoreFactory<?> storeBuilder;
+        final StoreFactory<?> storeFactory;
 
         if (materializedInternal != null) {
             if (materializedInternal.keySerde() == null) {
@@ -780,12 +780,12 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             keySerde = materializedInternal.keySerde();
             valueSerde = materializedInternal.valueSerde();
             queryableStoreName = materializedInternal.storeName();
-            storeBuilder = new KeyValueStoreMaterializer<>(materializedInternal).materialize();
+            storeFactory = new KeyValueStoreMaterializer<>(materializedInternal);
         } else {
             keySerde = this.keySerde;
             valueSerde = null;
             queryableStoreName = null;
-            storeBuilder = null;
+            storeFactory = null;
         }
 
         final KTableKTableJoinNode<K, V, VO, VR> kTableKTableJoinNode =
@@ -800,7 +800,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
                 .withKeySerde(keySerde)
                 .withValueSerde(valueSerde)
                 .withQueryableStoreName(queryableStoreName)
-                .withStoreBuilder(storeBuilder)
+                .withStoreBuilder(storeFactory)
                 .build();
 
         final boolean isOutputVersioned = materializedInternal != null
@@ -1298,7 +1298,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         );
 
         final StoreFactory<?> resultStore =
-            new KeyValueStoreMaterializer<>(materializedInternal).materialize();
+            new KeyValueStoreMaterializer<>(materializedInternal);
 
         final TableProcessorNode<K, VR> resultNode = new TableProcessorNode<>(
             resultProcessorName,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -69,6 +69,8 @@ import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.InternalTopicProperties;
 import org.apache.kafka.streams.processor.internals.StaticTopicNameExtractor;
+import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
@@ -182,7 +184,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final Serde<K> keySerde;
         final Serde<V> valueSerde;
         final String queryableStoreName;
-        final StoreBuilder<?> storeBuilder;
+        final StoreFactory<?> storeBuilder;
 
         if (materializedInternal != null) {
             // we actually do not need to generate store names at all since if it is not specified, we will not
@@ -298,7 +300,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final Serde<K> keySerde;
         final Serde<VR> valueSerde;
         final String queryableStoreName;
-        final StoreBuilder<?> storeBuilder;
+        final StoreFactory<?> storeBuilder;
 
         if (materializedInternal != null) {
             // we actually do not need to generate store names at all since if it is not specified, we will not
@@ -454,7 +456,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final Serde<K> keySerde;
         final Serde<VR> valueSerde;
         final String queryableStoreName;
-        final StoreBuilder<?> storeBuilder;
+        final StoreFactory<?> storeBuilder;
 
         if (materializedInternal != null) {
             // don't inherit parent value serde, since this operation may change the value type, more specifically:
@@ -590,7 +592,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final ProcessorGraphNode<K, Change<V>> node = new TableSuppressNode<>(
             name,
             new ProcessorParameters<>(suppressionSupplier, name),
-            storeBuilder
+            new StoreBuilderWrapper<>(storeBuilder)
         );
         node.setOutputVersioned(false);
 
@@ -769,7 +771,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final Serde<K> keySerde;
         final Serde<VR> valueSerde;
         final String queryableStoreName;
-        final StoreBuilder<?> storeBuilder;
+        final StoreFactory<?> storeBuilder;
 
         if (materializedInternal != null) {
             if (materializedInternal.keySerde() == null) {
@@ -1191,7 +1193,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
                 new Serdes.BytesSerde(),
                 subscriptionWrapperSerde
             );
-        builder.addStateStore(subscriptionStore);
+        builder.addStateStore(new StoreBuilderWrapper<>(subscriptionStore));
 
         final StatefulProcessorNode<KO, SubscriptionWrapper<K>> subscriptionReceiveNode =
             new StatefulProcessorNode<>(
@@ -1295,7 +1297,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             materializedInternal.queryableStoreName()
         );
 
-        final StoreBuilder<?> resultStore =
+        final StoreFactory<?> resultStore =
             new KeyValueStoreMaterializer<>(materializedInternal).materialize();
 
         final TableProcessorNode<K, VR> resultNode = new TableProcessorNode<>(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
@@ -165,7 +165,7 @@ public class KeyValueStoreMaterializer<K, V> implements StoreFactory {
     @Override
     public StoreFactory withLoggingDisabled() {
         materialized.withLoggingDisabled();
-        return null;
+        return this;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
@@ -17,7 +17,8 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -29,26 +30,48 @@ import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 /**
  * Materializes a key-value store as either a {@link TimestampedKeyValueStoreBuilder} or a
  * {@link VersionedKeyValueStoreBuilder} depending on whether the store is versioned or not.
  */
-public class KeyValueStoreMaterializer<K, V> {
+public class KeyValueStoreMaterializer<K, V> implements StoreFactory<KeyValueStore<Bytes, byte[]>> {
     private static final Logger LOG = LoggerFactory.getLogger(KeyValueStoreMaterializer.class);
 
     private final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materialized;
+    private final Set<String> connectedProcessorNames = new HashSet<>();
 
-    public KeyValueStoreMaterializer(final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materialized) {
+    private Materialized.StoreType defaultStoreType = Materialized.StoreType.ROCKS_DB;
+    private long historyRetention;
+
+    public KeyValueStoreMaterializer(
+            final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materialized
+    ) {
         this.materialized = materialized;
+
+        // this condition will never be false; in the next PR we will
+        // remove the initialization of storeType from MaterializedInternal
+        if (materialized.storeType() != null) {
+            defaultStoreType = materialized.storeType;
+        }
     }
 
-    /**
-     * @return  StoreBuilder
-     */
-    public StoreFactory<?> materialize() {
+    @Override
+    public void configure(final StreamsConfig config) {
+        // in a follow-up PR, this will set the defaultStoreType to the configured value
+    }
+
+    // both versionedKeyValueStoreBuilder and timestampedKeyValueStoreBuilder will
+    // provide the correct store types, so it is safe to suppress the unchecked warning
+    @SuppressWarnings("unchecked")
+    @Override
+    public KeyValueStore<Bytes, byte[]> build() {
         KeyValueBytesStoreSupplier supplier = (KeyValueBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
-            switch (materialized.storeType()) {
+            switch (defaultStoreType) {
                 case IN_MEMORY:
                     supplier = Stores.inMemoryKeyValueStore(materialized.storeName());
                     break;
@@ -63,14 +86,15 @@ public class KeyValueStoreMaterializer<K, V> {
         final StoreBuilder<?> builder;
         if (supplier instanceof VersionedBytesStoreSupplier) {
             builder = Stores.versionedKeyValueStoreBuilder(
-                (VersionedBytesStoreSupplier) supplier,
-                materialized.keySerde(),
-                materialized.valueSerde());
+                    (VersionedBytesStoreSupplier) supplier,
+                    materialized.keySerde(),
+                    materialized.valueSerde());
+            historyRetention = ((VersionedBytesStoreSupplier) supplier).historyRetentionMs();
         } else {
             builder = Stores.timestampedKeyValueStoreBuilder(
-                supplier,
-                materialized.keySerde(),
-                materialized.valueSerde());
+                    supplier,
+                    materialized.keySerde(),
+                    materialized.valueSerde());
         }
 
         if (materialized.loggingEnabled()) {
@@ -86,6 +110,71 @@ public class KeyValueStoreMaterializer<K, V> {
                 LOG.info("Not enabling caching for store '{}' as versioned stores do not support caching.", supplier.name());
             }
         }
-        return new StoreBuilderWrapper<>(builder);
+
+
+        return (KeyValueStore<Bytes, byte[]>) builder.build();
+    }
+
+    @Override
+    public long retentionPeriod() {
+        throw new IllegalStateException(
+                "retentionPeriod is not supported when not a window store");
+    }
+
+    @Override
+    public long historyRetention() {
+        if (!(materialized.storeSupplier() instanceof VersionedBytesStoreSupplier)) {
+            throw new IllegalStateException(
+                    "historyRetention is not supported when not a versioned store");
+        }
+        return historyRetention;
+    }
+
+    @Override
+    public Set<String> connectedProcessorNames() {
+        return connectedProcessorNames;
+    }
+
+    @Override
+    public boolean loggingEnabled() {
+        return materialized.loggingEnabled();
+    }
+
+    @Override
+    public String name() {
+        return materialized.storeName();
+    }
+
+    @Override
+    public boolean isWindowStore() {
+        return false;
+    }
+
+    @Override
+    public boolean isVersionedStore() {
+        return materialized.storeSupplier() instanceof VersionedBytesStoreSupplier;
+    }
+
+    @Override
+    public Map<String, String> logConfig() {
+        return materialized.logConfig();
+    }
+
+    @Override
+    public StoreFactory<?> withCachingDisabled() {
+        materialized.withCachingDisabled();
+        return this;
+    }
+
+    @Override
+    public StoreFactory<?> withLoggingDisabled() {
+        materialized.withLoggingDisabled();
+        return null;
+    }
+
+    @Override
+    public boolean isCompatibleWith(final StoreFactory<?> storeFactory) {
+        return (storeFactory instanceof KeyValueStoreMaterializer)
+                && ((KeyValueStoreMaterializer<?, ?>) storeFactory).materialized.equals(materialized);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
@@ -43,7 +45,7 @@ public class KeyValueStoreMaterializer<K, V> {
     /**
      * @return  StoreBuilder
      */
-    public StoreBuilder<?> materialize() {
+    public StoreFactory<?> materialize() {
         KeyValueBytesStoreSupplier supplier = (KeyValueBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
             switch (materialized.storeType()) {
@@ -84,6 +86,6 @@ public class KeyValueStoreMaterializer<K, V> {
                 LOG.info("Not enabling caching for store '{}' as versioned stores do not support caching.", supplier.name());
             }
         }
-        return builder;
+        return new StoreBuilderWrapper<>(builder);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
@@ -45,7 +45,8 @@ public class KeyValueStoreMaterializer<K, V> implements StoreFactory {
     private final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materialized;
     private final Set<String> connectedProcessorNames = new HashSet<>();
 
-    private Materialized.StoreType defaultStoreType = Materialized.StoreType.ROCKS_DB;
+    private Materialized.StoreType defaultStoreType
+            = Materialized.StoreType.parse(StreamsConfig.DEFAULT_DSL_STORE_DEFAULT);
 
     public KeyValueStoreMaterializer(
             final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materialized

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/MaterializedInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/MaterializedInternal.java
@@ -90,7 +90,7 @@ public class MaterializedInternal<K, V, S extends StateStore> extends Materializ
         return loggingEnabled;
     }
 
-    Map<String, String> logConfig() {
+    public Map<String, String> logConfig() {
         return topicConfig;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedCogroupedKStreamImpl.java
@@ -108,7 +108,7 @@ public class SessionWindowedCogroupedKStreamImpl<K, V> extends
             sessionMerger);
     }
 
-    private StoreFactory<SessionStore<K, V>> materialize(final MaterializedInternal<K, V, SessionStore<Bytes, byte[]>> materialized) {
+    private StoreFactory materialize(final MaterializedInternal<K, V, SessionStore<Bytes, byte[]>> materialized) {
         SessionBytesStoreSupplier supplier = (SessionBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
             final long retentionPeriod = materialized.retention() != null ?
@@ -157,7 +157,7 @@ public class SessionWindowedCogroupedKStreamImpl<K, V> extends
         if (materialized.cachingEnabled()) {
             builder.withCachingEnabled();
         }
-        return new StoreBuilderWrapper<>(builder);
+        return new StoreBuilderWrapper(builder);
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedCogroupedKStreamImpl.java
@@ -29,6 +29,8 @@ import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.WindowedSerdes;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
+import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.StoreBuilder;
@@ -106,7 +108,7 @@ public class SessionWindowedCogroupedKStreamImpl<K, V> extends
             sessionMerger);
     }
 
-    private  StoreBuilder<SessionStore<K, V>> materialize(final MaterializedInternal<K, V, SessionStore<Bytes, byte[]>> materialized) {
+    private StoreFactory<SessionStore<K, V>> materialize(final MaterializedInternal<K, V, SessionStore<Bytes, byte[]>> materialized) {
         SessionBytesStoreSupplier supplier = (SessionBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
             final long retentionPeriod = materialized.retention() != null ?
@@ -155,7 +157,7 @@ public class SessionWindowedCogroupedKStreamImpl<K, V> extends
         if (materialized.cachingEnabled()) {
             builder.withCachingEnabled();
         }
-        return builder;
+        return new StoreBuilderWrapper<>(builder);
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImpl.java
@@ -32,6 +32,8 @@ import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.WindowedSerdes;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
+import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.StoreBuilder;
@@ -238,7 +240,7 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
             false);
     }
 
-    private <VR> StoreBuilder<SessionStore<K, VR>> materialize(final MaterializedInternal<K, VR, SessionStore<Bytes, byte[]>> materialized) {
+    private <VR> StoreFactory<SessionStore<K, VR>> materialize(final MaterializedInternal<K, VR, SessionStore<Bytes, byte[]>> materialized) {
         SessionBytesStoreSupplier supplier = (SessionBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
             final long retentionPeriod = materialized.retention() != null ?
@@ -296,7 +298,7 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
             builder.withCachingDisabled();
         }
 
-        return builder;
+        return new StoreBuilderWrapper<>(builder);
     }
 
     private Merger<K, V> mergerForAggregator(final Aggregator<K, V, V> aggregator) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImpl.java
@@ -240,7 +240,7 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
             false);
     }
 
-    private <VR> StoreFactory<SessionStore<K, VR>> materialize(final MaterializedInternal<K, VR, SessionStore<Bytes, byte[]>> materialized) {
+    private <VR> StoreFactory materialize(final MaterializedInternal<K, VR, SessionStore<Bytes, byte[]>> materialized) {
         SessionBytesStoreSupplier supplier = (SessionBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
             final long retentionPeriod = materialized.retention() != null ?
@@ -298,7 +298,7 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
             builder.withCachingDisabled();
         }
 
-        return new StoreBuilderWrapper<>(builder);
+        return new StoreBuilderWrapper(builder);
     }
 
     private Merger<K, V> mergerForAggregator(final Aggregator<K, V, V> aggregator) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedCogroupedKStreamImpl.java
@@ -27,6 +27,8 @@ import org.apache.kafka.streams.kstream.SlidingWindows;
 import org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
+import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
@@ -98,7 +100,7 @@ public class SlidingWindowedCogroupedKStreamImpl<K, V> extends AbstractStream<K,
             windows);
     }
 
-    private StoreBuilder<TimestampedWindowStore<K, V>> materialize(final MaterializedInternal<K, V, WindowStore<Bytes, byte[]>> materialized) {
+    private StoreFactory<TimestampedWindowStore<K, V>> materialize(final MaterializedInternal<K, V, WindowStore<Bytes, byte[]>> materialized) {
         WindowBytesStoreSupplier supplier = (WindowBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
             final long retentionPeriod = materialized.retention() != null ? materialized.retention().toMillis() : windows.gracePeriodMs() + 2 * windows.timeDifferenceMs();
@@ -153,7 +155,7 @@ public class SlidingWindowedCogroupedKStreamImpl<K, V> extends AbstractStream<K,
         } else {
             builder.withCachingDisabled();
         }
-        return builder;
+        return new StoreBuilderWrapper<>(builder);
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedCogroupedKStreamImpl.java
@@ -100,7 +100,7 @@ public class SlidingWindowedCogroupedKStreamImpl<K, V> extends AbstractStream<K,
             windows);
     }
 
-    private StoreFactory<TimestampedWindowStore<K, V>> materialize(final MaterializedInternal<K, V, WindowStore<Bytes, byte[]>> materialized) {
+    private StoreFactory materialize(final MaterializedInternal<K, V, WindowStore<Bytes, byte[]>> materialized) {
         WindowBytesStoreSupplier supplier = (WindowBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
             final long retentionPeriod = materialized.retention() != null ? materialized.retention().toMillis() : windows.gracePeriodMs() + 2 * windows.timeDifferenceMs();
@@ -155,7 +155,7 @@ public class SlidingWindowedCogroupedKStreamImpl<K, V> extends AbstractStream<K,
         } else {
             builder.withCachingDisabled();
         }
-        return new StoreBuilderWrapper<>(builder);
+        return new StoreBuilderWrapper(builder);
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedKStreamImpl.java
@@ -207,7 +207,7 @@ public class SlidingWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
         return this;
     }
 
-    private <VR> StoreFactory<TimestampedWindowStore<K, VR>> materialize(final MaterializedInternal<K, VR, WindowStore<Bytes, byte[]>> materialized) {
+    private <VR> StoreFactory materialize(final MaterializedInternal<K, VR, WindowStore<Bytes, byte[]>> materialized) {
         WindowBytesStoreSupplier supplier = (WindowBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
             final long retentionPeriod = materialized.retention() != null ? materialized.retention().toMillis() : windows.gracePeriodMs() + 2 * windows.timeDifferenceMs();
@@ -270,7 +270,7 @@ public class SlidingWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
         } else {
             builder.withCachingDisabled();
         }
-        return new StoreBuilderWrapper<>(builder);
+        return new StoreBuilderWrapper(builder);
     }
 
     private Aggregator<K, V, V> aggregatorForReducer(final Reducer<V> reducer) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedKStreamImpl.java
@@ -31,6 +31,8 @@ import org.apache.kafka.streams.kstream.SlidingWindows;
 import org.apache.kafka.streams.kstream.TimeWindowedKStream;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
+import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
@@ -205,7 +207,7 @@ public class SlidingWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
         return this;
     }
 
-    private <VR> StoreBuilder<TimestampedWindowStore<K, VR>> materialize(final MaterializedInternal<K, VR, WindowStore<Bytes, byte[]>> materialized) {
+    private <VR> StoreFactory<TimestampedWindowStore<K, VR>> materialize(final MaterializedInternal<K, VR, WindowStore<Bytes, byte[]>> materialized) {
         WindowBytesStoreSupplier supplier = (WindowBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
             final long retentionPeriod = materialized.retention() != null ? materialized.retention().toMillis() : windows.gracePeriodMs() + 2 * windows.timeDifferenceMs();
@@ -268,7 +270,7 @@ public class SlidingWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
         } else {
             builder.withCachingDisabled();
         }
-        return builder;
+        return new StoreBuilderWrapper<>(builder);
     }
 
     private Aggregator<K, V, V> aggregatorForReducer(final Reducer<V> reducer) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
@@ -104,7 +104,7 @@ public class TimeWindowedCogroupedKStreamImpl<K, V, W extends Window> extends Ab
             windows);
     }
 
-    private StoreFactory<TimestampedWindowStore<K, V>> materialize(
+    private StoreFactory materialize(
         final MaterializedInternal<K, V, WindowStore<Bytes, byte[]>> materialized) {
         WindowBytesStoreSupplier supplier = (WindowBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
@@ -160,6 +160,6 @@ public class TimeWindowedCogroupedKStreamImpl<K, V, W extends Window> extends Ab
         if (materialized.cachingEnabled()) {
             builder.withCachingEnabled();
         }
-        return new StoreBuilderWrapper<>(builder);
+        return new StoreBuilderWrapper(builder);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
@@ -28,6 +28,8 @@ import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.Windows;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
+import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
@@ -102,7 +104,7 @@ public class TimeWindowedCogroupedKStreamImpl<K, V, W extends Window> extends Ab
             windows);
     }
 
-    private StoreBuilder<TimestampedWindowStore<K, V>> materialize(
+    private StoreFactory<TimestampedWindowStore<K, V>> materialize(
         final MaterializedInternal<K, V, WindowStore<Bytes, byte[]>> materialized) {
         WindowBytesStoreSupplier supplier = (WindowBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
@@ -158,6 +160,6 @@ public class TimeWindowedCogroupedKStreamImpl<K, V, W extends Window> extends Ab
         if (materialized.cachingEnabled()) {
             builder.withCachingEnabled();
         }
-        return builder;
+        return new StoreBuilderWrapper<>(builder);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
@@ -33,6 +33,8 @@ import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.Windows;
 import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
+import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
@@ -237,7 +239,7 @@ public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStr
         return this;
     }
 
-    private <VR> StoreBuilder<TimestampedWindowStore<K, VR>> materialize(final MaterializedInternal<K, VR, WindowStore<Bytes, byte[]>> materialized) {
+    private <VR> StoreFactory<TimestampedWindowStore<K, VR>> materialize(final MaterializedInternal<K, VR, WindowStore<Bytes, byte[]>> materialized) {
         WindowBytesStoreSupplier supplier = (WindowBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
             final long retentionPeriod = materialized.retention() != null ?
@@ -296,7 +298,7 @@ public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStr
         if (materialized.cachingEnabled()) {
             builder.withCachingEnabled();
         }
-        return builder;
+        return new StoreBuilderWrapper<>(builder);
     }
 
     private Aggregator<K, V, V> aggregatorForReducer(final Reducer<V> reducer) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
@@ -239,7 +239,7 @@ public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStr
         return this;
     }
 
-    private <VR> StoreFactory<TimestampedWindowStore<K, VR>> materialize(final MaterializedInternal<K, VR, WindowStore<Bytes, byte[]>> materialized) {
+    private <VR> StoreFactory materialize(final MaterializedInternal<K, VR, WindowStore<Bytes, byte[]>> materialized) {
         WindowBytesStoreSupplier supplier = (WindowBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
             final long retentionPeriod = materialized.retention() != null ?
@@ -298,7 +298,7 @@ public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStr
         if (materialized.cachingEnabled()) {
             builder.withCachingEnabled();
         }
-        return new StoreBuilderWrapper<>(builder);
+        return new StoreBuilderWrapper(builder);
     }
 
     private Aggregator<K, V, V> aggregatorForReducer(final Reducer<V> reducer) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
@@ -31,7 +31,7 @@ public class GlobalStoreNode<KIn, VIn, S extends StateStore> extends StateStoreN
     private final ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier;
 
 
-    public GlobalStoreNode(final StoreFactory<S> storeBuilder,
+    public GlobalStoreNode(final StoreFactory storeBuilder,
                            final String sourceName,
                            final String topic,
                            final ConsumedInternal<KIn, VIn> consumed,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
@@ -20,7 +20,7 @@ import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
-import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 
 public class GlobalStoreNode<KIn, VIn, S extends StateStore> extends StateStoreNode<S> {
 
@@ -31,7 +31,7 @@ public class GlobalStoreNode<KIn, VIn, S extends StateStore> extends StateStoreN
     private final ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier;
 
 
-    public GlobalStoreNode(final StoreBuilder<S> storeBuilder,
+    public GlobalStoreNode(final StoreFactory<S> storeBuilder,
                            final String sourceName,
                            final String topic,
                            final ConsumedInternal<KIn, VIn> consumed,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/KTableKTableJoinNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/KTableKTableJoinNode.java
@@ -37,7 +37,7 @@ public class KTableKTableJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
     private final Serde<VR> valueSerde;
     private final String[] joinThisStoreNames;
     private final String[] joinOtherStoreNames;
-    private final StoreFactory<?> storeFactory;
+    private final StoreFactory storeFactory;
 
     KTableKTableJoinNode(final String nodeName,
                          final ProcessorParameters<K, Change<V1>, ?, ?> joinThisProcessorParameters,
@@ -49,7 +49,7 @@ public class KTableKTableJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
                          final Serde<VR> valueSerde,
                          final String[] joinThisStoreNames,
                          final String[] joinOtherStoreNames,
-                         final StoreFactory<?> storeFactory) {
+                         final StoreFactory storeFactory) {
 
         super(nodeName,
             null,
@@ -169,7 +169,7 @@ public class KTableKTableJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
         private String[] joinThisStoreNames;
         private String[] joinOtherStoreNames;
         private String queryableStoreName;
-        private StoreFactory<?> storeFactory;
+        private StoreFactory storeFactory;
 
         private KTableKTableJoinNodeBuilder() {
         }
@@ -224,7 +224,7 @@ public class KTableKTableJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
             return this;
         }
 
-        public KTableKTableJoinNodeBuilder<K, V1, V2, VR> withStoreBuilder(final StoreFactory<?> storeFactory) {
+        public KTableKTableJoinNodeBuilder<K, V1, V2, VR> withStoreBuilder(final StoreFactory storeFactory) {
             this.storeFactory = storeFactory;
             return this;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/KTableKTableJoinNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/KTableKTableJoinNode.java
@@ -169,7 +169,7 @@ public class KTableKTableJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
         private String[] joinThisStoreNames;
         private String[] joinOtherStoreNames;
         private String queryableStoreName;
-        private StoreFactory<?> storeBuilder;
+        private StoreFactory<?> storeFactory;
 
         private KTableKTableJoinNodeBuilder() {
         }
@@ -224,8 +224,8 @@ public class KTableKTableJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
             return this;
         }
 
-        public KTableKTableJoinNodeBuilder<K, V1, V2, VR> withStoreBuilder(final StoreFactory<?> storeBuilder) {
-            this.storeBuilder = storeBuilder;
+        public KTableKTableJoinNodeBuilder<K, V1, V2, VR> withStoreBuilder(final StoreFactory<?> storeFactory) {
+            this.storeFactory = storeFactory;
             return this;
         }
 
@@ -247,7 +247,7 @@ public class KTableKTableJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
                 valueSerde,
                 joinThisStoreNames,
                 joinOtherStoreNames,
-                storeBuilder
+                storeFactory
             );
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/KTableKTableJoinNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/KTableKTableJoinNode.java
@@ -24,7 +24,7 @@ import org.apache.kafka.streams.kstream.internals.KTableKTableJoinMerger;
 import org.apache.kafka.streams.kstream.internals.KTableProcessorSupplier;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
-import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 
 import java.util.Arrays;
 
@@ -37,7 +37,7 @@ public class KTableKTableJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
     private final Serde<VR> valueSerde;
     private final String[] joinThisStoreNames;
     private final String[] joinOtherStoreNames;
-    private final StoreBuilder<?> storeBuilder;
+    private final StoreFactory<?> storeFactory;
 
     KTableKTableJoinNode(final String nodeName,
                          final ProcessorParameters<K, Change<V1>, ?, ?> joinThisProcessorParameters,
@@ -49,7 +49,7 @@ public class KTableKTableJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
                          final Serde<VR> valueSerde,
                          final String[] joinThisStoreNames,
                          final String[] joinOtherStoreNames,
-                         final StoreBuilder<?> storeBuilder) {
+                         final StoreFactory<?> storeFactory) {
 
         super(nodeName,
             null,
@@ -63,7 +63,7 @@ public class KTableKTableJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
         this.valueSerde = valueSerde;
         this.joinThisStoreNames = joinThisStoreNames;
         this.joinOtherStoreNames = joinOtherStoreNames;
-        this.storeBuilder = storeBuilder;
+        this.storeFactory = storeFactory;
     }
 
     public Serde<K> keySerde() {
@@ -141,8 +141,8 @@ public class KTableKTableJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
         topologyBuilder.connectProcessorAndStateStores(thisProcessorName, joinOtherStoreNames);
         topologyBuilder.connectProcessorAndStateStores(otherProcessorName, joinThisStoreNames);
 
-        if (storeBuilder != null) {
-            topologyBuilder.addStateStore(storeBuilder, mergeProcessorName);
+        if (storeFactory != null) {
+            topologyBuilder.addStateStore(storeFactory, mergeProcessorName);
         }
     }
 
@@ -169,7 +169,7 @@ public class KTableKTableJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
         private String[] joinThisStoreNames;
         private String[] joinOtherStoreNames;
         private String queryableStoreName;
-        private StoreBuilder<?> storeBuilder;
+        private StoreFactory<?> storeBuilder;
 
         private KTableKTableJoinNodeBuilder() {
         }
@@ -224,7 +224,7 @@ public class KTableKTableJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
             return this;
         }
 
-        public KTableKTableJoinNodeBuilder<K, V1, V2, VR> withStoreBuilder(final StoreBuilder<?> storeBuilder) {
+        public KTableKTableJoinNodeBuilder<K, V1, V2, VR> withStoreBuilder(final StoreFactory<?> storeBuilder) {
             this.storeBuilder = storeBuilder;
             return this;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
@@ -22,9 +22,9 @@ import org.apache.kafka.streams.processor.internals.StoreFactory;
 
 public class StateStoreNode<S extends StateStore> extends GraphNode {
 
-    protected final StoreFactory<S> storeBuilder;
+    protected final StoreFactory storeBuilder;
 
-    public StateStoreNode(final StoreFactory<S> storeBuilder) {
+    public StateStoreNode(final StoreFactory storeBuilder) {
         super(storeBuilder.name());
 
         this.storeBuilder = storeBuilder;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
@@ -18,13 +18,13 @@ package org.apache.kafka.streams.kstream.internals.graph;
 
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
-import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 
 public class StateStoreNode<S extends StateStore> extends GraphNode {
 
-    protected final StoreBuilder<S> storeBuilder;
+    protected final StoreFactory<S> storeBuilder;
 
-    public StateStoreNode(final StoreBuilder<S> storeBuilder) {
+    public StateStoreNode(final StoreFactory<S> storeBuilder) {
         super(storeBuilder.name());
 
         this.storeBuilder = storeBuilder;
@@ -32,7 +32,6 @@ public class StateStoreNode<S extends StateStore> extends GraphNode {
 
     @Override
     public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
-
         topologyBuilder.addStateStore(storeBuilder);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
@@ -27,7 +27,7 @@ import org.apache.kafka.streams.state.StoreBuilder;
 public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
 
     private final String[] storeNames;
-    private final StoreFactory<?> storeFactory;
+    private final StoreFactory storeFactory;
 
     /**
      * Create a node representing a stateful processor, where the named stores have already been registered.
@@ -61,7 +61,7 @@ public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
      */
     public StatefulProcessorNode(final String nodeName,
                                  final ProcessorParameters<K, V, ?, ?> processorParameters,
-                                 final StoreFactory<?> materializedKTableStoreBuilder) {
+                                 final StoreFactory materializedKTableStoreBuilder) {
         super(nodeName, processorParameters);
 
         this.storeNames = null;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
@@ -16,18 +16,18 @@
  */
 package org.apache.kafka.streams.kstream.internals.graph;
 
-import org.apache.kafka.streams.kstream.internals.KTableValueGetterSupplier;
-import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
-import org.apache.kafka.streams.state.StoreBuilder;
-
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.apache.kafka.streams.kstream.internals.KTableValueGetterSupplier;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
+import org.apache.kafka.streams.state.StoreBuilder;
 
 public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
 
     private final String[] storeNames;
-    private final StoreBuilder<?> storeBuilder;
+    private final StoreFactory<?> storeFactory;
 
     /**
      * Create a node representing a stateful processor, where the named stores have already been registered.
@@ -39,7 +39,7 @@ public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
         final Stream<String> registeredStoreNames = preRegisteredStores.stream().map(StoreBuilder::name);
         final Stream<String> valueGetterStoreNames = valueGetterSuppliers.stream().flatMap(s -> Arrays.stream(s.storeNames()));
         storeNames = Stream.concat(registeredStoreNames, valueGetterStoreNames).toArray(String[]::new);
-        storeBuilder = null;
+        storeFactory = null;
     }
 
     /**
@@ -51,7 +51,7 @@ public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
         super(nodeName, processorParameters);
 
         this.storeNames = storeNames;
-        this.storeBuilder = null;
+        this.storeFactory = null;
     }
 
 
@@ -61,18 +61,18 @@ public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
      */
     public StatefulProcessorNode(final String nodeName,
                                  final ProcessorParameters<K, V, ?, ?> processorParameters,
-                                 final StoreBuilder<?> materializedKTableStoreBuilder) {
+                                 final StoreFactory<?> materializedKTableStoreBuilder) {
         super(nodeName, processorParameters);
 
         this.storeNames = null;
-        this.storeBuilder = materializedKTableStoreBuilder;
+        this.storeFactory = materializedKTableStoreBuilder;
     }
 
     @Override
     public String toString() {
         return "StatefulProcessorNode{" +
             "storeNames=" + Arrays.toString(storeNames) +
-            ", storeBuilder=" + storeBuilder +
+            ", storeBuilder=" + storeFactory +
             "} " + super.toString();
     }
 
@@ -84,8 +84,8 @@ public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
             topologyBuilder.connectProcessorAndStateStores(processorParameters().processorName(), storeNames);
         }
 
-        if (storeBuilder != null) {
-            topologyBuilder.addStateStore(storeBuilder, processorParameters().processorName());
+        if (storeFactory != null) {
+            topologyBuilder.addStateStore(storeFactory, processorParameters().processorName());
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamToTableNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamToTableNode.java
@@ -22,8 +22,8 @@ import org.apache.kafka.streams.kstream.internals.KTableSource;
 import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
 import org.apache.kafka.streams.kstream.internals.KeyValueStoreMaterializer;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.StoreBuilder;
 
 /**
  * Represents a KTable convert From KStream
@@ -52,7 +52,7 @@ public class StreamToTableNode<K, V> extends GraphNode {
     @SuppressWarnings("unchecked")
     @Override
     public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
-        final StoreBuilder<?> storeBuilder =
+        final StoreFactory<?> storeBuilder =
             new KeyValueStoreMaterializer<>((MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>>) materializedInternal).materialize();
 
         final String processorName = processorParameters.processorName();

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamToTableNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamToTableNode.java
@@ -52,7 +52,7 @@ public class StreamToTableNode<K, V> extends GraphNode {
     @SuppressWarnings("unchecked")
     @Override
     public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
-        final StoreFactory<?> storeFactory =
+        final StoreFactory storeFactory =
             new KeyValueStoreMaterializer<>((MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>>) materializedInternal);
 
         final String processorName = processorParameters.processorName();

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamToTableNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamToTableNode.java
@@ -52,16 +52,16 @@ public class StreamToTableNode<K, V> extends GraphNode {
     @SuppressWarnings("unchecked")
     @Override
     public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
-        final StoreFactory<?> storeBuilder =
-            new KeyValueStoreMaterializer<>((MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>>) materializedInternal).materialize();
+        final StoreFactory<?> storeFactory =
+            new KeyValueStoreMaterializer<>((MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>>) materializedInternal);
 
         final String processorName = processorParameters.processorName();
         final KTableSource<K, V> tableSource =  processorParameters.processorSupplier() instanceof KTableSource ?
                 (KTableSource<K, V>) processorParameters.processorSupplier() : null;
         topologyBuilder.addProcessor(processorName, processorParameters.processorSupplier(), parentNodeNames());
 
-        if (storeBuilder != null && tableSource.materialized()) {
-            topologyBuilder.addStateStore(storeBuilder, processorName);
+        if (storeFactory != null && tableSource.materialized()) {
+            topologyBuilder.addStateStore(storeFactory, processorName);
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableFilterNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableFilterNode.java
@@ -19,13 +19,13 @@ package org.apache.kafka.streams.kstream.internals.graph;
 
 import org.apache.kafka.streams.kstream.internals.KTableFilter;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
-import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 
 public class TableFilterNode<K, V> extends TableProcessorNode<K, V> implements VersionedSemanticsGraphNode {
 
     public TableFilterNode(final String nodeName,
                            final ProcessorParameters<K, V, ?, ?> processorParameters,
-                           final StoreBuilder<?> storeBuilder) {
+                           final StoreFactory<?> storeBuilder) {
         super(nodeName, processorParameters, storeBuilder);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableFilterNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableFilterNode.java
@@ -25,8 +25,8 @@ public class TableFilterNode<K, V> extends TableProcessorNode<K, V> implements V
 
     public TableFilterNode(final String nodeName,
                            final ProcessorParameters<K, V, ?, ?> processorParameters,
-                           final StoreFactory<?> storeBuilder) {
-        super(nodeName, processorParameters, storeBuilder);
+                           final StoreFactory<?> storeFactory) {
+        super(nodeName, processorParameters, storeFactory);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableFilterNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableFilterNode.java
@@ -25,7 +25,7 @@ public class TableFilterNode<K, V> extends TableProcessorNode<K, V> implements V
 
     public TableFilterNode(final String nodeName,
                            final ProcessorParameters<K, V, ?, ?> processorParameters,
-                           final StoreFactory<?> storeFactory) {
+                           final StoreFactory storeFactory) {
         super(nodeName, processorParameters, storeFactory);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNode.java
@@ -26,22 +26,22 @@ import org.apache.kafka.streams.processor.internals.StoreFactory;
 public class TableProcessorNode<K, V> extends GraphNode {
 
     private final ProcessorParameters<K, V, ?, ?> processorParameters;
-    private final StoreFactory<?> storeBuilder;
+    private final StoreFactory<?> storeFactory;
     private final String[] storeNames;
 
     public TableProcessorNode(final String nodeName,
                               final ProcessorParameters<K, V, ?, ?> processorParameters,
-                              final StoreFactory<?> storeBuilder) {
-        this(nodeName, processorParameters, storeBuilder, null);
+                              final StoreFactory<?> storeFactory) {
+        this(nodeName, processorParameters, storeFactory, null);
     }
 
     public TableProcessorNode(final String nodeName,
                               final ProcessorParameters<K, V, ?, ?> processorParameters,
-                              final StoreFactory<?> storeBuilder,
+                              final StoreFactory<?> storeFactory,
                               final String[] storeNames) {
         super(nodeName);
         this.processorParameters = processorParameters;
-        this.storeBuilder = storeBuilder;
+        this.storeFactory = storeFactory;
         this.storeNames = storeNames != null ? storeNames : new String[] {};
     }
 
@@ -53,7 +53,7 @@ public class TableProcessorNode<K, V> extends GraphNode {
     public String toString() {
         return "TableProcessorNode{" +
             ", processorParameters=" + processorParameters +
-            ", storeBuilder=" + (storeBuilder == null ? "null" : storeBuilder.name()) +
+            ", storeFactory=" + (storeFactory == null ? "null" : storeFactory.name()) +
             ", storeNames=" + Arrays.toString(storeNames) +
             "} " + super.toString();
     }
@@ -72,11 +72,11 @@ public class TableProcessorNode<K, V> extends GraphNode {
                 (KTableSource<K, V>) processorParameters.processorSupplier() : null;
         if (tableSource != null) {
             if (tableSource.materialized()) {
-                topologyBuilder.addStateStore(Objects.requireNonNull(storeBuilder, "storeBuilder was null"),
+                topologyBuilder.addStateStore(Objects.requireNonNull(storeFactory, "storeFactory was null"),
                                               processorName);
             }
-        } else if (storeBuilder != null) {
-            topologyBuilder.addStateStore(storeBuilder, processorName);
+        } else if (storeFactory != null) {
+            topologyBuilder.addStateStore(storeFactory, processorName);
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNode.java
@@ -17,28 +17,27 @@
 
 package org.apache.kafka.streams.kstream.internals.graph;
 
-import org.apache.kafka.streams.kstream.internals.KTableSource;
-import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
-import org.apache.kafka.streams.state.StoreBuilder;
-
 import java.util.Arrays;
 import java.util.Objects;
+import org.apache.kafka.streams.kstream.internals.KTableSource;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 
 public class TableProcessorNode<K, V> extends GraphNode {
 
     private final ProcessorParameters<K, V, ?, ?> processorParameters;
-    private final StoreBuilder<?> storeBuilder;
+    private final StoreFactory<?> storeBuilder;
     private final String[] storeNames;
 
     public TableProcessorNode(final String nodeName,
                               final ProcessorParameters<K, V, ?, ?> processorParameters,
-                              final StoreBuilder<?> storeBuilder) {
+                              final StoreFactory<?> storeBuilder) {
         this(nodeName, processorParameters, storeBuilder, null);
     }
 
     public TableProcessorNode(final String nodeName,
                               final ProcessorParameters<K, V, ?, ?> processorParameters,
-                              final StoreBuilder<?> storeBuilder,
+                              final StoreFactory<?> storeBuilder,
                               final String[] storeNames) {
         super(nodeName);
         this.processorParameters = processorParameters;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNode.java
@@ -26,18 +26,18 @@ import org.apache.kafka.streams.processor.internals.StoreFactory;
 public class TableProcessorNode<K, V> extends GraphNode {
 
     private final ProcessorParameters<K, V, ?, ?> processorParameters;
-    private final StoreFactory<?> storeFactory;
+    private final StoreFactory storeFactory;
     private final String[] storeNames;
 
     public TableProcessorNode(final String nodeName,
                               final ProcessorParameters<K, V, ?, ?> processorParameters,
-                              final StoreFactory<?> storeFactory) {
+                              final StoreFactory storeFactory) {
         this(nodeName, processorParameters, storeFactory, null);
     }
 
     public TableProcessorNode(final String nodeName,
                               final ProcessorParameters<K, V, ?, ?> processorParameters,
-                              final StoreFactory<?> storeFactory,
+                              final StoreFactory storeFactory,
                               final String[] storeNames) {
         super(nodeName);
         this.processorParameters = processorParameters;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -93,12 +93,12 @@ public class TableSourceNode<K, V> extends SourceGraphNode<K, V> {
             throw new IllegalStateException("A table source node must have a single topic as input");
         }
 
-        final StoreFactory<?> storeBuilder =
-            new KeyValueStoreMaterializer<>((MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>>) materializedInternal).materialize();
+        final StoreFactory<?> storeFactory =
+            new KeyValueStoreMaterializer<>((MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>>) materializedInternal);
 
         if (isGlobalKTable) {
             topologyBuilder.addGlobalStore(
-                storeBuilder,
+                storeFactory,
                 sourceName,
                 consumedInternal().timestampExtractor(),
                 consumedInternal().keyDeserializer(),
@@ -120,11 +120,11 @@ public class TableSourceNode<K, V> extends SourceGraphNode<K, V> {
             // only add state store if the source KTable should be materialized
             final KTableSource<K, V> tableSource = (KTableSource<K, V>) processorParameters.processorSupplier();
             if (tableSource.materialized()) {
-                topologyBuilder.addStateStore(storeBuilder, nodeName());
+                topologyBuilder.addStateStore(storeFactory, nodeName());
 
                 if (shouldReuseSourceTopicForChangelog) {
-                    storeBuilder.withLoggingDisabled();
-                    topologyBuilder.connectSourceStoreAndTopic(storeBuilder.name(), topicName);
+                    storeFactory.withLoggingDisabled();
+                    topologyBuilder.connectSourceStoreAndTopic(storeFactory.name(), topicName);
                 }
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -93,7 +93,7 @@ public class TableSourceNode<K, V> extends SourceGraphNode<K, V> {
             throw new IllegalStateException("A table source node must have a single topic as input");
         }
 
-        final StoreFactory<?> storeFactory =
+        final StoreFactory storeFactory =
             new KeyValueStoreMaterializer<>((MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>>) materializedInternal);
 
         if (isGlobalKTable) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -25,8 +25,8 @@ import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
 import org.apache.kafka.streams.kstream.internals.KeyValueStoreMaterializer;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.StoreBuilder;
 
 import java.util.Collections;
 
@@ -93,7 +93,7 @@ public class TableSourceNode<K, V> extends SourceGraphNode<K, V> {
             throw new IllegalStateException("A table source node must have a single topic as input");
         }
 
-        final StoreBuilder<?> storeBuilder =
+        final StoreFactory<?> storeBuilder =
             new KeyValueStoreMaterializer<>((MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>>) materializedInternal).materialize();
 
         if (isGlobalKTable) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSuppressNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSuppressNode.java
@@ -21,7 +21,7 @@ import org.apache.kafka.streams.processor.internals.StoreFactory;
 public class TableSuppressNode<K, V> extends StatefulProcessorNode<K, V> {
     public TableSuppressNode(final String nodeName,
                              final ProcessorParameters<K, V, ?, ?> processorParameters,
-                             final StoreFactory<?> materializedKTableStoreBuilder) {
+                             final StoreFactory materializedKTableStoreBuilder) {
         super(nodeName, processorParameters, materializedKTableStoreBuilder);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSuppressNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSuppressNode.java
@@ -16,12 +16,12 @@
  */
 package org.apache.kafka.streams.kstream.internals.graph;
 
-import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 
 public class TableSuppressNode<K, V> extends StatefulProcessorNode<K, V> {
     public TableSuppressNode(final String nodeName,
                              final ProcessorParameters<K, V, ?, ?> processorParameters,
-                             final StoreBuilder<?> materializedKTableStoreBuilder) {
+                             final StoreFactory<?> materializedKTableStoreBuilder) {
         super(nodeName, processorParameters, materializedKTableStoreBuilder);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -16,30 +16,9 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.errors.TopologyException;
-import org.apache.kafka.streams.internals.ApiUtils;
-import org.apache.kafka.streams.processor.StateStore;
-import org.apache.kafka.streams.processor.StreamPartitioner;
-import org.apache.kafka.streams.processor.TimestampExtractor;
-import org.apache.kafka.streams.processor.TopicNameExtractor;
-import org.apache.kafka.streams.processor.api.FixedKeyProcessorSupplier;
-import org.apache.kafka.streams.processor.api.ProcessorSupplier;
-import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
-import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopology;
-import org.apache.kafka.streams.TopologyConfig;
-import org.apache.kafka.streams.state.StoreBuilder;
-import org.apache.kafka.streams.state.internals.SessionStoreBuilder;
-import org.apache.kafka.streams.state.internals.TimestampedWindowStoreBuilder;
-import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilder;
-import org.apache.kafka.streams.state.internals.WindowStoreBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.apache.kafka.clients.consumer.OffsetResetStrategy.EARLIEST;
+import static org.apache.kafka.clients.consumer.OffsetResetStrategy.LATEST;
+import static org.apache.kafka.clients.consumer.OffsetResetStrategy.NONE;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -60,10 +39,26 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import static org.apache.kafka.clients.consumer.OffsetResetStrategy.EARLIEST;
-import static org.apache.kafka.clients.consumer.OffsetResetStrategy.LATEST;
-import static org.apache.kafka.clients.consumer.OffsetResetStrategy.NONE;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyConfig;
+import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.internals.ApiUtils;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.processor.TimestampExtractor;
+import org.apache.kafka.streams.processor.TopicNameExtractor;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessorSupplier;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopology;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class InternalTopologyBuilder {
 
@@ -82,9 +77,9 @@ public class InternalTopologyBuilder {
     // node factories in a topological order
     private final Map<String, NodeFactory<?, ?, ?, ?>> nodeFactories = new LinkedHashMap<>();
 
-    private final Map<String, StateStoreFactory<?>> stateFactories = new HashMap<>();
+    private final Map<String, StoreFactory<?>> stateFactories = new HashMap<>();
 
-    private final Map<String, StoreBuilder<?>> globalStateBuilders = new LinkedHashMap<>();
+    private final Map<String, StoreFactory<?>> globalStateBuilders = new LinkedHashMap<>();
 
     // built global state stores
     private final Map<String, StateStore> globalStateStores = new LinkedHashMap<>();
@@ -157,68 +152,6 @@ public class InternalTopologyBuilder {
     private TopologyConfig topologyConfigs;  // the configs for this topology, including overrides and global defaults
 
     private boolean hasPersistentStores = false;
-
-    public static class StateStoreFactory<S extends StateStore> {
-        private final StoreBuilder<S> builder;
-        private final Set<String> users = new HashSet<>();
-
-        private StateStoreFactory(final StoreBuilder<S> builder) {
-            this.builder = builder;
-        }
-
-        public S build() {
-            return builder.build();
-        }
-
-        long retentionPeriod() {
-            if (builder instanceof WindowStoreBuilder) {
-                return ((WindowStoreBuilder<?, ?>) builder).retentionPeriod();
-            } else if (builder instanceof TimestampedWindowStoreBuilder) {
-                return ((TimestampedWindowStoreBuilder<?, ?>) builder).retentionPeriod();
-            } else if (builder instanceof SessionStoreBuilder) {
-                return ((SessionStoreBuilder<?, ?>) builder).retentionPeriod();
-            } else {
-                throw new IllegalStateException("retentionPeriod is not supported when not a window store");
-            }
-        }
-
-        private long historyRetention() {
-            if (builder instanceof VersionedKeyValueStoreBuilder) {
-                return ((VersionedKeyValueStoreBuilder<?, ?>) builder).historyRetention();
-            } else {
-                throw new IllegalStateException("historyRetention is not supported when not a versioned store");
-            }
-        }
-
-        private Set<String> users() {
-            return users;
-        }
-
-        public boolean loggingEnabled() {
-            return builder.loggingEnabled();
-        }
-
-        private String name() {
-            return builder.name();
-        }
-
-        private boolean isWindowStore() {
-            return builder instanceof WindowStoreBuilder
-                || builder instanceof TimestampedWindowStoreBuilder
-                || builder instanceof SessionStoreBuilder;
-        }
-
-        private boolean isVersionedStore() {
-            return builder instanceof VersionedKeyValueStoreBuilder;
-        }
-
-        // Apparently Java strips the generics from this method because we're using the raw type for builder,
-        // even though this method doesn't use builder's (missing) type parameter. Our usage seems obviously
-        // correct, though, hence the suppression.
-        private Map<String, String> logConfig() {
-            return builder.logConfig();
-        }
-    }
 
     private static abstract class NodeFactory<KIn, VIn, KOut, VOut> {
         final String name;
@@ -425,17 +358,18 @@ public class InternalTopologyBuilder {
 
         // maybe strip out caching layers
         if (topologyConfigs.cacheSize == 0L) {
-            for (final StateStoreFactory<?> storeFactory : stateFactories.values()) {
-                storeFactory.builder.withCachingDisabled();
+            for (final StoreFactory<?> storeFactory : stateFactories.values()) {
+                storeFactory.withCachingDisabled();
             }
 
-            for (final StoreBuilder<?> storeBuilder : globalStateBuilders.values()) {
+            for (final StoreFactory<?> storeBuilder : globalStateBuilders.values()) {
                 storeBuilder.withCachingDisabled();
             }
         }
 
         // build global state stores
-        for (final StoreBuilder<?> storeBuilder : globalStateBuilders.values()) {
+        for (final StoreFactory<?> storeBuilder : globalStateBuilders.values()) {
+            storeBuilder.configure(config);
             globalStateStores.put(storeBuilder.name(), storeBuilder.build());
         }
 
@@ -611,33 +545,38 @@ public class InternalTopologyBuilder {
 
     public final void addStateStore(final StoreBuilder<?> storeBuilder,
                                     final String... processorNames) {
+        addStateStore(new StoreBuilderWrapper<>(storeBuilder), false, processorNames);
+    }
+
+    public final void addStateStore(final StoreFactory<?> storeBuilder,
+                                    final String... processorNames) {
         addStateStore(storeBuilder, false, processorNames);
     }
 
-    public final void addStateStore(final StoreBuilder<?> storeBuilder,
+    public final void addStateStore(final StoreFactory<?> storeFactory,
                                     final boolean allowOverride,
                                     final String... processorNames) {
-        Objects.requireNonNull(storeBuilder, "storeBuilder can't be null");
-        final StateStoreFactory<?> stateFactory = stateFactories.get(storeBuilder.name());
-        if (!allowOverride && stateFactory != null && !stateFactory.builder.equals(storeBuilder)) {
-            throw new TopologyException("A different StateStore has already been added with the name " + storeBuilder.name());
+        Objects.requireNonNull(storeFactory, "stateStoreFactory can't be null");
+        final StoreFactory<?> stateFactory = stateFactories.get(storeFactory.name());
+        if (!allowOverride && stateFactory != null && !stateFactory.isCompatibleWith(storeFactory)) {
+            throw new TopologyException("A different StateStore has already been added with the name " + storeFactory.name());
         }
-        if (globalStateBuilders.containsKey(storeBuilder.name())) {
-            throw new TopologyException("A different GlobalStateStore has already been added with the name " + storeBuilder.name());
+        if (globalStateBuilders.containsKey(storeFactory.name())) {
+            throw new TopologyException("A different GlobalStateStore has already been added with the name " + storeFactory.name());
         }
 
-        stateFactories.put(storeBuilder.name(), new StateStoreFactory<>(storeBuilder));
+        stateFactories.put(storeFactory.name(), storeFactory);
 
         if (processorNames != null) {
             for (final String processorName : processorNames) {
                 Objects.requireNonNull(processorName, "processor name must not be null");
-                connectProcessorAndStateStore(processorName, storeBuilder.name());
+                connectProcessorAndStateStore(processorName, storeFactory.name());
             }
         }
         nodeGroups = null;
     }
 
-    public final <KIn, VIn> void addGlobalStore(final StoreBuilder<?> storeBuilder,
+    public final <KIn, VIn> void addGlobalStore(final StoreFactory<?> storeBuilder,
                                                 final String sourceName,
                                                 final TimestampExtractor timestampExtractor,
                                                 final Deserializer<KIn> keyDeserializer,
@@ -832,13 +771,13 @@ public class InternalTopologyBuilder {
             throw new TopologyException("Processor " + processorName + " is not added yet.");
         }
 
-        final StateStoreFactory<?> stateStoreFactory = stateFactories.get(stateStoreName);
-        final Iterator<String> iter = stateStoreFactory.users().iterator();
+        final StoreFactory<?> storeFactory = stateFactories.get(stateStoreName);
+        final Iterator<String> iter = storeFactory.users().iterator();
         if (iter.hasNext()) {
             final String user = iter.next();
             nodeGrouper.unite(user, processorName);
         }
-        stateStoreFactory.users().add(processorName);
+        storeFactory.users().add(processorName);
 
         final NodeFactory<?, ?, ?, ?> nodeFactory = nodeFactories.get(processorName);
         if (nodeFactory instanceof ProcessorNodeFactory) {
@@ -1128,10 +1067,10 @@ public class InternalTopologyBuilder {
             if (!stateStoreMap.containsKey(stateStoreName)) {
                 final StateStore store;
                 if (stateFactories.containsKey(stateStoreName)) {
-                    final StateStoreFactory<?> stateStoreFactory = stateFactories.get(stateStoreName);
+                    final StoreFactory<?> storeFactory = stateFactories.get(stateStoreName);
 
                     // remember the changelog topic if this state store is change-logging enabled
-                    if (stateStoreFactory.loggingEnabled() && !storeToChangelogTopic.containsKey(stateStoreName)) {
+                    if (storeFactory.loggingEnabled() && !storeToChangelogTopic.containsKey(stateStoreName)) {
                         final String prefix = topologyConfigs == null ?
                                 applicationId :
                                 ProcessorContextUtils.getPrefix(topologyConfigs.applicationConfigs.originals(), applicationId);
@@ -1140,7 +1079,8 @@ public class InternalTopologyBuilder {
                         storeToChangelogTopic.put(stateStoreName, changelogTopic);
                         changelogTopicToStore.put(changelogTopic, stateStoreName);
                     }
-                    store = stateStoreFactory.build();
+                    storeFactory.configure(topologyConfigs.applicationConfigs);
+                    store = storeFactory.build();
                     stateStoreMap.put(stateStoreName, store);
                 } else {
                     store = globalStateStores.get(stateStoreName);
@@ -1239,7 +1179,7 @@ public class InternalTopologyBuilder {
 
                 // if the node is connected to a state store whose changelog topics are not predefined,
                 // add to the changelog topics
-                for (final StateStoreFactory<?> stateFactory : stateFactories.values()) {
+                for (final StoreFactory<?> stateFactory : stateFactories.values()) {
                     if (stateFactory.users().contains(node) && storeToChangelogTopic.containsKey(stateFactory.name())) {
                         final String topicName = storeToChangelogTopic.get(stateFactory.name());
                         if (!stateChangelogTopics.containsKey(topicName)) {
@@ -1313,7 +1253,7 @@ public class InternalTopologyBuilder {
         }
     }
 
-    private <S extends StateStore> InternalTopicConfig createChangelogTopicConfig(final StateStoreFactory<S> factory,
+    private <S extends StateStore> InternalTopicConfig createChangelogTopicConfig(final StoreFactory<S> factory,
                                                                                   final String name) {
         if (factory.isVersionedStore()) {
             final VersionedChangelogTopicConfig config = new VersionedChangelogTopicConfig(name, factory.logConfig(), factory.historyRetention());
@@ -2218,7 +2158,7 @@ public class InternalTopologyBuilder {
         return topologyName != null;
     }
 
-    public synchronized Map<String, StateStoreFactory<?>> stateStores() {
+    public synchronized Map<String, StoreFactory<?>> stateStores() {
         return stateFactories;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreBuilderWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreBuilderWrapper.java
@@ -29,7 +29,7 @@ import org.apache.kafka.streams.state.internals.WindowStoreBuilder;
 public class StoreBuilderWrapper<S extends StateStore> implements StoreFactory<S> {
 
     private final StoreBuilder<S> builder;
-    private final Set<String> users = new HashSet<>();
+    private final Set<String> connectedProcessorNames = new HashSet<>();
 
     public StoreBuilderWrapper(final StoreBuilder<S> builder) {
         this.builder = builder;
@@ -65,8 +65,8 @@ public class StoreBuilderWrapper<S extends StateStore> implements StoreFactory<S
     }
 
     @Override
-    public Set<String> users() {
-        return users;
+    public Set<String> connectedProcessorNames() {
+        return connectedProcessorNames;
     }
 
     @Override
@@ -91,9 +91,6 @@ public class StoreBuilderWrapper<S extends StateStore> implements StoreFactory<S
         return builder instanceof VersionedKeyValueStoreBuilder;
     }
 
-    // Apparently Java strips the generics from this method because we're using the raw type for builder,
-    // even though this method doesn't use builder's (missing) type parameter. Our usage seems obviously
-    // correct, though, hence the suppression.
     @Override
     public Map<String, String> logConfig() {
         return builder.logConfig();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreBuilderWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreBuilderWrapper.java
@@ -26,17 +26,17 @@ import org.apache.kafka.streams.state.internals.TimestampedWindowStoreBuilder;
 import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilder;
 import org.apache.kafka.streams.state.internals.WindowStoreBuilder;
 
-public class StoreBuilderWrapper<S extends StateStore> implements StoreFactory<S> {
+public class StoreBuilderWrapper implements StoreFactory {
 
-    private final StoreBuilder<S> builder;
+    private final StoreBuilder<?> builder;
     private final Set<String> connectedProcessorNames = new HashSet<>();
 
-    public StoreBuilderWrapper(final StoreBuilder<S> builder) {
+    public StoreBuilderWrapper(final StoreBuilder<?> builder) {
         this.builder = builder;
     }
 
     @Override
-    public S build() {
+    public StateStore build() {
         return builder.build();
     }
 
@@ -97,20 +97,20 @@ public class StoreBuilderWrapper<S extends StateStore> implements StoreFactory<S
     }
 
     @Override
-    public StoreFactory<S> withCachingDisabled() {
+    public StoreFactory withCachingDisabled() {
         builder.withCachingDisabled();
         return this;
     }
 
     @Override
-    public StoreFactory<S> withLoggingDisabled() {
+    public StoreFactory withLoggingDisabled() {
         builder.withLoggingDisabled();
         return this;
     }
 
     @Override
-    public boolean isCompatibleWith(final StoreFactory<?> storeFactory) {
+    public boolean isCompatibleWith(final StoreFactory storeFactory) {
         return storeFactory instanceof StoreBuilderWrapper
-                && builder.equals(((StoreBuilderWrapper<?>) storeFactory).builder);
+                && builder.equals(((StoreBuilderWrapper) storeFactory).builder);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreBuilderWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreBuilderWrapper.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.internals.SessionStoreBuilder;
+import org.apache.kafka.streams.state.internals.TimestampedWindowStoreBuilder;
+import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.WindowStoreBuilder;
+
+public class StoreBuilderWrapper<S extends StateStore> implements StoreFactory<S> {
+
+    private final StoreBuilder<S> builder;
+    private final Set<String> users = new HashSet<>();
+
+    public StoreBuilderWrapper(final StoreBuilder<S> builder) {
+        this.builder = builder;
+    }
+
+    @Override
+    public S build() {
+        return builder.build();
+    }
+
+    @Override
+    public long retentionPeriod() {
+        if (builder instanceof WindowStoreBuilder) {
+            return ((WindowStoreBuilder<?, ?>) builder).retentionPeriod();
+        } else if (builder instanceof TimestampedWindowStoreBuilder) {
+            return ((TimestampedWindowStoreBuilder<?, ?>) builder).retentionPeriod();
+        } else if (builder instanceof SessionStoreBuilder) {
+            return ((SessionStoreBuilder<?, ?>) builder).retentionPeriod();
+        } else {
+            throw new IllegalStateException(
+                    "retentionPeriod is not supported when not a window store");
+        }
+    }
+
+    @Override
+    public long historyRetention() {
+        if (builder instanceof VersionedKeyValueStoreBuilder) {
+            return ((VersionedKeyValueStoreBuilder<?, ?>) builder).historyRetention();
+        } else {
+            throw new IllegalStateException(
+                    "historyRetention is not supported when not a versioned store");
+        }
+    }
+
+    @Override
+    public Set<String> users() {
+        return users;
+    }
+
+    @Override
+    public boolean loggingEnabled() {
+        return builder.loggingEnabled();
+    }
+
+    @Override
+    public String name() {
+        return builder.name();
+    }
+
+    @Override
+    public boolean isWindowStore() {
+        return builder instanceof WindowStoreBuilder
+                || builder instanceof TimestampedWindowStoreBuilder
+                || builder instanceof SessionStoreBuilder;
+    }
+
+    @Override
+    public boolean isVersionedStore() {
+        return builder instanceof VersionedKeyValueStoreBuilder;
+    }
+
+    // Apparently Java strips the generics from this method because we're using the raw type for builder,
+    // even though this method doesn't use builder's (missing) type parameter. Our usage seems obviously
+    // correct, though, hence the suppression.
+    @Override
+    public Map<String, String> logConfig() {
+        return builder.logConfig();
+    }
+
+    @Override
+    public StoreFactory<S> withCachingDisabled() {
+        builder.withCachingDisabled();
+        return this;
+    }
+
+    @Override
+    public StoreFactory<S> withLoggingDisabled() {
+        builder.withLoggingDisabled();
+        return this;
+    }
+
+    @Override
+    public boolean isCompatibleWith(final StoreFactory<?> storeFactory) {
+        return storeFactory instanceof StoreBuilderWrapper
+                && builder.equals(((StoreBuilderWrapper<?>) storeFactory).builder);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreBuilderWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreBuilderWrapper.java
@@ -26,6 +26,12 @@ import org.apache.kafka.streams.state.internals.TimestampedWindowStoreBuilder;
 import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilder;
 import org.apache.kafka.streams.state.internals.WindowStoreBuilder;
 
+/**
+ * An implementation of {@link StoreFactory} which wraps an instantiated
+ * {@link StoreBuilder}. This should be used in situations where the user
+ * directly builds and supplies the topology with a {@code StoreBuilder}
+ * instead of providing a {@link org.apache.kafka.streams.state.StoreSupplier}.
+ */
 public class StoreBuilderWrapper implements StoreFactory {
 
     private final StoreBuilder<?> builder;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
@@ -33,8 +33,7 @@ import org.apache.kafka.streams.processor.StateStore;
  *
  *     <li>{@link org.apache.kafka.streams.state.StoreSupplier} is used by the
  *     DSL to provide preconfigured state stores as well as type-safe stores
- *     (e.g. {@link org.apache.kafka.streams.state.KeyValueBytesStoreSupplier}.
- *     Before passing the {@code StoreSupplier} into the </li>
+ *     (e.g. {@link org.apache.kafka.streams.state.KeyValueBytesStoreSupplier}.</li>
  *
  *     <li>{@link StoreFactory} (this class) is internal and not exposed to
  *     the users. It allows the above store specifications to be wrapped in

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
@@ -45,13 +45,13 @@ import org.apache.kafka.streams.processor.StateStore;
  *     to {@link org.apache.kafka.streams.StreamsBuilder#StreamsBuilder(TopologyConfig)}</li>
  * </ul>
  */
-public interface StoreFactory<S extends StateStore> {
+public interface StoreFactory {
 
     default void configure(final StreamsConfig config) {
         // do nothing
     }
 
-    S build();
+    StateStore build();
 
     long retentionPeriod();
 
@@ -69,10 +69,10 @@ public interface StoreFactory<S extends StateStore> {
 
     Map<String, String> logConfig();
 
-    StoreFactory<?> withCachingDisabled();
+    StoreFactory withCachingDisabled();
 
-    StoreFactory<?> withLoggingDisabled();
+    StoreFactory withLoggingDisabled();
 
-    boolean isCompatibleWith(StoreFactory<?> storeFactory);
+    boolean isCompatibleWith(StoreFactory storeFactory);
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyConfig;
+import org.apache.kafka.streams.processor.StateStore;
+
+/**
+ * What! Another mechanism for obtaining a {@link StateStore}? This isn't just
+ * an abuse of Java-isms... there's good reason for it. Here's how they are
+ * interconnected:
+ *
+ * <ul>
+ *     <li>{@link org.apache.kafka.streams.state.StoreBuilder} is the innermost
+ *     layer to provide state stores and is used directly by the PAPI.</li>
+ *
+ *     <li>{@link org.apache.kafka.streams.state.StoreSupplier} is used by the
+ *     DSL to provide preconfigured state stores as well as type-safe stores
+ *     (e.g. {@link org.apache.kafka.streams.state.KeyValueBytesStoreSupplier}.
+ *     Before passing the {@code StoreSupplier} into the </li>
+ *
+ *     <li>{@link StoreFactory} (this class) is internal and not exposed to
+ *     the users. It allows the above store specifications to be wrapped in
+ *     an internal interface that can then be configured <i>after</i> the
+ *     creation of the Topology but before the stores themselves are created.
+ *     This allows Kafka Streams to respect configurations such as
+ *     {@link StreamsConfig#DEFAULT_DSL_STORE_CONFIG} even if it isn't passed
+ *     to {@link org.apache.kafka.streams.StreamsBuilder#StreamsBuilder(TopologyConfig)}</li>
+ * </ul>
+ */
+public interface StoreFactory<S extends StateStore> {
+
+    default void configure(final StreamsConfig config) {
+        // do nothing
+    }
+
+    S build();
+
+    long retentionPeriod();
+
+    long historyRetention();
+
+    Set<String> users();
+
+    boolean loggingEnabled();
+
+    String name();
+
+    boolean isWindowStore();
+
+    boolean isVersionedStore();
+
+    Map<String, String> logConfig();
+
+    StoreFactory<?> withCachingDisabled();
+
+    StoreFactory<?> withLoggingDisabled();
+
+    boolean isCompatibleWith(StoreFactory<?> storeFactory);
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreFactory.java
@@ -57,7 +57,7 @@ public interface StoreFactory<S extends StateStore> {
 
     long historyRetention();
 
-    Set<String> users();
+    Set<String> connectedProcessorNames();
 
     boolean loggingEnabled();
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/GraphGraceSearchUtilTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/GraphGraceSearchUtilTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.streams.kstream.internals.KStreamWindowAggregate;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.junit.Test;
 
@@ -59,7 +60,7 @@ public class GraphGraceSearchUtilTest {
                 },
                 "dummy"
             ),
-            (StoreBuilder<?>) null
+            (StoreFactory<?>) null
         );
 
         final ProcessorGraphNode<String, Long> node = new ProcessorGraphNode<>("stateless", null);
@@ -88,7 +89,7 @@ public class GraphGraceSearchUtilTest {
                 ),
                 "asdf"
             ),
-            (StoreBuilder<?>) null
+            (StoreFactory<?>) null
         );
 
         final long extracted = GraphGraceSearchUtil.findAndVerifyWindowGrace(node);
@@ -112,7 +113,7 @@ public class GraphGraceSearchUtilTest {
                 ),
                 "asdf"
             ),
-            (StoreBuilder<?>) null
+            (StoreFactory<?>) null
         );
 
         final long extracted = GraphGraceSearchUtil.findAndVerifyWindowGrace(node);
@@ -127,7 +128,7 @@ public class GraphGraceSearchUtilTest {
             new ProcessorParameters<>(new KStreamSessionWindowAggregate<String, Long, Integer>(
                 windows, "asdf", EmitStrategy.onWindowUpdate(), null, null, null
             ), "asdf"),
-            (StoreBuilder<?>) null
+            (StoreFactory<?>) null
         );
 
         final StatefulProcessorNode<String, Long> statefulParent = new StatefulProcessorNode<>(
@@ -141,7 +142,7 @@ public class GraphGraceSearchUtilTest {
                 },
                 "dummy"
             ),
-            (StoreBuilder<?>) null
+            (StoreFactory<?>) null
         );
         graceGrandparent.addChild(statefulParent);
 
@@ -168,7 +169,7 @@ public class GraphGraceSearchUtilTest {
                 ),
                 "asdf"
             ),
-            (StoreBuilder<?>) null
+            (StoreFactory<?>) null
         );
 
         final ProcessorGraphNode<String, Long> statelessParent = new ProcessorGraphNode<>("stateless", null);
@@ -196,7 +197,7 @@ public class GraphGraceSearchUtilTest {
                 ),
                 "asdf"
             ),
-            (StoreBuilder<?>) null
+            (StoreFactory<?>) null
         );
 
         final StatefulProcessorNode<String, Long> rightParent = new StatefulProcessorNode<>(
@@ -211,7 +212,7 @@ public class GraphGraceSearchUtilTest {
                 ),
                 "asdf"
             ),
-            (StoreBuilder<?>) null
+            (StoreFactory<?>) null
         );
 
         final ProcessorGraphNode<String, Long> node = new ProcessorGraphNode<>("stateless", null);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/GraphGraceSearchUtilTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/GraphGraceSearchUtilTest.java
@@ -59,7 +59,7 @@ public class GraphGraceSearchUtilTest {
                 },
                 "dummy"
             ),
-            (StoreFactory<?>) null
+            (StoreFactory) null
         );
 
         final ProcessorGraphNode<String, Long> node = new ProcessorGraphNode<>("stateless", null);
@@ -88,7 +88,7 @@ public class GraphGraceSearchUtilTest {
                 ),
                 "asdf"
             ),
-            (StoreFactory<?>) null
+            (StoreFactory) null
         );
 
         final long extracted = GraphGraceSearchUtil.findAndVerifyWindowGrace(node);
@@ -112,7 +112,7 @@ public class GraphGraceSearchUtilTest {
                 ),
                 "asdf"
             ),
-            (StoreFactory<?>) null
+            (StoreFactory) null
         );
 
         final long extracted = GraphGraceSearchUtil.findAndVerifyWindowGrace(node);
@@ -127,7 +127,7 @@ public class GraphGraceSearchUtilTest {
             new ProcessorParameters<>(new KStreamSessionWindowAggregate<String, Long, Integer>(
                 windows, "asdf", EmitStrategy.onWindowUpdate(), null, null, null
             ), "asdf"),
-            (StoreFactory<?>) null
+            (StoreFactory) null
         );
 
         final StatefulProcessorNode<String, Long> statefulParent = new StatefulProcessorNode<>(
@@ -141,7 +141,7 @@ public class GraphGraceSearchUtilTest {
                 },
                 "dummy"
             ),
-            (StoreFactory<?>) null
+            (StoreFactory) null
         );
         graceGrandparent.addChild(statefulParent);
 
@@ -168,7 +168,7 @@ public class GraphGraceSearchUtilTest {
                 ),
                 "asdf"
             ),
-            (StoreFactory<?>) null
+            (StoreFactory) null
         );
 
         final ProcessorGraphNode<String, Long> statelessParent = new ProcessorGraphNode<>("stateless", null);
@@ -196,7 +196,7 @@ public class GraphGraceSearchUtilTest {
                 ),
                 "asdf"
             ),
-            (StoreFactory<?>) null
+            (StoreFactory) null
         );
 
         final StatefulProcessorNode<String, Long> rightParent = new StatefulProcessorNode<>(
@@ -211,7 +211,7 @@ public class GraphGraceSearchUtilTest {
                 ),
                 "asdf"
             ),
-            (StoreFactory<?>) null
+            (StoreFactory) null
         );
 
         final ProcessorGraphNode<String, Long> node = new ProcessorGraphNode<>("stateless", null);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/GraphGraceSearchUtilTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/GraphGraceSearchUtilTest.java
@@ -26,7 +26,6 @@ import org.apache.kafka.streams.kstream.internals.TimeWindow;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.StoreFactory;
-import org.apache.kafka.streams.state.StoreBuilder;
 import org.junit.Test;
 
 import static java.time.Duration.ofMillis;

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNodeTest.java
@@ -42,7 +42,7 @@ public class TableProcessorNodeTest {
         );
 
         final String asString = node.toString();
-        final String expected = "storeBuilder=null";
+        final String expected = "storeFactory=null";
         assertTrue(
             String.format(
                 "Expected toString to return string with \"%s\", received: %s",

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -100,7 +100,7 @@ public class GlobalStreamThreadTest {
             };
 
         builder.addGlobalStore(
-            new KeyValueStoreMaterializer<>(materialized).materialize().withLoggingDisabled(),
+            new KeyValueStoreMaterializer<>(materialized),
             "sourceName",
             null,
             null,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -100,7 +100,7 @@ public class GlobalStreamThreadTest {
             };
 
         builder.addGlobalStore(
-            new KeyValueStoreMaterializer<>(materialized),
+            new KeyValueStoreMaterializer<>(materialized).withLoggingDisabled(),
             "sourceName",
             null,
             null,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -83,7 +83,7 @@ public class InternalTopologyBuilderTest {
 
     private final Serde<String> stringSerde = Serdes.String();
     private final InternalTopologyBuilder builder = new InternalTopologyBuilder();
-    private final StoreBuilder<?> storeBuilder = new MockKeyValueStoreBuilder("testStore", false);
+    private final StoreFactory<KeyValueStore<Object, Object>> storeBuilder = new MockKeyValueStoreBuilder("testStore", false).asFactory();
 
     @Test
     public void shouldAddSourceWithOffsetReset() {
@@ -213,7 +213,7 @@ public class InternalTopologyBuilderTest {
         final IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
             () -> builder.addGlobalStore(
-                        new MockKeyValueStoreBuilder("global-store", false).withLoggingDisabled(),
+                        new MockKeyValueStoreBuilder("global-store", false).asFactory().withLoggingDisabled(),
                         "globalSource",
                         null,
                         null,
@@ -321,7 +321,7 @@ public class InternalTopologyBuilderTest {
         builder.addSource(null, "source-1", null, null, null, Pattern.compile("topic-1"));
         builder.addSource(null, "source-2", null, null, null, Pattern.compile("topic-2"));
         builder.addGlobalStore(
-            new MockKeyValueStoreBuilder("global-store", false).withLoggingDisabled(),
+            new MockKeyValueStoreBuilder("global-store", false).asFactory().withLoggingDisabled(),
             "globalSource",
             null,
             null,
@@ -345,7 +345,7 @@ public class InternalTopologyBuilderTest {
         builder.addSource(null, "source-1", null, null, null, "topic-1");
         builder.addSource(null, "source-2", null, null, null, "topic-2");
         builder.addGlobalStore(
-            new MockKeyValueStoreBuilder("global-store", false).withLoggingDisabled(),
+            new MockKeyValueStoreBuilder("global-store", false).asFactory().withLoggingDisabled(),
             "globalSource",
             null,
             null,
@@ -453,8 +453,8 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void shouldNotAllowToAddStoresWithSameNameWhenFirstStoreIsGlobal() {
-        final StoreBuilder<KeyValueStore<Object, Object>> globalBuilder =
-            new MockKeyValueStoreBuilder("testStore", false).withLoggingDisabled();
+        final StoreFactory<?> globalBuilder =
+            new MockKeyValueStoreBuilder("testStore", false).asFactory().withLoggingDisabled();
 
         builder.addGlobalStore(
             globalBuilder,
@@ -480,8 +480,8 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void shouldNotAllowToAddStoresWithSameNameWhenSecondStoreIsGlobal() {
-        final StoreBuilder<KeyValueStore<Object, Object>> globalBuilder =
-            new MockKeyValueStoreBuilder("testStore", false).withLoggingDisabled();
+        final StoreFactory<?> globalBuilder =
+            new MockKeyValueStoreBuilder("testStore", false).asFactory().withLoggingDisabled();
 
         builder.addStateStore(storeBuilder);
 
@@ -507,10 +507,10 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void shouldNotAllowToAddGlobalStoresWithSameName() {
-        final StoreBuilder<KeyValueStore<Object, Object>> firstGlobalBuilder =
-            new MockKeyValueStoreBuilder("testStore", false).withLoggingDisabled();
-        final StoreBuilder<KeyValueStore<Object, Object>> secondGlobalBuilder =
-            new MockKeyValueStoreBuilder("testStore", false).withLoggingDisabled();
+        final StoreFactory<?> firstGlobalBuilder =
+            new MockKeyValueStoreBuilder("testStore", false).asFactory().withLoggingDisabled();
+        final StoreFactory<?> secondGlobalBuilder =
+            new MockKeyValueStoreBuilder("testStore", false).asFactory().withLoggingDisabled();
 
         builder.addGlobalStore(
             firstGlobalBuilder,
@@ -721,7 +721,7 @@ public class InternalTopologyBuilderTest {
 
         oldNodeGroups = newNodeGroups;
         builder.addGlobalStore(
-            new MockKeyValueStoreBuilder("global-store", false).withLoggingDisabled(),
+            new MockKeyValueStoreBuilder("global-store", false).asFactory().withLoggingDisabled(),
             "globalSource",
             null,
             null,
@@ -820,7 +820,7 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void shouldNotAddNullStateStoreSupplier() {
-        assertThrows(NullPointerException.class, () -> builder.addStateStore(null));
+        assertThrows(NullPointerException.class, () -> builder.addStateStore((StoreBuilder<?>) null));
     }
 
     private Set<String> nodeNames(final Collection<ProcessorNode<?, ?, ?, ?>> nodes) {
@@ -1288,7 +1288,7 @@ public class InternalTopologyBuilderTest {
         final String globalTopic = "global-topic";
         builder.setApplicationId("X");
         builder.addGlobalStore(
-            new MockKeyValueStoreBuilder(globalStoreName, false).withLoggingDisabled(),
+            new MockKeyValueStoreBuilder(globalStoreName, false).asFactory().withLoggingDisabled(),
             "globalSource",
             null,
             null,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -83,7 +83,7 @@ public class InternalTopologyBuilderTest {
 
     private final Serde<String> stringSerde = Serdes.String();
     private final InternalTopologyBuilder builder = new InternalTopologyBuilder();
-    private final StoreFactory<KeyValueStore<Object, Object>> storeBuilder = new MockKeyValueStoreBuilder("testStore", false).asFactory();
+    private final StoreFactory storeBuilder = new MockKeyValueStoreBuilder("testStore", false).asFactory();
 
     @Test
     public void shouldAddSourceWithOffsetReset() {
@@ -453,7 +453,7 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void shouldNotAllowToAddStoresWithSameNameWhenFirstStoreIsGlobal() {
-        final StoreFactory<?> globalBuilder =
+        final StoreFactory globalBuilder =
             new MockKeyValueStoreBuilder("testStore", false).asFactory().withLoggingDisabled();
 
         builder.addGlobalStore(
@@ -480,7 +480,7 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void shouldNotAllowToAddStoresWithSameNameWhenSecondStoreIsGlobal() {
-        final StoreFactory<?> globalBuilder =
+        final StoreFactory globalBuilder =
             new MockKeyValueStoreBuilder("testStore", false).asFactory().withLoggingDisabled();
 
         builder.addStateStore(storeBuilder);
@@ -507,9 +507,9 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void shouldNotAllowToAddGlobalStoresWithSameName() {
-        final StoreFactory<?> firstGlobalBuilder =
+        final StoreFactory firstGlobalBuilder =
             new MockKeyValueStoreBuilder("testStore", false).asFactory().withLoggingDisabled();
-        final StoreFactory<?> secondGlobalBuilder =
+        final StoreFactory secondGlobalBuilder =
             new MockKeyValueStoreBuilder("testStore", false).asFactory().withLoggingDisabled();
 
         builder.addGlobalStore(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/KeyValueStoreMaterializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/KeyValueStoreMaterializerTest.java
@@ -231,7 +231,7 @@ public class KeyValueStoreMaterializerTest {
     private static TimestampedKeyValueStore<String, String> getTimestampedStore(
         final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materialized) {
         final KeyValueStoreMaterializer<String, String> materializer = new KeyValueStoreMaterializer<>(materialized);
-        final StoreBuilder<?> builder = materializer.materialize();
+        final StoreFactory<?> builder = materializer.materialize();
         return (TimestampedKeyValueStore<String, String>) builder.build();
     }
 
@@ -239,7 +239,7 @@ public class KeyValueStoreMaterializerTest {
     private static VersionedKeyValueStore<String, String> getVersionedStore(
         final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materialized) {
         final KeyValueStoreMaterializer<String, String> materializer = new KeyValueStoreMaterializer<>(materialized);
-        final StoreBuilder<?> builder = materializer.materialize();
+        final StoreFactory<?> builder = materializer.materialize();
         return (VersionedKeyValueStore<String, String>) builder.build();
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/KeyValueStoreMaterializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/KeyValueStoreMaterializerTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.streams.kstream.internals.KeyValueStoreMaterializer;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.VersionedBytesStore;
 import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
@@ -231,15 +230,13 @@ public class KeyValueStoreMaterializerTest {
     private static TimestampedKeyValueStore<String, String> getTimestampedStore(
         final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materialized) {
         final KeyValueStoreMaterializer<String, String> materializer = new KeyValueStoreMaterializer<>(materialized);
-        final StoreFactory<?> builder = materializer.materialize();
-        return (TimestampedKeyValueStore<String, String>) builder.build();
+        return (TimestampedKeyValueStore<String, String>) ((StoreFactory<?>) materializer).build();
     }
 
     @SuppressWarnings("unchecked")
     private static VersionedKeyValueStore<String, String> getVersionedStore(
         final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materialized) {
         final KeyValueStoreMaterializer<String, String> materializer = new KeyValueStoreMaterializer<>(materialized);
-        final StoreFactory<?> builder = materializer.materialize();
-        return (VersionedKeyValueStore<String, String>) builder.build();
+        return (VersionedKeyValueStore<String, String>) ((StoreFactory<?>) materializer).build();
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/KeyValueStoreMaterializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/KeyValueStoreMaterializerTest.java
@@ -230,13 +230,13 @@ public class KeyValueStoreMaterializerTest {
     private static TimestampedKeyValueStore<String, String> getTimestampedStore(
         final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materialized) {
         final KeyValueStoreMaterializer<String, String> materializer = new KeyValueStoreMaterializer<>(materialized);
-        return (TimestampedKeyValueStore<String, String>) ((StoreFactory<?>) materializer).build();
+        return (TimestampedKeyValueStore<String, String>) ((StoreFactory) materializer).build();
     }
 
     @SuppressWarnings("unchecked")
     private static VersionedKeyValueStore<String, String> getVersionedStore(
         final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materialized) {
         final KeyValueStoreMaterializer<String, String> materializer = new KeyValueStoreMaterializer<>(materialized);
-        return (VersionedKeyValueStore<String, String>) ((StoreFactory<?>) materializer).build();
+        return (VersionedKeyValueStore<String, String>) ((StoreFactory) materializer).build();
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -94,8 +94,8 @@ public class StandbyTaskTest {
     private final String storeChangelogTopicName2 = ProcessorStateManager.storeChangelogTopic(applicationId, storeName2, taskId.topologyName());
 
     private final TopicPartition partition = new TopicPartition(storeChangelogTopicName1, 0);
-    private final MockKeyValueStore store1 = (MockKeyValueStore) new MockKeyValueStoreBuilder(storeName1, false).build();
-    private final MockKeyValueStore store2 = (MockKeyValueStore) new MockKeyValueStoreBuilder(storeName2, true).build();
+    private final MockKeyValueStore store1 = new MockKeyValueStoreBuilder(storeName1, false).build();
+    private final MockKeyValueStore store2 = new MockKeyValueStoreBuilder(storeName2, true).build();
 
     private final ProcessorTopology topology = ProcessorTopologyFactories.withLocalStores(
         asList(store1, store2),

--- a/streams/src/test/java/org/apache/kafka/test/MockKeyValueStoreBuilder.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockKeyValueStoreBuilder.java
@@ -38,8 +38,8 @@ public class MockKeyValueStoreBuilder extends AbstractStoreBuilder<Integer, byte
         return new MockKeyValueStore(name, persistent);
     }
 
-    public StoreFactory<KeyValueStore<Object, Object>> asFactory() {
-        return new StoreBuilderWrapper<>(this);
+    public StoreFactory asFactory() {
+        return new StoreBuilderWrapper(this);
     }
 }
 

--- a/streams/src/test/java/org/apache/kafka/test/MockKeyValueStoreBuilder.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockKeyValueStoreBuilder.java
@@ -18,6 +18,8 @@ package org.apache.kafka.test;
 
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.streams.processor.internals.StoreBuilderWrapper;
+import org.apache.kafka.streams.processor.internals.StoreFactory;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.internals.AbstractStoreBuilder;
 
@@ -32,8 +34,12 @@ public class MockKeyValueStoreBuilder extends AbstractStoreBuilder<Integer, byte
     }
 
     @Override
-    public KeyValueStore<Object, Object> build() {
+    public MockKeyValueStore build() {
         return new MockKeyValueStore(name, persistent);
+    }
+
+    public StoreFactory<KeyValueStore<Object, Object>> asFactory() {
+        return new StoreBuilderWrapper<>(this);
     }
 }
 


### PR DESCRIPTION
### Overview

This PR sets up the necessary prerequisites to respect configurations such as `dsl.default.store.type` and the `dsl.store.suppliers.class` (introduced in #14648) without requiring them to be passed in to `StreamBuilder#new(TopologyConfig)` (passing them only into `new KafkaStreams(...)`.

It essentially makes `StoreBuilder` an external-only API and internally it uses the `StoreFactory` equivalent. It replaces `KeyValueStoreMaterializer` with an implementation of `StoreFactory` that creates the store builder only after `configure()` is called (in a Future PR we will create the missing equivalents for all of the places where the same thing happens for window stores, such as in all the `*WindowKStreamImpl` classes)

### Testing

There is no change in functionality for this PR

### Review Guide

1. Start with looking at `StoreFactory` and read the JavaDocs, this is an interface representing what used to be `InternalTopologyBuilder.StateStoreFactory`
2. Look at how `StoreBuilderWrapper` is what used to be the implementation of `InternalTopologyBuilder.StateStoreFactory`
3. Note that `InternalTopologyBuilder#addStateStore` now takes in a `StoreFactory` instead of a `StoreBuilder` from everywhere that uses the DSL.
4. The rest is piping that change around and wrapping `StoreBuilder` with `StoreBuilderWrapper`. In a future PR all `StoreBuilderWrappers` in the DSL will be replaced with a new one that respects the configurations passed in to `new KafkaStreams`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
