### PR TITLE
MINOR: small optimization for DirectoryId.random

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/common/DirectoryId.java
+++ b/server-common/src/main/java/org/apache/kafka/common/DirectoryId.java
@@ -42,16 +42,6 @@ public class DirectoryId {
     public static final Uuid MIGRATING = new Uuid(0L, 2L);
 
     /**
-     * @return true if the given ID is reserved. An ID is reserved if it is one of the first 100,
-     * or if its string representation starts with a dash. ("-")
-     */
-    public boolean isReserved(Uuid id) {
-        return id.toString().startsWith("-") ||
-            (uuid.getMostSignificantBits() == 0 &&
-                uuid.getLeastSignificantBits() < 100);
-    }
-
-    /**
      * Static factory to generate a directory ID.
      *
      * This will not generate a reserved UUID (first 100), or one whose string representation
@@ -59,8 +49,11 @@ public class DirectoryId {
      */
     public static Uuid random() {
         while (true) {
+            // Uuid.randomUuid does not generate Uuids whose string representation starts with a
+            // dash.
             Uuid uuid = Uuid.randomUuid();
-            if (isReserved(uuid)) {
+            if (uuid.getMostSignificantBits() != 0 ||
+                    uuid.getLeastSignificantBits() >= 100) {
                 return uuid;
             }
         }

--- a/server-common/src/main/java/org/apache/kafka/common/DirectoryId.java
+++ b/server-common/src/main/java/org/apache/kafka/common/DirectoryId.java
@@ -42,29 +42,27 @@ public class DirectoryId {
     public static final Uuid MIGRATING = new Uuid(0L, 2L);
 
     /**
-     * The set of reserved UUIDs that will never be returned by the random method.
+     * @return true if the given ID is reserved. An ID is reserved if it is one of the first 100,
+     * or if its string representation starts with a dash. ("-")
      */
-    public static final Set<Uuid> RESERVED;
-
-    static {
-        HashSet<Uuid> reserved = new HashSet<>(Uuid.RESERVED);
-        // The first 100 UUIDs are reserved for future use.
-        for (long i = 0L; i < 100L; i++) {
-            reserved.add(new Uuid(0L, i));
-        }
-        RESERVED = Collections.unmodifiableSet(reserved);
+    public boolean isReserved(Uuid id) {
+        return id.toString().startsWith("-") ||
+            (uuid.getMostSignificantBits() == 0 &&
+                uuid.getLeastSignificantBits() < 100);
     }
 
     /**
      * Static factory to generate a directory ID.
      *
-     * This will not generate a reserved UUID (first 100), or one whose string representation starts with a dash ("-")
+     * This will not generate a reserved UUID (first 100), or one whose string representation
+     * starts with a dash ("-")
      */
     public static Uuid random() {
-        Uuid uuid = Uuid.randomUuid();
-        while (RESERVED.contains(uuid) || uuid.toString().startsWith("-")) {
-            uuid = Uuid.randomUuid();
+        while (true) {
+            Uuid uuid = Uuid.randomUuid();
+            if (isReserved(uuid)) {
+                return uuid;
+            }
         }
-        return uuid;
     }
 }

--- a/server-common/src/main/java/org/apache/kafka/common/DirectoryId.java
+++ b/server-common/src/main/java/org/apache/kafka/common/DirectoryId.java
@@ -16,10 +16,6 @@
  */
 package org.apache.kafka.common;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 public class DirectoryId {
 
     /**


### PR DESCRIPTION
DirectoryId.random doesn't need to instantiate the first 100 IDs to check if an ID is one of them.