### PR TITLE
KAFKA-15781: KIP-998, Change the ProducerConfig constructor that allows disabling logging to "protected"

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -618,7 +618,7 @@ public class ProducerConfig extends AbstractConfig {
         super(CONFIG, props);
     }
 
-    ProducerConfig(Map<?, ?> props, boolean doLog) {
+    protected ProducerConfig(Map<?, ?> props, boolean doLog) {
         super(CONFIG, props, doLog);
     }
 


### PR DESCRIPTION
In applications that construct the various client configs multiple times, the config logging can be pretty extreme, so it's nice to be able to disable this for subsequent config objects that are created. We don't expose the constructors that accept a `doLog` parameter in the public API, but all the other clients at least make this constructor `protected` so it's possible to extend the class and suppress the excessive logging ([for example](https://github.com/apache/kafka/blob/ed3fa83d385bbe2fa6dc4943660f56fec708bbc8/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java#L690))

However the ProducerConfig is the one case where this constructor is package-private. It would be nice to align it with the other client config classes and make this `protected` to allow turning off logging