### PR TITLE
MINOR: Remove unsed code in clients:common:errors

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/BrokerIdNotRegisteredException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/BrokerIdNotRegisteredException.java
@@ -22,8 +22,4 @@ public class BrokerIdNotRegisteredException extends ApiException {
         super(message);
     }
 
-    public BrokerIdNotRegisteredException(String message, Throwable throwable) {
-        super(message, throwable);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/BrokerNotAvailableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/BrokerNotAvailableException.java
@@ -24,8 +24,4 @@ public class BrokerNotAvailableException extends ApiException {
         super(message);
     }
 
-    public BrokerNotAvailableException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/ClusterAuthorizationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ClusterAuthorizationException.java
@@ -24,7 +24,4 @@ public class ClusterAuthorizationException extends AuthorizationException {
         super(message);
     }
 
-    public ClusterAuthorizationException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/ControllerMovedException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ControllerMovedException.java
@@ -24,8 +24,4 @@ public class ControllerMovedException extends ApiException {
         super(message);
     }
 
-    public ControllerMovedException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/CoordinatorLoadInProgressException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/CoordinatorLoadInProgressException.java
@@ -32,8 +32,4 @@ public class CoordinatorLoadInProgressException extends RetriableException {
         super(message);
     }
 
-    public CoordinatorLoadInProgressException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/CoordinatorNotAvailableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/CoordinatorNotAvailableException.java
@@ -36,8 +36,4 @@ public class CoordinatorNotAvailableException extends RetriableException {
         super(message);
     }
 
-    public CoordinatorNotAvailableException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/CorruptRecordException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/CorruptRecordException.java
@@ -32,10 +32,6 @@ public class CorruptRecordException extends RetriableException {
         super(message);
     }
 
-    public CorruptRecordException(Throwable cause) {
-        super(cause);
-    }
-
     public CorruptRecordException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenAuthorizationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenAuthorizationException.java
@@ -24,8 +24,4 @@ public class DelegationTokenAuthorizationException extends AuthorizationExceptio
         super(message);
     }
 
-    public DelegationTokenAuthorizationException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenDisabledException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenDisabledException.java
@@ -24,8 +24,4 @@ public class DelegationTokenDisabledException extends ApiException {
         super(message);
     }
 
-    public DelegationTokenDisabledException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenExpiredException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenExpiredException.java
@@ -24,8 +24,4 @@ public class DelegationTokenExpiredException extends ApiException {
         super(message);
     }
 
-    public DelegationTokenExpiredException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenNotFoundException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenNotFoundException.java
@@ -24,8 +24,4 @@ public class DelegationTokenNotFoundException extends ApiException {
         super(message);
     }
 
-    public DelegationTokenNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenOwnerMismatchException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenOwnerMismatchException.java
@@ -24,8 +24,4 @@ public class DelegationTokenOwnerMismatchException extends ApiException {
         super(message);
     }
 
-    public DelegationTokenOwnerMismatchException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/DisconnectException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DisconnectException.java
@@ -29,16 +29,8 @@ public class DisconnectException extends RetriableException {
         super();
     }
 
-    public DisconnectException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public DisconnectException(String message) {
         super(message);
-    }
-
-    public DisconnectException(Throwable cause) {
-        super(cause);
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/DuplicateBrokerRegistrationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DuplicateBrokerRegistrationException.java
@@ -22,8 +22,4 @@ public class DuplicateBrokerRegistrationException extends ApiException {
         super(message);
     }
 
-    public DuplicateBrokerRegistrationException(String message, Throwable throwable) {
-        super(message, throwable);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/DuplicateResourceException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DuplicateResourceException.java
@@ -36,15 +36,6 @@ public class DuplicateResourceException extends ApiException {
     }
 
     /**
-     *
-     * @param message the exception's message
-     * @param cause the exception's cause
-     */
-    public DuplicateResourceException(String message, Throwable cause) {
-        this(null, message, cause);
-    }
-
-    /**
      * Constructor
      *
      * @param resource the (potentially null) resource that was referred to twice
@@ -52,18 +43,6 @@ public class DuplicateResourceException extends ApiException {
      */
     public DuplicateResourceException(String resource, String message) {
         super(message);
-        this.resource = resource;
-    }
-
-    /**
-     * Constructor
-     *
-     * @param resource the (potentially null) resource that was referred to twice
-     * @param message the exception's message
-     * @param cause the exception's cause
-     */
-    public DuplicateResourceException(String resource, String message, Throwable cause) {
-        super(message, cause);
         this.resource = resource;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/ElectionNotNeededException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ElectionNotNeededException.java
@@ -22,7 +22,4 @@ public class ElectionNotNeededException extends InvalidMetadataException {
         super(message);
     }
 
-    public ElectionNotNeededException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/EligibleLeadersNotAvailableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/EligibleLeadersNotAvailableException.java
@@ -22,7 +22,4 @@ public class EligibleLeadersNotAvailableException extends InvalidMetadataExcepti
         super(message);
     }
 
-    public EligibleLeadersNotAvailableException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/FeatureUpdateFailedException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/FeatureUpdateFailedException.java
@@ -23,7 +23,4 @@ public class FeatureUpdateFailedException extends ApiException {
         super(message);
     }
 
-    public FeatureUpdateFailedException(final String message, final Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/FencedInstanceIdException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/FencedInstanceIdException.java
@@ -23,7 +23,4 @@ public class FencedInstanceIdException extends ApiException {
         super(message);
     }
 
-    public FencedInstanceIdException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/FencedLeaderEpochException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/FencedLeaderEpochException.java
@@ -28,8 +28,4 @@ public class FencedLeaderEpochException extends InvalidMetadataException {
         super(message);
     }
 
-    public FencedLeaderEpochException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/FetchSessionIdNotFoundException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/FetchSessionIdNotFoundException.java
@@ -20,9 +20,6 @@ package org.apache.kafka.common.errors;
 public class FetchSessionIdNotFoundException extends RetriableException {
     private static final long serialVersionUID = 1L;
 
-    public FetchSessionIdNotFoundException() {
-    }
-
     public FetchSessionIdNotFoundException(String message) {
         super(message);
     }

--- a/clients/src/main/java/org/apache/kafka/common/errors/IllegalGenerationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/IllegalGenerationException.java
@@ -19,19 +19,8 @@ package org.apache.kafka.common.errors;
 public class IllegalGenerationException extends ApiException {
     private static final long serialVersionUID = 1L;
 
-    public IllegalGenerationException() {
-        super();
-    }
-
-    public IllegalGenerationException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public IllegalGenerationException(String message) {
         super(message);
     }
 
-    public IllegalGenerationException(Throwable cause) {
-        super(cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InconsistentClusterIdException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InconsistentClusterIdException.java
@@ -22,7 +22,4 @@ public class InconsistentClusterIdException extends ApiException {
         super(message);
     }
 
-    public InconsistentClusterIdException(String message, Throwable throwable) {
-        super(message, throwable);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InconsistentGroupProtocolException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InconsistentGroupProtocolException.java
@@ -19,10 +19,6 @@ package org.apache.kafka.common.errors;
 public class InconsistentGroupProtocolException extends ApiException {
     private static final long serialVersionUID = 1L;
 
-    public InconsistentGroupProtocolException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public InconsistentGroupProtocolException(String message) {
         super(message);
     }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InconsistentVoterSetException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InconsistentVoterSetException.java
@@ -24,8 +24,4 @@ public class InconsistentVoterSetException extends ApiException {
         super(s);
     }
 
-    public InconsistentVoterSetException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InterruptException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InterruptException.java
@@ -35,9 +35,4 @@ public class InterruptException extends KafkaException {
         Thread.currentThread().interrupt();
     }
 
-    public InterruptException(String message) {
-        super(message, new InterruptedException());
-        Thread.currentThread().interrupt();
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidCommitOffsetSizeException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidCommitOffsetSizeException.java
@@ -19,10 +19,6 @@ package org.apache.kafka.common.errors;
 public class InvalidCommitOffsetSizeException extends ApiException {
     private static final long serialVersionUID = 1L;
 
-    public InvalidCommitOffsetSizeException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public InvalidCommitOffsetSizeException(String message) {
         super(message);
     }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidFetchSessionEpochException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidFetchSessionEpochException.java
@@ -20,9 +20,6 @@ package org.apache.kafka.common.errors;
 public class InvalidFetchSessionEpochException extends RetriableException {
     private static final long serialVersionUID = 1L;
 
-    public InvalidFetchSessionEpochException() {
-    }
-
     public InvalidFetchSessionEpochException(String message) {
         super(message);
     }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidFetchSizeException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidFetchSizeException.java
@@ -24,8 +24,4 @@ public class InvalidFetchSizeException extends ApiException {
         super(message);
     }
 
-    public InvalidFetchSizeException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidGroupIdException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidGroupIdException.java
@@ -19,10 +19,6 @@ package org.apache.kafka.common.errors;
 public class InvalidGroupIdException extends ApiException {
     private static final long serialVersionUID = 1L;
 
-    public InvalidGroupIdException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public InvalidGroupIdException(String message) {
         super(message);
     }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidPartitionsException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidPartitionsException.java
@@ -24,8 +24,4 @@ public class InvalidPartitionsException extends ApiException {
         super(message);
     }
 
-    public InvalidPartitionsException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidPrincipalTypeException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidPrincipalTypeException.java
@@ -24,8 +24,4 @@ public class InvalidPrincipalTypeException extends ApiException {
         super(message);
     }
 
-    public InvalidPrincipalTypeException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidReplicaAssignmentException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidReplicaAssignmentException.java
@@ -24,8 +24,4 @@ public class InvalidReplicaAssignmentException extends ApiException {
         super(message);
     }
 
-    public InvalidReplicaAssignmentException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidReplicationFactorException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidReplicationFactorException.java
@@ -24,8 +24,4 @@ public class InvalidReplicationFactorException extends ApiException {
         super(message);
     }
 
-    public InvalidReplicationFactorException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidSessionTimeoutException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidSessionTimeoutException.java
@@ -19,10 +19,6 @@ package org.apache.kafka.common.errors;
 public class InvalidSessionTimeoutException extends ApiException {
     private static final long serialVersionUID = 1L;
 
-    public InvalidSessionTimeoutException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public InvalidSessionTimeoutException(String message) {
         super(message);
     }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidTimestampException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidTimestampException.java
@@ -27,7 +27,4 @@ public class InvalidTimestampException extends ApiException {
         super(message);
     }
 
-    public InvalidTimestampException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidTopicException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidTopicException.java
@@ -32,23 +32,8 @@ public class InvalidTopicException extends ApiException {
 
     private final Set<String> invalidTopics;
 
-    public InvalidTopicException() {
-        super();
-        invalidTopics = new HashSet<>();
-    }
-
-    public InvalidTopicException(String message, Throwable cause) {
-        super(message, cause);
-        invalidTopics = new HashSet<>();
-    }
-
     public InvalidTopicException(String message) {
         super(message);
-        invalidTopics = new HashSet<>();
-    }
-
-    public InvalidTopicException(Throwable cause) {
-        super(cause);
         invalidTopics = new HashSet<>();
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidTxnTimeoutException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidTxnTimeoutException.java
@@ -23,10 +23,6 @@ package org.apache.kafka.common.errors;
 public class InvalidTxnTimeoutException extends ApiException {
     private static final long serialVersionUID = 1L;
 
-    public InvalidTxnTimeoutException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public InvalidTxnTimeoutException(String message) {
         super(message);
     }

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidUpdateVersionException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidUpdateVersionException.java
@@ -22,8 +22,4 @@ public class InvalidUpdateVersionException extends ApiException {
         super(message);
     }
 
-    public InvalidUpdateVersionException(String message, Throwable throwable) {
-        super(message, throwable);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/ListenerNotFoundException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ListenerNotFoundException.java
@@ -31,8 +31,4 @@ public class ListenerNotFoundException extends InvalidMetadataException {
         super(message);
     }
 
-    public ListenerNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/LogDirNotFoundException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/LogDirNotFoundException.java
@@ -27,11 +27,4 @@ public class LogDirNotFoundException extends ApiException {
         super(message);
     }
 
-    public LogDirNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public LogDirNotFoundException(Throwable cause) {
-        super(cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/MemberIdRequiredException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/MemberIdRequiredException.java
@@ -24,7 +24,4 @@ public class MemberIdRequiredException extends ApiException {
         super(message);
     }
 
-    public MemberIdRequiredException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/NetworkException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/NetworkException.java
@@ -24,20 +24,8 @@ public class NetworkException extends InvalidMetadataException {
 
     private static final long serialVersionUID = 1L;
 
-    public NetworkException() {
-        super();
-    }
-
-    public NetworkException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public NetworkException(String message) {
         super(message);
-    }
-
-    public NetworkException(Throwable cause) {
-        super(cause);
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/NoReassignmentInProgressException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/NoReassignmentInProgressException.java
@@ -25,7 +25,4 @@ public class NoReassignmentInProgressException extends ApiException {
         super(message);
     }
 
-    public NoReassignmentInProgressException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/NotControllerException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/NotControllerException.java
@@ -24,8 +24,4 @@ public class NotControllerException extends RetriableException {
         super(message);
     }
 
-    public NotControllerException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/NotEnoughReplicasException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/NotEnoughReplicasException.java
@@ -26,15 +26,8 @@ public class NotEnoughReplicasException extends RetriableException {
         super();
     }
 
-    public NotEnoughReplicasException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public NotEnoughReplicasException(String message) {
         super(message);
     }
 
-    public NotEnoughReplicasException(Throwable cause) {
-        super(cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/OffsetMetadataTooLarge.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/OffsetMetadataTooLarge.java
@@ -23,19 +23,8 @@ public class OffsetMetadataTooLarge extends ApiException {
 
     private static final long serialVersionUID = 1L;
 
-    public OffsetMetadataTooLarge() {
-    }
-
     public OffsetMetadataTooLarge(String message) {
         super(message);
-    }
-
-    public OffsetMetadataTooLarge(Throwable cause) {
-        super(cause);
-    }
-
-    public OffsetMetadataTooLarge(String message, Throwable cause) {
-        super(message, cause);
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/OffsetMovedToTieredStorageException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/OffsetMovedToTieredStorageException.java
@@ -24,8 +24,4 @@ public class OffsetMovedToTieredStorageException extends ApiException {
         super(message);
     }
 
-    public OffsetMovedToTieredStorageException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/OffsetOutOfRangeException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/OffsetOutOfRangeException.java
@@ -28,8 +28,4 @@ public class OffsetOutOfRangeException extends InvalidOffsetException {
         super(message);
     }
 
-    public OffsetOutOfRangeException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/PolicyViolationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/PolicyViolationException.java
@@ -25,7 +25,4 @@ public class PolicyViolationException extends ApiException {
         super(message);
     }
 
-    public PolicyViolationException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/PositionOutOfRangeException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/PositionOutOfRangeException.java
@@ -24,8 +24,4 @@ public class PositionOutOfRangeException extends ApiException {
         super(s);
     }
 
-    public PositionOutOfRangeException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/PreferredLeaderNotAvailableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/PreferredLeaderNotAvailableException.java
@@ -22,7 +22,4 @@ public class PreferredLeaderNotAvailableException extends InvalidMetadataExcepti
         super(message);
     }
 
-    public PreferredLeaderNotAvailableException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/ReassignmentInProgressException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ReassignmentInProgressException.java
@@ -26,7 +26,4 @@ public class ReassignmentInProgressException extends ApiException {
         super(msg);
     }
 
-    public ReassignmentInProgressException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/RebalanceInProgressException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/RebalanceInProgressException.java
@@ -23,15 +23,8 @@ public class RebalanceInProgressException extends ApiException {
         super();
     }
 
-    public RebalanceInProgressException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public RebalanceInProgressException(String message) {
         super(message);
     }
 
-    public RebalanceInProgressException(Throwable cause) {
-        super(cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/RecordBatchTooLargeException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/RecordBatchTooLargeException.java
@@ -27,16 +27,8 @@ public class RecordBatchTooLargeException extends ApiException {
         super();
     }
 
-    public RecordBatchTooLargeException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public RecordBatchTooLargeException(String message) {
         super(message);
-    }
-
-    public RecordBatchTooLargeException(Throwable cause) {
-        super(cause);
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/RecordTooLargeException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/RecordTooLargeException.java
@@ -32,16 +32,8 @@ public class RecordTooLargeException extends ApiException {
         super();
     }
 
-    public RecordTooLargeException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public RecordTooLargeException(String message) {
         super(message);
-    }
-
-    public RecordTooLargeException(Throwable cause) {
-        super(cause);
     }
 
     public RecordTooLargeException(String message, Map<TopicPartition, Long> recordTooLargePartitions) {

--- a/clients/src/main/java/org/apache/kafka/common/errors/ReplicaNotAvailableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ReplicaNotAvailableException.java
@@ -30,12 +30,4 @@ public class ReplicaNotAvailableException extends InvalidMetadataException {
         super(message);
     }
 
-    public ReplicaNotAvailableException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public ReplicaNotAvailableException(Throwable cause) {
-        super(cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/ResourceNotFoundException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ResourceNotFoundException.java
@@ -35,15 +35,6 @@ public class ResourceNotFoundException extends ApiException {
     }
 
     /**
-     *
-     * @param message the exception's message
-     * @param cause the exception's cause
-     */
-    public ResourceNotFoundException(String message, Throwable cause) {
-        this(null, message, cause);
-    }
-
-    /**
      * Constructor
      *
      * @param resource the (potentially null) resource that was not found
@@ -51,18 +42,6 @@ public class ResourceNotFoundException extends ApiException {
      */
     public ResourceNotFoundException(String resource, String message) {
         super(message);
-        this.resource = resource;
-    }
-
-    /**
-     * Constructor
-     *
-     * @param resource the (potentially null) resource that was not found
-     * @param message the exception's message
-     * @param cause the exception's cause
-     */
-    public ResourceNotFoundException(String resource, String message, Throwable cause) {
-        super(message, cause);
         this.resource = resource;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/SecurityDisabledException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/SecurityDisabledException.java
@@ -26,7 +26,4 @@ public class SecurityDisabledException extends ApiException {
         super(message);
     }
 
-    public SecurityDisabledException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/SnapshotNotFoundException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/SnapshotNotFoundException.java
@@ -24,8 +24,4 @@ public class SnapshotNotFoundException extends ApiException {
         super(s);
     }
 
-    public SnapshotNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/SslAuthenticationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/SslAuthenticationException.java
@@ -33,10 +33,6 @@ public class SslAuthenticationException extends AuthenticationException {
 
     private static final long serialVersionUID = 1L;
 
-    public SslAuthenticationException(String message) {
-        super(message);
-    }
-
     public SslAuthenticationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/clients/src/main/java/org/apache/kafka/common/errors/StaleBrokerEpochException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/StaleBrokerEpochException.java
@@ -24,8 +24,4 @@ public class StaleBrokerEpochException extends ApiException {
         super(message);
     }
 
-    public StaleBrokerEpochException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/TopicExistsException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/TopicExistsException.java
@@ -24,8 +24,4 @@ public class TopicExistsException extends ApiException {
         super(message);
     }
 
-    public TopicExistsException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/TransactionAbortedException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/TransactionAbortedException.java
@@ -24,14 +24,6 @@ public class TransactionAbortedException extends ApiException {
 
     private final static long serialVersionUID = 1L;
 
-    public TransactionAbortedException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public TransactionAbortedException(String message) {
-        super(message);
-    }
-
     public TransactionAbortedException() {
         super("Failing batch since transaction was aborted");
     }

--- a/clients/src/main/java/org/apache/kafka/common/errors/TransactionCoordinatorFencedException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/TransactionCoordinatorFencedException.java
@@ -24,7 +24,4 @@ public class TransactionCoordinatorFencedException extends ApiException {
         super(message);
     }
 
-    public TransactionCoordinatorFencedException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/UnknownLeaderEpochException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/UnknownLeaderEpochException.java
@@ -28,8 +28,4 @@ public class UnknownLeaderEpochException extends RetriableException {
         super(message);
     }
 
-    public UnknownLeaderEpochException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/UnknownMemberIdException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/UnknownMemberIdException.java
@@ -23,15 +23,8 @@ public class UnknownMemberIdException extends ApiException {
         super();
     }
 
-    public UnknownMemberIdException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public UnknownMemberIdException(String message) {
         super(message);
     }
 
-    public UnknownMemberIdException(Throwable cause) {
-        super(cause);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/UnknownTopicOrPartitionException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/UnknownTopicOrPartitionException.java
@@ -34,12 +34,4 @@ public class UnknownTopicOrPartitionException extends InvalidMetadataException {
         super(message);
     }
 
-    public UnknownTopicOrPartitionException(Throwable throwable) {
-        super(throwable);
-    }
-
-    public UnknownTopicOrPartitionException(String message, Throwable throwable) {
-        super(message, throwable);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/UnsupportedByAuthenticationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/UnsupportedByAuthenticationException.java
@@ -26,8 +26,4 @@ public class UnsupportedByAuthenticationException extends ApiException {
         super(message);
     }
 
-    public UnsupportedByAuthenticationException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/UnsupportedCompressionTypeException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/UnsupportedCompressionTypeException.java
@@ -27,8 +27,4 @@ public class UnsupportedCompressionTypeException extends ApiException {
         super(message);
     }
 
-    public UnsupportedCompressionTypeException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/UnsupportedForMessageFormatException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/UnsupportedForMessageFormatException.java
@@ -27,8 +27,4 @@ public class UnsupportedForMessageFormatException extends ApiException {
         super(message);
     }
 
-    public UnsupportedForMessageFormatException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
 }


### PR DESCRIPTION
There are many unused codes in the exceptions, which lowered the coverage rate by a lot.
Removing to improve the readability and coverage. Tested with compilation and testing in local env.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
