### PR TITLE
MINOR: Log a warning when connectors generate greater than tasks.max task configs

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -145,7 +145,7 @@
               files="LoggingResource.java" />
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(RestServer|AbstractHerder|DistributedHerder|Worker).java"/>
+              files="(RestServer|AbstractHerder|DistributedHerder|Worker(Test)?).java"/>
 
     <suppress checks="BooleanExpressionComplexity"
               files="JsonConverter.java"/>

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -391,7 +391,21 @@ public class Worker {
             Connector connector = workerConnector.connector();
             try (LoaderSwap loaderSwap = plugins.withClassLoader(workerConnector.loader())) {
                 String taskClassName = connector.taskClass().getName();
-                for (Map<String, String> taskProps : connector.taskConfigs(maxTasks)) {
+                List<Map<String, String>> taskConfigs = connector.taskConfigs(maxTasks);
+                if (taskConfigs.size() > maxTasks) {
+                    log.warn(
+                            "The connector {} has generated {} tasks, which is greater than {}, "
+                                    + "the maximum number of tasks it is configured to create. "
+                                    + "This behavior should be considered a bug and may be disallowed "
+                                    + "in future releases of Kafka Connect. Please report this to the "
+                                    + "maintainers of the connector and request that they adjust their "
+                                    + "connector's taskConfigs() method to respect the maxTasks parameter.",
+                            connName,
+                            taskConfigs.size(),
+                            maxTasks
+                    );
+                }
+                for (Map<String, String> taskProps : taskConfigs) {
                     // Ensure we don't modify the connector's copy of the config
                     Map<String, String> taskConfig = new HashMap<>(taskProps);
                     taskConfig.put(TaskConfig.TASK_CLASS_CONFIG, taskClassName);


### PR DESCRIPTION
The discussion around [KIP-987](https://cwiki.apache.org/confluence/display/KAFKA/KIP-987%3A+Connect+Static+Assignments) has highlighted some strange behavior in the Connect runtime: if a connector's [taskConfigs method](https://kafka.apache.org/36/javadoc/org/apache/kafka/connect/connector/Connector.html#taskConfigs(int)) returns more tasks than the value for its configuration's [tasks.max property](https://kafka.apache.org/documentation.html#sourceconnectorconfigs_tasks.max), nothing happens (i.e., every task the connector generated a config for is brought up).

In [KAFKA-15575](https://issues.apache.org/jira/browse/KAFKA-15575), we discuss the possibility of taking action in this situation: failing the connector, only bringing up `tasks.max` tasks, and others. We may adopt one of these approaches in the future. For now, this warning message should at least get the ball rolling and decrease the likelihood of buggy connectors causing problems for Connect clusters that use static assignment (if/when that feature lands).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
