### PR TITLE
KAFKA-12886: Enable request forwarding by default

### DIFF
--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -62,12 +62,6 @@ object Kafka extends Logging {
     props
   }
 
-  // For Zk mode, the API forwarding is currently enabled only under migration flag. We can
-  // directly do a static IBP check to see API forwarding is enabled here because IBP check is
-  // static in Zk mode.
-  private def enableApiForwarding(config: KafkaConfig) =
-    config.migrationEnabled && config.interBrokerProtocolVersion.isApiForwardingEnabled
-
   private def buildServer(props: Properties): Server = {
     val config = KafkaConfig.fromProps(props, false)
     if (config.requiresZookeeper) {
@@ -75,7 +69,7 @@ object Kafka extends Logging {
         config,
         Time.SYSTEM,
         threadNamePrefix = None,
-        enableForwarding = enableApiForwarding(config)
+        enableForwarding = config.interBrokerProtocolVersion.isApiForwardingEnabled
       )
     } else {
       new KafkaRaftServer(

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -19,7 +19,6 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 import java.util.regex.Pattern
 import java.util.{Locale, Optional, Properties}
-
 import kafka.server.{KafkaServer, QuotaType}
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.{NewPartitions, NewTopic}
@@ -551,9 +550,9 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   def testPartitionsForAutoCreate(): Unit = {
     val consumer = createConsumer()
     // First call would create the topic
-    consumer.partitionsFor("non-exist-topic")
-    val partitions = consumer.partitionsFor("non-exist-topic")
-    assertFalse(partitions.isEmpty)
+    TestUtils.waitUntilTrue(
+      () => !consumer.partitionsFor("non-exist-topic").isEmpty,
+      "Timeout waiting for non-exist-topic being created")
   }
 
   @Test

--- a/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
@@ -177,41 +177,41 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
     // Delete only ACLs on literal 'mytopic2' topic
     var deleted = client.deleteAcls(List(acl2.toFilter).asJava).all().get().asScala.toSet
     assertEquals(Set(acl2), deleted)
-    assertEquals(Set(anyAcl, fooAcl, prefixAcl), getAcls(allTopicAcls))
+    TestUtils.waitUntilAssertEquals(Set(anyAcl, fooAcl, prefixAcl), () => getAcls(allTopicAcls))
 
     ensureAcls(deleted)
 
     // Delete only ACLs on literal '*' topic
     deleted = client.deleteAcls(List(anyAcl.toFilter).asJava).all().get().asScala.toSet
     assertEquals(Set(anyAcl), deleted)
-    assertEquals(Set(acl2, fooAcl, prefixAcl), getAcls(allTopicAcls))
+    TestUtils.waitUntilAssertEquals(Set(acl2, fooAcl, prefixAcl), () => getAcls(allTopicAcls))
 
     ensureAcls(deleted)
 
     // Delete only ACLs on specific prefixed 'mytopic' topics:
     deleted = client.deleteAcls(List(prefixAcl.toFilter).asJava).all().get().asScala.toSet
     assertEquals(Set(prefixAcl), deleted)
-    assertEquals(Set(anyAcl, acl2, fooAcl), getAcls(allTopicAcls))
+    TestUtils.waitUntilAssertEquals(Set(anyAcl, acl2, fooAcl), () => getAcls(allTopicAcls))
 
     ensureAcls(deleted)
 
     // Delete all literal ACLs:
     deleted = client.deleteAcls(List(allLiteralTopicAcls).asJava).all().get().asScala.toSet
     assertEquals(Set(anyAcl, acl2, fooAcl), deleted)
-    assertEquals(Set(prefixAcl), getAcls(allTopicAcls))
+    TestUtils.waitUntilAssertEquals(Set(prefixAcl), () => getAcls(allTopicAcls))
 
     ensureAcls(deleted)
 
     // Delete all prefixed ACLs:
     deleted = client.deleteAcls(List(allPrefixedTopicAcls).asJava).all().get().asScala.toSet
     assertEquals(Set(prefixAcl), deleted)
-    assertEquals(Set(anyAcl, acl2, fooAcl), getAcls(allTopicAcls))
+    TestUtils.waitUntilAssertEquals(Set(anyAcl, acl2, fooAcl), () => getAcls(allTopicAcls))
 
     ensureAcls(deleted)
 
     // Delete all topic ACLs:
     deleted = client.deleteAcls(List(allTopicAcls).asJava).all().get().asScala.toSet
-    assertEquals(Set(), getAcls(allTopicAcls))
+    TestUtils.waitUntilAssertEquals(Set(), () => getAcls(allTopicAcls))
   }
 
   //noinspection ScalaDeprecation - test explicitly covers clients using legacy / deprecated constructors

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -368,7 +368,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
         time = brokerTime(config.brokerId),
         threadNamePrefix = None,
         startup = false,
-        enableZkApiForwarding = isZkMigrationTest() || (config.migrationEnabled && config.interBrokerProtocolVersion.isApiForwardingEnabled)
+        enableZkApiForwarding = config.interBrokerProtocolVersion.isApiForwardingEnabled
       )
     }
   }

--- a/core/src/test/scala/unit/kafka/server/CreateTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreateTopicsRequestTest.scala
@@ -149,17 +149,6 @@ class CreateTopicsRequestTest extends AbstractCreateTopicsRequestTest {
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk", "zkMigration"))
-  def testNotController(quorum: String): Unit = {
-    // Note: we don't run this test when in KRaft mode, because KRaft doesn't have this
-    // behavior of returning NOT_CONTROLLER. Instead, the request is forwarded.
-    val req = topicsReq(Seq(topicReq("topic1")))
-    val response = sendCreateTopicRequest(req, notControllerSocketServer)
-    val error = if (isZkMigrationTest()) Errors.NONE else Errors.NOT_CONTROLLER
-    assertEquals(1, response.errorCounts().get(error))
-  }
-
-  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
   @ValueSource(strings = Array("zk"))
   def testCreateTopicsRequestVersions(quorum: String): Unit = {
     // Note: we don't run this test when in KRaft mode, because kraft does not yet support returning topic

--- a/core/src/test/scala/unit/kafka/server/DeleteTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DeleteTopicsRequestTest.scala
@@ -18,7 +18,6 @@
 package kafka.server
 
 import java.util.Arrays
-import java.util.Collections
 import kafka.network.SocketServer
 import kafka.utils._
 import org.apache.kafka.common.Uuid
@@ -214,24 +213,6 @@ class DeleteTopicsRequestTest extends BaseRequestTest with Logging {
         validateTopicIsDeleted(names(topic))
       }
     }
-  }
-
-  /*
-   * Only run this test against ZK clusters. KRaft doesn't have this behavior of returning NOT_CONTROLLER.
-   * Instead, the request is forwarded.
-   */
-  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
-  @ValueSource(strings = Array("zk", "zkMigration"))
-  def testNotController(quorum: String): Unit = {
-    val request = new DeleteTopicsRequest.Builder(
-        new DeleteTopicsRequestData()
-          .setTopicNames(Collections.singletonList("not-controller"))
-          .setTimeoutMs(1000)).build()
-    val response = sendDeleteTopicsRequest(request, notControllerSocketServer)
-
-    val expectedError = if (isZkMigrationTest()) Errors.NONE else Errors.NOT_CONTROLLER
-    val error = response.data.responses.find("not-controller").errorCode()
-    assertEquals(expectedError.code(),  error)
   }
 
   private def validateTopicIsDeleted(topic: String): Unit = {

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -199,7 +199,7 @@ object TestUtils extends Logging {
   }
 
   def createServer(config: KafkaConfig, time: Time, threadNamePrefix: Option[String], startup: Boolean): KafkaServer = {
-    createServer(config, time, threadNamePrefix, startup, enableZkApiForwarding = false)
+    createServer(config, time, threadNamePrefix, startup, enableZkApiForwarding = true)
   }
 
   def createServer(config: KafkaConfig, time: Time, threadNamePrefix: Option[String],

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1144,6 +1144,21 @@ object TestUtils extends Logging {
   }
 
   /**
+   * Wait until the values are match, or throw an error if cannot
+   *
+   * @param expected   the function for getting expected value
+   * @param actual     the function for getting actual value
+   * @param waitTimeMs the wait time in milliseconds
+   * @param pause      the pause time between each try
+   */
+  def waitUntilAssertEquals(expected: Object, actual: () => Object,
+                            waitTimeMs: Long = JTestUtils.DEFAULT_MAX_WAIT_MS, pause: Long = 100L): Unit = {
+    tryUntilNoAssertionError() {
+      assertEquals(expected, actual())
+    }
+  }
+
+  /**
     * Invoke `compute` until `predicate` is true or `waitTime` elapses.
     *
     * Return the last `compute` result and a boolean indicating whether `predicate` succeeded for that value.

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1151,7 +1151,7 @@ object TestUtils extends Logging {
    * @param waitTimeMs the wait time in milliseconds
    * @param pause      the pause time between each try
    */
-  def waitUntilAssertEquals(expected: Object, actual: () => Object,
+  def waitUntilAssertEquals[T](expected: T, actual: () => T,
                             waitTimeMs: Long = JTestUtils.DEFAULT_MAX_WAIT_MS, pause: Long = 100L): Unit = {
     tryUntilNoAssertionError() {
       assertEquals(expected, actual())

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -199,7 +199,7 @@ object TestUtils extends Logging {
   }
 
   def createServer(config: KafkaConfig, time: Time, threadNamePrefix: Option[String], startup: Boolean): KafkaServer = {
-    createServer(config, time, threadNamePrefix, startup, enableZkApiForwarding = true)
+    createServer(config, time, threadNamePrefix, startup, enableZkApiForwarding = false)
   }
 
   def createServer(config: KafkaConfig, time: Time, threadNamePrefix: Option[String],

--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,0 @@
-./gradlew clean :core:test --tests "kafka.api.PlaintextConsumerTest.testPartitionsForAutoCreate"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,1 @@
+./gradlew clean :core:test --tests "kafka.api.PlaintextConsumerTest.testPartitionsForAutoCreate"


### PR DESCRIPTION
Making forwarding enabled by default

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
