### PR TITLE
KAFKA-15327: ensure the commit manager commit on close

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -249,7 +249,7 @@ public class CommitRequestManager implements RequestManager {
      * {@link OffsetCommitRequestState} and enqueue it to send later.
      */
     public CompletableFuture<Void> addOffsetCommitRequest(final Map<TopicPartition, OffsetAndMetadata> offsets) {
-        return pendingRequests.addOffsetCommitRequest(offsets).future;
+        return pendingRequests.addOffsetCommitRequest(offsets).future();
     }
 
     /**
@@ -786,8 +786,8 @@ public class CommitRequestManager implements RequestManager {
         private boolean hasInflightCommit;
 
         public AutoCommitState(
-            final Time time,
-            final long autoCommitInterval) {
+                final Time time,
+                final long autoCommitInterval) {
             this.autoCommitInterval = autoCommitInterval;
             this.timer = time.timer(autoCommitInterval);
             this.hasInflightCommit = false;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -547,7 +547,6 @@ public class CommitRequestManager implements RequestManager {
         private void retry(final long currentTimeMs) {
             onFailedAttempt(currentTimeMs);
             pendingRequests.addOffsetFetchRequest(this);
-            System.out.println(this);
         }
 
         private void onSuccess(final long currentTimeMs,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
@@ -105,7 +105,7 @@ public class CoordinatorRequestManager implements RequestManager {
         return new NetworkClientDelegate.PollResult(coordinatorRequestState.remainingBackoffMs(currentTimeMs));
     }
 
-    private NetworkClientDelegate.UnsentRequest makeFindCoordinatorRequest(final long currentTimeMs) {
+    NetworkClientDelegate.UnsentRequest makeFindCoordinatorRequest(final long currentTimeMs) {
         coordinatorRequestState.onSendAttempt(currentTimeMs);
         FindCoordinatorRequestData data = new FindCoordinatorRequestData()
                 .setKeyType(FindCoordinatorRequest.CoordinatorType.GROUP.id())
@@ -218,5 +218,15 @@ public class CoordinatorRequestManager implements RequestManager {
      */
     public Optional<Node> coordinator() {
         return Optional.ofNullable(this.coordinator);
+    }
+
+    @Override
+    public NetworkClientDelegate.PollResult pollOnClose() {
+        if (this.coordinator != null)
+            return EMPTY;
+
+        // Using Long.MAX_VALUE because we don't need to reset backoff timer on close.  So any value would work
+        NetworkClientDelegate.UnsentRequest request = makeFindCoordinatorRequest(Long.MAX_VALUE);
+        return new NetworkClientDelegate.PollResult(request);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CoordinatorRequestManager.java
@@ -219,14 +219,4 @@ public class CoordinatorRequestManager implements RequestManager {
     public Optional<Node> coordinator() {
         return Optional.ofNullable(this.coordinator);
     }
-
-    @Override
-    public NetworkClientDelegate.PollResult pollOnClose() {
-        if (this.coordinator != null)
-            return EMPTY;
-
-        // Using Long.MAX_VALUE because we don't need to reset backoff timer on close.  So any value would work
-        NetworkClientDelegate.UnsentRequest request = makeFindCoordinatorRequest(Long.MAX_VALUE);
-        return new NetworkClientDelegate.PollResult(request);
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManager.java
@@ -35,6 +35,7 @@ public interface RequestManager {
      * synchronization protection in this method's implementation.
      *
      * <p/>
+     * 
      * <em>Note</em>: no network I/O occurs in this method. The method itself should not block for any reason. This
      * method is called from the consumer's network I/O thread, so quick execution of this method in <em>all</em>
      * request managers is critical to ensure that we can heartbeat in a timely fashion.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManager.java
@@ -35,7 +35,6 @@ public interface RequestManager {
      * synchronization protection in this method's implementation.
      *
      * <p/>
-     *Close(
      * <em>Note</em>: no network I/O occurs in this method. The method itself should not block for any reason. This
      * method is called from the consumer's network I/O thread, so quick execution of this method in <em>all</em>
      * request managers is critical to ensure that we can heartbeat in a timely fashion.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManager.java
@@ -35,7 +35,7 @@ public interface RequestManager {
      * synchronization protection in this method's implementation.
      *
      * <p/>
-     * 
+     *
      * <em>Note</em>: no network I/O occurs in this method. The method itself should not block for any reason. This
      * method is called from the consumer's network I/O thread, so quick execution of this method in <em>all</em>
      * request managers is critical to ensure that we can heartbeat in a timely fashion.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManager.java
@@ -35,7 +35,7 @@ public interface RequestManager {
      * synchronization protection in this method's implementation.
      *
      * <p/>
-     *
+     *Close(
      * <em>Note</em>: no network I/O occurs in this method. The method itself should not block for any reason. This
      * method is called from the consumer's network I/O thread, so quick execution of this method in <em>all</em>
      * request managers is critical to ensure that we can heartbeat in a timely fashion.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -164,13 +164,19 @@ public class RequestManagers implements Closeable {
                             retryBackoffMaxMs,
                             backgroundEventHandler,
                             groupState.groupId);
-                    commit = new CommitRequestManager(time, logContext, subscriptions, config, coordinator, groupState);
                     membershipManager = new MembershipManagerImpl(
                             groupState.groupId,
                             subscriptions,
                             commit,
                             metadata,
                             logContext);
+                    commit = new CommitRequestManager(time,
+                            logContext,
+                            subscriptions,
+                            config,
+                            coordinator,
+                            backgroundEventHandler,
+                            groupState);
                     heartbeatRequestManager = new HeartbeatRequestManager(
                             logContext,
                             time,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -164,12 +164,6 @@ public class RequestManagers implements Closeable {
                             retryBackoffMaxMs,
                             backgroundEventHandler,
                             groupState.groupId);
-                    membershipManager = new MembershipManagerImpl(
-                            groupState.groupId,
-                            subscriptions,
-                            commit,
-                            metadata,
-                            logContext);
                     commit = new CommitRequestManager(time,
                             logContext,
                             subscriptions,
@@ -177,6 +171,12 @@ public class RequestManagers implements Closeable {
                             coordinator,
                             backgroundEventHandler,
                             groupState);
+                    membershipManager = new MembershipManagerImpl(
+                            groupState.groupId,
+                            subscriptions,
+                            commit,
+                            metadata,
+                            logContext);
                     heartbeatRequestManager = new HeartbeatRequestManager(
                             logContext,
                             time,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/AutoCommitCompletionBackgroundEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/AutoCommitCompletionBackgroundEvent.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals.events;
+
+public class AutoCommitCompletionBackgroundEvent extends BackgroundEvent {
+    public AutoCommitCompletionBackgroundEvent() {
+        super(Type.AUTO_COMMIT_COMPLETION);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEvent.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEvent.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 public abstract class BackgroundEvent {
 
     public enum Type {
-        ERROR,
+        ERROR, AUTO_COMMIT_COMPLETION
     }
 
     protected final Type type;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/BackgroundEventProcessor.java
@@ -58,10 +58,17 @@ public class BackgroundEventProcessor extends EventProcessor<BackgroundEvent> {
 
     @Override
     public void process(final BackgroundEvent event) {
-        if (event.type() == BackgroundEvent.Type.ERROR)
-            process((ErrorBackgroundEvent) event);
-        else
-            throw new IllegalArgumentException("Background event type " + event.type() + " was not expected");
+        switch (event.type()) {
+            case ERROR:
+                process((ErrorBackgroundEvent) event);
+                break;
+            case AUTO_COMMIT_COMPLETION:
+                process((AutoCommitCompletionBackgroundEvent) event);
+                break;
+            default:
+                throw new IllegalArgumentException("Background event type " + event.type() + " was not expected");
+
+        }
     }
 
     @Override
@@ -71,5 +78,9 @@ public class BackgroundEventProcessor extends EventProcessor<BackgroundEvent> {
 
     private void process(final ErrorBackgroundEvent event) {
         throw event.error();
+    }
+
+    private void process(final AutoCommitCompletionBackgroundEvent event) {
+        // TODO: invoke OffsetCommitCallback
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -380,7 +380,8 @@ public class CommitRequestManagerTest {
                                final List<CompletableFuture<Map<TopicPartition, OffsetAndMetadata>>> futures) {
         futures.forEach(f -> assertFalse(f.isDone()));
 
-        time.sleep(500);
+        // The manager should backoff for 100ms
+        time.sleep(100);
         commitRequestManger.poll(time.milliseconds());
         futures.forEach(f -> assertFalse(f.isDone()));
     }
@@ -400,7 +401,6 @@ public class CommitRequestManagerTest {
             Arguments.of(Errors.INVALID_COMMIT_OFFSET_SIZE, false),
             Arguments.of(Errors.UNKNOWN_TOPIC_OR_PARTITION, true),
             Arguments.of(Errors.COORDINATOR_NOT_AVAILABLE, true),
-            Arguments.of(Errors.NOT_COORDINATOR, true),
             Arguments.of(Errors.REQUEST_TIMED_OUT, true),
             Arguments.of(Errors.FENCED_INSTANCE_ID, false),
             Arguments.of(Errors.TOPIC_AUTHORIZATION_FAILED, false));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThreadTest.java
@@ -28,10 +28,15 @@ import org.apache.kafka.clients.consumer.internals.events.NewTopicsMetadataUpdat
 import org.apache.kafka.clients.consumer.internals.events.ResetPositionsApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.TopicMetadataApplicationEvent;
 import org.apache.kafka.clients.consumer.internals.events.ValidatePositionsApplicationEvent;
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.OffsetCommitRequest;
+import org.apache.kafka.common.requests.OffsetCommitResponse;
 import org.apache.kafka.common.requests.RequestTestUtils;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestCondition;
@@ -42,6 +47,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -49,6 +55,8 @@ import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
 import static org.apache.kafka.clients.consumer.internals.ConsumerTestBuilder.DEFAULT_REQUEST_TIMEOUT_MS;
 import static org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -74,9 +82,11 @@ public class ConsumerNetworkThreadTest {
     private BlockingQueue<ApplicationEvent> applicationEventsQueue;
     private ApplicationEventProcessor applicationEventProcessor;
     private OffsetsRequestManager offsetsRequestManager;
-    private CommitRequestManager commitManager;
+    private CommitRequestManager commitRequestManager;
+    private CoordinatorRequestManager coordinatorRequestManager;
     private ConsumerNetworkThread consumerNetworkThread;
     private MockClient client;
+    private SubscriptionState subscriptions;
 
     @BeforeEach
     public void setup() {
@@ -87,9 +97,11 @@ public class ConsumerNetworkThreadTest {
         client = testBuilder.client;
         applicationEventsQueue = testBuilder.applicationEventQueue;
         applicationEventProcessor = testBuilder.applicationEventProcessor;
-        commitManager = testBuilder.commitRequestManager.orElseThrow(IllegalStateException::new);
+        commitRequestManager = testBuilder.commitRequestManager.orElseThrow(IllegalStateException::new);
         offsetsRequestManager = testBuilder.offsetsRequestManager;
+        coordinatorRequestManager = testBuilder.coordinatorRequestManager.orElseThrow(IllegalStateException::new);
         consumerNetworkThread = testBuilder.consumerNetworkThread;
+        subscriptions = testBuilder.subscriptions;
         consumerNetworkThread.initializeResources();
     }
 
@@ -113,6 +125,7 @@ public class ConsumerNetworkThreadTest {
         TestUtils.waitForCondition(isStarted,
                 "The consumer network thread did not start within " + DEFAULT_MAX_WAIT_MS + " ms");
 
+        prepareTearDown();
         consumerNetworkThread.close(Duration.ofMillis(DEFAULT_MAX_WAIT_MS));
 
         TestUtils.waitForCondition(isClosed,
@@ -193,8 +206,8 @@ public class ConsumerNetworkThreadTest {
         consumerNetworkThread.runOnce();
         verify(applicationEventProcessor).process(any(AssignmentChangeApplicationEvent.class));
         verify(networkClient, times(1)).poll(anyLong(), anyLong());
-        verify(commitManager, times(1)).updateAutoCommitTimer(currentTimeMs);
-        verify(commitManager, times(1)).maybeAutoCommit(offset);
+        verify(commitRequestManager, times(1)).updateAutoCommitTimer(currentTimeMs);
+        verify(commitRequestManager, times(1)).maybeAutoCommit(offset);
     }
 
     @Test
@@ -244,6 +257,10 @@ public class ConsumerNetworkThreadTest {
 
     @Test
     void testEnsureEventsAreCompleted() {
+        Node node = metadata.fetch().nodes().get(0);
+        coordinatorRequestManager.markCoordinatorUnknown("test", time.milliseconds());
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "group-id", node));
+        prepareOffsetCommitRequest(new HashMap<>(), Errors.NONE, false);
         CompletableApplicationEvent<Void> event1 = spy(new CommitApplicationEvent(Collections.emptyMap()));
         ApplicationEvent event2 = new CommitApplicationEvent(Collections.emptyMap());
         CompletableFuture<Void> future = new CompletableFuture<>();
@@ -256,6 +273,83 @@ public class ConsumerNetworkThreadTest {
         consumerNetworkThread.cleanup();
         assertTrue(future.isCompletedExceptionally());
         assertTrue(applicationEventsQueue.isEmpty());
+    }
+
+    @Test
+    void testCoordinatorConnectionOnClose() {
+        Node node = metadata.fetch().nodes().get(0);
+        coordinatorRequestManager.markCoordinatorUnknown("test", time.milliseconds());
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "group-id", node));
+        prepareOffsetCommitRequest(new HashMap<>(), Errors.NONE, false);
+        consumerNetworkThread.coordinatorOnClose(time.timer(1000));
+        assertTrue(coordinatorRequestManager.coordinator().isPresent());
+        assertFalse(client.hasPendingResponses());
+        assertFalse(client.hasInFlightRequests());
+    }
+
+    @Test
+    void testAutoCommitOnClose() {
+        TopicPartition tp = new TopicPartition("topic", 0);
+        Node node = metadata.fetch().nodes().get(0);
+        subscriptions.assignFromUser(singleton(tp));
+        subscriptions.seek(tp, 100);
+        coordinatorRequestManager.markCoordinatorUnknown("test", time.milliseconds());
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "group-id", node));
+        prepareOffsetCommitRequest(singletonMap(tp, 100L), Errors.NONE, false);
+        consumerNetworkThread.coordinatorOnClose(time.timer(1000));
+        assertTrue(coordinatorRequestManager.coordinator().isPresent());
+        verify(commitRequestManager).maybeAutoCommitOnClose();
+
+        assertFalse(client.hasPendingResponses());
+        assertFalse(client.hasInFlightRequests());
+    }
+
+    private void prepareTearDown() {
+        Node node = metadata.fetch().nodes().get(0);
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "group-id", node));
+        prepareOffsetCommitRequest(new HashMap<>(), Errors.NONE, false);
+
+    }
+
+    private void prepareOffsetCommitRequest(final Map<TopicPartition, Long> expectedOffsets,
+                                            final Errors error,
+                                            final boolean disconnected) {
+        Map<TopicPartition, Errors> errors = partitionErrors(expectedOffsets.keySet(), error);
+        client.prepareResponse(offsetCommitRequestMatcher(expectedOffsets), offsetCommitResponse(errors), disconnected);
+    }
+
+    private Map<TopicPartition, Errors> partitionErrors(final Collection<TopicPartition> partitions,
+                                                        final Errors error) {
+        final Map<TopicPartition, Errors> errors = new HashMap<>();
+        for (TopicPartition partition : partitions) {
+            errors.put(partition, error);
+        }
+        return errors;
+    }
+
+    private OffsetCommitResponse offsetCommitResponse(final Map<TopicPartition, Errors> responseData) {
+        return new OffsetCommitResponse(responseData);
+    }
+
+    private MockClient.RequestMatcher offsetCommitRequestMatcher(final Map<TopicPartition, Long> expectedOffsets) {
+        return body -> {
+            OffsetCommitRequest req = (OffsetCommitRequest) body;
+            Map<TopicPartition, Long> offsets = req.offsets();
+            if (offsets.size() != expectedOffsets.size())
+                return false;
+
+            for (Map.Entry<TopicPartition, Long> expectedOffset : expectedOffsets.entrySet()) {
+                if (!offsets.containsKey(expectedOffset.getKey())) {
+                    return false;
+                } else {
+                    Long actualOffset = offsets.get(expectedOffset.getKey());
+                    if (!actualOffset.equals(expectedOffset.getValue())) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        };
     }
 
     private HashMap<TopicPartition, OffsetAndMetadata> mockTopicPartitionOffset() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThreadTest.java
@@ -281,7 +281,7 @@ public class ConsumerNetworkThreadTest {
         coordinatorRequestManager.markCoordinatorUnknown("test", time.milliseconds());
         client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "group-id", node));
         prepareOffsetCommitRequest(new HashMap<>(), Errors.NONE, false);
-        consumerNetworkThread.waitForClosingTasks(time.timer(1000));
+        consumerNetworkThread.maybeAutoCommitAndLeaveGroup(time.timer(1000));
         assertTrue(coordinatorRequestManager.coordinator().isPresent());
         assertFalse(client.hasPendingResponses());
         assertFalse(client.hasInFlightRequests());
@@ -296,9 +296,9 @@ public class ConsumerNetworkThreadTest {
         coordinatorRequestManager.markCoordinatorUnknown("test", time.milliseconds());
         client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "group-id", node));
         prepareOffsetCommitRequest(singletonMap(tp, 100L), Errors.NONE, false);
-        consumerNetworkThread.waitForClosingTasks(time.timer(1000));
+        consumerNetworkThread.maybeAutoCommitAndLeaveGroup(time.timer(1000));
         assertTrue(coordinatorRequestManager.coordinator().isPresent());
-        verify(commitRequestManager).maybeAutoCommit();
+        verify(commitRequestManager).maybeCreateAutoCommitRequest();
 
         assertFalse(client.hasPendingResponses());
         assertFalse(client.hasInFlightRequests());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThreadTest.java
@@ -281,7 +281,7 @@ public class ConsumerNetworkThreadTest {
         coordinatorRequestManager.markCoordinatorUnknown("test", time.milliseconds());
         client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "group-id", node));
         prepareOffsetCommitRequest(new HashMap<>(), Errors.NONE, false);
-        consumerNetworkThread.coordinatorOnClose(time.timer(1000));
+        consumerNetworkThread.waitForClosingTasks(time.timer(1000));
         assertTrue(coordinatorRequestManager.coordinator().isPresent());
         assertFalse(client.hasPendingResponses());
         assertFalse(client.hasInFlightRequests());
@@ -296,9 +296,9 @@ public class ConsumerNetworkThreadTest {
         coordinatorRequestManager.markCoordinatorUnknown("test", time.milliseconds());
         client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "group-id", node));
         prepareOffsetCommitRequest(singletonMap(tp, 100L), Errors.NONE, false);
-        consumerNetworkThread.coordinatorOnClose(time.timer(1000));
+        consumerNetworkThread.waitForClosingTasks(time.timer(1000));
         assertTrue(coordinatorRequestManager.coordinator().isPresent());
-        verify(commitRequestManager).maybeAutoCommitOnClose();
+        verify(commitRequestManager).maybeAutoCommit();
 
         assertFalse(client.hasPendingResponses());
         assertFalse(client.hasInFlightRequests());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -183,6 +183,7 @@ public class ConsumerTestBuilder implements Closeable {
                     subscriptions,
                     config,
                     coordinator,
+                    backgroundEventHandler,
                     groupState));
             MembershipManager mm = spy(
                     new MembershipManagerImpl(


### PR DESCRIPTION
@lucasbru 
When shutting down the network thread, we need to do the following:
1. autocommit the current progress
2. send a leave group heartbeat (KIP-848)
3. Send out the pending request (for example, unsent commits) and complete them within the timebound

In this PR, I added a closing procedure to the `ConsumerNetworkThread`.  The actions can be summarized into the following:
1. Make sure we have a reachable coordinator node, if not, try to discover one
2. Once the node is discovered, prepare the requests (we need the node prior to sending because we need to know the destination)
4. Continue to poll until either: 1. timer runs out of time or 2. all requests are completed.

After the closingTasks are done: we then perform the last poll for the request managers, via the `pollOnClose` method, to send out the remaining requests.  For commit request manager, we need to send out the unsent commits and block until 1. timer runs out or 2. all requests are completed.

This is the original code I'm trying to implement:
```
 try {
            maybeAutoCommitOffsetsSync(timer);
            while (pendingAsyncCommits.get() > 0 && timer.notExpired()) {
                ensureCoordinatorReady(timer);
                client.poll(timer);
                invokeCompletedOffsetCommitCallbacks();
            }
        } finally {
            super.close(timer);
        }
```