### PR TITLE
KAFKA-15800: Prevent DataExceptions from corrupting KafkaOffsetBackingStore

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetUtils.java
@@ -89,7 +89,13 @@ public class OffsetUtils {
         }
         // The topic parameter is irrelevant for the JsonConverter which is the internal converter used by
         // Connect workers.
-        Object deserializedKey = keyConverter.toConnectData("", partitionKey).value();
+        Object deserializedKey;
+        try {
+            deserializedKey = keyConverter.toConnectData("", partitionKey).value();
+        } catch (DataException e) {
+            log.warn("Ignoring offset partition key with unknown serialization. Expected json.", e);
+            return;
+        }
         if (!(deserializedKey instanceof List)) {
             log.warn("Ignoring offset partition key with an unexpected format. Expected type: {}, actual type: {}",
                     List.class.getName(), className(deserializedKey));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetUtilsTest.java
@@ -78,42 +78,42 @@ public class OffsetUtilsTest {
 
     @Test
     public void testProcessPartitionKeyWithUnknownSerialization() {
-        assertProcessPartitionKeyLogMessage(
+        assertInvalidPartitionKey(
                 new byte[]{0},
                 "Ignoring offset partition key with unknown serialization");
-        assertProcessPartitionKeyLogMessage(
+        assertInvalidPartitionKey(
                 "i-am-not-json".getBytes(StandardCharsets.UTF_8),
                 "Ignoring offset partition key with unknown serialization");
     }
 
     @Test
     public void testProcessPartitionKeyNotList() {
-        assertProcessPartitionKeyLogMessage(
+        assertInvalidPartitionKey(
                 new byte[]{},
                 "Ignoring offset partition key with an unexpected format");
-        assertProcessPartitionKeyLogMessage(
+        assertInvalidPartitionKey(
                 serializePartitionKey(new HashMap<>()),
                 "Ignoring offset partition key with an unexpected format");
     }
 
     @Test
     public void testProcessPartitionKeyListWithOneElement() {
-        assertProcessPartitionKeyLogMessage(
+        assertInvalidPartitionKey(
                 serializePartitionKey(Collections.singletonList("")),
                 "Ignoring offset partition key with an unexpected number of elements");
     }
 
     @Test
     public void testProcessPartitionKeyListWithElementsOfWrongType() {
-        assertProcessPartitionKeyLogMessage(
+        assertInvalidPartitionKey(
                 serializePartitionKey(Arrays.asList(1, new HashMap<>())),
                 "Ignoring offset partition key with an unexpected format for the first element in the partition key list");
-        assertProcessPartitionKeyLogMessage(
+        assertInvalidPartitionKey(
                 serializePartitionKey(Arrays.asList("connector-name", new ArrayList<>())),
                 "Ignoring offset partition key with an unexpected format for the second element in the partition key list");
     }
 
-    public void assertProcessPartitionKeyLogMessage(byte[] key, String message) {
+    public void assertInvalidPartitionKey(byte[] key, String message) {
         try (LogCaptureAppender logCaptureAppender = LogCaptureAppender.createAndRegister(OffsetUtils.class)) {
             Map<String, Set<Map<String, Object>>> connectorPartitions = new HashMap<>();
             OffsetUtils.processPartitionKey(key, new byte[0], CONVERTER, connectorPartitions);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-15800

The JsonConverter may throw DataException when encountering malformed data. This causes part or all of the batch of ConsumerRecords from the KafkaBasedLog consumer to be dropped, corrupting the state of the KafkaOffsetBackingStore.

This is a narrow-scope fix for just the KafkaOffsetBackingStore, and i'd like to follow up with a fix to the KafkaBasedLog to make these sorts of mistakes less impactful in the future.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
