### PR TITLE
Update subscriptions at the end.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -417,9 +417,9 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         if (firstException.get() == null) {
             subscriptions.assignFromSubscribed(assignedPartitions);
         } else if (firstException.get() instanceof KafkaException) {
-                throw (KafkaException) firstException.get();
+            throw (KafkaException) firstException.get();
         } else {
-                throw new KafkaException("User rebalance callback throws an error", firstException.get());
+            throw new KafkaException("User rebalance callback throws an error", firstException.get());
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -411,17 +411,15 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         if (autoCommitEnabled)
             this.nextAutoCommitTimer.updateAndReset(autoCommitIntervalMs);
 
-        subscriptions.assignFromSubscribed(assignedPartitions);
-
         // Add partitions that were not previously owned but are now assigned
         firstException.compareAndSet(null, rebalanceListenerInvoker.invokePartitionsAssigned(addedPartitions));
 
-        if (firstException.get() != null) {
-            if (firstException.get() instanceof KafkaException) {
+        if (firstException.get() == null) {
+            subscriptions.assignFromSubscribed(assignedPartitions);
+        } else if (firstException.get() instanceof KafkaException) {
                 throw (KafkaException) firstException.get();
-            } else {
+        } else {
                 throw new KafkaException("User rebalance callback throws an error", firstException.get());
-            }
         }
     }
 


### PR DESCRIPTION
ConsumerCoordinator should first call invokePartitionsAssigned and then save the subscription state.

Otherwise the following scenario is possible:
1. ConsumerCoordinator is notified that partition P is assigned
2. P is not owned and and treated as addedPartition
3. ConsumerCoordinator saves P as owned
4. ConsumerCoordinator call listener with addedPartition=[P]
5. Listener throws exception
6. ConsumerCoordinator is again that P is assigned
7. P is owned
8. ConsumerCoordinator call listener with empty addedPartition

3 and 4 must be reordered to allow listener fix problem with P

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
