### PR TITLE
POC: run group coordinator state machine on request handler pool

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorEvent.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorEvent.java
@@ -18,6 +18,8 @@ package org.apache.kafka.coordinator.group.runtime;
 
 import org.apache.kafka.common.TopicPartition;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * The base event type used by all events processed in the
  * coordinator runtime.
@@ -28,6 +30,15 @@ public interface CoordinatorEvent extends EventAccumulator.Event<TopicPartition>
      * Executes the event.
      */
     void run();
+
+    /**
+     * Executes the event asynchronously
+     * @return Completable future
+     */
+    default CompletableFuture<Void> runAsync() {
+        run();
+        return CompletableFuture.completedFuture(null);
+    }
 
     /**
      * Completes the event with the provided exception.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -47,6 +47,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * The CoordinatorRuntime provides a framework to implement coordinators such as the group coordinator
@@ -660,8 +661,20 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         @Override
         public void run() {
             try {
+                runAsync().get();
+            } catch (Throwable t) {
+                complete(t);
+            }
+        }
+
+        /**
+         * Called by the CoordinatorEventProcessor when the event is executed.
+         */
+        @Override
+        public CompletableFuture<Void> runAsync() {
+            try {
                 // Get the context of the coordinator or fail if the coordinator is not in active state.
-                withActiveContextOrThrow(tp, context -> {
+                return withActiveContextOrThrowAsync(tp, context -> {
                     long prevLastWrittenOffset = context.lastWrittenOffset;
 
                     // Execute the operation.
@@ -677,6 +690,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         } else {
                             complete(null);
                         }
+                        return CompletableFuture.completedFuture(null);
                     } else {
                         // If the records are not empty, first, they are applied to the state machine,
                         // second, then are written to the partition/log, and finally, the response
@@ -689,23 +703,31 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
 
                             // Write the records to the log and update the last written
                             // offset.
-                            long offset = partitionWriter.append(tp, result.records());
-                            context.updateLastWrittenOffset(offset);
+                            return partitionWriter.appendAsync(tp, result.records()).thenAccept(offset -> {
+                                context.updateLastWrittenOffset(offset);
 
-                            // Add the response to the deferred queue.
-                            if (!future.isDone()) {
-                                context.deferredEventQueue.add(offset, this);
-                            } else {
-                                complete(null);
-                            }
+                                // Add the response to the deferred queue.
+                                if (!future.isDone()) {
+                                    context.deferredEventQueue.add(offset, this);
+                                } else {
+                                    complete(null);
+                                }
+                            }).whenComplete((none, t) -> {
+                                if (t != null) {
+                                    context.revertLastWrittenOffset(prevLastWrittenOffset);
+                                    complete(t);
+                                }
+                            });
                         } catch (Throwable t) {
                             context.revertLastWrittenOffset(prevLastWrittenOffset);
                             complete(t);
+                            return CompletableFuture.completedFuture(null);
                         }
                     }
                 });
             } catch (Throwable t) {
                 complete(t);
+                return CompletableFuture.completedFuture(null);
             }
         }
 
@@ -1192,6 +1214,40 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             }
         } finally {
             context.lock.unlock();
+        }
+    }
+
+    /**
+     * Calls the provided function with the context iff the context is active; throws
+     * an exception otherwise. This method ensures that the context lock is acquired
+     * before calling the function and releases afterwards.
+     *
+     * @param tp    The topic partition.
+     * @param asyncFunc  The function that will receive the context.
+     * @throws NotCoordinatorException
+     * @throws CoordinatorLoadInProgressException
+     */
+    private CompletableFuture<Void> withActiveContextOrThrowAsync(
+            TopicPartition tp,
+            Function<CoordinatorContext, CompletableFuture<Void>> asyncFunc
+    ) throws NotCoordinatorException, CoordinatorLoadInProgressException {
+        CoordinatorContext context = contextOrThrow(tp);
+
+        CompletableFuture<Void> result = null;
+        try {
+            context.lock.lock();
+            if (context.state == CoordinatorState.ACTIVE) {
+                // TODO: it's not a good practice to hold lock around async calls, should use event accumulator to synchronize
+                result = asyncFunc.apply(context).whenComplete((none, t) -> context.lock.unlock());
+                return result;
+            } else if (context.state == CoordinatorState.LOADING) {
+                throw Errors.COORDINATOR_LOAD_IN_PROGRESS.exception();
+            } else {
+                throw Errors.NOT_COORDINATOR.exception();
+            }
+        } finally {
+            if (result == null)
+                context.lock.unlock();
         }
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/PartitionWriter.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/PartitionWriter.java
@@ -20,6 +20,8 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 /**
  * A simple interface to write records to Partitions/Logs. It contains the minimum
@@ -92,4 +94,20 @@ public interface PartitionWriter<T> {
         TopicPartition tp,
         List<T> records
     ) throws KafkaException;
+
+    /**
+     * Write records to the partitions. Records are written in one batch so
+     * atomicity is guaranteed.
+     *
+     * @param tp        The partition to write records to.
+     * @param records   The list of records. The records are written in a single batch.
+     * @return The future log end offset right after the written records.
+     * @throws KafkaException Any KafkaException caught during the write operation.
+     */
+    default CompletableFuture<Long> appendAsync(
+            TopicPartition tp,
+            List<T> records
+    ) throws KafkaException {
+        return CompletableFuture.completedFuture(append(tp, records));
+    }
 }


### PR DESCRIPTION
This is a PoC (not tested and probably needs some corner cases
addressed) for running group coordinator on the request handler pool
instead of dedicated thread pool.
    
The main new piece of code is NonBlockingSynchronizer that is an async
equivalent of locking -- it makes sure that async tasks with a given
key don't run concurrently.  The actual work is scheduled back on the
request thread pool using KafkaRequestHandler.wrap primitive that was
first introduced for KIP-890 work.