### PR TITLE
[Draft] KIP-994 (Part 1) Minor Enhancements to ListTransactionsRequest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1633,7 +1633,8 @@ public interface Admin extends AutoCloseable {
      * coordinators in the cluster and collect the state of all transactions. Users
      * should typically attempt to reduce the size of the result set using
      * {@link ListTransactionsOptions#filterProducerIds(Collection)} or
-     * {@link ListTransactionsOptions#filterStates(Collection)}
+     * {@link ListTransactionsOptions#filterStates(Collection)} or
+     * {@link ListTransactionsOptions#durationFilter(Long)}
      *
      * @param options Options to control the method behavior (including filters)
      * @return The result

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListTransactionsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListTransactionsOptions.java
@@ -35,6 +35,7 @@ public class ListTransactionsOptions extends AbstractOptions<ListTransactionsOpt
     private Set<TransactionState> filteredStates = Collections.emptySet();
     private Set<Long> filteredProducerIds = Collections.emptySet();
 
+    private Long durationFilter = 0L;
     /**
      * Filter only the transactions that are in a specific set of states. If no filter
      * is specified or if the passed set of states is empty, then transactions in all
@@ -61,6 +62,11 @@ public class ListTransactionsOptions extends AbstractOptions<ListTransactionsOpt
         return this;
     }
 
+    public ListTransactionsOptions durationFilter(Long durationMs) {
+        this.durationFilter = durationMs;
+        return this;
+    }
+
     /**
      * Returns the set of states to be filtered or empty if no states have been specified.
      *
@@ -81,11 +87,16 @@ public class ListTransactionsOptions extends AbstractOptions<ListTransactionsOpt
         return filteredProducerIds;
     }
 
+    public Long getDurationFilter() {
+        return durationFilter;
+    }
+
     @Override
     public String toString() {
         return "ListTransactionsOptions(" +
             "filteredStates=" + filteredStates +
             ", filteredProducerIds=" + filteredProducerIds +
+            ", durationFilter=" + durationFilter +
             ", timeoutMs=" + timeoutMs +
             ')';
     }
@@ -96,11 +107,12 @@ public class ListTransactionsOptions extends AbstractOptions<ListTransactionsOpt
         if (o == null || getClass() != o.getClass()) return false;
         ListTransactionsOptions that = (ListTransactionsOptions) o;
         return Objects.equals(filteredStates, that.filteredStates) &&
-            Objects.equals(filteredProducerIds, that.filteredProducerIds);
+            Objects.equals(filteredProducerIds, that.filteredProducerIds) &&
+            Objects.equals(durationFilter, that.durationFilter);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(filteredStates, filteredProducerIds);
+        return Objects.hash(filteredStates, filteredProducerIds, durationFilter);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandler.java
@@ -73,6 +73,7 @@ public class ListTransactionsHandler extends AdminApiHandler.Batched<AllBrokersS
         request.setStateFilters(options.filteredStates().stream()
             .map(TransactionState::toString)
             .collect(Collectors.toList()));
+        request.setDurationFilter(options.getDurationFilter());
         return new ListTransactionsRequest.Builder(request);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListTransactionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListTransactionsRequest.java
@@ -38,7 +38,7 @@ public class ListTransactionsRequest extends AbstractRequest {
         public ListTransactionsRequest build(short version) {
             if (data.durationFilter() > 0 && version < 1) {
                 throw new UnsupportedVersionException("Duration filter can be set only when using API version 1 or higher." +
-                        " If client is connected to an older broker, set duration filter to <= 0.");
+                        " If client is connected to an older broker, set duration filter to 0.");
             }
             return new ListTransactionsRequest(data, version);
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListTransactionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListTransactionsRequest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ListTransactionsRequestData;
 import org.apache.kafka.common.message.ListTransactionsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -35,6 +36,10 @@ public class ListTransactionsRequest extends AbstractRequest {
 
         @Override
         public ListTransactionsRequest build(short version) {
+            if (data.durationFilter() > 0 && version < 1) {
+                throw new UnsupportedVersionException("Duration filter can be set only when using API version 1 or higher." +
+                        " If client is connected to an older broker, set duration filter to <= 0.");
+            }
             return new ListTransactionsRequest(data, version);
         }
 

--- a/clients/src/main/resources/common/message/ListTransactionsRequest.json
+++ b/clients/src/main/resources/common/message/ListTransactionsRequest.json
@@ -28,7 +28,7 @@
     { "name": "ProducerIdFilters", "type": "[]int64", "versions": "0+", "entityType": "producerId",
       "about": "The producerIds to filter by: if empty, all transactions will be returned; if non-empty, only transactions which match one of the filtered producerIds will be returned"
     },
-    { "name": "DurationFilter", "type": "int64", "versions": "1+",
+    { "name": "DurationFilter", "type": "int64", "versions": "1+", "default": 0,
       "about": "Duration (in millis) to filter by: if <= 0, all transactions will be returned; otherwise, only transactions running longer than this duration will be returned"
     }
   ]

--- a/clients/src/main/resources/common/message/ListTransactionsRequest.json
+++ b/clients/src/main/resources/common/message/ListTransactionsRequest.json
@@ -13,12 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// version 1: adds DurationFilter to list transactions older than specified duration
 {
   "apiKey": 66,
   "type": "request",
   "listeners": ["zkBroker", "broker"],
   "name": "ListTransactionsRequest",
+  // version 1: adds DurationFilter to list transactions older than specified duration
   "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [

--- a/clients/src/main/resources/common/message/ListTransactionsRequest.json
+++ b/clients/src/main/resources/common/message/ListTransactionsRequest.json
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// version 1: adds DurationFilter to list transactions older than specified duration
 {
   "apiKey": 66,
   "type": "request",
   "listeners": ["zkBroker", "broker"],
   "name": "ListTransactionsRequest",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "StateFilters", "type": "[]string", "versions": "0+",
@@ -26,6 +27,9 @@
     },
     { "name": "ProducerIdFilters", "type": "[]int64", "versions": "0+", "entityType": "producerId",
       "about": "The producerIds to filter by: if empty, all transactions will be returned; if non-empty, only transactions which match one of the filtered producerIds will be returned"
+    },
+    { "name": "DurationFilter", "type": "int64", "versions": "1+",
+      "about": "Duration (in millis) to filter by: if <= 0, all transactions will be returned; otherwise, only transactions running longer than this duration will be returned"
     }
   ]
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandlerTest.java
@@ -91,14 +91,19 @@ public class ListTransactionsHandlerTest {
         BrokerKey brokerKey = new BrokerKey(OptionalInt.of(brokerId));
         ListTransactionsOptions options = new ListTransactionsOptions();
         ListTransactionsHandler handler = new ListTransactionsHandler(options, logContext);
-        // case 1: able to set a valid duration filter when using API version 1
-        options.durationFilter(10L);
+        // case 1: check the default value for durationFilter
         ListTransactionsRequest request = handler.buildBatchedRequest(brokerId, singleton(brokerKey)).build((short) 1);
+        assertEquals(0L, request.data().durationFilter());
+        request = handler.buildBatchedRequest(brokerId, singleton(brokerKey)).build((short) 0);
+        assertEquals(0L, request.data().durationFilter());
+        // case 2: able to set a valid duration filter when using API version 1
+        options.durationFilter(10L);
+        request = handler.buildBatchedRequest(brokerId, singleton(brokerKey)).build((short) 1);
         assertEquals(10L, request.data().durationFilter());
         assertEquals(Collections.emptyList(), request.data().producerIdFilters());
-        // case 2: unable to set a valid duration filter when using API version 0
+        // case 3: unable to set a valid duration filter when using API version 0
         assertThrows(UnsupportedVersionException.class, () -> handler.buildBatchedRequest(brokerId, singleton(brokerKey)).build((short) 0));
-        // case 3: able to set duration filter to a value <= 0 when using API version 0
+        // case 4: able to set duration filter to 0 when using API version 0
         options.durationFilter(0L);
         ListTransactionsRequest request1 = handler.buildBatchedRequest(brokerId, singleton(brokerKey)).build((short) 0);
         assertEquals(0L, request1.data().durationFilter());

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandlerTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.admin.TransactionState;
 import org.apache.kafka.clients.admin.internals.AdminApiHandler.ApiResult;
 import org.apache.kafka.clients.admin.internals.AllBrokersStrategy.BrokerKey;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ListTransactionsResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ListTransactionsRequest;
@@ -41,6 +42,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ListTransactionsHandlerTest {
     private final LogContext logContext = new LogContext();
@@ -81,6 +83,25 @@ public class ListTransactionsHandlerTest {
         ListTransactionsRequest request = handler.buildBatchedRequest(brokerId, singleton(brokerKey)).build();
         assertEquals(Collections.singletonList(filteredState.toString()), request.data().stateFilters());
         assertEquals(Collections.emptyList(), request.data().producerIdFilters());
+    }
+
+    @Test
+    public void testBuildRequestWithDurationFilter() {
+        int brokerId = 1;
+        BrokerKey brokerKey = new BrokerKey(OptionalInt.of(brokerId));
+        ListTransactionsOptions options = new ListTransactionsOptions();
+        ListTransactionsHandler handler = new ListTransactionsHandler(options, logContext);
+        // case 1: able to set a valid duration filter when using API version 1
+        options.durationFilter(10L);
+        ListTransactionsRequest request = handler.buildBatchedRequest(brokerId, singleton(brokerKey)).build((short) 1);
+        assertEquals(10L, request.data().durationFilter());
+        assertEquals(Collections.emptyList(), request.data().producerIdFilters());
+        // case 2: unable to set a valid duration filter when using API version 0
+        assertThrows(UnsupportedVersionException.class, () -> handler.buildBatchedRequest(brokerId, singleton(brokerKey)).build((short) 0));
+        // case 3: able to set duration filter to a value <= 0 when using API version 0
+        options.durationFilter(0L);
+        ListTransactionsRequest request1 = handler.buildBatchedRequest(brokerId, singleton(brokerKey)).build((short) 0);
+        assertEquals(0L, request1.data().durationFilter());
     }
 
     @Test

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -278,12 +278,13 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
 
   def handleListTransactions(
     filteredProducerIds: Set[Long],
-    filteredStates: Set[String]
+    filteredStates: Set[String],
+    durationFilter: Long = -1
   ): ListTransactionsResponseData = {
     if (!isActive.get()) {
       new ListTransactionsResponseData().setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code)
     } else {
-      txnManager.listTransactionStates(filteredProducerIds, filteredStates)
+      txnManager.listTransactionStates(filteredProducerIds, filteredStates, durationFilter)
     }
   }
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -327,8 +327,8 @@ class TransactionStateManager(brokerId: Int,
           }
         }
 
+        val now : Long = System.currentTimeMillis()
         def shouldInclude(txnMetadata: TransactionMetadata): Boolean = {
-          val now : Long = System.currentTimeMillis()
           if (txnMetadata.state == Dead) {
             // We filter the `Dead` state since it is a transient state which
             // indicates that the transactionalId and its metadata are in the

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3630,7 +3630,8 @@ class KafkaApis(val requestChannel: RequestChannel,
     val listTransactionsRequest = request.body[ListTransactionsRequest]
     val filteredProducerIds = listTransactionsRequest.data.producerIdFilters.asScala.map(Long.unbox).toSet
     val filteredStates = listTransactionsRequest.data.stateFilters.asScala.toSet
-    val response = txnCoordinator.handleListTransactions(filteredProducerIds, filteredStates)
+    val durationFilter = listTransactionsRequest.data.durationFilter()
+    val response = txnCoordinator.handleListTransactions(filteredProducerIds, filteredStates, durationFilter)
 
     // The response should contain only transactionalIds that the principal
     // has `Describe` permission to access.

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -489,7 +489,8 @@ class TransactionStateManagerTest {
     transactionManager.addLoadingPartition(partitionId = 0, coordinatorEpoch = 15)
     val listResponse = transactionManager.listTransactionStates(
       filterProducerIds = Set.empty,
-      filterStateNames = Set.empty
+      filterStateNames = Set.empty,
+      0L
     )
     assertEquals(Errors.COORDINATOR_LOAD_IN_PROGRESS, Errors.forCode(listResponse.errorCode))
   }
@@ -529,7 +530,7 @@ class TransactionStateManagerTest {
       filterProducerIds: Set[Long] = Set.empty,
       filterStates: Set[String] = Set.empty
     ): Unit = {
-      val listResponse = transactionManager.listTransactionStates(filterProducerIds, filterStates)
+      val listResponse = transactionManager.listTransactionStates(filterProducerIds, filterStates, 0L)
       assertEquals(Errors.NONE, Errors.forCode(listResponse.errorCode))
       assertEquals(expectedTransactionalIds, listResponse.transactionStates.asScala.map(_.transactionalId).toSet)
       val expectedUnknownStates = filterStates.filter(state => TransactionState.fromName(state).isEmpty)
@@ -843,7 +844,7 @@ class TransactionStateManagerTest {
   }
 
   private def listExpirableTransactionalIds(): Set[String] = {
-    val activeTransactionalIds = transactionManager.listTransactionStates(Set.empty, Set.empty)
+    val activeTransactionalIds = transactionManager.listTransactionStates(Set.empty, Set.empty, 0L)
       .transactionStates
       .asScala
       .map(_.transactionalId)


### PR DESCRIPTION
Introduces a new filter in ListTransactionsRequest API. This enables caller to filter on transactions that have been running for longer than a certain duration of time.
This change bumps version for `ListTransactionsRequest` API to 1. Set the `durationFilter` to 0 when communicating with an older broker that does not support version 1.

Tests:
- Client side test to build request with correct combination of duration filter and API version. `testBuildRequestWithDurationFilter`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
