### PR TITLE
HOTFIX: Fix compilation error in BrokerLifecycleManager

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -302,7 +302,7 @@ class BrokerLifecycleManager(
       if (offlineDirsPending.isEmpty) {
         offlineDirsPending = Set(dir)
       } else {
-        offlineDirsPending = offlineDirsPending.incl(dir)
+        offlineDirsPending = offlineDirsPending + dir
       }
       if (registered) {
         scheduleNextCommunicationImmediately()


### PR DESCRIPTION
https://github.com/apache/kafka/pull/14392 has introduces a compilation error (JDK 8 and Scala 2.12):

```
> Task :core:compileScala

[Error] /home/jenkins/workspace/Kafka_kafka-pr_PR-14392/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala:305:49: value incl is not a member of scala.collection.immutable.Set[org.apache.kafka.common.Uuid]
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
