### PR TITLE
KAFKA-15362: Resolve offline replicas in metadata cache

### DIFF
--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -163,7 +163,7 @@ class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging w
     partition.directory(broker.id()) match {
       case DirectoryId.LOST => true
       case DirectoryId.MIGRATING => false
-      case dir => !broker.directories().contains(dir)
+      case dir => !broker.hasOnlineDir(dir)
     }
   }
 

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -23,7 +23,7 @@ import kafka.utils.Logging
 import org.apache.kafka.admin.BrokerMetadata
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.message.MetadataResponseData.{MetadataResponsePartition, MetadataResponseTopic}
-import org.apache.kafka.common.{Cluster, Node, PartitionInfo, TopicPartition, Uuid}
+import org.apache.kafka.common.{Cluster, DirectoryId, Node, PartitionInfo, TopicPartition, Uuid}
 import org.apache.kafka.common.message.UpdateMetadataRequestData.UpdateMetadataPartitionState
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
@@ -36,7 +36,7 @@ import java.util.concurrent.ThreadLocalRandom
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.message.{DescribeClientQuotasRequestData, DescribeClientQuotasResponseData}
 import org.apache.kafka.common.message.{DescribeUserScramCredentialsRequestData, DescribeUserScramCredentialsResponseData}
-import org.apache.kafka.metadata.{PartitionRegistration, Replicas}
+import org.apache.kafka.metadata.{BrokerRegistration, PartitionRegistration, Replicas}
 import org.apache.kafka.server.common.{Features, MetadataVersion}
 
 import scala.collection.{Map, Seq, Set, mutable}
@@ -143,19 +143,28 @@ class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging w
   private def getOfflineReplicas(image: MetadataImage,
                                  partition: PartitionRegistration,
                                  listenerName: ListenerName): util.List[Integer] = {
-    // TODO: in order to really implement this correctly, we would need JBOD support.
-    // That would require us to track which replicas were offline on a per-replica basis.
-    // See KAFKA-13005.
     val offlineReplicas = new util.ArrayList[Integer](0)
     for (brokerId <- partition.replicas) {
       Option(image.cluster().broker(brokerId)) match {
         case None => offlineReplicas.add(brokerId)
-        case Some(broker) => if (broker.fenced() || !broker.listeners().containsKey(listenerName.value())) {
+        case Some(broker) => if (isReplicaOffline(partition, listenerName, broker)) {
           offlineReplicas.add(brokerId)
         }
       }
     }
     offlineReplicas
+  }
+
+  private def isReplicaOffline(partition: PartitionRegistration, listenerName: ListenerName, broker: BrokerRegistration) = {
+    broker.fenced() || !broker.listeners().containsKey(listenerName.value()) || isInOfflineDir(broker, partition)
+  }
+
+  private def isInOfflineDir(broker: BrokerRegistration, partition: PartitionRegistration): Boolean = {
+    partition.directory(broker.id()) match {
+      case DirectoryId.LOST => true
+      case DirectoryId.MIGRATING => false
+      case dir => !broker.directories().contains(dir)
+    }
   }
 
   /**

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -163,6 +163,7 @@ class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging w
     partition.directory(broker.id()) match {
       case DirectoryId.LOST => true
       case DirectoryId.MIGRATING => false
+      case DirectoryId.UNASSIGNED => false
       case dir => !broker.hasOnlineDir(dir)
     }
   }

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -16,7 +16,7 @@
   */
 package kafka.server
 
-import org.apache.kafka.common.{Node, TopicPartition, Uuid}
+import org.apache.kafka.common.{DirectoryId, Node, TopicPartition, Uuid}
 
 import java.util
 import java.util.Arrays.asList
@@ -1005,5 +1005,46 @@ class MetadataCacheTest {
       assertTrue(cache.contains("test-topic-1"))
       assertTrue(cache.contains("test-topic-1"))
     }
+  }
+
+  @Test
+  def testGetOfflineReplicasConsidersDirAssignment(): Unit = {
+    case class Broker(id: Int, dirs: util.List[Uuid])
+    case class Partition(id: Int, replicas: util.List[Integer], dirs: util.List[Uuid])
+
+    def offlinePartitions(brokers: Seq[Broker], partitions: Seq[Partition]): Map[Int, util.List[Integer]] = {
+      val delta = new MetadataDelta.Builder().build()
+      brokers.foreach(broker => delta.replay(
+        new RegisterBrokerRecord().setFenced(false).
+          setBrokerId(broker.id).setLogDirs(broker.dirs).
+          setEndPoints(new BrokerEndpointCollection(Collections.singleton(
+            new RegisterBrokerRecord.BrokerEndpoint().setSecurityProtocol(SecurityProtocol.PLAINTEXT.id).
+              setPort(9093.toShort).setName("PLAINTEXT").setHost(s"broker-${broker.id}")).iterator()))))
+      val topicId = Uuid.fromString("95OVr1IPRYGrcNCLlpImCA")
+      delta.replay(new TopicRecord().setTopicId(topicId).setName("foo"))
+      partitions.foreach(partition => delta.replay(
+        new PartitionRecord().setTopicId(topicId).setPartitionId(partition.id).
+          setReplicas(partition.replicas).setDirectories(partition.dirs).
+          setLeader(partition.replicas.get(0)).setIsr(partition.replicas)))
+      val cache = MetadataCache.kRaftMetadataCache(1)
+      cache.setImage(delta.apply(MetadataProvenance.EMPTY))
+      val topicMetadata = cache.getTopicMetadata(Set("foo"), ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)).head
+      topicMetadata.partitions().asScala.map(p => (p.partitionIndex(), p.offlineReplicas())).toMap
+    }
+
+    val brokers = Seq(
+      Broker(0, asList(Uuid.fromString("broker1logdirjEo71BG0w"))),
+      Broker(1, asList(Uuid.fromString("broker2logdirRmQQgLxgw")))
+    )
+    val partitions = Seq(
+      Partition(0, asList(0, 1), asList(Uuid.fromString("broker1logdirjEo71BG0w"), DirectoryId.LOST)),
+      Partition(1, asList(0, 1), asList(Uuid.fromString("unknownlogdirjEo71BG0w"), Uuid.fromString("broker2logdirRmQQgLxgw"))),
+      Partition(2, asList(0, 1), asList(DirectoryId.MIGRATING, Uuid.fromString("broker2logdirRmQQgLxgw")))
+    )
+    assertEquals(Map(
+      0 -> asList(1),
+      1 -> asList(0),
+      2 -> asList(),
+    ), offlinePartitions(brokers, partitions))
   }
 }

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -1038,7 +1038,7 @@ class MetadataCacheTest {
     )
     val partitions = Seq(
       Partition(0, asList(0, 1), asList(Uuid.fromString("broker1logdirjEo71BG0w"), DirectoryId.LOST)),
-      Partition(1, asList(0, 1), asList(Uuid.fromString("unknownlogdirjEo71BG0w"), Uuid.fromString("broker2logdirRmQQgLxgw"))),
+      Partition(1, asList(0, 1), asList(Uuid.fromString("unknownlogdirjEo71BG0w"), DirectoryId.UNASSIGNED)),
       Partition(2, asList(0, 1), asList(DirectoryId.MIGRATING, Uuid.fromString("broker2logdirRmQQgLxgw")))
     )
     assertEquals(Map(

--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -458,7 +458,9 @@ public class ClusterControlManager {
                 setRack(Optional.ofNullable(record.rack())).
                 setFenced(record.fenced()).
                 setInControlledShutdown(record.inControlledShutdown()).
-                setIsMigratingZkBroker(record.isMigratingZkBroker()).build());
+                setIsMigratingZkBroker(record.isMigratingZkBroker()).
+                setDirectories(record.logDirs()).
+                    build());
         if (heartbeatManager != null) {
             if (prevRegistration != null) heartbeatManager.remove(brokerId);
             heartbeatManager.register(brokerId, record.fenced());

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;
@@ -335,6 +336,15 @@ public class PartitionRegistration {
 
     public int preferredReplica() {
         return replicas.length == 0 ? LeaderConstants.NO_LEADER : replicas[0];
+    }
+
+    public Uuid directory(int replica) {
+        Map<Integer, Uuid> assignment = DirectoryId.createAssignmentMap(replicas, directories);
+        Uuid uuid = assignment.get(replica);
+        if (uuid == null) {
+            throw new IllegalArgumentException("Replica " + replica + " is not assigned to this partition.");
+        }
+        return uuid;
     }
 
     public ApiMessageAndVersion toRecord(Uuid topicId, int partitionId, ImageWriterOptions options) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -30,7 +30,6 @@ import org.slf4j.Logger;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;
@@ -339,12 +338,12 @@ public class PartitionRegistration {
     }
 
     public Uuid directory(int replica) {
-        Map<Integer, Uuid> assignment = DirectoryId.createAssignmentMap(replicas, directories);
-        Uuid uuid = assignment.get(replica);
-        if (uuid == null) {
-            throw new IllegalArgumentException("Replica " + replica + " is not assigned to this partition.");
+        for (int i = 0; i < replicas.length; i++) {
+            if (replicas[i] == replica) {
+                return directories[i];
+            }
         }
-        return uuid;
+        throw new IllegalArgumentException("Replica " + replica + " is not assigned to this partition.");
     }
 
     public ApiMessageAndVersion toRecord(Uuid topicId, int partitionId, ImageWriterOptions options) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -197,6 +197,9 @@ public class PartitionRegistration {
     private PartitionRegistration(int[] replicas, Uuid[] directories, int[] isr, int[] removingReplicas,
                                  int[] addingReplicas, int leader, LeaderRecoveryState leaderRecoveryState,
                                  int leaderEpoch, int partitionEpoch, int[] elr, int[] lastKnownElr) {
+        if (directories != null && directories.length > 0 && directories.length != replicas.length) {
+            throw new IllegalArgumentException("The lengths for replicas and directories do not match.");
+        }
         this.replicas = replicas;
         this.directories = directories != null && directories.length > 0 ? directories : DirectoryId.unassignedArray(replicas.length);
         this.isr = isr;
@@ -215,8 +218,14 @@ public class PartitionRegistration {
     public PartitionRegistration merge(PartitionChangeRecord record) {
         int[] newReplicas = (record.replicas() == null) ?
             replicas : Replicas.toArray(record.replicas());
-        Uuid[] newDirectories = (record.directories() == null) ?
-                directories : Uuid.toArray(checkDirectories(record));
+        Uuid[] newDirectories;
+        if (record.directories() != null && !record.directories().isEmpty()) {
+            newDirectories = Uuid.toArray(checkDirectories(record));
+        } else if (record.replicas() != null) {
+            newDirectories = Uuid.toArray(DirectoryId.createDirectoriesFrom(replicas, directories, record.replicas()));
+        } else {
+            newDirectories = directories;
+        }
         int[] newIsr = (record.isr() == null) ? isr : Replicas.toArray(record.isr());
         int[] newRemovingReplicas = (record.removingReplicas() == null) ?
             removingReplicas : Replicas.toArray(record.removingReplicas());
@@ -397,7 +406,7 @@ public class PartitionRegistration {
     @Override
     public int hashCode() {
         return Objects.hash(Arrays.hashCode(replicas), Arrays.hashCode(isr), Arrays.hashCode(removingReplicas),
-            Arrays.hashCode(elr), Arrays.hashCode(lastKnownElr),
+            Arrays.hashCode(directories), Arrays.hashCode(elr), Arrays.hashCode(lastKnownElr),
             Arrays.hashCode(addingReplicas), leader, leaderRecoveryState, leaderEpoch, partitionEpoch);
     }
 
@@ -406,6 +415,7 @@ public class PartitionRegistration {
         if (!(o instanceof PartitionRegistration)) return false;
         PartitionRegistration other = (PartitionRegistration) o;
         return Arrays.equals(replicas, other.replicas) &&
+            Arrays.equals(directories, other.directories) &&
             Arrays.equals(isr, other.isr) &&
             Arrays.equals(removingReplicas, other.removingReplicas) &&
             Arrays.equals(addingReplicas, other.addingReplicas) &&
@@ -421,6 +431,7 @@ public class PartitionRegistration {
     public String toString() {
         StringBuilder builder = new StringBuilder("PartitionRegistration(");
         builder.append("replicas=").append(Arrays.toString(replicas));
+        builder.append(", directories=").append(Arrays.toString(directories));
         builder.append(", isr=").append(Arrays.toString(isr));
         builder.append(", removingReplicas=").append(Arrays.toString(removingReplicas));
         builder.append(", addingReplicas=").append(Arrays.toString(addingReplicas));
@@ -436,6 +447,7 @@ public class PartitionRegistration {
 
     public boolean hasSameAssignment(PartitionRegistration registration) {
         return Arrays.equals(this.replicas, registration.replicas) &&
+            Arrays.equals(this.directories, registration.directories) &&
             Arrays.equals(this.addingReplicas, registration.addingReplicas) &&
             Arrays.equals(this.removingReplicas, registration.removingReplicas);
     }

--- a/metadata/src/test/java/org/apache/kafka/image/node/ClusterImageBrokersNodeTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/node/ClusterImageBrokersNodeTest.java
@@ -66,7 +66,7 @@ public class ClusterImageBrokersNodeTest {
             "rack=Optional.empty, " +
             "fenced=false, " +
             "inControlledShutdown=false, " +
-            "isMigratingZkBroker=false)", child.stringify());
+            "isMigratingZkBroker=false, directories=[])", child.stringify());
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/image/node/ClusterImageBrokersNodeTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/node/ClusterImageBrokersNodeTest.java
@@ -45,6 +45,7 @@ public class ClusterImageBrokersNodeTest {
                     setSupportedFeatures(Collections.singletonMap(MetadataVersion.FEATURE_NAME, VersionRange.of(1, 4))).
                     setRack(Optional.empty()).
                     setFenced(false).
+                    setDirectories(Arrays.asList(Uuid.fromString("anCdBWcFTlu8gE1wP6bh3g"), Uuid.fromString("JsnDDNVyTL289kYk6sPzig"))).
                     setInControlledShutdown(false).build()),
             Collections.emptyMap());
 
@@ -66,7 +67,9 @@ public class ClusterImageBrokersNodeTest {
             "rack=Optional.empty, " +
             "fenced=false, " +
             "inControlledShutdown=false, " +
-            "isMigratingZkBroker=false, directories=[])", child.stringify());
+            "isMigratingZkBroker=false, " +
+            "directories=[JsnDDNVyTL289kYk6sPzig, anCdBWcFTlu8gE1wP6bh3g])",
+            child.stringify());
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/metadata/BrokerRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/BrokerRegistrationTest.java
@@ -37,7 +37,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -168,5 +170,30 @@ public class BrokerRegistrationTest {
             REGISTRATIONS.get(2).node("INTERNAL"));
         assertEquals(Optional.of(new Node(3, "localhost", 9093, null)),
             REGISTRATIONS.get(3).node("INTERNAL"));
+    }
+
+    @Test
+    void testDirectoryListOrderDoesNotMatter() {
+        BrokerRegistration.Builder builder = new BrokerRegistration.Builder().
+                setId(0).
+                setEpoch(0).
+                setIncarnationId(Uuid.fromString("ik32HZbLTW6ulw1yyrC8jQ")).
+                setListeners(Arrays.asList(new Endpoint("INTERNAL", SecurityProtocol.PLAINTEXT, "localhost", 9090))).
+                setSupportedFeatures(Collections.singletonMap("foo", VersionRange.of((short) 1, (short) 2))).
+                setRack(Optional.empty()).
+                setFenced(false).
+                setInControlledShutdown(false);
+        Uuid dir1 = Uuid.fromString("apL5H78tQQqio31Od2xYRQ");
+        Uuid dir2 = Uuid.fromString("3b4Y3zHCScGAEnz4op4blg");
+        BrokerRegistration registration1 = builder.setDirectories(Arrays.asList(dir1, dir2)).build();
+        BrokerRegistration registration2 = builder.setDirectories(Arrays.asList(dir2, dir1)).build();
+        assertEquals(registration1, registration2);
+        assertEquals(registration1.hashCode(), registration2.hashCode());
+        assertTrue(registration1.hasOnlineDir(dir1));
+        assertTrue(registration1.hasOnlineDir(dir2));
+        assertTrue(registration2.hasOnlineDir(dir1));
+        assertTrue(registration2.hasOnlineDir(dir2));
+        assertFalse(registration1.hasOnlineDir(Uuid.fromString("sOwN7HH7S1maxpU1WzlzXg")));
+        assertFalse(registration2.hasOnlineDir(Uuid.fromString("sOwN7HH7S1maxpU1WzlzXg")));
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -132,14 +132,18 @@ public class PartitionRegistrationTest {
 
     @Test
     public void testMergePartitionChangeRecordWithReassignmentData() {
+        Uuid dir1 = Uuid.fromString("FbRuu7CeQtq5YFreEzg16g");
+        Uuid dir2 = Uuid.fromString("4rtHTelWSSStAFMODOg3cQ");
+        Uuid dir3 = Uuid.fromString("Id1WXzHURROilVxZWJNZlw");
         PartitionRegistration partition0 = new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).
-            setDirectories(new Uuid[]{Uuid.fromString("FbRuu7CeQtq5YFreEzg16g"), Uuid.fromString("4rtHTelWSSStAFMODOg3cQ"), Uuid.fromString("Id1WXzHURROilVxZWJNZlw")}).
+            setDirectories(new Uuid[]{dir1, dir2, dir3}).
             setIsr(new int[] {1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionRegistration partition1 = partition0.merge(new PartitionChangeRecord().
             setRemovingReplicas(Collections.singletonList(3)).
             setAddingReplicas(Collections.singletonList(4)).
             setReplicas(Arrays.asList(1, 2, 3, 4)));
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).
+            setDirectories(new Uuid[]{dir1, dir2, dir3, DirectoryId.UNASSIGNED}).
             setIsr(new int[] {1, 2, 3}).setRemovingReplicas(new int[] {3}).setAddingReplicas(new int[] {4}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(201).build(), partition1);
         PartitionRegistration partition2 = partition1.merge(new PartitionChangeRecord().
             setIsr(Arrays.asList(1, 2, 4)).
@@ -147,6 +151,7 @@ public class PartitionRegistrationTest {
             setAddingReplicas(Collections.emptyList()).
             setReplicas(Arrays.asList(1, 2, 4)));
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 4}).
+            setDirectories(new Uuid[]{dir1, dir2, DirectoryId.UNASSIGNED}).
             setIsr(new int[] {1, 2, 4}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(202).build(), partition2);
     }
 


### PR DESCRIPTION
The metadata cache now considers registered log directories and directory assignments when determining offline replicas.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
