### PR TITLE
Adding this-escape for MaterializedStoreFactory implementors

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
  * Materializes a key-value store as either a {@link TimestampedKeyValueStoreBuilder} or a
  * {@link VersionedKeyValueStoreBuilder} depending on whether the store is versioned or not.
  */
+@SuppressWarnings("this-escape")
 public class KeyValueStoreMaterializer<K, V> extends MaterializedStoreFactory<K, V, KeyValueStore<Bytes, byte[]>> {
     private static final Logger LOG = LoggerFactory.getLogger(KeyValueStoreMaterializer.class);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionStoreMaterializer.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.internals.RocksDbTimeOrderedSessionBytesStoreSupplier;
 
+@SuppressWarnings("this-escape")
 public class SessionStoreMaterializer<K, V> extends MaterializedStoreFactory<K, V, SessionStore<Bytes, byte[]>> {
 
     private final MaterializedInternal<K, V, SessionStore<Bytes, byte[]>> materialized;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowStoreMaterializer.java
@@ -28,6 +28,7 @@ import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.internals.RocksDbIndexedTimeOrderedWindowBytesStoreSupplier;
 
+@SuppressWarnings("this-escape")
 public class SlidingWindowStoreMaterializer<K, V> extends MaterializedStoreFactory<K, V, WindowStore<Bytes, byte[]>> {
 
     private final SlidingWindows windows;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowStoreMaterializer.java
@@ -28,6 +28,7 @@ import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.internals.RocksDbIndexedTimeOrderedWindowBytesStoreSupplier;
 
+@SuppressWarnings("this-escape")
 public class WindowStoreMaterializer<K, V> extends MaterializedStoreFactory<K, V, WindowStore<Bytes, byte[]>> {
 
     private final Windows<?> windows;


### PR DESCRIPTION
Noticed the latest https://github.com/apache/kafka/pull/14741 [failed compileJava on JDK 21](https://ci-builds.apache.org/blue/organizations/jenkins/Kafka%2Fkafka-pr/detail/PR-14741/1/pipeline/) due to =>

```
> Task :streams:compileJava

/home/jenkins/jenkins-agent/workspace/Kafka_kafka-pr_PR-14741/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowStoreMaterializer.java:46: warning: [this-escape] possible 'this' escape before subclass is fully initialized

        retentionPeriod = retentionPeriod();

                                         ^

error: warnings found and -Werror specified
```

This seems to be happening because this-escape is [a new linter added in JDK 21](https://bugs.openjdk.org/browse/JDK-8015831), which warns about the constructor calling other methods. This PR is an attempt to check if this suppression helps in getting around this issue. 