### PR TITLE
KAFKA-15795: Support fetch(fromKey, toKey, from, to) to WindowRangeQuery and unify WindowKeyQuery and WindowRangeQuery

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -185,7 +185,7 @@
               files="(KafkaStreams|KStreamImpl|KTableImpl|InternalTopologyBuilder|StreamsPartitionAssignor|StreamThread|IQv2StoreIntegrationTest|KStreamImplTest|RocksDBStore).java"/>
 
     <suppress checks="MethodLength"
-              files="KTableImpl.java"/>
+              files="(KTableImpl|IQv2StoreIntegrationTest).java"/>
 
     <suppress checks="ParameterNumber"
               files="StreamThread.java"/>

--- a/streams/src/main/java/org/apache/kafka/streams/query/WindowRangeQuery.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/WindowRangeQuery.java
@@ -84,12 +84,12 @@ public class WindowRangeQuery<K, V> implements Query<KeyValueIterator<Windowed<K
         return upper;
     }
 
-    //@Deprecated
+    @Deprecated
     public Optional<Instant> getTimeFrom() {
         return oldTimeFrom;
     }
 
-    //@Deprecated
+    @Deprecated
     public Optional<Instant> getTimeTo() {
         return oldTimeTo;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/query/WindowRangeQuery.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/WindowRangeQuery.java
@@ -25,43 +25,95 @@ import java.util.Optional;
 
 public class WindowRangeQuery<K, V> implements Query<KeyValueIterator<Windowed<K>, V>> {
 
+    private final Optional<K> lower;
+    private final Optional<K> upper;
     private final Optional<K> key;
+    private final Optional<Instant> oldTimeFrom;
+    private final Optional<Instant> oldTimeTo;
     private final Optional<Instant> timeFrom;
     private final Optional<Instant> timeTo;
 
-    private WindowRangeQuery(final Optional<K> key,
+    private WindowRangeQuery(final Optional<K> lower,
+                             final Optional<K> upper,
+                             final Optional<Instant> oldTimeFrom,
+                             final Optional<Instant> oldTimeTo,
+                             final Optional<K> key,
                              final Optional<Instant> timeFrom,
                              final Optional<Instant> timeTo) {
+        this.lower = lower;
+        this.upper = upper;
+        this.oldTimeFrom = oldTimeFrom;
+        this.oldTimeTo = oldTimeTo;
         this.key = key;
         this.timeFrom = timeFrom;
         this.timeTo = timeTo;
     }
 
     public static <K, V> WindowRangeQuery<K, V> withKey(final K key) {
-        return new WindowRangeQuery<>(Optional.of(key), Optional.empty(), Optional.empty());
+        return new WindowRangeQuery<>(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(key), Optional.empty(), Optional.empty());
     }
 
     public static <K, V> WindowRangeQuery<K, V> withWindowStartRange(final Instant timeFrom,
                                                                      final Instant timeTo) {
-        return new WindowRangeQuery<>(Optional.empty(), Optional.of(timeFrom), Optional.of(timeTo));
+        return new WindowRangeQuery<>(Optional.empty(), Optional.empty(), Optional.of(timeFrom), Optional.of(timeTo), Optional.empty(), Optional.empty(), Optional.empty());
     }
 
-    public Optional<K> getKey() {
-        return key;
+    public static <K, V> WindowRangeQuery<K, V> withAllKey() {
+        return new WindowRangeQuery<>(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     }
 
+
+    public WindowRangeQuery<K, V> fromTime(final Instant timeFrom) {
+        return new WindowRangeQuery<>(lower, upper, Optional.empty(), Optional.empty(), Optional.empty(), Optional.ofNullable(timeFrom), timeTo);
+    }
+
+
+    public WindowRangeQuery<K, V> toTime(final Instant timeTo) {
+        return new WindowRangeQuery<>(lower, upper, Optional.empty(), Optional.empty(), Optional.empty(), timeFrom, Optional.ofNullable(timeTo));
+    }
+
+    public static <K, V> WindowRangeQuery<K, V> withKeyRange(final K lower, final K upper) {
+        return new WindowRangeQuery<>(Optional.ofNullable(lower), Optional.ofNullable(upper), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    public Optional<K> lowerKeyBound() {
+        return lower;
+    }
+
+    public Optional<K> upperKeyBound() {
+        return upper;
+    }
+
+    //@Deprecated
     public Optional<Instant> getTimeFrom() {
+        return oldTimeFrom;
+    }
+
+    //@Deprecated
+    public Optional<Instant> getTimeTo() {
+        return oldTimeTo;
+    }
+
+    public Optional<Instant> timeFrom() {
         return timeFrom;
     }
 
-    public Optional<Instant> getTimeTo() {
+    public Optional<Instant> timeTo() {
         return timeTo;
+    }
+
+    public Optional<K> key() {
+        return key;
     }
 
     @Override
     public String toString() {
         return "WindowRangeQuery{" +
-            "key=" + key +
+            "lower=" + lower +
+            ", upper=" + upper +
+            ", oldTimeFrom=" + oldTimeFrom +
+            ", oldTimeTo=" + oldTimeTo +
+            ", key=" + key +
             ", timeFrom=" + timeFrom +
             ", timeTo=" + timeTo +
             '}';

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -47,6 +47,7 @@ import org.apache.kafka.streams.state.internals.metrics.StateStoreMetrics;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -432,10 +433,11 @@ public class MeteredSessionStore<K, V>
                                              final QueryConfig config) {
         final QueryResult<R> result;
         final WindowRangeQuery<K, V> typedQuery = (WindowRangeQuery<K, V>) query;
-        if (typedQuery.getKey().isPresent()) {
+        final Optional<K> key = typedQuery.key();
+        if (key.isPresent()) {
             final WindowRangeQuery<Bytes, byte[]> rawKeyQuery =
                 WindowRangeQuery.withKey(
-                    Bytes.wrap(serdes.rawKey(typedQuery.getKey().get()))
+                    Bytes.wrap(serdes.rawKey(key.get()))
                 );
             final QueryResult<KeyValueIterator<Windowed<Bytes>, byte[]>> rawResult =
                 wrapped().query(rawKeyQuery, positionBound, config);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -385,7 +385,7 @@ public class MeteredWindowStore<K, V>
         return result;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "deprecation"})
     private <R> QueryResult<R> runRangeQuery(final Query<R> query,
                                              final PositionBound positionBound,
                                              final QueryConfig config) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
@@ -284,7 +284,7 @@ public final class StoreQueryUtils {
         }
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked","deprecation"})
     private static <R> QueryResult<R> runWindowRangeQuery(final Query<R> query,
                                                           final PositionBound positionBound,
                                                           final QueryConfig config,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
@@ -297,10 +297,21 @@ public final class StoreQueryUtils {
                 // There's no store API for open time ranges
                 if (windowRangeQuery.getTimeFrom().isPresent() && windowRangeQuery.getTimeTo().isPresent()) {
                     final KeyValueIterator<Windowed<Bytes>, byte[]> iterator =
-                        windowStore.fetchAll(
+                        windowStore.fetch(
+                            windowRangeQuery.lowerKeyBound().orElse(null),
+                            windowRangeQuery.upperKeyBound().orElse(null),
                             windowRangeQuery.getTimeFrom().get(),
                             windowRangeQuery.getTimeTo().get()
                         );
+                    return (QueryResult<R>) QueryResult.forResult(iterator);
+                } else if (!windowRangeQuery.getTimeFrom().isPresent() && !windowRangeQuery.getTimeTo().isPresent()) {
+                    final KeyValueIterator<Windowed<Bytes>, byte[]> iterator =
+                        windowStore.fetch(
+                            windowRangeQuery.lowerKeyBound().orElse(null),
+                            windowRangeQuery.upperKeyBound().orElse(null),
+                            windowRangeQuery.timeFrom().get(),
+                            windowRangeQuery.timeTo().get()
+                    );
                     return (QueryResult<R>) QueryResult.forResult(iterator);
                 } else {
                     return QueryResult.forFailure(
@@ -324,9 +335,9 @@ public final class StoreQueryUtils {
                 (WindowRangeQuery<Bytes, byte[]>) query;
             final SessionStore<Bytes, byte[]> sessionStore = (SessionStore<Bytes, byte[]>) store;
             try {
-                if (windowRangeQuery.getKey().isPresent()) {
+                if (windowRangeQuery.key().isPresent()) {
                     final KeyValueIterator<Windowed<Bytes>, byte[]> iterator = sessionStore.fetch(
-                        windowRangeQuery.getKey().get());
+                        windowRangeQuery.key().get());
                     return (QueryResult<R>) QueryResult.forResult(iterator);
                 } else {
                     return QueryResult.forFailure(

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -1221,6 +1221,8 @@ public class IQv2StoreIntegrationTest {
 
         // miss the window start
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart - 1),
             Instant.ofEpochMilli(windowStart - 1),
             extractor,
@@ -1229,6 +1231,8 @@ public class IQv2StoreIntegrationTest {
 
         // do the query at the first window
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart),
             Instant.ofEpochMilli(windowStart),
             extractor,
@@ -1237,6 +1241,8 @@ public class IQv2StoreIntegrationTest {
 
         // do the query at the first and the second windows
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart),
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(5).toMillis()),
             extractor,
@@ -1245,6 +1251,8 @@ public class IQv2StoreIntegrationTest {
 
         // do the query at the second and the third windows
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(5).toMillis()),
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(10).toMillis()),
             extractor,
@@ -1253,6 +1261,8 @@ public class IQv2StoreIntegrationTest {
 
         // do the query at the third and the fourth windows
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(10).toMillis()),
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
             extractor,
@@ -1261,6 +1271,8 @@ public class IQv2StoreIntegrationTest {
 
         // do the query at the fourth and the fifth windows
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(20).toMillis()),
             extractor,
@@ -1269,6 +1281,8 @@ public class IQv2StoreIntegrationTest {
 
         //do the query at the fifth and the sixth windows
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(20).toMillis()),
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(25).toMillis()),
             extractor,
@@ -1277,6 +1291,8 @@ public class IQv2StoreIntegrationTest {
 
         // do the query from the second to the fourth windows
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(5).toMillis()),
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
             extractor,
@@ -1285,10 +1301,192 @@ public class IQv2StoreIntegrationTest {
 
         // do the query from the first to the fourth windows
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart),
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
             extractor,
             mkSet(1, 17, 2, 3, 4, 5, 13)
+        );
+
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart - 1),
+            Instant.ofEpochMilli(windowStart - 1),
+            extractor,
+            mkSet()
+        );
+
+        // do the query at the first window
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart),
+            Instant.ofEpochMilli(windowStart),
+            extractor,
+            mkSet(1, 2)
+        );
+
+        // do the query at the first and the second windows
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart),
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(5).toMillis()),
+            extractor,
+            mkSet(1, 2, 3, 4)
+        );
+
+        // do the query at the second and the third windows
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(5).toMillis()),
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(10).toMillis()),
+            extractor,
+            mkSet(3, 4, 5, 13)
+        );
+
+        // do the query at the third and the fourth windows
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(10).toMillis()),
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
+            extractor,
+            mkSet(17, 5, 13)
+        );
+
+        // do the query at the fourth and the fifth windows
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(20).toMillis()),
+            extractor,
+            mkSet(17)
+        );
+
+        //do the query at the fifth and the sixth windows
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(20).toMillis()),
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(25).toMillis()),
+            extractor,
+            mkSet()
+        );
+
+        // do the query from the second to the fourth windows
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(5).toMillis()),
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
+            extractor,
+            mkSet(17, 3, 4, 5, 13)
+        );
+
+        // do the query from the first to the fourth windows
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart),
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
+            extractor,
+            mkSet(1, 17, 2, 3, 4, 5, 13)
+        );
+
+        shouldHandleWindowRangeQuery(
+            0,
+            0,
+            Instant.ofEpochMilli(WINDOW_START),
+            Instant.ofEpochMilli(WINDOW_START),
+            extractor,
+            mkSet(1)
+        );
+
+        // miss the window start range
+        shouldHandleWindowRangeQuery(
+            0,
+            0,
+            Instant.ofEpochMilli(WINDOW_START - 1),
+            Instant.ofEpochMilli(WINDOW_START - 1),
+            extractor,
+            mkSet()
+        );
+
+        // do the window key query at the first window and the key of record which we want to query is 2
+        shouldHandleWindowRangeQuery(
+            2,
+            2,
+            Instant.ofEpochMilli(WINDOW_START),
+            Instant.ofEpochMilli(WINDOW_START),
+            extractor,
+            mkSet()
+        );
+
+        // miss the key
+        shouldHandleWindowRangeQuery(
+            999,
+            999,
+            Instant.ofEpochMilli(WINDOW_START),
+            Instant.ofEpochMilli(WINDOW_START),
+            extractor,
+            mkSet()
+        );
+
+        // miss both
+        shouldHandleWindowRangeQuery(
+            999,
+            999,
+            Instant.ofEpochMilli(WINDOW_START - 1),
+            Instant.ofEpochMilli(WINDOW_START - 1),
+            extractor,
+            mkSet()
+        );
+
+        // do the window key query at the first and the second windows and the key of record which we want to query is 0
+        shouldHandleWindowRangeQuery(
+            0,
+            0,
+            Instant.ofEpochMilli(WINDOW_START),
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(5).toMillis()),
+            extractor,
+            mkSet(1)
+        );
+
+        // do the window key query at the first window and the key of record which we want to query is 1
+        shouldHandleWindowRangeQuery(
+            1,
+            1,
+            Instant.ofEpochMilli(WINDOW_START),
+            Instant.ofEpochMilli(WINDOW_START),
+            extractor,
+            mkSet(2)
+        );
+
+        // do the window key query at the second and the third windows and the key of record which we want to query is 2
+        shouldHandleWindowRangeQuery(
+            2,
+            2,
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(5).toMillis()),
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(10).toMillis()),
+            extractor,
+            mkSet(4, 5)
+        );
+
+        // do the window key query at the second and the third windows and the key of record which we want to query is 3
+        shouldHandleWindowRangeQuery(
+            3,
+            3,
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(5).toMillis()),
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(10).toMillis()),
+            extractor,
+            mkSet(13)
+        );
+
+        // do the window key query at the fourth and the fifth windows and the key of record which we want to query is 4
+        shouldHandleWindowRangeQuery(
+            4,
+            4,
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(15).toMillis()),
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(20).toMillis()),
+            extractor,
+            mkSet(17)
+        );
+
+        // do the window key query at the fifth window and the key of record which we want to query is 4
+        shouldHandleWindowRangeQuery(
+            4,
+            4,
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(20).toMillis()),
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(24).toMillis()),
+            extractor,
+            mkSet()
         );
 
         // Should fail to execute this query on a WindowStore.
@@ -1320,7 +1518,7 @@ public class IQv2StoreIntegrationTest {
                     "This store"
                         + " \\(class org.apache.kafka.streams.state.internals.Metered.*WindowStore\\)"
                         + " doesn't know how to execute the given query"
-                        + " \\(WindowRangeQuery\\{key=Optional\\[2], timeFrom=Optional.empty, timeTo=Optional.empty}\\)"
+                        + " \\(WindowRangeQuery\\{lower=Optional.empty, upper=Optional.empty, oldTimeFrom=Optional.empty, oldTimeTo=Optional.empty, key=Optional\\[2], timeFrom=Optional.empty, timeTo=Optional.empty}\\)"
                         + " because WindowStores only supports WindowRangeQuery.withWindowStartRange\\."
                         + " Contact the store maintainer if you need support for a new query type\\."
                 ));
@@ -1334,6 +1532,8 @@ public class IQv2StoreIntegrationTest {
 
         // miss the window start
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart - 1),
             Instant.ofEpochMilli(windowStart - 1),
             extractor,
@@ -1342,6 +1542,8 @@ public class IQv2StoreIntegrationTest {
 
         // do the query at the first window
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart),
             Instant.ofEpochMilli(windowStart),
             extractor,
@@ -1350,6 +1552,8 @@ public class IQv2StoreIntegrationTest {
 
         // do the query at the first and the second windows
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart),
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(5).toMillis()),
             extractor,
@@ -1358,6 +1562,8 @@ public class IQv2StoreIntegrationTest {
 
         // do the query at the second and the third windows
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(5).toMillis()),
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(10).toMillis()),
             extractor,
@@ -1366,6 +1572,8 @@ public class IQv2StoreIntegrationTest {
 
         // do the query at the third and the fourth windows
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(10).toMillis()),
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
             extractor,
@@ -1374,6 +1582,8 @@ public class IQv2StoreIntegrationTest {
 
         // do the query at the fourth and the fifth windows
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(20).toMillis()),
             extractor,
@@ -1382,6 +1592,8 @@ public class IQv2StoreIntegrationTest {
 
         //do the query at the fifth and the sixth windows
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(20).toMillis()),
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(25).toMillis()),
             extractor,
@@ -1390,6 +1602,8 @@ public class IQv2StoreIntegrationTest {
 
         // do the query from the second to the fourth windows
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(5).toMillis()),
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
             extractor,
@@ -1398,10 +1612,194 @@ public class IQv2StoreIntegrationTest {
 
         // do the query from the first to the fourth windows
         shouldHandleWindowRangeQuery(
+            null,
+            null,
             Instant.ofEpochMilli(windowStart),
             Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
             extractor,
             mkSet(1, 2, 3, 4, 5, 7, 9)
+        );
+
+        // miss the window start
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart - 1),
+            Instant.ofEpochMilli(windowStart - 1),
+            extractor,
+            mkSet()
+        );
+
+        // do the query at the first window
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart),
+            Instant.ofEpochMilli(windowStart),
+            extractor,
+            mkSet(1, 2)
+        );
+
+        // do the query at the first and the second windows
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart),
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(5).toMillis()),
+            extractor,
+            mkSet(1, 2, 3, 4)
+        );
+
+        // do the query at the second and the third windows
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(5).toMillis()),
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(10).toMillis()),
+            extractor,
+            mkSet(3, 4, 5, 7)
+        );
+
+        // do the query at the third and the fourth windows
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(10).toMillis()),
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
+            extractor,
+            mkSet(5, 7, 9)
+        );
+
+        // do the query at the fourth and the fifth windows
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(20).toMillis()),
+            extractor,
+            mkSet(9)
+        );
+
+        //do the query at the fifth and the sixth windows
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(20).toMillis()),
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(25).toMillis()),
+            extractor,
+            mkSet()
+        );
+
+        // do the query from the second to the fourth windows
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(5).toMillis()),
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
+            extractor,
+            mkSet(3, 4, 5, 7, 9)
+        );
+
+        // do the query from the first to the fourth windows
+        shouldHandleWindowRangeQuery2(
+            Instant.ofEpochMilli(windowStart),
+            Instant.ofEpochMilli(windowStart + Duration.ofMinutes(15).toMillis()),
+            extractor,
+            mkSet(1, 2, 3, 4, 5, 7, 9)
+        );
+
+        // tightest possible start range
+        shouldHandleWindowRangeQuery(
+            0,
+            0,
+            Instant.ofEpochMilli(WINDOW_START),
+            Instant.ofEpochMilli(WINDOW_START),
+            extractor,
+            mkSet(1)
+        );
+
+        // miss the window start range
+        shouldHandleWindowRangeQuery(
+            0,
+            0,
+            Instant.ofEpochMilli(WINDOW_START - 1),
+            Instant.ofEpochMilli(WINDOW_START - 1),
+            extractor,
+            mkSet()
+        );
+
+        // do the window key query at the first window and the key of record which we want to query is 2
+        shouldHandleWindowRangeQuery(
+            2,
+            2,
+            Instant.ofEpochMilli(WINDOW_START),
+            Instant.ofEpochMilli(WINDOW_START),
+            extractor,
+            mkSet()
+        );
+
+        // miss the key
+        shouldHandleWindowRangeQuery(
+            999,
+            999,
+            Instant.ofEpochMilli(WINDOW_START),
+            Instant.ofEpochMilli(WINDOW_START),
+            extractor,
+            mkSet()
+        );
+
+        // miss both
+        shouldHandleWindowRangeQuery(
+            999,
+            999,
+            Instant.ofEpochMilli(WINDOW_START - 1),
+            Instant.ofEpochMilli(WINDOW_START - 1),
+            extractor,
+            mkSet()
+        );
+
+        // do the window key query at the first and the second windows and the key of record which we want to query is 0
+        shouldHandleWindowRangeQuery(
+            0,
+            0,
+            Instant.ofEpochMilli(WINDOW_START),
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(5).toMillis()),
+            extractor,
+            mkSet(1)
+        );
+
+        // do the window key query at the first window and the key of record which we want to query is 1
+        shouldHandleWindowRangeQuery(
+            1,
+            1,
+            Instant.ofEpochMilli(WINDOW_START),
+            Instant.ofEpochMilli(WINDOW_START),
+            extractor,
+            mkSet(2)
+        );
+
+        // do the window key query at the second and the third windows and the key of record which we want to query is 2
+        shouldHandleWindowRangeQuery(
+            2,
+            2,
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(5).toMillis()),
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(10).toMillis()),
+            extractor,
+            mkSet(4, 5)
+        );
+
+        // do the window key query at the second and the third windows and the key of record which we want to query is 3
+        shouldHandleWindowRangeQuery(
+            3,
+            3,
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(5).toMillis()),
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(10).toMillis()),
+            extractor,
+            mkSet(7)
+        );
+
+        // do the window key query at the fourth and the fifth windows and the key of record which we want to query is 4
+        shouldHandleWindowRangeQuery(
+            4,
+            4,
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(15).toMillis()),
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(20).toMillis()),
+            extractor,
+            mkSet(9)
+        );
+
+        // do the window key query at the fifth window and the key of record which we want to query is 4
+        shouldHandleWindowRangeQuery(
+            4,
+            4,
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(20).toMillis()),
+            Instant.ofEpochMilli(WINDOW_START + Duration.ofMinutes(24).toMillis()),
+            extractor,
+            mkSet()
         );
 
         // Should fail to execute this query on a WindowStore.
@@ -1433,7 +1831,7 @@ public class IQv2StoreIntegrationTest {
                     "This store"
                         + " \\(class org.apache.kafka.streams.state.internals.Metered.*WindowStore\\)"
                         + " doesn't know how to execute the given query"
-                        + " \\(WindowRangeQuery\\{key=Optional\\[2], timeFrom=Optional.empty, timeTo=Optional.empty}\\)"
+                        + " \\(WindowRangeQuery\\{lower=Optional.empty, upper=Optional.empty, oldTimeFrom=Optional.empty, oldTimeTo=Optional.empty, key=Optional\\[2], timeFrom=Optional.empty, timeTo=Optional.empty}\\)"
                         + " because WindowStores only supports WindowRangeQuery.withWindowStartRange\\."
                         + " Contact the store maintainer if you need support for a new query type\\."
                 ));
@@ -1506,7 +1904,7 @@ public class IQv2StoreIntegrationTest {
                     "This store"
                         + " (class org.apache.kafka.streams.state.internals.MeteredSessionStore)"
                         + " doesn't know how to execute the given query"
-                        + " (WindowRangeQuery{key=Optional.empty, timeFrom=Optional[1970-01-01T00:00:00Z], timeTo=Optional[1970-01-01T00:00:00Z]})"
+                        + " (WindowRangeQuery{lower=Optional.empty, upper=Optional.empty, oldTimeFrom=Optional[1970-01-01T00:00:00Z], oldTimeTo=Optional[1970-01-01T00:00:00Z], key=Optional.empty, timeFrom=Optional.empty, timeTo=Optional.empty})"
                         + " because SessionStores only support WindowRangeQuery.withKey."
                         + " Contact the store maintainer if you need support for a new query type."
                 ));
@@ -1579,7 +1977,7 @@ public class IQv2StoreIntegrationTest {
                     "This store"
                         + " (class org.apache.kafka.streams.state.internals.MeteredSessionStore)"
                         + " doesn't know how to execute the given query"
-                        + " (WindowRangeQuery{key=Optional.empty, timeFrom=Optional[1970-01-01T00:00:00Z], timeTo=Optional[1970-01-01T00:00:00Z]})"
+                        + " (WindowRangeQuery{lower=Optional.empty, upper=Optional.empty, oldTimeFrom=Optional[1970-01-01T00:00:00Z], oldTimeTo=Optional[1970-01-01T00:00:00Z], key=Optional.empty, timeFrom=Optional.empty, timeTo=Optional.empty})"
                         + " because SessionStores only support WindowRangeQuery.withKey."
                         + " Contact the store maintainer if you need support for a new query type."
                 ));
@@ -1877,6 +2275,58 @@ public class IQv2StoreIntegrationTest {
     }
 
     public <V> void shouldHandleWindowRangeQuery(
+        final Integer keyFrom,
+        final Integer keyTo,
+        final Instant timeFrom,
+        final Instant timeTo,
+        final Function<V, Integer> valueExtactor,
+        final Set<Integer> expectedValues) {
+
+        final WindowRangeQuery<Integer, V> query = WindowRangeQuery.<Integer, V>withKeyRange(keyFrom, keyTo).fromTime(timeFrom).toTime(timeTo);
+
+        final StateQueryRequest<KeyValueIterator<Windowed<Integer>, V>> request =
+            inStore(STORE_NAME)
+                .withQuery(query)
+                .withPartitions(mkSet(0, 1))
+                .withPositionBound(PositionBound.at(INPUT_POSITION));
+
+        final StateQueryResult<KeyValueIterator<Windowed<Integer>, V>> result =
+            IntegrationTestUtils.iqv2WaitForResult(kafkaStreams, request);
+
+        if (result.getGlobalResult() != null) {
+            fail("global tables aren't implemented");
+        } else {
+            final Set<Integer> actualValues = new HashSet<>();
+            final Map<Integer, QueryResult<KeyValueIterator<Windowed<Integer>, V>>> queryResult = result.getPartitionResults();
+            for (final int partition : queryResult.keySet()) {
+                final boolean failure = queryResult.get(partition).isFailure();
+                if (failure) {
+                    throw new AssertionError(queryResult.toString());
+                }
+                assertThat(queryResult.get(partition).isSuccess(), is(true));
+
+                assertThrows(
+                    IllegalArgumentException.class,
+                    queryResult.get(partition)::getFailureReason
+                );
+                assertThrows(
+                    IllegalArgumentException.class,
+                    queryResult.get(partition)::getFailureMessage
+                );
+
+                try (final KeyValueIterator<Windowed<Integer>, V> iterator = queryResult.get(partition).getResult()) {
+                    while (iterator.hasNext()) {
+                        actualValues.add(valueExtactor.apply(iterator.next().value));
+                    }
+                }
+                assertThat(queryResult.get(partition).getExecutionInfo(), is(empty()));
+            }
+            assertThat("Result:" + result, actualValues, is(expectedValues));
+            assertThat("Result:" + result, result.getPosition(), is(INPUT_POSITION));
+        }
+    }
+
+    public <V> void shouldHandleWindowRangeQuery2(
         final Instant timeFrom,
         final Instant timeTo,
         final Function<V, Integer> valueExtactor,


### PR DESCRIPTION
KIP-997: https://cwiki.apache.org/confluence/display/KAFKA/KIP-997%3A++Support+fetch%28fromKey%2C+toKey%2C+from%2C+to%29+to+WindowRangeQuery+and+unify+WindowKeyQuery+and+WindowRangeQuery

We aim to enhance the WindowRangeQuery  by supporting a new method: fetch(keyFrom, keyTo, from, to). Currently, WindowRangeQuery  utilizes KeyValueIterator<Windowed<K>, V> fetchAll(Instant timeFrom, Instant timeTo)  for retrieving all key-value pairs within a specified time range. However, we propose to use KeyValueIterator<Windowed<K>, V> fetch(K keyFrom, K keyTo, Instant timeFrom, Instant timeTo)  instead. This new method will provide a KeyValueIterator<Windowed<K>, V>  that allows users to iterate over windowed key-value pairs {{

{<Windowed<K>, value>}
}} , spanning the entire time range.

With this new method, users can retrieve window sessions for specific keys, rather than all keys, which enables a more targeted query. This is an improvement over the fetchAll  method, which only allows retrieval of all key's window sessions without the ability to specify a range of keys.

Additionally, this enhancement also allows the WindowRangeQuery  to support WindowKeyQuery  functionality. Users seeking to query window sessions for a specific key can do so by setting keyFrom  and keyTo  to be equal. This dual functionality provides more flexibility and efficiency in querying windowed keys.

 
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
