### PR TITLE
KAFKA-15555: Ensure wakeups are handled correctly in poll()

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ def isChangeRequest(env) {
   env.CHANGE_ID != null && !env.CHANGE_ID.isEmpty()
 }
 
-def doTest(env, target = "test") {
+def doTest(env, target = "clients:test --tests org.apache.kafka.clients.consumer.internals.AsyncKafkaConsumerTest") {
   sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
       --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
       -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ def isChangeRequest(env) {
   env.CHANGE_ID != null && !env.CHANGE_ID.isEmpty()
 }
 
-def doTest(env, target = "clients:test --tests org.apache.kafka.clients.consumer.internals.AsyncKafkaConsumerTest --tests org.apache.kafka.clients.consumer.internals.FetchBufferTest") {
+def doTest(env, target = "clients:test") {
   sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
       --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
       -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ def isChangeRequest(env) {
   env.CHANGE_ID != null && !env.CHANGE_ID.isEmpty()
 }
 
-def doTest(env, target = "clients:test --tests org.apache.kafka.clients.consumer.internals.AsyncKafkaConsumerTest") {
+def doTest(env, target = "clients:test --tests org.apache.kafka.clients.consumer.internals.AsyncKafkaConsumerTest --tests org.apache.kafka.clients.consumer.internals.FetchBufferTest") {
   sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
       --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
       -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ def isChangeRequest(env) {
   env.CHANGE_ID != null && !env.CHANGE_ID.isEmpty()
 }
 
-def doTest(env, target = "clients:test") {
+def doTest(env, target = "test") {
   sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
       --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
       -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""

--- a/build.gradle
+++ b/build.gradle
@@ -1423,6 +1423,7 @@ project(':clients') {
     testImplementation libs.junitJupiter
     testImplementation libs.log4j
     testImplementation libs.mockitoCore
+    testImplementation libs.mockitoJunitJupiter // supports MockitoExtension
 
     testRuntimeOnly libs.slf4jlog4j
     testRuntimeOnly libs.jacksonDatabind

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/WakeupTrigger.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/WakeupTrigger.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.errors.WakeupException;
 
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -44,6 +45,10 @@ public class WakeupTrigger {
                 ActiveFuture active = (ActiveFuture) task;
                 active.future().completeExceptionally(new WakeupException());
                 return null;
+            } else if (task instanceof FetchAction) {
+                FetchAction fetchAction = (FetchAction) task;
+                fetchAction.fetchBuffer().wakeup();
+                return new WakeupFuture();
             } else {
                 return task;
             }
@@ -75,15 +80,49 @@ public class WakeupTrigger {
         return currentTask;
     }
 
-    public void clearActiveTask() {
+    public void setFetchAction(final FetchBuffer fetchBuffer) {
+        final AtomicBoolean throwWakeupException = new AtomicBoolean(false);
+        pendingTask.getAndUpdate(task -> {
+            if (task == null) {
+                return new FetchAction(fetchBuffer);
+            } else if (task instanceof WakeupFuture) {
+                throwWakeupException.set(true);
+                return null;
+            }
+            // last active state is still active
+            throw new IllegalStateException("Last active task is still active");
+        });
+        if (throwWakeupException.get()) {
+            throw new WakeupException();
+        }
+    }
+
+    public void clearTask() {
         pendingTask.getAndUpdate(task -> {
             if (task == null) {
                 return null;
-            } else if (task instanceof ActiveFuture) {
+            } else if (task instanceof ActiveFuture || task instanceof FetchAction) {
                 return null;
             }
             return task;
         });
+    }
+
+    public void maybeTriggerWakeup() {
+        final AtomicBoolean throwWakeupException = new AtomicBoolean(false);
+        pendingTask.getAndUpdate(task -> {
+            if (task == null) {
+                return null;
+            } else if (task instanceof WakeupFuture) {
+                throwWakeupException.set(true);
+                return null;
+            } else {
+                return task;
+            }
+        });
+        if (throwWakeupException.get()) {
+            throw new WakeupException();
+        }
     }
 
     Wakeupable getPendingTask() {
@@ -105,4 +144,17 @@ public class WakeupTrigger {
     }
 
     static class WakeupFuture implements Wakeupable { }
+
+    static class FetchAction implements Wakeupable {
+
+        private final FetchBuffer fetchBuffer;
+
+        public FetchAction(FetchBuffer fetchBuffer) {
+            this.fetchBuffer = fetchBuffer;
+        }
+
+        public FetchBuffer fetchBuffer() {
+            return fetchBuffer;
+        }
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
@@ -54,7 +53,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -76,11 +74,8 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
-import static org.apache.kafka.common.utils.Utils.mkEntry;
-import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -92,7 +87,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -106,8 +100,8 @@ public class AsyncKafkaConsumerTest {
     private ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder;
     private ApplicationEventHandler applicationEventHandler;
 
-    @Mock
-    private FetchCollector<String, String> fetchCollector;
+//    @Mock
+//    private FetchCollector<String, String> fetchCollector;
 
     @BeforeEach
     public void setup() {
@@ -232,142 +226,125 @@ public class AsyncKafkaConsumerTest {
         }
     }
 
-    @Test
-    public void testWakeupBeforeCallingPoll() {
-        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
-        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
-                 new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
-                     ConsumerTestBuilder.createDefaultGroupInformation(),
-                     fetchCollector,
-                     applicationEventHandler
-                 )) {
-            final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
-            final String topicName = "foo";
-            final int partition = 3;
-            final TopicPartition tp = new TopicPartition(topicName, partition);
-            when(fetchCollector.collectFetch(Mockito.any(FetchBuffer.class)))
-                .thenReturn(Fetch.empty());
-            Map<TopicPartition, OffsetAndMetadata> offsets = mkMap(mkEntry(tp, new OffsetAndMetadata(1)));
-            when(applicationEventHandler.addAndGet(any(OffsetFetchApplicationEvent.class), any(Timer.class)))
-                .thenReturn(offsets);
-            consumer.assign(singleton(tp));
-
-            consumer.wakeup();
-
-            assertThrows(WakeupException.class, () -> consumer.poll(Duration.ZERO));
-            assertDoesNotThrow(() -> consumer.poll(Duration.ZERO));
-        }
-    }
-
-    @Test
-    public void testWakeupAfterEmptyFetch() {
-        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
-        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
-            new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
-                ConsumerTestBuilder.createDefaultGroupInformation(),
-                fetchCollector,
-                applicationEventHandler
-            )) {
-            final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
-            final String topicName = "foo";
-            final int partition = 3;
-            final TopicPartition tp = new TopicPartition(topicName, partition);
-            when(fetchCollector.collectFetch(Mockito.any(FetchBuffer.class)))
-                .thenAnswer(invocation -> {
-                    consumer.wakeup();
-                    return Fetch.empty();
-                })
-                .thenReturn(Fetch.empty());
-            Map<TopicPartition, OffsetAndMetadata> offsets = mkMap(mkEntry(tp, new OffsetAndMetadata(1)));
-            when(applicationEventHandler.addAndGet(any(OffsetFetchApplicationEvent.class), any(Timer.class)))
-                .thenReturn(offsets);
-            consumer.assign(singleton(tp));
-
-            assertThrows(WakeupException.class, () -> consumer.poll(Duration.ofMinutes(1)));
-            assertDoesNotThrow(() -> consumer.poll(Duration.ZERO));
-        }
-    }
-
-    private <K, V> void setupWakeupTestsWithEmptyFetches(final AsyncKafkaConsumer<K, V> consumer,
-                                                         final ApplicationEventHandler applicationEventHandler) {
-        final String topicName = "foo";
-        final int partition = 3;
-        final TopicPartition tp = new TopicPartition(topicName, partition);
-        when(fetchCollector.collectFetch(Mockito.any(FetchBuffer.class)))
-            .thenAnswer(invocation -> {
-                consumer.wakeup();
-                return Fetch.empty();
-            })
-            .thenReturn(Fetch.empty());
-        Map<TopicPartition, OffsetAndMetadata> offsets = mkMap(mkEntry(tp, new OffsetAndMetadata(1)));
-        when(applicationEventHandler.addAndGet(any(OffsetFetchApplicationEvent.class), any(Timer.class)))
-            .thenReturn(offsets);
-        consumer.assign(singleton(tp));
-    }
-
-    @Test
-    public void testWakeupAfterNonEmptyFetch() {
-        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
-        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
-            new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
-                ConsumerTestBuilder.createDefaultGroupInformation(),
-                fetchCollector,
-                applicationEventHandler
-            )) {
-            final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
-            final String topicName = "foo";
-            final int partition = 3;
-            final TopicPartition tp = new TopicPartition(topicName, partition);
-            final List<ConsumerRecord<String, String>> records = asList(
-                new ConsumerRecord<>(topicName, partition, 2, "key1", "value1"),
-                new ConsumerRecord<>(topicName, partition, 3, "key2", "value2")
-            );
-            when(fetchCollector.collectFetch(Mockito.any(FetchBuffer.class)))
-                .thenAnswer(invocation -> {
-                    consumer.wakeup();
-                    return Fetch.forPartition(tp, records, true);
-                });
-            Map<TopicPartition, OffsetAndMetadata> offsets = mkMap(mkEntry(tp, new OffsetAndMetadata(1)));
-            when(applicationEventHandler.addAndGet(any(OffsetFetchApplicationEvent.class), any(Timer.class)))
-                .thenReturn(offsets);
-            consumer.assign(singleton(tp));
-
-            // since wakeup() is called when the non-empty fetch is returned the wakeup should be ignored
-            assertDoesNotThrow(() -> consumer.poll(Duration.ofMinutes(1)));
-            // the previously ignored wake-up should not be ignored in the next call
-            assertThrows(WakeupException.class, () -> consumer.poll(Duration.ZERO));
-        }
-    }
-
-    @Test
-    public void testClearWakeupTriggerAfterPoll() {
-        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
-        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
-                 new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
-                     ConsumerTestBuilder.createDefaultGroupInformation(),
-                     fetchCollector,
-                     applicationEventHandler
-                 )) {
-            final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
-            final String topicName = "foo";
-            final int partition = 3;
-            final TopicPartition tp = new TopicPartition(topicName, partition);
-            final List<ConsumerRecord<String, String>> records = asList(
-                new ConsumerRecord<>(topicName, partition, 2, "key1", "value1"),
-                new ConsumerRecord<>(topicName, partition, 3, "key2", "value2")
-            );
-            when(fetchCollector.collectFetch(Mockito.any(FetchBuffer.class)))
-                .thenReturn(Fetch.forPartition(tp, records, true));
-            Map<TopicPartition, OffsetAndMetadata> offsets = mkMap(mkEntry(tp, new OffsetAndMetadata(1)));
-            when(applicationEventHandler.addAndGet(any(OffsetFetchApplicationEvent.class), any(Timer.class)))
-                .thenReturn(offsets);
-            consumer.assign(singleton(tp));
-
-            consumer.poll(Duration.ZERO);
-
-            assertDoesNotThrow(() -> consumer.poll(Duration.ZERO));
-        }
-    }
+//    @Test
+//    public void testWakeupBeforeCallingPoll() {
+//        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
+//        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
+//                 new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
+//                     ConsumerTestBuilder.createDefaultGroupInformation(),
+//                     fetchCollector,
+//                     applicationEventHandler
+//                 )) {
+//            final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
+//            final String topicName = "foo";
+//            final int partition = 3;
+//            final TopicPartition tp = new TopicPartition(topicName, partition);
+//            when(fetchCollector.collectFetch(Mockito.any(FetchBuffer.class)))
+//                .thenReturn(Fetch.empty());
+//            Map<TopicPartition, OffsetAndMetadata> offsets = mkMap(mkEntry(tp, new OffsetAndMetadata(1)));
+//            when(applicationEventHandler.addAndGet(any(OffsetFetchApplicationEvent.class), any(Timer.class)))
+//                .thenReturn(offsets);
+//            consumer.assign(singleton(tp));
+//
+//            consumer.wakeup();
+//
+//            assertThrows(WakeupException.class, () -> consumer.poll(Duration.ZERO));
+//            assertDoesNotThrow(() -> consumer.poll(Duration.ZERO));
+//        }
+//    }
+//
+//    @Test
+//    public void testWakeupAfterEmptyFetch() {
+//        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
+//        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
+//            new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
+//                ConsumerTestBuilder.createDefaultGroupInformation(),
+//                fetchCollector,
+//                applicationEventHandler
+//            )) {
+//            final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
+//            final String topicName = "foo";
+//            final int partition = 3;
+//            final TopicPartition tp = new TopicPartition(topicName, partition);
+//            when(fetchCollector.collectFetch(Mockito.any(FetchBuffer.class)))
+//                .thenAnswer(invocation -> {
+//                    consumer.wakeup();
+//                    return Fetch.empty();
+//                })
+//                .thenReturn(Fetch.empty());
+//            Map<TopicPartition, OffsetAndMetadata> offsets = mkMap(mkEntry(tp, new OffsetAndMetadata(1)));
+//            when(applicationEventHandler.addAndGet(any(OffsetFetchApplicationEvent.class), any(Timer.class)))
+//                .thenReturn(offsets);
+//            consumer.assign(singleton(tp));
+//
+//            assertThrows(WakeupException.class, () -> consumer.poll(Duration.ofMinutes(1)));
+//            assertDoesNotThrow(() -> consumer.poll(Duration.ZERO));
+//        }
+//    }
+//
+//    @Test
+//    public void testWakeupAfterNonEmptyFetch() {
+//        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
+//        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
+//            new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
+//                ConsumerTestBuilder.createDefaultGroupInformation(),
+//                fetchCollector,
+//                applicationEventHandler
+//            )) {
+//            final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
+//            final String topicName = "foo";
+//            final int partition = 3;
+//            final TopicPartition tp = new TopicPartition(topicName, partition);
+//            final List<ConsumerRecord<String, String>> records = asList(
+//                new ConsumerRecord<>(topicName, partition, 2, "key1", "value1"),
+//                new ConsumerRecord<>(topicName, partition, 3, "key2", "value2")
+//            );
+//            when(fetchCollector.collectFetch(Mockito.any(FetchBuffer.class)))
+//                .thenAnswer(invocation -> {
+//                    consumer.wakeup();
+//                    return Fetch.forPartition(tp, records, true);
+//                });
+//            Map<TopicPartition, OffsetAndMetadata> offsets = mkMap(mkEntry(tp, new OffsetAndMetadata(1)));
+//            when(applicationEventHandler.addAndGet(any(OffsetFetchApplicationEvent.class), any(Timer.class)))
+//                .thenReturn(offsets);
+//            consumer.assign(singleton(tp));
+//
+//            // since wakeup() is called when the non-empty fetch is returned the wakeup should be ignored
+//            assertDoesNotThrow(() -> consumer.poll(Duration.ofMinutes(1)));
+//            // the previously ignored wake-up should not be ignored in the next call
+//            assertThrows(WakeupException.class, () -> consumer.poll(Duration.ZERO));
+//        }
+//    }
+//
+//    @Test
+//    public void testClearWakeupTriggerAfterPoll() {
+//        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
+//        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
+//                 new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
+//                     ConsumerTestBuilder.createDefaultGroupInformation(),
+//                     fetchCollector,
+//                     applicationEventHandler
+//                 )) {
+//            final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
+//            final String topicName = "foo";
+//            final int partition = 3;
+//            final TopicPartition tp = new TopicPartition(topicName, partition);
+//            final List<ConsumerRecord<String, String>> records = asList(
+//                new ConsumerRecord<>(topicName, partition, 2, "key1", "value1"),
+//                new ConsumerRecord<>(topicName, partition, 3, "key2", "value2")
+//            );
+//            when(fetchCollector.collectFetch(Mockito.any(FetchBuffer.class)))
+//                .thenReturn(Fetch.forPartition(tp, records, true));
+//            Map<TopicPartition, OffsetAndMetadata> offsets = mkMap(mkEntry(tp, new OffsetAndMetadata(1)));
+//            when(applicationEventHandler.addAndGet(any(OffsetFetchApplicationEvent.class), any(Timer.class)))
+//                .thenReturn(offsets);
+//            consumer.assign(singleton(tp));
+//
+//            consumer.poll(Duration.ZERO);
+//
+//            assertDoesNotThrow(() -> consumer.poll(Duration.ZERO));
+//        }
+//    }
 
     @Test
     public void testEnsureCallbackExecutedByApplicationThread() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -234,13 +234,15 @@ public class AsyncKafkaConsumerTest {
 
     @Test
     public void testWakeupBeforeCallingPoll() {
-        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
-        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
-                 new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
-                     ConsumerTestBuilder.createDefaultGroupInformation(),
-                     fetchCollector,
-                     applicationEventHandler
-                 )) {
+        try (
+            final ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
+            final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
+                new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
+                    ConsumerTestBuilder.createDefaultGroupInformation(),
+                    fetchCollector,
+                    applicationEventHandler
+                )
+        ) {
             final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
             final String topicName = "foo";
             final int partition = 3;
@@ -261,13 +263,15 @@ public class AsyncKafkaConsumerTest {
 
     @Test
     public void testWakeupAfterEmptyFetch() {
-        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
-        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
-            new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
-                ConsumerTestBuilder.createDefaultGroupInformation(),
-                fetchCollector,
-                applicationEventHandler
-            )) {
+        try (
+            final ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
+            final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
+                new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
+                    ConsumerTestBuilder.createDefaultGroupInformation(),
+                    fetchCollector,
+                    applicationEventHandler
+                )
+        ) {
             final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
             final String topicName = "foo";
             final int partition = 3;
@@ -290,13 +294,15 @@ public class AsyncKafkaConsumerTest {
 
     @Test
     public void testWakeupAfterNonEmptyFetch() {
-        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
-        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
-            new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
-                ConsumerTestBuilder.createDefaultGroupInformation(),
-                fetchCollector,
-                applicationEventHandler
-            )) {
+        try (
+            final ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
+            final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
+                new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
+                    ConsumerTestBuilder.createDefaultGroupInformation(),
+                    fetchCollector,
+                    applicationEventHandler
+                )
+        ) {
             final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
             final String topicName = "foo";
             final int partition = 3;
@@ -324,13 +330,15 @@ public class AsyncKafkaConsumerTest {
 
     @Test
     public void testClearWakeupTriggerAfterPoll() {
-        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
-        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
-                 new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
-                     ConsumerTestBuilder.createDefaultGroupInformation(),
-                     fetchCollector,
-                     applicationEventHandler
-                 )) {
+        try (
+            final ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
+            final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
+                new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
+                    ConsumerTestBuilder.createDefaultGroupInformation(),
+                    fetchCollector,
+                    applicationEventHandler
+                )
+        ) {
             final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
             final String topicName = "foo";
             final int partition = 3;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
@@ -45,12 +46,18 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
 import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 
 import java.time.Duration;
@@ -69,8 +76,11 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -82,16 +92,22 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class AsyncKafkaConsumerTest {
 
     private AsyncKafkaConsumer<?, ?> consumer;
     private ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder;
     private ApplicationEventHandler applicationEventHandler;
+
+    @Mock
+    private FetchCollector<String, String> fetchCollector;
 
     @BeforeEach
     public void setup() {
@@ -213,6 +229,143 @@ public class AsyncKafkaConsumerTest {
         try (MockedConstruction<OffsetFetchApplicationEvent> ignored = offsetFetchEventMocker(committedFuture)) {
             assertThrows(KafkaException.class, () -> consumer.committed(offsets.keySet(), Duration.ofMillis(1000)));
             verify(applicationEventHandler).add(ArgumentMatchers.isA(OffsetFetchApplicationEvent.class));
+        }
+    }
+
+    @Test
+    public void testWakeupBeforeCallingPoll() {
+        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
+        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
+                 new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
+                     ConsumerTestBuilder.createDefaultGroupInformation(),
+                     fetchCollector,
+                     applicationEventHandler
+                 )) {
+            final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
+            final String topicName = "foo";
+            final int partition = 3;
+            final TopicPartition tp = new TopicPartition(topicName, partition);
+            when(fetchCollector.collectFetch(Mockito.any(FetchBuffer.class)))
+                .thenReturn(Fetch.empty());
+            Map<TopicPartition, OffsetAndMetadata> offsets = mkMap(mkEntry(tp, new OffsetAndMetadata(1)));
+            when(applicationEventHandler.addAndGet(any(OffsetFetchApplicationEvent.class), any(Timer.class)))
+                .thenReturn(offsets);
+            consumer.assign(singleton(tp));
+
+            consumer.wakeup();
+
+            assertThrows(WakeupException.class, () -> consumer.poll(Duration.ZERO));
+            assertDoesNotThrow(() -> consumer.poll(Duration.ZERO));
+        }
+    }
+
+    @Test
+    public void testWakeupAfterEmptyFetch() {
+        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
+        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
+            new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
+                ConsumerTestBuilder.createDefaultGroupInformation(),
+                fetchCollector,
+                applicationEventHandler
+            )) {
+            final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
+            final String topicName = "foo";
+            final int partition = 3;
+            final TopicPartition tp = new TopicPartition(topicName, partition);
+            when(fetchCollector.collectFetch(Mockito.any(FetchBuffer.class)))
+                .thenAnswer(invocation -> {
+                    consumer.wakeup();
+                    return Fetch.empty();
+                })
+                .thenReturn(Fetch.empty());
+            Map<TopicPartition, OffsetAndMetadata> offsets = mkMap(mkEntry(tp, new OffsetAndMetadata(1)));
+            when(applicationEventHandler.addAndGet(any(OffsetFetchApplicationEvent.class), any(Timer.class)))
+                .thenReturn(offsets);
+            consumer.assign(singleton(tp));
+
+            assertThrows(WakeupException.class, () -> consumer.poll(Duration.ofMinutes(1)));
+            assertDoesNotThrow(() -> consumer.poll(Duration.ZERO));
+        }
+    }
+
+    private <K, V> void setupWakeupTestsWithEmptyFetches(final AsyncKafkaConsumer<K, V> consumer,
+                                                         final ApplicationEventHandler applicationEventHandler) {
+        final String topicName = "foo";
+        final int partition = 3;
+        final TopicPartition tp = new TopicPartition(topicName, partition);
+        when(fetchCollector.collectFetch(Mockito.any(FetchBuffer.class)))
+            .thenAnswer(invocation -> {
+                consumer.wakeup();
+                return Fetch.empty();
+            })
+            .thenReturn(Fetch.empty());
+        Map<TopicPartition, OffsetAndMetadata> offsets = mkMap(mkEntry(tp, new OffsetAndMetadata(1)));
+        when(applicationEventHandler.addAndGet(any(OffsetFetchApplicationEvent.class), any(Timer.class)))
+            .thenReturn(offsets);
+        consumer.assign(singleton(tp));
+    }
+
+    @Test
+    public void testWakeupAfterNonEmptyFetch() {
+        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
+        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
+            new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
+                ConsumerTestBuilder.createDefaultGroupInformation(),
+                fetchCollector,
+                applicationEventHandler
+            )) {
+            final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
+            final String topicName = "foo";
+            final int partition = 3;
+            final TopicPartition tp = new TopicPartition(topicName, partition);
+            final List<ConsumerRecord<String, String>> records = asList(
+                new ConsumerRecord<>(topicName, partition, 2, "key1", "value1"),
+                new ConsumerRecord<>(topicName, partition, 3, "key2", "value2")
+            );
+            when(fetchCollector.collectFetch(Mockito.any(FetchBuffer.class)))
+                .thenAnswer(invocation -> {
+                    consumer.wakeup();
+                    return Fetch.forPartition(tp, records, true);
+                });
+            Map<TopicPartition, OffsetAndMetadata> offsets = mkMap(mkEntry(tp, new OffsetAndMetadata(1)));
+            when(applicationEventHandler.addAndGet(any(OffsetFetchApplicationEvent.class), any(Timer.class)))
+                .thenReturn(offsets);
+            consumer.assign(singleton(tp));
+
+            // since wakeup() is called when the non-empty fetch is returned the wakeup should be ignored
+            assertDoesNotThrow(() -> consumer.poll(Duration.ofMinutes(1)));
+            // the previously ignored wake-up should not be ignored in the next call
+            assertThrows(WakeupException.class, () -> consumer.poll(Duration.ZERO));
+        }
+    }
+
+    @Test
+    public void testClearWakeupTriggerAfterPoll() {
+        ApplicationEventHandler applicationEventHandler = mock(ApplicationEventHandler.class);
+        try (final ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder testBuilder =
+                 new ConsumerTestBuilder.AsyncKafkaConsumerTestBuilder(
+                     ConsumerTestBuilder.createDefaultGroupInformation(),
+                     fetchCollector,
+                     applicationEventHandler
+                 )) {
+            final AsyncKafkaConsumer<String, String> consumer = testBuilder.consumer;
+            final String topicName = "foo";
+            final int partition = 3;
+            final TopicPartition tp = new TopicPartition(topicName, partition);
+            final List<ConsumerRecord<String, String>> records = asList(
+                new ConsumerRecord<>(topicName, partition, 2, "key1", "value1"),
+                new ConsumerRecord<>(topicName, partition, 3, "key2", "value2")
+            );
+            when(fetchCollector.collectFetch(Mockito.any(FetchBuffer.class)))
+                .thenReturn(Fetch.forPartition(tp, records, true));
+            Map<TopicPartition, OffsetAndMetadata> offsets = mkMap(mkEntry(tp, new OffsetAndMetadata(1)));
+            when(applicationEventHandler.addAndGet(any(OffsetFetchApplicationEvent.class), any(Timer.class)))
+                .thenReturn(offsets);
+            consumer.assign(singleton(tp));
+
+            consumer.poll(Duration.ZERO);
+
+            assertDoesNotThrow(() -> consumer.poll(Duration.ZERO));
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -51,7 +51,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -345,6 +345,35 @@ public class ConsumerTestBuilder implements Closeable {
                     groupInfo.map(groupInformation -> groupInformation.groupState.groupId).orElse(null)));
         }
 
+        public AsyncKafkaConsumerTestBuilder(Optional<GroupInformation> groupInfo,
+                                        FetchCollector<String, String> fetchCollector,
+                                        ApplicationEventHandler applicationEventHandler) {
+            super(groupInfo);
+            String clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
+            List<ConsumerPartitionAssignor> assignors = ConsumerPartitionAssignor.getAssignorInstances(
+                config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG),
+                config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId))
+            );
+            Deserializers<String, String> deserializers = new Deserializers<>(new StringDeserializer(), new StringDeserializer());
+            this.consumer = spy(new AsyncKafkaConsumer<>(
+                logContext,
+                clientId,
+                deserializers,
+                new FetchBuffer(logContext),
+                fetchCollector,
+                new ConsumerInterceptors<>(Collections.emptyList()),
+                time,
+                applicationEventHandler,
+                backgroundEventQueue,
+                metrics,
+                subscriptions,
+                metadata,
+                retryBackoffMs,
+                60000,
+                assignors,
+                groupInfo.map(groupInformation -> groupInformation.groupState.groupId).orElse(null)));
+        }
+
         @Override
         public void close() {
             consumer.close();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -346,8 +346,8 @@ public class ConsumerTestBuilder implements Closeable {
         }
 
         public AsyncKafkaConsumerTestBuilder(Optional<GroupInformation> groupInfo,
-                                        FetchCollector<String, String> fetchCollector,
-                                        ApplicationEventHandler applicationEventHandler) {
+                                             FetchCollector<String, String> fetchCollector,
+                                             ApplicationEventHandler applicationEventHandler) {
             super(groupInfo);
             String clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
             List<ConsumerPartitionAssignor> assignors = ConsumerPartitionAssignor.getAssignorInstances(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
@@ -173,19 +173,19 @@ public class FetchBufferTest {
         }
     }
 
-    @Test
-    public void testWakeup() throws Exception {
-        try (FetchBuffer fetchBuffer = new FetchBuffer(logContext)) {
-            final Thread waitingThread = new Thread(() -> {
-                final Timer timer = time.timer(Duration.ofMinutes(1));
-                fetchBuffer.awaitNotEmpty(timer);
-            });
-            waitingThread.start();
-            fetchBuffer.wakeup();
-            waitingThread.join(Duration.ofSeconds(30).toMillis());
-            assertFalse(waitingThread.isAlive());
-        }
-    }
+//    @Test
+//    public void testWakeup() throws Exception {
+//        try (FetchBuffer fetchBuffer = new FetchBuffer(logContext)) {
+//            final Thread waitingThread = new Thread(() -> {
+//                final Timer timer = time.timer(Duration.ofMinutes(1));
+//                fetchBuffer.awaitNotEmpty(timer);
+//            });
+//            waitingThread.start();
+//            fetchBuffer.wakeup();
+//            waitingThread.join(Duration.ofSeconds(30).toMillis());
+//            assertFalse(waitingThread.isAlive());
+//        }
+//    }
 
     private CompletedFetch completedFetch(TopicPartition tp) {
         FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
@@ -26,11 +26,11 @@ import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
-//import org.apache.kafka.common.utils.Timer;
+import org.apache.kafka.common.utils.Timer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-//import java.time.Duration;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Properties;
@@ -173,19 +173,19 @@ public class FetchBufferTest {
         }
     }
 
-//    @Test
-//    public void testWakeup() throws Exception {
-//        try (FetchBuffer fetchBuffer = new FetchBuffer(logContext)) {
-//            final Thread waitingThread = new Thread(() -> {
-//                final Timer timer = time.timer(Duration.ofMinutes(1));
-//                fetchBuffer.awaitNotEmpty(timer);
-//            });
-//            waitingThread.start();
-//            fetchBuffer.wakeup();
-//            waitingThread.join(Duration.ofSeconds(30).toMillis());
-//            assertFalse(waitingThread.isAlive());
-//        }
-//    }
+    @Test
+    public void testWakeup() throws Exception {
+        try (FetchBuffer fetchBuffer = new FetchBuffer(logContext)) {
+            final Thread waitingThread = new Thread(() -> {
+                final Timer timer = time.timer(Duration.ofMinutes(1));
+                fetchBuffer.awaitNotEmpty(timer);
+            });
+            waitingThread.start();
+            fetchBuffer.wakeup();
+            waitingThread.join(Duration.ofSeconds(30).toMillis());
+            assertFalse(waitingThread.isAlive());
+        }
+    }
 
     private CompletedFetch completedFetch(TopicPartition tp) {
         FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
@@ -26,11 +26,11 @@ import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.common.utils.Timer;
+//import org.apache.kafka.common.utils.Timer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
+//import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Properties;
@@ -173,19 +173,19 @@ public class FetchBufferTest {
         }
     }
 
-    @Test
-    public void testWakeup() throws Exception {
-        try (FetchBuffer fetchBuffer = new FetchBuffer(logContext)) {
-            final Thread waitingThread = new Thread(() -> {
-                final Timer timer = time.timer(Duration.ofMinutes(1));
-                fetchBuffer.awaitNotEmpty(timer);
-            });
-            waitingThread.start();
-            fetchBuffer.wakeup();
-            waitingThread.join(Duration.ofSeconds(30).toMillis());
-            assertFalse(waitingThread.isAlive());
-        }
-    }
+//    @Test
+//    public void testWakeup() throws Exception {
+//        try (FetchBuffer fetchBuffer = new FetchBuffer(logContext)) {
+//            final Thread waitingThread = new Thread(() -> {
+//                final Timer timer = time.timer(Duration.ofMinutes(1));
+//                fetchBuffer.awaitNotEmpty(timer);
+//            });
+//            waitingThread.start();
+//            fetchBuffer.wakeup();
+//            waitingThread.join(Duration.ofSeconds(30).toMillis());
+//            assertFalse(waitingThread.isAlive());
+//        }
+//    }
 
     private CompletedFetch completedFetch(TopicPartition tp) {
         FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
@@ -26,9 +26,11 @@ import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Timer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Properties;
@@ -171,19 +173,19 @@ public class FetchBufferTest {
         }
     }
 
-//    @Test
-//    public void testWakeup() throws Exception {
-//        try (FetchBuffer fetchBuffer = new FetchBuffer(logContext)) {
-//            final Thread waitingThread = new Thread(() -> {
-//                final Timer timer = time.timer(Duration.ofMinutes(1));
-//                fetchBuffer.awaitNotEmpty(timer);
-//            });
-//            waitingThread.start();
-//            fetchBuffer.wakeup();
-//            waitingThread.join(Duration.ofSeconds(30).toMillis());
-//            assertFalse(waitingThread.isAlive());
-//        }
-//    }
+    @Test
+    public void testWakeup() throws Exception {
+        try (FetchBuffer fetchBuffer = new FetchBuffer(logContext)) {
+            final Thread waitingThread = new Thread(() -> {
+                final Timer timer = time.timer(Duration.ofMinutes(1));
+                fetchBuffer.awaitNotEmpty(timer);
+            });
+            waitingThread.start();
+            fetchBuffer.wakeup();
+            waitingThread.join(Duration.ofSeconds(30).toMillis());
+            assertFalse(waitingThread.isAlive());
+        }
+    }
 
     private CompletedFetch completedFetch(TopicPartition tp) {
         FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
@@ -26,11 +26,9 @@ import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.common.utils.Timer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Properties;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
@@ -26,15 +26,15 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-//import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
-//import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class WakeupTriggerTest {
@@ -72,60 +72,66 @@ public class WakeupTriggerTest {
         assertNull(wakeupTrigger.getPendingTask());
     }
 
-//    @Test
-//    public void testSettingFetchAction() {
-//        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
-//        wakeupTrigger.setFetchAction(fetchBuffer);
-//
-//        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
-//        assertInstanceOf(WakeupTrigger.FetchAction.class, wakeupable);
-//        assertEquals(fetchBuffer, ((WakeupTrigger.FetchAction) wakeupable).fetchBuffer());
-//    }
-//
-//    @Test
-//    public void testUnsetFetchAction() {
-//        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
-//
-//        wakeupTrigger.clearTask();
-//
-//        assertNull(wakeupTrigger.getPendingTask());
-//    }
-//
-//    @Test
-//    public void testWakeupFromFetchAction() {
-//        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
-//        wakeupTrigger.setFetchAction(fetchBuffer);
-//
-//        wakeupTrigger.wakeup();
-//
-//        verify(fetchBuffer).wakeup();
-//        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
-//        assertInstanceOf(WakeupTrigger.WakeupFuture.class, wakeupable);
-//    }
-//
-//    @Test
-//    public void testManualTriggerWhenWakeupCalled() {
-//        wakeupTrigger.wakeup();
-//        assertThrows(WakeupException.class, () -> wakeupTrigger.maybeTriggerWakeup());
-//    }
-//
-//    @Test
-//    public void testManualTriggerWhenWakeupNotCalled() {
-//        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
-//    }
-//
-//    @Test
-//    public void testManualTriggerWhenWakeupCalledAndActiveTaskSet() {
-//        final CompletableFuture<Void> future = new CompletableFuture<>();
-//        wakeupTrigger.setActiveTask(future);
-//        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
-//    }
-//
-//    @Test
-//    public void testManualTriggerWhenWakeupCalledAndFetchActionSet() {
-//        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
-//        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
-//    }
+    @Test
+    public void testSettingFetchAction() {
+        try (final FetchBuffer fetchBuffer = mock(FetchBuffer.class)) {
+            wakeupTrigger.setFetchAction(fetchBuffer);
+
+            final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
+            assertInstanceOf(WakeupTrigger.FetchAction.class, wakeupable);
+            assertEquals(fetchBuffer, ((WakeupTrigger.FetchAction) wakeupable).fetchBuffer());
+        }
+    }
+
+    @Test
+    public void testUnsetFetchAction() {
+        try (final FetchBuffer fetchBuffer = mock(FetchBuffer.class)) {
+            wakeupTrigger.setFetchAction(fetchBuffer);
+
+            wakeupTrigger.clearTask();
+
+            assertNull(wakeupTrigger.getPendingTask());
+        }
+    }
+
+    @Test
+    public void testWakeupFromFetchAction() {
+        try (final FetchBuffer fetchBuffer = mock(FetchBuffer.class)) {
+            wakeupTrigger.setFetchAction(fetchBuffer);
+
+            wakeupTrigger.wakeup();
+
+            verify(fetchBuffer).wakeup();
+            final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
+            assertInstanceOf(WakeupTrigger.WakeupFuture.class, wakeupable);
+        }
+    }
+
+    @Test
+    public void testManualTriggerWhenWakeupCalled() {
+        wakeupTrigger.wakeup();
+        assertThrows(WakeupException.class, () -> wakeupTrigger.maybeTriggerWakeup());
+    }
+
+    @Test
+    public void testManualTriggerWhenWakeupNotCalled() {
+        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
+    }
+
+    @Test
+    public void testManualTriggerWhenWakeupCalledAndActiveTaskSet() {
+        final CompletableFuture<Void> future = new CompletableFuture<>();
+        wakeupTrigger.setActiveTask(future);
+        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
+    }
+
+    @Test
+    public void testManualTriggerWhenWakeupCalledAndFetchActionSet() {
+        try (final FetchBuffer fetchBuffer = mock(FetchBuffer.class)) {
+            wakeupTrigger.setFetchAction(fetchBuffer);
+            assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
+        }
+    }
 
     private void assertWakeupExceptionIsThrown(final CompletableFuture<?> future) {
         assertTrue(future.isCompletedExceptionally());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
@@ -26,15 +26,15 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+//import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+//import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.verify;
 
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class WakeupTriggerTest {
@@ -72,60 +72,60 @@ public class WakeupTriggerTest {
         assertNull(wakeupTrigger.getPendingTask());
     }
 
-    @Test
-    public void testSettingFetchAction() {
-        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
-        wakeupTrigger.setFetchAction(fetchBuffer);
-
-        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
-        assertInstanceOf(WakeupTrigger.FetchAction.class, wakeupable);
-        assertEquals(fetchBuffer, ((WakeupTrigger.FetchAction) wakeupable).fetchBuffer());
-    }
-
-    @Test
-    public void testUnsetFetchAction() {
-        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
-
-        wakeupTrigger.clearTask();
-
-        assertNull(wakeupTrigger.getPendingTask());
-    }
-
-    @Test
-    public void testWakeupFromFetchAction() {
-        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
-        wakeupTrigger.setFetchAction(fetchBuffer);
-
-        wakeupTrigger.wakeup();
-
-        verify(fetchBuffer).wakeup();
-        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
-        assertInstanceOf(WakeupTrigger.WakeupFuture.class, wakeupable);
-    }
-
-    @Test
-    public void testManualTriggerWhenWakeupCalled() {
-        wakeupTrigger.wakeup();
-        assertThrows(WakeupException.class, () -> wakeupTrigger.maybeTriggerWakeup());
-    }
-
-    @Test
-    public void testManualTriggerWhenWakeupNotCalled() {
-        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
-    }
-
-    @Test
-    public void testManualTriggerWhenWakeupCalledAndActiveTaskSet() {
-        final CompletableFuture<Void> future = new CompletableFuture<>();
-        wakeupTrigger.setActiveTask(future);
-        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
-    }
-
-    @Test
-    public void testManualTriggerWhenWakeupCalledAndFetchActionSet() {
-        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
-        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
-    }
+//    @Test
+//    public void testSettingFetchAction() {
+//        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+//        wakeupTrigger.setFetchAction(fetchBuffer);
+//
+//        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
+//        assertInstanceOf(WakeupTrigger.FetchAction.class, wakeupable);
+//        assertEquals(fetchBuffer, ((WakeupTrigger.FetchAction) wakeupable).fetchBuffer());
+//    }
+//
+//    @Test
+//    public void testUnsetFetchAction() {
+//        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
+//
+//        wakeupTrigger.clearTask();
+//
+//        assertNull(wakeupTrigger.getPendingTask());
+//    }
+//
+//    @Test
+//    public void testWakeupFromFetchAction() {
+//        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+//        wakeupTrigger.setFetchAction(fetchBuffer);
+//
+//        wakeupTrigger.wakeup();
+//
+//        verify(fetchBuffer).wakeup();
+//        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
+//        assertInstanceOf(WakeupTrigger.WakeupFuture.class, wakeupable);
+//    }
+//
+//    @Test
+//    public void testManualTriggerWhenWakeupCalled() {
+//        wakeupTrigger.wakeup();
+//        assertThrows(WakeupException.class, () -> wakeupTrigger.maybeTriggerWakeup());
+//    }
+//
+//    @Test
+//    public void testManualTriggerWhenWakeupNotCalled() {
+//        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
+//    }
+//
+//    @Test
+//    public void testManualTriggerWhenWakeupCalledAndActiveTaskSet() {
+//        final CompletableFuture<Void> future = new CompletableFuture<>();
+//        wakeupTrigger.setActiveTask(future);
+//        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
+//    }
+//
+//    @Test
+//    public void testManualTriggerWhenWakeupCalledAndFetchActionSet() {
+//        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
+//        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
+//    }
 
     private void assertWakeupExceptionIsThrown(final CompletableFuture<?> future) {
         assertTrue(future.isCompletedExceptionally());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
@@ -26,9 +26,15 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class WakeupTriggerTest {
@@ -66,60 +72,60 @@ public class WakeupTriggerTest {
         assertNull(wakeupTrigger.getPendingTask());
     }
 
-//    @Test
-//    public void testSettingFetchAction() {
-//        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
-//        wakeupTrigger.setFetchAction(fetchBuffer);
-//
-//        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
-//        assertInstanceOf(WakeupTrigger.FetchAction.class, wakeupable);
-//        assertEquals(fetchBuffer, ((WakeupTrigger.FetchAction) wakeupable).fetchBuffer());
-//    }
-//
-//    @Test
-//    public void testUnsetFetchAction() {
-//        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
-//
-//        wakeupTrigger.clearTask();
-//
-//        assertNull(wakeupTrigger.getPendingTask());
-//    }
-//
-//    @Test
-//    public void testWakeupFromFetchAction() {
-//        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
-//        wakeupTrigger.setFetchAction(fetchBuffer);
-//
-//        wakeupTrigger.wakeup();
-//
-//        verify(fetchBuffer).wakeup();
-//        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
-//        assertInstanceOf(WakeupTrigger.WakeupFuture.class, wakeupable);
-//    }
-//
-//    @Test
-//    public void testManualTriggerWhenWakeupCalled() {
-//        wakeupTrigger.wakeup();
-//        assertThrows(WakeupException.class, () -> wakeupTrigger.maybeTriggerWakeup());
-//    }
-//
-//    @Test
-//    public void testManualTriggerWhenWakeupNotCalled() {
-//        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
-//    }
-//
-//    @Test
-//    public void testManualTriggerWhenWakeupCalledAndActiveTaskSet() {
-//        final CompletableFuture<Void> future = new CompletableFuture<>();
-//        wakeupTrigger.setActiveTask(future);
-//        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
-//    }
-//
-//    @Test
-//    public void testManualTriggerWhenWakeupCalledAndFetchActionSet() {
-//        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
-//        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
-//    }
+    @Test
+    public void testSettingFetchAction() {
+        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+        wakeupTrigger.setFetchAction(fetchBuffer);
+
+        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
+        assertInstanceOf(WakeupTrigger.FetchAction.class, wakeupable);
+        assertEquals(fetchBuffer, ((WakeupTrigger.FetchAction) wakeupable).fetchBuffer());
+    }
+
+    @Test
+    public void testUnsetFetchAction() {
+        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
+
+        wakeupTrigger.clearTask();
+
+        assertNull(wakeupTrigger.getPendingTask());
+    }
+
+    @Test
+    public void testWakeupFromFetchAction() {
+        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+        wakeupTrigger.setFetchAction(fetchBuffer);
+
+        wakeupTrigger.wakeup();
+
+        verify(fetchBuffer).wakeup();
+        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
+        assertInstanceOf(WakeupTrigger.WakeupFuture.class, wakeupable);
+    }
+
+    @Test
+    public void testManualTriggerWhenWakeupCalled() {
+        wakeupTrigger.wakeup();
+        assertThrows(WakeupException.class, () -> wakeupTrigger.maybeTriggerWakeup());
+    }
+
+    @Test
+    public void testManualTriggerWhenWakeupNotCalled() {
+        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
+    }
+
+    @Test
+    public void testManualTriggerWhenWakeupCalledAndActiveTaskSet() {
+        final CompletableFuture<Void> future = new CompletableFuture<>();
+        wakeupTrigger.setActiveTask(future);
+        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
+    }
+
+    @Test
+    public void testManualTriggerWhenWakeupCalledAndFetchActionSet() {
+        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
+        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
+    }
 
     private void assertWakeupExceptionIsThrown(final CompletableFuture<?> future) {
         assertTrue(future.isCompletedExceptionally());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
@@ -17,19 +17,29 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.utils.LogContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class WakeupTriggerTest {
-    private static long defaultTimeoutMs = 1000;
+    private final static long DEFAULT_TIMEOUT_MS = 1000;
     private WakeupTrigger wakeupTrigger;
 
     @BeforeEach
@@ -59,14 +69,70 @@ public class WakeupTriggerTest {
     public void testUnsetActiveFuture() {
         CompletableFuture<Void> task = new CompletableFuture<>();
         wakeupTrigger.setActiveTask(task);
-        wakeupTrigger.clearActiveTask();
+        wakeupTrigger.clearTask();
         assertNull(wakeupTrigger.getPendingTask());
+    }
+
+    @Test
+    public void testSettingFetchAction() {
+        final FetchBuffer fetchBuffer = new FetchBuffer(new LogContext());
+
+        wakeupTrigger.setFetchAction(fetchBuffer);
+
+        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
+        assertInstanceOf(WakeupTrigger.FetchAction.class, wakeupable);
+        assertEquals(fetchBuffer, ((WakeupTrigger.FetchAction) wakeupable).fetchBuffer());
+    }
+
+    @Test
+    public void testUnsetFetchAction() {
+        wakeupTrigger.setFetchAction(new FetchBuffer(new LogContext()));
+
+        wakeupTrigger.clearTask();
+
+        assertNull(wakeupTrigger.getPendingTask());
+    }
+
+    @Test
+    public void testWakeupFromFetchAction() {
+        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+        wakeupTrigger.setFetchAction(fetchBuffer);
+
+        wakeupTrigger.wakeup();
+
+        verify(fetchBuffer).wakeup();
+        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
+        assertInstanceOf(WakeupTrigger.WakeupFuture.class, wakeupable);
+    }
+
+    @Test
+    public void testManualTriggerWhenWakeupCalled() {
+        wakeupTrigger.wakeup();
+        assertThrows(WakeupException.class, () -> wakeupTrigger.maybeTriggerWakeup());
+    }
+
+    @Test
+    public void testManualTriggerWhenWakeupNotCalled() {
+        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
+    }
+
+    @Test
+    public void testManualTriggerWhenWakeupCalledAndActiveTaskSet() {
+        final CompletableFuture<Void> future = new CompletableFuture<>();
+        wakeupTrigger.setActiveTask(future);
+        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
+    }
+
+    @Test
+    public void testManualTriggerWhenWakeupCalledAndFetchActionSet() {
+        wakeupTrigger.setFetchAction(new FetchBuffer(new LogContext()));
+        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
     }
 
     private void assertWakeupExceptionIsThrown(final CompletableFuture<?> future) {
         assertTrue(future.isCompletedExceptionally());
         try {
-            future.get(defaultTimeoutMs, TimeUnit.MILLISECONDS);
+            future.get(DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof WakeupException);
             return;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.common.errors.WakeupException;
-import org.apache.kafka.common.utils.LogContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -75,8 +74,7 @@ public class WakeupTriggerTest {
 
     @Test
     public void testSettingFetchAction() {
-        final FetchBuffer fetchBuffer = new FetchBuffer(new LogContext());
-
+        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
         wakeupTrigger.setFetchAction(fetchBuffer);
 
         final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
@@ -86,7 +84,7 @@ public class WakeupTriggerTest {
 
     @Test
     public void testUnsetFetchAction() {
-        wakeupTrigger.setFetchAction(new FetchBuffer(new LogContext()));
+        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
 
         wakeupTrigger.clearTask();
 
@@ -125,7 +123,7 @@ public class WakeupTriggerTest {
 
     @Test
     public void testManualTriggerWhenWakeupCalledAndFetchActionSet() {
-        wakeupTrigger.setFetchAction(new FetchBuffer(new LogContext()));
+        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
         assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
@@ -26,15 +26,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class WakeupTriggerTest {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/WakeupTriggerTest.java
@@ -72,60 +72,60 @@ public class WakeupTriggerTest {
         assertNull(wakeupTrigger.getPendingTask());
     }
 
-    @Test
-    public void testSettingFetchAction() {
-        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
-        wakeupTrigger.setFetchAction(fetchBuffer);
-
-        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
-        assertInstanceOf(WakeupTrigger.FetchAction.class, wakeupable);
-        assertEquals(fetchBuffer, ((WakeupTrigger.FetchAction) wakeupable).fetchBuffer());
-    }
-
-    @Test
-    public void testUnsetFetchAction() {
-        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
-
-        wakeupTrigger.clearTask();
-
-        assertNull(wakeupTrigger.getPendingTask());
-    }
-
-    @Test
-    public void testWakeupFromFetchAction() {
-        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
-        wakeupTrigger.setFetchAction(fetchBuffer);
-
-        wakeupTrigger.wakeup();
-
-        verify(fetchBuffer).wakeup();
-        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
-        assertInstanceOf(WakeupTrigger.WakeupFuture.class, wakeupable);
-    }
-
-    @Test
-    public void testManualTriggerWhenWakeupCalled() {
-        wakeupTrigger.wakeup();
-        assertThrows(WakeupException.class, () -> wakeupTrigger.maybeTriggerWakeup());
-    }
-
-    @Test
-    public void testManualTriggerWhenWakeupNotCalled() {
-        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
-    }
-
-    @Test
-    public void testManualTriggerWhenWakeupCalledAndActiveTaskSet() {
-        final CompletableFuture<Void> future = new CompletableFuture<>();
-        wakeupTrigger.setActiveTask(future);
-        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
-    }
-
-    @Test
-    public void testManualTriggerWhenWakeupCalledAndFetchActionSet() {
-        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
-        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
-    }
+//    @Test
+//    public void testSettingFetchAction() {
+//        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+//        wakeupTrigger.setFetchAction(fetchBuffer);
+//
+//        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
+//        assertInstanceOf(WakeupTrigger.FetchAction.class, wakeupable);
+//        assertEquals(fetchBuffer, ((WakeupTrigger.FetchAction) wakeupable).fetchBuffer());
+//    }
+//
+//    @Test
+//    public void testUnsetFetchAction() {
+//        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
+//
+//        wakeupTrigger.clearTask();
+//
+//        assertNull(wakeupTrigger.getPendingTask());
+//    }
+//
+//    @Test
+//    public void testWakeupFromFetchAction() {
+//        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+//        wakeupTrigger.setFetchAction(fetchBuffer);
+//
+//        wakeupTrigger.wakeup();
+//
+//        verify(fetchBuffer).wakeup();
+//        final WakeupTrigger.Wakeupable wakeupable = wakeupTrigger.getPendingTask();
+//        assertInstanceOf(WakeupTrigger.WakeupFuture.class, wakeupable);
+//    }
+//
+//    @Test
+//    public void testManualTriggerWhenWakeupCalled() {
+//        wakeupTrigger.wakeup();
+//        assertThrows(WakeupException.class, () -> wakeupTrigger.maybeTriggerWakeup());
+//    }
+//
+//    @Test
+//    public void testManualTriggerWhenWakeupNotCalled() {
+//        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
+//    }
+//
+//    @Test
+//    public void testManualTriggerWhenWakeupCalledAndActiveTaskSet() {
+//        final CompletableFuture<Void> future = new CompletableFuture<>();
+//        wakeupTrigger.setActiveTask(future);
+//        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
+//    }
+//
+//    @Test
+//    public void testManualTriggerWhenWakeupCalledAndFetchActionSet() {
+//        wakeupTrigger.setFetchAction(mock(FetchBuffer.class));
+//        assertDoesNotThrow(() -> wakeupTrigger.maybeTriggerWakeup());
+//    }
 
     private void assertWakeupExceptionIsThrown(final CompletableFuture<?> future) {
         assertTrue(future.isCompletedExceptionally());


### PR DESCRIPTION
We need to be careful when aborting a long poll with wakeup() since the consumer might never return records if the poll is interrupted after the consumer position has been updated but the records have not been returned to the caller of poll().

This PR avoids wake-ups during this critical period in the PrototypeAsyncConsumer, similarly as in the current consumer.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
