### PR TITLE
KAFKA-15814 Patched the SASL/GSSAPI server construction

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -218,9 +218,11 @@ public class SaslServerAuthenticator implements Authenticator {
         // server is using a JAAS-authenticated subject: determine service principal name and hostname from kafka server's subject.
         final String servicePrincipal;
         if (subject.getPrincipals().isEmpty()) {
-            String serviceName = (String)configs.get("kerberos.service.name");
+            // server-only JAAS with principal="*" and isInitiator=false
+            // we need to construct servicePrincipal to statisfy Sasl.createSaslServer
+            String serviceName = (String) configs.get("kerberos.service.name");
             if (serviceName == null) serviceName = "kafka";
-            String serviceRealm = (String)configs.get("kerberos.service.realm");
+            String serviceRealm = (String) configs.get("kerberos.service.realm");
             if (serviceRealm == null) serviceRealm = "DEFAULT";
             servicePrincipal = serviceName + "@" + serviceRealm;
         } else {


### PR DESCRIPTION
The patch fixes how the SASL/GSSAPI server is created in Kafka brokers. 
As described in the JIRA ticket, Kafka forces client JAAS configuration for both client and server side.
This patch removes the constraint and allows to accept authentication addressed at different hosts.
If the listener is used for the inter-broker communication, it must stay in the current form.

Assume that Kafka cluster is accessible using `CLIENT` listener that each broker is accessible at `b-N.kafka.sample.home.arpa:9092` (N is broker id). For convenience the bootstrap uses load balanced endpoint `kafka.sample.home.arpa:9092`  that distributes the traffic to the active brokers.

After this patch it is possible to configure the listener's JAAS configuration to use wildcard principal:

```
listener.name.client.gssapi.sasl.jaas.config=com.sun.security.auth.module.Krb5LoginModule required
  useKeyTab=true
  storeKey=true
  keyTab="/etc/kafka/security/kafka.keytab"
  principal="*"
  isInitiator=false
; 
```

The goal of this patch is to enable wildcard principal and acceptor-only mode (isInitiator=false).

The keytab must contain entries for SPNs on all acceptable service FQDNs, i.e. on broker 0 we must have entries for both `kafka/kafka.sample.home.arpa@DOMAIN` and `kafka/b-0.kafka.sample.home.arpa@DOMAIN`.

The patch does not change behavior of the existing configurations.

For this patch the only reasonable testing strategy is manual one. That's the reason that even if the solution was already known 3 years ago, the code has not been submitted.

Any ideas for automated testing of this change are warmly welcome.

The comparison for various ways to configure SASL:

https://github.com/piotrsmolinski/kerberos-sandbox/blob/main/src/test/java/io/confluent/sandbox/kerberos/KerberosTest.java

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
