### PR TITLE
KAFKA-15816: Fix leaked sockets in core tests

### DIFF
--- a/core/src/test/scala/integration/kafka/server/GssapiAuthenticationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/GssapiAuthenticationTest.scala
@@ -247,6 +247,7 @@ class GssapiAuthenticationTest extends IntegrationTestHarness with SaslSetup {
         assertEquals(ChannelState.State.AUTHENTICATION_FAILED, disconnectState.state())
       disconnectState != null
     }, "Client not disconnected within timeout")
+    selector.close()
   }
 
   private def createSelector(): Selector = {

--- a/core/src/test/scala/integration/kafka/tools/MirrorMakerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/tools/MirrorMakerIntegrationTest.scala
@@ -70,6 +70,7 @@ class MirrorMakerIntegrationTest extends KafkaServerTestHarness {
     val mirrorMakerConsumer = new ConsumerWrapper(consumer, None, includeOpt = Some("any"))
     mirrorMakerConsumer.offsets.put(new TopicPartition("test", 0), 0L)
     assertThrows(classOf[TimeoutException], () => mirrorMakerConsumer.commit())
+    mirrorMakerConsumer.close()
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
@@ -86,6 +87,7 @@ class MirrorMakerIntegrationTest extends KafkaServerTestHarness {
     mirrorMakerConsumer.offsets.put(new TopicPartition("nonexistent-topic2", 0), 0L)
     MirrorMaker.commitOffsets(mirrorMakerConsumer)
     assertTrue(mirrorMakerConsumer.offsets.isEmpty, "Offsets for non-existent topics should be removed")
+    mirrorMakerConsumer.close()
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -274,6 +274,12 @@ class MiniKdc(config: Properties, workDir: File) extends Logging {
       if (kdc != null) {
         System.clearProperty(MiniKdc.JavaSecurityKrb5Conf)
         System.clearProperty(MiniKdc.SunSecurityKrb5Debug)
+
+        // Close kdc acceptors and wait for them to terminate, ensuring that sockets are closed before returning.
+        for (transport <- kdc.getTransports) {
+          val acceptor = transport.getAcceptor
+          if (acceptor != null) acceptor.dispose(true)
+        }
         kdc.stop()
         try ds.shutdown()
         catch {

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -80,7 +80,7 @@ class SocketServerTest {
 
   private val apiVersionManager = new SimpleApiVersionManager(ListenerType.BROKER, true, false,
     () => new Features(MetadataVersion.latest(), Collections.emptyMap[String, java.lang.Short], 0, true))
-  val server = new SocketServer(config, metrics, Time.SYSTEM, credentialProvider, apiVersionManager)
+  var server: SocketServer = _
   val sockets = new ArrayBuffer[Socket]
 
   private val kafkaLogger = org.apache.log4j.LogManager.getLogger("kafka")
@@ -93,6 +93,7 @@ class SocketServerTest {
 
   @BeforeEach
   def setUp(): Unit = {
+    server = new SocketServer(config, metrics, Time.SYSTEM, credentialProvider, apiVersionManager);
     server.enableRequestProcessing(Map.empty).get(1, TimeUnit.MINUTES)
     // Run the tests with TRACE logging to exercise request logging path
     logLevelToRestore = kafkaLogger.getLevel

--- a/core/src/test/scala/unit/kafka/server/epoch/EpochDrivenReplicationProtocolAcceptanceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/EpochDrivenReplicationProtocolAcceptanceTest.scala
@@ -246,6 +246,7 @@ class EpochDrivenReplicationProtocolAcceptanceTest extends QuorumTestHarness wit
 
     //Are the files identical?
     assertEquals(getLogFile(brokers(0), 0).length, getLogFile(brokers(1), 0).length, "Log files should match Broker0 vs Broker 1")
+    consumer.close()
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochIntegrationTest.scala
@@ -125,6 +125,7 @@ class LeaderEpochIntegrationTest extends QuorumTestHarness with Logging {
 
     //When
     val offsetsForEpochs = fetcher0.leaderOffsetsFor(epochsRequested)
+    fetcher0.close()
 
     //Then end offset should be correct
     assertEquals(10, offsetsForEpochs(t1p0).endOffset)
@@ -138,6 +139,7 @@ class LeaderEpochIntegrationTest extends QuorumTestHarness with Logging {
     val fetcher1 = new TestFetcherThread(sender(from = brokers(2), to = brokers(1)))
     val offsetsForEpochs1 = fetcher1.leaderOffsetsFor(epochsRequested)
     assertEquals(20, offsetsForEpochs1(t1p1).endOffset)
+    fetcher1.close()
   }
 
   @Test
@@ -168,6 +170,7 @@ class LeaderEpochIntegrationTest extends QuorumTestHarness with Logging {
     brokers(1).startup()
 
     producer.send(new ProducerRecord(tp.topic, tp.partition, null, "IHeartLogs".getBytes)).get
+    fetcher.close()
     fetcher = new TestFetcherThread(sender(brokers(0), brokers(1)))
 
     //Then epoch 0 should still be the start offset of epoch 1
@@ -193,6 +196,7 @@ class LeaderEpochIntegrationTest extends QuorumTestHarness with Logging {
     brokers(1).startup()
 
     producer.send(new ProducerRecord(tp.topic, tp.partition, null, "IHeartLogs".getBytes)).get
+    fetcher.close()
     fetcher = new TestFetcherThread(sender(brokers(0), brokers(1)))
 
     //Then Epoch 0 should still map to offset 1
@@ -207,6 +211,7 @@ class LeaderEpochIntegrationTest extends QuorumTestHarness with Logging {
 
     //Adding some extra assertions here to save test setup.
     shouldSupportRequestsForEpochsNotOnTheLeader(fetcher)
+    fetcher.close()
   }
 
   //Appended onto the previous test to save on setup cost.
@@ -299,5 +304,7 @@ class LeaderEpochIntegrationTest extends QuorumTestHarness with Logging {
         }
       }.toMap
     }
+
+    def close(): Unit = sender.close()
   }
 }


### PR DESCRIPTION
These tests leak sockets due to various typos. Additionally, many tests leaked sockets because MiniKdc stops asynchronously, leaving sockets open at the end of the test which are eventually cleaned up. This patch uses the alternative dispose method which awaits termination of the internal resources of the KDC before proceeding with the normal shutdown.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
