### PR TITLE
MINOR: Query before creating the internal remote log metadata topic

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
@@ -449,7 +449,7 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
         }
     }
 
-    boolean isTopicExists(Admin adminClient, String topic) {
+    boolean doesTopicExist(Admin adminClient, String topic) {
         try {
             TopicDescription description = adminClient.describeTopics(Collections.singleton(topic))
                     .topicNameValues()
@@ -495,11 +495,11 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
      * @return Returns true if the topic already exists, or it is created successfully.
      */
     private boolean createTopic(Admin adminClient, NewTopic newTopic) {
-        boolean topicExists = false;
+        boolean doesTopicExist = false;
         String topic = newTopic.name();
         try {
-            topicExists = isTopicExists(adminClient, topic);
-            if (!topicExists) {
+            doesTopicExist = doesTopicExist(adminClient, topic);
+            if (!doesTopicExist) {
                 CreateTopicsResult result = adminClient.createTopics(Collections.singleton(newTopic));
                 result.all().get();
                 List<String> overriddenConfigs = result.config(topic).get()
@@ -511,19 +511,19 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
                 log.info("Topic {} created. TopicId: {}, numPartitions: {}, replicationFactor: {}, config: {}",
                         topic, result.topicId(topic).get(), result.numPartitions(topic).get(),
                         result.replicationFactor(topic).get(), overriddenConfigs);
-                topicExists = true;
+                doesTopicExist = true;
             }
         } catch (Exception e) {
             // This exception can still occur as multiple brokers may call create topics and one of them may become
             // successful and other would throw TopicExistsException
             if (e.getCause() instanceof TopicExistsException) {
                 log.info("Topic [{}] already exists", topic);
-                topicExists = true;
+                doesTopicExist = true;
             } else {
                 log.error("Encountered error while creating {} topic.", topic, e);
             }
         }
-        return topicExists;
+        return doesTopicExist;
     }
 
     public boolean isInitialized() {

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
@@ -446,7 +446,7 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
         }
     }
 
-    private boolean isTopicExists(Admin adminClient, String topic) {
+    boolean isTopicExists(Admin adminClient, String topic) {
         try {
             TopicDescription description = adminClient.describeTopics(Collections.singleton(topic))
                     .topicNameValues()
@@ -477,7 +477,7 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
         return true;
     }
 
-    private NewTopic createRemoteLogMetadataTopicRequest() {
+    NewTopic createRemoteLogMetadataTopicRequest() {
         Map<String, String> topicConfigs = new HashMap<>();
         topicConfigs.put(TopicConfig.RETENTION_MS_CONFIG, Long.toString(rlmmConfig.metadataTopicRetentionMs()));
         topicConfigs.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE);

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.server.log.remote.metadata.storage;
 
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -45,6 +46,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -54,6 +56,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 /**
  * This is the {@link RemoteLogMetadataManager} implementation with storage as an internal topic with name {@link TopicBasedRemoteLogMetadataManagerConfig#REMOTE_LOG_METADATA_TOPIC_NAME}.
@@ -477,7 +480,7 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
         return true;
     }
 
-    NewTopic createRemoteLogMetadataTopicRequest() {
+    private NewTopic createRemoteLogMetadataTopicRequest() {
         Map<String, String> topicConfigs = new HashMap<>();
         topicConfigs.put(TopicConfig.RETENTION_MS_CONFIG, Long.toString(rlmmConfig.metadataTopicRetentionMs()));
         topicConfigs.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE);
@@ -488,23 +491,36 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
     }
 
     /**
-     * @param topic topic to be created.
+     * @param newTopic topic to be created.
      * @return Returns true if the topic already exists, or it is created successfully.
      */
-    private boolean createTopic(Admin adminClient, NewTopic topic) {
+    private boolean createTopic(Admin adminClient, NewTopic newTopic) {
         boolean topicExists = false;
+        String topic = newTopic.name();
         try {
-            topicExists = isTopicExists(adminClient, topic.name());
+            topicExists = isTopicExists(adminClient, topic);
             if (!topicExists) {
-                adminClient.createTopics(Collections.singleton(topic)).all().get();
+                CreateTopicsResult result = adminClient.createTopics(Collections.singleton(newTopic));
+                result.all().get();
+                List<String> overriddenConfigs = result.config(topic).get()
+                        .entries()
+                        .stream()
+                        .filter(entry -> !entry.isDefault())
+                        .map(entry -> entry.name() + "=" + entry.value())
+                        .collect(Collectors.toList());
+                log.info("Topic {} created. TopicId: {}, numPartitions: {}, replicationFactor: {}, config: {}",
+                        topic, result.topicId(topic).get(), result.numPartitions(topic).get(),
+                        result.replicationFactor(topic).get(), overriddenConfigs);
                 topicExists = true;
             }
         } catch (Exception e) {
+            // This exception can still occur as multiple brokers may call create topics and one of them may become
+            // successful and other would throw TopicExistsException
             if (e.getCause() instanceof TopicExistsException) {
-                log.info("Topic [{}] already exists", topic.name());
+                log.info("Topic [{}] already exists", topic);
                 topicExists = true;
             } else {
-                log.error("Encountered error while creating remote log metadata topic.", e);
+                log.error("Encountered error while creating {} topic.", topic, e);
             }
         }
         return topicExists;

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.server.log.remote.metadata.storage;
 
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
@@ -75,9 +74,20 @@ public class TopicBasedRemoteLogMetadataManagerTest {
         Properties adminConfig = remoteLogMetadataManagerHarness.adminClientConfig();
         ListenerName listenerName = remoteLogMetadataManagerHarness.listenerName();
         try (Admin admin = remoteLogMetadataManagerHarness.createAdminClient(listenerName, adminConfig)) {
-            NewTopic newTopic = topicBasedRlmm().createRemoteLogMetadataTopicRequest();
-            boolean isTopicExists = topicBasedRlmm().isTopicExists(admin, newTopic.name());
+            String topic = topicBasedRlmm().config().remoteLogMetadataTopicName();
+            boolean isTopicExists = topicBasedRlmm().isTopicExists(admin, topic);
             Assertions.assertTrue(isTopicExists);
+        }
+    }
+
+    @Test
+    public void testTopicDoesNotExists() {
+        Properties adminConfig = remoteLogMetadataManagerHarness.adminClientConfig();
+        ListenerName listenerName = remoteLogMetadataManagerHarness.listenerName();
+        try (Admin admin = remoteLogMetadataManagerHarness.createAdminClient(listenerName, adminConfig)) {
+            String topic = "dummy-test-topic";
+            boolean isTopicExists = topicBasedRlmm().isTopicExists(admin, topic);
+            Assertions.assertFalse(isTopicExists);
         }
     }
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerTest.java
@@ -75,8 +75,8 @@ public class TopicBasedRemoteLogMetadataManagerTest {
         ListenerName listenerName = remoteLogMetadataManagerHarness.listenerName();
         try (Admin admin = remoteLogMetadataManagerHarness.createAdminClient(listenerName, adminConfig)) {
             String topic = topicBasedRlmm().config().remoteLogMetadataTopicName();
-            boolean isTopicExists = topicBasedRlmm().isTopicExists(admin, topic);
-            Assertions.assertTrue(isTopicExists);
+            boolean doesTopicExist = topicBasedRlmm().doesTopicExist(admin, topic);
+            Assertions.assertTrue(doesTopicExist);
         }
     }
 
@@ -86,8 +86,8 @@ public class TopicBasedRemoteLogMetadataManagerTest {
         ListenerName listenerName = remoteLogMetadataManagerHarness.listenerName();
         try (Admin admin = remoteLogMetadataManagerHarness.createAdminClient(listenerName, adminConfig)) {
             String topic = "dummy-test-topic";
-            boolean isTopicExists = topicBasedRlmm().isTopicExists(admin, topic);
-            Assertions.assertFalse(isTopicExists);
+            boolean doesTopicExist = topicBasedRlmm().doesTopicExist(admin, topic);
+            Assertions.assertFalse(doesTopicExist);
         }
     }
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerTest.java
@@ -16,9 +16,12 @@
  */
 package org.apache.kafka.server.log.remote.metadata.storage;
 
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -40,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 
 @SuppressWarnings("deprecation") // Added for Scala 2.12 compatibility for usages of JavaConverters
@@ -64,6 +68,17 @@ public class TopicBasedRemoteLogMetadataManagerTest {
 
     public TopicBasedRemoteLogMetadataManager topicBasedRlmm() {
         return remoteLogMetadataManagerHarness.remoteLogMetadataManager();
+    }
+
+    @Test
+    public void testInternalTopicExists() {
+        Properties adminConfig = remoteLogMetadataManagerHarness.adminClientConfig();
+        ListenerName listenerName = remoteLogMetadataManagerHarness.listenerName();
+        try (Admin admin = remoteLogMetadataManagerHarness.createAdminClient(listenerName, adminConfig)) {
+            NewTopic newTopic = topicBasedRlmm().createRemoteLogMetadataTopicRequest();
+            boolean isTopicExists = topicBasedRlmm().isTopicExists(admin, newTopic.name());
+            Assertions.assertTrue(isTopicExists);
+        }
     }
 
     @Test


### PR DESCRIPTION
When a node starts (or) restarts, then we send a _CREATE_TOPICS_ request to the controller to create the internal ___remote_log_metadata_ topic.

Topic creation event is costly and handled by the controller. During re-balance, the controller can have pending requests in its queue and can lead to CREATE_TOPICS timeout. Instead of firing the _CREATE_TOPICS_ request when a node restarts, send a _METADATA_ request (topic describe) which is handled by the least loaded node before sending a request to create the topic.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
