### PR TITLE
KAFKA-15824: SubscriptionState's maybeValidatePositionForCurrentLeader should handle partition which isn't subscribed yet

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -569,6 +569,11 @@ public class SubscriptionStateTest {
         assertTrue(state.maybeValidatePositionForCurrentLeader(apiVersions, tp0, new Metadata.LeaderAndEpoch(
                 Optional.of(broker1), Optional.of(10))));
         assertFalse(state.hasValidPosition(tp0));
+
+        // tp1 is not part of the subscription, so validation should be skipped.
+        assertFalse(state.maybeValidatePositionForCurrentLeader(apiVersions, tp1, new Metadata.LeaderAndEpoch(
+            Optional.of(broker1), Optional.of(10))));
+        assertFalse(state.assignedPartitions().contains(tp1));
     }
 
     @Test


### PR DESCRIPTION
See the motivation in jira description https://issues.apache.org/jira/browse/KAFKA-15824

This was discovered as `ReassignReplicaShrinkTest` started to fail with KIP-951 changes. KIP-951 changes since then have been reverted([PR](
https://github.com/apache/kafka/pull/14738)), would be put back once this is in.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
