### PR TITLE
KAFKA-15823: disconnect from controller on AuthenticationException

### DIFF
--- a/core/src/main/scala/kafka/server/NodeToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/NodeToControllerChannelManager.scala
@@ -345,7 +345,8 @@ class NodeToControllerRequestThread(
   private[server] def handleResponse(queueItem: NodeToControllerQueueItem)(response: ClientResponse): Unit = {
     debug(s"Request ${queueItem.request} received $response")
     if (response.authenticationException != null) {
-      error(s"Request ${queueItem.request} failed due to authentication error with controller",
+      error(s"Request ${queueItem.request} failed due to authentication error with controller. Disconnecting the " +
+        s"connection to the stale controller ${activeControllerAddress().map(_.idString).getOrElse("null")}",
         response.authenticationException)
       maybeDisconnectAndUpdateController()
       queueItem.callback.onComplete(response)

--- a/core/src/main/scala/kafka/server/NodeToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/NodeToControllerChannelManager.scala
@@ -347,6 +347,7 @@ class NodeToControllerRequestThread(
     if (response.authenticationException != null) {
       error(s"Request ${queueItem.request} failed due to authentication error with controller",
         response.authenticationException)
+      maybeDisconnectAndUpdateController()
       queueItem.callback.onComplete(response)
     } else if (response.versionMismatch != null) {
       error(s"Request ${queueItem.request} failed due to unsupported version error",
@@ -358,20 +359,23 @@ class NodeToControllerRequestThread(
     } else if (response.responseBody().errorCounts().containsKey(Errors.NOT_CONTROLLER)) {
       debug(s"Request ${queueItem.request} received NOT_CONTROLLER exception. Disconnecting the " +
         s"connection to the stale controller ${activeControllerAddress().map(_.idString).getOrElse("null")}")
-      // just close the controller connection and wait for metadata cache update in doWork
-      activeControllerAddress().foreach { controllerAddress =>
-        try {
-          // We don't care if disconnect has an error, just log it and get a new network client
-          networkClient.disconnect(controllerAddress.idString)
-        } catch {
-          case t: Throwable => error("Had an error while disconnecting from NetworkClient.", t)
-        }
-        updateControllerAddress(null)
-      }
-
+      maybeDisconnectAndUpdateController()
       requestQueue.putFirst(queueItem)
     } else {
       queueItem.callback.onComplete(response)
+    }
+  }
+
+  private def maybeDisconnectAndUpdateController(): Unit = {
+    // just close the controller connection and wait for metadata cache update in doWork
+    activeControllerAddress().foreach { controllerAddress =>
+      try {
+        // We don't care if disconnect has an error, just log it and get a new network client
+        networkClient.disconnect(controllerAddress.idString)
+      } catch {
+        case t: Throwable => error("Had an error while disconnecting from NetworkClient.", t)
+      }
+      updateControllerAddress(null)
     }
   }
 

--- a/core/src/test/scala/kafka/server/NodeToControllerRequestThreadTest.scala
+++ b/core/src/test/scala/kafka/server/NodeToControllerRequestThreadTest.scala
@@ -427,6 +427,7 @@ class NodeToControllerRequestThreadTest {
     testRequestThread.enqueue(queueItem)
     pollUntil(testRequestThread, () => callbackResponse.get != null)
     assertNotNull(callbackResponse.get.authenticationException)
+    assertEquals(None, testRequestThread.activeControllerAddress())
   }
 
   @Test


### PR DESCRIPTION
This PR changes the handling of authenticationException on a request from the node to the controller.

We disconnect controller connection and invalidate the cache so that the next run of the thread will establish a connection with the (potentially) updated controller.