### PR TITLE
KAFKA-15816: Fix leaked sockets in mirror tests

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
@@ -113,9 +113,6 @@ public class DedicatedMirrorIntegrationTest {
         EmbeddedKafkaCluster clusterA = startKafkaCluster("A", 1, brokerProps);
         EmbeddedKafkaCluster clusterB = startKafkaCluster("B", 1, brokerProps);
 
-        clusterA.start();
-        clusterB.start();
-
         try (Admin adminB = clusterB.createAdminClient()) {
 
             // Cluster aliases
@@ -186,9 +183,6 @@ public class DedicatedMirrorIntegrationTest {
         brokerProps.put("transaction.state.log.min.isr", "1");
         EmbeddedKafkaCluster clusterA = startKafkaCluster("A", 1, brokerProps);
         EmbeddedKafkaCluster clusterB = startKafkaCluster("B", 1, brokerProps);
-
-        clusterA.start();
-        clusterB.start();
 
         try (Admin adminB = clusterB.createAdminClient()) {
             // Cluster aliases

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -561,27 +561,30 @@ public class MirrorConnectorsIntegrationBaseTest {
         String remoteTopic = remoteTopicName("test-topic-1", PRIMARY_CLUSTER_ALIAS);
 
         // Check offsets are pushed to the checkpoint topic
-        Consumer<byte[], byte[]> backupConsumer = backup.kafka().createConsumerAndSubscribeTo(Collections.singletonMap(
-                "auto.offset.reset", "earliest"), PRIMARY_CLUSTER_ALIAS + ".checkpoints.internal");
-        waitForCondition(() -> {
-            ConsumerRecords<byte[], byte[]> records = backupConsumer.poll(Duration.ofSeconds(1L));
-            for (ConsumerRecord<byte[], byte[]> record : records) {
-                Checkpoint checkpoint = Checkpoint.deserializeRecord(record);
-                if (remoteTopic.equals(checkpoint.topicPartition().topic())) {
-                    return true;
+        try (Consumer<byte[], byte[]> backupConsumer = backup.kafka().createConsumerAndSubscribeTo(Collections.singletonMap(
+                "auto.offset.reset", "earliest"), PRIMARY_CLUSTER_ALIAS + ".checkpoints.internal")) {
+            waitForCondition(() -> {
+                ConsumerRecords<byte[], byte[]> records = backupConsumer.poll(Duration.ofSeconds(1L));
+                for (ConsumerRecord<byte[], byte[]> record : records) {
+                    Checkpoint checkpoint = Checkpoint.deserializeRecord(record);
+                    if (remoteTopic.equals(checkpoint.topicPartition().topic())) {
+                        return true;
+                    }
                 }
-            }
-            return false;
-        }, 30_000,
-            "Unable to find checkpoints for " + PRIMARY_CLUSTER_ALIAS + ".test-topic-1"
-        );
+                return false;
+            }, 30_000,
+                "Unable to find checkpoints for " + PRIMARY_CLUSTER_ALIAS + ".test-topic-1"
+            );
+        }
 
         assertMonotonicCheckpoints(backup, PRIMARY_CLUSTER_ALIAS + ".checkpoints.internal");
 
         // Ensure no offset-syncs topics have been created on the primary cluster
-        Set<String> primaryTopics = primary.kafka().createAdminClient().listTopics().names().get();
-        assertFalse(primaryTopics.contains("mm2-offset-syncs." + PRIMARY_CLUSTER_ALIAS + ".internal"));
-        assertFalse(primaryTopics.contains("mm2-offset-syncs." + BACKUP_CLUSTER_ALIAS + ".internal"));
+        try (Admin adminClient = primary.kafka().createAdminClient()) {
+            Set<String> primaryTopics = adminClient.listTopics().names().get();
+            assertFalse(primaryTopics.contains("mm2-offset-syncs." + PRIMARY_CLUSTER_ALIAS + ".internal"));
+            assertFalse(primaryTopics.contains("mm2-offset-syncs." + BACKUP_CLUSTER_ALIAS + ".internal"));
+        }
     }
 
     @Test
@@ -647,6 +650,8 @@ public class MirrorConnectorsIntegrationBaseTest {
             return translatedOffsets.containsKey(remoteTopicPartition(tp1, PRIMARY_CLUSTER_ALIAS)) &&
                    translatedOffsets.containsKey(remoteTopicPartition(tp2, PRIMARY_CLUSTER_ALIAS));
         }, OFFSET_SYNC_DURATION_MS, "Checkpoints were not emitted correctly to backup cluster");
+
+        backupClient.close();
     }
 
     @Test
@@ -728,6 +733,8 @@ public class MirrorConnectorsIntegrationBaseTest {
                     backupClient, consumerGroupName, PRIMARY_CLUSTER_ALIAS, remoteTopic, partialCheckpoints);
             log.info("Final checkpoints: {}", finalCheckpoints);
         }
+
+        backupClient.close();
 
         for (TopicPartition tp : partialCheckpoints.keySet()) {
             assertTrue(finalCheckpoints.get(tp).offset() < partialCheckpoints.get(tp).offset(),

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsWithCustomForwardingAdminIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsWithCustomForwardingAdminIntegrationTest.java
@@ -163,18 +163,22 @@ public class MirrorConnectorsWithCustomForwardingAdminIntegrationTest extends Mi
 
         startClusters(additionalConfig);
 
-        primary.kafka().createAdminClient().createAcls(Arrays.asList(
-                new AclBinding(
-                        new ResourcePattern(ResourceType.TOPIC, "*", PatternType.LITERAL),
-                        new AccessControlEntry("User:connector", "*", AclOperation.ALL, AclPermissionType.ALLOW)
-                )
-        )).all().get();
-        backup.kafka().createAdminClient().createAcls(Arrays.asList(
-                new AclBinding(
-                        new ResourcePattern(ResourceType.TOPIC, "*", PatternType.LITERAL),
-                        new AccessControlEntry("User:connector", "*", AclOperation.ALL, AclPermissionType.ALLOW)
-                )
-        )).all().get();
+        try (Admin adminClient = primary.kafka().createAdminClient()) {
+            adminClient.createAcls(Arrays.asList(
+                    new AclBinding(
+                            new ResourcePattern(ResourceType.TOPIC, "*", PatternType.LITERAL),
+                            new AccessControlEntry("User:connector", "*", AclOperation.ALL, AclPermissionType.ALLOW)
+                    )
+            )).all().get();
+        }
+        try (Admin adminClient = backup.kafka().createAdminClient()) {
+            adminClient.createAcls(Arrays.asList(
+                    new AclBinding(
+                            new ResourcePattern(ResourceType.TOPIC, "*", PatternType.LITERAL),
+                            new AccessControlEntry("User:connector", "*", AclOperation.ALL, AclPermissionType.ALLOW)
+                    )
+            )).all().get();
+        }
     }
 
     @AfterEach
@@ -244,7 +248,9 @@ public class MirrorConnectorsWithCustomForwardingAdminIntegrationTest extends Mi
 
         // increase number of partitions
         Map<String, NewPartitions> newPartitions = Collections.singletonMap("test-topic-1", NewPartitions.increaseTo(NUM_PARTITIONS + 1));
-        primary.kafka().createAdminClient().createPartitions(newPartitions).all().get();
+        try (Admin adminClient = primary.kafka().createAdminClient()) {
+            adminClient.createPartitions(newPartitions).all().get();
+        }
 
         // make sure partition is created in the other cluster
         waitForTopicPartitionCreated(backup, "primary.test-topic-1", NUM_PARTITIONS + 1);
@@ -293,8 +299,12 @@ public class MirrorConnectorsWithCustomForwardingAdminIntegrationTest extends Mi
                         new AccessControlEntry("User:dummy", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW)
                 )
         );
-        primary.kafka().createAdminClient().createAcls(aclBindings).all().get();
-        backup.kafka().createAdminClient().createAcls(aclBindings).all().get();
+        try (Admin adminClient = primary.kafka().createAdminClient()) {
+            adminClient.createAcls(aclBindings).all().get();
+        }
+        try (Admin adminClient = backup.kafka().createAdminClient()) {
+            adminClient.createAcls(aclBindings).all().get();
+        }
 
         waitUntilMirrorMakerIsRunning(primary, CONNECTOR_LIST, mm2Config, BACKUP_CLUSTER_ALIAS, PRIMARY_CLUSTER_ALIAS);
         waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);


### PR DESCRIPTION
These socket leaks were caused by typos, either an extra call to start() or a missing call to close().

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
