### PR TITLE
KAFKA-15827: Prevent KafkaBasedLog subclasses from leaking passed-in clients

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
@@ -111,6 +111,12 @@ class OffsetSyncStore implements AutoCloseable {
             protected boolean readPartition(TopicPartition topicPartition) {
                 return topicPartition.partition() == 0;
             }
+
+            @Override
+            public void stop() {
+                super.stop();
+                Utils.closeQuietly(consumer, "consumer");
+            }
         };
     }
 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
@@ -97,6 +97,8 @@ class OffsetSyncStore implements AutoCloseable {
                 ignored -> {
                 }
         ) {
+
+            private boolean started = false;
             @Override
             protected Producer<byte[], byte[]> createProducer() {
                 return null;
@@ -113,9 +115,18 @@ class OffsetSyncStore implements AutoCloseable {
             }
 
             @Override
+            public void start() {
+                super.start();
+                started = true;
+            }
+
+            @Override
             public void stop() {
                 super.stop();
-                Utils.closeQuietly(consumer, "consumer");
+                // Close the consumer if the thread in the store responsible for closing the clients was never started.
+                if (!started) {
+                    Utils.closeQuietly(consumer, "consumer");
+                }
             }
         };
     }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
@@ -18,7 +18,6 @@ package org.apache.kafka.connect.mirror;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -28,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -94,7 +92,7 @@ class OffsetSyncStore implements AutoCloseable {
                 admin,
                 (error, record) -> this.handleRecord(record),
                 Time.SYSTEM,
-                ignored -> {},
+                ignored -> { },
                 topicPartition -> topicPartition.partition() == 0
         );
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -156,7 +156,7 @@ public class Worker {
 
     private final ConcurrentMap<String, WorkerConnector> connectors = new ConcurrentHashMap<>();
     private final ConcurrentMap<ConnectorTaskId, WorkerTask> tasks = new ConcurrentHashMap<>();
-    private Optional<SourceTaskOffsetCommitter> sourceTaskOffsetCommitter;
+    private Optional<SourceTaskOffsetCommitter> sourceTaskOffsetCommitter = Optional.empty();
     private final WorkerConfigTransformer workerConfigTransformer;
     private final ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy;
     private final Function<Map<String, Object>, Admin> adminFactory;
@@ -269,7 +269,9 @@ public class Worker {
         log.info("Worker stopped");
 
         workerMetricsGroup.close();
-        connectorStatusMetricsGroup.close();
+        if (connectorStatusMetricsGroup != null) {
+            connectorStatusMetricsGroup.close();
+        }
 
         workerConfigTransformer.close();
         ThreadUtils.shutdownExecutorServiceQuietly(executor, EXECUTOR_SHUTDOWN_TERMINATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -812,6 +812,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         ThreadUtils.shutdownExecutorServiceQuietly(herderExecutor, herderExecutorTimeoutMs(), TimeUnit.MILLISECONDS);
         ThreadUtils.shutdownExecutorServiceQuietly(forwardRequestExecutor, FORWARD_REQUEST_SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         ThreadUtils.shutdownExecutorServiceQuietly(startAndStopExecutor, START_AND_STOP_SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        stopServices();
         log.info("Herder stopped");
         running = false;
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -775,8 +775,6 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             worker.stopAndAwaitConnectors();
             worker.stopAndAwaitTasks();
 
-            member.stop();
-
             // Explicitly fail any outstanding requests so they actually get a response and get an
             // understandable reason for their failure.
             DistributedHerderRequest request = requests.pollFirst();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -99,7 +99,8 @@ public class KafkaOffsetBackingStore extends KafkaTopicBasedBackingStore impleme
                         topicAdmin,
                         consumedCallback,
                         Time.SYSTEM,
-                        topicInitializer(topic, newTopicDescription(topic, config), config, Time.SYSTEM)
+                        topicInitializer(topic, newTopicDescription(topic, config), config, Time.SYSTEM),
+                        ignored -> true
                 );
             }
         };
@@ -131,7 +132,8 @@ public class KafkaOffsetBackingStore extends KafkaTopicBasedBackingStore impleme
                         topicAdmin,
                         consumedCallback,
                         Time.SYSTEM,
-                        topicInitializer(topic, newTopicDescription(topic, config), config, Time.SYSTEM)
+                        topicInitializer(topic, newTopicDescription(topic, config), config, Time.SYSTEM),
+                        ignored -> true
                 );
             }
         };

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -226,8 +226,11 @@ public class KafkaBasedLog<K, V> {
             @Override
             public void stop() {
                 super.stop();
-                Utils.closeQuietly(producer, "producer");
-                Utils.closeQuietly(consumer, "consumer");
+                // Close the clients here, if the thread that was responsible for closing them was never started.
+                if (thread == null) {
+                    Utils.closeQuietly(producer, "producer");
+                    Utils.closeQuietly(consumer, "consumer");
+                }
             }
         };
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -222,6 +222,13 @@ public class KafkaBasedLog<K, V> {
             protected Consumer<K, V> createConsumer() {
                 return consumer;
             }
+
+            @Override
+            public void stop() {
+                super.stop();
+                Utils.closeQuietly(producer, "producer");
+                Utils.closeQuietly(consumer, "consumer");
+            }
         };
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -54,6 +54,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 
@@ -195,6 +196,7 @@ public class KafkaBasedLog<K, V> {
      * @param consumedCallback   callback to invoke for each {@link ConsumerRecord} consumed when tailing the log
      * @param time               Time interface
      * @param initializer        the function that should be run when this log is {@link #start() started}; may be null
+     * @param readTopicPartition A predicate which returns true for each {@link TopicPartition} that should be read
      * @return a {@link KafkaBasedLog} using the given clients
      */
     public static <K, V> KafkaBasedLog<K, V> withExistingClients(String topic,
@@ -203,8 +205,11 @@ public class KafkaBasedLog<K, V> {
                                                                  TopicAdmin topicAdmin,
                                                                  Callback<ConsumerRecord<K, V>> consumedCallback,
                                                                  Time time,
-                                                                 java.util.function.Consumer<TopicAdmin> initializer) {
+                                                                 java.util.function.Consumer<TopicAdmin> initializer,
+                                                                 Predicate<TopicPartition> readTopicPartition
+    ) {
         Objects.requireNonNull(topicAdmin);
+        Objects.requireNonNull(readTopicPartition);
         return new KafkaBasedLog<K, V>(topic,
                 Collections.emptyMap(),
                 Collections.emptyMap(),
@@ -221,6 +226,11 @@ public class KafkaBasedLog<K, V> {
             @Override
             protected Consumer<K, V> createConsumer() {
                 return consumer;
+            }
+
+            @Override
+            protected boolean readPartition(TopicPartition topicPartition) {
+                return readTopicPartition.test(topicPartition);
             }
 
             @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -237,10 +237,8 @@ public class KafkaBasedLog<K, V> {
             public void stop() {
                 super.stop();
                 // Close the clients here, if the thread that was responsible for closing them was never started.
-                if (thread == null) {
-                    Utils.closeQuietly(producer, "producer");
-                    Utils.closeQuietly(consumer, "consumer");
-                }
+                Utils.closeQuietly(producer, "producer");
+                Utils.closeQuietly(consumer, "consumer");
             }
         };
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -59,6 +59,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
@@ -122,6 +123,7 @@ public class KafkaBasedLogTest {
     private KafkaProducer<String, String> producer;
     private TopicAdmin admin;
     private final Supplier<TopicAdmin> topicAdminSupplier = () -> admin;
+    private final Predicate<TopicPartition> predicate = ignored -> true;
     private MockConsumer<String, String> consumer;
 
     private final Map<TopicPartition, List<ConsumerRecord<String, String>>> consumedRecords = new HashMap<>();
@@ -483,7 +485,7 @@ public class KafkaBasedLogTest {
     @Test
     public void testWithExistingClientsStartAndStop() {
         admin = mock(TopicAdmin.class);
-        store = KafkaBasedLog.withExistingClients(TOPIC, consumer, producer, admin, consumedCallback, time, initializer);
+        store = KafkaBasedLog.withExistingClients(TOPIC, consumer, producer, admin, consumedCallback, time, initializer, predicate);
         store.start();
         store.stop();
         verifyStartAndStop();
@@ -492,7 +494,7 @@ public class KafkaBasedLogTest {
     @Test
     public void testWithExistingClientsStopOnly() {
         admin = mock(TopicAdmin.class);
-        store = KafkaBasedLog.withExistingClients(TOPIC, consumer, producer, admin, consumedCallback, time, initializer);
+        store = KafkaBasedLog.withExistingClients(TOPIC, consumer, producer, admin, consumedCallback, time, initializer, predicate);
         store.stop();
         verifyStop();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -480,10 +480,31 @@ public class KafkaBasedLogTest {
         verify(admin).endOffsets(eq(tps));
     }
 
+    @Test
+    public void testWithExistingClientsStartAndStop() {
+        admin = mock(TopicAdmin.class);
+        store = KafkaBasedLog.withExistingClients(TOPIC, consumer, producer, admin, consumedCallback, time, initializer);
+        store.start();
+        store.stop();
+        verifyStartAndStop();
+    }
+
+    @Test
+    public void testWithExistingClientsStopOnly() {
+        admin = mock(TopicAdmin.class);
+        store = KafkaBasedLog.withExistingClients(TOPIC, consumer, producer, admin, consumedCallback, time, initializer);
+        store.stop();
+        verifyStop();
+    }
+
     private void verifyStartAndStop() {
         verify(initializer).accept(admin);
+        verifyStop();
+        assertFalse(store.thread.isAlive());
+    }
+
+    private void verifyStop() {
         verify(producer).close();
         assertTrue(consumer.closed());
-        assertFalse(store.thread.isAlive());
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -70,6 +70,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -506,7 +507,7 @@ public class KafkaBasedLogTest {
     }
 
     private void verifyStop() {
-        verify(producer).close();
+        verify(producer, atLeastOnce()).close();
         assertTrue(consumer.closed());
     }
 }


### PR DESCRIPTION
The KafkaBasedLog normally creates clients during start() and closes them in stop().
Some KafkaBasedLog subclasses accept already-created clients, and close them in stop() if start() is called first.
These clients should also be closed if stop() is called without first calling start().

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
