### PR TITLE
MINOR: clear inFlightCorrelationId when ConnectionState is changed to READY

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/RequestManager.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RequestManager.java
@@ -123,7 +123,7 @@ public class RequestManager {
 
         boolean isReady(long timeMs) {
             if (isBackoffComplete(timeMs) || hasRequestTimedOut(timeMs)) {
-                state = State.READY;
+                reset();
             }
             return state == State.READY;
         }


### PR DESCRIPTION
When a request is timed out, a old inFlightCorrelationId value is remaining