### PR TITLE
KAFKA-14438: Throw error when consumer configured with empty/whitespace-only group.id for AsyncKafkaConsumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -163,11 +163,9 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
             this.clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
             LogContext logContext = createLogContext(config, groupRebalanceConfig);
             this.log = logContext.logger(getClass());
-            groupId.ifPresent(groupIdStr -> {
-                if (groupIdStr.isEmpty()) {
-                    log.warn("Support for using the empty group id by consumers is deprecated and will be removed in the next major release.");
-                }
-            });
+
+            if (this.groupId.isPresent() && this.groupId.get().isEmpty())
+                throw new InvalidGroupIdException("The configured group.id should not be an empty string or whitespace");
 
             log.debug("Initializing the Kafka consumer");
             this.defaultApiTimeoutMs = config.getInt(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
@@ -578,7 +576,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
     }
 
     private void maybeThrowInvalidGroupIdException() {
-        if (!groupId.isPresent() || groupId.get().isEmpty()) {
+        if (!groupId.isPresent()) {
             throw new InvalidGroupIdException("To use the group management or offset commit APIs, you must " +
                     "provide a valid " + ConsumerConfig.GROUP_ID_CONFIG + " in the consumer configuration.");
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/LegacyKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/LegacyKafkaConsumer.java
@@ -150,9 +150,11 @@ public class LegacyKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
             LogContext logContext = createLogContext(config, groupRebalanceConfig);
             this.log = logContext.logger(getClass());
             boolean enableAutoCommit = config.getBoolean(ENABLE_AUTO_COMMIT_CONFIG);
-
-            if (this.groupId.isPresent() && this.groupId.get().isEmpty())
-                throw new InvalidGroupIdException("The configured group.id should not be an empty string or whitespace");
+            groupId.ifPresent(groupIdStr -> {
+                if (groupIdStr.isEmpty()) {
+                    log.warn("Support for using the empty group id by consumers is deprecated and will be removed in the next major release.");
+                }
+            });
 
             log.debug("Initializing the Kafka consumer");
             this.requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/LegacyKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/LegacyKafkaConsumer.java
@@ -150,11 +150,9 @@ public class LegacyKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
             LogContext logContext = createLogContext(config, groupRebalanceConfig);
             this.log = logContext.logger(getClass());
             boolean enableAutoCommit = config.getBoolean(ENABLE_AUTO_COMMIT_CONFIG);
-            groupId.ifPresent(groupIdStr -> {
-                if (groupIdStr.isEmpty()) {
-                    log.warn("Support for using the empty group id by consumers is deprecated and will be removed in the next major release.");
-                }
-            });
+
+            if (this.groupId.isPresent() && this.groupId.get().isEmpty())
+                throw new InvalidGroupIdException("The configured group.id should not be an empty string or whitespace");
 
             log.debug("Initializing the Kafka consumer");
             this.requestTimeoutMs = config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -408,13 +408,13 @@ public class KafkaConsumerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(GroupProtocol.class)
+    @EnumSource(value = GroupProtocol.class, names = "CONSUMER")
     public void testEmptyGroupId(GroupProtocol groupProtocol) {
         assertThrows(KafkaException.class, () -> newConsumer(groupProtocol, ""));
     }
 
     @ParameterizedTest
-    @EnumSource(GroupProtocol.class)
+    @EnumSource(value = GroupProtocol.class, names = "CONSUMER")
     public void testWhitespaceGroupId(GroupProtocol groupProtocol) {
         assertThrows(KafkaException.class, () -> newConsumer(groupProtocol, "    "));
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -409,6 +409,28 @@ public class KafkaConsumerTest {
 
     @ParameterizedTest
     @EnumSource(GroupProtocol.class)
+    public void testEmptyGroupId(GroupProtocol groupProtocol) {
+        assertThrows(KafkaException.class, () -> newConsumer(groupProtocol, ""));
+    }
+
+    @ParameterizedTest
+    @EnumSource(GroupProtocol.class)
+    public void testWhitespaceGroupId(GroupProtocol groupProtocol) {
+        assertThrows(KafkaException.class, () -> newConsumer(groupProtocol, "    "));
+    }
+
+    // TODO: this test requires rebalance logic which is not yet implemented in the CONSUMER group protocol.
+    //       Once it is implemented, this should use both group protocols.
+    @ParameterizedTest
+    @EnumSource(value = GroupProtocol.class, names = "GENERIC")
+    public void testTrimWhitespaceFromGroupId(GroupProtocol groupProtocol) {
+        String groupId = "test";
+        KafkaConsumer<byte[], byte[]> kafkaConsumer = newConsumer(groupProtocol, "    " + groupId + "    ");
+        assertEquals(groupId, kafkaConsumer.groupMetadata().groupId());
+    }
+
+    @ParameterizedTest
+    @EnumSource(GroupProtocol.class)
     public void testSubscription(GroupProtocol groupProtocol) {
         consumer = newConsumer(groupProtocol, groupId);
 


### PR DESCRIPTION
Per [KIP-289 (Improve the default group id behavior in `KafkaConsumer`)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-289%3A+Improve+the+default+group+id+behavior+in+KafkaConsumer), the `group.id` configuration should no longer allow string values that—when trimmed of any whitespace—are zero length. By virtue of the existing `AbstractConfig` logic, string values are trimmed of whitespace on use.

Prior to this change, the constructors of both `LegacyKafkaConsumer` and `AsyncKafkaConsumer` checked the value, and if it was empty, would log a warning. The new `AsyncKafkaConsumer` will enforce this by throwing an `InvalidGroupIdException` if the value is empty instead of logging.

There is no attempt to prevent the creation of a `ConsumerConfig` that contains an invalid `group.id` value. It is only checked and enforced on use when creating a `Consumer` instance.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
