### PR TITLE
KAFKA-15816: Fix leaked sockets in streams tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
@@ -418,6 +418,8 @@ public class IQv2IntegrationTest {
             })
         );
 
+        // do not use the harness streams
+        kafkaStreams.close();
         kafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration(testInfo));
         kafkaStreams.cleanUp();
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
@@ -418,7 +418,7 @@ public class IQv2IntegrationTest {
             })
         );
 
-        // do not use the harness streams
+        // Discard the basic streams and replace with test-specific topology
         kafkaStreams.close();
         kafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration(testInfo));
         kafkaStreams.cleanUp();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsReporterIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsReporterIntegrationTest.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.Tag;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -120,14 +119,12 @@ public class MetricsReporterIntegrationTest {
         builder.stream(STREAM_INPUT, Consumed.with(Serdes.Integer(), Serdes.String()))
                 .to(STREAM_OUTPUT, Produced.with(Serdes.Integer(), Serdes.String()));
         final Topology topology = builder.build();
-        final KafkaStreams kafkaStreams = new KafkaStreams(topology, streamsConfiguration);
-
-        kafkaStreams.metrics().keySet().forEach(metricName -> {
-            final Object initialMetricValue = METRIC_NAME_TO_INITIAL_VALUE.get(metricName.name());
-            assertThat(initialMetricValue, notNullValue());
-        });
-
-        kafkaStreams.close(Duration.ofSeconds(30));
+        try (KafkaStreams kafkaStreams = new KafkaStreams(topology, streamsConfiguration)) {
+            kafkaStreams.metrics().keySet().forEach(metricName -> {
+                final Object initialMetricValue = METRIC_NAME_TO_INITIAL_VALUE.get(metricName.name());
+                assertThat(initialMetricValue, notNullValue());
+            });
+        }
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsReporterIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsReporterIntegrationTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.Tag;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -125,6 +126,8 @@ public class MetricsReporterIntegrationTest {
             final Object initialMetricValue = METRIC_NAME_TO_INITIAL_VALUE.get(metricName.name());
             assertThat(initialMetricValue, notNullValue());
         });
+
+        kafkaStreams.close(Duration.ofSeconds(30));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -840,7 +840,7 @@ public class NamedTopologyIntegrationTest {
             props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class);
             props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
 
-            // do not use the harness streams
+            // Discard the pre-created streams and replace with test-specific topology
             streams.close();
             streams = new KafkaStreamsNamedTopologyWrapper(props);
             streams.setUncaughtExceptionHandler(exception -> StreamThreadExceptionResponse.REPLACE_THREAD);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -715,6 +715,7 @@ public class NamedTopologyIntegrationTest {
 
     @Test
     public void shouldContinueProcessingOtherTopologiesWhenNewTopologyHasMissingInputTopics() throws Exception {
+        // This test leaks sockets due to KAFKA-15834
         try {
             CLUSTER.createTopic(EXISTING_STREAM, 2, 1);
             produceToInputTopics(EXISTING_STREAM, STANDARD_INPUT_DATA);
@@ -839,6 +840,8 @@ public class NamedTopologyIntegrationTest {
             props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class);
             props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
 
+            // do not use the harness streams
+            streams.close();
             streams = new KafkaStreamsNamedTopologyWrapper(props);
             streams.setUncaughtExceptionHandler(exception -> StreamThreadExceptionResponse.REPLACE_THREAD);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/PurgeRepartitionTopicIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/PurgeRepartitionTopicIntegrationTest.java
@@ -181,6 +181,9 @@ public class PurgeRepartitionTopicIntegrationTest {
 
     @AfterEach
     public void shutdown() {
+        if (adminClient != null) {
+            adminClient.close();
+        }
         if (kafkaStreams != null) {
             kafkaStreams.close(Duration.ofSeconds(30));
         }


### PR DESCRIPTION
These tests leak sockets via Kafka clients, either directly or via KafkaStreams instances. The tests should close these resources when appropriate.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
