### PR TITLE
MINOR: Always send cumulative failed dirs in HB request

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -148,10 +148,10 @@ class BrokerLifecycleManager(
   private var readyToUnfence = false
 
   /**
-   * List of offline directories pending to be sent.
+   * List of accumulated offline directories.
    * This variable can only be read or written from the event queue thread.
    */
-  private var offlineDirsPending = Set[Uuid]()
+  private var offlineDirs = Set[Uuid]()
 
   /**
    * True if we sent a event queue to the active controller requesting controlled
@@ -299,10 +299,10 @@ class BrokerLifecycleManager(
 
   private class OfflineDirEvent(val dir: Uuid) extends EventQueue.Event {
     override def run(): Unit = {
-      if (offlineDirsPending.isEmpty) {
-        offlineDirsPending = Set(dir)
+      if (offlineDirs.isEmpty) {
+        offlineDirs = Set(dir)
       } else {
-        offlineDirsPending = offlineDirsPending + dir
+        offlineDirs = offlineDirs + dir
       }
       if (registered) {
         scheduleNextCommunicationImmediately()
@@ -423,15 +423,15 @@ class BrokerLifecycleManager(
       setCurrentMetadataOffset(metadataOffset).
       setWantFence(!readyToUnfence).
       setWantShutDown(_state == BrokerState.PENDING_CONTROLLED_SHUTDOWN).
-      setOfflineLogDirs(offlineDirsPending.toSeq.asJava)
+      setOfflineLogDirs(offlineDirs.toSeq.asJava)
     if (isTraceEnabled) {
       trace(s"Sending broker heartbeat $data")
     }
-    val handler = new BrokerHeartbeatResponseHandler(offlineDirsPending)
+    val handler = new BrokerHeartbeatResponseHandler()
     _channelManager.sendRequest(new BrokerHeartbeatRequest.Builder(data), handler)
   }
 
-  private class BrokerHeartbeatResponseHandler(dirsInFlight: Set[Uuid]) extends ControllerRequestCompletionHandler {
+  private class BrokerHeartbeatResponseHandler() extends ControllerRequestCompletionHandler {
     override def onComplete(response: ClientResponse): Unit = {
       if (response.authenticationException() != null) {
         error(s"Unable to send broker heartbeat for $nodeId because of an " +
@@ -455,7 +455,7 @@ class BrokerLifecycleManager(
           // this response handler is not invoked from the event handler thread,
           // and processing a successful heartbeat response requires updating
           // state, so to continue we need to schedule an event
-          eventQueue.prepend(new BrokerHeartbeatResponseEvent(message.data(), dirsInFlight))
+          eventQueue.prepend(new BrokerHeartbeatResponseEvent(message.data()))
         } else {
           warn(s"Broker $nodeId sent a heartbeat request but received error $errorCode.")
           scheduleNextCommunicationAfterFailure()
@@ -469,10 +469,9 @@ class BrokerLifecycleManager(
     }
   }
 
-  private class BrokerHeartbeatResponseEvent(response: BrokerHeartbeatResponseData, dirsInFlight: Set[Uuid]) extends EventQueue.Event {
+  private class BrokerHeartbeatResponseEvent(response: BrokerHeartbeatResponseData) extends EventQueue.Event {
     override def run(): Unit = {
       failedAttempts = 0
-      offlineDirsPending = offlineDirsPending.diff(dirsInFlight)
       _state match {
         case BrokerState.STARTING =>
           if (response.isCaughtUp) {


### PR DESCRIPTION
Instead of only sending failed log directory UUIDs in the heartbeat request until a successful response is received, the broker sends the full cumulative set of failed directories since startup time.

This aims to simplify the handling of log directory failure in the controller side, considering overload mode handling of heartbeat requests, which returns an undifferentiated reply.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
