### PR TITLE
KAFKA-15460: Add group type filter to the List Groups API

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupListing.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupListing.java
@@ -21,95 +21,111 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.kafka.common.ConsumerGroupState;
+import org.apache.kafka.common.ConsumerGroupType;
 
 /**
- * A listing of a consumer group in the cluster.
+ * Represents a listing of a consumer group in the cluster.
  */
 public class ConsumerGroupListing {
     private final String groupId;
     private final boolean isSimpleConsumerGroup;
-    private final Optional<ConsumerGroupState> state;
+    private Optional<ConsumerGroupState> state;
+    private Optional<ConsumerGroupType> groupType;
 
     /**
      * Create an instance with the specified parameters.
      *
-     * @param groupId Group Id
-     * @param isSimpleConsumerGroup If consumer group is simple or not.
+     * @param groupId                   The group Id.
+     * @param isSimpleConsumerGroup     Indicates whether the consumer group is simple or not.
      */
     public ConsumerGroupListing(String groupId, boolean isSimpleConsumerGroup) {
-        this(groupId, isSimpleConsumerGroup, Optional.empty());
-    }
-
-    /**
-     * Create an instance with the specified parameters.
-     *
-     * @param groupId Group Id
-     * @param isSimpleConsumerGroup If consumer group is simple or not.
-     * @param state The state of the consumer group
-     */
-    public ConsumerGroupListing(String groupId, boolean isSimpleConsumerGroup, Optional<ConsumerGroupState> state) {
         this.groupId = groupId;
         this.isSimpleConsumerGroup = isSimpleConsumerGroup;
-        this.state = Objects.requireNonNull(state);
+        this.state = Optional.empty();
+        this.groupType = Optional.empty();
     }
 
     /**
-     * Consumer Group Id
+     * Set the state of the consumer group.
+     *
+     * @param state         The state of the consumer group.
+     * @return This ConsumerGroupListing instance.
+     */
+    public ConsumerGroupListing setState(Optional<ConsumerGroupState> state) {
+        this.state = Objects.requireNonNull(state);
+        return this;
+    }
+
+    /**
+     * Set the type of the consumer group.
+     *
+     * @param groupType     The type of the consumer group.
+     * @return This ConsumerGroupListing instance.
+     */
+    public ConsumerGroupListing setType(Optional<ConsumerGroupType> groupType) {
+        this.groupType = Objects.requireNonNull(groupType);
+        return this;
+    }
+
+    /**
+     * The group Id of the consumer group.
+     *
+     * @return The group Id.
      */
     public String groupId() {
         return groupId;
     }
 
     /**
-     * If Consumer Group is simple or not.
+     * Check if the consumer group is a simple consumer group.
+     *
+     * @return True if it is a simple consumer group, false otherwise.
      */
     public boolean isSimpleConsumerGroup() {
         return isSimpleConsumerGroup;
     }
 
     /**
-     * Consumer Group state
+     * The consumer group's state.
+     *
+     * @return An Optional containing the state if available.
      */
     public Optional<ConsumerGroupState> state() {
         return state;
     }
 
+    /**
+     * The type of the consumer group.
+     *
+     * @return An Optional containing the type if available.
+     */
+    public Optional<ConsumerGroupType> groupType() {
+        return groupType;
+    }
+
     @Override
     public String toString() {
-        return "(" +
+        return "ConsumerGroupListing{" +
             "groupId='" + groupId + '\'' +
             ", isSimpleConsumerGroup=" + isSimpleConsumerGroup +
             ", state=" + state +
-            ')';
+            ", groupType=" + groupType +
+            '}';
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(groupId, isSimpleConsumerGroup, state);
+        return Objects.hash(groupId, isSimpleConsumerGroup(), state, groupType);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ConsumerGroupListing other = (ConsumerGroupListing) obj;
-        if (groupId == null) {
-            if (other.groupId != null)
-                return false;
-        } else if (!groupId.equals(other.groupId))
-            return false;
-        if (isSimpleConsumerGroup != other.isSimpleConsumerGroup)
-            return false;
-        if (state == null) {
-            if (other.state != null)
-                return false;
-        } else if (!state.equals(other.state))
-            return false;
-        return true;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ConsumerGroupListing)) return false;
+        ConsumerGroupListing that = (ConsumerGroupListing) o;
+        return isSimpleConsumerGroup() == that.isSimpleConsumerGroup() &&
+               groupId.equals(that.groupId) &&
+               state.equals(that.state) &&
+               groupType.equals(that.groupType);
     }
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -58,6 +58,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.ConsumerGroupState;
+import org.apache.kafka.common.ConsumerGroupType;
 import org.apache.kafka.common.ElectionType;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
@@ -3381,7 +3382,14 @@ public class KafkaAdminClient extends AdminClient {
                                     .stream()
                                     .map(ConsumerGroupState::toString)
                                     .collect(Collectors.toList());
-                            return new ListGroupsRequest.Builder(new ListGroupsRequestData().setStatesFilter(states));
+                            List<String> groupTypes = options.groupTypes()
+                                    .stream()
+                                    .map(ConsumerGroupType::toString)
+                                    .collect(Collectors.toList());
+                            return new ListGroupsRequest.Builder(new ListGroupsRequestData()
+                                .setStatesFilter(states)
+                                .setTypesFilter(groupTypes)
+                            );
                         }
 
                         private void maybeAddConsumerGroup(ListGroupsResponseData.ListedGroup group) {
@@ -3391,7 +3399,12 @@ public class KafkaAdminClient extends AdminClient {
                                 final Optional<ConsumerGroupState> state = group.groupState().equals("")
                                         ? Optional.empty()
                                         : Optional.of(ConsumerGroupState.parse(group.groupState()));
-                                final ConsumerGroupListing groupListing = new ConsumerGroupListing(groupId, protocolType.isEmpty(), state);
+                                final Optional<ConsumerGroupType> groupType = group.groupType().equals("")
+                                        ? Optional.empty()
+                                        : Optional.of(ConsumerGroupType.parse(group.groupType()));
+                                final ConsumerGroupListing groupListing = new ConsumerGroupListing(groupId, protocolType.isEmpty())
+                                        .setState(state)
+                                        .setType(groupType);
                                 results.addListing(groupListing);
                             }
                         }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsOptions.java
@@ -34,6 +34,8 @@ public class ListConsumerGroupsOptions extends AbstractOptions<ListConsumerGroup
 
     private Set<ConsumerGroupState> states = Collections.emptySet();
 
+    private Set<String> types = Collections.emptySet();
+
     /**
      * If states is set, only groups in these states will be returned by listConsumerGroups()
      * Otherwise, all groups are returned.
@@ -45,9 +47,26 @@ public class ListConsumerGroupsOptions extends AbstractOptions<ListConsumerGroup
     }
 
     /**
+     * If types is set, only groups of these types will be returned by listConsumerGroups()
+     * Otherwise, all groups are returned.
+     *
+     */
+    public ListConsumerGroupsOptions inTypes(Set<GroupType> types) {
+        this.types = (types == null) ? Collections.emptySet() : new HashSet<>(types);
+        return this;
+    }
+
+    /**
      * Returns the list of States that are requested or empty if no states have been specified
      */
     public Set<ConsumerGroupState> states() {
         return states;
+    }
+
+    /**
+     * Returns the list of Types that are requested or empty if no types have been specified
+     */
+    public Set<String> types() {
+        return types;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsOptions.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.kafka.common.ConsumerGroupState;
+import org.apache.kafka.common.ConsumerGroupType;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
 /**
@@ -34,10 +35,10 @@ public class ListConsumerGroupsOptions extends AbstractOptions<ListConsumerGroup
 
     private Set<ConsumerGroupState> states = Collections.emptySet();
 
-    private Set<String> types = Collections.emptySet();
+    private Set<ConsumerGroupType> groupTypes = Collections.emptySet();
 
     /**
-     * If states is set, only groups in these states will be returned by listConsumerGroups()
+     * If states is set, only groups in these states will be returned by listConsumerGroups().
      * Otherwise, all groups are returned.
      * This operation is supported by brokers with version 2.6.0 or later.
      */
@@ -47,12 +48,12 @@ public class ListConsumerGroupsOptions extends AbstractOptions<ListConsumerGroup
     }
 
     /**
-     * If types is set, only groups of these types will be returned by listConsumerGroups()
+     * If groupTypes is set, only groups of these groupTypes will be returned by listConsumerGroups().
      * Otherwise, all groups are returned.
      *
      */
-    public ListConsumerGroupsOptions inTypes(Set<GroupType> types) {
-        this.types = (types == null) ? Collections.emptySet() : new HashSet<>(types);
+    public ListConsumerGroupsOptions inTypes(Set<ConsumerGroupType> groupTypes) {
+        this.groupTypes = (groupTypes == null) ? Collections.emptySet() : new HashSet<>(groupTypes);
         return this;
     }
 
@@ -64,9 +65,9 @@ public class ListConsumerGroupsOptions extends AbstractOptions<ListConsumerGroup
     }
 
     /**
-     * Returns the list of Types that are requested or empty if no types have been specified
+     * Returns the list of types that are requested or empty if no groupTypes have been specified
      */
-    public Set<String> types() {
-        return types;
+    public Set<ConsumerGroupType> groupTypes() {
+        return groupTypes;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsOptions.java
@@ -18,7 +18,6 @@
 package org.apache.kafka.clients.admin;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.kafka.common.ConsumerGroupState;
@@ -43,7 +42,7 @@ public class ListConsumerGroupsOptions extends AbstractOptions<ListConsumerGroup
      * This operation is supported by brokers with version 2.6.0 or later.
      */
     public ListConsumerGroupsOptions inStates(Set<ConsumerGroupState> states) {
-        this.states = (states == null) ? Collections.emptySet() : new HashSet<>(states);
+        this.states = (states == null || states.isEmpty()) ? Collections.emptySet() : states;
         return this;
     }
 
@@ -53,7 +52,7 @@ public class ListConsumerGroupsOptions extends AbstractOptions<ListConsumerGroup
      *
      */
     public ListConsumerGroupsOptions inTypes(Set<ConsumerGroupType> groupTypes) {
-        this.groupTypes = (groupTypes == null) ? Collections.emptySet() : new HashSet<>(groupTypes);
+        this.groupTypes = (groupTypes == null || groupTypes.isEmpty()) ? Collections.emptySet() : groupTypes;
         return this;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/ConsumerGroupType.java
+++ b/clients/src/main/java/org/apache/kafka/common/ConsumerGroupType.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 public enum ConsumerGroupType {
     UNKNOWN("unknown"),
     CONSUMER("consumer"),
-    GENERIC("generic");
+    CLASSIC("classic");
 
     private final static Map<String, ConsumerGroupType> NAME_TO_ENUM = Arrays.stream(values())
         .collect(Collectors.toMap(type -> type.name, Function.identity()));

--- a/clients/src/main/java/org/apache/kafka/common/ConsumerGroupType.java
+++ b/clients/src/main/java/org/apache/kafka/common/ConsumerGroupType.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum ConsumerGroupType {
+    UNKNOWN("unknown"),
+    CONSUMER("consumer"),
+    GENERIC("generic");
+
+    private final static Map<String, ConsumerGroupType> NAME_TO_ENUM = Arrays.stream(values())
+        .collect(Collectors.toMap(type -> type.name, Function.identity()));
+
+    private final String name;
+
+    ConsumerGroupType(String name) { this.name = name; }
+
+    /**
+     * Parse a string into a consumer group type.
+     */
+    public static ConsumerGroupType parse(String name) {
+        ConsumerGroupType type = NAME_TO_ENUM.get(name);
+        return type == null ? UNKNOWN : type;
+    }
+
+    @Override
+    public String toString() { return name; }
+}

--- a/clients/src/main/java/org/apache/kafka/common/ConsumerGroupType.java
+++ b/clients/src/main/java/org/apache/kafka/common/ConsumerGroupType.java
@@ -31,7 +31,9 @@ public enum ConsumerGroupType {
 
     private final String name;
 
-    ConsumerGroupType(String name) { this.name = name; }
+    ConsumerGroupType(String name) {
+        this.name = name;
+    }
 
     /**
      * Parse a string into a consumer group type.
@@ -42,5 +44,7 @@ public enum ConsumerGroupType {
     }
 
     @Override
-    public String toString() { return name; }
+    public String toString() {
+        return name;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListGroupsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListGroupsRequest.java
@@ -50,6 +50,10 @@ public class ListGroupsRequest extends AbstractRequest {
                 throw new UnsupportedVersionException("The broker only supports ListGroups " +
                         "v" + version + ", but we need v4 or newer to request groups by states.");
             }
+            if (!data.typesFilter().isEmpty() && version < 5) {
+                throw new UnsupportedVersionException("The broker only supports ListGroups " +
+                    "v" + version + ", but we need v5 or newer to request groups by type.");
+            }
             return new ListGroupsRequest(data, version);
         }
 

--- a/clients/src/main/resources/common/message/ListGroupsRequest.json
+++ b/clients/src/main/resources/common/message/ListGroupsRequest.json
@@ -23,11 +23,14 @@
   // Version 3 is the first flexible version.
   //
   // Version 4 adds the StatesFilter field (KIP-518).
-  "validVersions": "0-4",
+  //
+  // Version 5 adds the TypesFilter field (KIP-848).
+  "validVersions": "0-5",
   "flexibleVersions": "3+",
   "fields": [
     { "name": "StatesFilter", "type": "[]string", "versions": "4+",
-      "about": "The states of the groups we want to list. If empty all groups are returned with their state."
-    }
+      "about": "The states of the groups we want to list. If empty all groups are returned with their state." },
+    { "name": "TypesFilter", "type": "[]string", "versions": "5+",
+      "about": "The types of the groups we want to list. If empty all groups are returned" }
   ]
 }

--- a/clients/src/main/resources/common/message/ListGroupsResponse.json
+++ b/clients/src/main/resources/common/message/ListGroupsResponse.json
@@ -19,26 +19,33 @@
   "name": "ListGroupsResponse",
   // Version 1 adds the throttle time.
   //
-  // Starting in version 2, on quota violation, brokers send out responses before throttling.
+  // Starting in version 2, on quota violation, brokers send out
+  // responses before throttling.
   //
   // Version 3 is the first flexible version.
   //
   // Version 4 adds the GroupState field (KIP-518).
-  "validVersions": "0-4",
+  //
+  // Version 5 adds the GroupType field (KIP-848).
+  "validVersions": "0-5",
   "flexibleVersions": "3+",
   "fields": [
-    { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+",
+      "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
     { "name": "Groups", "type": "[]ListedGroup", "versions": "0+",
       "about": "Each group in the response.", "fields": [
-      { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
+      { "name": "GroupId", "type": "string", "versions": "0+",
+        "entityType": "groupId",
         "about": "The group ID." },
       { "name": "ProtocolType", "type": "string", "versions": "0+",
         "about": "The group protocol type." },
       { "name": "GroupState", "type": "string", "versions": "4+", "ignorable": true,
-        "about": "The group state name." }
+        "about": "The group state name." },
+      { "name": "GroupType", "type": "string", "versions": "5+", "ignorable": true,
+        "about": "The group type name." }
     ]}
   ]
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -2799,8 +2799,8 @@ public class KafkaAdminClientTest {
 
             assertEquals(2, listings.size());
             List<ConsumerGroupListing> expected = new ArrayList<>();
-            expected.add(new ConsumerGroupListing("group-2", true, Optional.of(ConsumerGroupState.EMPTY)));
-            expected.add(new ConsumerGroupListing("group-1", false, Optional.of(ConsumerGroupState.STABLE)));
+            expected.add(new ConsumerGroupListing("group-2", true).setState(Optional.of(ConsumerGroupState.EMPTY)));
+            expected.add(new ConsumerGroupListing("group-1", false).setState(Optional.of(ConsumerGroupState.STABLE)));
             assertEquals(expected, listings);
             assertEquals(0, result.errors().get().size());
         }
@@ -2830,7 +2830,7 @@ public class KafkaAdminClientTest {
             ListConsumerGroupsResult result = env.adminClient().listConsumerGroups(options);
             Collection<ConsumerGroupListing> listing = result.all().get();
             assertEquals(1, listing.size());
-            List<ConsumerGroupListing> expected = Collections.singletonList(new ConsumerGroupListing("group-1", false, Optional.empty()));
+            List<ConsumerGroupListing> expected = Collections.singletonList(new ConsumerGroupListing("group-1", false));
             assertEquals(expected, listing);
 
             // But we cannot set a state filter with older broker

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -200,31 +200,23 @@ object ConsumerGroupCommand extends Logging {
       val includeState = opts.options.has(opts.stateOpt)
       val includeType = opts.options.has(opts.typeOpt)
 
-      val groupInfoMap = mutable.Map[String, (String, String)]() // Mutable map
+      val groupInfoMap = mutable.Map[String, (String, String)]()
 
-      if (includeState) {
+      if (includeType || includeState) {
         val states = getStateValues()
-        val listings = listConsumerGroupsWithState(states)
-        listings.foreach { e =>
-          groupInfoMap.update(e.groupId, (e.state().toString, groupInfoMap.getOrElse(e.groupId, ("", ""))._2))
-        }
-      }
-
-      if (includeType) {
         val types = getTypeValues()
-        val listings = listConsumerGroupsWithType(types)
+        val listings = {
+          listConsumerGroupsWithFilters(states, types)
+        }
         listings.foreach { listing =>
           val groupId = listing.groupId
-          val groupType = listing.groupType().toString
-          val currentState = groupInfoMap.getOrElse(groupId, ("", ""))._1
-          groupInfoMap.update(groupId, (currentState, groupType))
+          val groupType = listing.groupType().orElse(ConsumerGroupType.UNKNOWN).toString
+          val state = listing.state().orElse(ConsumerGroupState.UNKNOWN).toString
+          groupInfoMap.update(groupId, (state, groupType))
         }
-      }
-
-      val groupInfoList = groupInfoMap.toList.map { case (groupId, (state, groupType)) => (groupId, state, groupType) }
-
-      if (groupInfoList.nonEmpty) {
+        val groupInfoList = groupInfoMap.toList.map { case (groupId, (state, groupType)) => (groupId, state, groupType) }
         printGroupInfo(groupInfoList, includeState, includeType)
+
       } else {
         listConsumerGroups().foreach(println(_))
       }
@@ -274,16 +266,11 @@ object ConsumerGroupCommand extends Logging {
       listings.map(_.groupId).toList
     }
 
-    def listConsumerGroupsWithState(states: Set[ConsumerGroupState]): List[ConsumerGroupListing] = {
+    def listConsumerGroupsWithFilters(states: Set[ConsumerGroupState], types: Set[ConsumerGroupType]): List[ConsumerGroupListing] = {
       val listConsumerGroupsOptions = withTimeoutMs(new ListConsumerGroupsOptions())
-      listConsumerGroupsOptions.inStates(states.asJava)
-      val result = adminClient.listConsumerGroups(listConsumerGroupsOptions)
-      result.all.get.asScala.toList
-    }
-
-    def listConsumerGroupsWithType(types: Set[ConsumerGroupType]): List[ConsumerGroupListing] = {
-      val listConsumerGroupsOptions = withTimeoutMs(new ListConsumerGroupsOptions())
-      listConsumerGroupsOptions.inTypes(types.asJava)
+      listConsumerGroupsOptions
+        .inStates(states.asJava)
+        .inTypes(types.asJava)
       val result = adminClient.listConsumerGroups(listConsumerGroupsOptions)
       result.all.get.asScala.toList
     }

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -32,7 +32,6 @@ import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.utils.Time
-import org.apache.kafka.coordinator.group.Group.GroupType
 import org.apache.kafka.server.record.BrokerCompressionType
 import org.apache.kafka.storage.internals.log.VerificationGuard
 
@@ -1114,7 +1113,7 @@ private[group] class GroupCoordinator(
       // Filter groups based on states and groupTypes. If either is empty, it won't filter on that criterion.
       val groups = groupManager.currentGroups.filter { g =>
         (states.isEmpty || states.contains(g.summary.state)) &&
-          (groupTypes.isEmpty || groupTypes.contains(g.overview.groupType))
+        (groupTypes.isEmpty || groupTypes.contains(g.overview.groupType))
       }
       (errorCode, groups.map(_.overview).toList)
     }

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -1111,9 +1111,10 @@ private[group] class GroupCoordinator(
     } else {
       val errorCode = if (groupManager.isLoading) Errors.COORDINATOR_LOAD_IN_PROGRESS else Errors.NONE
       // Filter groups based on states and groupTypes. If either is empty, it won't filter on that criterion.
+      // If groupType is mentioned then no group is returned since the notion of groupTypes doesn't exist in the
+      // old group coordinator.
       val groups = groupManager.currentGroups.filter { g =>
-        (states.isEmpty || states.contains(g.summary.state)) &&
-        (groupTypes.isEmpty || groupTypes.contains(g.overview.groupType))
+        (states.isEmpty || states.contains(g.summary.state)) && groupTypes.isEmpty
       }
       (errorCode, groups.map(_.overview).toList)
     }

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
@@ -225,7 +225,7 @@ private[group] class GroupCoordinatorAdapter(
         .setGroupId(group.groupId)
         .setProtocolType(group.protocolType)
         .setGroupState(group.state)
-        .setGroupType(group.protocolType))
+        .setGroupType(group.groupType))
     }
 
     CompletableFuture.completedFuture(response)

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
@@ -213,7 +213,8 @@ private[group] class GroupCoordinatorAdapter(
   ): CompletableFuture[ListGroupsResponseData] = {
     // Handle a null array the same as empty
     val (error, groups) = coordinator.handleListGroups(
-      Option(request.statesFilter).map(_.asScala.toSet).getOrElse(Set.empty)
+      Option(request.statesFilter).map(_.asScala.toSet).getOrElse(Set.empty),
+      Option(request.typesFilter).map(_.asScala.toSet).getOrElse(Set.empty)
     )
 
     val response = new ListGroupsResponseData()
@@ -223,7 +224,8 @@ private[group] class GroupCoordinatorAdapter(
       response.groups.add(new ListGroupsResponseData.ListedGroup()
         .setGroupId(group.groupId)
         .setProtocolType(group.protocolType)
-        .setGroupState(group.state))
+        .setGroupState(group.state)
+        .setGroupType(group.protocolType))
     }
 
     CompletableFuture.completedFuture(response)

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinatorAdapter.scala
@@ -224,8 +224,7 @@ private[group] class GroupCoordinatorAdapter(
       response.groups.add(new ListGroupsResponseData.ListedGroup()
         .setGroupId(group.groupId)
         .setProtocolType(group.protocolType)
-        .setGroupState(group.state)
-        .setGroupType(group.groupType))
+        .setGroupState(group.state))
     }
 
     CompletableFuture.completedFuture(response)

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -156,8 +156,7 @@ private object GroupMetadata extends Logging {
  */
 case class GroupOverview(groupId: String,
                          protocolType: String,
-                         state: String,
-                         groupType: String)
+                         state: String)
 
 /**
  * Case class used to represent group metadata for the DescribeGroup API
@@ -622,7 +621,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   }
 
   def overview: GroupOverview = {
-    GroupOverview(groupId, protocolType.getOrElse(""), state.toString, "generic")
+    GroupOverview(groupId, protocolType.getOrElse(""), state.toString)
   }
 
   def initializeOffsets(offsets: collection.Map[TopicPartition, CommitRecordMetadataAndOffset],

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -28,7 +28,6 @@ import org.apache.kafka.common.message.JoinGroupResponseData.JoinGroupResponseMe
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.protocol.types.SchemaException
 import org.apache.kafka.common.utils.Time
-import org.apache.kafka.coordinator.group.Group.GroupType
 
 import scala.collection.{Seq, immutable, mutable}
 import scala.jdk.CollectionConverters._

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -622,7 +622,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   }
 
   def overview: GroupOverview = {
-    GroupOverview(groupId, protocolType.getOrElse(""), state.toString, protocolType.get)
+    GroupOverview(groupId, protocolType.getOrElse(""), state.toString, "generic")
   }
 
   def initializeOffsets(offsets: collection.Map[TopicPartition, CommitRecordMetadataAndOffset],

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -19,7 +19,6 @@ package kafka.coordinator.group
 import java.nio.ByteBuffer
 import java.util.UUID
 import java.util.concurrent.locks.ReentrantLock
-
 import kafka.common.OffsetAndMetadata
 import kafka.utils.{CoreUtils, Logging, nonthreadsafe}
 import kafka.utils.Implicits._
@@ -29,6 +28,7 @@ import org.apache.kafka.common.message.JoinGroupResponseData.JoinGroupResponseMe
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.protocol.types.SchemaException
 import org.apache.kafka.common.utils.Time
+import org.apache.kafka.coordinator.group.Group.GroupType
 
 import scala.collection.{Seq, immutable, mutable}
 import scala.jdk.CollectionConverters._
@@ -157,7 +157,8 @@ private object GroupMetadata extends Logging {
  */
 case class GroupOverview(groupId: String,
                          protocolType: String,
-                         state: String)
+                         state: String,
+                         groupType: String)
 
 /**
  * Case class used to represent group metadata for the DescribeGroup API
@@ -622,7 +623,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   }
 
   def overview: GroupOverview = {
-    GroupOverview(groupId, protocolType.getOrElse(""), state.toString)
+    GroupOverview(groupId, protocolType.getOrElse(""), state.toString, protocolType.get)
   }
 
   def initializeOffsets(offsets: collection.Map[TopicPartition, CommitRecordMetadataAndOffset],

--- a/core/src/test/scala/unit/kafka/admin/ConsumerGroupCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConsumerGroupCommandTest.scala
@@ -40,6 +40,8 @@ class ConsumerGroupCommandTest extends KafkaServerTestHarness {
 
   val topic = "foo"
   val group = "test.group"
+  val classicGroup = "classic.test.group"
+  val consumerGroup = "consumer.test.group"
 
   private var consumerGroupService: List[ConsumerGroupService] = List()
   private var consumerGroupExecutors: List[AbstractConsumerGroupExecutor] = List()

--- a/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
@@ -113,8 +113,8 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
     var result = ConsumerGroupCommand.consumerGroupTypesFromString("consumer")
     assertEquals(Set(ConsumerGroupType.CONSUMER), result)
 
-    result = ConsumerGroupCommand.consumerGroupTypesFromString("consumer, generic")
-    assertEquals(Set(ConsumerGroupType.CONSUMER, ConsumerGroupType.GENERIC), result)
+    result = ConsumerGroupCommand.consumerGroupTypesFromString("consumer, classic")
+    assertEquals(Set(ConsumerGroupType.CONSUMER, ConsumerGroupType.CLASSIC), result)
 
     assertThrows(classOf[IllegalArgumentException], () => ConsumerGroupCommand.consumerGroupTypesFromString("bad, wrong"))
 
@@ -124,7 +124,6 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
 
     assertThrows(classOf[IllegalArgumentException], () => ConsumerGroupCommand.consumerGroupTypesFromString("   ,   ,"))
   }
-
 
   @ParameterizedTest
   @ValueSource(strings = Array("zk", "kraft"))
@@ -144,24 +143,24 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
     TestUtils.waitUntilTrue(() => {
       out = TestUtils.grabConsoleOutput(ConsumerGroupCommand.main(cgcArgs))
       out.contains("STATE") && !out.contains("TYPE") && out.contains(simpleGroup) && out.contains(group)
-    }, s"Expected 2 to find $simpleGroup, $group and the header, but found $out")
+    }, s"Expected to find $simpleGroup, $group and the header, but found $out")
 
     cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list", "--type")
     TestUtils.waitUntilTrue(() => {
       out = TestUtils.grabConsoleOutput(ConsumerGroupCommand.main(cgcArgs))
       out.contains("TYPE") && !out.contains("STATE") && out.contains(simpleGroup) && out.contains(group)
-    }, s"Expected 3 to find $simpleGroup, $group and the header, but found $out")
+    }, s"Expected to find $simpleGroup, $group and the header, but found $out")
 
     cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list", "--state", "--type")
     TestUtils.waitUntilTrue(() => {
       out = TestUtils.grabConsoleOutput(ConsumerGroupCommand.main(cgcArgs))
       out.contains("TYPE") && out.contains("STATE") && out.contains(simpleGroup) && out.contains(group)
-    }, s"Expected 4 to find $simpleGroup, $group and the header, but found $out")
+    }, s"Expected to find $simpleGroup, $group and the header, but found $out")
 
     cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list", "--state", "Stable")
     TestUtils.waitUntilTrue(() => {
       out = TestUtils.grabConsoleOutput(ConsumerGroupCommand.main(cgcArgs))
       out.contains("STATE") && out.contains(group) && out.contains("Stable")
-    }, s"Expected 5 to find $group in state Stable and the header, but found $out")
+    }, s"Expected to find $group in state Stable and the header, but found $out")
   }
 }

--- a/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
@@ -29,13 +29,13 @@ import java.util.Optional
 class ListConsumerGroupTest extends ConsumerGroupCommandTest {
 
   @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft"))
+  @ValueSource(strings = Array("zk", "kraft", "kraft+kip848"))
   def testListConsumerGroups(quorum: String): Unit = {
     val simpleGroup = "simple-group"
     addSimpleGroupExecutor(group = simpleGroup)
     addConsumerGroupExecutor(numConsumers = 1)
 
-    val cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list")
+    val cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list", "unknown")
     val service = getConsumerGroupService(cgcArgs)
 
     val expectedGroups = Set(group, simpleGroup)
@@ -47,14 +47,14 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft"))
+  @ValueSource(strings = Array("zk", "kraft", "kraft+kip848"))
   def testListWithUnrecognizedNewConsumerOption(): Unit = {
     val cgcArgs = Array("--new-consumer", "--bootstrap-server", bootstrapServers(), "--list")
     assertThrows(classOf[OptionException], () => getConsumerGroupService(cgcArgs))
   }
 
   @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft"))
+  @ValueSource(strings = Array("zk", "kraft", "kraft+kip848"))
   def testListConsumerGroupsWithStates(): Unit = {
     val simpleGroup = "simple-group"
     addSimpleGroupExecutor(group = simpleGroup)
@@ -87,7 +87,7 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft"))
+  @ValueSource(strings = Array("zk", "kraft", "kraft+kip848"))
   def testConsumerGroupStatesFromString(quorum: String): Unit = {
     var result = ConsumerGroupCommand.consumerGroupStatesFromString("Stable")
     assertEquals(Set(ConsumerGroupState.STABLE), result)
@@ -108,7 +108,7 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft"))
+  @ValueSource(strings = Array("zk", "kraft", "kraft+kip848"))
   def testConsumerGroupTypesFromString(quorum: String): Unit = {
     var result = ConsumerGroupCommand.consumerGroupTypesFromString("consumer")
     assertEquals(Set(ConsumerGroupType.CONSUMER), result)
@@ -126,7 +126,7 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft"))
+  @ValueSource(strings = Array("zk", "kraft", "kraft+kip848"))
   def testListGroupCommand(quorum: String): Unit = {
     val simpleGroup = "simple-group"
     addSimpleGroupExecutor(group = simpleGroup)

--- a/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
@@ -18,24 +18,24 @@ package kafka.admin
 
 import joptsimple.OptionException
 import org.junit.jupiter.api.Assertions._
-import kafka.utils.TestUtils
+import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.admin.ConsumerGroupListing
 import org.apache.kafka.common.{ConsumerGroupState, ConsumerGroupType}
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
+import org.junit.jupiter.params.provider.MethodSource
 
 import java.util.Optional
 
 class ListConsumerGroupTest extends ConsumerGroupCommandTest {
 
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft", "kraft+kip848"))
-  def testListConsumerGroups(quorum: String): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testListConsumerGroupsWithoutFilters(quorum: String, groupProtocol: String): Unit = {
     val simpleGroup = "simple-group"
     addSimpleGroupExecutor(group = simpleGroup)
     addConsumerGroupExecutor(numConsumers = 1)
 
-    val cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list", "unknown")
+    val cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list")
     val service = getConsumerGroupService(cgcArgs)
 
     val expectedGroups = Set(group, simpleGroup)
@@ -46,16 +46,16 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
     }, s"Expected --list to show groups $expectedGroups, but found $foundGroups.")
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft", "kraft+kip848"))
-  def testListWithUnrecognizedNewConsumerOption(): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testListWithUnrecognizedNewConsumerOption(quorum: String, groupProtocol: String): Unit = {
     val cgcArgs = Array("--new-consumer", "--bootstrap-server", bootstrapServers(), "--list")
     assertThrows(classOf[OptionException], () => getConsumerGroupService(cgcArgs))
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft", "kraft+kip848"))
-  def testListConsumerGroupsWithStates(): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testListConsumerGroupsWithStates(quorum: String, groupProtocol: String): Unit = {
     val simpleGroup = "simple-group"
     addSimpleGroupExecutor(group = simpleGroup)
     addConsumerGroupExecutor(numConsumers = 1)
@@ -65,15 +65,16 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
 
     val expectedListing = Set(
       new ConsumerGroupListing(simpleGroup, true)
-        .setState(Optional.of(ConsumerGroupState.EMPTY)),
+        .setState(Optional.of(ConsumerGroupState.EMPTY))
+        .setType(if (quorum.contains("kip848")) Optional.of(ConsumerGroupType.CLASSIC) else Optional.empty()),
       new ConsumerGroupListing(group, false)
         .setState(Optional.of(ConsumerGroupState.STABLE))
-        .setType(Optional.of(ConsumerGroupType.CONSUMER))
+        .setType(if (quorum.contains("kip848")) Optional.of(ConsumerGroupType.CLASSIC) else Optional.empty())
     )
 
     var foundListing = Set.empty[ConsumerGroupListing]
     TestUtils.waitUntilTrue(() => {
-      foundListing = service.listConsumerGroupsWithState(ConsumerGroupState.values.toSet).toSet
+      foundListing = service.listConsumerGroupsWithFilters(ConsumerGroupState.values.toSet, Set.empty).toSet
       expectedListing == foundListing
     }, s"Expected to show groups $expectedListing, but found $foundListing")
 
@@ -81,14 +82,71 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
 
     foundListing = Set.empty[ConsumerGroupListing]
     TestUtils.waitUntilTrue(() => {
-      foundListing = service.listConsumerGroupsWithState(Set(ConsumerGroupState.PREPARING_REBALANCE)).toSet
+      foundListing = service.listConsumerGroupsWithFilters(Set(ConsumerGroupState.PREPARING_REBALANCE), Set.empty).toSet
       expectedListingStable == foundListing
     }, s"Expected to show groups $expectedListingStable, but found $foundListing")
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft", "kraft+kip848"))
-  def testConsumerGroupStatesFromString(quorum: String): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testListConsumerGroupsWithTypes(quorum: String, groupProtocol: String): Unit = {
+    val simpleGroup = "simple-group"
+    addSimpleGroupExecutor(group = simpleGroup)
+    addConsumerGroupExecutor(numConsumers = 1)
+
+    val cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list", "--type")
+    val service = getConsumerGroupService(cgcArgs)
+
+    val expectedListingStable = Set.empty[ConsumerGroupListing]
+
+    val expectedListing = Set(
+      new ConsumerGroupListing(simpleGroup, true)
+        .setState(Optional.of(ConsumerGroupState.EMPTY))
+        .setType(if(quorum.contains("kip848")) Optional.of(ConsumerGroupType.CLASSIC) else Optional.empty()),
+      new ConsumerGroupListing(group, false)
+        .setState(Optional.of(ConsumerGroupState.STABLE))
+        .setType(if(quorum.contains("kip848")) Optional.of(ConsumerGroupType.CLASSIC) else Optional.empty())
+    )
+
+    var foundListing = Set.empty[ConsumerGroupListing]
+    TestUtils.waitUntilTrue(() => {
+      foundListing = service.listConsumerGroupsWithFilters(Set.empty, Set.empty).toSet
+      expectedListing == foundListing
+    }, s"Expected to show groups $expectedListing, but found $foundListing")
+
+    // When group type is mentioned:
+    // Old Group Coordinator returns empty listings.
+    // New Group Coordinator returns groups according to the filter.
+    val expectedListing2 = Set(
+      new ConsumerGroupListing(simpleGroup, true)
+        .setState(Optional.of(ConsumerGroupState.EMPTY))
+        .setType(Optional.of(ConsumerGroupType.CLASSIC)),
+      new ConsumerGroupListing(group, false)
+        .setState(Optional.of(ConsumerGroupState.STABLE))
+        .setType(Optional.of(ConsumerGroupType.CLASSIC))
+    )
+
+    foundListing = Set.empty[ConsumerGroupListing]
+    TestUtils.waitUntilTrue(() => {
+      foundListing = service.listConsumerGroupsWithFilters(Set.empty, Set(ConsumerGroupType.CLASSIC)).toSet
+      if (quorum.contains("kip848")) {
+        expectedListing2 == foundListing
+      } else {
+        expectedListingStable == foundListing
+      }
+    }, s"Expected to show groups $expectedListing2, but found $foundListing")
+
+    // Groups with Consumer type aren't available so empty group listing is returned.
+    foundListing = Set.empty[ConsumerGroupListing]
+    TestUtils.waitUntilTrue(() => {
+      foundListing = service.listConsumerGroupsWithFilters(Set.empty, Set(ConsumerGroupType.CONSUMER)).toSet
+      expectedListingStable == foundListing
+    }, s"Expected to show groups $expectedListingStable, but found $foundListing")
+  }
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testConsumerGroupStatesFromString(quorum: String, groupProtocol: String): Unit = {
     var result = ConsumerGroupCommand.consumerGroupStatesFromString("Stable")
     assertEquals(Set(ConsumerGroupState.STABLE), result)
 
@@ -107,9 +165,9 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
     assertThrows(classOf[IllegalArgumentException], () => ConsumerGroupCommand.consumerGroupStatesFromString("   ,   ,"))
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft", "kraft+kip848"))
-  def testConsumerGroupTypesFromString(quorum: String): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testConsumerGroupTypesFromString(quorum: String, groupProtocol: String): Unit = {
     var result = ConsumerGroupCommand.consumerGroupTypesFromString("consumer")
     assertEquals(Set(ConsumerGroupType.CONSUMER), result)
 
@@ -125,9 +183,9 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
     assertThrows(classOf[IllegalArgumentException], () => ConsumerGroupCommand.consumerGroupTypesFromString("   ,   ,"))
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = Array("zk", "kraft", "kraft+kip848"))
-  def testListGroupCommand(quorum: String): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testListGroupCommand(quorum: String, groupProtocol: String): Unit = {
     val simpleGroup = "simple-group"
     addSimpleGroupExecutor(group = simpleGroup)
     addConsumerGroupExecutor(numConsumers = 1)
@@ -161,6 +219,16 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
     TestUtils.waitUntilTrue(() => {
       out = TestUtils.grabConsoleOutput(ConsumerGroupCommand.main(cgcArgs))
       out.contains("STATE") && out.contains(group) && out.contains("Stable")
+    }, s"Expected to find $group in state Stable and the header, but found $out")
+
+    cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list", "--type", "classic")
+    TestUtils.waitUntilTrue(() => {
+      out = TestUtils.grabConsoleOutput(ConsumerGroupCommand.main(cgcArgs))
+      if (quorum.contains("kip848")) {
+        out.contains("TYPE") && out.contains(group) && out.contains("classic")
+      } else {
+        out.contains("TYPE")
+      }
     }, s"Expected to find $group in state Stable and the header, but found $out")
   }
 }

--- a/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
@@ -64,8 +64,8 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
     val service = getConsumerGroupService(cgcArgs)
 
     val expectedListing = Set(
-      new ConsumerGroupListing(simpleGroup, true, Optional.of(ConsumerGroupState.EMPTY)),
-      new ConsumerGroupListing(group, false, Optional.of(ConsumerGroupState.STABLE)))
+      new ConsumerGroupListing(simpleGroup, true).setState(Optional.of(ConsumerGroupState.EMPTY)),
+      new ConsumerGroupListing(group, false).setState(Optional.of(ConsumerGroupState.STABLE)))
 
     var foundListing = Set.empty[ConsumerGroupListing]
     TestUtils.waitUntilTrue(() => {
@@ -74,7 +74,7 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
     }, s"Expected to show groups $expectedListing, but found $foundListing")
 
     val expectedListingStable = Set(
-      new ConsumerGroupListing(group, false, Optional.of(ConsumerGroupState.STABLE)))
+      new ConsumerGroupListing(group, false).setState(Optional.of(ConsumerGroupState.STABLE)))
 
     foundListing = Set.empty[ConsumerGroupListing]
     TestUtils.waitUntilTrue(() => {
@@ -124,11 +124,22 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
       out.contains("STATE") && out.contains(simpleGroup) && out.contains(group)
     }, s"Expected to find $simpleGroup, $group and the header, but found $out")
 
+    cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list", "--type")
+    TestUtils.waitUntilTrue(() => {
+      out = TestUtils.grabConsoleOutput(ConsumerGroupCommand.main(cgcArgs))
+      out.contains("TYPE") && out.contains(simpleGroup) && out.contains(group)
+    }, s"Expected to find $simpleGroup, $group and the header, but found $out")
+
+    cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list", "--state", "--type")
+    TestUtils.waitUntilTrue(() => {
+      out = TestUtils.grabConsoleOutput(ConsumerGroupCommand.main(cgcArgs))
+      out.contains("TYPE") && out.contains("STATE") && out.contains(simpleGroup) && out.contains(group)
+    }, s"Expected to find $simpleGroup, $group and the header, but found $out")
+
     cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list", "--state", "Stable")
     TestUtils.waitUntilTrue(() => {
       out = TestUtils.grabConsoleOutput(ConsumerGroupCommand.main(cgcArgs))
       out.contains("STATE") && out.contains(group) && out.contains("Stable")
     }, s"Expected to find $group in state Stable and the header, but found $out")
   }
-
 }

--- a/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
@@ -19,12 +19,12 @@ package kafka.admin
 import joptsimple.OptionException
 import org.junit.jupiter.api.Assertions._
 import kafka.utils.TestUtils
-import org.apache.kafka.common.ConsumerGroupState
 import org.apache.kafka.clients.admin.ConsumerGroupListing
-import java.util.Optional
-
+import org.apache.kafka.common.{ConsumerGroupState, ConsumerGroupType}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+
+import java.util.Optional
 
 class ListConsumerGroupTest extends ConsumerGroupCommandTest {
 
@@ -64,8 +64,12 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
     val service = getConsumerGroupService(cgcArgs)
 
     val expectedListing = Set(
-      new ConsumerGroupListing(simpleGroup, true).setState(Optional.of(ConsumerGroupState.EMPTY)),
-      new ConsumerGroupListing(group, false).setState(Optional.of(ConsumerGroupState.STABLE)))
+      new ConsumerGroupListing(simpleGroup, true)
+        .setState(Optional.of(ConsumerGroupState.EMPTY)),
+      new ConsumerGroupListing(group, false)
+        .setState(Optional.of(ConsumerGroupState.STABLE))
+        .setType(Optional.of(ConsumerGroupType.CONSUMER))
+    )
 
     var foundListing = Set.empty[ConsumerGroupListing]
     TestUtils.waitUntilTrue(() => {
@@ -73,12 +77,11 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
       expectedListing == foundListing
     }, s"Expected to show groups $expectedListing, but found $foundListing")
 
-    val expectedListingStable = Set(
-      new ConsumerGroupListing(group, false).setState(Optional.of(ConsumerGroupState.STABLE)))
+    val expectedListingStable = Set.empty[ConsumerGroupListing]
 
     foundListing = Set.empty[ConsumerGroupListing]
     TestUtils.waitUntilTrue(() => {
-      foundListing = service.listConsumerGroupsWithState(Set(ConsumerGroupState.STABLE)).toSet
+      foundListing = service.listConsumerGroupsWithState(Set(ConsumerGroupState.PREPARING_REBALANCE)).toSet
       expectedListingStable == foundListing
     }, s"Expected to show groups $expectedListingStable, but found $foundListing")
   }
@@ -106,6 +109,25 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
 
   @ParameterizedTest
   @ValueSource(strings = Array("zk", "kraft"))
+  def testConsumerGroupTypesFromString(quorum: String): Unit = {
+    var result = ConsumerGroupCommand.consumerGroupTypesFromString("consumer")
+    assertEquals(Set(ConsumerGroupType.CONSUMER), result)
+
+    result = ConsumerGroupCommand.consumerGroupTypesFromString("consumer, generic")
+    assertEquals(Set(ConsumerGroupType.CONSUMER, ConsumerGroupType.GENERIC), result)
+
+    assertThrows(classOf[IllegalArgumentException], () => ConsumerGroupCommand.consumerGroupTypesFromString("bad, wrong"))
+
+    assertThrows(classOf[IllegalArgumentException], () => ConsumerGroupCommand.consumerGroupTypesFromString("Consumer"))
+
+    assertThrows(classOf[IllegalArgumentException], () => ConsumerGroupCommand.consumerGroupTypesFromString("  bad, generic"))
+
+    assertThrows(classOf[IllegalArgumentException], () => ConsumerGroupCommand.consumerGroupTypesFromString("   ,   ,"))
+  }
+
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("zk", "kraft"))
   def testListGroupCommand(quorum: String): Unit = {
     val simpleGroup = "simple-group"
     addSimpleGroupExecutor(group = simpleGroup)
@@ -121,25 +143,25 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
     cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list", "--state")
     TestUtils.waitUntilTrue(() => {
       out = TestUtils.grabConsoleOutput(ConsumerGroupCommand.main(cgcArgs))
-      out.contains("STATE") && out.contains(simpleGroup) && out.contains(group)
-    }, s"Expected to find $simpleGroup, $group and the header, but found $out")
+      out.contains("STATE") && !out.contains("TYPE") && out.contains(simpleGroup) && out.contains(group)
+    }, s"Expected 2 to find $simpleGroup, $group and the header, but found $out")
 
     cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list", "--type")
     TestUtils.waitUntilTrue(() => {
       out = TestUtils.grabConsoleOutput(ConsumerGroupCommand.main(cgcArgs))
-      out.contains("TYPE") && out.contains(simpleGroup) && out.contains(group)
-    }, s"Expected to find $simpleGroup, $group and the header, but found $out")
+      out.contains("TYPE") && !out.contains("STATE") && out.contains(simpleGroup) && out.contains(group)
+    }, s"Expected 3 to find $simpleGroup, $group and the header, but found $out")
 
     cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list", "--state", "--type")
     TestUtils.waitUntilTrue(() => {
       out = TestUtils.grabConsoleOutput(ConsumerGroupCommand.main(cgcArgs))
       out.contains("TYPE") && out.contains("STATE") && out.contains(simpleGroup) && out.contains(group)
-    }, s"Expected to find $simpleGroup, $group and the header, but found $out")
+    }, s"Expected 4 to find $simpleGroup, $group and the header, but found $out")
 
     cgcArgs = Array("--bootstrap-server", bootstrapServers(), "--list", "--state", "Stable")
     TestUtils.waitUntilTrue(() => {
       out = TestUtils.grabConsoleOutput(ConsumerGroupCommand.main(cgcArgs))
       out.contains("STATE") && out.contains(group) && out.contains("Stable")
-    }, s"Expected to find $group in state Stable and the header, but found $out")
+    }, s"Expected 5 to find $group in state Stable and the header, but found $out")
   }
 }

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
@@ -348,8 +348,8 @@ class GroupCoordinatorAdapterTest {
 
     when(groupCoordinator.handleListGroups(expectedStatesFilter, expectedTypesFilter)).thenReturn {
       (Errors.NOT_COORDINATOR, List(
-        GroupOverview("group1", "protocol1", "Stable", "classic"),
-        GroupOverview("group2", "qwerty", "Empty", "consumer")
+        GroupOverview("group1", "protocol1", "Stable"),
+        GroupOverview("group2", "qwerty", "Empty")
       ))
     }
 
@@ -362,13 +362,11 @@ class GroupCoordinatorAdapterTest {
         new ListGroupsResponseData.ListedGroup()
           .setGroupId("group1")
           .setGroupState("Stable")
-          .setProtocolType("protocol1")
-          .setGroupType("classic"),
+          .setProtocolType("protocol1"),
         new ListGroupsResponseData.ListedGroup()
           .setGroupId("group2")
           .setGroupState("Empty")
           .setProtocolType("qwerty")
-          .setGroupType("consumer")
       ).asJava)
 
     assertTrue(future.isDone)

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
@@ -327,13 +327,14 @@ class GroupCoordinatorAdapterTest {
 
   @Test
   def testListGroups(): Unit = {
-    testListGroups(null, Set.empty, Set.empty)
-    testListGroups(List(), Set.empty, Set.empty)
-    testListGroups(List("Stable"), Set("Stable"), Set.empty)
+    testListGroups(null, null, Set.empty, Set.empty)
+    testListGroups(List(), List(), Set.empty, Set.empty)
+    testListGroups(List("Stable, Empty"), List(), Set("Stable, Empty"), Set.empty)
   }
 
   def testListGroups(
     statesFilter: List[String],
+    typesFilter: List[String],
     expectedStatesFilter: Set[String],
     expectedTypesFilter: Set[String]
   ): Unit = {
@@ -343,10 +344,11 @@ class GroupCoordinatorAdapterTest {
     val ctx = makeContext(ApiKeys.LIST_GROUPS, ApiKeys.LIST_GROUPS.latestVersion)
     val data = new ListGroupsRequestData()
       .setStatesFilter(statesFilter.asJava)
+      .setTypesFilter(typesFilter.asJava)
 
     when(groupCoordinator.handleListGroups(expectedStatesFilter, expectedTypesFilter)).thenReturn {
       (Errors.NOT_COORDINATOR, List(
-        GroupOverview("group1", "protocol1", "Stable", "generic"),
+        GroupOverview("group1", "protocol1", "Stable", "classic"),
         GroupOverview("group2", "qwerty", "Empty", "consumer")
       ))
     }
@@ -361,7 +363,7 @@ class GroupCoordinatorAdapterTest {
           .setGroupId("group1")
           .setGroupState("Stable")
           .setProtocolType("protocol1")
-          .setGroupType("generic"),
+          .setGroupType("classic"),
         new ListGroupsResponseData.ListedGroup()
           .setGroupId("group2")
           .setGroupState("Empty")

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorAdapterTest.scala
@@ -327,14 +327,15 @@ class GroupCoordinatorAdapterTest {
 
   @Test
   def testListGroups(): Unit = {
-    testListGroups(null, Set.empty)
-    testListGroups(List(), Set.empty)
-    testListGroups(List("Stable"), Set("Stable"))
+    testListGroups(null, Set.empty, Set.empty)
+    testListGroups(List(), Set.empty, Set.empty)
+    testListGroups(List("Stable"), Set("Stable"), Set.empty)
   }
 
   def testListGroups(
     statesFilter: List[String],
-    expectedStatesFilter: Set[String]
+    expectedStatesFilter: Set[String],
+    expectedTypesFilter: Set[String]
   ): Unit = {
     val groupCoordinator = mock(classOf[GroupCoordinator])
     val adapter = new GroupCoordinatorAdapter(groupCoordinator, Time.SYSTEM)
@@ -343,10 +344,10 @@ class GroupCoordinatorAdapterTest {
     val data = new ListGroupsRequestData()
       .setStatesFilter(statesFilter.asJava)
 
-    when(groupCoordinator.handleListGroups(expectedStatesFilter)).thenReturn {
+    when(groupCoordinator.handleListGroups(expectedStatesFilter, expectedTypesFilter)).thenReturn {
       (Errors.NOT_COORDINATOR, List(
-        GroupOverview("group1", "protocol1", "Stable"),
-        GroupOverview("group2", "qwerty", "Empty")
+        GroupOverview("group1", "protocol1", "Stable", "generic"),
+        GroupOverview("group2", "qwerty", "Empty", "consumer")
       ))
     }
 
@@ -359,11 +360,13 @@ class GroupCoordinatorAdapterTest {
         new ListGroupsResponseData.ListedGroup()
           .setGroupId("group1")
           .setGroupState("Stable")
-          .setProtocolType("protocol1"),
+          .setProtocolType("protocol1")
+          .setGroupType("generic"),
         new ListGroupsResponseData.ListedGroup()
           .setGroupId("group2")
           .setGroupState("Empty")
           .setProtocolType("qwerty")
+          .setGroupType("consumer")
       ).asJava)
 
     assertTrue(future.isDone)

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -176,7 +176,7 @@ class GroupCoordinatorTest {
     assertEquals(Errors.COORDINATOR_LOAD_IN_PROGRESS, describeGroupError)
 
     // ListGroups
-    val (listGroupsError, _) = groupCoordinator.handleListGroups(Set())
+    val (listGroupsError, _) = groupCoordinator.handleListGroups(Set(), Set())
     assertEquals(Errors.COORDINATOR_LOAD_IN_PROGRESS, listGroupsError)
 
     // DeleteGroups
@@ -3300,10 +3300,10 @@ class GroupCoordinatorTest {
     val syncGroupResult = syncGroupLeader(groupId, generationId, assignedMemberId, Map(assignedMemberId -> Array[Byte]()))
     assertEquals(Errors.NONE, syncGroupResult.error)
 
-    val (error, groups) = groupCoordinator.handleListGroups(Set())
+    val (error, groups) = groupCoordinator.handleListGroups(Set(), Set())
     assertEquals(Errors.NONE, error)
     assertEquals(1, groups.size)
-    assertEquals(GroupOverview("groupId", "consumer", Stable.toString), groups.head)
+    assertEquals(GroupOverview("groupId", "consumer", Stable.toString, "consumer"), groups.head)
   }
 
   @Test
@@ -3312,10 +3312,10 @@ class GroupCoordinatorTest {
     val joinGroupResult = dynamicJoinGroup(groupId, memberId, protocolType, protocols)
     assertEquals(Errors.NONE, joinGroupResult.error)
 
-    val (error, groups) = groupCoordinator.handleListGroups(Set())
+    val (error, groups) = groupCoordinator.handleListGroups(Set(), Set())
     assertEquals(Errors.NONE, error)
     assertEquals(1, groups.size)
-    assertEquals(GroupOverview("groupId", "consumer", CompletingRebalance.toString), groups.head)
+    assertEquals(GroupOverview("groupId", "consumer", CompletingRebalance.toString, "consumer"), groups.head)
   }
 
   @Test
@@ -3330,10 +3330,10 @@ class GroupCoordinatorTest {
     assertEquals(Errors.NONE, joinGroupResult.error)
 
     // The group should be in CompletingRebalance
-    val (error, groups) = groupCoordinator.handleListGroups(Set(CompletingRebalance.toString))
+    val (error, groups) = groupCoordinator.handleListGroups(Set(CompletingRebalance.toString), Set())
     assertEquals(Errors.NONE, error)
     assertEquals(1, groups.size)
-    val (error2, groups2) = groupCoordinator.handleListGroups(allStates.filterNot(s => s == CompletingRebalance.toString))
+    val (error2, groups2) = groupCoordinator.handleListGroups(allStates.filterNot(s => s == CompletingRebalance.toString), Set())
     assertEquals(Errors.NONE, error2)
     assertEquals(0, groups2.size)
 
@@ -3342,10 +3342,10 @@ class GroupCoordinatorTest {
     assertEquals(Errors.NONE, syncGroupResult.error)
 
     // The group is now stable
-    val (error3, groups3) = groupCoordinator.handleListGroups(Set(Stable.toString))
+    val (error3, groups3) = groupCoordinator.handleListGroups(Set(Stable.toString), Set())
     assertEquals(Errors.NONE, error3)
     assertEquals(1, groups3.size)
-    val (error4, groups4) = groupCoordinator.handleListGroups(allStates.filterNot(s => s == Stable.toString))
+    val (error4, groups4) = groupCoordinator.handleListGroups(allStates.filterNot(s => s == Stable.toString), Set())
     assertEquals(Errors.NONE, error4)
     assertEquals(0, groups4.size)
 
@@ -3354,12 +3354,34 @@ class GroupCoordinatorTest {
     verifyLeaveGroupResult(leaveGroupResults)
 
     // The group is now empty
-    val (error5, groups5) = groupCoordinator.handleListGroups(Set(Empty.toString))
+    val (error5, groups5) = groupCoordinator.handleListGroups(Set(Empty.toString), Set())
     assertEquals(Errors.NONE, error5)
     assertEquals(1, groups5.size)
-    val (error6, groups6) = groupCoordinator.handleListGroups(allStates.filterNot(s => s == Empty.toString))
+    val (error6, groups6) = groupCoordinator.handleListGroups(allStates.filterNot(s => s == Empty.toString), Set())
     assertEquals(Errors.NONE, error6)
     assertEquals(0, groups6.size)
+  }
+
+  @Test
+  def testListGroupsWithTypes(): Unit = {
+    val memberId = JoinGroupRequest.UNKNOWN_MEMBER_ID
+    val joinGroupResult = dynamicJoinGroup(groupId, memberId, protocolType, protocols)
+    val assignedMemberId = joinGroupResult.memberId
+    val generationId = joinGroupResult.generationId
+    assertEquals(Errors.NONE, joinGroupResult.error)
+
+    val syncGroupResult = syncGroupLeader(groupId, generationId, assignedMemberId, Map(assignedMemberId -> Array[Byte]()))
+    assertEquals(Errors.NONE, syncGroupResult.error)
+
+    // Group is of type "consumer" so generic filter should return an empty result.
+    val (error1, groups1) = groupCoordinator.handleListGroups(Set(), Set("generic"))
+    assertEquals(Errors.NONE, error1)
+    assertEquals(0, groups1.size)
+
+    val (error2, groups2) = groupCoordinator.handleListGroups(Set(), Set("consumer"))
+    assertEquals(Errors.NONE, error2)
+    assertEquals(1, groups2.size)
+    assertEquals(GroupOverview("groupId", "consumer", Stable.toString, "consumer"), groups2.head)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -3303,7 +3303,7 @@ class GroupCoordinatorTest {
     val (error, groups) = groupCoordinator.handleListGroups(Set(), Set())
     assertEquals(Errors.NONE, error)
     assertEquals(1, groups.size)
-    assertEquals(GroupOverview("groupId", "consumer", Stable.toString, "consumer"), groups.head)
+    assertEquals(GroupOverview("groupId", "consumer", Stable.toString), groups.head)
   }
 
   @Test
@@ -3315,7 +3315,7 @@ class GroupCoordinatorTest {
     val (error, groups) = groupCoordinator.handleListGroups(Set(), Set())
     assertEquals(Errors.NONE, error)
     assertEquals(1, groups.size)
-    assertEquals(GroupOverview("groupId", "consumer", CompletingRebalance.toString, "consumer"), groups.head)
+    assertEquals(GroupOverview("groupId", "consumer", CompletingRebalance.toString), groups.head)
   }
 
   @Test
@@ -3373,15 +3373,16 @@ class GroupCoordinatorTest {
     val syncGroupResult = syncGroupLeader(groupId, generationId, assignedMemberId, Map(assignedMemberId -> Array[Byte]()))
     assertEquals(Errors.NONE, syncGroupResult.error)
 
-    // Group is of type "consumer" so generic filter should return an empty result.
-    val (error1, groups1) = groupCoordinator.handleListGroups(Set(), Set("generic"))
+    // When a group type filter is specified, no groups are returned since group types don't exist in this coordinator.
+    val (error1, groups1) = groupCoordinator.handleListGroups(Set(), Set("classic"))
     assertEquals(Errors.NONE, error1)
     assertEquals(0, groups1.size)
 
-    val (error2, groups2) = groupCoordinator.handleListGroups(Set(), Set("consumer"))
+    // When no group type filter is specified, all groups are returned with unknown group type.
+    val (error2, groups2) = groupCoordinator.handleListGroups(Set(), Set())
     assertEquals(Errors.NONE, error2)
     assertEquals(1, groups2.size)
-    assertEquals(GroupOverview("groupId", "consumer", Stable.toString, "consumer"), groups2.head)
+    assertEquals(GroupOverview("groupId", "consumer", Stable.toString), groups2.head)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -5740,7 +5740,6 @@ class KafkaApisTest extends Logging {
   @ParameterizedTest
   @ApiKeyVersionsSource(apiKey = ApiKeys.LIST_GROUPS)
   def testListGroupsRequest(version: Short): Unit = {
-    System.out.println("Version is " + version);
     val listGroupsRequest = new ListGroupsRequestData()
       .setStatesFilter(if (version >= 4) List("Stable", "Empty").asJava else List.empty.asJava)
       .setTypesFilter(if (version >= 5) List("generic", "consumer").asJava else List.empty.asJava)

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -537,7 +537,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
             runtime.scheduleReadOperation(
                 "list-groups",
                 tp,
-                (coordinator, lastCommittedOffset) -> coordinator.listGroups(request.statesFilter(), lastCommittedOffset)
+                (coordinator, lastCommittedOffset) -> coordinator.listGroups(request.statesFilter(), request.typesFilter(), lastCommittedOffset)
             ).handle((groups, exception) -> {
                 if (exception == null) {
                     synchronized (results) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -476,16 +476,19 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
     /**
      * Handles a ListGroups request.
      *
-     * @param statesFilter    The states of the groups we want to list.
-     *                        If empty all groups are returned with their state.
-     * @param committedOffset A specified committed offset corresponding to this shard
+     * @param statesFilter      The states of the groups we want to list.
+     *                          If empty all groups are returned with their state.
+     * @param typesFilter       The types of the groups we want to list.
+     *                          If empty all groups are returned.
+     * @param committedOffset   A specified committed offset corresponding to this shard.
      * @return A list containing the ListGroupsResponseData.ListedGroup
      */
     public List<ListGroupsResponseData.ListedGroup> listGroups(
         List<String> statesFilter,
+        List<String> typesFilter,
         long committedOffset
     ) throws ApiException {
-        return groupMetadataManager.listGroups(statesFilter, committedOffset);
+        return groupMetadataManager.listGroups(statesFilter, typesFilter, committedOffset);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -453,14 +453,20 @@ public class GroupMetadataManager {
     /**
      * Get the Group List.
      *
-     * @param statesFilter The states of the groups we want to list.
-     *                     If empty all groups are returned with their state.
-     * @param committedOffset A specified committed offset corresponding to this shard
+     * @param statesFilter      The states of the groups we want to list.
+     *                          If empty all groups are returned with their state.
+     * @param typesFilter       The types of the groups we want to list.
+     *                          If empty all groups are returned.
+     * @param committedOffset   A specified committed offset corresponding to this shard
      *
      * @return A list containing the ListGroupsResponseData.ListedGroup
      */
 
-    public List<ListGroupsResponseData.ListedGroup> listGroups(List<String> statesFilter, long committedOffset) {
+    public List<ListGroupsResponseData.ListedGroup> listGroups(
+        List<String> statesFilter,
+        List<String> typesFilter,
+        long committedOffset
+    ) {
         Stream<Group> groupStream = groups.values(committedOffset).stream();
         if (!statesFilter.isEmpty()) {
             groupStream = groupStream.filter(group -> statesFilter.contains(group.stateAsString(committedOffset)));

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
@@ -1293,7 +1293,8 @@ public class ClassicGroup implements Group {
         return new ListGroupsResponseData.ListedGroup()
             .setGroupId(groupId)
             .setProtocolType(protocolType.orElse(""))
-            .setGroupState(state.toString());
+            .setGroupState(state.toString())
+            .setGroupType(type().toString());
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -222,7 +222,8 @@ public class ConsumerGroup implements Group {
         return new ListGroupsResponseData.ListedGroup()
             .setGroupId(groupId)
             .setProtocolType(ConsumerProtocol.PROTOCOL_TYPE)
-            .setGroupState(state.get(committedOffset).toString());
+            .setGroupState(state.get(committedOffset).toString())
+            .setGroupType(type().toString());
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -744,16 +744,19 @@ public class GroupCoordinatorServiceTest {
         List<ListGroupsResponseData.ListedGroup> expectedResults = Arrays.asList(
             new ListGroupsResponseData.ListedGroup()
                 .setGroupId("group0")
+                .setProtocolType("protocol1")
                 .setGroupState("Stable")
-                .setProtocolType("protocol1"),
+                .setGroupType("classic"),
             new ListGroupsResponseData.ListedGroup()
                 .setGroupId("group1")
+                .setProtocolType(ConsumerProtocol.PROTOCOL_TYPE)
                 .setGroupState("Empty")
-                .setProtocolType(ConsumerProtocol.PROTOCOL_TYPE),
+                .setGroupType("consumer"),
             new ListGroupsResponseData.ListedGroup()
                 .setGroupId("group2")
-                .setGroupState("Dead")
                 .setProtocolType(ConsumerProtocol.PROTOCOL_TYPE)
+                .setGroupState("Dead")
+                .setGroupType("consumer")
         );
         when(runtime.partitions()).thenReturn(Sets.newSet(
             new TopicPartition("__consumer_offsets", 0),
@@ -793,12 +796,14 @@ public class GroupCoordinatorServiceTest {
         List<ListGroupsResponseData.ListedGroup> expectedResults = Arrays.asList(
             new ListGroupsResponseData.ListedGroup()
                 .setGroupId("group0")
+                .setProtocolType("protocol1")
                 .setGroupState("Stable")
-                .setProtocolType("protocol1"),
+                .setGroupType("classic"),
             new ListGroupsResponseData.ListedGroup()
                 .setGroupId("group1")
-                .setGroupState("Empty")
                 .setProtocolType(ConsumerProtocol.PROTOCOL_TYPE)
+                .setGroupState("Empty")
+                .setGroupType("consumer")
         );
 
         ListGroupsRequestData request = new ListGroupsRequestData();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.coordinator.group;
 
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
+import org.apache.kafka.common.ConsumerGroupType;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.CoordinatorNotAvailableException;
@@ -9583,10 +9584,8 @@ public class GroupMetadataManagerTest {
     @Test
     public void testListGroups() {
         String consumerGroupId = "consumer-group-id";
-        String classicGroupId = "generic-group-id";
+        String classicGroupId = "classic-group-id";
         String memberId1 = Uuid.randomUuid().toString();
-        String classicGroupType = "generic";
-        Uuid fooTopicId = Uuid.randomUuid();
         String fooTopicName = "foo";
 
         MockPartitionAssignor assignor = new MockPartitionAssignor("range");
@@ -9595,14 +9594,14 @@ public class GroupMetadataManagerTest {
             .withConsumerGroup(new ConsumerGroupBuilder(consumerGroupId, 10))
             .build();
 
-        // Create one generic group record.
+        // Create one classic group record.
         context.replay(newGroupMetadataRecord(
             classicGroupId,
             new GroupMetadataValue()
                 .setMembers(Collections.emptyList())
                 .setGeneration(2)
                 .setLeader(null)
-                .setProtocolType(classicGroupType)
+                .setProtocolType("classic")
                 .setProtocol("range")
                 .setCurrentStateTimestamp(context.time.milliseconds()),
             MetadataVersion.latest()));
@@ -9622,13 +9621,14 @@ public class GroupMetadataManagerTest {
             Stream.of(
                 new ListGroupsResponseData.ListedGroup()
                     .setGroupId(classicGroup.groupId())
-                    .setProtocolType(classicGroupType)
-                    .setGroupState(EMPTY.toString()),
+                    .setProtocolType("classic")
+                    .setGroupState(EMPTY.toString())
+                    .setGroupType(ConsumerGroupType.CLASSIC.toString()),
                 new ListGroupsResponseData.ListedGroup()
                     .setGroupId(consumerGroupId)
                     .setProtocolType(ConsumerProtocol.PROTOCOL_TYPE)
                     .setGroupState(ConsumerGroup.ConsumerGroupState.EMPTY.toString())
-                    .setGroupType(EMPTY.toString())
+                    .setGroupType(ConsumerGroupType.CONSUMER.toString())
             ).collect(Collectors.toMap(ListGroupsResponseData.ListedGroup::groupId, Function.identity()));
 
         assertEquals(expectAllGroupMap, actualAllGroupMap);
@@ -9642,12 +9642,14 @@ public class GroupMetadataManagerTest {
             Stream.of(
                 new ListGroupsResponseData.ListedGroup()
                     .setGroupId(classicGroup.groupId())
-                    .setProtocolType(classicGroupType)
-                    .setGroupState(EMPTY.toString()),
+                    .setProtocolType("classic")
+                    .setGroupState(EMPTY.toString())
+                    .setGroupType(ConsumerGroupType.CLASSIC.toString()),
                 new ListGroupsResponseData.ListedGroup()
                     .setGroupId(consumerGroupId)
                     .setProtocolType(ConsumerProtocol.PROTOCOL_TYPE)
                     .setGroupState(ConsumerGroup.ConsumerGroupState.ASSIGNING.toString())
+                    .setGroupType(ConsumerGroupType.CONSUMER.toString())
             ).collect(Collectors.toMap(ListGroupsResponseData.ListedGroup::groupId, Function.identity()));
 
         assertEquals(expectAllGroupMap, actualAllGroupMap);
@@ -9658,20 +9660,22 @@ public class GroupMetadataManagerTest {
         expectAllGroupMap = Stream.of(
             new ListGroupsResponseData.ListedGroup()
                 .setGroupId(classicGroup.groupId())
-                .setProtocolType(classicGroupType)
+                .setProtocolType("classic")
                 .setGroupState(EMPTY.toString())
+                .setGroupType(ConsumerGroupType.CLASSIC.toString())
         ).collect(Collectors.toMap(ListGroupsResponseData.ListedGroup::groupId, Function.identity()));
 
         assertEquals(expectAllGroupMap, actualAllGroupMap);
 
         // Test list group response with no group state filter and with group type filter.
-        actualAllGroupMap = context.sendListGroups(Collections.emptyList(), Collections.singletonList(classicGroupType)).stream()
+        actualAllGroupMap = context.sendListGroups(Collections.emptyList(), Collections.singletonList(ConsumerGroupType.CLASSIC.toString())).stream()
             .collect(Collectors.toMap(ListGroupsResponseData.ListedGroup::groupId, Function.identity()));
         expectAllGroupMap = Stream.of(
             new ListGroupsResponseData.ListedGroup()
                 .setGroupId(classicGroup.groupId())
-                .setProtocolType(classicGroupType)
+                .setProtocolType("classic")
                 .setGroupState(EMPTY.toString())
+                .setGroupType(ConsumerGroupType.CLASSIC.toString())
         ).collect(Collectors.toMap(ListGroupsResponseData.ListedGroup::groupId, Function.identity()));
 
         assertEquals(expectAllGroupMap, actualAllGroupMap);


### PR DESCRIPTION
KIP-848 introduces the concept of "group types" in the context of the ListGroups API. The ListGroups API has been extended to support both filtering on the group types and returning the group types of the queried groups.

The valid group types are: Generic and Consumer. [https://cwiki.apache.org/confluence/display/KAFKA/KIP-848%3A+The+Next+Generation+of+the+Consumer+Rebalance+Protocol#KIP848:TheNextGenerationoftheConsumerRebalanceProtocol-ConsumerGroups](url)



