### PR TITLE
KAFKA-15821: Delete active topics after connector deletion in standal…

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -515,6 +515,7 @@ public class StandaloneHerder extends AbstractHerder {
             synchronized (StandaloneHerder.this) {
                 configState = configBackingStore.snapshot();
             }
+            resetConnectorActiveTopics(connector);
         }
 
         @Override


### PR DESCRIPTION
Fixes a bug where the active topics for a connector are not removed when the connector is deleted if connect is running in standalone mode. 

https://issues.apache.org/jira/browse/KAFKA-15821
