### PR TITLE
KAFKA-15582 Unset the previous broker epoch if version < 2

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationRequest.java
@@ -45,6 +45,10 @@ public class BrokerRegistrationRequest extends AbstractRequest {
 
         @Override
         public BrokerRegistrationRequest build(short version) {
+            if (version < 2) {
+                // Reset the PreviousBrokerEpoch to default if not supported.
+                data.setPreviousBrokerEpoch(new BrokerRegistrationRequestData().previousBrokerEpoch());
+            }
             return new BrokerRegistrationRequest(data, version);
         }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/BrokerRegistrationRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/BrokerRegistrationRequestTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.BrokerRegistrationRequestData;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BrokerRegistrationRequestTest {
+    private static Stream<Arguments> BrokerRegistrationRequestVersions() {
+        return IntStream.range(BrokerRegistrationRequestData.LOWEST_SUPPORTED_VERSION, BrokerRegistrationRequestData.HIGHEST_SUPPORTED_VERSION + 1).mapToObj(version -> Arguments.of((short) version));
+    }
+
+    @ParameterizedTest
+    @MethodSource("BrokerRegistrationRequestVersions")
+    public void testBasicBuild(short version) {
+        Uuid incarnationId = Uuid.randomUuid();
+        BrokerRegistrationRequestData data = new BrokerRegistrationRequestData();
+        data.setBrokerId(0)
+            .setIsMigratingZkBroker(false)
+            .setClusterId("test")
+            .setFeatures(new BrokerRegistrationRequestData.FeatureCollection())
+            .setIncarnationId(incarnationId)
+            .setListeners(new BrokerRegistrationRequestData.ListenerCollection())
+            .setRack("a")
+            .setPreviousBrokerEpoch(1L);
+        BrokerRegistrationRequest.Builder builder = new BrokerRegistrationRequest.Builder(data);
+        BrokerRegistrationRequest request = builder.build(version);
+        assertEquals(0, request.data().brokerId(), request.toString());
+        assertEquals("test", request.data().clusterId(), request.toString());
+        assertEquals(incarnationId, request.data().incarnationId(), request.toString());
+        assertEquals("a", request.data().rack(), request.toString());
+        if (version < 2) {
+            assertEquals(-1, request.data().previousBrokerEpoch(), request.toString());
+        } else {
+            assertEquals(1, request.data().previousBrokerEpoch(), request.toString());
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/requests/BrokerRegistrationRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/BrokerRegistrationRequestTest.java
@@ -30,7 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class BrokerRegistrationRequestTest {
     private static Stream<Arguments> BrokerRegistrationRequestVersions() {
-        return IntStream.range(BrokerRegistrationRequestData.LOWEST_SUPPORTED_VERSION, BrokerRegistrationRequestData.HIGHEST_SUPPORTED_VERSION + 1).mapToObj(version -> Arguments.of((short) version));
+        return IntStream.range(BrokerRegistrationRequestData.LOWEST_SUPPORTED_VERSION,
+            BrokerRegistrationRequestData.HIGHEST_SUPPORTED_VERSION + 1).mapToObj(version -> Arguments.of((short) version));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
A bug fix where the previous broker epoch should not be set if the version is smaller than 2.
