### PR TITLE
MINOR: Expose earliest local timestamp via the GetOffsetShell

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4464,6 +4464,8 @@ public class KafkaAdminClient extends AdminClient {
             return ListOffsetsRequest.EARLIEST_TIMESTAMP;
         } else if (offsetSpec instanceof OffsetSpec.MaxTimestampSpec) {
             return ListOffsetsRequest.MAX_TIMESTAMP;
+        } else if (offsetSpec instanceof OffsetSpec.EarliestLocalTimestampSpec) {
+            return ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP;
         }
         return ListOffsetsRequest.LATEST_TIMESTAMP;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/OffsetSpec.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/OffsetSpec.java
@@ -26,6 +26,7 @@ public class OffsetSpec {
     public static class EarliestSpec extends OffsetSpec { }
     public static class LatestSpec extends OffsetSpec { }
     public static class MaxTimestampSpec extends OffsetSpec { }
+    public static class EarliestLocalTimestampSpec extends OffsetSpec { }
     public static class TimestampSpec extends OffsetSpec {
         private final long timestamp;
 
@@ -68,6 +69,10 @@ public class OffsetSpec {
      */
     public static OffsetSpec maxTimestamp() {
         return new MaxTimestampSpec();
+    }
+
+    public static OffsetSpec earliestLocalTimestamp() {
+        return new EarliestLocalTimestampSpec();
     }
 
 }

--- a/core/src/test/scala/integration/kafka/admin/ListOffsetsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ListOffsetsIntegrationTest.scala
@@ -74,6 +74,13 @@ class ListOffsetsIntegrationTest extends KafkaServerTestHarness {
     assertEquals(1, maxTimestampOffset.offset())
   }
 
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("zk", "kraft"))
+  def testEarliestLocalTimestampOffset(quorum: String): Unit = {
+    val earliestLocalTimestamp = runFetchOffsets(adminClient, OffsetSpec.earliestLocalTimestamp())
+    assertEquals(0, earliestLocalTimestamp.offset())
+  }
+
   private def runFetchOffsets(adminClient: Admin,
                               offsetSpec: OffsetSpec): ListOffsetsResult.ListOffsetsResultInfo = {
     val tp = new TopicPartition(topicName, 0)

--- a/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
+++ b/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
@@ -132,7 +132,7 @@ public class GetOffsetShell {
                     .ofType(String.class);
             timeOpt = parser.accepts("time", "timestamp of the offsets before that. [Note: No offset is returned, if the timestamp greater than recently committed record timestamp is given.]")
                     .withRequiredArg()
-                    .describedAs("<timestamp> / -1 or latest / -2 or earliest / -3 or max-timestamp")
+                    .describedAs("<timestamp> / -1 or latest / -2 or earliest / -3 or max-timestamp / -4 or earliest-local-timestamp")
                     .ofType(String.class)
                     .defaultsTo("latest");
             commandConfigOpt = parser.accepts("command-config", "Property file containing configs to be passed to Admin Client.")
@@ -281,6 +281,8 @@ public class GetOffsetShell {
                 return OffsetSpec.latest();
             case "max-timestamp":
                 return OffsetSpec.maxTimestamp();
+            case "earliest-local-timestamp":
+                return OffsetSpec.earliestLocalTimestamp();
             default:
                 long timestamp;
 
@@ -288,7 +290,7 @@ public class GetOffsetShell {
                     timestamp = Long.parseLong(listOffsetsTimestamp);
                 } catch (NumberFormatException e) {
                     throw new TerseException("Malformed time argument " + listOffsetsTimestamp + ". " +
-                            "Please use -1 or latest / -2 or earliest / -3 or max-timestamp, or a specified long format timestamp");
+                            "Please use -1 or latest / -2 or earliest / -3 or max-timestamp / -4 or earliest-local-timestamp, or a specified long format timestamp");
                 }
 
                 if (timestamp == ListOffsetsRequest.EARLIEST_TIMESTAMP) {
@@ -297,6 +299,8 @@ public class GetOffsetShell {
                     return OffsetSpec.latest();
                 } else if (timestamp == ListOffsetsRequest.MAX_TIMESTAMP) {
                     return OffsetSpec.maxTimestamp();
+                } else if (timestamp == ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP) {
+                    return OffsetSpec.earliestLocalTimestamp();
                 } else {
                     return OffsetSpec.forTimestamp(timestamp);
                 }

--- a/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
@@ -236,6 +236,23 @@ public class GetOffsetShellTest {
     }
 
     @ClusterTest
+    public void testGetEarliestLocalTimestampOffsets() {
+        setUp();
+
+        for (String time : new String[] {"-4", "earliest-local-timestamp"}) {
+            List<Row> offsets = executeAndParse("--topic-partitions", "topic.*:0", "--time", time);
+            List<Row> expected = Arrays.asList(
+                    new Row("topic1", 0, 0L),
+                    new Row("topic2", 0, 0L),
+                    new Row("topic3", 0, 0L),
+                    new Row("topic4", 0, 0L)
+            );
+
+            assertEquals(expected, offsets);
+        }
+    }
+
+    @ClusterTest
     public void testGetOffsetsByTimestamp() {
         setUp();
 


### PR DESCRIPTION
With the introduction of tiered storage the ListOffsets API can now return the earliest local timestamp.

The purpose of this pull request is to enable the Kafka tools to get this information in a similar way as the earliest, latest and maximum timestamps.
