### PR TITLE
KAFKA-15363: Broker log directory failure changes

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -298,8 +298,9 @@ class BrokerServer(
         () => lifecycleManager.brokerEpoch
       )
       val directoryEventHandler = new DirectoryEventHandler {
-        override def handleAssignment(partition: TopicIdPartition, directoryId: Uuid): Unit =
-          assignmentsManager.onAssignment(partition, directoryId)
+        override def handleAssignment(partition: TopicIdPartition, directoryId: Uuid, callback: Runnable): Unit =
+          assignmentsManager.onAssignment(partition, directoryId, callback)
+
         override def handleFailure(directoryId: Uuid): Unit =
           lifecycleManager.propagateDirectoryFailure(directoryId)
       }

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsManager.scala
@@ -19,11 +19,14 @@ package kafka.server
 
 import kafka.cluster.BrokerEndPoint
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.server.common.DirectoryEventHandler
 
 class ReplicaAlterLogDirsManager(brokerConfig: KafkaConfig,
                                  replicaManager: ReplicaManager,
                                  quotaManager: ReplicationQuotaManager,
-                                 brokerTopicStats: BrokerTopicStats)
+                                 brokerTopicStats: BrokerTopicStats,
+                                 directoryEventHandler: DirectoryEventHandler = DirectoryEventHandler.NOOP
+                                )
   extends AbstractFetcherManager[ReplicaAlterLogDirsThread](
     name = s"ReplicaAlterLogDirsManager on broker ${brokerConfig.brokerId}",
     clientId = "ReplicaAlterLogDirs",
@@ -33,7 +36,7 @@ class ReplicaAlterLogDirsManager(brokerConfig: KafkaConfig,
     val threadName = s"ReplicaAlterLogDirsThread-$fetcherId"
     val leader = new LocalLeaderEndPoint(sourceBroker, brokerConfig, replicaManager, quotaManager)
     new ReplicaAlterLogDirsThread(threadName, leader, failedPartitions, replicaManager,
-      quotaManager, brokerTopicStats, brokerConfig.replicaFetchBackoffMs)
+      quotaManager, brokerTopicStats, brokerConfig.replicaFetchBackoffMs, directoryEventHandler)
   }
 
   override protected def addPartitionsToFetcherThread(fetcherThread: ReplicaAlterLogDirsThread,

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2370,7 +2370,7 @@ class ReplicaManager(val config: KafkaConfig,
                 throw new IllegalStateException(s"Assignment for topic without ID: ${tp.topic()}")
               case Some(topicId) =>
                 val topicIdPartition = new common.TopicIdPartition(topicId, tp.partition())
-                directoryEventHandler.handleAssignment(topicIdPartition, dirId)
+                directoryEventHandler.handleAssignment(topicIdPartition, dirId, () => ())
             }
           }
         }
@@ -2419,7 +2419,7 @@ class ReplicaManager(val config: KafkaConfig,
   }
 
   protected def createReplicaAlterLogDirsManager(quotaManager: ReplicationQuotaManager, brokerTopicStats: BrokerTopicStats) = {
-    new ReplicaAlterLogDirsManager(config, this, quotaManager, brokerTopicStats)
+    new ReplicaAlterLogDirsManager(config, this, quotaManager, brokerTopicStats, directoryEventHandler)
   }
 
   protected def createReplicaSelector(): Option[ReplicaSelector] = {

--- a/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
@@ -30,12 +30,12 @@ import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record.MemoryRecords
 import org.apache.kafka.common.requests.{FetchRequest, UpdateMetadataRequest}
 import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
-import org.apache.kafka.server.common.{OffsetAndEpoch, MetadataVersion}
+import org.apache.kafka.server.common.{DirectoryEventHandler, MetadataVersion, OffsetAndEpoch}
 import org.apache.kafka.storage.internals.log.{FetchIsolation, FetchParams, FetchPartitionData}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.{any, anyBoolean}
-import org.mockito.Mockito.{doNothing, mock, never, times, verify, when}
+import org.mockito.Mockito.{doNothing, mock, never, times, verify, verifyNoInteractions, when}
 import org.mockito.{ArgumentCaptor, ArgumentMatchers, Mockito}
 
 import java.util.{Collections, Optional, OptionalInt, OptionalLong}
@@ -266,6 +266,202 @@ class ReplicaAlterLogDirsThreadTest {
 
     assertEquals(None, thread.fetchState(t1p0))
     assertEquals(0, thread.partitionCount)
+  }
+
+  def updateAssignmentRequestState(thread: ReplicaAlterLogDirsThread, partitionId:Int, newState: ReplicaAlterLogDirsThread.DirectoryEventRequestState) = {
+    topicNames.get(topicId).map(topicName => {
+      thread.updatedAssignmentRequestState(new TopicPartition(topicName, partitionId))(newState)
+    })
+  }
+
+  @Test
+  def shouldReplaceCurrentLogDirWhenCaughtUpWithAfterAssignmentRequestHasBeenCompleted(): Unit = {
+    val brokerId = 1
+    val partitionId = 0
+    val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(brokerId, "localhost:1234"))
+
+    val partition = Mockito.mock(classOf[Partition])
+    val replicaManager = Mockito.mock(classOf[ReplicaManager])
+    val quotaManager = Mockito.mock(classOf[ReplicationQuotaManager])
+
+    val directoryEventHandler = mock(classOf[DirectoryEventHandler])
+
+    val futureLog = Mockito.mock(classOf[UnifiedLog])
+
+    val leaderEpoch = 5
+    val logEndOffset = 0
+
+    when(partition.partitionId).thenReturn(partitionId)
+    when(partition.topicId).thenReturn(Some(topicId))
+    when(partition.futureReplicaDirectoryId()).thenReturn(Some(Uuid.randomUuid()))
+    when(replicaManager.metadataCache).thenReturn(metadataCache)
+    when(replicaManager.futureLocalLogOrException(t1p0)).thenReturn(futureLog)
+    when(replicaManager.futureLogExists(t1p0)).thenReturn(true)
+    when(replicaManager.onlinePartition(t1p0)).thenReturn(Some(partition))
+    when(replicaManager.getPartitionOrException(t1p0)).thenReturn(partition)
+
+    when(quotaManager.isQuotaExceeded).thenReturn(false)
+
+    when(partition.lastOffsetForLeaderEpoch(Optional.empty(), leaderEpoch, fetchOnlyFromLeader = false))
+      .thenReturn(new EpochEndOffset()
+        .setPartition(partitionId)
+        .setErrorCode(Errors.NONE.code)
+        .setLeaderEpoch(leaderEpoch)
+        .setEndOffset(logEndOffset))
+    when(partition.futureLocalLogOrException).thenReturn(futureLog)
+    doNothing().when(partition).truncateTo(offset = 0, isFuture = true)
+    when(partition.maybeReplaceCurrentWithFutureReplica()).thenReturn(true)
+    when(partition.runCallbackIfFutureReplicaCaughtUp(any())).thenReturn(true)
+
+    when(futureLog.logStartOffset).thenReturn(0L)
+    when(futureLog.logEndOffset).thenReturn(0L)
+    when(futureLog.latestEpoch).thenReturn(None)
+
+    val requestData = new FetchRequest.PartitionData(topicId, 0L, 0L,
+      config.replicaFetchMaxBytes, Optional.of(leaderEpoch))
+    val responseData = new FetchPartitionData(
+      Errors.NONE,
+      0L,
+      0L,
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false)
+    mockFetchFromCurrentLog(tid1p0, requestData, config, replicaManager, responseData)
+
+    val endPoint = new BrokerEndPoint(0, "localhost", 1000)
+    val leader = new LocalLeaderEndPoint(endPoint, config, replicaManager, quotaManager)
+    val thread = new ReplicaAlterLogDirsThread(
+      "alter-logs-dirs-thread",
+      leader,
+      failedPartitions,
+      replicaManager,
+      quotaManager,
+      new BrokerTopicStats,
+      config.replicaFetchBackoffMs,
+      directoryEventHandler)
+
+    thread.addPartitions(Map(t1p0 -> initialFetchState(fetchOffset = 0L, leaderEpoch)))
+
+    assertTrue(thread.fetchState(t1p0).isDefined)
+    assertEquals(1, thread.partitionCount)
+
+    // Don't promote future replica if no assignment state for this partition
+    thread.doWork()
+    assertTrue(thread.fetchState(t1p0).isDefined)
+    assertEquals(1, thread.partitionCount)
+
+    updateAssignmentRequestState(thread, partitionId, ReplicaAlterLogDirsThread.QUEUED)
+
+    // Don't promote future replica if assignment request is queued but not completed
+    thread.doWork()
+    assertTrue(thread.fetchState(t1p0).isDefined)
+    assertEquals(1, thread.partitionCount)
+    updateAssignmentRequestState(thread, partitionId, ReplicaAlterLogDirsThread.COMPLETED)
+
+    // Promote future replica if assignment request is completed
+    thread.doWork()
+    assertEquals(None, thread.fetchState(t1p0))
+    assertEquals(0, thread.partitionCount)
+    verifyNoInteractions(directoryEventHandler)
+
+  }
+
+  @Test
+  def shouldRevertAnyScheduledAssignmentRequestIfAssignmentIsCancelled(): Unit = {
+    val brokerId = 1
+    val partitionId = 0
+    val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(brokerId, "localhost:1234"))
+
+    val partition = Mockito.mock(classOf[Partition])
+    val replicaManager = Mockito.mock(classOf[ReplicaManager])
+    val quotaManager = Mockito.mock(classOf[ReplicationQuotaManager])
+    val directoryEventHandler = mock(classOf[DirectoryEventHandler])
+
+    val futureLog = Mockito.mock(classOf[UnifiedLog])
+
+    val leaderEpoch = 5
+    val logEndOffset = 0
+
+    when(partition.partitionId).thenReturn(partitionId)
+    when(partition.topicId).thenReturn(Some(topicId))
+    when(partition.futureReplicaDirectoryId()).thenReturn(Some(Uuid.randomUuid()))
+    when(partition.logDirectoryId()).thenReturn(Some(Uuid.randomUuid()))
+    when(replicaManager.metadataCache).thenReturn(metadataCache)
+    when(replicaManager.futureLocalLogOrException(t1p0)).thenReturn(futureLog)
+    when(replicaManager.futureLogExists(t1p0)).thenReturn(true)
+    when(replicaManager.onlinePartition(t1p0)).thenReturn(Some(partition))
+    when(replicaManager.getPartitionOrException(t1p0)).thenReturn(partition)
+
+    when(quotaManager.isQuotaExceeded).thenReturn(false)
+
+    when(partition.lastOffsetForLeaderEpoch(Optional.empty(), leaderEpoch, fetchOnlyFromLeader = false))
+      .thenReturn(new EpochEndOffset()
+        .setPartition(partitionId)
+        .setErrorCode(Errors.NONE.code)
+        .setLeaderEpoch(leaderEpoch)
+        .setEndOffset(logEndOffset))
+    when(partition.futureLocalLogOrException).thenReturn(futureLog)
+    doNothing().when(partition).truncateTo(offset = 0, isFuture = true)
+    when(partition.maybeReplaceCurrentWithFutureReplica()).thenReturn(true)
+    when(partition.runCallbackIfFutureReplicaCaughtUp(any())).thenReturn(true)
+
+    when(futureLog.logStartOffset).thenReturn(0L)
+    when(futureLog.logEndOffset).thenReturn(0L)
+    when(futureLog.latestEpoch).thenReturn(None)
+
+    val requestData = new FetchRequest.PartitionData(topicId, 0L, 0L,
+      config.replicaFetchMaxBytes, Optional.of(leaderEpoch))
+    val responseData = new FetchPartitionData(
+      Errors.NONE,
+      0L,
+      0L,
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false)
+    mockFetchFromCurrentLog(tid1p0, requestData, config, replicaManager, responseData)
+
+    val endPoint = new BrokerEndPoint(0, "localhost", 1000)
+    val leader = new LocalLeaderEndPoint(endPoint, config, replicaManager, quotaManager)
+    val thread = new ReplicaAlterLogDirsThread(
+      "alter-logs-dirs-thread",
+      leader,
+      failedPartitions,
+      replicaManager,
+      quotaManager,
+      new BrokerTopicStats,
+      config.replicaFetchBackoffMs,
+      directoryEventHandler)
+
+    thread.addPartitions(Map(t1p0 -> initialFetchState(fetchOffset = 0L, leaderEpoch)))
+
+    assertTrue(thread.fetchState(t1p0).isDefined)
+    assertEquals(1, thread.partitionCount)
+
+    // Don't promote future replica if no assignment state for this partition
+    thread.doWork()
+    assertTrue(thread.fetchState(t1p0).isDefined)
+    assertEquals(1, thread.partitionCount)
+
+    updateAssignmentRequestState(thread, partitionId, ReplicaAlterLogDirsThread.QUEUED)
+
+    // revert assignment and delete request state if assignment is cancelled
+    thread.removePartitions(Set(t1p0))
+    assertTrue(thread.fetchState(t1p0).isEmpty)
+    assertEquals(0, thread.partitionCount)
+    val topicIdPartitionCaptureT1p0: ArgumentCaptor[org.apache.kafka.server.common.TopicIdPartition] =
+      ArgumentCaptor.forClass(classOf[org.apache.kafka.server.common.TopicIdPartition])
+    val logIdCaptureT1p0: ArgumentCaptor[Uuid] = ArgumentCaptor.forClass(classOf[Uuid])
+
+    verify(directoryEventHandler).handleAssignment(topicIdPartitionCaptureT1p0.capture(), logIdCaptureT1p0.capture(), any())
+
+    assertEquals(new org.apache.kafka.server.common.TopicIdPartition(topicId, t1p0.partition()), topicIdPartitionCaptureT1p0.getValue)
+    assertEquals(partition.logDirectoryId().get, logIdCaptureT1p0.getValue)
   }
 
   private def mockFetchFromCurrentLog(topicIdPartition: TopicIdPartition,

--- a/server-common/src/main/java/org/apache/kafka/server/common/DirectoryEventHandler.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/DirectoryEventHandler.java
@@ -25,7 +25,7 @@ public interface DirectoryEventHandler {
      * A no-op implementation of {@link DirectoryEventHandler}.
      */
     DirectoryEventHandler NOOP = new DirectoryEventHandler() {
-        @Override public void handleAssignment(TopicIdPartition partition, Uuid directoryId) {}
+        @Override public void handleAssignment(TopicIdPartition partition, Uuid directoryId, Runnable callback) {}
         @Override public void handleFailure(Uuid directoryId) {}
     };
 
@@ -33,8 +33,9 @@ public interface DirectoryEventHandler {
      * Handle the assignment of a topic partition to a directory.
      * @param directoryId  The directory ID
      * @param partition    The topic partition
+     * @param callback     Callback to apply when the request is completed.
      */
-    void handleAssignment(TopicIdPartition partition, Uuid directoryId);
+    void handleAssignment(TopicIdPartition partition, Uuid directoryId, Runnable callback);
 
     /**
      * Handle the transition of an online log directory to the offline state.

--- a/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.requests.AssignReplicasToDirsResponse;
 import org.apache.kafka.common.utils.ExponentialBackoff;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.queue.EventQueue;
 import org.apache.kafka.queue.KafkaEventQueue;
 import org.apache.kafka.server.common.TopicIdPartition;
@@ -94,8 +95,11 @@ public class AssignmentsManager {
         channelManager.shutdown();
     }
 
-    public void onAssignment(TopicIdPartition topicPartition, Uuid dirId) {
-        eventQueue.append(new AssignmentEvent(time.nanoseconds(), topicPartition, dirId));
+    public void onAssignment(TopicIdPartition topicPartition, Uuid dirId, Runnable callback) {
+        if (callback == null) {
+            callback = () -> { };
+        }
+        eventQueue.append(new AssignmentEvent(time.nanoseconds(), topicPartition, dirId, callback));
     }
 
     // only for testing
@@ -128,10 +132,12 @@ public class AssignmentsManager {
         final long timestampNs;
         final TopicIdPartition partition;
         final Uuid dirId;
-        AssignmentEvent(long timestampNs, TopicIdPartition partition, Uuid dirId) {
+        final Runnable callback;
+        AssignmentEvent(long timestampNs, TopicIdPartition partition, Uuid dirId, Runnable callback) {
             this.timestampNs = timestampNs;
             this.partition = partition;
             this.dirId = dirId;
+            this.callback = callback == null ? () -> { } : callback;
         }
         @Override
         public void run() throws Exception {
@@ -146,6 +152,7 @@ public class AssignmentsManager {
                 log.debug("Received new assignment {}", this);
             }
             pending.put(partition, this);
+
             if (inflight == null || inflight.isEmpty()) {
                 scheduleDispatch();
             }
@@ -231,7 +238,11 @@ public class AssignmentsManager {
             } else {
                 failedAttempts = 0;
                 AssignReplicasToDirsResponseData data = ((AssignReplicasToDirsResponse) response.responseBody()).data();
+
                 Set<AssignmentEvent> failed = filterFailures(data, inflight);
+                Set<AssignmentEvent> completed = Utils.diff(HashSet::new, inflight.values().stream().collect(Collectors.toSet()), failed);
+                completed.forEach(assignmentEvent -> assignmentEvent.callback.run());
+
                 log.warn("Re-queueing assignments: {}", failed);
                 if (!failed.isEmpty()) {
                     for (AssignmentEvent event : failed) {

--- a/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
@@ -155,11 +155,11 @@ public class AssignmentsManagerTest {
             return null;
         }).when(channelManager).sendRequest(any(AssignReplicasToDirsRequest.Builder.class), any(ControllerRequestCompletionHandler.class));
 
-        manager.onAssignment(new TopicIdPartition(TOPIC_1, 1), DIR_1);
-        manager.onAssignment(new TopicIdPartition(TOPIC_1, 2), DIR_2);
-        manager.onAssignment(new TopicIdPartition(TOPIC_1, 3), DIR_3);
-        manager.onAssignment(new TopicIdPartition(TOPIC_1, 4), DIR_1);
-        manager.onAssignment(new TopicIdPartition(TOPIC_2, 5), DIR_2);
+        manager.onAssignment(new TopicIdPartition(TOPIC_1, 1), DIR_1, () -> { });
+        manager.onAssignment(new TopicIdPartition(TOPIC_1, 2), DIR_2, () -> { });
+        manager.onAssignment(new TopicIdPartition(TOPIC_1, 3), DIR_3, () -> { });
+        manager.onAssignment(new TopicIdPartition(TOPIC_1, 4), DIR_1, () -> { });
+        manager.onAssignment(new TopicIdPartition(TOPIC_2, 5), DIR_2, () -> { });
         while (!readyToAssert.await(1, TimeUnit.MILLISECONDS)) {
             time.sleep(100);
             manager.wakeup();
@@ -191,21 +191,21 @@ public class AssignmentsManagerTest {
             }
             if (readyToAssert.getCount() == 4) {
                 invocation.getArgument(1, ControllerRequestCompletionHandler.class).onTimeout();
-                manager.onAssignment(new TopicIdPartition(TOPIC_1, 2), DIR_3);
+                manager.onAssignment(new TopicIdPartition(TOPIC_1, 2), DIR_3, () -> { });
             }
             if (readyToAssert.getCount() == 3) {
                 invocation.getArgument(1, ControllerRequestCompletionHandler.class).onComplete(
                         new ClientResponse(null, null, null, 0L, 0L, false, false,
                                 new UnsupportedVersionException("test unsupported version exception"), null, null)
                 );
-                manager.onAssignment(new TopicIdPartition(TOPIC_1, 3), Uuid.fromString("xHLCnG54R9W3lZxTPnpk1Q"));
+                manager.onAssignment(new TopicIdPartition(TOPIC_1, 3), Uuid.fromString("xHLCnG54R9W3lZxTPnpk1Q"), () -> { });
             }
             if (readyToAssert.getCount() == 2) {
                 invocation.getArgument(1, ControllerRequestCompletionHandler.class).onComplete(
                         new ClientResponse(null, null, null, 0L, 0L, false, false, null,
                                 new AuthenticationException("test authentication exception"), null)
                 );
-                manager.onAssignment(new TopicIdPartition(TOPIC_1, 4), Uuid.fromString("RCYu1A0CTa6eEIpuKDOfxw"));
+                manager.onAssignment(new TopicIdPartition(TOPIC_1, 4), Uuid.fromString("RCYu1A0CTa6eEIpuKDOfxw"), () -> { });
             }
             if (readyToAssert.getCount() == 1) {
                 invocation.getArgument(1, ControllerRequestCompletionHandler.class).onComplete(
@@ -218,7 +218,7 @@ public class AssignmentsManagerTest {
             return null;
         }).when(channelManager).sendRequest(any(AssignReplicasToDirsRequest.Builder.class), any(ControllerRequestCompletionHandler.class));
 
-        manager.onAssignment(new TopicIdPartition(TOPIC_1, 1), DIR_1);
+        manager.onAssignment(new TopicIdPartition(TOPIC_1, 1), DIR_1, () -> { });
         while (!readyToAssert.await(1, TimeUnit.MILLISECONDS)) {
             time.sleep(TimeUnit.SECONDS.toMillis(1));
             manager.wakeup();


### PR DESCRIPTION
- Extend the ReplicaAlterLogDirsThread to send an AssignReplicasToDirsRequestData RPC before promoting the future replica in JBOD mode with KRAFT. 
- Extend AssignmentsManager and DirectoryEventHandler to attach a callback to the events which will run when the RPC is completed. 
- The state of RPCs is kept in memory in ReplicaAlterLogDirsThread, and it gets updated using the callback that is sent to AssignmentsManager. Once we promote the future replica we clear the state of the RPCs related to this replica in question 

_**Update:**_
- During cancellation of the assignment if the ReplicaAlterLogDirsThread had already sent RPC for queuing then it will fire the revert assignment first before it removes the fetch state of this partition. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
