### PR TITLE
MINOR: Fix unstable sorting in AssignmentsManagerTest

### DIFF
--- a/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
@@ -33,12 +33,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -76,22 +74,15 @@ public class AssignmentsManagerTest {
     }
 
     AssignReplicasToDirsRequestData normalize(AssignReplicasToDirsRequestData request) {
-        List<AssignReplicasToDirsRequestData.DirectoryData> directories = new ArrayList<>(request.directories());
-        directories.sort(Comparator.comparing(AssignReplicasToDirsRequestData.DirectoryData::id));
-        for (AssignReplicasToDirsRequestData.DirectoryData directory : directories) {
-            ArrayList<AssignReplicasToDirsRequestData.TopicData> topics = new ArrayList<>(directory.topics());
-            topics.sort(Comparator.comparing(AssignReplicasToDirsRequestData.TopicData::topicId));
-            for (AssignReplicasToDirsRequestData.TopicData topic : topics) {
-                ArrayList<AssignReplicasToDirsRequestData.PartitionData> partitions = new ArrayList<>(topic.partitions());
-                partitions.sort(Comparator.comparing(AssignReplicasToDirsRequestData.PartitionData::partitionIndex));
-                topic.setPartitions(partitions);
+        request = request.duplicate();
+        request.directories().sort(Comparator.comparing(AssignReplicasToDirsRequestData.DirectoryData::id));
+        for (AssignReplicasToDirsRequestData.DirectoryData directory : request.directories()) {
+            directory.topics().sort(Comparator.comparing(AssignReplicasToDirsRequestData.TopicData::topicId));
+            for (AssignReplicasToDirsRequestData.TopicData topic : directory.topics()) {
+                topic.partitions().sort(Comparator.comparing(AssignReplicasToDirsRequestData.PartitionData::partitionIndex));
             }
-            directory.setTopics(topics);
         }
-        return new AssignReplicasToDirsRequestData()
-                .setBrokerId(request.brokerId())
-                .setBrokerEpoch(request.brokerEpoch())
-                .setDirectories(directories);
+        return request;
     }
 
     void assertRequestEquals(AssignReplicasToDirsRequestData expected, AssignReplicasToDirsRequestData actual) {

--- a/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
@@ -35,9 +35,12 @@ import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 import org.mockito.ArgumentCaptor;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -72,6 +75,29 @@ public class AssignmentsManagerTest {
     @AfterEach
     void tearDown() throws InterruptedException {
         manager.close();
+    }
+
+    AssignReplicasToDirsRequestData normalize(AssignReplicasToDirsRequestData request) {
+        List<AssignReplicasToDirsRequestData.DirectoryData> directories = new ArrayList<>(request.directories());
+        directories.sort(Comparator.comparing(AssignReplicasToDirsRequestData.DirectoryData::id));
+        for (AssignReplicasToDirsRequestData.DirectoryData directory : directories) {
+            ArrayList<AssignReplicasToDirsRequestData.TopicData> topics = new ArrayList<>(directory.topics());
+            topics.sort(Comparator.comparing(AssignReplicasToDirsRequestData.TopicData::topicId));
+            for (AssignReplicasToDirsRequestData.TopicData topic : topics) {
+                ArrayList<AssignReplicasToDirsRequestData.PartitionData> partitions = new ArrayList<>(topic.partitions());
+                partitions.sort(Comparator.comparing(AssignReplicasToDirsRequestData.PartitionData::partitionIndex));
+                topic.setPartitions(partitions);
+            }
+            directory.setTopics(topics);
+        }
+        return new AssignReplicasToDirsRequestData()
+                .setBrokerId(request.brokerId())
+                .setBrokerEpoch(request.brokerEpoch())
+                .setDirectories(directories);
+    }
+
+    void assertRequestEquals(AssignReplicasToDirsRequestData expected, AssignReplicasToDirsRequestData actual) {
+        assertEquals(normalize(expected), normalize(actual));
     }
 
     @Test
@@ -127,7 +153,7 @@ public class AssignmentsManagerTest {
                                                 ))
                                 ))
                 ));
-        assertEquals(expected, built);
+        assertRequestEquals(expected, built);
     }
 
     @Test
@@ -165,7 +191,7 @@ public class AssignmentsManagerTest {
                         put(new TopicIdPartition(TOPIC_2, 5), DIR_2);
                     }}
         );
-        assertEquals(expected, actual);
+        assertRequestEquals(expected, actual);
     }
 
     @Test
@@ -214,18 +240,18 @@ public class AssignmentsManagerTest {
         verify(channelManager, times(5)).sendRequest(captor.capture(), any(ControllerRequestCompletionHandler.class));
         verifyNoMoreInteractions(channelManager);
         assertEquals(5, captor.getAllValues().size());
-        assertEquals(AssignmentsManager.buildRequestData(
+        assertRequestEquals(AssignmentsManager.buildRequestData(
                 8, 100L, new HashMap<TopicIdPartition, Uuid>() {{
                         put(new TopicIdPartition(TOPIC_1, 1), DIR_1);
                     }}
         ), captor.getAllValues().get(0).build().data());
-        assertEquals(AssignmentsManager.buildRequestData(
+        assertRequestEquals(AssignmentsManager.buildRequestData(
                 8, 100L, new HashMap<TopicIdPartition, Uuid>() {{
                         put(new TopicIdPartition(TOPIC_1, 1), DIR_1);
                         put(new TopicIdPartition(TOPIC_1, 2), DIR_3);
                     }}
         ), captor.getAllValues().get(1).build().data());
-        assertEquals(AssignmentsManager.buildRequestData(
+        assertRequestEquals(AssignmentsManager.buildRequestData(
                 8, 100L, new HashMap<TopicIdPartition, Uuid>() {{
                         put(new TopicIdPartition(TOPIC_1, 1), DIR_1);
                         put(new TopicIdPartition(TOPIC_1, 2), DIR_3);

--- a/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
@@ -31,8 +31,6 @@ import org.apache.kafka.server.common.TopicIdPartition;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
-import org.junit.jupiter.api.condition.JRE;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
@@ -157,7 +155,6 @@ public class AssignmentsManagerTest {
     }
 
     @Test
-    @DisabledOnJre(JRE.JAVA_8)
     public void testAssignmentAggregation() throws InterruptedException {
         CountDownLatch readyToAssert = new CountDownLatch(1);
         doAnswer(invocation -> {


### PR DESCRIPTION
Building AssignReplicasToDirsRequestData relies on iteration over Map entries, which can result in different sorting order. The order does not matter to the semantics of the request, but it can cause issues with test assertions.

This issue was introduced in #14369

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
