### PR TITLE
MINOR: Change test logging capture to per-test, reducing jenkins truncation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -436,6 +436,7 @@ subprojects {
       displayGranularity = 0
     }
     logTestStdout.rehydrate(delegate, owner, this)()
+    reports.junitXml.setOutputPerTestCase true
 
     exclude testsToExclude
 


### PR DESCRIPTION
Jenkins truncates stdout/stderr from tests which exceed 100,000 bytes. This truncation is computed once per-suite, meaning that each suite gets a 100kb budget for logs, and suites that log too much have the middle of the log truncated. This unfairly discards complete logs for tests in the middle of the suite, while keeping logs from the beginning and end of the suite.

If a failure occurs in a single test in the middle of a suite, the relevant logs may be completely elided, making investigation of the failure more difficult. This has made debugging with the CI logging almost completely ineffective, as the relevant logs are often swallowed by Jenkins, and irrelevant logs are shown.

Instead, we can enable this feature in the Gradle JunitXmlReport: https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/testing/JUnitXmlReport.html#setOutputPerTestCase-boolean-
This changes the way that stdout/stderr is embedded in the XML report, separating the output for each test into different xml tags. This enables Jenkins to perform truncation on a per-test basis, so that each test in a suite gets a fair distribution of the logging budget.

This will reduce the total stored logs for small numbers of failures, and increases the amount of stored logs in situations with an excessive number of failures.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
