### PR TITLE
MINOR: Upgrade Zstd-jni to 1.5.5-11

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -322,7 +322,7 @@ pcollections-4.0.1, see: licenses/pcollections-MIT
 ---------------------------------------
 BSD 2-Clause
 
-zstd-jni-1.5.5-9 see: licenses/zstd-jni-BSD-2-clause
+zstd-jni-1.5.5-11 see: licenses/zstd-jni-BSD-2-clause
 
 ---------------------------------------
 BSD 3-Clause

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -322,7 +322,7 @@ pcollections-4.0.1, see: licenses/pcollections-MIT
 ---------------------------------------
 BSD 2-Clause
 
-zstd-jni-1.5.5-6 see: licenses/zstd-jni-BSD-2-clause
+zstd-jni-1.5.5-9 see: licenses/zstd-jni-BSD-2-clause
 
 ---------------------------------------
 BSD 3-Clause

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -164,7 +164,7 @@ versions += [
   spotbugs: "4.8.0",
   zinc: "1.9.2",
   zookeeper: "3.8.3",
-  zstd: "1.5.5-6"
+  zstd: "1.5.5-9"
 ]
 
 libs += [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -164,7 +164,7 @@ versions += [
   spotbugs: "4.8.0",
   zinc: "1.9.2",
   zookeeper: "3.8.3",
-  zstd: "1.5.5-9"
+  zstd: "1.5.5-11"
 ]
 
 libs += [


### PR DESCRIPTION
### Notable changes in the upgrade
1. Upgrade minimum JDK from 6 to 8
2. Dependency (sbt) upgrade to work with JDK 17
3. Add new platforms such as win/aarch64

None of the changes are especially relevant to Kakfa.

Diff between 1.5.5-6 to 1.5.5-11: https://github.com/luben/zstd-jni/compare/v1.5.5-6...v1.5.5-11