### PR TITLE
KAFKA-15801: improve Kafka broker/NetworkClient logging for connectiv…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -855,10 +855,11 @@ public class NetworkClient implements KafkaClient {
         List<String> nodes = connectionStates.nodesWithConnectionSetupTimeout(now);
         for (String nodeId : nodes) {
             this.selector.close(nodeId);
-            log.info(
-                "Disconnecting from node {} due to socket connection setup timeout. " +
+            log.warn(
+                "Disconnecting from node {} on {} due to socket connection setup timeout. " +
                 "The timeout value is {} ms.",
                 nodeId,
+                ChannelState.LOCAL_CLOSE.remoteAddress(),
                 connectionStates.connectionSetupTimeoutMs(nodeId));
             processTimeoutDisconnection(responses, nodeId, now);
         }

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -855,7 +855,7 @@ public class NetworkClient implements KafkaClient {
         List<String> nodes = connectionStates.nodesWithConnectionSetupTimeout(now);
         for (String nodeId : nodes) {
             this.selector.close(nodeId);
-            log.warn(
+            log.info(
                 "Disconnecting from node {} on {} due to socket connection setup timeout. " +
                 "The timeout value is {} ms.",
                 nodeId,


### PR DESCRIPTION
When a component of the Kafka broker tries to reach another broker within the cluster the logging should be more elaborate and include the IP/hostname and port it tries to connect to, and have a higher severity WARN rather than INFO.

Current logging:

[2023-11-09 07:33:36,106] INFO [TransactionCoordinator id=1] Disconnecting from node 1 due to socket connection setup timeout. The timeout value is 26590 ms. (org.apache.kafka.clients.NetworkClient)

Suggested logging:

[2023-11-09 07:33:36,106] WARN [TransactionCoordinator id=1] Disconnecting from node 1 on kafka-headless.m2-mgex.svc.cluster.local:9093 due to socket connection setup timeout. The timeout value is 26590 ms. (org.apache.kafka.clients.NetworkClient)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
