### PR TITLE
MINOR: Increase the delta for a flaky quota test

### DIFF
--- a/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
@@ -408,7 +408,7 @@ class ConnectionQuotasTest {
     val futures = listeners.values.map { listener =>
       executor.submit((() =>
         // epsilon is set to account for the worst-case where the measurement is taken just before or after the quota window
-        acceptConnectionsAndVerifyRate(connectionQuotas, listener, connectionsPerListener, connCreateIntervalMs, listenerRateLimit, 7)): Runnable)
+        acceptConnectionsAndVerifyRate(connectionQuotas, listener, connectionsPerListener, connCreateIntervalMs, listenerRateLimit, 8)): Runnable)
     }
     futures.foreach(_.get(30, TimeUnit.SECONDS))
 


### PR DESCRIPTION
Flaky test failing with assertion error just outside the defined threshold. So, bumping up the delta for quota by 1.

`java.util.concurrent.ExecutionException: org.opentest4j.AssertionFailedError: Expected rate (30 +- 7), but got 37.50937734433608 (600 connections / 15.996 sec) ==> expected: <30.0> but was: <37.50937734433608>`