### PR TITLE
KAFKA-15860: ControllerRegistration must be written out to the metadata image

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/ClusterImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClusterImage.java
@@ -25,6 +25,7 @@ import org.apache.kafka.metadata.ControllerRegistration;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 
 /**
@@ -73,18 +74,28 @@ public final class ClusterImage {
         for (BrokerRegistration broker : brokers.values()) {
             writer.write(broker.toRecord(options));
         }
+        if (!controllers.isEmpty()) {
+            if (!options.metadataVersion().isControllerRegistrationSupported()) {
+                options.handleLoss("controller registration data");
+            } else {
+                for (ControllerRegistration controller : controllers.values()) {
+                    writer.write(controller.toRecord(options));
+                }
+            }
+        }
     }
 
     @Override
     public int hashCode() {
-        return brokers.hashCode();
+        return Objects.hash(brokers, controllers);
     }
 
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof ClusterImage)) return false;
         ClusterImage other = (ClusterImage) o;
-        return brokers.equals(other.brokers);
+        return brokers.equals(other.brokers) &&
+            controllers.equals(other.controllers);
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/image/writer/ImageWriterOptions.java
+++ b/metadata/src/main/java/org/apache/kafka/image/writer/ImageWriterOptions.java
@@ -43,25 +43,15 @@ public final class ImageWriterOptions {
         }
 
         public Builder setMetadataVersion(MetadataVersion metadataVersion) {
-            setRequestedMetadataVersion(metadataVersion);
+            this.requestedMetadataVersion = metadataVersion;
             if (metadataVersion.isLessThan(MetadataVersion.MINIMUM_BOOTSTRAP_VERSION)) {
                 // When writing an image, all versions less than 3.3-IV0 are treated as 3.0-IV1.
                 // This is because those versions don't support FeatureLevelRecord.
-                setRawMetadataVersion(MetadataVersion.MINIMUM_KRAFT_VERSION);
+                this.metadataVersion = MetadataVersion.MINIMUM_KRAFT_VERSION;
             } else {
-                setRawMetadataVersion(metadataVersion);
+                this.metadataVersion = metadataVersion;
             }
             return this;
-        }
-
-        // Visible for testing
-        public Builder setRawMetadataVersion(MetadataVersion metadataVersion) {
-            this.metadataVersion = metadataVersion;
-            return this;
-        }
-
-        public void setRequestedMetadataVersion(MetadataVersion orgMetadataVersion) {
-            this.requestedMetadataVersion = orgMetadataVersion;
         }
 
         public MetadataVersion metadataVersion() {

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -45,16 +45,19 @@ import java.util.stream.IntStream;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.BrokerIdNotRegisteredException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.message.ControllerRegistrationRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.metadata.AbortTransactionRecord;
 import org.apache.kafka.common.metadata.BeginTransactionRecord;
 import org.apache.kafka.common.metadata.BrokerRegistrationChangeRecord;
 import org.apache.kafka.common.metadata.ConfigRecord;
 import org.apache.kafka.common.metadata.EndTransactionRecord;
+import org.apache.kafka.common.metadata.RegisterControllerRecord;
 import org.apache.kafka.common.metadata.UnfenceBrokerRecord;
 import org.apache.kafka.common.metadata.ZkMigrationStateRecord;
 import org.apache.kafka.common.requests.AlterPartitionRequest;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -170,7 +173,7 @@ public class QuorumControllerTest {
     private final static Logger log = LoggerFactory.getLogger(QuorumControllerTest.class);
 
     static final BootstrapMetadata SIMPLE_BOOTSTRAP = BootstrapMetadata.
-            fromVersion(MetadataVersion.IBP_3_3_IV3, "test-provided bootstrap");
+            fromVersion(MetadataVersion.IBP_3_7_IV0, "test-provided bootstrap");
 
     /**
      * Test setting some configuration values and reading them back.
@@ -288,7 +291,7 @@ public class QuorumControllerTest {
                     new BrokerRegistrationRequestData().
                         setBrokerId(brokerId).
                         setClusterId(active.clusterId()).
-                        setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_3_IV3)).
+                        setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV0)).
                         setIncarnationId(Uuid.randomUuid()).
                         setListeners(listeners));
                 brokerEpochs.put(brokerId, reply.get().epoch());
@@ -388,7 +391,7 @@ public class QuorumControllerTest {
                     new BrokerRegistrationRequestData().
                         setBrokerId(brokerId).
                         setClusterId(active.clusterId()).
-                        setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_3_IV3)).
+                        setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV0)).
                         setIncarnationId(Uuid.randomUuid()).
                         setListeners(listeners));
                 brokerEpochs.put(brokerId, reply.get().epoch());
@@ -449,7 +452,7 @@ public class QuorumControllerTest {
                     new BrokerRegistrationRequestData().
                         setBrokerId(brokerId).
                         setClusterId(active.clusterId()).
-                        setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_3_IV3)).
+                        setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV0)).
                         setIncarnationId(Uuid.randomUuid()).
                         setListeners(listeners));
                 brokerEpochs.put(brokerId, reply.get().epoch());
@@ -646,13 +649,37 @@ public class QuorumControllerTest {
                 build()
         ) {
             QuorumController active = controlEnv.activeController();
+            for (int i = 0; i < logEnv.logManagers().size(); i++) {
+                active.registerController(ANONYMOUS_CONTEXT,
+                    new ControllerRegistrationRequestData().
+                        setControllerId(i).
+                        setIncarnationId(new Uuid(3465346L, i)).
+                        setZkMigrationReady(false).
+                        setListeners(new ControllerRegistrationRequestData.ListenerCollection(
+                            Arrays.asList(
+                                new ControllerRegistrationRequestData.Listener().
+                                    setName("CONTROLLER").
+                                    setHost("localhost").
+                                    setPort(8000 + i).
+                                    setSecurityProtocol(SecurityProtocol.PLAINTEXT.id)
+                                ).iterator()
+                        )).
+                        setFeatures(new ControllerRegistrationRequestData.FeatureCollection(
+                            Arrays.asList(
+                                new ControllerRegistrationRequestData.Feature().
+                                    setName(MetadataVersion.FEATURE_NAME).
+                                    setMinSupportedVersion(MetadataVersion.MINIMUM_KRAFT_VERSION.featureLevel()).
+                                    setMaxSupportedVersion(MetadataVersion.IBP_3_7_IV0.featureLevel())
+                            ).iterator()
+                        ))).get();
+            }
             for (int i = 0; i < numBrokers; i++) {
                 BrokerRegistrationReply reply = active.registerBroker(ANONYMOUS_CONTEXT,
                     new BrokerRegistrationRequestData().
                         setBrokerId(i).
                         setRack(null).
                         setClusterId(active.clusterId()).
-                        setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_3_IV3)).
+                        setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV0)).
                         setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwB" + i)).
                         setListeners(new ListenerCollection(Arrays.asList(new Listener().
                             setName("PLAINTEXT").setHost("localhost").
@@ -691,45 +718,101 @@ public class QuorumControllerTest {
 
     private List<ApiMessageAndVersion> generateTestRecords(Uuid fooId, Map<Integer, Long> brokerEpochs) {
         return Arrays.asList(
+            new ApiMessageAndVersion(new BeginTransactionRecord().
+                setName("Bootstrap records"), (short) 0),
             new ApiMessageAndVersion(new FeatureLevelRecord().
                 setName(MetadataVersion.FEATURE_NAME).
-                setFeatureLevel(MetadataVersion.IBP_3_3_IV3.featureLevel()), (short) 0),
+                setFeatureLevel(MetadataVersion.IBP_3_7_IV0.featureLevel()), (short) 0),
+            new ApiMessageAndVersion(new ZkMigrationStateRecord().
+                setZkMigrationState((byte) 0), (short) 0),
+            new ApiMessageAndVersion(new EndTransactionRecord(), (short) 0),
+            new ApiMessageAndVersion(new RegisterControllerRecord().
+                setControllerId(0).
+                setIncarnationId(Uuid.fromString("AAAAAAA04IIAAAAAAAAAAA")).
+                setEndPoints(new RegisterControllerRecord.ControllerEndpointCollection(
+                    Arrays.asList(
+                        new RegisterControllerRecord.ControllerEndpoint().
+                            setName("CONTROLLER").
+                            setHost("localhost").
+                            setPort(8000).
+                            setSecurityProtocol(SecurityProtocol.PLAINTEXT.id)).iterator())).
+                setFeatures(new RegisterControllerRecord.ControllerFeatureCollection(
+                    Arrays.asList(
+                        new RegisterControllerRecord.ControllerFeature().
+                            setName(MetadataVersion.FEATURE_NAME).
+                            setMinSupportedVersion(MetadataVersion.MINIMUM_KRAFT_VERSION.featureLevel()).
+                            setMaxSupportedVersion(MetadataVersion.IBP_3_7_IV0.featureLevel())).iterator())),
+                    (short) 0),
+            new ApiMessageAndVersion(new RegisterControllerRecord().
+                setControllerId(1).
+                setIncarnationId(Uuid.fromString("AAAAAAA04IIAAAAAAAAAAQ")).
+                setEndPoints(new RegisterControllerRecord.ControllerEndpointCollection(
+                    Arrays.asList(
+                        new RegisterControllerRecord.ControllerEndpoint().
+                            setName("CONTROLLER").
+                            setHost("localhost").
+                            setPort(8001).
+                            setSecurityProtocol(SecurityProtocol.PLAINTEXT.id)).iterator())).
+                setFeatures(new RegisterControllerRecord.ControllerFeatureCollection(
+                    Arrays.asList(
+                        new RegisterControllerRecord.ControllerFeature().
+                            setName(MetadataVersion.FEATURE_NAME).
+                            setMinSupportedVersion(MetadataVersion.MINIMUM_KRAFT_VERSION.featureLevel()).
+                            setMaxSupportedVersion(MetadataVersion.IBP_3_7_IV0.featureLevel())).iterator())),
+                    (short) 0),
+            new ApiMessageAndVersion(new RegisterControllerRecord().
+                setControllerId(2).
+                setIncarnationId(Uuid.fromString("AAAAAAA04IIAAAAAAAAAAg")).
+                setEndPoints(new RegisterControllerRecord.ControllerEndpointCollection(
+                    Arrays.asList(
+                        new RegisterControllerRecord.ControllerEndpoint().
+                            setName("CONTROLLER").
+                            setHost("localhost").
+                            setPort(8002).
+                            setSecurityProtocol(SecurityProtocol.PLAINTEXT.id)).iterator())).
+                setFeatures(new RegisterControllerRecord.ControllerFeatureCollection(
+                    Arrays.asList(
+                        new RegisterControllerRecord.ControllerFeature().
+                            setName(MetadataVersion.FEATURE_NAME).
+                            setMinSupportedVersion(MetadataVersion.MINIMUM_KRAFT_VERSION.featureLevel()).
+                            setMaxSupportedVersion(MetadataVersion.IBP_3_7_IV0.featureLevel())).iterator())),
+                (short) 0),
             new ApiMessageAndVersion(new RegisterBrokerRecord().
                 setBrokerId(0).setBrokerEpoch(brokerEpochs.get(0)).
                 setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwB0")).
                 setEndPoints(new BrokerEndpointCollection(
                     Arrays.asList(new BrokerEndpoint().setName("PLAINTEXT").setHost("localhost").
                         setPort(9092).setSecurityProtocol((short) 0)).iterator())).
-                setFeatures(registrationFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_3_IV3)).
+                setFeatures(registrationFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV0)).
                 setRack(null).
-                setFenced(true), (short) 1),
+                setFenced(true), (short) 2),
             new ApiMessageAndVersion(new RegisterBrokerRecord().
                 setBrokerId(1).setBrokerEpoch(brokerEpochs.get(1)).
                 setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwB1")).
                 setEndPoints(new BrokerEndpointCollection(Arrays.asList(
                     new BrokerEndpoint().setName("PLAINTEXT").setHost("localhost").
                         setPort(9093).setSecurityProtocol((short) 0)).iterator())).
-                setFeatures(registrationFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_3_IV3)).
+                setFeatures(registrationFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV0)).
                 setRack(null).
-                setFenced(true), (short) 1),
+                setFenced(true), (short) 2),
             new ApiMessageAndVersion(new RegisterBrokerRecord().
                 setBrokerId(2).setBrokerEpoch(brokerEpochs.get(2)).
                 setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwB2")).
                 setEndPoints(new BrokerEndpointCollection(
                     Arrays.asList(new BrokerEndpoint().setName("PLAINTEXT").setHost("localhost").
                         setPort(9094).setSecurityProtocol((short) 0)).iterator())).
-                setFeatures(registrationFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_3_IV3)).
+                setFeatures(registrationFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV0)).
                 setRack(null).
-                setFenced(true), (short) 1),
+                setFenced(true), (short) 2),
             new ApiMessageAndVersion(new RegisterBrokerRecord().
                 setBrokerId(3).setBrokerEpoch(brokerEpochs.get(3)).
                 setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwB3")).
                 setEndPoints(new BrokerEndpointCollection(Arrays.asList(
                     new BrokerEndpoint().setName("PLAINTEXT").setHost("localhost").
                         setPort(9095).setSecurityProtocol((short) 0)).iterator())).
-                setFeatures(registrationFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_3_IV3)).
+                setFeatures(registrationFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV0)).
                 setRack(null).
-                setFenced(true), (short) 1),
+                setFenced(true), (short) 2),
             new ApiMessageAndVersion(new BrokerRegistrationChangeRecord().
                 setBrokerId(0).
                 setBrokerEpoch(brokerEpochs.get(0)).

--- a/metadata/src/test/java/org/apache/kafka/image/ClusterImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/ClusterImageTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.metadata.ControllerRegistration;
 import org.apache.kafka.metadata.RecordTestUtils;
 import org.apache.kafka.metadata.VersionRange;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.MetadataVersion;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -45,6 +46,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.kafka.common.metadata.MetadataRecordType.FENCE_BROKER_RECORD;
 import static org.apache.kafka.common.metadata.MetadataRecordType.UNFENCE_BROKER_RECORD;
@@ -115,11 +117,11 @@ public class ClusterImageTest {
             (short) 0));
 
         ControllerEndpointCollection endpointsFor1001 = new ControllerEndpointCollection();
-        new ControllerEndpointCollection().add(new ControllerEndpoint().
-                setHost("localhost").
-                setName("PLAINTEXT").
-                setPort(19093).
-                setSecurityProtocol(SecurityProtocol.PLAINTEXT.id));
+        endpointsFor1001.add(new ControllerEndpoint().
+            setHost("localhost").
+            setName("PLAINTEXT").
+            setPort(19093).
+            setSecurityProtocol(SecurityProtocol.PLAINTEXT.id));
         DELTA1_RECORDS.add(new ApiMessageAndVersion(new RegisterControllerRecord().
             setControllerId(1001).
             setIncarnationId(Uuid.fromString("FdEHF-IqScKfYyjZ1CjfNQ")).
@@ -204,5 +206,23 @@ public class ClusterImageTest {
         RecordListWriter writer = new RecordListWriter();
         image.write(writer, new ImageWriterOptions.Builder().build());
         return writer.records();
+    }
+
+    @Test
+    public void testHandleLossOfControllerRegistrations() {
+        ClusterImage testImage = new ClusterImage(Collections.emptyMap(),
+            Collections.singletonMap(1000, new ControllerRegistration.Builder().
+                setId(1000).
+                setIncarnationId(Uuid.fromString("9ABu6HEgRuS-hjHLgC4cHw")).
+                setListeners(Collections.singletonMap("PLAINTEXT",
+                    new Endpoint("PLAINTEXT", SecurityProtocol.PLAINTEXT, "localhost", 19092))).
+                setSupportedFeatures(Collections.emptyMap()).build()));
+        RecordListWriter writer = new RecordListWriter();
+        final AtomicReference<String> lossString = new AtomicReference<>("");
+        testImage.write(writer, new ImageWriterOptions.Builder().
+            setMetadataVersion(MetadataVersion.IBP_3_6_IV2).
+            setLossHandler(loss -> lossString.compareAndSet("controller registration data", loss.loss())).
+                build());
+        assertEquals("", lossString.get());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/image/ClusterImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/ClusterImageTest.java
@@ -221,8 +221,8 @@ public class ClusterImageTest {
         final AtomicReference<String> lossString = new AtomicReference<>("");
         testImage.write(writer, new ImageWriterOptions.Builder().
             setMetadataVersion(MetadataVersion.IBP_3_6_IV2).
-            setLossHandler(loss -> lossString.compareAndSet("controller registration data", loss.loss())).
+            setLossHandler(loss -> lossString.compareAndSet("", loss.loss())).
                 build());
-        assertEquals("", lossString.get());
+        assertEquals("controller registration data", lossString.get());
     }
 }


### PR DESCRIPTION
The ControllerRegistration records added in KIP-919 should be written out to the metadata
image, not just the log.