### PR TITLE
MINOR: Fix unchecked warning in CredentialCache

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -43,7 +43,6 @@ import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslCli
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredValidatorCallbackHandler;
 import org.apache.kafka.common.security.plain.internals.PlainSaslServer;
 import org.apache.kafka.common.security.plain.internals.PlainServerCallbackHandler;
-import org.apache.kafka.common.security.scram.ScramCredential;
 import org.apache.kafka.common.security.scram.internals.ScramMechanism;
 import org.apache.kafka.common.security.scram.internals.ScramServerCallbackHandler;
 import org.apache.kafka.common.security.ssl.SslFactory;
@@ -317,7 +316,7 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
             else if (mechanism.equals(PlainSaslServer.PLAIN_MECHANISM))
                 callbackHandler = new PlainServerCallbackHandler();
             else if (ScramMechanism.isScram(mechanism))
-                callbackHandler = new ScramServerCallbackHandler(credentialCache.cache(mechanism, ScramCredential.class), tokenCache);
+                callbackHandler = new ScramServerCallbackHandler(credentialCache.scramCache(mechanism), tokenCache);
             else if (mechanism.equals(OAuthBearerLoginModule.OAUTHBEARER_MECHANISM))
                 callbackHandler = new OAuthBearerUnsecuredValidatorCallbackHandler();
             else

--- a/clients/src/main/java/org/apache/kafka/common/security/scram/ScramCache.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/ScramCache.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.scram;
+
+import org.apache.kafka.common.security.authenticator.CredentialCache;
+
+public class ScramCache extends CredentialCache.Cache {
+    public ScramCache() {
+        super();
+    }
+
+    @Override
+    public ScramCredential get(String username) {
+        return (ScramCredential) super.get(username);
+    }
+    @Override
+    public ScramCredential put(String username, Object credential) {
+        if (credential instanceof ScramCredential) {
+            return (ScramCredential) super.put(username, credential);
+        }
+        throw new IllegalArgumentException("Invalid credential class " + credential.getClass() + ", expected " + ScramCredential.class);
+    }
+
+    @Override
+    public ScramCredential remove(String username) {
+        return (ScramCredential) super.remove(username);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramCredentialUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramCredentialUtils.java
@@ -80,7 +80,7 @@ public final class ScramCredentialUtils {
     public static void createCache(CredentialCache cache, Collection<String> mechanisms) {
         for (String mechanism : ScramMechanism.mechanismNames()) {
             if (mechanisms.contains(mechanism))
-                cache.createCache(mechanism, ScramCredential.class);
+                cache.createScramCache(mechanism);
         }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramServerCallbackHandler.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramServerCallbackHandler.java
@@ -25,20 +25,19 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.AppConfigurationEntry;
 
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
-import org.apache.kafka.common.security.authenticator.CredentialCache;
-import org.apache.kafka.common.security.scram.ScramCredential;
 import org.apache.kafka.common.security.scram.ScramCredentialCallback;
+import org.apache.kafka.common.security.scram.ScramCache;
 import org.apache.kafka.common.security.token.delegation.TokenInformation;
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache;
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCredentialCallback;
 
 public class ScramServerCallbackHandler implements AuthenticateCallbackHandler {
 
-    private final CredentialCache.Cache<ScramCredential> credentialCache;
+    private final ScramCache credentialCache;
     private final DelegationTokenCache tokenCache;
     private String saslMechanism;
 
-    public ScramServerCallbackHandler(CredentialCache.Cache<ScramCredential> credentialCache,
+    public ScramServerCallbackHandler(ScramCache credentialCache,
                                       DelegationTokenCache tokenCache) {
         this.credentialCache = credentialCache;
         this.tokenCache = tokenCache;

--- a/clients/src/main/java/org/apache/kafka/common/security/token/delegation/internals/DelegationTokenCache.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/token/delegation/internals/DelegationTokenCache.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.security.token.delegation.internals;
 
 import org.apache.kafka.common.security.authenticator.CredentialCache;
 import org.apache.kafka.common.security.scram.ScramCredential;
+import org.apache.kafka.common.security.scram.ScramCache;
 import org.apache.kafka.common.security.scram.internals.ScramCredentialUtils;
 import org.apache.kafka.common.security.scram.internals.ScramMechanism;
 import org.apache.kafka.common.security.token.delegation.DelegationToken;
@@ -48,7 +49,7 @@ public class DelegationTokenCache {
     }
 
     public ScramCredential credential(String mechanism, String tokenId) {
-        CredentialCache.Cache<ScramCredential> cache = credentialCache.cache(mechanism, ScramCredential.class);
+        ScramCache cache = credentialCache.scramCache(mechanism);
         return cache == null ? null : cache.get(tokenId);
     }
 
@@ -105,13 +106,13 @@ public class DelegationTokenCache {
         return tokenCache.get(tokenId);
     }
 
-    public CredentialCache.Cache<ScramCredential> credentialCache(String mechanism) {
-        return credentialCache.cache(mechanism, ScramCredential.class);
+    public ScramCache credentialCache(String mechanism) {
+        return credentialCache.scramCache(mechanism);
     }
 
     private void updateCredentials(String tokenId, Map<String, ScramCredential> scramCredentialMap) {
         for (String mechanism : ScramMechanism.mechanismNames()) {
-            CredentialCache.Cache<ScramCredential> cache = credentialCache.cache(mechanism, ScramCredential.class);
+            ScramCache cache = credentialCache.scramCache(mechanism);
             if (cache != null) {
                 ScramCredential credential = scramCredentialMap.get(mechanism);
                 if (credential == null) {

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.authenticator.CredentialCache;
-import org.apache.kafka.common.security.scram.ScramCredential;
 import org.apache.kafka.common.security.scram.internals.ScramMechanism;
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache;
 import org.apache.kafka.common.utils.LogContext;
@@ -117,8 +116,8 @@ public class NioEchoServer extends Thread {
         this.tokenCache = tokenCache;
         if (securityProtocol == SecurityProtocol.SASL_PLAINTEXT || securityProtocol == SecurityProtocol.SASL_SSL) {
             for (String mechanism : ScramMechanism.mechanismNames()) {
-                if (credentialCache.cache(mechanism, ScramCredential.class) == null)
-                    credentialCache.createCache(mechanism, ScramCredential.class);
+                if (credentialCache.scramCache(mechanism) == null)
+                    credentialCache.createScramCache(mechanism);
             }
         }
         LogContext logContext = new LogContext();

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -562,7 +562,7 @@ public class SaslAuthenticatorTest {
         server = createEchoServer(securityProtocol);
         updateScramCredentialCache(TestJaasConfig.USERNAME, TestJaasConfig.PASSWORD);
 
-        server.credentialCache().cache(ScramMechanism.SCRAM_SHA_256.mechanismName(), ScramCredential.class).remove(TestJaasConfig.USERNAME);
+        server.credentialCache().scramCache(ScramMechanism.SCRAM_SHA_256.mechanismName()).remove(TestJaasConfig.USERNAME);
         String node = "1";
         saslClientConfigs.put(SaslConfigs.SASL_MECHANISM, "SCRAM-SHA-256");
         createAndCheckClientAuthenticationFailure(securityProtocol, node, "SCRAM-SHA-256", null);
@@ -2342,7 +2342,7 @@ public class SaslAuthenticatorTest {
             if (scramMechanism != null) {
                 ScramFormatter formatter = new ScramFormatter(scramMechanism);
                 ScramCredential credential = formatter.generateCredential(password, 4096);
-                credentialCache.cache(scramMechanism.mechanismName(), ScramCredential.class).put(username, credential);
+                credentialCache.scramCache(scramMechanism.mechanismName()).put(username, credential);
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramCredentialUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramCredentialUtilsTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import org.apache.kafka.common.security.authenticator.CredentialCache;
 import org.apache.kafka.common.security.scram.ScramCredential;
 
+import org.apache.kafka.common.security.scram.ScramCache;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -85,10 +86,10 @@ public class ScramCredentialUtilsTest {
     public void scramCredentialCache() throws Exception {
         CredentialCache cache = new CredentialCache();
         ScramCredentialUtils.createCache(cache, Arrays.asList("SCRAM-SHA-512", "PLAIN"));
-        assertNotNull(cache.cache(ScramMechanism.SCRAM_SHA_512.mechanismName(), ScramCredential.class), "Cache not created for enabled mechanism");
-        assertNull(cache.cache(ScramMechanism.SCRAM_SHA_256.mechanismName(), ScramCredential.class), "Cache created for disabled mechanism");
+        assertNotNull(cache.scramCache(ScramMechanism.SCRAM_SHA_512.mechanismName()), "Cache not created for enabled mechanism");
+        assertNull(cache.scramCache(ScramMechanism.SCRAM_SHA_256.mechanismName()), "Cache created for disabled mechanism");
 
-        CredentialCache.Cache<ScramCredential> sha512Cache = cache.cache(ScramMechanism.SCRAM_SHA_512.mechanismName(), ScramCredential.class);
+        ScramCache sha512Cache = cache.scramCache(ScramMechanism.SCRAM_SHA_512.mechanismName());
         ScramFormatter formatter = new ScramFormatter(ScramMechanism.SCRAM_SHA_512);
         ScramCredential credentialA = formatter.generateCredential("password", 4096);
         sha512Cache.put("userA", credentialA);

--- a/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramSaslServerTest.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.security.authenticator.CredentialCache;
-import org.apache.kafka.common.security.scram.ScramCredential;
+import org.apache.kafka.common.security.scram.ScramCache;
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -44,7 +44,7 @@ public class ScramSaslServerTest {
     public void setUp() throws Exception {
         mechanism = ScramMechanism.SCRAM_SHA_256;
         formatter  = new ScramFormatter(mechanism);
-        CredentialCache.Cache<ScramCredential> credentialCache = new CredentialCache().createCache(mechanism.mechanismName(), ScramCredential.class);
+        ScramCache credentialCache = new CredentialCache().createScramCache(mechanism.mechanismName());
         credentialCache.put(USER_A, formatter.generateCredential("passwordA", 4096));
         credentialCache.put(USER_B, formatter.generateCredential("passwordB", 4096));
         ScramServerCallbackHandler callbackHandler = new ScramServerCallbackHandler(credentialCache, new DelegationTokenCache(ScramMechanism.mechanismNames()));

--- a/core/src/main/scala/kafka/security/CredentialProvider.scala
+++ b/core/src/main/scala/kafka/security/CredentialProvider.scala
@@ -33,7 +33,7 @@ class CredentialProvider(scramMechanisms: Collection[String], val tokenCache: De
 
   def updateCredentials(username: String, config: Properties): Unit = {
     for (mechanism <- ScramMechanism.values()) {
-      val cache = credentialCache.cache(mechanism.mechanismName, classOf[ScramCredential])
+      val cache = credentialCache.scramCache(mechanism.mechanismName)
       if (cache != null) {
         config.getProperty(mechanism.mechanismName) match {
           case null => cache.remove(username)
@@ -48,7 +48,7 @@ class CredentialProvider(scramMechanisms: Collection[String], val tokenCache: De
     name: String,
     credential: ScramCredential
   ): Unit = {
-    val cache = credentialCache.cache(mechanism.mechanismName(), classOf[ScramCredential])
+    val cache = credentialCache.scramCache(mechanism.mechanismName())
     cache.put(name, credential)
   }
 
@@ -56,7 +56,7 @@ class CredentialProvider(scramMechanisms: Collection[String], val tokenCache: De
     mechanism: AdminScramMechanism,
     name: String
   ): Unit = {
-    val cache = credentialCache.cache(mechanism.mechanismName(), classOf[ScramCredential])
+    val cache = credentialCache.scramCache(mechanism.mechanismName())
     if (cache != null) {
       cache.remove(name)
     }

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -1151,8 +1151,8 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     List(JaasTestUtils.KafkaScramUser, JaasTestUtils.KafkaScramAdmin).foreach { scramUser =>
       servers.foreach { server =>
         ScramMechanism.values().filter(_ != ScramMechanism.UNKNOWN).foreach(mechanism =>
-          TestUtils.waitUntilTrue(() => server.credentialProvider.credentialCache.cache(
-            mechanism.mechanismName(), classOf[ScramCredential]).get(scramUser) != null,
+          TestUtils.waitUntilTrue(() => server.credentialProvider.credentialCache.scramCache(
+            mechanism.mechanismName()).get(scramUser) != null,
             s"$mechanism credentials not created for $scramUser"))
       }}
 

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -57,7 +57,6 @@ import org.apache.kafka.common.network.CertStores.{KEYSTORE_PROPS, TRUSTSTORE_PR
 import org.apache.kafka.common.record.TimestampType
 import org.apache.kafka.common.requests.MetadataRequest
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.apache.kafka.common.security.scram.ScramCredential
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.record.BrokerCompressionType

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -74,7 +74,6 @@ import scala.annotation.nowarn
 import scala.collection._
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
-import scala.collection.Seq
 
 object DynamicBrokerReconfigurationTest {
   val Plain = "PLAIN"

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -34,7 +34,6 @@ import org.apache.kafka.common.acl.AccessControlEntry
 import org.apache.kafka.common.{KafkaException, Uuid}
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.resource.ResourcePattern
-import org.apache.kafka.common.security.scram.ScramCredential
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.controller.ControllerRequestContextUtil.ANONYMOUS_CONTEXT
 

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -295,7 +295,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
 
   def waitForUserScramCredentialToAppearOnAllBrokers(clientPrincipal: String, mechanismName: String): Unit = {
     _brokers.foreach { server =>
-      val cache = server.credentialProvider.credentialCache.cache(mechanismName, classOf[ScramCredential])
+      val cache = server.credentialProvider.credentialCache.scramCache(mechanismName)
       TestUtils.waitUntilTrue(() => cache.get(clientPrincipal) != null, s"SCRAM credentials not created for $clientPrincipal")
     }
   }


### PR DESCRIPTION
The CredentialCache uses generic and unavoidably introduced unchecked conversion. To avoid this, we have to make it explicit. This cache is only used in Scram though.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
