### PR TITLE
MINOR: Update LICENSE-binary for 3.6.1

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -205,7 +205,7 @@
 This project bundles some components that are also licensed under the Apache
 License Version 2.0:
 
-audience-annotations-0.13.0
+audience-annotations-0.12.0
 caffeine-2.9.3
 commons-beanutils-1.9.4
 commons-cli-1.4
@@ -327,6 +327,7 @@ zstd-jni-1.5.5-1 see: licenses/zstd-jni-BSD-2-clause
 BSD 3-Clause
 
 jline-3.22.0, see: licenses/jline-BSD-3-clause
+jsr305-3.0.2, see: licenses/jsr305-BSD-3-clause
 paranamer-2.8, see: licenses/paranamer-BSD-3-clause
 
 ---------------------------------------

--- a/licenses/jsr305-BSD-3-clause
+++ b/licenses/jsr305-BSD-3-clause
@@ -1,0 +1,28 @@
+Copyright (c) 2007-2009, JSR305 expert group
+All rights reserved.
+
+http://www.opensource.org/licenses/bsd-license.php
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of the JSR305 expert group nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
- `audience-annotations` seems to come from ZooKeeper. I was surprised I had to downgrade it but I confirmed that [ZK 3.8.3](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.8.3/apache-zookeeper-3.8.3-bin.tar.gz) ships an earlier version than [ZK 3.6.4](https://archive.apache.org/dist/zookeeper/zookeeper-3.6.4/apache-zookeeper-3.6.4-bin.tar.gz)! 
- `jsr305` seems to come from reflections 0.10.2

Even though [Maven Central](https://mvnrepository.com/artifact/com.google.code.findbugs/jsr305/3.0.2) says `jsr305` is under the Apache 2.0 license, it seems it's actually under the BSD-3 license according to the original repository: https://code.google.com/archive/p/jsr-305/.

It's also a dependency of Pulsar and they count it as [BSD-3](https://github.com/apache/pulsar/blob/master/distribution/server/src/assemble/LICENSE.bin.txt#L512)

These changes should have been done in 3.6.0, the dependencies have not changed since then. I confirmed that the license check documented in https://issues.apache.org/jira/browse/KAFKA-12622 fails for 3.6.0.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
