### PR TITLE
KAFKA-15875 Make Snapshot public

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/timeline/Delta.java
+++ b/server-common/src/main/java/org/apache/kafka/timeline/Delta.java
@@ -20,7 +20,7 @@ package org.apache.kafka.timeline;
 /**
  * An API which snapshot delta structures implement.
  */
-interface Delta {
+public interface Delta {
     /**
      * Merge the source delta into this one.
      *

--- a/server-common/src/main/java/org/apache/kafka/timeline/Revertable.java
+++ b/server-common/src/main/java/org/apache/kafka/timeline/Revertable.java
@@ -21,7 +21,7 @@ package org.apache.kafka.timeline;
  * An API which all snapshot data structures implement, indicating that their contents
  * can be reverted to a point in time.
  */
-interface Revertable {
+public interface Revertable {
     /**
      * Revert to the target epoch.
      *

--- a/server-common/src/main/java/org/apache/kafka/timeline/Snapshot.java
+++ b/server-common/src/main/java/org/apache/kafka/timeline/Snapshot.java
@@ -24,10 +24,10 @@ import java.util.Map;
  * A snapshot of some timeline data structures.
  * <br>
  * The snapshot contains historical data for several timeline data structures.
- * We use an IdentityHashMap to store this data.  This way, we can easily drop all of
+ * We use an IdentityHashMap to store this data.  This way, we can easily drop all
  * the snapshot data.
  */
-class Snapshot {
+public class Snapshot {
     private final long epoch;
     private IdentityHashMap<Revertable, Delta> map = new IdentityHashMap<>(4);
     private Snapshot prev = this;
@@ -42,7 +42,7 @@ class Snapshot {
     }
 
     @SuppressWarnings("unchecked")
-    <T extends Delta> T getDelta(Revertable owner) {
+    public <T extends Delta> T getDelta(Revertable owner) {
         return (T) map.get(owner);
     }
 
@@ -73,11 +73,11 @@ class Snapshot {
         source.erase();
     }
 
-    Snapshot prev() {
+    public Snapshot prev() {
         return prev;
     }
 
-    Snapshot next() {
+    public Snapshot next() {
         return next;
     }
 


### PR DESCRIPTION
Makes Snapshop, Revertable and Delta classes public. Only read methods are made public as well.

Snapshot, Revertable and Delta are package protected but they potentially leak to classes in other packages (org.apache.kafka.controller.OffsetControlManager).

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
