### PR TITLE
KAFKA-15886: Always specify directories for new partition registrations

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -34,7 +34,7 @@ import org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata
 import org.apache.kafka.common.requests.{FetchRequest, ProduceResponse}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.utils.Time
-import org.apache.kafka.common.{IsolationLevel, TopicIdPartition, TopicPartition, Uuid}
+import org.apache.kafka.common.{DirectoryId, IsolationLevel, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.image.{MetadataDelta, MetadataImage}
 import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.metadata.PartitionRegistration
@@ -474,6 +474,7 @@ class ReplicaManagerConcurrencyTest {
   ): PartitionRegistration = {
     new PartitionRegistration.Builder().
       setReplicas(replicaIds.toArray).
+      setDirectories(DirectoryId.unassignedArray(replicaIds.size)).
       setIsr(isr.toArray).
       setLeader(leader).
       setLeaderRecoveryState(leaderRecoveryState).

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.clients.admin.{Admin, AlterConfigOp, ConfigEntry, NewTop
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.config.ConfigResource.Type.BROKER
 import org.apache.kafka.common.utils.Exit
-import org.apache.kafka.common.{TopicPartition, Uuid}
+import org.apache.kafka.common.{DirectoryId, TopicPartition, Uuid}
 import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.image.{MetadataDelta, MetadataImage, MetadataImageTest, MetadataProvenance, TopicImage, TopicsImage}
 import org.apache.kafka.image.loader.LogDeltaManifest
@@ -162,6 +162,7 @@ class BrokerMetadataPublisherTest {
     val partitionRegistrations = partitions.map { case (partitionId, replicas) =>
       Int.box(partitionId) -> new PartitionRegistration.Builder().
         setReplicas(replicas.toArray).
+        setDirectories(DirectoryId.unassignedArray(replicas.size)).
         setIsr(replicas.toArray).
         setLeader(replicas.head).
         setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
@@ -23,7 +23,7 @@ import kafka.server.{ConfigType, KafkaConfig}
 import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.errors.ControllerMovedException
 import org.apache.kafka.common.metadata.{ConfigRecord, MetadataRecordType, PartitionRecord, ProducerIdsRecord, TopicRecord}
-import org.apache.kafka.common.{TopicPartition, Uuid}
+import org.apache.kafka.common.{DirectoryId, TopicPartition, Uuid}
 import org.apache.kafka.image.{MetadataDelta, MetadataImage, MetadataProvenance}
 import org.apache.kafka.metadata.migration.{KRaftMigrationZkWriter, ZkMigrationLeadershipState}
 import org.apache.kafka.metadata.{LeaderRecoveryState, PartitionRegistration}
@@ -79,8 +79,24 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals(0, migrationState.migrationZkVersion())
 
     val partitions = Map(
-      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(1, 2)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(6).setPartitionEpoch(-1).build(),
-      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(3)).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(7).setPartitionEpoch(-1).build()
+      0 -> new PartitionRegistration.Builder()
+        .setReplicas(Array(0, 1, 2))
+        .setDirectories(DirectoryId.migratingArray(3))
+        .setIsr(Array(1, 2))
+        .setLeader(1)
+        .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+        .setLeaderEpoch(6)
+        .setPartitionEpoch(-1)
+        .build(),
+      1 -> new PartitionRegistration.Builder()
+        .setReplicas(Array(1, 2, 3))
+        .setDirectories(DirectoryId.migratingArray(3))
+        .setIsr(Array(3))
+        .setLeader(3)
+        .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+        .setLeaderEpoch(7)
+        .setPartitionEpoch(-1)
+        .build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().updateTopicPartitions(Map("test" -> partitions).asJava, migrationState)
     assertEquals(1, migrationState.migrationZkVersion())
@@ -106,8 +122,24 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals(0, migrationState.migrationZkVersion())
 
     val partitions = Map(
-      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
-      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
+      0 -> new PartitionRegistration.Builder()
+        .setReplicas(Array(0, 1, 2))
+        .setDirectories(DirectoryId.unassignedArray(3))
+        .setIsr(Array(0, 1, 2))
+        .setLeader(0)
+        .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+        .setLeaderEpoch(0)
+        .setPartitionEpoch(-1)
+        .build(),
+      1 -> new PartitionRegistration.Builder()
+        .setReplicas(Array(1, 2, 3))
+        .setDirectories(DirectoryId.unassignedArray(3))
+        .setIsr(Array(1, 2, 3))
+        .setLeader(1)
+        .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+        .setLeaderEpoch(0)
+        .setPartitionEpoch(-1)
+        .build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().createTopic("test", Uuid.randomUuid(), partitions, migrationState)
     assertEquals(1, migrationState.migrationZkVersion())
@@ -129,8 +161,24 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals(0, migrationState.migrationZkVersion())
 
     val partitions = Map(
-      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
-      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
+      0 -> new PartitionRegistration.Builder()
+        .setReplicas(Array(0, 1, 2))
+        .setDirectories(DirectoryId.unassignedArray(3))
+        .setIsr(Array(0, 1, 2))
+        .setLeader(0)
+        .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+        .setLeaderEpoch(0)
+        .setPartitionEpoch(-1)
+        .build(),
+      1 -> new PartitionRegistration.Builder()
+        .setReplicas(Array(1, 2, 3))
+        .setDirectories(DirectoryId.unassignedArray(3))
+        .setIsr(Array(1, 2, 3))
+        .setLeader(1)
+        .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+        .setLeaderEpoch(0)
+        .setPartitionEpoch(-1)
+        .build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     val topicId = Uuid.randomUuid()
     migrationState = migrationClient.topicClient().createTopic("test", topicId, partitions, migrationState)
@@ -375,8 +423,24 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
 
     val topicId = Uuid.randomUuid()
     val partitions = Map(
-      0 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
-      1 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
+      0 -> new PartitionRegistration.Builder()
+        .setReplicas(Array(0, 1, 2))
+        .setDirectories(DirectoryId.unassignedArray(3))
+        .setIsr(Array(0, 1, 2))
+        .setLeader(0)
+        .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+        .setLeaderEpoch(0)
+        .setPartitionEpoch(-1)
+        .build(),
+      1 -> new PartitionRegistration.Builder()
+        .setReplicas(Array(1, 2, 3))
+        .setDirectories(DirectoryId.unassignedArray(3))
+        .setIsr(Array(1, 2, 3))
+        .setLeader(1)
+        .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+        .setLeaderEpoch(0)
+        .setPartitionEpoch(-1)
+        .build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().createTopic("test", topicId, partitions, migrationState)
     assertEquals(1, migrationState.migrationZkVersion())
@@ -384,8 +448,24 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     // Change assignment in partitions and update the topic assignment. See the change is
     // reflected.
     val changedPartitions = Map(
-      0 -> new PartitionRegistration.Builder().setReplicas(Array(1, 2, 3)).setIsr(Array(1, 2, 3)).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build(),
-      1 -> new PartitionRegistration.Builder().setReplicas(Array(0, 1, 2)).setIsr(Array(0, 1, 2)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
+      0 -> new PartitionRegistration.Builder()
+        .setReplicas(Array(1, 2, 3))
+        .setDirectories(DirectoryId.unassignedArray(3))
+        .setIsr(Array(1, 2, 3))
+        .setLeader(0)
+        .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+        .setLeaderEpoch(0)
+        .setPartitionEpoch(-1)
+        .build(),
+      1 -> new PartitionRegistration.Builder()
+        .setReplicas(Array(0, 1, 2))
+        .setDirectories(DirectoryId.unassignedArray(3))
+        .setIsr(Array(0, 1, 2))
+        .setLeader(1)
+        .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+        .setLeaderEpoch(0)
+        .setPartitionEpoch(-1)
+        .build()
     ).map { case (k, v) => Integer.valueOf(k) -> v }.asJava
     migrationState = migrationClient.topicClient().updateTopic("test", topicId, changedPartitions, migrationState)
     assertEquals(2, migrationState.migrationZkVersion())
@@ -406,7 +486,15 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
 
     // Add a new Partition.
     val newPartition = Map(
-      2 -> new PartitionRegistration.Builder().setReplicas(Array(2, 3, 4)).setIsr(Array(2, 3, 4)).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(-1).build()
+      2 -> new PartitionRegistration.Builder()
+        .setReplicas(Array(2, 3, 4))
+        .setDirectories(DirectoryId.unassignedArray(3))
+        .setIsr(Array(2, 3, 4))
+        .setLeader(1)
+        .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+        .setLeaderEpoch(0)
+        .setPartitionEpoch(-1)
+        .build()
     ).map { case (k, v) => int2Integer(k) -> v }.asJava
     migrationState = migrationClient.topicClient().createTopicPartitions(Map("test" -> newPartition).asJava, migrationState)
     assertEquals(3, migrationState.migrationZkVersion())

--- a/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistration.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.metadata;
 
+import org.apache.kafka.common.DirectoryId;
 import org.apache.kafka.common.Endpoint;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.Uuid;
@@ -264,7 +265,7 @@ public class BrokerRegistration {
     }
 
     public boolean hasOnlineDir(Uuid dir) {
-        return Collections.binarySearch(directories, dir) >= 0;
+        return DirectoryId.isOnline(dir, directories);
     }
 
     public ApiMessageAndVersion toRecord(ImageWriterOptions options) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/DefaultDirProvider.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/DefaultDirProvider.java
@@ -18,23 +18,15 @@
 package org.apache.kafka.metadata.placement;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.annotation.InterfaceStability;
-
-import java.util.Iterator;
-
 
 /**
- * Can describe a cluster to a ReplicaPlacer.
+ * Provide the default directory for new partitions in a given broker.
+ * For brokers that are registered with multiple directories, the return value
+ * should always be {@link org.apache.kafka.common.DirectoryId#UNASSIGNED}.
+ * For brokers that are registered with a single log directory, then the return
+ * value should be the ID for that directory.
  */
-@InterfaceStability.Unstable
-public interface ClusterDescriber extends DefaultDirProvider {
-    /**
-     * Get an iterator through the usable brokers.
-     */
-    Iterator<UsableBroker> usableBrokers();
-
-    /**
-     * Get the default directory for new partitions placed in a given broker.
-     */
+@FunctionalInterface
+public interface DefaultDirProvider {
     Uuid defaultDir(int brokerId);
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/PartitionAssignment.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/PartitionAssignment.java
@@ -17,7 +17,11 @@
 
 package org.apache.kafka.metadata.placement;
 
+import org.apache.kafka.common.DirectoryId;
+import org.apache.kafka.common.Uuid;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -25,14 +29,28 @@ import java.util.Objects;
 /**
  * The partition assignment.
  *
- * The assignment is represented as a list of integers where each integer is the replica ID. This class is immutable.
- * It's internal state does not change.
+ * The assignment is represented as a list of integers and {@link Uuid}s
+ * where each integer is the replica ID, and each Uuid is the ID of the
+ * directory hosting the replica in the broker.
+ * This class is immutable. It's internal state does not change.
  */
 public class PartitionAssignment {
-    private final List<Integer> replicas;
 
+    private final List<Integer> replicas;
+    private final List<Uuid> directories;
+
+    // TODO remove -- just here for testing
     public PartitionAssignment(List<Integer> replicas) {
+        this(replicas, brokerId -> DirectoryId.UNASSIGNED);
+    }
+
+    public PartitionAssignment(List<Integer> replicas, DefaultDirProvider defaultDirProvider) {
         this.replicas = Collections.unmodifiableList(new ArrayList<>(replicas));
+        Uuid[] directories = new Uuid[replicas.size()];
+        for (int i = 0; i < directories.length; i++) {
+            directories[i] = defaultDirProvider.defaultDir(replicas.get(i));
+        }
+        this.directories = Collections.unmodifiableList(Arrays.asList(directories));
     }
 
     /**
@@ -42,22 +60,28 @@ public class PartitionAssignment {
         return replicas;
     }
 
+    public List<Uuid> directories() {
+        return directories;
+    }
+
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof PartitionAssignment)) return false;
-        PartitionAssignment other = (PartitionAssignment) o;
-        return replicas.equals(other.replicas);
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PartitionAssignment that = (PartitionAssignment) o;
+        return Objects.equals(replicas, that.replicas) && Objects.equals(directories, that.directories);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(replicas);
+        return Objects.hash(replicas, directories);
     }
 
     @Override
     public String toString() {
         return "PartitionAssignment" +
-            "(replicas=" + replicas +
-            ")";
+                "(replicas=" + replicas +
+                ", directories=" + directories +
+                ")";
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/placement/StripedReplicaPlacer.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/placement/StripedReplicaPlacer.java
@@ -438,7 +438,7 @@ public class StripedReplicaPlacer implements ReplicaPlacer {
             placements.add(rackList.place(placement.numReplicas()));
         }
         return new TopicAssignment(
-            placements.stream().map(PartitionAssignment::new).collect(Collectors.toList())
+            placements.stream().map(replicas -> new PartitionAssignment(replicas, cluster)).collect(Collectors.toList())
         );
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentReplicasTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentReplicasTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.metadata.placement.PartitionAssignment;
@@ -134,6 +135,11 @@ public class PartitionReassignmentReplicasTest {
         assertTrue(PartitionReassignmentReplicas.isReassignmentInProgress(
             new PartitionRegistration.Builder().
                 setReplicas(new int[]{0, 1, 3, 2}).
+                setDirectories(new Uuid[]{
+                    Uuid.fromString("HEKOeWDdQOqr2cmHrnjqjA"),
+                    Uuid.fromString("I8kmmcM5TjOwNFnGvJLCjA"),
+                    Uuid.fromString("x8osEoRkQdupZNYpU5c3Lw"),
+                    Uuid.fromString("OT6qgtRqTiuiX8EikvAVow")}).
                 setIsr(new int[]{0, 1, 3, 2}).
                 setRemovingReplicas(new int[]{2}).
                 setAddingReplicas(new int[]{3}).
@@ -145,6 +151,12 @@ public class PartitionReassignmentReplicasTest {
         assertTrue(PartitionReassignmentReplicas.isReassignmentInProgress(
             new PartitionRegistration.Builder().
                 setReplicas(new int[]{0, 1, 3, 2}).
+                setDirectories(new Uuid[]{
+                    Uuid.fromString("QrbOddSYQg6JgFu7hLvOTg"),
+                    Uuid.fromString("S585FNNoSmiSH6ZYCrNqCg"),
+                    Uuid.fromString("wjT5ieLARfKYMWIzTFwcag"),
+                    Uuid.fromString("qzX9qWPVTWuLbiEQL0cgeg")
+                }).
                 setIsr(new int[]{0, 1, 3, 2}).
                 setRemovingReplicas(new int[]{2}).
                 setLeader(0).
@@ -155,6 +167,12 @@ public class PartitionReassignmentReplicasTest {
         assertTrue(PartitionReassignmentReplicas.isReassignmentInProgress(
             new PartitionRegistration.Builder().
                 setReplicas(new int[]{0, 1, 3, 2}).
+                setDirectories(new Uuid[]{
+                    Uuid.fromString("QIyJnfdUSz6laFLCgj3AjA"),
+                    Uuid.fromString("1QIvvBx2QVqNw2dsnYXUZg"),
+                    Uuid.fromString("yPvPnGrxR0q8KC2Q5k0FIg"),
+                    Uuid.fromString("a0lnxzleTcWVf1IyalE9cA")
+                }).
                 setIsr(new int[]{0, 1, 3, 2}).
                 setAddingReplicas(new int[]{3}).
                 setLeader(0).
@@ -165,6 +183,11 @@ public class PartitionReassignmentReplicasTest {
         assertFalse(PartitionReassignmentReplicas.isReassignmentInProgress(
             new PartitionRegistration.Builder().
                 setReplicas(new int[]{0, 1, 2}).
+                setDirectories(new Uuid[]{
+                    Uuid.fromString("I4qCCBe9TYGOB0xvmvTI7w"),
+                    Uuid.fromString("JvzGem0nTxiNPM5jIzNzlA"),
+                    Uuid.fromString("EfWjZ2EsSKSvEn9PkG7lWQ")
+                }).
                 setIsr(new int[]{0, 1, 2}).
                 setLeader(0).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentRevertTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionReassignmentRevertTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.controller;
 
 import java.util.Arrays;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.metadata.PartitionRegistration;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,11 @@ public class PartitionReassignmentRevertTest {
     public void testNoneAddedOrRemoved() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {3, 2, 1}).setIsr(new int[] {3, 2}).
+            setDirectories(new Uuid[]{
+                    Uuid.fromString("Qln01zZAQMKzFTRCw22Y4w"),
+                    Uuid.fromString("jjUcnIL2TxWEGMZ1mHvkPA"),
+                    Uuid.fromString("JSZNFA0uQFmH1N75hQxWug")
+            }).
             setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
@@ -46,6 +52,11 @@ public class PartitionReassignmentRevertTest {
     public void testSomeRemoving() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {3, 2, 1}).setIsr(new int[] {3, 2}).
+            setDirectories(new Uuid[]{
+                    Uuid.fromString("WG58zlb5RR6TqdI81SCXeA"),
+                    Uuid.fromString("izoB1H6TQdOExQ4XNMNXeQ"),
+                    Uuid.fromString("TluNaJDjRemuy17sO7dDKg")
+            }).
             setRemovingReplicas(new int[]{2, 1}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
@@ -57,6 +68,13 @@ public class PartitionReassignmentRevertTest {
     public void testSomeAdding() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5, 2}).
+            setDirectories(new Uuid[]{
+                    Uuid.fromString("gR9P3R9NQ5GhtewattwuZw"),
+                    Uuid.fromString("vzgieGUjSr6vPvl3ZAWQcg"),
+                    Uuid.fromString("8UWF5CQfQDqSyzcChmbrgw"),
+                    Uuid.fromString("X3J9b4K5TumAM5a3YOKk2w"),
+                    Uuid.fromString("LjZGhHfFRSCSCQw42dLlNA")
+            }).
             setAddingReplicas(new int[]{4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
@@ -68,6 +86,13 @@ public class PartitionReassignmentRevertTest {
     public void testSomeRemovingAndAdding() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5, 2}).
+            setDirectories(new Uuid[]{
+                Uuid.fromString("IHR5DKGdQju05pbDpwfdbA"),
+                Uuid.fromString("9zsVmGReTDOAyuPEtp58Cw"),
+                Uuid.fromString("bsUouEfRSLi50Pj3nqke2A"),
+                Uuid.fromString("8l9R5BMcQZGbICOXPmxZNw"),
+                Uuid.fromString("3n5Gwv8jRMiIFMgoTxVCdA")
+            }).
             setRemovingReplicas(new int[]{2}).setAddingReplicas(new int[]{4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());
@@ -79,6 +104,13 @@ public class PartitionReassignmentRevertTest {
     public void testIsrSpecialCase() {
         PartitionRegistration registration = new PartitionRegistration.Builder().
             setReplicas(new int[] {4, 5, 3, 2, 1}).setIsr(new int[] {4, 5}).
+            setDirectories(new Uuid[]{
+                    Uuid.fromString("1oXnuHL6T8y7yMtEP4FSdg"),
+                    Uuid.fromString("3ddu6izxT2aCpQrA3C2bjw"),
+                    Uuid.fromString("WvCpqmaZTaSbifd43Vl2Xg"),
+                    Uuid.fromString("n0cmj6NgTaahRMwa75FnRA"),
+                    Uuid.fromString("S2mDcyiAQAe92ZrlyodaDw")
+            }).
             setRemovingReplicas(new int[]{2}).setAddingReplicas(new int[]{4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(100).setPartitionEpoch(200).build();
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(registration);
         assertEquals(Arrays.asList(3, 2, 1), revert.replicas());

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.controller;
 
+import org.apache.kafka.common.DirectoryId;
 import org.apache.kafka.common.ElectionType;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
@@ -140,6 +141,7 @@ import static org.apache.kafka.controller.ControllerRequestContextUtil.QUOTA_EXC
 import static org.apache.kafka.controller.ControllerRequestContextUtil.anonymousContextFor;
 import static org.apache.kafka.controller.ControllerRequestContextUtil.anonymousContextWithMutationQuotaExceededFor;
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;
+import static org.apache.kafka.metadata.util.MetadataFeatureUtil.withDirectoryAssignmentSupport;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -344,15 +346,31 @@ public class ReplicationControlManagerTest {
         }
 
         void registerBrokers(Integer... brokerIds) throws Exception {
-            for (int brokerId : brokerIds) {
+            Object[] brokersAndDirs = new Object[brokerIds.length * 2];
+            for (int i = 0; i < brokerIds.length; i++) {
+                brokersAndDirs[i * 2] = brokerIds[i];
+                brokersAndDirs[i * 2 + 1] = Collections.singletonList(DirectoryId.UNASSIGNED);
+            }
+            registerBrokersWithDirs(brokersAndDirs);
+        }
+
+        @SuppressWarnings("unchecked")
+        void registerBrokersWithDirs(Object... brokerIdsAndDirs) throws Exception {
+            if (brokerIdsAndDirs.length % 2 != 0) {
+                throw new IllegalArgumentException("uneven number of arguments");
+            }
+            for (int i = 0; i < brokerIdsAndDirs.length / 2; i++) {
+                int brokerId = (int) brokerIdsAndDirs[i * 2];
+                List<Uuid> logDirs = (List<Uuid>) brokerIdsAndDirs[i * 2 + 1];
                 RegisterBrokerRecord brokerRecord = new RegisterBrokerRecord().
-                    setBrokerEpoch(defaultBrokerEpoch(brokerId)).setBrokerId(brokerId).setRack(null);
+                    setBrokerEpoch(defaultBrokerEpoch(brokerId)).setBrokerId(brokerId).
+                        setRack(null).setLogDirs(logDirs);
                 brokerRecord.endPoints().add(new RegisterBrokerRecord.BrokerEndpoint().
                     setSecurityProtocol(SecurityProtocol.PLAINTEXT.id).
                     setPort((short) 9092 + brokerId).
                     setName("PLAINTEXT").
                     setHost("localhost"));
-                replay(Collections.singletonList(new ApiMessageAndVersion(brokerRecord, (short) 0)));
+                replay(Collections.singletonList(new ApiMessageAndVersion(brokerRecord, (short) 3)));
             }
         }
 
@@ -507,7 +525,9 @@ public class ReplicationControlManagerTest {
 
     @Test
     public void testCreateTopics() throws Exception {
-        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setMetadataVersion(withDirectoryAssignmentSupport(MetadataVersion.latest()))
+                .build();
         ReplicationControlManager replicationControl = ctx.replicationControl;
         CreateTopicsRequestData request = new CreateTopicsRequestData();
         request.topics().add(new CreatableTopic().setName("foo").
@@ -549,6 +569,7 @@ public class ReplicationControlManagerTest {
         assertEquals(expectedResponse3, result3.response());
         ctx.replay(result3.records());
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 0}).
+            setDirectories(DirectoryId.migratingArray(3)).
             setIsr(new int[] {1, 2, 0}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build(),
             replicationControl.getPartition(
                 ((TopicRecord) result3.records().get(0).message()).topicId(), 0));
@@ -583,7 +604,9 @@ public class ReplicationControlManagerTest {
 
     @Test
     public void testCreateTopicsISRInvariants() throws Exception {
-        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setMetadataVersion(withDirectoryAssignmentSupport(MetadataVersion.latest()))
+                .build();
         ReplicationControlManager replicationControl = ctx.replicationControl;
 
         CreateTopicsRequestData request = new CreateTopicsRequestData();
@@ -611,6 +634,7 @@ public class ReplicationControlManagerTest {
         // cannot be in the ISR because it is in controlled shutdown.
         assertEquals(
             new PartitionRegistration.Builder().setReplicas(new int[]{1, 0, 2}).
+                setDirectories(DirectoryId.migratingArray(3)).
                 setIsr(new int[]{0}).
                 setLeader(0).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
@@ -1514,6 +1538,7 @@ public class ReplicationControlManagerTest {
         // cannot be in the ISR because it is in controlled shutdown.
         assertEquals(
             new PartitionRegistration.Builder().setReplicas(new int[]{0, 1, 2}).
+                setDirectories(DirectoryId.migratingArray(3)).
                 setIsr(new int[]{0}).
                 setLeader(0).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
@@ -1567,7 +1592,10 @@ public class ReplicationControlManagerTest {
     @ParameterizedTest
     @ApiKeyVersionsSource(apiKey = ApiKeys.ALTER_PARTITION)
     public void testReassignPartitions(short version) throws Exception {
-        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
+        MetadataVersion metadataVersion = withDirectoryAssignmentSupport(MetadataVersion.latest());
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setMetadataVersion(metadataVersion)
+                .build();
         ReplicationControlManager replication = ctx.replicationControl;
         ctx.registerBrokers(0, 1, 2, 3);
         ctx.unfenceBrokers(0, 1, 2, 3);
@@ -1633,9 +1661,10 @@ public class ReplicationControlManagerTest {
             new PartitionChangeRecord().setTopicId(fooId).
                 setPartitionId(1).
                 setReplicas(asList(2, 1, 3)).
+                setDirectories(asList(DirectoryId.migratingArray(3))).
                 setLeader(3).
                 setRemovingReplicas(Collections.emptyList()).
-                setAddingReplicas(Collections.emptyList()), MetadataVersion.latest().partitionChangeRecordVersion())),
+                setAddingReplicas(Collections.emptyList()), metadataVersion.partitionChangeRecordVersion())),
             new AlterPartitionReassignmentsResponseData().setErrorMessage(null).setResponses(asList(
                 new ReassignableTopicResponse().setName("foo").setPartitions(asList(
                     new ReassignablePartitionResponse().setPartitionIndex(0).
@@ -1684,7 +1713,9 @@ public class ReplicationControlManagerTest {
     @ParameterizedTest
     @ApiKeyVersionsSource(apiKey = ApiKeys.ALTER_PARTITION)
     public void testAlterPartitionShouldRejectFencedBrokers(short version) throws Exception {
-        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setMetadataVersion(withDirectoryAssignmentSupport(MetadataVersion.latest()))
+                .build();
         ReplicationControlManager replication = ctx.replicationControl;
         ctx.registerBrokers(0, 1, 2, 3, 4);
         ctx.unfenceBrokers(0, 1, 2, 3, 4);
@@ -1700,6 +1731,7 @@ public class ReplicationControlManagerTest {
         assertEquals(
             new PartitionRegistration.Builder().
                 setReplicas(new int[] {1, 2, 3, 4}).
+                setDirectories(DirectoryId.migratingArray(4)).
                 setIsr(new int[] {1, 2, 4}).
                 setLeader(1).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
@@ -1830,7 +1862,9 @@ public class ReplicationControlManagerTest {
     @ParameterizedTest
     @ApiKeyVersionsSource(apiKey = ApiKeys.ALTER_PARTITION)
     public void testAlterPartitionShouldRejectShuttingDownBrokers(short version) throws Exception {
-        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setMetadataVersion(withDirectoryAssignmentSupport(MetadataVersion.latest()))
+                .build();
         ReplicationControlManager replication = ctx.replicationControl;
         ctx.registerBrokers(0, 1, 2, 3, 4);
         ctx.unfenceBrokers(0, 1, 2, 3, 4);
@@ -1842,6 +1876,7 @@ public class ReplicationControlManagerTest {
         assertEquals(
             new PartitionRegistration.Builder().
                 setReplicas(new int[] {1, 2, 3, 4}).
+                setDirectories(DirectoryId.migratingArray(4)).
                 setIsr(new int[] {1, 2, 3, 4}).
                 setLeader(1).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
@@ -1884,7 +1919,10 @@ public class ReplicationControlManagerTest {
 
     @Test
     public void testCancelReassignPartitions() throws Exception {
-        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
+        MetadataVersion metadataVersion = withDirectoryAssignmentSupport(MetadataVersion.latest());
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setMetadataVersion(metadataVersion)
+                .build();
         ReplicationControlManager replication = ctx.replicationControl;
         ctx.registerBrokers(0, 1, 2, 3, 4);
         ctx.unfenceBrokers(0, 1, 2, 3, 4);
@@ -1898,6 +1936,7 @@ public class ReplicationControlManagerTest {
         replication.handleBrokerFenced(3, fenceRecords);
         ctx.replay(fenceRecords);
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).setIsr(new int[] {1, 2, 4}).
+            setDirectories(DirectoryId.migratingArray(4)).
             setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(1).build(), replication.getPartition(fooId, 0));
         ControllerResult<AlterPartitionReassignmentsResponseData> alterResult =
             replication.alterPartitionReassignments(
@@ -1935,10 +1974,13 @@ public class ReplicationControlManagerTest {
             alterResult.response());
         ctx.replay(alterResult.records());
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3}).setIsr(new int[] {1, 2}).
+            setDirectories(DirectoryId.migratingArray(3)).
             setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(2).build(), replication.getPartition(fooId, 0));
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 0}).setIsr(new int[] {0, 1, 2}).
+            setDirectories(DirectoryId.migratingArray(4)).
             setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(2).build(), replication.getPartition(fooId, 1));
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 0}).setIsr(new int[] {4, 2}).
+            setDirectories(DirectoryId.migratingArray(5)).
             setAddingReplicas(new int[] {0, 1}).setLeader(4).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(2).build(), replication.getPartition(barId, 0));
         ListPartitionReassignmentsResponseData currentReassigning =
             new ListPartitionReassignmentsResponseData().setErrorMessage(null).
@@ -1985,8 +2027,9 @@ public class ReplicationControlManagerTest {
                     setPartitionId(0).
                     setLeader(4).
                     setReplicas(asList(2, 3, 4)).
+                    setDirectories(asList(DirectoryId.migratingArray(3))).
                     setRemovingReplicas(null).
-                    setAddingReplicas(Collections.emptyList()), MetadataVersion.latest().partitionChangeRecordVersion())),
+                    setAddingReplicas(Collections.emptyList()), metadataVersion.partitionChangeRecordVersion())),
             new AlterPartitionReassignmentsResponseData().setErrorMessage(null).setResponses(asList(
                 new ReassignableTopicResponse().setName("foo").setPartitions(asList(
                     new ReassignablePartitionResponse().setPartitionIndex(0).
@@ -1998,6 +2041,7 @@ public class ReplicationControlManagerTest {
         ctx.replay(cancelResult.records());
         assertEquals(NONE_REASSIGNING, replication.listPartitionReassignments(null, Long.MAX_VALUE));
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {2, 3, 4}).setIsr(new int[] {4, 2}).
+            setDirectories(DirectoryId.migratingArray(3)).
             setLeader(4).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(3).build(), replication.getPartition(barId, 0));
     }
 
@@ -2011,7 +2055,9 @@ public class ReplicationControlManagerTest {
 
     @Test
     public void testCreatePartitionsFailsWithManualAssignmentWithAllFenced() throws Exception {
-        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setMetadataVersion(withDirectoryAssignmentSupport(MetadataVersion.latest()))
+                .build();
         ctx.registerBrokers(0, 1, 2, 3, 4, 5);
         ctx.unfenceBrokers(0, 1, 2);
         Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
@@ -2019,6 +2065,7 @@ public class ReplicationControlManagerTest {
             INVALID_REPLICA_ASSIGNMENT.code());
         ctx.createPartitions(2, "foo", new int[][] {new int[] {2, 4, 5}}, NONE.code());
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {2, 4, 5}).
+                setDirectories(DirectoryId.migratingArray(3)).
                 setIsr(new int[] {2}).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build(),
             ctx.replicationControl.getPartition(fooId, 1));
     }

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisherTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisherTest.java
@@ -47,6 +47,7 @@ import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.Fak
 import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.fakePartitionRegistration;
 import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.fakeTopicImage;
 import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.fakeTopicsImage;
+import static org.apache.kafka.metadata.util.MetadataFeatureUtil.withDirectoryAssignmentSupport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ControllerMetadataMetricsPublisherTest {
@@ -145,7 +146,7 @@ public class ControllerMetadataMetricsPublisherTest {
             MetadataDelta delta = new MetadataDelta(MetadataImage.EMPTY);
             ImageReWriter writer = new ImageReWriter(delta);
             IMAGE1.write(writer, new ImageWriterOptions.Builder().
-                    setMetadataVersion(delta.image().features().metadataVersion()).
+                    setMetadataVersion(withDirectoryAssignmentSupport(delta.image().features().metadataVersion())).
                     build());
             env.publisher.onMetadataUpdate(delta, IMAGE1, fakeManifest(true));
             assertEquals(0, env.metrics.activeBrokerCount());

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsChangesTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsChangesTest.java
@@ -36,6 +36,7 @@ import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.Fak
 import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.FakePartitionRegistrationType.NON_PREFERRED_LEADER;
 import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.FakePartitionRegistrationType.OFFLINE;
 import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.fakePartitionRegistration;
+import static org.apache.kafka.metadata.util.MetadataFeatureUtil.withDirectoryAssignmentSupport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ControllerMetricsChangesTest {
@@ -156,7 +157,7 @@ public class ControllerMetricsChangesTest {
 
     static {
         ImageWriterOptions options = new ImageWriterOptions.Builder().
-                setMetadataVersion(MetadataVersion.IBP_3_7_IV0).build(); // highest MV for PartitionRecord v0
+                setMetadataVersion(withDirectoryAssignmentSupport(MetadataVersion.IBP_3_7_IV0)).build(); // highest MV for PartitionRecord v0
         TOPIC_DELTA1 = new TopicDelta(new TopicImage("foo", FOO_ID, Collections.emptyMap()));
         TOPIC_DELTA1.replay((PartitionRecord) fakePartitionRegistration(NORMAL).
                 toRecord(FOO_ID, 0, options).message());

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsTestUtils.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsTestUtils.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.controller.metrics;
 
 import com.yammer.metrics.core.MetricsRegistry;
+import org.apache.kafka.common.DirectoryId;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.image.TopicImage;
 import org.apache.kafka.image.TopicsImage;
@@ -73,6 +74,7 @@ public class ControllerMetricsTestUtils {
         }
         return new PartitionRegistration.Builder().
             setReplicas(new int[] {0, 1, 2}).
+            setDirectories(DirectoryId.migratingArray(3)).
             setIsr(new int[] {0, 1, 2}).
             setLeader(leader).
             setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).

--- a/metadata/src/test/java/org/apache/kafka/image/ImageDowngradeTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/ImageDowngradeTest.java
@@ -38,9 +38,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
+import static org.apache.kafka.metadata.util.MetadataFeatureUtil.withDirectoryAssignmentSupport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 
 @Timeout(value = 40)
@@ -133,8 +132,7 @@ public class ImageDowngradeTest {
     @Test
     void testDirectoryAssignmentState() {
         MetadataVersion outputMetadataVersion = MetadataVersion.IBP_3_7_IV0;
-        MetadataVersion inputMetadataVersion = spy(outputMetadataVersion); // TODO replace with actual MV after bump for KIP-858
-        when(inputMetadataVersion.isDirectoryAssignmentSupported()).thenReturn(true);
+        MetadataVersion inputMetadataVersion = withDirectoryAssignmentSupport(outputMetadataVersion);
         PartitionRecord testPartitionRecord = (PartitionRecord) TEST_RECORDS.get(1).message();
         writeWithExpectedLosses(outputMetadataVersion,
                 Collections.singletonList("the directory assignment state of one or more replicas"),

--- a/metadata/src/test/java/org/apache/kafka/image/MetadataImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/MetadataImageTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Timeout;
 import java.util.List;
 import java.util.Optional;
 
+import static org.apache.kafka.metadata.util.MetadataFeatureUtil.withDirectoryAssignmentSupport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
@@ -114,7 +115,7 @@ public class MetadataImageTest {
 
     private static void testToImage(MetadataImage image) {
         testToImage(image, new ImageWriterOptions.Builder()
-            .setMetadataVersion(image.features().metadataVersion())
+            .setMetadataVersion(withDirectoryAssignmentSupport(image.features().metadataVersion()))
             .build(), Optional.empty());
     }
 

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.image;
 
+import org.apache.kafka.common.DirectoryId;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.metadata.PartitionChangeRecord;
@@ -28,6 +29,7 @@ import org.apache.kafka.image.writer.RecordListWriter;
 import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.metadata.RecordTestUtils;
+import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.server.immutable.ImmutableMap;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.junit.jupiter.api.Test;
@@ -47,6 +49,7 @@ import static org.apache.kafka.common.metadata.MetadataRecordType.PARTITION_CHAN
 import static org.apache.kafka.common.metadata.MetadataRecordType.PARTITION_RECORD;
 import static org.apache.kafka.common.metadata.MetadataRecordType.REMOVE_TOPIC_RECORD;
 import static org.apache.kafka.common.metadata.MetadataRecordType.TOPIC_RECORD;
+import static org.apache.kafka.metadata.util.MetadataFeatureUtil.withDirectoryAssignmentSupport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -101,13 +104,17 @@ public class TopicsImageTest {
         TOPIC_IMAGES1 = Arrays.asList(
             newTopicImage("foo", FOO_UUID,
                 new PartitionRegistration.Builder().setReplicas(new int[] {2, 3, 4}).
+                    setDirectories(DirectoryId.migratingArray(3)).
                     setIsr(new int[] {2, 3}).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(345).build(),
                 new PartitionRegistration.Builder().setReplicas(new int[] {3, 4, 5}).
+                        setDirectories(DirectoryId.migratingArray(3)).
                     setIsr(new int[] {3, 4, 5}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(4).setPartitionEpoch(684).build(),
                 new PartitionRegistration.Builder().setReplicas(new int[] {2, 4, 5}).
+                        setDirectories(DirectoryId.migratingArray(3)).
                     setIsr(new int[] {2, 4, 5}).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(10).setPartitionEpoch(84).build()),
             newTopicImage("bar", BAR_UUID,
                 new PartitionRegistration.Builder().setReplicas(new int[] {0, 1, 2, 3, 4}).
+                    setDirectories(DirectoryId.migratingArray(5)).
                     setIsr(new int[] {0, 1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {3, 4}).setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(345).build()));
 
         IMAGE1 = new TopicsImage(newTopicsByIdMap(TOPIC_IMAGES1), newTopicsByNameMap(TOPIC_IMAGES1));
@@ -140,9 +147,11 @@ public class TopicsImageTest {
         List<TopicImage> topics2 = Arrays.asList(
             newTopicImage("bar", BAR_UUID,
                 new PartitionRegistration.Builder().setReplicas(new int[] {0, 1, 2, 3, 4}).
+                    setDirectories(DirectoryId.migratingArray(5)).
                     setIsr(new int[] {0, 1, 2, 3}).setRemovingReplicas(new int[] {1}).setAddingReplicas(new int[] {3, 4}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(346).build()),
             newTopicImage("baz", BAZ_UUID,
                 new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4}).
+                    setDirectories(DirectoryId.migratingArray(4)).
                     setIsr(new int[] {3, 4}).setRemovingReplicas(new int[] {2}).setAddingReplicas(new int[] {1}).setLeader(3).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(2).setPartitionEpoch(1).build()));
         IMAGE2 = new TopicsImage(newTopicsByIdMap(topics2), newTopicsByNameMap(topics2));
     }
@@ -162,8 +171,13 @@ public class TopicsImageTest {
     }
 
     private PartitionRegistration newPartition(int[] replicas) {
+        Uuid[] directories = new Uuid[replicas.length];
+        for (int i = 0; i < replicas.length; i++) {
+            directories[i] = DirectoryId.random();
+        }
         return new PartitionRegistration.Builder().
             setReplicas(replicas).
+            setDirectories(directories).
             setIsr(replicas).
             setLeader(replicas[0]).
             setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
@@ -426,7 +440,9 @@ public class TopicsImageTest {
 
     private static List<ApiMessageAndVersion> getImageRecords(TopicsImage image) {
         RecordListWriter writer = new RecordListWriter();
-        image.write(writer, new ImageWriterOptions.Builder().build());
+        image.write(writer, new ImageWriterOptions.Builder().
+                setMetadataVersion(withDirectoryAssignmentSupport(MetadataVersion.latest())).
+                build());
         return writer.records();
     }
 

--- a/metadata/src/test/java/org/apache/kafka/metadata/BrokerRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/BrokerRegistrationTest.java
@@ -36,12 +36,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.kafka.metadata.util.MetadataFeatureUtil.withDirectoryAssignmentSupport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 @Timeout(value = 40)
 public class BrokerRegistrationTest {
@@ -144,10 +143,8 @@ public class BrokerRegistrationTest {
     }
 
     private void testRoundTrip(BrokerRegistration registration) {
-        MetadataVersion metdataVersion = spy(MetadataVersion.latest()); // TODO replace with actual MV after bump for KIP-858
-        when(metdataVersion.isDirectoryAssignmentSupported()).thenReturn(true);
         ImageWriterOptions options = new ImageWriterOptions.Builder().
-                setMetadataVersion(metdataVersion).
+                setMetadataVersion(withDirectoryAssignmentSupport(MetadataVersion.latest())).
                 build();
         ApiMessageAndVersion messageAndVersion = registration.
             toRecord(options);

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/PartitionAssignmentTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/PartitionAssignmentTest.java
@@ -20,6 +20,7 @@ package org.apache.kafka.metadata.placement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import org.apache.kafka.common.Uuid;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -61,7 +62,13 @@ public class PartitionAssignmentTest {
     @Test
     public void testToString() {
         List<Integer> replicas = Arrays.asList(0, 1, 2);
-        PartitionAssignment partitionAssignment = new PartitionAssignment(replicas);
-        assertEquals("PartitionAssignment(replicas=[0, 1, 2])", partitionAssignment.toString());
+        List<Uuid> directories = Arrays.asList(
+                Uuid.fromString("65WMNfybQpCDVulYOxMCTw"),
+                Uuid.fromString("VkZ5AkuESPGkMc2OxpKUjw"),
+                Uuid.fromString("wFtTi4FxTlOhhHytfxv7fQ")
+        );
+        PartitionAssignment partitionAssignment = new PartitionAssignment(replicas, directories::get);
+        assertEquals("PartitionAssignment(replicas=[0, 1, 2], " +
+                "directories=[65WMNfybQpCDVulYOxMCTw, VkZ5AkuESPGkMc2OxpKUjw, wFtTi4FxTlOhhHytfxv7fQ])", partitionAssignment.toString());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/StripedReplicaPlacerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/StripedReplicaPlacerTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.kafka.metadata.placement;
 
+import org.apache.kafka.common.DirectoryId;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.InvalidReplicationFactorException;
 import org.apache.kafka.metadata.placement.StripedReplicaPlacer.BrokerList;
 import org.apache.kafka.metadata.placement.StripedReplicaPlacer.RackList;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Timeout;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -94,7 +97,17 @@ public class StripedReplicaPlacerTest {
         PlacementSpec placementSpec = new PlacementSpec(startPartition,
             numPartitions,
             replicationFactor);
-        return placer.place(placementSpec, brokers::iterator);
+        return placer.place(placementSpec, new ClusterDescriber() {
+            @Override
+            public Iterator<UsableBroker> usableBrokers() {
+                return brokers.iterator();
+            }
+
+            @Override
+            public Uuid defaultDir(int brokerId) {
+                return DirectoryId.UNASSIGNED;
+            }
+        });
     }
 
     /**

--- a/metadata/src/test/java/org/apache/kafka/metadata/placement/TopicAssignmentTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/placement/TopicAssignmentTest.java
@@ -20,6 +20,7 @@ package org.apache.kafka.metadata.placement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import org.apache.kafka.common.Uuid;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -74,10 +75,16 @@ public class TopicAssignmentTest {
     @Test
     public void testToString() {
         List<Integer> replicas = Arrays.asList(0, 1, 2);
+        List<Uuid> directories = Arrays.asList(
+                Uuid.fromString("v56qeYzNRrqNtXsxzcReog"),
+                Uuid.fromString("MvUIAsOiRlSePeiBHdZrSQ"),
+                Uuid.fromString("jUqCchHtTHqMxeVv4dw1RA")
+        );
         List<PartitionAssignment> partitionAssignments = Arrays.asList(
-            new PartitionAssignment(replicas)
+            new PartitionAssignment(replicas, directories::get)
         );
         TopicAssignment topicAssignment = new TopicAssignment(partitionAssignments);
-        assertEquals("TopicAssignment(assignments=[PartitionAssignment(replicas=[0, 1, 2])])", topicAssignment.toString());
+        assertEquals("TopicAssignment(assignments=[PartitionAssignment(replicas=[0, 1, 2], " +
+                "directories=[v56qeYzNRrqNtXsxzcReog, MvUIAsOiRlSePeiBHdZrSQ, jUqCchHtTHqMxeVv4dw1RA])])", topicAssignment.toString());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/util/MetadataFeatureUtil.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/util/MetadataFeatureUtil.java
@@ -15,26 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.kafka.metadata.placement;
+package org.apache.kafka.metadata.util;
 
-import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.server.common.MetadataVersion;
+import org.mockito.internal.util.MockUtil;
 
-import java.util.Iterator;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
-
-/**
- * Can describe a cluster to a ReplicaPlacer.
- */
-@InterfaceStability.Unstable
-public interface ClusterDescriber extends DefaultDirProvider {
-    /**
-     * Get an iterator through the usable brokers.
-     */
-    Iterator<UsableBroker> usableBrokers();
-
-    /**
-     * Get the default directory for new partitions placed in a given broker.
-     */
-    Uuid defaultDir(int brokerId);
+public class MetadataFeatureUtil {
+    public static MetadataVersion withDirectoryAssignmentSupport(MetadataVersion metadataVersion) {
+        MetadataVersion spy = MockUtil.isMock(metadataVersion) ? metadataVersion : spy(metadataVersion);
+        when(spy.isDirectoryAssignmentSupported()).thenReturn(true);
+        return spy;
+    }
 }

--- a/server-common/src/main/java/org/apache/kafka/common/DirectoryId.java
+++ b/server-common/src/main/java/org/apache/kafka/common/DirectoryId.java
@@ -18,6 +18,7 @@ package org.apache.kafka.common;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -121,8 +122,38 @@ public class DirectoryId {
      * Create an array with the specified number of entries set to {@link #UNASSIGNED}.
      */
     public static Uuid[] unassignedArray(int length) {
+        return array(length, UNASSIGNED);
+    }
+
+    /**
+     * Create an array with the specified number of entries set to {@link #MIGRATING}.
+     */
+    public static Uuid[] migratingArray(int length) {
+        return array(length, MIGRATING);
+    }
+
+    /**
+     * Create an array with the specified number of entries set to the specified value.
+     */
+    private static Uuid[] array(int length, Uuid value) {
         Uuid[] array = new Uuid[length];
-        Arrays.fill(array, UNASSIGNED);
+        Arrays.fill(array, value);
         return array;
+    }
+
+    /**
+     * Check if a directory is online, given a sorted list of online directories.
+     * @param dir              The directory to check
+     * @param sortedOnlineDirs The sorted list of online directories
+     * @return                 true if the directory is considered online, false otherwise
+     */
+    public static boolean isOnline(Uuid dir, List<Uuid> sortedOnlineDirs) {
+        if (UNASSIGNED.equals(dir) || MIGRATING.equals(dir)) {
+            return true;
+        }
+        if (LOST.equals(dir)) {
+            return false;
+        }
+        return Collections.binarySearch(sortedOnlineDirs, dir) >= 0;
     }
 }

--- a/server-common/src/test/java/org/apache/kafka/common/DirectoryIdTest.java
+++ b/server-common/src/test/java/org/apache/kafka/common/DirectoryIdTest.java
@@ -20,8 +20,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -42,49 +44,9 @@ public class DirectoryIdTest {
     }
 
     @Test
-    void testCreateDirectoriesFrom() {
-        assertThrows(IllegalArgumentException.class, () -> DirectoryId.createDirectoriesFrom(
-                new int[] {1},
-                new Uuid[] {DirectoryId.UNASSIGNED, DirectoryId.LOST},
-                Arrays.asList(2, 3)
-        ));
-        assertEquals(
-            Arrays.asList(
-                Uuid.fromString("YXY0bQYEQmmyOQ6ZDfGgSQ"),
-                Uuid.fromString("5SZij3DRQgaFbvzR9KooLg"),
-                DirectoryId.UNASSIGNED
-            ),
-            DirectoryId.createDirectoriesFrom(
-                new int[] {1, 2, 3},
-                new Uuid[] {
-                        Uuid.fromString("MgVK5KSwTxe65eYATaoQrg"),
-                        Uuid.fromString("YXY0bQYEQmmyOQ6ZDfGgSQ"),
-                        Uuid.fromString("5SZij3DRQgaFbvzR9KooLg")
-                },
-                Arrays.asList(2, 3, 4)
-            )
-        );
-        assertEquals(
-                Arrays.asList(
-                        DirectoryId.UNASSIGNED,
-                        DirectoryId.UNASSIGNED,
-                        DirectoryId.UNASSIGNED
-                ),
-                DirectoryId.createDirectoriesFrom(
-                        new int[] {1, 2},
-                        new Uuid[] {
-                            DirectoryId.UNASSIGNED,
-                            DirectoryId.UNASSIGNED
-                        },
-                        Arrays.asList(1, 2, 3)
-                )
-        );
-    }
-
-    @Test
     void testCreateAssignmentMap() {
-        assertThrows(IllegalArgumentException.class,
-                () -> DirectoryId.createAssignmentMap(new int[]{1, 2}, DirectoryId.unassignedArray(3)));
+        assertThrows(IllegalArgumentException.class, () ->
+                DirectoryId.createAssignmentMap(new int[]{1, 2}, DirectoryId.unassignedArray(3)));
         assertEquals(
             new HashMap<Integer, Uuid>() {{
                     put(1, Uuid.fromString("upjfkCrUR9GNn1i94ip1wg"));
@@ -101,5 +63,22 @@ public class DirectoryIdTest {
                             Uuid.fromString("bv9TEYi4TqOm52hLmrxT5w")
                     })
         );
+    }
+
+    @Test
+    void testIsOnline() {
+        List<Uuid> sortedDirs = Arrays.asList(
+                Uuid.fromString("imQKg2cXTVe8OUFNa3R9bg"),
+                Uuid.fromString("Mwy5wxTDQxmsZwGzjsaX7w"),
+                Uuid.fromString("s8rHMluuSDCnxt3FmKwiyw")
+        );
+        sortedDirs.sort(Uuid::compareTo);
+        assertTrue(DirectoryId.isOnline(Uuid.fromString("imQKg2cXTVe8OUFNa3R9bg"), sortedDirs));
+        assertTrue(DirectoryId.isOnline(Uuid.fromString("Mwy5wxTDQxmsZwGzjsaX7w"), sortedDirs));
+        assertTrue(DirectoryId.isOnline(Uuid.fromString("s8rHMluuSDCnxt3FmKwiyw"), sortedDirs));
+        assertTrue(DirectoryId.isOnline(DirectoryId.MIGRATING, sortedDirs));
+        assertTrue(DirectoryId.isOnline(DirectoryId.UNASSIGNED, sortedDirs));
+        assertFalse(DirectoryId.isOnline(DirectoryId.LOST, sortedDirs));
+        assertFalse(DirectoryId.isOnline(Uuid.fromString("AMYchbMtS6yhtsXbca7DQg"), sortedDirs));
     }
 }


### PR DESCRIPTION
When creating partition registrations directories must always be defined.

If creating a partition from a PartitionRecord or PartitionChangeRecord from an older version that does not support directory assignments, then DirectoryId.MIGRATING is assumed.

If creating a new partition, or triggering a change in assignment, DirectoryId.UNASSIGNED should be specified, unless the target broker has a single online directory registered, in which case the replica should be assigned directly to that single directory.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
