### PR TITLE
KAFKA-15876: Introduce RemoteStorageNotReadyException retryable error

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/RemoteStorageNotReadyException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/RemoteStorageNotReadyException.java
@@ -17,7 +17,22 @@
 package org.apache.kafka.common.errors;
 
 /**
- * An exception that indicates remote storage is not ready to receive the requests yet.
+ * This retryable exception indicates that remote storage is not ready to receive the requests yet.
+ * <ul>
+ *     <li>The consumer reads data from a known offset. If there's no initial offset, then it's determined by the
+ *     {@link org.apache.kafka.clients.consumer.ConsumerConfig#AUTO_OFFSET_RESET_CONFIG} configuration which can be
+ *     set to earliest, latest, or none.</li>
+ *     <li>If the auto.offset.reset is set to earliest and the offset is in remote storage, then the consumer FETCH
+ *     request can't make progress until the remote log metadata is synced.</li>
+ *     <li>In a FETCH request, if there are multiple partitions with some fetching from local and others from remote
+ *     storage, only the partitions fetching from remote storage will be blocked. The ones fetching from local
+ *     storage can make progress.</li>
+ *     <li>If the fetch-offset for a partition is within local storage, then the consumer can fetch the messages.</li>
+ *     <li>All calls to LIST_OFFSETS will fail until the remote log metadata gets synced for that partition.</li>
+ * </ul>
+ * The behavior ensures that the consumer can continue to consume messages from local storage even if the remote
+ * storage is not available or not yet synced. However, it also means that the consumer can't consume messages from
+ * remote storage until the remote log metadata gets synced.
  */
 public class RemoteStorageNotReadyException extends RetriableException {
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/RemoteStorageNotReadyException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/RemoteStorageNotReadyException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+/**
+ * An exception that indicates remote storage is not ready to receive the requests yet.
+ */
+public class RemoteStorageNotReadyException extends RetriableException {
+
+    private static final long serialVersionUID = 1L;
+
+    public RemoteStorageNotReadyException(String message) {
+        super(message);
+    }
+
+    public RemoteStorageNotReadyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RemoteStorageNotReadyException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/errors/RemoteStorageNotReadyException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/RemoteStorageNotReadyException.java
@@ -17,7 +17,11 @@
 package org.apache.kafka.common.errors;
 
 /**
- * This retryable exception indicates that remote storage is not ready to receive the requests yet.
+ * This retriable exception indicates that remote storage is not ready to receive the requests yet.
+ * This exception will be thrown only when using the
+ * {@code org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager} as the implementation
+ * for {@code org.apache.kafka.server.log.remote.metadata.storage.RemoteLogMetadataManager}.
+ *
  * <ul>
  *     <li>The consumer reads data from a known offset. If there's no initial offset, then it's determined by the
  *     {@link org.apache.kafka.clients.consumer.ConsumerConfig#AUTO_OFFSET_RESET_CONFIG} configuration which can be

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -104,6 +104,7 @@ import org.apache.kafka.common.errors.ReassignmentInProgressException;
 import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.errors.RecordBatchTooLargeException;
 import org.apache.kafka.common.errors.RecordTooLargeException;
+import org.apache.kafka.common.errors.RemoteStorageNotReadyException;
 import org.apache.kafka.common.errors.ReplicaNotAvailableException;
 import org.apache.kafka.common.errors.ResourceNotFoundException;
 import org.apache.kafka.common.errors.RetriableException;
@@ -392,7 +393,8 @@ public enum Errors {
     UNKNOWN_CONTROLLER_ID(116, "This controller ID is not known.", UnknownControllerIdException::new),
     UNKNOWN_SUBSCRIPTION_ID(117, "Client sent a push telemetry request with an invalid or outdated subscription ID.", UnknownSubscriptionIdException::new),
     TELEMETRY_TOO_LARGE(118, "Client sent a push telemetry request larger than the maximum size the broker will accept.", TelemetryTooLargeException::new),
-    INVALID_REGISTRATION(119, "The controller has considered the broker registration to be invalid.", InvalidRegistrationException::new);
+    INVALID_REGISTRATION(119, "The controller has considered the broker registration to be invalid.", InvalidRegistrationException::new),
+    REMOTE_STORAGE_NOT_READY(120, "The remote storage is not ready.", RemoteStorageNotReadyException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataStore.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataStore.java
@@ -18,7 +18,7 @@ package org.apache.kafka.server.log.remote.metadata.storage;
 
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.ReplicaNotAvailableException;
+import org.apache.kafka.common.errors.RemoteStorageNotReadyException;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadataUpdate;
@@ -153,9 +153,7 @@ public class RemotePartitionMetadataStore extends RemotePartitionMetadataEventHa
         }
 
         if (!remoteLogMetadataCache.isInitialized()) {
-            // Throwing a retriable ReplicaNotAvailableException here for clients retry. We can introduce a new more
-            // appropriate exception with a KIP in the future.
-            throw new ReplicaNotAvailableException("Remote log metadata cache is not initialized for partition: " + topicIdPartition);
+            throw new RemoteStorageNotReadyException("Remote log metadata cache is not initialized for partition: " + topicIdPartition);
         }
 
         return remoteLogMetadataCache;

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataStoreTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataStoreTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.log.remote.metadata.storage;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.RemoteStorageNotReadyException;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
+import org.apache.kafka.server.log.remote.storage.RemoteStorageException;
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RemotePartitionMetadataStoreTest {
+
+    Time time = new MockTime();
+    Path logDirPath = Paths.get(TestUtils.tempDirectory().getPath());
+    RemotePartitionMetadataStore metadataStore = new RemotePartitionMetadataStore(logDirPath);
+
+    @Test
+    void shouldThrowRetriableErrorWhenNotInitialized() throws RemoteStorageException, IOException {
+        int brokerId = 0;
+        String topic = "test";
+        int partition = 0;
+        Uuid topicId = Uuid.randomUuid();
+        TopicPartition topicPartition = new TopicPartition(topic, partition);
+        TopicIdPartition topicIdPartition = new TopicIdPartition(topicId, topicPartition);
+        int startOffset = 0;
+        int endOffset = 99;
+        int segmentSizeInBytes = 1024;
+
+        Files.createDirectories(logDirPath.resolve(topicPartition.toString()));
+        metadataStore.maybeLoadPartition(topicIdPartition);
+        RemoteLogSegmentId segmentId = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
+        Map<Integer, Long> segmentLeaderEpochs = Collections.singletonMap(0, 0L);
+        RemoteLogSegmentMetadata metadata = new RemoteLogSegmentMetadata(segmentId, startOffset, endOffset,
+                time.milliseconds(), brokerId, time.milliseconds(), segmentSizeInBytes, segmentLeaderEpochs);
+        metadataStore.handleRemoteLogSegmentMetadata(metadata);
+        assertThrows(RemoteStorageNotReadyException.class, () -> metadataStore.listRemoteLogSegments(topicIdPartition));
+        metadataStore.markInitialized(topicIdPartition);
+        assertEquals(metadata, metadataStore.listRemoteLogSegments(topicIdPartition).next());
+    }
+}


### PR DESCRIPTION
[KIP-1007](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1007%3A+Introduce+Remote+Storage+Not+Ready+Exception)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
