### PR TITLE
HOTFIX: Fix compilation error with Scala 2.12

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -2643,7 +2643,7 @@ class ReplicaManagerTest {
   def testFullLeaderAndIsrStrayPartitions(zkMigrationEnabled: Boolean): Unit = {
     val props = TestUtils.createBrokerConfig(1, TestUtils.MockZkConnect)
     if (zkMigrationEnabled) {
-      props.put(KafkaConfig.MigrationEnabledProp, zkMigrationEnabled)
+      props.put(KafkaConfig.MigrationEnabledProp, zkMigrationEnabled.toString)
       props.put(RaftConfig.QUORUM_VOTERS_CONFIG, "3000@localhost:9071")
       props.put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
       props.put(KafkaConfig.ListenerSecurityProtocolMapProp, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")


### PR DESCRIPTION
Fixes [Error] /home/jenkins/jenkins-agent/workspace/Kafka_kafka_3.6/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala:2646:51: the result type of an implicit conversion must be more specific than Object



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
