### PR TITLE
MINOR: Fix broken method link in DistributedHerder::writeToConfigTopicAsLeader Javadoc

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1644,7 +1644,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
      * exclusively by the leader. For example, {@link ConfigBackingStore#putTargetState(String, TargetState)} does not require this
      * method, as it can be invoked by any worker in the cluster.
      * @param write the action that writes to the config topic, such as {@link ConfigBackingStore#putSessionKey(SessionKey)} or
-     *              {@link ConfigBackingStore#putConnectorConfig(String, Map)}.
+     *              {@link ConfigBackingStore#putConnectorConfig(String, Map, TargetState)}.
      */
     private void writeToConfigTopicAsLeader(Runnable write) {
         try {


### PR DESCRIPTION
- The `ConfigBackingStore::putConnectorConfig` method was modified in https://github.com/apache/kafka/pull/14704 to take in a third parameter (`TargetState`).
- This breaks the method link in the doc comment for `DistributedHerder::writeToConfigTopicAsLeader`. It doesn't break the build since we don't generate public Javadocs for this class, but it does affect things like code navigation in IDEs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
