### PR TITLE
MINOR: Correcting Javadoc for ConnectAssertions

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/ConnectAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/ConnectAssertions.java
@@ -554,7 +554,7 @@ public class ConnectAssertions {
      * @param connectorState
      * @param numTasks the expected number of tasks
      * @param tasksState
-     * @return true if the connector and tasks are in expected states; false otherwise
+     * @return true if the connector and tasks are in the expected state; false otherwise
      */
     protected Optional<Boolean> checkConnectorState(
             String connectorName,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/ConnectAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/ConnectAssertions.java
@@ -524,7 +524,7 @@ public class ConnectAssertions {
      * @param connectorState
      * @param numTasks the expected number of tasks
      * @param tasksState
-     * @return true if the connector and tasks are in expected states; false otherwise
+     * @return true if the connector and tasks are in the expected state; false otherwise
      */
     protected Optional<Boolean> checkConnectorState(
             String connectorName,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/ConnectAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/ConnectAssertions.java
@@ -524,7 +524,7 @@ public class ConnectAssertions {
      * @param connectorState
      * @param numTasks the expected number of tasks
      * @param tasksState
-     * @return true if the connector and tasks are in RUNNING state; false otherwise
+     * @return true if the connector and tasks are in expected states; false otherwise
      */
     protected Optional<Boolean> checkConnectorState(
             String connectorName,
@@ -554,7 +554,7 @@ public class ConnectAssertions {
      * @param connectorState
      * @param numTasks the expected number of tasks
      * @param tasksState
-     * @return true if the connector and tasks are in RUNNING state; false otherwise
+     * @return true if the connector and tasks are in expected states; false otherwise
      */
     protected Optional<Boolean> checkConnectorState(
             String connectorName,


### PR DESCRIPTION
The 2 `checkConnectorState` method implementations have the following text in their return Javadocs:

`* @return true if the connector and tasks are in RUNNING state; false otherwise`

However, this isn't true because the 2 methods are being invoked where it is expected that the connector and/or tasks can be in FAILED (`assertConnectorIsFailedAndTasksHaveFailed`) / PAUSED (`assertConnectorAndExactlyNumTasksArePaused`) state for example. This PR updates the string in an attempt to generalise it because the assertion request can be in any state (not just `RUNNING` as the original string seems to imply).