### PR TITLE
KAFKA-15883: Implement RemoteCopyLagBytes

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -778,6 +778,11 @@ public class RemoteLogManager implements Closeable {
             // are not deleted before they are copied to remote storage.
             log.updateHighestOffsetInRemoteStorage(endOffset);
             logger.info("Copied {} to remote storage with segment-id: {}", logFileName, copySegmentFinishedRlsm.remoteLogSegmentId());
+
+            long bytesLag = log.onlyLocalLogSegmentsSize() - log.activeSegment().size();
+            String topic = topicIdPartition.topic();
+            int partition = topicIdPartition.partition();
+            brokerTopicStats.topicStats(topic).remoteCopyLagBytesWrapper().setPartitionMetricValue(partition, bytesLag);
         }
 
         private Path toPathIfExists(File file) {

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -344,7 +344,8 @@ public class RemoteLogManager implements Closeable {
             followerPartitions.forEach(
                     topicIdPartition -> brokerTopicStats.topicStats(topicIdPartition.topic()).removeRemoteCopyBytesLag(topicIdPartition.partition()));
 
-            remoteLogMetadataManager.onPartitionLeadershipChanges(leaderPartitions, followerPartitions);followerPartitions.forEach(topicIdPartition ->
+            remoteLogMetadataManager.onPartitionLeadershipChanges(leaderPartitions, followerPartitions);
+            followerPartitions.forEach(topicIdPartition ->
                     doHandleLeaderOrFollowerPartitions(topicIdPartition, RLMTask::convertToFollower));
 
             leaderPartitionsWithLeaderEpoch.forEach((topicIdPartition, leaderEpoch) ->

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -782,7 +782,7 @@ public class RemoteLogManager implements Closeable {
             long bytesLag = log.onlyLocalLogSegmentsSize() - log.activeSegment().size();
             String topic = topicIdPartition.topic();
             int partition = topicIdPartition.partition();
-            brokerTopicStats.topicStats(topic).remoteCopyLagBytesWrapper().setPartitionMetricValue(partition, bytesLag);
+            brokerTopicStats.topicStats(topic).remoteBrokerTopicAggregateMetrics().get().setPartitionMetricValue(partition, bytesLag);
         }
 
         private Path toPathIfExists(File file) {

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -293,7 +293,7 @@ class BrokerTopicMetrics(name: Option[String], configOpt: java.util.Optional[Kaf
         gaugeLock synchronized {
           gauge = lazyGauge
           if (gauge == null) {
-            gauge = metricsGroup.newGauge(metricType, () => brokerTopicAggregatedMetric.value(), tags)
+            gauge = metricsGroup.newGauge(metricType, () => brokerTopicAggregatedMetric.value())
             lazyGauge = gauge
           }
         }
@@ -303,14 +303,13 @@ class BrokerTopicMetrics(name: Option[String], configOpt: java.util.Optional[Kaf
 
     def close(): Unit = gaugeLock synchronized {
       if (lazyGauge != null) {
-        metricsGroup.removeMetric(metricType, tags)
+        metricsGroup.removeMetric(metricType)
         brokerTopicAggregatedMetric.close()
         lazyGauge = null
       }
     }
 
-    if (tags.isEmpty) // greedily initialize the general topic metrics
-      gauge()
+    gauge() // greedily initialize the general topic metrics
   }
 
   // an internal map for "lazy initialization" of certain metrics

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -17,8 +17,6 @@
 package kafka.log.remote;
 
 import com.yammer.metrics.core.Gauge;
-import com.yammer.metrics.core.Metric;
-import com.yammer.metrics.core.MetricName;
 import kafka.cluster.EndPoint;
 import kafka.cluster.Partition;
 import kafka.log.UnifiedLog;

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -797,9 +797,8 @@ public class RemoteLogManagerTest {
         assertThrows(NoSuchElementException.class, () -> yammerMetricValue("RemoteCopyLogBytes"));
         remoteLogManager.onLeadershipChange(Collections.singleton(mockLeaderPartition), Collections.singleton(mockFollowerPartition), topicIds);
         TestUtils.waitForCondition(
-                () -> 75 == safeYammerMetricValue("RemoteCopyLagBytes"),
-                1000,
-                String.format("Expected to find 75, but found %d", safeYammerMetricValue("RemoteCopyLagBytes")));
+                () -> 75 == safeLongYammerMetricValue("RemoteCopyLagBytes"),
+                String.format("Expected to find 75 for RemoteCopyLagBytes metric value, but found", safeLongYammerMetricValue("RemoteCopyLagBytes")));
         // unlock copyLogSegmentData
         latch.countDown();
     }
@@ -813,7 +812,7 @@ public class RemoteLogManagerTest {
         return gauge.value();
     }
 
-    private long safeYammerMetricValue(String name) {
+    private long safeLongYammerMetricValue(String name) {
         try {
             return (long) yammerMetricValue(name);
         } catch (NoSuchElementException ex) {

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -17,6 +17,8 @@
 package kafka.log.remote;
 
 import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.Metric;
+import com.yammer.metrics.core.MetricName;
 import kafka.cluster.EndPoint;
 import kafka.cluster.Partition;
 import kafka.log.UnifiedLog;
@@ -101,6 +103,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
@@ -699,20 +702,123 @@ public class RemoteLogManagerTest {
         Partition mockFollowerPartition = mockPartition(followerTopicIdPartition);
 
         // before running tasks, the remote log manager tasks should be all idle
-        assertEquals(1.0, yammerMetricValue("RemoteLogManagerTasksAvgIdlePercent"));
+        assertEquals(1.0, (double) yammerMetricValue("RemoteLogManagerTasksAvgIdlePercent"));
+        Map<MetricName, Metric> metricNameMetricMapBefore = KafkaYammerMetrics.defaultRegistry().allMetrics();
         remoteLogManager.onLeadershipChange(Collections.singleton(mockLeaderPartition), Collections.singleton(mockFollowerPartition), topicIds);
-        assertTrue(yammerMetricValue("RemoteLogManagerTasksAvgIdlePercent") < 1.0);
+        Map<MetricName, Metric> metricNameMetricMapAfter = KafkaYammerMetrics.defaultRegistry().allMetrics();
+        assertTrue((double) yammerMetricValue("RemoteLogManagerTasksAvgIdlePercent") < 1.0);
         // unlock copyLogSegmentData
         latch.countDown();
     }
 
-    private double yammerMetricValue(String name) {
-        Gauge<Double> gauge = (Gauge) KafkaYammerMetrics.defaultRegistry().allMetrics().entrySet().stream()
+    @Test
+    void testRemoteLogManagerRemoteCopyLagBytes() throws Exception {
+        long oldestSegmentStartOffset = 0L;
+        long olderSegmentStartOffset = 75L;
+        long nextSegmentStartOffset = 150L;
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+
+        // leader epoch preparation
+        checkpoint.write(totalEpochEntries);
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(leaderTopicIdPartition.topicPartition(), checkpoint);
+        when(mockLog.leaderEpochCache()).thenReturn(Option.apply(cache));
+        when(remoteLogMetadataManager.highestOffsetForEpoch(any(TopicIdPartition.class), anyInt())).thenReturn(Optional.of(0L));
+
+        File tempFile = TestUtils.tempFile();
+        File mockProducerSnapshotIndex = TestUtils.tempFile();
+        File tempDir = TestUtils.tempDirectory();
+        // create 3 log segments, with 0, 75 and 150 as log start offset
+        LogSegment oldestSegment = mock(LogSegment.class);
+        LogSegment olderSegment = mock(LogSegment.class);
+        LogSegment activeSegment = mock(LogSegment.class);
+
+        when(oldestSegment.baseOffset()).thenReturn(oldestSegmentStartOffset);
+        when(olderSegment.baseOffset()).thenReturn(olderSegmentStartOffset);
+        when(activeSegment.baseOffset()).thenReturn(nextSegmentStartOffset);
+
+        FileRecords oldestFileRecords = mock(FileRecords.class);
+        when(oldestSegment.log()).thenReturn(oldestFileRecords);
+        when(oldestFileRecords.file()).thenReturn(tempFile);
+        when(oldestFileRecords.sizeInBytes()).thenReturn(10);
+        when(oldestSegment.readNextOffset()).thenReturn(olderSegmentStartOffset);
+
+        FileRecords olderFileRecords = mock(FileRecords.class);
+        when(olderSegment.log()).thenReturn(olderFileRecords);
+        // TODO: Do I need another temporary file?
+        when(olderFileRecords.file()).thenReturn(tempFile);
+        when(olderFileRecords.sizeInBytes()).thenReturn(10);
+        when(olderSegment.readNextOffset()).thenReturn(nextSegmentStartOffset);
+
+        when(mockLog.activeSegment()).thenReturn(activeSegment);
+        when(mockLog.logStartOffset()).thenReturn(oldestSegmentStartOffset);
+        when(mockLog.logSegments(anyLong(), anyLong())).thenReturn(JavaConverters.collectionAsScalaIterable(Arrays.asList(oldestSegment, olderSegment, activeSegment)));
+
+        ProducerStateManager mockStateManager = mock(ProducerStateManager.class);
+        when(mockLog.producerStateManager()).thenReturn(mockStateManager);
+        when(mockStateManager.fetchSnapshot(anyLong())).thenReturn(Optional.of(mockProducerSnapshotIndex));
+        when(mockLog.lastStableOffset()).thenReturn(250L);
+
+        OffsetIndex oldestIdx = LazyIndex.forOffset(LogFileUtils.offsetIndexFile(tempDir, oldestSegmentStartOffset, ""), oldestSegmentStartOffset, 1000).get();
+        TimeIndex oldestTimeIdx = LazyIndex.forTime(LogFileUtils.timeIndexFile(tempDir, oldestSegmentStartOffset, ""), oldestSegmentStartOffset, 1500).get();
+        File oldestTxnFile = UnifiedLog.transactionIndexFile(tempDir, oldestSegmentStartOffset, "");
+        oldestTxnFile.createNewFile();
+        TransactionIndex oldestTxnIndex = new TransactionIndex(oldestSegmentStartOffset, oldestTxnFile);
+        when(oldestSegment.timeIndex()).thenReturn(oldestTimeIdx);
+        when(oldestSegment.offsetIndex()).thenReturn(oldestIdx);
+        when(oldestSegment.txnIndex()).thenReturn(oldestTxnIndex);
+
+        OffsetIndex olderIdx = LazyIndex.forOffset(LogFileUtils.offsetIndexFile(tempDir, olderSegmentStartOffset, ""), olderSegmentStartOffset, 1000).get();
+        TimeIndex olderTimeIdx = LazyIndex.forTime(LogFileUtils.timeIndexFile(tempDir, olderSegmentStartOffset, ""), olderSegmentStartOffset, 1500).get();
+        File olderTxnFile = UnifiedLog.transactionIndexFile(tempDir, olderSegmentStartOffset, "");
+        oldestTxnFile.createNewFile();
+        TransactionIndex olderTxnIndex = new TransactionIndex(olderSegmentStartOffset, olderTxnFile);
+        when(olderSegment.timeIndex()).thenReturn(olderTimeIdx);
+        when(olderSegment.offsetIndex()).thenReturn(olderIdx);
+        when(olderSegment.txnIndex()).thenReturn(olderTxnIndex);
+
+        CompletableFuture<Void> dummyFuture = new CompletableFuture<>();
+        dummyFuture.complete(null);
+        when(remoteLogMetadataManager.addRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadata.class))).thenReturn(dummyFuture);
+        when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class))).thenReturn(dummyFuture);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(ans -> Optional.empty()).doAnswer(ans -> {
+            // waiting for verification
+            latch.await();
+            return Optional.empty();
+        }).when(remoteStorageManager).copyLogSegmentData(any(RemoteLogSegmentMetadata.class), any(LogSegmentData.class));
+        Partition mockLeaderPartition = mockPartition(leaderTopicIdPartition);
+        Partition mockFollowerPartition = mockPartition(followerTopicIdPartition);
+
+        when(mockLog.onlyLocalLogSegmentsSize()).thenReturn(175L, 100L);
+        when(activeSegment.size()).thenReturn(100);
+
+        // before running tasks, the metric should not be registered
+        assertThrows(NoSuchElementException.class, () -> yammerMetricValue("RemoteCopyLogBytes"));
+        remoteLogManager.onLeadershipChange(Collections.singleton(mockLeaderPartition), Collections.singleton(mockFollowerPartition), topicIds);
+        TestUtils.waitForCondition(
+                () -> 75 == safeYammerMetricValue("RemoteCopyLagBytes"),
+                1000,
+                String.format("Expected to find 75, but found %d", safeYammerMetricValue("RemoteCopyLagBytes")));
+        // unlock copyLogSegmentData
+        latch.countDown();
+    }
+
+    private Object yammerMetricValue(String name) {
+        Gauge gauge = (Gauge) KafkaYammerMetrics.defaultRegistry().allMetrics().entrySet().stream()
                 .filter(e -> e.getKey().getMBeanName().contains(name))
                 .findFirst()
                 .get()
                 .getValue();
         return gauge.value();
+    }
+
+    private long safeYammerMetricValue(String name) {
+        try {
+            return (long) yammerMetricValue(name);
+        } catch (NoSuchElementException ex) {
+            return 0L;
+        }
     }
 
     @Test

--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -13,7 +13,7 @@
 package kafka.api
 
 import java.util.{Locale, Properties}
-import kafka.server.{BrokerTopicStats, KafkaConfig, KafkaServer}
+import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.utils.{JaasTestUtils, TestUtils}
 import com.yammer.metrics.core.{Gauge, Histogram, Meter}
 import org.apache.kafka.clients.consumer.Consumer
@@ -330,7 +330,7 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
         metric._1.getMBeanName().equals(name.getMBeanName)
       }).isDefined
     ).toList
-    val aggregatedBrokerTopicStats = Set(BrokerTopicStats.RemoteCopyLagBytes)
+    val aggregatedBrokerTopicStats = Set(RemoteStorageMetrics.REMOTE_COPY_LOG_BYTES_METRIC.getName)
     val aggregatedBrokerTopicMetrics = aggregatedBrokerTopicStats.filter(name =>
       KafkaYammerMetrics.defaultRegistry().allMetrics().asScala.find(metric => {
         metric._1.getMBeanName().equals(fromNameToBrokerTopicStatsMBean(name))

--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -13,7 +13,7 @@
 package kafka.api
 
 import java.util.{Locale, Properties}
-import kafka.server.{KafkaConfig, KafkaServer}
+import kafka.server.{BrokerTopicStats, KafkaConfig, KafkaServer}
 import kafka.utils.{JaasTestUtils, TestUtils}
 import com.yammer.metrics.core.{Gauge, Histogram, Meter}
 import org.apache.kafka.clients.consumer.Consumer
@@ -320,16 +320,28 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
     assertTrue(metrics.isEmpty, s"$errorMessage: ${metrics.keys}")
   }
 
+  private def fromNameToBrokerTopicStatsMBean(name: String): String = {
+    s"kafka.server:type=BrokerTopicMetrics,name=$name"
+  }
+
   private def verifyRemoteStorageMetrics(shouldContainMetrics: Boolean): Unit = {
     val metrics = RemoteStorageMetrics.allMetrics().asScala.filter(name =>
       KafkaYammerMetrics.defaultRegistry.allMetrics.asScala.find(metric => {
         metric._1.getMBeanName().equals(name.getMBeanName)
       }).isDefined
     ).toList
+    val aggregatedBrokerTopicStats = Set(BrokerTopicStats.RemoteCopyLagBytes)
+    val aggregatedBrokerTopicMetrics = aggregatedBrokerTopicStats.filter(name =>
+      KafkaYammerMetrics.defaultRegistry().allMetrics().asScala.find(metric => {
+        metric._1.getMBeanName().equals(fromNameToBrokerTopicStatsMBean(name))
+      }).isDefined
+    ).toList
     if (shouldContainMetrics) {
       assertEquals(RemoteStorageMetrics.allMetrics().size(), metrics.size, s"Only $metrics appear in the metrics")
+      assertEquals(aggregatedBrokerTopicStats.size, aggregatedBrokerTopicMetrics.size, s"Only $aggregatedBrokerTopicMetrics appear in the metrics")
     } else {
       assertEquals(0, metrics.size, s"$metrics should not appear in the metrics")
+      assertEquals(0, aggregatedBrokerTopicMetrics.size, s"$aggregatedBrokerTopicMetrics should not appear in the metrics")
     }
   }
 }

--- a/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
@@ -148,6 +148,7 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
     // The broker metrics for all topics should be greedily registered
     assertTrue(topicMetrics(None).nonEmpty, "General topic metrics don't exist")
     assertEquals(brokers.head.brokerTopicStats.allTopicsStats.metricMap.size, topicMetrics(None).size)
+    assertEquals(0, brokers.head.brokerTopicStats.allTopicsStats.metricGaugeMap.size)
     // topic metrics should be lazily registered
     assertTrue(topicMetricGroups(topic).isEmpty, "Topic metrics aren't lazily registered")
     TestUtils.generateAndProduceMessages(brokers, topic, nMessages)

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteStorageMetrics.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteStorageMetrics.java
@@ -41,6 +41,7 @@ public class RemoteStorageMetrics {
     private static final String REMOTE_COPY_REQUESTS_PER_SEC = "RemoteCopyRequestsPerSec";
     private static final String FAILED_REMOTE_FETCH_PER_SEC = "RemoteFetchErrorsPerSec";
     private static final String FAILED_REMOTE_COPY_PER_SEC = "RemoteCopyErrorsPerSec";
+    private static final String REMOTE_COPY_LAG_BYTES = "RemoteCopyLagBytes";
     private static final String REMOTE_LOG_READER_TASK_QUEUE_SIZE = REMOTE_LOG_READER_METRICS_NAME_PREFIX + TASK_QUEUE_SIZE;
     private static final String REMOTE_LOG_READER_AVG_IDLE_PERCENT = REMOTE_LOG_READER_METRICS_NAME_PREFIX + AVG_IDLE_PERCENT;
     public static final Set<String> REMOTE_STORAGE_THREAD_POOL_METRICS = Collections.unmodifiableSet(
@@ -58,6 +59,8 @@ public class RemoteStorageMetrics {
             "kafka.server", "BrokerTopicMetrics", FAILED_REMOTE_FETCH_PER_SEC);
     public final static MetricName FAILED_REMOTE_COPY_PER_SEC_METRIC = getMetricName(
             "kafka.server", "BrokerTopicMetrics", FAILED_REMOTE_COPY_PER_SEC);
+    public final static MetricName REMOTE_COPY_LOG_BYTES_METRIC = getMetricName(
+            "kafka.server", "BrokerTopicMetrics", REMOTE_COPY_LAG_BYTES);
     public final static MetricName REMOTE_LOG_MANAGER_TASKS_AVG_IDLE_PERCENT_METRIC = getMetricName(
             "kafka.log.remote", "RemoteLogManager", REMOTE_LOG_MANAGER_TASKS_AVG_IDLE_PERCENT);
     public final static MetricName REMOTE_LOG_READER_TASK_QUEUE_SIZE_METRIC = getMetricName(
@@ -67,12 +70,14 @@ public class RemoteStorageMetrics {
 
     public static Set<MetricName> allMetrics() {
         Set<MetricName> metrics = new HashSet<>();
+
         metrics.add(REMOTE_COPY_BYTES_PER_SEC_METRIC);
         metrics.add(REMOTE_FETCH_BYTES_PER_SEC_METRIC);
         metrics.add(REMOTE_FETCH_REQUESTS_PER_SEC_METRIC);
         metrics.add(REMOTE_COPY_REQUESTS_PER_SEC_METRIC);
         metrics.add(FAILED_REMOTE_FETCH_PER_SEC_METRIC);
         metrics.add(FAILED_REMOTE_COPY_PER_SEC_METRIC);
+        metrics.add(REMOTE_COPY_LOG_BYTES_METRIC);
         metrics.add(REMOTE_LOG_MANAGER_TASKS_AVG_IDLE_PERCENT_METRIC);
         metrics.add(REMOTE_LOG_READER_AVG_IDLE_PERCENT_METRIC);
         metrics.add(REMOTE_LOG_READER_TASK_QUEUE_SIZE_METRIC);
@@ -82,15 +87,18 @@ public class RemoteStorageMetrics {
 
     public static Set<MetricName> brokerTopicStatsMetrics() {
         Set<MetricName> metrics = new HashSet<>();
+
         metrics.add(REMOTE_COPY_BYTES_PER_SEC_METRIC);
         metrics.add(REMOTE_FETCH_BYTES_PER_SEC_METRIC);
         metrics.add(REMOTE_FETCH_REQUESTS_PER_SEC_METRIC);
         metrics.add(REMOTE_COPY_REQUESTS_PER_SEC_METRIC);
         metrics.add(FAILED_REMOTE_FETCH_PER_SEC_METRIC);
         metrics.add(FAILED_REMOTE_COPY_PER_SEC_METRIC);
+        metrics.add(REMOTE_COPY_LOG_BYTES_METRIC);
 
         return metrics;
     }
+
     private static MetricName getMetricName(String group, String type, String name) {
         return KafkaYammerMetrics.getMetricName(group, type, name);
     }


### PR DESCRIPTION
### Summary
This pull request implements the first in the list of metrics in [KIP-963: Additional metrics in Tiered Storage](https://cwiki.apache.org/confluence/display/KAFKA/KIP-963%3A+Additional+metrics+in+Tiered+Storage).

Since each partition of a topic will be serviced by its own RLMTask we need an aggregator object for a topic. The aggregator object in this pull request is `BrokerTopicAggregatedMetric`. Since the RemoteCopyLagBytes is a gauge I have introduced a new `GaugeWrapper`. The GaugeWrapper is used by the metrics collection system to interact with the BrokerTopicAggregatedMetric. The RemoteLogManager interacts with the BrokerTopicAggregatedMetric directly.