### PR TITLE
KAFKA-15361: Process and persist dir info with broker registration

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidRegistrationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidRegistrationException.java
@@ -14,19 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.kafka.common.errors;
 
-package org.apache.kafka.metadata.util;
+/**
+ * Thrown when a broker registration request is considered invalid by the controller.
+ */
+public class InvalidRegistrationException extends ApiException {
 
-import org.apache.kafka.server.common.MetadataVersion;
-import org.mockito.internal.util.MockUtil;
+    private static final long serialVersionUID = 1L;
 
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-
-public class MetadataFeatureUtil {
-    public static MetadataVersion withDirectoryAssignmentSupport(MetadataVersion metadataVersion) {
-        MetadataVersion spy = MockUtil.isMock(metadataVersion) ? metadataVersion : spy(metadataVersion);
-        when(spy.isDirectoryAssignmentSupported()).thenReturn(true);
-        return spy;
+    public InvalidRegistrationException(String message) {
+        super(message);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -64,6 +64,7 @@ import org.apache.kafka.common.errors.InvalidPartitionsException;
 import org.apache.kafka.common.errors.InvalidPidMappingException;
 import org.apache.kafka.common.errors.InvalidPrincipalTypeException;
 import org.apache.kafka.common.errors.InvalidProducerEpochException;
+import org.apache.kafka.common.errors.InvalidRegistrationException;
 import org.apache.kafka.common.errors.InvalidReplicaAssignmentException;
 import org.apache.kafka.common.errors.InvalidReplicationFactorException;
 import org.apache.kafka.common.errors.InvalidRequestException;
@@ -390,7 +391,8 @@ public enum Errors {
     UNSUPPORTED_ENDPOINT_TYPE(115, "This endpoint type is not supported yet.", UnsupportedEndpointTypeException::new),
     UNKNOWN_CONTROLLER_ID(116, "This controller ID is not known.", UnknownControllerIdException::new),
     UNKNOWN_SUBSCRIPTION_ID(117, "Client sent a push telemetry request with an invalid or outdated subscription ID.", UnknownSubscriptionIdException::new),
-    TELEMETRY_TOO_LARGE(118, "Client sent a push telemetry request larger than the maximum size the broker will accept.", TelemetryTooLargeException::new);
+    TELEMETRY_TOO_LARGE(118, "Client sent a push telemetry request larger than the maximum size the broker will accept.", TelemetryTooLargeException::new),
+    INVALID_REGISTRATION(119, "The controller has considered the broker registration to be invalid.", InvalidRegistrationException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -249,8 +249,11 @@ public class ReplicationControlManager {
 
         @Override
         public Uuid defaultDir(int brokerId) {
-            // TODO KAFKA-15361 & KAFKA-15364 determine default dir based on broker registration and heartbeat
-            return DirectoryId.MIGRATING;
+            if (featureControl.metadataVersion().isDirectoryAssignmentSupported()) {
+                return clusterControl.defaultDir(brokerId);
+            } else {
+                return DirectoryId.MIGRATING;
+            }
         }
     }
 
@@ -2104,8 +2107,7 @@ public class ReplicationControlManager {
                 return false;
             }
             Uuid replicaDirectory = partition.directory(brokerId);
-            BrokerRegistration brokerRegistration = clusterControl.brokerRegistrations().get(brokerId);
-            return brokerRegistration.hasOnlineDir(replicaDirectory);
+            return clusterControl.hasOnlineDir(brokerId, replicaDirectory);
         }
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -347,7 +347,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
         }
         metrics.updateLastAppliedImageProvenance(image.provenance());
         metrics.setCurrentMetadataVersion(image.features().metadataVersion());
-        if (uninitializedPublishers.isEmpty()) {
+        if (!uninitializedPublishers.isEmpty()) {
             scheduleInitializeNewPublishers(0);
         }
     }

--- a/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistration.java
@@ -159,7 +159,7 @@ public class BrokerRegistration {
     private final boolean fenced;
     private final boolean inControlledShutdown;
     private final boolean isMigratingZkBroker;
-    private final List<Uuid> directories;
+    private final List<Uuid> sortedDirectories;
 
     private BrokerRegistration(
         int id,
@@ -192,7 +192,7 @@ public class BrokerRegistration {
         this.isMigratingZkBroker = isMigratingZkBroker;
         directories = new ArrayList<>(directories);
         directories.sort(Uuid::compareTo);
-        this.directories = Collections.unmodifiableList(directories);
+        this.sortedDirectories = Collections.unmodifiableList(directories);
     }
 
     public static BrokerRegistration fromRecord(RegisterBrokerRecord record) {
@@ -264,8 +264,12 @@ public class BrokerRegistration {
         return isMigratingZkBroker;
     }
 
+    public List<Uuid> directories() {
+        return sortedDirectories;
+    }
+
     public boolean hasOnlineDir(Uuid dir) {
-        return DirectoryId.isOnline(dir, directories);
+        return DirectoryId.isOnline(dir, sortedDirectories);
     }
 
     public ApiMessageAndVersion toRecord(ImageWriterOptions options) {
@@ -292,8 +296,8 @@ public class BrokerRegistration {
             }
         }
 
-        if (directories.isEmpty() || options.metadataVersion().isDirectoryAssignmentSupported()) {
-            registrationRecord.setLogDirs(directories);
+        if (sortedDirectories.isEmpty() || options.metadataVersion().isDirectoryAssignmentSupported()) {
+            registrationRecord.setLogDirs(sortedDirectories);
         } else {
             options.handleLoss("the online log directories of one or more brokers");
         }
@@ -321,7 +325,7 @@ public class BrokerRegistration {
     @Override
     public int hashCode() {
         return Objects.hash(id, epoch, incarnationId, listeners, supportedFeatures,
-            rack, fenced, inControlledShutdown, isMigratingZkBroker, directories);
+            rack, fenced, inControlledShutdown, isMigratingZkBroker, sortedDirectories);
     }
 
     @Override
@@ -337,7 +341,7 @@ public class BrokerRegistration {
             other.fenced == fenced &&
             other.inControlledShutdown == inControlledShutdown &&
             other.isMigratingZkBroker == isMigratingZkBroker &&
-            other.directories.equals(directories);
+            other.sortedDirectories.equals(sortedDirectories);
     }
 
     @Override
@@ -359,7 +363,7 @@ public class BrokerRegistration {
         bld.append(", fenced=").append(fenced);
         bld.append(", inControlledShutdown=").append(inControlledShutdown);
         bld.append(", isMigratingZkBroker=").append(isMigratingZkBroker);
-        bld.append(", directories=").append(directories);
+        bld.append(", directories=").append(sortedDirectories);
         bld.append(")");
         return bld.toString();
     }
@@ -384,7 +388,7 @@ public class BrokerRegistration {
             newFenced,
             newInControlledShutdownChange,
             isMigratingZkBroker,
-            directories
+            sortedDirectories
         );
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -49,7 +49,6 @@ import static org.apache.kafka.controller.PartitionChangeBuilder.Election;
 import static org.apache.kafka.controller.PartitionChangeBuilder.changeRecordIsNoOp;
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;
 import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER_CHANGE;
-import static org.apache.kafka.metadata.util.MetadataFeatureUtil.withDirectoryAssignmentSupport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1058,7 +1057,7 @@ public class PartitionChangeBuilderTest {
                 setPartitionEpoch(200).
                 build();
         Optional<ApiMessageAndVersion> built = new PartitionChangeBuilder(registration, FOO_ID,
-                0, r -> true, withDirectoryAssignmentSupport(MetadataVersion.latest()), 2).
+                0, r -> true, MetadataVersion.latest(), 2).
                 setDirectory(3, Uuid.fromString("pN1VKs9zRzK4APflpegAVg")).
                 setDirectory(1, DirectoryId.LOST).
                 setDefaultDirProvider(DEFAULT_DIR_PROVIDER).

--- a/metadata/src/test/java/org/apache/kafka/controller/ProducerIdControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ProducerIdControlManagerTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.metadata.RegisterBrokerRecord;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.server.common.ProducerIdsBlock;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +50,6 @@ public class ProducerIdControlManagerTest {
             setQuorumFeatures(new QuorumFeatures(0,
                 QuorumFeatures.defaultFeatureMap(true),
                 Collections.singletonList(0))).
-            setMetadataVersion(MetadataVersion.latest()).
             build();
         clusterControl = new ClusterControlManager.Builder().
             setTime(time).

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerIntegrationTestUtils.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerIntegrationTestUtils.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.controller;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -95,6 +96,9 @@ public class QuorumControllerIntegrationTestUtils {
                     .setClusterId(controller.clusterId())
                     .setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.latest()))
                     .setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwB" + brokerId))
+                    .setLogDirs(Collections.singletonList(
+                        Uuid.fromString("TESTBROKER" + Integer.toString(100000 + brokerId).substring(1) + "DIRAAAA")
+                    ))
                     .setListeners(new ListenerCollection(
                         Arrays.asList(
                             new Listener()

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -193,6 +193,7 @@ public class QuorumControllerTest {
                 new BrokerRegistrationRequestData().
                 setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV3)).
                 setBrokerId(0).
+                setLogDirs(Collections.singletonList(Uuid.fromString("iiaQjkRPQcuMULNII0MUeA"))).
                 setClusterId(logEnv.clusterId())).get();
             testConfigurationOperations(controlEnv.activeController());
 
@@ -236,6 +237,7 @@ public class QuorumControllerTest {
                 new BrokerRegistrationRequestData().
                     setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV3)).
                     setBrokerId(0).
+                    setLogDirs(Collections.singletonList(Uuid.fromString("sTbzRAMnTpahIyIPNjiLhw"))).
                     setClusterId(logEnv.clusterId())).get();
             testDelayedConfigurationOperations(logEnv, controlEnv.activeController());
 
@@ -577,6 +579,7 @@ public class QuorumControllerTest {
                     setClusterId(active.clusterId()).
                     setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwBA")).
                     setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV3)).
+                    setLogDirs(Collections.singletonList(Uuid.fromString("vBpaRsZVSaGsQT53wtYGtg"))).
                     setListeners(listeners));
             assertEquals(5L, reply.get().epoch());
             CreateTopicsRequestData createTopicsRequestData =

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisherTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisherTest.java
@@ -47,7 +47,6 @@ import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.Fak
 import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.fakePartitionRegistration;
 import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.fakeTopicImage;
 import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.fakeTopicsImage;
-import static org.apache.kafka.metadata.util.MetadataFeatureUtil.withDirectoryAssignmentSupport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ControllerMetadataMetricsPublisherTest {
@@ -146,7 +145,7 @@ public class ControllerMetadataMetricsPublisherTest {
             MetadataDelta delta = new MetadataDelta(MetadataImage.EMPTY);
             ImageReWriter writer = new ImageReWriter(delta);
             IMAGE1.write(writer, new ImageWriterOptions.Builder().
-                    setMetadataVersion(withDirectoryAssignmentSupport(delta.image().features().metadataVersion())).
+                    setMetadataVersion(delta.image().features().metadataVersion()).
                     build());
             env.publisher.onMetadataUpdate(delta, IMAGE1, fakeManifest(true));
             assertEquals(0, env.metrics.activeBrokerCount());

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsChangesTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsChangesTest.java
@@ -36,7 +36,6 @@ import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.Fak
 import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.FakePartitionRegistrationType.NON_PREFERRED_LEADER;
 import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.FakePartitionRegistrationType.OFFLINE;
 import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.fakePartitionRegistration;
-import static org.apache.kafka.metadata.util.MetadataFeatureUtil.withDirectoryAssignmentSupport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ControllerMetricsChangesTest {
@@ -157,7 +156,7 @@ public class ControllerMetricsChangesTest {
 
     static {
         ImageWriterOptions options = new ImageWriterOptions.Builder().
-                setMetadataVersion(withDirectoryAssignmentSupport(MetadataVersion.IBP_3_7_IV0)).build(); // highest MV for PartitionRecord v0
+                setMetadataVersion(MetadataVersion.IBP_3_7_IV0).build(); // highest MV for PartitionRecord v0
         TOPIC_DELTA1 = new TopicDelta(new TopicImage("foo", FOO_ID, Collections.emptyMap()));
         TOPIC_DELTA1.replay((PartitionRecord) fakePartitionRegistration(NORMAL).
                 toRecord(FOO_ID, 0, options).message());

--- a/metadata/src/test/java/org/apache/kafka/image/ImageDowngradeTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/ImageDowngradeTest.java
@@ -38,7 +38,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
-import static org.apache.kafka.metadata.util.MetadataFeatureUtil.withDirectoryAssignmentSupport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
@@ -132,7 +131,7 @@ public class ImageDowngradeTest {
     @Test
     void testDirectoryAssignmentState() {
         MetadataVersion outputMetadataVersion = MetadataVersion.IBP_3_7_IV0;
-        MetadataVersion inputMetadataVersion = withDirectoryAssignmentSupport(outputMetadataVersion);
+        MetadataVersion inputMetadataVersion = outputMetadataVersion;
         PartitionRecord testPartitionRecord = (PartitionRecord) TEST_RECORDS.get(1).message();
         writeWithExpectedLosses(outputMetadataVersion,
                 Collections.singletonList("the directory assignment state of one or more replicas"),

--- a/metadata/src/test/java/org/apache/kafka/image/MetadataImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/MetadataImageTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Timeout;
 import java.util.List;
 import java.util.Optional;
 
-import static org.apache.kafka.metadata.util.MetadataFeatureUtil.withDirectoryAssignmentSupport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
@@ -115,7 +114,7 @@ public class MetadataImageTest {
 
     private static void testToImage(MetadataImage image) {
         testToImage(image, new ImageWriterOptions.Builder()
-            .setMetadataVersion(withDirectoryAssignmentSupport(image.features().metadataVersion()))
+            .setMetadataVersion(image.features().metadataVersion())
             .build(), Optional.empty());
     }
 

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -29,7 +29,6 @@ import org.apache.kafka.image.writer.RecordListWriter;
 import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.metadata.RecordTestUtils;
-import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.server.immutable.ImmutableMap;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.junit.jupiter.api.Test;
@@ -49,7 +48,6 @@ import static org.apache.kafka.common.metadata.MetadataRecordType.PARTITION_CHAN
 import static org.apache.kafka.common.metadata.MetadataRecordType.PARTITION_RECORD;
 import static org.apache.kafka.common.metadata.MetadataRecordType.REMOVE_TOPIC_RECORD;
 import static org.apache.kafka.common.metadata.MetadataRecordType.TOPIC_RECORD;
-import static org.apache.kafka.metadata.util.MetadataFeatureUtil.withDirectoryAssignmentSupport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -440,9 +438,7 @@ public class TopicsImageTest {
 
     private static List<ApiMessageAndVersion> getImageRecords(TopicsImage image) {
         RecordListWriter writer = new RecordListWriter();
-        image.write(writer, new ImageWriterOptions.Builder().
-                setMetadataVersion(withDirectoryAssignmentSupport(MetadataVersion.latest())).
-                build());
+        image.write(writer, new ImageWriterOptions.Builder().build());
         return writer.records();
     }
 


### PR DESCRIPTION
Controllers should process and persist directory information from the broker registration request


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
