### PR TITLE
KAFKA-14412: Add ProcessingThread tag interface

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessingThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessingThread.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.streams.processor.internals.tasks.DefaultTaskExecutor;
+
+/**
+ * Common interface for {@link StreamThread} and {@link DefaultTaskExecutor} threads.
+ *
+ * This interface defines no behaviour, but tags processing threads so they can be differentiated from interactive query
+ * threads.
+ */
+public interface ProcessingThread {
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -76,7 +76,7 @@ import static org.apache.kafka.streams.processor.internals.ClientUtils.getConsum
 import static org.apache.kafka.streams.processor.internals.ClientUtils.getRestoreConsumerClientId;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.getSharedAdminClientId;
 
-public class StreamThread extends Thread {
+public class StreamThread extends Thread implements ProcessingThread {
 
     /**
      * Stream thread states are the possible states that a stream thread can be in.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.processor.internals.ProcessingThread;
 import org.apache.kafka.streams.processor.internals.ReadOnlyTask;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.Task;
@@ -39,7 +40,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class DefaultTaskExecutor implements TaskExecutor {
 
-    private class TaskExecutorThread extends Thread {
+    private class TaskExecutorThread extends Thread implements ProcessingThread {
 
         private final AtomicBoolean shutdownRequested = new AtomicBoolean(false);
         private final AtomicReference<KafkaFutureImpl<StreamTask>> taskReleaseRequested = new AtomicReference<>(null);


### PR DESCRIPTION
This interface provides a common supertype for `StreamThread` and `DefaultTaskExecutor.TaskExecutorThread`, which will be used by KIP-892 to differentiate between "processing" threads and interactive query threads.

This is needed because `DefaultTaskExecutor.TaskExecutorThread` is `private`, so cannot be seen directly from `RocksDBStore`.
