### PR TITLE
KAFKA-15894: Fix KafkaApis.updateRecordConversionStats to ensure MessageConversionsTimeMs and TemporaryMemoryBytes are recorded correctly

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3920,9 +3920,9 @@ class KafkaApis(val requestChannel: RequestChannel,
         case _ =>
           throw new IllegalStateException("Message conversion info is recorded only for Produce/Fetch requests")
       }
-      request.messageConversionsTimeNanos = conversionStats.conversionTimeNanos
+      request.messageConversionsTimeNanos += conversionStats.conversionTimeNanos
     }
-    request.temporaryMemoryBytes = conversionStats.temporaryMemoryBytes
+    request.temporaryMemoryBytes += conversionStats.temporaryMemoryBytes
   }
 }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -7274,4 +7274,57 @@ class KafkaApisTest extends Logging {
     val expectedResponse = new ListClientMetricsResourcesResponseData().setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code)
     assertEquals(expectedResponse, response.data)
   }
+
+  @Test
+  def testUpdateConversionStats(): Unit = {
+    val topic = "topic"
+    addTopicToMetadataCache(topic, numPartitions = 2)
+
+    reset(replicaManager, requestChannel)
+
+    val tp0 = new TopicPartition("topic", 0)
+    val tp1 = new TopicPartition("topic", 1)
+
+    val produceRequest = ProduceRequest.forCurrentMagic(new ProduceRequestData()
+        .setTopicData(new ProduceRequestData.TopicProduceDataCollection(
+          Collections.singletonList(new ProduceRequestData.TopicProduceData()
+              .setName(tp0.topic).setPartitionData(
+                asList(
+                  new ProduceRequestData.PartitionProduceData()
+                    .setIndex(tp0.partition)
+                    .setRecords(MemoryRecords.withRecords(CompressionType.NONE, new SimpleRecord("test".getBytes))),
+                  new ProduceRequestData.PartitionProduceData()
+                    .setIndex(tp1.partition)
+                    .setRecords(MemoryRecords.withRecords(CompressionType.NONE, new SimpleRecord("test".getBytes)))
+                )))
+            .iterator))
+        .setAcks(1.toShort)
+        .setTimeoutMs(5000))
+      .build(ApiKeys.PRODUCE.latestVersion)
+
+    val request = buildRequest(produceRequest)
+
+    val recordValidationStatsCallback: ArgumentCaptor[Map[TopicPartition, RecordValidationStats] => Unit] =
+      ArgumentCaptor.forClass(classOf[Map[TopicPartition, RecordValidationStats] => Unit])
+
+    val recordConversionStats = Map(
+      tp0 -> new RecordValidationStats(256, 1, 1000),
+      tp1 -> new RecordValidationStats(128, 1, 500))
+
+    when(replicaManager.handleProduceAppend(anyLong,
+      anyShort,
+      ArgumentMatchers.eq(false),
+      any(),
+      any(),
+      any(),
+      recordValidationStatsCallback.capture(),
+      any(),
+      any()
+    )).thenAnswer(_ => recordValidationStatsCallback.getValue.apply(recordConversionStats))
+
+    createKafkaApis().handleProduceRequest(request, RequestLocal.withThreadConfinedCaching)
+
+    assertEquals(1500, request.messageConversionsTimeNanos)
+    assertEquals(384, request.temporaryMemoryBytes)
+  }
 }


### PR DESCRIPTION
`KafkaApis.updateRecordConversionStats` may be called multiple times for a request, and `request.messageConversionsTimeNanos` and `request.temporaryMemoryBytes` are overwritten in this method. 

```scala
def processingStatsCallback(processingStats: FetchResponseStats): Unit = {
  processingStats.forKeyValue { (tp, info) =>
    updateRecordConversionStats(request, tp, info)
  }
}
```
```scala
private def updateRecordConversionStats(request: RequestChannel.Request,
                                          tp: TopicPartition,
                                          conversionStats: RecordValidationStats): Unit = {
...
    request.messageConversionsTimeNanos = conversionStats.conversionTimeNanos
  }
  request.temporaryMemoryBytes = conversionStats.temporaryMemoryBytes
}
```

So, in that case, MessageConversionsTimeMs and TemporaryMemoryBytes are not recorded correctly.
This Pull Request has fixed the code to add up each value instead of overwriting.

To test this behavior, this PR also added a test that sends a ProduceRequest containing multiple partitions and calls `updateRecordConversionStats` through `processingStatsCallback`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
