### PR TITLE
KAFKA-14505; [1/N] Add support for transactional writes to CoordinatorRuntime

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/CoordinatorLoaderImpl.scala
+++ b/core/src/main/scala/kafka/coordinator/group/CoordinatorLoaderImpl.scala
@@ -139,7 +139,11 @@ class CoordinatorLoaderImpl[T](
                 batch.asScala.foreach { record =>
                   numRecords = numRecords + 1
                   try {
-                    coordinator.replay(deserializer.deserialize(record.key, record.value))
+                    coordinator.replay(
+                      batch.producerId,
+                      batch.producerEpoch,
+                      deserializer.deserialize(record.key, record.value)
+                    )
                   } catch {
                     case ex: UnknownRecordTypeException =>
                       warn(s"Unknown record type ${ex.unknownType} while loading offsets and group metadata " +

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -590,12 +590,18 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
 
     /**
      * Replays the Record to update the hard state of the group coordinator.
-
-     * @param record The record to apply to the state machine.
+     *
+     * @param producerId    The producer id.
+     * @param producerEpoch The producer epoch.
+     * @param record        The record to apply to the state machine.
      * @throws RuntimeException
      */
     @Override
-    public void replay(Record record) throws RuntimeException {
+    public void replay(
+        long producerId,
+        short producerEpoch,
+        Record record
+    ) throws RuntimeException {
         ApiMessageAndVersion key = record.key();
         ApiMessageAndVersion value = record.value();
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorPlayback.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorPlayback.java
@@ -25,12 +25,17 @@ package org.apache.kafka.coordinator.group.runtime;
  * @param <U> The type of the record.
  */
 public interface CoordinatorPlayback<U> {
-
     /**
      * Applies the given record to this object.
      *
-     * @param record A record.
+     * @param producerId    The producer id.
+     * @param producerEpoch The producer epoch.
+     * @param record        A record.
      * @throws RuntimeException if the record can not be applied.
      */
-    void replay(U record) throws RuntimeException;
+    void replay(
+        long producerId,
+        short producerEpoch,
+        U record
+    ) throws RuntimeException;
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/PartitionWriter.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/PartitionWriter.java
@@ -83,13 +83,17 @@ public interface PartitionWriter<T> {
      * Write records to the partitions. Records are written in one batch so
      * atomicity is guaranteed.
      *
-     * @param tp        The partition to write records to.
-     * @param records   The list of records. The records are written in a single batch.
+     * @param tp            The partition to write records to.
+     * @param producerId    The producer id.
+     * @param producerEpoch The producer epoch.
+     * @param records       The list of records. The records are written in a single batch.
      * @return The log end offset right after the written records.
      * @throws KafkaException Any KafkaException caught during the write operation.
      */
     long append(
         TopicPartition tp,
+        long producerId,
+        short producerEpoch,
         List<T> records
     ) throws KafkaException;
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.message.OffsetCommitRequestData;
 import org.apache.kafka.common.message.OffsetCommitResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
@@ -282,12 +283,12 @@ public class GroupCoordinatorShardTest {
         OffsetCommitKey key = new OffsetCommitKey();
         OffsetCommitValue value = new OffsetCommitValue();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 0),
             new ApiMessageAndVersion(value, (short) 0)
         ));
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 1),
             new ApiMessageAndVersion(value, (short) 0)
         ));
@@ -313,12 +314,12 @@ public class GroupCoordinatorShardTest {
 
         OffsetCommitKey key = new OffsetCommitKey();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 0),
             null
         ));
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 1),
             null
         ));
@@ -345,7 +346,7 @@ public class GroupCoordinatorShardTest {
         ConsumerGroupMetadataKey key = new ConsumerGroupMetadataKey();
         ConsumerGroupMetadataValue value = new ConsumerGroupMetadataValue();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 3),
             new ApiMessageAndVersion(value, (short) 0)
         ));
@@ -371,7 +372,7 @@ public class GroupCoordinatorShardTest {
 
         ConsumerGroupMetadataKey key = new ConsumerGroupMetadataKey();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 3),
             null
         ));
@@ -398,7 +399,7 @@ public class GroupCoordinatorShardTest {
         ConsumerGroupPartitionMetadataKey key = new ConsumerGroupPartitionMetadataKey();
         ConsumerGroupPartitionMetadataValue value = new ConsumerGroupPartitionMetadataValue();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 4),
             new ApiMessageAndVersion(value, (short) 0)
         ));
@@ -424,7 +425,7 @@ public class GroupCoordinatorShardTest {
 
         ConsumerGroupPartitionMetadataKey key = new ConsumerGroupPartitionMetadataKey();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 4),
             null
         ));
@@ -451,7 +452,7 @@ public class GroupCoordinatorShardTest {
         ConsumerGroupMemberMetadataKey key = new ConsumerGroupMemberMetadataKey();
         ConsumerGroupMemberMetadataValue value = new ConsumerGroupMemberMetadataValue();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 5),
             new ApiMessageAndVersion(value, (short) 0)
         ));
@@ -477,7 +478,7 @@ public class GroupCoordinatorShardTest {
 
         ConsumerGroupMemberMetadataKey key = new ConsumerGroupMemberMetadataKey();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 5),
             null
         ));
@@ -504,7 +505,7 @@ public class GroupCoordinatorShardTest {
         ConsumerGroupTargetAssignmentMetadataKey key = new ConsumerGroupTargetAssignmentMetadataKey();
         ConsumerGroupTargetAssignmentMetadataValue value = new ConsumerGroupTargetAssignmentMetadataValue();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 6),
             new ApiMessageAndVersion(value, (short) 0)
         ));
@@ -530,7 +531,7 @@ public class GroupCoordinatorShardTest {
 
         ConsumerGroupTargetAssignmentMetadataKey key = new ConsumerGroupTargetAssignmentMetadataKey();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 6),
             null
         ));
@@ -557,7 +558,7 @@ public class GroupCoordinatorShardTest {
         ConsumerGroupTargetAssignmentMemberKey key = new ConsumerGroupTargetAssignmentMemberKey();
         ConsumerGroupTargetAssignmentMemberValue value = new ConsumerGroupTargetAssignmentMemberValue();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 7),
             new ApiMessageAndVersion(value, (short) 0)
         ));
@@ -583,7 +584,7 @@ public class GroupCoordinatorShardTest {
 
         ConsumerGroupTargetAssignmentMemberKey key = new ConsumerGroupTargetAssignmentMemberKey();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 7),
             null
         ));
@@ -610,7 +611,7 @@ public class GroupCoordinatorShardTest {
         ConsumerGroupCurrentMemberAssignmentKey key = new ConsumerGroupCurrentMemberAssignmentKey();
         ConsumerGroupCurrentMemberAssignmentValue value = new ConsumerGroupCurrentMemberAssignmentValue();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 8),
             new ApiMessageAndVersion(value, (short) 0)
         ));
@@ -636,7 +637,7 @@ public class GroupCoordinatorShardTest {
 
         ConsumerGroupCurrentMemberAssignmentKey key = new ConsumerGroupCurrentMemberAssignmentKey();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 8),
             null
         ));
@@ -660,7 +661,12 @@ public class GroupCoordinatorShardTest {
             metricsShard
         );
 
-        assertThrows(NullPointerException.class, () -> coordinator.replay(new Record(null, null)));
+        assertThrows(NullPointerException.class, () ->
+            coordinator.replay(
+                RecordBatch.NO_PRODUCER_ID,
+                RecordBatch.NO_PRODUCER_EPOCH,
+                new Record(null, null))
+        );
     }
 
     @Test
@@ -682,10 +688,12 @@ public class GroupCoordinatorShardTest {
         ConsumerGroupCurrentMemberAssignmentKey key = new ConsumerGroupCurrentMemberAssignmentKey();
         ConsumerGroupCurrentMemberAssignmentValue value = new ConsumerGroupCurrentMemberAssignmentValue();
 
-        assertThrows(IllegalStateException.class, () -> coordinator.replay(new Record(
-            new ApiMessageAndVersion(key, (short) 255),
-            new ApiMessageAndVersion(value, (short) 0)
-        )));
+        assertThrows(IllegalStateException.class, () ->
+            coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
+                new ApiMessageAndVersion(key, (short) 255),
+                new ApiMessageAndVersion(value, (short) 0)
+            ))
+        );
     }
 
     @Test
@@ -734,7 +742,7 @@ public class GroupCoordinatorShardTest {
         GroupMetadataKey key = new GroupMetadataKey();
         GroupMetadataValue value = new GroupMetadataValue();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 2),
             new ApiMessageAndVersion(value, (short) 4)
         ));
@@ -760,7 +768,7 @@ public class GroupCoordinatorShardTest {
 
         GroupMetadataKey key = new GroupMetadataKey();
 
-        coordinator.replay(new Record(
+        coordinator.replay(RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, new Record(
             new ApiMessageAndVersion(key, (short) 2),
             null
         ));

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/InMemoryPartitionWriter.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/InMemoryPartitionWriter.java
@@ -86,6 +86,8 @@ public class InMemoryPartitionWriter<T> implements PartitionWriter<T> {
     @Override
     public long append(
         TopicPartition tp,
+        long producerId,
+        short producerEpoch,
         List<T> records
     ) throws KafkaException {
         PartitionState state = partitionState(tp);


### PR DESCRIPTION
This patch adds support for transactional writes to the `CoordinatorRuntime` framework. This mainly consists in adding `CoordinatorRuntime#scheduleTransactionalWriteOperation` and in adding the `producerId` and `producerEpoch` to various interfaces. The patch also extends the `CoordinatorLoaderImpl` and the `CoordinatorPartitionWriter` accordingly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
