### PR TITLE
KAFKA-15870: Move new group coordinator metrics from Yammer to Metrics

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -62,7 +62,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.kafka.common.requests.OffsetFetchResponse.INVALID_OFFSET;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_OFFSETS;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.OFFSET_DELETIONS_SENSOR_NAME;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.OFFSET_EXPIRED_SENSOR_NAME;
 
@@ -871,7 +870,7 @@ public class OffsetMetadataManager {
                     OffsetAndMetadata.fromRecord(value)
                 );
                 if (previousValue == null) {
-                    metrics.incrementLocalGauge(NUM_OFFSETS);
+                    metrics.incrementNumOffsets();
                 }
             } else {
                 // Otherwise, the transaction offset is stored in the pending transactional
@@ -887,7 +886,7 @@ public class OffsetMetadataManager {
             }
         } else {
             if (offsets.remove(groupId, topic, partition) != null) {
-                metrics.decrementLocalGauge(NUM_OFFSETS);
+                metrics.decrementNumOffsets();
             }
         }
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/CoordinatorMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/CoordinatorMetrics.java
@@ -22,19 +22,59 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.server.metrics.KafkaYammerMetrics;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
+/**
+ * CoordinatorMetrics contain all coordinator related metrics. It delegates metrics collection to
+ * {@link CoordinatorMetricsShard}s and aggregates them all when it reports to the metrics registry.
+ */
 public abstract class CoordinatorMetrics {
 
+    /**
+     * Create a new metrics shard.
+     * @param snapshotRegistry  The snapshot registry.
+     * @param tp                The topic partition corresponding to the shard.
+     *
+     * @return The metrics shard.
+     */
     public abstract CoordinatorMetricsShard newMetricsShard(SnapshotRegistry snapshotRegistry, TopicPartition tp);
 
+    /**
+     * Activate the metrics shard. This shard is now able to collect metrics.
+     *
+     * @param shard  The metrics shard.
+     */
     public abstract void activateMetricsShard(CoordinatorMetricsShard shard);
 
+    /**
+     * Deactivate the metrics shard. This shard should not be part of the metrics aggregation.
+     *
+     * @param shard  The metrics shard.
+     */
     public abstract void deactivateMetricsShard(CoordinatorMetricsShard shard);
 
+    /**
+     * @return The metrics registry.
+     */
     public abstract MetricsRegistry registry();
 
+    /**
+     * Generate the Yammer MetricName.
+     *
+     * @param group The metric group.
+     * @param type  The metric type.
+     * @param name  The metric name.
+     *
+     * @return the yammer metric name.
+     */
     public static MetricName getMetricName(String group, String type, String name) {
         return KafkaYammerMetrics.getMetricName(group, type, name);
     }
 
+    /**
+     * Invoked when the last committed offset has been updated. This is used as a listener for metrics
+     * relying on a snapshot registry.
+     *
+     * @param tp      The topic partition.
+     * @param offset  The updated offset.
+     */
     public abstract void onUpdateLastCommittedOffset(TopicPartition tp, long offset);
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/CoordinatorMetricsShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/CoordinatorMetricsShard.java
@@ -16,58 +16,16 @@
  */
 package org.apache.kafka.coordinator.group.metrics;
 
-import com.yammer.metrics.core.MetricName;
 import org.apache.kafka.common.TopicPartition;
 
 /**
- * A CoordinatorMetricsShard is mapped to a single CoordinatorShard. For gauges, each metrics shard increments/decrements
- * based on the operations performed. Then, {@link CoordinatorMetrics} will perform aggregations across all shards.
+ * A CoordinatorMetricsShard is mapped to a single CoordinatorShard. The metrics shard records sensors that have been
+ * defined in {@link CoordinatorMetrics}. Coordinator specific gauges and related methods are exposed in the
+ * implementation of CoordinatorMetricsShard (i.e. {@link GroupCoordinatorMetricsShard}).
  *
  * For sensors, each shard individually records the observed values.
  */
 public interface CoordinatorMetricsShard {
-    /**
-     * Increment a global gauge.
-     *
-     * @param metricName the metric name.
-     */
-    void incrementGlobalGauge(MetricName metricName);
-
-    /**
-     * Increment a local gauge.
-     *
-     * @param metricName the metric name.
-     */
-    void incrementLocalGauge(MetricName metricName);
-
-    /**
-     * Decrement a global gauge.
-     *
-     * @param metricName the metric name.
-     */
-    void decrementGlobalGauge(MetricName metricName);
-
-    /**
-     * Decrement a local gauge.
-     *
-     * @param metricName the metric name.
-     */
-    void decrementLocalGauge(MetricName metricName);
-
-    /**
-     * Obtain the current value of a global gauge.
-     *
-     * @param metricName the metric name.
-     */
-    long globalGaugeValue(MetricName metricName);
-
-    /**
-     * Obtain the current value of a local gauge.
-     *
-     * @param metricName the metric name.
-     */
-    long localGaugeValue(MetricName metricName);
-
     /**
      * Increment the value of a sensor.
      *

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
@@ -16,57 +16,50 @@
  */
 package org.apache.kafka.coordinator.group.metrics;
 
-import com.yammer.metrics.core.Gauge;
-import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Meter;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.coordinator.group.Group;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroup;
+import org.apache.kafka.coordinator.group.generic.GenericGroupState;
 import org.apache.kafka.server.metrics.KafkaYammerMetrics;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * These are the metrics which are managed by the {@link org.apache.kafka.coordinator.group.GroupMetadataManager} class.
  * They generally pertain to aspects of group management, such as the number of groups in different states.
  */
 public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoCloseable {
+
     public static final String METRICS_GROUP = "group-coordinator-metrics";
 
-    public final static MetricName NUM_OFFSETS = getMetricName(
+    public final static com.yammer.metrics.core.MetricName NUM_OFFSETS = getMetricName(
         "GroupMetadataManager", "NumOffsets");
-    public final static MetricName NUM_GENERIC_GROUPS = getMetricName(
-        "GroupMetadataManager", "NumGroups");
-    public final static MetricName NUM_GENERIC_GROUPS_PREPARING_REBALANCE = getMetricName(
+    public final static com.yammer.metrics.core.MetricName NUM_GENERIC_GROUPS_PREPARING_REBALANCE = getMetricName(
         "GroupMetadataManager", "NumGroupsPreparingRebalance");
-    public final static MetricName NUM_GENERIC_GROUPS_COMPLETING_REBALANCE = getMetricName(
+    public final static com.yammer.metrics.core.MetricName NUM_GENERIC_GROUPS_COMPLETING_REBALANCE = getMetricName(
         "GroupMetadataManager", "NumGroupsCompletingRebalance");
-    public final static MetricName NUM_GENERIC_GROUPS_STABLE = getMetricName(
+    public final static com.yammer.metrics.core.MetricName NUM_GENERIC_GROUPS_STABLE = getMetricName(
         "GroupMetadataManager", "NumGroupsStable");
-    public final static MetricName NUM_GENERIC_GROUPS_DEAD = getMetricName(
+    public final static com.yammer.metrics.core.MetricName NUM_GENERIC_GROUPS_DEAD = getMetricName(
         "GroupMetadataManager", "NumGroupsDead");
-    public final static MetricName NUM_GENERIC_GROUPS_EMPTY = getMetricName(
+    public final static com.yammer.metrics.core.MetricName NUM_GENERIC_GROUPS_EMPTY = getMetricName(
         "GroupMetadataManager", "NumGroupsEmpty");
-    public final static MetricName NUM_CONSUMER_GROUPS = getMetricName(
-        "GroupMetadataManager", "NumConsumerGroups");
-    public final static MetricName NUM_CONSUMER_GROUPS_EMPTY = getMetricName(
-        "GroupMetadataManager", "NumConsumerGroupsEmpty");
-    public final static MetricName NUM_CONSUMER_GROUPS_ASSIGNING = getMetricName(
-        "GroupMetadataManager", "NumConsumerGroupsAssigning");
-    public final static MetricName NUM_CONSUMER_GROUPS_RECONCILING = getMetricName(
-        "GroupMetadataManager", "NumConsumerGroupsReconciling");
-    public final static MetricName NUM_CONSUMER_GROUPS_STABLE = getMetricName(
-        "GroupMetadataManager", "NumConsumerGroupsStable");
-    public final static MetricName NUM_CONSUMER_GROUPS_DEAD = getMetricName(
-        "GroupMetadataManager", "NumConsumerGroupsDead");
+
+    public final static String GROUPS_COUNT_METRIC_NAME = "groups-count";
+    public final static String GROUPS_COUNT_TYPE_TAG = "type";
+    public final static String CONSUMER_GROUPS_COUNT_METRIC_NAME = "consumer-groups-count";
+    public final static String CONSUMER_GROUPS_COUNT_STATE_TAG = "state";
 
     public static final String OFFSET_COMMITS_SENSOR_NAME = "OffsetCommits";
     public static final String OFFSET_EXPIRED_SENSOR_NAME = "OffsetExpired";
@@ -77,28 +70,12 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
 
     private final MetricsRegistry registry;
     private final Metrics metrics;
-    private final Map<TopicPartition, CoordinatorMetricsShard> shards = new HashMap<>();
-    private static final AtomicLong NUM_GENERIC_GROUPS_PREPARING_REBALANCE_COUNTER = new AtomicLong(0);
-    private static final AtomicLong NUM_GENERIC_GROUPS_COMPLETING_REBALANCE_COUNTER = new AtomicLong(0);
-    private static final AtomicLong NUM_GENERIC_GROUPS_STABLE_COUNTER = new AtomicLong(0);
-    private static final AtomicLong NUM_GENERIC_GROUPS_DEAD_COUNTER = new AtomicLong(0);
-    private static final AtomicLong NUM_GENERIC_GROUPS_EMPTY_COUNTER = new AtomicLong(0);
+    private final Map<TopicPartition, GroupCoordinatorMetricsShard> shards = new ConcurrentHashMap<>();
 
     /**
      * Global sensors. These are shared across all metrics shards.
      */
     public final Map<String, Sensor> globalSensors;
-
-    /**
-     * Global gauge counters. These are shared across all metrics shards.
-     */
-    public static final Map<String, AtomicLong> GLOBAL_GAUGES = Collections.unmodifiableMap(Utils.mkMap(
-        Utils.mkEntry(NUM_GENERIC_GROUPS_PREPARING_REBALANCE.getName(), NUM_GENERIC_GROUPS_PREPARING_REBALANCE_COUNTER),
-        Utils.mkEntry(NUM_GENERIC_GROUPS_COMPLETING_REBALANCE.getName(), NUM_GENERIC_GROUPS_COMPLETING_REBALANCE_COUNTER),
-        Utils.mkEntry(NUM_GENERIC_GROUPS_STABLE.getName(), NUM_GENERIC_GROUPS_STABLE_COUNTER),
-        Utils.mkEntry(NUM_GENERIC_GROUPS_DEAD.getName(), NUM_GENERIC_GROUPS_DEAD_COUNTER),
-        Utils.mkEntry(NUM_GENERIC_GROUPS_EMPTY.getName(), NUM_GENERIC_GROUPS_EMPTY_COUNTER)
-    ));
 
     public GroupCoordinatorMetrics() {
         this(KafkaYammerMetrics.defaultRegistry(), new Metrics());
@@ -174,74 +151,90 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
         ));
     }
 
-    public Long numOffsets() {
-        return shards.values().stream().mapToLong(shard -> shard.localGaugeValue(NUM_OFFSETS)).sum();
+    private Long numOffsets() {
+        return shards.values().stream().mapToLong(GroupCoordinatorMetricsShard::numOffsets).sum();
     }
 
-    public Long numGenericGroups() {
-        return shards.values().stream().mapToLong(shard -> shard.localGaugeValue(NUM_GENERIC_GROUPS)).sum();
+    private Long numGenericGroups() {
+        return shards.values().stream().mapToLong(shard -> shard.numGenericGroups(null)).sum();
     }
 
-    public Long numGenericGroupsPreparingRebalanceCount() {
-        return NUM_GENERIC_GROUPS_PREPARING_REBALANCE_COUNTER.get();
+    private Long numGenericGroupsPreparingRebalance() {
+        return shards.values().stream().mapToLong(shard -> shard.numGenericGroups(GenericGroupState.PREPARING_REBALANCE)).sum();
     }
 
-    public Long numGenericGroupsCompletingRebalanceCount() {
-        return NUM_GENERIC_GROUPS_COMPLETING_REBALANCE_COUNTER.get();
+    private Long numGenericGroupsCompletingRebalance() {
+        return shards.values().stream().mapToLong(shard -> shard.numGenericGroups(GenericGroupState.COMPLETING_REBALANCE)).sum();
     }
-    public Long numGenericGroupsStableCount() {
-        return NUM_GENERIC_GROUPS_STABLE_COUNTER.get();
-    }
-
-    public Long numGenericGroupsDeadCount() {
-        return NUM_GENERIC_GROUPS_DEAD_COUNTER.get();
+    private Long numGenericGroupsStable() {
+        return shards.values().stream().mapToLong(shard -> shard.numGenericGroups(GenericGroupState.STABLE)).sum();
     }
 
-    public Long numGenericGroupsEmptyCount() {
-        return NUM_GENERIC_GROUPS_EMPTY_COUNTER.get();
+    private Long numGenericGroupsDead() {
+        return shards.values().stream().mapToLong(shard -> shard.numGenericGroups(GenericGroupState.DEAD)).sum();
     }
 
-    public long numConsumerGroups() {
-        return shards.values().stream().mapToLong(shard -> shard.localGaugeValue(NUM_CONSUMER_GROUPS)).sum();
+    private Long numGenericGroupsEmpty() {
+        return shards.values().stream().mapToLong(shard -> shard.numGenericGroups(GenericGroupState.EMPTY)).sum();
     }
 
-    public long numConsumerGroupsEmpty() {
-        return shards.values().stream().mapToLong(shard -> shard.localGaugeValue(NUM_CONSUMER_GROUPS_EMPTY)).sum();
+    private long numConsumerGroups() {
+        return shards.values().stream().mapToLong(shard -> shard.numConsumerGroups(null)).sum();
     }
 
-    public long numConsumerGroupsAssigning() {
-        return shards.values().stream().mapToLong(shard -> shard.localGaugeValue(NUM_CONSUMER_GROUPS_ASSIGNING)).sum();
+    private long numConsumerGroupsEmpty() {
+        return shards.values().stream().mapToLong(shard -> shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.EMPTY)).sum();
     }
 
-    public long numConsumerGroupsReconciling() {
-        return shards.values().stream().mapToLong(shard -> shard.localGaugeValue(NUM_CONSUMER_GROUPS_RECONCILING)).sum();
+    private long numConsumerGroupsAssigning() {
+        return shards.values().stream().mapToLong(shard -> shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.ASSIGNING)).sum();
     }
 
-    public long numConsumerGroupsStable() {
-        return shards.values().stream().mapToLong(shard -> shard.localGaugeValue(NUM_CONSUMER_GROUPS_STABLE)).sum();
+    private long numConsumerGroupsReconciling() {
+        return shards.values().stream().mapToLong(shard -> shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.RECONCILING)).sum();
     }
 
-    public long numConsumerGroupsDead() {
-        return shards.values().stream().mapToLong(shard -> shard.localGaugeValue(NUM_CONSUMER_GROUPS_DEAD)).sum();
+    private long numConsumerGroupsStable() {
+        return shards.values().stream().mapToLong(shard -> shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE)).sum();
+    }
+
+    private long numConsumerGroupsDead() {
+        return shards.values().stream().mapToLong(shard -> shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.DEAD)).sum();
     }
 
     @Override
     public void close() {
         Arrays.asList(
             NUM_OFFSETS,
-            NUM_GENERIC_GROUPS,
             NUM_GENERIC_GROUPS_PREPARING_REBALANCE,
             NUM_GENERIC_GROUPS_COMPLETING_REBALANCE,
             NUM_GENERIC_GROUPS_STABLE,
             NUM_GENERIC_GROUPS_DEAD,
-            NUM_GENERIC_GROUPS_EMPTY,
-            NUM_CONSUMER_GROUPS,
-            NUM_CONSUMER_GROUPS_EMPTY,
-            NUM_CONSUMER_GROUPS_ASSIGNING,
-            NUM_CONSUMER_GROUPS_RECONCILING,
-            NUM_CONSUMER_GROUPS_STABLE,
-            NUM_CONSUMER_GROUPS_DEAD
+            NUM_GENERIC_GROUPS_EMPTY
         ).forEach(registry::removeMetric);
+
+        metrics.removeMetric(metrics.metricName(CONSUMER_GROUPS_COUNT_METRIC_NAME, METRICS_GROUP));
+
+        Arrays.asList(
+            Group.GroupType.GENERIC,
+            Group.GroupType.CONSUMER
+        ).forEach(tag -> metrics.removeMetric(metrics.metricName(
+            GROUPS_COUNT_METRIC_NAME,
+            METRICS_GROUP,
+            Collections.singletonMap(GROUPS_COUNT_TYPE_TAG, tag.toString())
+        )));
+
+        Arrays.asList(
+            ConsumerGroup.ConsumerGroupState.EMPTY,
+            ConsumerGroup.ConsumerGroupState.ASSIGNING,
+            ConsumerGroup.ConsumerGroupState.RECONCILING,
+            ConsumerGroup.ConsumerGroupState.STABLE,
+            ConsumerGroup.ConsumerGroupState.DEAD
+        ).forEach(tag -> metrics.removeMetric(metrics.metricName(
+            CONSUMER_GROUPS_COUNT_METRIC_NAME,
+            METRICS_GROUP,
+            Collections.singletonMap(CONSUMER_GROUPS_COUNT_STATE_TAG, tag.toString())
+        )));
 
         Arrays.asList(
             OFFSET_COMMITS_SENSOR_NAME,
@@ -255,12 +248,15 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
 
     @Override
     public GroupCoordinatorMetricsShard newMetricsShard(SnapshotRegistry snapshotRegistry, TopicPartition tp) {
-        return new GroupCoordinatorMetricsShard(snapshotRegistry, globalSensors, GLOBAL_GAUGES, tp);
+        return new GroupCoordinatorMetricsShard(snapshotRegistry, globalSensors, tp);
     }
 
     @Override
     public void activateMetricsShard(CoordinatorMetricsShard shard) {
-        shards.put(shard.topicPartition(), shard);
+        if (!(shard instanceof GroupCoordinatorMetricsShard)) {
+            throw new IllegalArgumentException("GroupCoordinatorMetrics can only activate GroupCoordinatorMetricShard");
+        }
+        shards.put(shard.topicPartition(), (GroupCoordinatorMetricsShard) shard);
     }
 
     @Override
@@ -281,100 +277,99 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
         }
     }
 
-    public static MetricName getMetricName(String type, String name) {
+    public static com.yammer.metrics.core.MetricName getMetricName(String type, String name) {
         return getMetricName("kafka.coordinator.group", type, name);
     }
 
     private void registerGauges() {
-        registry.newGauge(NUM_OFFSETS, new Gauge<Long>() {
+        registry.newGauge(NUM_OFFSETS, new com.yammer.metrics.core.Gauge<Long>() {
             @Override
             public Long value() {
                 return numOffsets();
             }
         });
 
-        registry.newGauge(NUM_GENERIC_GROUPS, new Gauge<Long>() {
+        registry.newGauge(NUM_GENERIC_GROUPS_PREPARING_REBALANCE, new com.yammer.metrics.core.Gauge<Long>() {
             @Override
             public Long value() {
-                return numGenericGroups();
+                return numGenericGroupsPreparingRebalance();
             }
         });
 
-        registry.newGauge(NUM_GENERIC_GROUPS_PREPARING_REBALANCE, new Gauge<Long>() {
+        registry.newGauge(NUM_GENERIC_GROUPS_COMPLETING_REBALANCE, new com.yammer.metrics.core.Gauge<Long>() {
             @Override
             public Long value() {
-                return numGenericGroupsPreparingRebalanceCount();
+                return numGenericGroupsCompletingRebalance();
             }
         });
 
-        registry.newGauge(NUM_GENERIC_GROUPS_COMPLETING_REBALANCE, new Gauge<Long>() {
+        registry.newGauge(NUM_GENERIC_GROUPS_STABLE, new com.yammer.metrics.core.Gauge<Long>() {
             @Override
             public Long value() {
-                return numGenericGroupsCompletingRebalanceCount();
+                return numGenericGroupsStable();
             }
         });
 
-        registry.newGauge(NUM_GENERIC_GROUPS_STABLE, new Gauge<Long>() {
+        registry.newGauge(NUM_GENERIC_GROUPS_DEAD, new com.yammer.metrics.core.Gauge<Long>() {
             @Override
             public Long value() {
-                return numGenericGroupsStableCount();
+                return numGenericGroupsDead();
             }
         });
 
-        registry.newGauge(NUM_GENERIC_GROUPS_DEAD, new Gauge<Long>() {
+        registry.newGauge(NUM_GENERIC_GROUPS_EMPTY, new com.yammer.metrics.core.Gauge<Long>() {
             @Override
             public Long value() {
-                return numGenericGroupsDeadCount();
+                return numGenericGroupsEmpty();
             }
         });
+        metrics.addMetric(
+            metrics.metricName(GROUPS_COUNT_METRIC_NAME, METRICS_GROUP, Collections.singletonMap(
+                GROUPS_COUNT_TYPE_TAG, Group.GroupType.GENERIC.toString()
+            )),
+            (Gauge<Long>) (config, now) -> numGenericGroups()
+        );
 
-        registry.newGauge(NUM_GENERIC_GROUPS_EMPTY, new Gauge<Long>() {
-            @Override
-            public Long value() {
-                return numGenericGroupsEmptyCount();
-            }
-        });
+        metrics.addMetric(
+            metrics.metricName(GROUPS_COUNT_METRIC_NAME, METRICS_GROUP, Collections.singletonMap(
+                GROUPS_COUNT_TYPE_TAG, Group.GroupType.CONSUMER.toString()
+            )),
+            (Gauge<Long>) (config, now) -> numConsumerGroups()
+        );
 
-        registry.newGauge(NUM_CONSUMER_GROUPS, new Gauge<Long>() {
-            @Override
-            public Long value() {
-                return numConsumerGroups();
-            }
-        });
+        metrics.addMetric(
+            metrics.metricName(CONSUMER_GROUPS_COUNT_METRIC_NAME, METRICS_GROUP, Collections.singletonMap(
+                CONSUMER_GROUPS_COUNT_STATE_TAG, ConsumerGroup.ConsumerGroupState.EMPTY.toString()
+            )),
+            (Gauge<Long>) (config, now) -> numConsumerGroupsEmpty()
+        );
 
-        registry.newGauge(NUM_CONSUMER_GROUPS_EMPTY, new Gauge<Long>() {
-            @Override
-            public Long value() {
-                return numConsumerGroupsEmpty();
-            }
-        });
+        metrics.addMetric(
+            metrics.metricName(CONSUMER_GROUPS_COUNT_METRIC_NAME, METRICS_GROUP, Collections.singletonMap(
+                CONSUMER_GROUPS_COUNT_STATE_TAG, ConsumerGroup.ConsumerGroupState.ASSIGNING.toString()
+            )),
+            (Gauge<Long>) (config, now) -> numConsumerGroupsAssigning()
+        );
 
-        registry.newGauge(NUM_CONSUMER_GROUPS_ASSIGNING, new Gauge<Long>() {
-            @Override
-            public Long value() {
-                return numConsumerGroupsAssigning();
-            }
-        });
+        metrics.addMetric(
+            metrics.metricName(CONSUMER_GROUPS_COUNT_METRIC_NAME, METRICS_GROUP, Collections.singletonMap(
+                CONSUMER_GROUPS_COUNT_STATE_TAG, ConsumerGroup.ConsumerGroupState.RECONCILING.toString()
+            )),
+            (Gauge<Long>) (config, now) -> numConsumerGroupsReconciling()
+        );
 
-        registry.newGauge(NUM_CONSUMER_GROUPS_RECONCILING, new Gauge<Long>() {
-            @Override
-            public Long value() {
-                return numConsumerGroupsReconciling();
-            }
-        });
+        metrics.addMetric(
+            metrics.metricName(CONSUMER_GROUPS_COUNT_METRIC_NAME, METRICS_GROUP, Collections.singletonMap(
+                CONSUMER_GROUPS_COUNT_STATE_TAG, ConsumerGroup.ConsumerGroupState.STABLE.toString()
+            )),
+            (Gauge<Long>) (config, now) -> numConsumerGroupsStable()
+        );
 
-        registry.newGauge(NUM_CONSUMER_GROUPS_STABLE, new Gauge<Long>() {
-            @Override
-            public Long value() {
-                return numConsumerGroupsStable();
-            }
-        });
-
-        registry.newGauge(NUM_CONSUMER_GROUPS_DEAD, new Gauge<Long>() {
-            @Override
-            public Long value() {
-                return numConsumerGroupsDead();
-            }
-        });
+        metrics.addMetric(
+            metrics.metricName(CONSUMER_GROUPS_COUNT_METRIC_NAME, METRICS_GROUP, Collections.singletonMap(
+                CONSUMER_GROUPS_COUNT_STATE_TAG, ConsumerGroup.ConsumerGroupState.DEAD.toString()
+            )),
+            (Gauge<Long>) (config, now) -> numConsumerGroupsDead()
+        );
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
@@ -63,7 +63,7 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
         "GroupMetadataManager", "NumGroupsEmpty");
 
     public final static String GROUP_COUNT_METRIC_NAME = "group-count";
-    public final static String GROUP_COUNT_TYPE_TAG = "group-type";
+    public final static String GROUP_COUNT_PROTOCOL_TAG = "protocol";
     public final static String CONSUMER_GROUP_COUNT_METRIC_NAME = "consumer-group-count";
     public final static String CONSUMER_GROUP_COUNT_STATE_TAG = "state";
 
@@ -103,14 +103,14 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
             GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The total number of groups using the generic rebalance protocol.",
-            Collections.singletonMap(GROUP_COUNT_TYPE_TAG, Group.GroupType.GENERIC.toString())
+            Collections.singletonMap(GROUP_COUNT_PROTOCOL_TAG, Group.GroupType.GENERIC.toString())
         );
 
         consumerGroupCountMetricName = metrics.metricName(
             GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The total number of groups using the consumer rebalance protocol.",
-            Collections.singletonMap(GROUP_COUNT_TYPE_TAG, Group.GroupType.CONSUMER.toString())
+            Collections.singletonMap(GROUP_COUNT_PROTOCOL_TAG, Group.GroupType.CONSUMER.toString())
         );
 
         consumerGroupCountEmptyMetricName = metrics.metricName(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
@@ -62,10 +62,10 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
     public final static com.yammer.metrics.core.MetricName NUM_GENERIC_GROUPS_EMPTY = getMetricName(
         "GroupMetadataManager", "NumGroupsEmpty");
 
-    public final static String GROUPS_COUNT_METRIC_NAME = "groups-count";
-    public final static String GROUPS_COUNT_TYPE_TAG = "type";
-    public final static String CONSUMER_GROUPS_COUNT_METRIC_NAME = "consumer-groups-count";
-    public final static String CONSUMER_GROUPS_COUNT_STATE_TAG = "state";
+    public final static String GROUP_COUNT_METRIC_NAME = "group-count";
+    public final static String GROUP_COUNT_TYPE_TAG = "type";
+    public final static String CONSUMER_GROUP_COUNT_METRIC_NAME = "consumer-group-count";
+    public final static String CONSUMER_GROUP_COUNT_STATE_TAG = "state";
 
     public static final String OFFSET_COMMITS_SENSOR_NAME = "OffsetCommits";
     public static final String OFFSET_EXPIRED_SENSOR_NAME = "OffsetExpired";
@@ -74,13 +74,13 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
     public static final String GENERIC_GROUP_REBALANCES_SENSOR_NAME = "GenericGroupRebalances";
     public static final String CONSUMER_GROUP_REBALANCES_SENSOR_NAME = "ConsumerGroupRebalances";
 
-    private final MetricName genericGroupsCountMetricName;
-    private final MetricName consumerGroupsCountMetricName;
-    private final MetricName consumerGroupsCountEmptyMetricName;
-    private final MetricName consumerGroupsCountAssigningMetricName;
-    private final MetricName consumerGroupsCountReconcilingMetricName;
-    private final MetricName consumerGroupsCountStableMetricName;
-    private final MetricName consumerGroupsCountDeadMetricName;
+    private final MetricName genericGroupCountMetricName;
+    private final MetricName consumerGroupCountMetricName;
+    private final MetricName consumerGroupCountEmptyMetricName;
+    private final MetricName consumerGroupCountAssigningMetricName;
+    private final MetricName consumerGroupCountReconcilingMetricName;
+    private final MetricName consumerGroupCountStableMetricName;
+    private final MetricName consumerGroupCountDeadMetricName;
 
     private final MetricsRegistry registry;
     private final Metrics metrics;
@@ -99,53 +99,53 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
         this.registry = Objects.requireNonNull(registry);
         this.metrics = Objects.requireNonNull(metrics);
 
-        genericGroupsCountMetricName = metrics.metricName(
-            GROUPS_COUNT_METRIC_NAME,
+        genericGroupCountMetricName = metrics.metricName(
+            GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
-            "The total number of generic groups.",
-            Collections.singletonMap(GROUPS_COUNT_TYPE_TAG, Group.GroupType.GENERIC.toString())
+            "The total number of groups using the generic rebalance protocol.",
+            Collections.singletonMap(GROUP_COUNT_TYPE_TAG, Group.GroupType.GENERIC.toString())
         );
 
-        consumerGroupsCountMetricName = metrics.metricName(
-            GROUPS_COUNT_METRIC_NAME,
+        consumerGroupCountMetricName = metrics.metricName(
+            GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
-            "The total number of consumer groups.",
-            Collections.singletonMap(GROUPS_COUNT_TYPE_TAG, Group.GroupType.CONSUMER.toString())
+            "The total number of groups using the consumer rebalance protocol.",
+            Collections.singletonMap(GROUP_COUNT_TYPE_TAG, Group.GroupType.CONSUMER.toString())
         );
 
-        consumerGroupsCountEmptyMetricName = metrics.metricName(
-            CONSUMER_GROUPS_COUNT_METRIC_NAME,
+        consumerGroupCountEmptyMetricName = metrics.metricName(
+            CONSUMER_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of consumer groups in empty state.",
-            Collections.singletonMap(CONSUMER_GROUPS_COUNT_STATE_TAG, ConsumerGroupState.EMPTY.toString())
+            Collections.singletonMap(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.EMPTY.toString())
         );
 
-        consumerGroupsCountAssigningMetricName = metrics.metricName(
-            CONSUMER_GROUPS_COUNT_METRIC_NAME,
+        consumerGroupCountAssigningMetricName = metrics.metricName(
+            CONSUMER_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of consumer groups in assigning state.",
-            Collections.singletonMap(CONSUMER_GROUPS_COUNT_STATE_TAG, ConsumerGroupState.ASSIGNING.toString())
+            Collections.singletonMap(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.ASSIGNING.toString())
         );
 
-        consumerGroupsCountReconcilingMetricName = metrics.metricName(
-            CONSUMER_GROUPS_COUNT_METRIC_NAME,
+        consumerGroupCountReconcilingMetricName = metrics.metricName(
+            CONSUMER_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of consumer groups in reconciling state.",
-            Collections.singletonMap(CONSUMER_GROUPS_COUNT_STATE_TAG, ConsumerGroupState.RECONCILING.toString())
+            Collections.singletonMap(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.RECONCILING.toString())
         );
 
-        consumerGroupsCountStableMetricName = metrics.metricName(
-            CONSUMER_GROUPS_COUNT_METRIC_NAME,
+        consumerGroupCountStableMetricName = metrics.metricName(
+            CONSUMER_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of consumer groups in stable state.",
-            Collections.singletonMap(CONSUMER_GROUPS_COUNT_STATE_TAG, ConsumerGroupState.STABLE.toString())
+            Collections.singletonMap(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.STABLE.toString())
         );
 
-        consumerGroupsCountDeadMetricName = metrics.metricName(
-            CONSUMER_GROUPS_COUNT_METRIC_NAME,
+        consumerGroupCountDeadMetricName = metrics.metricName(
+            CONSUMER_GROUP_COUNT_METRIC_NAME,
             METRICS_GROUP,
             "The number of consumer groups in dead state.",
-            Collections.singletonMap(CONSUMER_GROUPS_COUNT_STATE_TAG, ConsumerGroupState.DEAD.toString())
+            Collections.singletonMap(CONSUMER_GROUP_COUNT_STATE_TAG, ConsumerGroupState.DEAD.toString())
         );
 
         registerGauges();
@@ -247,13 +247,13 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
         ).forEach(registry::removeMetric);
 
         Arrays.asList(
-            genericGroupsCountMetricName,
-            consumerGroupsCountMetricName,
-            consumerGroupsCountEmptyMetricName,
-            consumerGroupsCountAssigningMetricName,
-            consumerGroupsCountReconcilingMetricName,
-            consumerGroupsCountStableMetricName,
-            consumerGroupsCountDeadMetricName
+            genericGroupCountMetricName,
+            consumerGroupCountMetricName,
+            consumerGroupCountEmptyMetricName,
+            consumerGroupCountAssigningMetricName,
+            consumerGroupCountReconcilingMetricName,
+            consumerGroupCountStableMetricName,
+            consumerGroupCountDeadMetricName
         ).forEach(metrics::removeMetric);
 
         Arrays.asList(
@@ -352,37 +352,37 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
         });
 
         metrics.addMetric(
-            genericGroupsCountMetricName,
+            genericGroupCountMetricName,
             (Gauge<Long>) (config, now) -> numGenericGroups()
         );
 
         metrics.addMetric(
-            consumerGroupsCountMetricName,
+            consumerGroupCountMetricName,
             (Gauge<Long>) (config, now) -> numConsumerGroups()
         );
 
         metrics.addMetric(
-            consumerGroupsCountEmptyMetricName,
+            consumerGroupCountEmptyMetricName,
             (Gauge<Long>) (config, now) -> numConsumerGroups(ConsumerGroupState.EMPTY)
         );
 
         metrics.addMetric(
-            consumerGroupsCountAssigningMetricName,
+            consumerGroupCountAssigningMetricName,
             (Gauge<Long>) (config, now) -> numConsumerGroups(ConsumerGroupState.ASSIGNING)
         );
 
         metrics.addMetric(
-            consumerGroupsCountReconcilingMetricName,
+            consumerGroupCountReconcilingMetricName,
             (Gauge<Long>) (config, now) -> numConsumerGroups(ConsumerGroupState.RECONCILING)
         );
 
         metrics.addMetric(
-            consumerGroupsCountStableMetricName,
+            consumerGroupCountStableMetricName,
             (Gauge<Long>) (config, now) -> numConsumerGroups(ConsumerGroupState.STABLE)
         );
 
         metrics.addMetric(
-            consumerGroupsCountDeadMetricName,
+            consumerGroupCountDeadMetricName,
             (Gauge<Long>) (config, now) -> numConsumerGroups(ConsumerGroupState.DEAD)
         );
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
@@ -63,7 +63,7 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
         "GroupMetadataManager", "NumGroupsEmpty");
 
     public final static String GROUP_COUNT_METRIC_NAME = "group-count";
-    public final static String GROUP_COUNT_TYPE_TAG = "type";
+    public final static String GROUP_COUNT_TYPE_TAG = "group-type";
     public final static String CONSUMER_GROUP_COUNT_METRIC_NAME = "consumer-group-count";
     public final static String CONSUMER_GROUP_COUNT_STATE_TAG = "state";
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.coordinator.group.metrics;
 
-import com.yammer.metrics.core.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Utils;
@@ -25,24 +24,9 @@ import org.apache.kafka.coordinator.group.generic.GenericGroupState;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineLong;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
-
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_CONSUMER_GROUPS;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_CONSUMER_GROUPS_ASSIGNING;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_CONSUMER_GROUPS_DEAD;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_CONSUMER_GROUPS_EMPTY;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_CONSUMER_GROUPS_RECONCILING;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_CONSUMER_GROUPS_STABLE;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_GENERIC_GROUPS;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_GENERIC_GROUPS_COMPLETING_REBALANCE;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_GENERIC_GROUPS_DEAD;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_GENERIC_GROUPS_EMPTY;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_GENERIC_GROUPS_PREPARING_REBALANCE;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_GENERIC_GROUPS_STABLE;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_OFFSETS;
 
 /**
  * This class is mapped to a single {@link org.apache.kafka.coordinator.group.GroupCoordinatorShard}. It will
@@ -71,11 +55,15 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
             this.atomicLong = atomicLong;
         }
     }
+    /**
+     * Consumer group size gauge counters keyed by the metric name.
+     */
+    private final Map<GenericGroupState, AtomicLong> genericGroupGauges;
 
     /**
-     * Local timeline gauge counters keyed by the metric name.
+     * Consumer group size gauge counters keyed by the metric name.
      */
-    private final Map<String, TimelineGaugeCounter> localGauges;
+    private final Map<ConsumerGroup.ConsumerGroupState, TimelineGaugeCounter> consumerGroupGauges;
 
     /**
      * All sensors keyed by the sensor name. A Sensor object is shared across all metrics shards.
@@ -83,9 +71,14 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
     private final Map<String, Sensor> globalSensors;
 
     /**
-     * Global gauge counters keyed by the metric name. The same counter is shared across all metrics shards.
+     * The number of offsets gauge counter.
      */
-    private final Map<String, AtomicLong> globalGauges;
+    private final TimelineGaugeCounter numOffsetsTimelineGaugeCounter;
+
+    /**
+     * The number of generic groups metric counter.
+     */
+    private final TimelineGaugeCounter numGenericGroupsTimelineCounter;
 
     /**
      * The topic partition.
@@ -95,54 +88,66 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
     public GroupCoordinatorMetricsShard(
         SnapshotRegistry snapshotRegistry,
         Map<String, Sensor> globalSensors,
-        Map<String, AtomicLong> globalGauges,
         TopicPartition topicPartition
     ) {
         Objects.requireNonNull(snapshotRegistry);
-        TimelineLong numOffsetsTimeline = new TimelineLong(snapshotRegistry);
-        TimelineLong numGenericGroupsTimeline = new TimelineLong(snapshotRegistry);
-        TimelineLong numConsumerGroupsTimeline = new TimelineLong(snapshotRegistry);
+        numOffsetsTimelineGaugeCounter = new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0));
+        numGenericGroupsTimelineCounter = new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0));
+
+        this.genericGroupGauges = Utils.mkMap(
+            Utils.mkEntry(GenericGroupState.PREPARING_REBALANCE, new AtomicLong(0)),
+            Utils.mkEntry(GenericGroupState.COMPLETING_REBALANCE, new AtomicLong(0)),
+            Utils.mkEntry(GenericGroupState.STABLE, new AtomicLong(0)),
+            Utils.mkEntry(GenericGroupState.DEAD, new AtomicLong(0)),
+            Utils.mkEntry(GenericGroupState.EMPTY, new AtomicLong(0))
+        );
+        
         TimelineLong numConsumerGroupsEmptyTimeline = new TimelineLong(snapshotRegistry);
         TimelineLong numConsumerGroupsAssigningTimeline = new TimelineLong(snapshotRegistry);
         TimelineLong numConsumerGroupsReconcilingTimeline = new TimelineLong(snapshotRegistry);
         TimelineLong numConsumerGroupsStableTimeline = new TimelineLong(snapshotRegistry);
         TimelineLong numConsumerGroupsDeadTimeline = new TimelineLong(snapshotRegistry);
 
-        this.localGauges = Collections.unmodifiableMap(Utils.mkMap(
-            Utils.mkEntry(NUM_OFFSETS.getName(),
-                new TimelineGaugeCounter(numOffsetsTimeline, new AtomicLong(0))),
-            Utils.mkEntry(NUM_GENERIC_GROUPS.getName(),
-                new TimelineGaugeCounter(numGenericGroupsTimeline, new AtomicLong(0))),
-            Utils.mkEntry(NUM_CONSUMER_GROUPS.getName(),
-                new TimelineGaugeCounter(numConsumerGroupsTimeline, new AtomicLong(0))),
-            Utils.mkEntry(NUM_CONSUMER_GROUPS_EMPTY.getName(),
+        this.consumerGroupGauges = Utils.mkMap(
+            Utils.mkEntry(ConsumerGroup.ConsumerGroupState.EMPTY,
                 new TimelineGaugeCounter(numConsumerGroupsEmptyTimeline, new AtomicLong(0))),
-            Utils.mkEntry(NUM_CONSUMER_GROUPS_ASSIGNING.getName(),
+            Utils.mkEntry(ConsumerGroup.ConsumerGroupState.ASSIGNING,
                 new TimelineGaugeCounter(numConsumerGroupsAssigningTimeline, new AtomicLong(0))),
-            Utils.mkEntry(NUM_CONSUMER_GROUPS_RECONCILING.getName(),
+            Utils.mkEntry(ConsumerGroup.ConsumerGroupState.RECONCILING,
                 new TimelineGaugeCounter(numConsumerGroupsReconcilingTimeline, new AtomicLong(0))),
-            Utils.mkEntry(NUM_CONSUMER_GROUPS_STABLE.getName(),
+            Utils.mkEntry(ConsumerGroup.ConsumerGroupState.STABLE,
                 new TimelineGaugeCounter(numConsumerGroupsStableTimeline, new AtomicLong(0))),
-            Utils.mkEntry(NUM_CONSUMER_GROUPS_DEAD.getName(),
+            Utils.mkEntry(ConsumerGroup.ConsumerGroupState.DEAD,
                 new TimelineGaugeCounter(numConsumerGroupsDeadTimeline, new AtomicLong(0)))
-        ));
+        );
 
         this.globalSensors = Objects.requireNonNull(globalSensors);
-        this.globalGauges = Objects.requireNonNull(globalGauges);
         this.topicPartition = Objects.requireNonNull(topicPartition);
     }
 
-    @Override
-    public void incrementGlobalGauge(MetricName metricName) {
-        AtomicLong gaugeCounter = globalGauges.get(metricName.getName());
-        if (gaugeCounter != null) {
-            gaugeCounter.incrementAndGet();
+    public void incrementNumGenericGroups(GenericGroupState state) {
+        AtomicLong counter = genericGroupGauges.get(state);
+        if (counter != null) {
+            counter.incrementAndGet();
         }
     }
 
-    @Override
-    public void incrementLocalGauge(MetricName metricName) {
-        TimelineGaugeCounter gaugeCounter = localGauges.get(metricName.getName());
+    /**
+     * Increment the number of offsets.
+     */
+    public void incrementNumOffsets() {
+        synchronized (numOffsetsTimelineGaugeCounter.timelineLong) {
+            numOffsetsTimelineGaugeCounter.timelineLong.increment();
+        }
+    }
+
+    /**
+     * Increment the number of consumer groups.
+     *
+     * @param state the consumer group state.
+     */
+    public void incrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState state) {
+        TimelineGaugeCounter gaugeCounter = consumerGroupGauges.get(state);
         if (gaugeCounter != null) {
             synchronized (gaugeCounter.timelineLong) {
                 gaugeCounter.timelineLong.increment();
@@ -150,17 +155,34 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
         }
     }
 
-    @Override
-    public void decrementGlobalGauge(MetricName metricName) {
-        AtomicLong gaugeCounter = globalGauges.get(metricName.getName());
-        if (gaugeCounter != null) {
-            gaugeCounter.decrementAndGet();
+    /**
+     * Decrement the number of offsets.
+     */
+    public void decrementNumOffsets() {
+        synchronized (numOffsetsTimelineGaugeCounter.timelineLong) {
+            numOffsetsTimelineGaugeCounter.timelineLong.decrement();
         }
     }
 
-    @Override
-    public void decrementLocalGauge(MetricName metricName) {
-        TimelineGaugeCounter gaugeCounter = localGauges.get(metricName.getName());
+    /**
+     * Decrement the number of consumer groups.
+     *
+     * @param state the consumer group state.
+     */
+    public void decrementNumGenericGroups(GenericGroupState state) {
+        AtomicLong counter = genericGroupGauges.get(state);
+        if (counter != null) {
+            counter.decrementAndGet();
+        }
+    }
+
+    /**
+     * Decrement the number of consumer groups.
+     *
+     * @param state the consumer group state.
+     */
+    public void decrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState state) {
+        TimelineGaugeCounter gaugeCounter = consumerGroupGauges.get(state);
         if (gaugeCounter != null) {
             synchronized (gaugeCounter.timelineLong) {
                 gaugeCounter.timelineLong.decrement();
@@ -168,22 +190,47 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
         }
     }
 
-    @Override
-    public long globalGaugeValue(MetricName metricName) {
-        AtomicLong gaugeCounter = globalGauges.get(metricName.getName());
-        if (gaugeCounter != null) {
-            return gaugeCounter.get();
-        }
-        return 0;
+    /**
+     * Obtain the number of offsets.
+     */
+    public long numOffsets() {
+        return numOffsetsTimelineGaugeCounter.atomicLong.get();
     }
 
-    @Override
-    public long localGaugeValue(MetricName metricName) {
-        TimelineGaugeCounter gaugeCounter = localGauges.get(metricName.getName());
+    /**
+     * Obtain the number of generic groups.
+     *
+     * @param state  The generic group state. `null` indicates all states.
+     */
+    public long numGenericGroups(GenericGroupState state) {
+        if (state == null) {
+            return genericGroupGauges.values().stream()
+                .mapToLong(AtomicLong::get).sum();
+        }
+
+        AtomicLong counter = genericGroupGauges.get(state);
+        if (counter != null) {
+            return counter.get();
+        }
+        return 0L;
+    }
+
+    /**
+     * Obtain the current value of a local consumer group gauge.
+     *
+     * @param state  the consumer group state. `null` indicates all states.
+     */
+    public long numConsumerGroups(ConsumerGroup.ConsumerGroupState state) {
+        if (state == null) {
+            return consumerGroupGauges.values().stream()
+                .mapToLong(timelineGaugeCounter -> timelineGaugeCounter.atomicLong.get()).sum();
+        }
+
+        TimelineGaugeCounter gaugeCounter = consumerGroupGauges.get(state);
         if (gaugeCounter != null) {
             return gaugeCounter.atomicLong.get();
         }
-        return 0;
+        return 0L;
     }
 
     @Override
@@ -209,13 +256,23 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
 
     @Override
     public void commitUpTo(long offset) {
-        this.localGauges.forEach((__, gaugeCounter) -> {
+        this.consumerGroupGauges.forEach((__, gaugeCounter) -> {
             long value;
             synchronized (gaugeCounter.timelineLong) {
                 value = gaugeCounter.timelineLong.get(offset);
             }
             gaugeCounter.atomicLong.set(value);
         });
+
+        synchronized (numGenericGroupsTimelineCounter.timelineLong) {
+            long value = numGenericGroupsTimelineCounter.timelineLong.get(offset);
+            numGenericGroupsTimelineCounter.atomicLong.set(value);
+        }
+
+        synchronized (numOffsetsTimelineGaugeCounter.timelineLong) {
+            long value = numOffsetsTimelineGaugeCounter.timelineLong.get(offset);
+            numOffsetsTimelineGaugeCounter.atomicLong.set(value);
+        }
     }
 
     /**
@@ -225,47 +282,46 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
      * @param oldState The previous state. null value means that it's a new group.
      * @param newState The next state. null value means that the group has been removed.
      */
-    public void onGenericGroupStateTransition(GenericGroupState oldState, GenericGroupState newState) {
+    public void onGenericGroupStateTransition(
+        GenericGroupState oldState,
+        GenericGroupState newState
+    ) {
         if (newState != null) {
             switch (newState) {
                 case PREPARING_REBALANCE:
-                    incrementGlobalGauge(NUM_GENERIC_GROUPS_PREPARING_REBALANCE);
+                    incrementNumGenericGroups(GenericGroupState.PREPARING_REBALANCE);
                     break;
                 case COMPLETING_REBALANCE:
-                    incrementGlobalGauge(NUM_GENERIC_GROUPS_COMPLETING_REBALANCE);
+                    incrementNumGenericGroups(GenericGroupState.COMPLETING_REBALANCE);
                     break;
                 case STABLE:
-                    incrementGlobalGauge(NUM_GENERIC_GROUPS_STABLE);
+                    incrementNumGenericGroups(GenericGroupState.STABLE);
                     break;
                 case DEAD:
-                    incrementGlobalGauge(NUM_GENERIC_GROUPS_DEAD);
+                    incrementNumGenericGroups(GenericGroupState.DEAD);
                     break;
                 case EMPTY:
-                    incrementGlobalGauge(NUM_GENERIC_GROUPS_EMPTY);
+                    incrementNumGenericGroups(GenericGroupState.EMPTY);
             }
-        } else {
-            decrementLocalGauge(NUM_GENERIC_GROUPS);
         }
 
         if (oldState != null) {
             switch (oldState) {
                 case PREPARING_REBALANCE:
-                    decrementGlobalGauge(NUM_GENERIC_GROUPS_PREPARING_REBALANCE);
+                    decrementNumGenericGroups(GenericGroupState.PREPARING_REBALANCE);
                     break;
                 case COMPLETING_REBALANCE:
-                    decrementGlobalGauge(NUM_GENERIC_GROUPS_COMPLETING_REBALANCE);
+                    decrementNumGenericGroups(GenericGroupState.COMPLETING_REBALANCE);
                     break;
                 case STABLE:
-                    decrementGlobalGauge(NUM_GENERIC_GROUPS_STABLE);
+                    decrementNumGenericGroups(GenericGroupState.STABLE);
                     break;
                 case DEAD:
-                    decrementGlobalGauge(NUM_GENERIC_GROUPS_DEAD);
+                    decrementNumGenericGroups(GenericGroupState.DEAD);
                     break;
                 case EMPTY:
-                    decrementGlobalGauge(NUM_GENERIC_GROUPS_EMPTY);
+                    decrementNumGenericGroups(GenericGroupState.EMPTY);
             }
-        } else {
-            incrementLocalGauge(NUM_GENERIC_GROUPS);
         }
     }
 
@@ -283,43 +339,39 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
         if (newState != null) {
             switch (newState) {
                 case EMPTY:
-                    incrementLocalGauge(NUM_CONSUMER_GROUPS_EMPTY);
+                    incrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.EMPTY);
                     break;
                 case ASSIGNING:
-                    incrementLocalGauge(NUM_CONSUMER_GROUPS_ASSIGNING);
+                    incrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.ASSIGNING);
                     break;
                 case RECONCILING:
-                    incrementLocalGauge(NUM_CONSUMER_GROUPS_RECONCILING);
+                    incrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.RECONCILING);
                     break;
                 case STABLE:
-                    incrementLocalGauge(NUM_CONSUMER_GROUPS_STABLE);
+                    incrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE);
                     break;
                 case DEAD:
-                    incrementLocalGauge(NUM_CONSUMER_GROUPS_DEAD);
+                    incrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.DEAD);
             }
-        } else {
-            decrementLocalGauge(NUM_CONSUMER_GROUPS);
         }
 
         if (oldState != null) {
             switch (oldState) {
                 case EMPTY:
-                    decrementLocalGauge(NUM_CONSUMER_GROUPS_EMPTY);
+                    decrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.EMPTY);
                     break;
                 case ASSIGNING:
-                    decrementLocalGauge(NUM_CONSUMER_GROUPS_ASSIGNING);
+                    decrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.ASSIGNING);
                     break;
                 case RECONCILING:
-                    decrementLocalGauge(NUM_CONSUMER_GROUPS_RECONCILING);
+                    decrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.RECONCILING);
                     break;
                 case STABLE:
-                    decrementLocalGauge(NUM_CONSUMER_GROUPS_STABLE);
+                    decrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE);
                     break;
                 case DEAD:
-                    decrementLocalGauge(NUM_CONSUMER_GROUPS_DEAD);
+                    decrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.DEAD);
             }
-        } else {
-            incrementLocalGauge(NUM_CONSUMER_GROUPS);
         }
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
@@ -101,24 +101,18 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
             Utils.mkEntry(GenericGroupState.DEAD, new AtomicLong(0)),
             Utils.mkEntry(GenericGroupState.EMPTY, new AtomicLong(0))
         );
-        
-        TimelineLong numConsumerGroupsEmptyTimeline = new TimelineLong(snapshotRegistry);
-        TimelineLong numConsumerGroupsAssigningTimeline = new TimelineLong(snapshotRegistry);
-        TimelineLong numConsumerGroupsReconcilingTimeline = new TimelineLong(snapshotRegistry);
-        TimelineLong numConsumerGroupsStableTimeline = new TimelineLong(snapshotRegistry);
-        TimelineLong numConsumerGroupsDeadTimeline = new TimelineLong(snapshotRegistry);
 
         this.consumerGroupGauges = Utils.mkMap(
             Utils.mkEntry(ConsumerGroupState.EMPTY,
-                new TimelineGaugeCounter(numConsumerGroupsEmptyTimeline, new AtomicLong(0))),
+                new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
             Utils.mkEntry(ConsumerGroupState.ASSIGNING,
-                new TimelineGaugeCounter(numConsumerGroupsAssigningTimeline, new AtomicLong(0))),
+                new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
             Utils.mkEntry(ConsumerGroupState.RECONCILING,
-                new TimelineGaugeCounter(numConsumerGroupsReconcilingTimeline, new AtomicLong(0))),
+                new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
             Utils.mkEntry(ConsumerGroupState.STABLE,
-                new TimelineGaugeCounter(numConsumerGroupsStableTimeline, new AtomicLong(0))),
+                new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0))),
             Utils.mkEntry(ConsumerGroupState.DEAD,
-                new TimelineGaugeCounter(numConsumerGroupsDeadTimeline, new AtomicLong(0)))
+                new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0)))
         );
 
         this.globalSensors = Objects.requireNonNull(globalSensors);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -4775,7 +4775,6 @@ public class GroupMetadataManagerTest {
             new GroupCoordinatorMetricsShard(
                 context.snapshotRegistry,
                 Collections.emptyMap(),
-                Collections.emptyMap(),
                 new TopicPartition("__consumer_offsets", 0)
             ),
             1,

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
@@ -708,7 +708,6 @@ public class ConsumerGroupTest {
         GroupCoordinatorMetricsShard metricsShard = new GroupCoordinatorMetricsShard(
             snapshotRegistry,
             Collections.emptyMap(),
-            Collections.emptyMap(),
             new TopicPartition("__consumer_offsets", 0)
         );
         ConsumerGroup group = new ConsumerGroup(snapshotRegistry, "group-foo", metricsShard);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/generic/GenericGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/generic/GenericGroupTest.java
@@ -79,7 +79,6 @@ public class GenericGroupTest {
     private final GroupCoordinatorMetricsShard metrics = new GroupCoordinatorMetricsShard(
         new SnapshotRegistry(logContext),
         Collections.emptyMap(),
-        Collections.emptyMap(),
         new TopicPartition("__consumer_offsets", 0)
     );
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
@@ -138,7 +138,7 @@ public class GroupCoordinatorMetricsShardTest {
 
         assertGaugeValue(
             metrics,
-            metrics.metricName("groups-count", "group-coordinator-metrics", Collections.singletonMap("type", "generic")),
+            metrics.metricName("group-count", "group-coordinator-metrics", Collections.singletonMap("type", "generic")),
             4
         );
         assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroups"), 4);
@@ -224,17 +224,17 @@ public class GroupCoordinatorMetricsShardTest {
         assertEquals(1, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.RECONCILING));
         assertEquals(2, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE));
 
-        assertGaugeValue(metrics, metrics.metricName("groups-count", "group-coordinator-metrics",
+        assertGaugeValue(metrics, metrics.metricName("group-count", "group-coordinator-metrics",
             Collections.singletonMap("type", "consumer")), 4);
-        assertGaugeValue(metrics, metrics.metricName("consumer-groups-count", "group-coordinator-metrics",
+        assertGaugeValue(metrics, metrics.metricName("consumer-group-count", "group-coordinator-metrics",
             Collections.singletonMap("state", "empty")), 0);
-        assertGaugeValue(metrics, metrics.metricName("consumer-groups-count", "group-coordinator-metrics",
+        assertGaugeValue(metrics, metrics.metricName("consumer-group-count", "group-coordinator-metrics",
             Collections.singletonMap("state", "assigning")), 1);
-        assertGaugeValue(metrics, metrics.metricName("consumer-groups-count", "group-coordinator-metrics",
+        assertGaugeValue(metrics, metrics.metricName("consumer-group-count", "group-coordinator-metrics",
             Collections.singletonMap("state", "reconciling")), 1);
-        assertGaugeValue(metrics, metrics.metricName("consumer-groups-count", "group-coordinator-metrics",
+        assertGaugeValue(metrics, metrics.metricName("consumer-group-count", "group-coordinator-metrics",
             Collections.singletonMap("state", "stable")), 2);
-        assertGaugeValue(metrics, metrics.metricName("consumer-groups-count", "group-coordinator-metrics",
+        assertGaugeValue(metrics, metrics.metricName("consumer-group-count", "group-coordinator-metrics",
             Collections.singletonMap("state", "dead")), 0);
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
@@ -138,7 +138,7 @@ public class GroupCoordinatorMetricsShardTest {
 
         assertGaugeValue(
             metrics,
-            metrics.metricName("group-count", "group-coordinator-metrics", Collections.singletonMap("group-type", "generic")),
+            metrics.metricName("group-count", "group-coordinator-metrics", Collections.singletonMap("protocol", "generic")),
             4
         );
         assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroups"), 4);
@@ -225,7 +225,7 @@ public class GroupCoordinatorMetricsShardTest {
         assertEquals(2, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE));
 
         assertGaugeValue(metrics, metrics.metricName("group-count", "group-coordinator-metrics",
-            Collections.singletonMap("group-type", "consumer")), 4);
+            Collections.singletonMap("protocol", "consumer")), 4);
         assertGaugeValue(metrics, metrics.metricName("consumer-group-count", "group-coordinator-metrics",
             Collections.singletonMap("state", "empty")), 0);
         assertGaugeValue(metrics, metrics.metricName("consumer-group-count", "group-coordinator-metrics",

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.group.consumer.ConsumerGroup;
 import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
 import org.apache.kafka.coordinator.group.generic.GenericGroup;
+import org.apache.kafka.coordinator.group.generic.GenericGroupState;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.junit.jupiter.api.Test;
 
@@ -36,19 +37,6 @@ import static org.apache.kafka.coordinator.group.generic.GenericGroupState.DEAD;
 import static org.apache.kafka.coordinator.group.generic.GenericGroupState.EMPTY;
 import static org.apache.kafka.coordinator.group.generic.GenericGroupState.PREPARING_REBALANCE;
 import static org.apache.kafka.coordinator.group.generic.GenericGroupState.STABLE;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_CONSUMER_GROUPS;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_CONSUMER_GROUPS_ASSIGNING;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_CONSUMER_GROUPS_DEAD;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_CONSUMER_GROUPS_EMPTY;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_CONSUMER_GROUPS_RECONCILING;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_CONSUMER_GROUPS_STABLE;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_GENERIC_GROUPS;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_GENERIC_GROUPS_COMPLETING_REBALANCE;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_GENERIC_GROUPS_DEAD;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_GENERIC_GROUPS_EMPTY;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_GENERIC_GROUPS_PREPARING_REBALANCE;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_GENERIC_GROUPS_STABLE;
-import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.NUM_OFFSETS;
 import static org.apache.kafka.coordinator.group.metrics.MetricsTestUtils.assertGaugeValue;
 import static org.apache.kafka.coordinator.group.metrics.MetricsTestUtils.metricName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -56,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class GroupCoordinatorMetricsShardTest {
 
     @Test
-    public void testLocalGauges() {
+    public void testTimelineGaugeCounters() {
         MetricsRegistry registry = new MetricsRegistry();
         Metrics metrics = new Metrics();
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
@@ -64,65 +52,57 @@ public class GroupCoordinatorMetricsShardTest {
         GroupCoordinatorMetrics coordinatorMetrics = new GroupCoordinatorMetrics(registry, metrics);
         GroupCoordinatorMetricsShard shard = coordinatorMetrics.newMetricsShard(snapshotRegistry, tp);
 
-        shard.incrementLocalGauge(NUM_OFFSETS);
-        shard.incrementLocalGauge(NUM_GENERIC_GROUPS);
-        shard.incrementLocalGauge(NUM_CONSUMER_GROUPS);
-        shard.incrementLocalGauge(NUM_CONSUMER_GROUPS_EMPTY);
-        shard.incrementLocalGauge(NUM_CONSUMER_GROUPS_ASSIGNING);
-        shard.incrementLocalGauge(NUM_CONSUMER_GROUPS_RECONCILING);
-        shard.incrementLocalGauge(NUM_CONSUMER_GROUPS_STABLE);
-        shard.incrementLocalGauge(NUM_CONSUMER_GROUPS_DEAD);
+        shard.incrementNumOffsets();
+        shard.incrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.EMPTY);
+        shard.incrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.ASSIGNING);
+        shard.incrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.RECONCILING);
+        shard.incrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE);
+        shard.incrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.DEAD);
 
         snapshotRegistry.getOrCreateSnapshot(1000);
         // The value should not be updated until the offset has been committed.
-        assertEquals(0, shard.localGaugeValue(NUM_OFFSETS));
-        assertEquals(0, shard.localGaugeValue(NUM_GENERIC_GROUPS));
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS));
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS_EMPTY));
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS_ASSIGNING));
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS_RECONCILING));
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS_STABLE));
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS_DEAD));
+        assertEquals(0, shard.numOffsets());
+        assertEquals(0, shard.numConsumerGroups(null));
+        assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.EMPTY));
+        assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.ASSIGNING));
+        assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.RECONCILING));
+        assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE));
+        assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.DEAD));
 
         shard.commitUpTo(1000);
-        assertEquals(1, shard.localGaugeValue(NUM_OFFSETS));
-        assertEquals(1, shard.localGaugeValue(NUM_GENERIC_GROUPS));
-        assertEquals(1, shard.localGaugeValue(NUM_CONSUMER_GROUPS));
-        assertEquals(1, shard.localGaugeValue(NUM_CONSUMER_GROUPS_EMPTY));
-        assertEquals(1, shard.localGaugeValue(NUM_CONSUMER_GROUPS_ASSIGNING));
-        assertEquals(1, shard.localGaugeValue(NUM_CONSUMER_GROUPS_RECONCILING));
-        assertEquals(1, shard.localGaugeValue(NUM_CONSUMER_GROUPS_STABLE));
-        assertEquals(1, shard.localGaugeValue(NUM_CONSUMER_GROUPS_DEAD));
+        assertEquals(1, shard.numOffsets());
+        assertEquals(5, shard.numConsumerGroups(null));
+        assertEquals(1, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.EMPTY));
+        assertEquals(1, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.ASSIGNING));
+        assertEquals(1, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.RECONCILING));
+        assertEquals(1, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE));
+        assertEquals(1, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.DEAD));
 
-        shard.decrementLocalGauge(NUM_OFFSETS);
-        shard.decrementLocalGauge(NUM_GENERIC_GROUPS);
-        shard.decrementLocalGauge(NUM_CONSUMER_GROUPS);
-        shard.decrementLocalGauge(NUM_CONSUMER_GROUPS_EMPTY);
-        shard.decrementLocalGauge(NUM_CONSUMER_GROUPS_ASSIGNING);
-        shard.decrementLocalGauge(NUM_CONSUMER_GROUPS_RECONCILING);
-        shard.decrementLocalGauge(NUM_CONSUMER_GROUPS_STABLE);
-        shard.decrementLocalGauge(NUM_CONSUMER_GROUPS_DEAD);
+        shard.decrementNumOffsets();
+        shard.decrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.EMPTY);
+        shard.decrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.ASSIGNING);
+        shard.decrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.RECONCILING);
+        shard.decrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE);
+        shard.decrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.DEAD);
 
         snapshotRegistry.getOrCreateSnapshot(2000);
         shard.commitUpTo(2000);
-        assertEquals(0, shard.localGaugeValue(NUM_OFFSETS));
-        assertEquals(0, shard.localGaugeValue(NUM_GENERIC_GROUPS));
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS));
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS_EMPTY));
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS_ASSIGNING));
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS_RECONCILING));
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS_STABLE));
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS_DEAD));
+        assertEquals(0, shard.numOffsets());
+        assertEquals(0, shard.numConsumerGroups(null));
+        assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.EMPTY));
+        assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.ASSIGNING));
+        assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.RECONCILING));
+        assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE));
+        assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.DEAD));
     }
 
     @Test
     public void testGenericGroupStateTransitionMetrics() {
         MetricsRegistry registry = new MetricsRegistry();
         Metrics metrics = new Metrics();
-        SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
         TopicPartition tp = new TopicPartition("__consumer_offsets", 0);
         GroupCoordinatorMetrics coordinatorMetrics = new GroupCoordinatorMetrics(registry, metrics);
-        GroupCoordinatorMetricsShard shard = coordinatorMetrics.newMetricsShard(snapshotRegistry, tp);
+        GroupCoordinatorMetricsShard shard = coordinatorMetrics.newMetricsShard(new SnapshotRegistry(new LogContext()), tp);
         coordinatorMetrics.activateMetricsShard(shard);
 
         LogContext logContext = new LogContext();
@@ -132,38 +112,32 @@ public class GroupCoordinatorMetricsShardTest {
         GenericGroup group3 = new GenericGroup(logContext, "groupId3", EMPTY, Time.SYSTEM, shard);
 
         IntStream.range(0, 4).forEach(__ -> {
-            shard.incrementLocalGauge(NUM_GENERIC_GROUPS);
-            shard.incrementGlobalGauge(NUM_GENERIC_GROUPS_EMPTY);
+            shard.incrementNumGenericGroups(null);
+            shard.incrementNumGenericGroups(EMPTY);
         });
 
-        snapshotRegistry.getOrCreateSnapshot(1000);
-        shard.commitUpTo(1000);
-        assertEquals(4, shard.localGaugeValue(NUM_GENERIC_GROUPS));
+        assertEquals(4, shard.numGenericGroups(null));
 
         group0.transitionTo(PREPARING_REBALANCE);
         group0.transitionTo(COMPLETING_REBALANCE);
         group1.transitionTo(PREPARING_REBALANCE);
         group2.transitionTo(DEAD);
 
-        snapshotRegistry.getOrCreateSnapshot(2000);
-        shard.commitUpTo(2000);
-        assertEquals(1, shard.globalGaugeValue(NUM_GENERIC_GROUPS_EMPTY));
-        assertEquals(1, shard.globalGaugeValue(NUM_GENERIC_GROUPS_PREPARING_REBALANCE));
-        assertEquals(1, shard.globalGaugeValue(NUM_GENERIC_GROUPS_COMPLETING_REBALANCE));
-        assertEquals(1, shard.globalGaugeValue(NUM_GENERIC_GROUPS_DEAD));
-        assertEquals(0, shard.globalGaugeValue(NUM_GENERIC_GROUPS_STABLE));
+        assertEquals(1, shard.numGenericGroups(GenericGroupState.EMPTY));
+        assertEquals(1, shard.numGenericGroups(GenericGroupState.PREPARING_REBALANCE));
+        assertEquals(1, shard.numGenericGroups(GenericGroupState.COMPLETING_REBALANCE));
+        assertEquals(1, shard.numGenericGroups(GenericGroupState.DEAD));
+        assertEquals(0, shard.numGenericGroups(GenericGroupState.STABLE));
 
         group0.transitionTo(STABLE);
         group1.transitionTo(COMPLETING_REBALANCE);
         group3.transitionTo(DEAD);
 
-        snapshotRegistry.getOrCreateSnapshot(3000);
-        shard.commitUpTo(3000);
-        assertEquals(0, shard.globalGaugeValue(NUM_GENERIC_GROUPS_EMPTY));
-        assertEquals(0, shard.globalGaugeValue(NUM_GENERIC_GROUPS_PREPARING_REBALANCE));
-        assertEquals(1, shard.globalGaugeValue(NUM_GENERIC_GROUPS_COMPLETING_REBALANCE));
-        assertEquals(2, shard.globalGaugeValue(NUM_GENERIC_GROUPS_DEAD));
-        assertEquals(1, shard.globalGaugeValue(NUM_GENERIC_GROUPS_STABLE));
+        assertEquals(0, shard.numGenericGroups(GenericGroupState.EMPTY));
+        assertEquals(0, shard.numGenericGroups(GenericGroupState.PREPARING_REBALANCE));
+        assertEquals(1, shard.numGenericGroups(GenericGroupState.COMPLETING_REBALANCE));
+        assertEquals(2, shard.numGenericGroups(GenericGroupState.DEAD));
+        assertEquals(1, shard.numGenericGroups(GenericGroupState.STABLE));
 
         assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroups"), 4);
         assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsEmpty"), 0);
@@ -205,14 +179,14 @@ public class GroupCoordinatorMetricsShardTest {
         );
 
         IntStream.range(0, 4).forEach(__ -> {
-            shard.incrementLocalGauge(NUM_CONSUMER_GROUPS);
-            shard.incrementLocalGauge(NUM_CONSUMER_GROUPS_EMPTY);
+            shard.incrementNumConsumerGroups(null);
+            shard.incrementNumConsumerGroups(ConsumerGroup.ConsumerGroupState.EMPTY);
         });
 
         snapshotRegistry.getOrCreateSnapshot(1000);
         shard.commitUpTo(1000);
-        assertEquals(4, shard.localGaugeValue(NUM_CONSUMER_GROUPS));
-        assertEquals(4, shard.localGaugeValue(NUM_CONSUMER_GROUPS_EMPTY));
+        assertEquals(4, shard.numConsumerGroups(null));
+        assertEquals(4, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.EMPTY));
 
         ConsumerGroupMember member0 = group0.getOrMaybeCreateMember("member-id", true);
         ConsumerGroupMember member1 = group1.getOrMaybeCreateMember("member-id", true);
@@ -225,17 +199,17 @@ public class GroupCoordinatorMetricsShardTest {
 
         snapshotRegistry.getOrCreateSnapshot(2000);
         shard.commitUpTo(2000);
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS_EMPTY));
-        assertEquals(4, shard.localGaugeValue(NUM_CONSUMER_GROUPS_STABLE));
+        assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.EMPTY));
+        assertEquals(4, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE));
 
         group2.setGroupEpoch(1);
         group3.setGroupEpoch(1);
 
         snapshotRegistry.getOrCreateSnapshot(3000);
         shard.commitUpTo(3000);
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS_EMPTY));
-        assertEquals(2, shard.localGaugeValue(NUM_CONSUMER_GROUPS_ASSIGNING));
-        assertEquals(2, shard.localGaugeValue(NUM_CONSUMER_GROUPS_STABLE));
+        assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.EMPTY));
+        assertEquals(2, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.ASSIGNING));
+        assertEquals(2, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE));
 
         group2.setTargetAssignmentEpoch(1);
         // Set member2 to ASSIGNING state.
@@ -245,16 +219,21 @@ public class GroupCoordinatorMetricsShardTest {
 
         snapshotRegistry.getOrCreateSnapshot(4000);
         shard.commitUpTo(4000);
-        assertEquals(0, shard.localGaugeValue(NUM_CONSUMER_GROUPS_EMPTY));
-        assertEquals(1, shard.localGaugeValue(NUM_CONSUMER_GROUPS_ASSIGNING));
-        assertEquals(1, shard.localGaugeValue(NUM_CONSUMER_GROUPS_RECONCILING));
-        assertEquals(2, shard.localGaugeValue(NUM_CONSUMER_GROUPS_STABLE));
+        assertEquals(0, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.EMPTY));
+        assertEquals(1, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.ASSIGNING));
+        assertEquals(1, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.RECONCILING));
+        assertEquals(2, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE));
 
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumConsumerGroups"), 4);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumConsumerGroupsEmpty"), 0);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumConsumerGroupsAssigning"), 1);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumConsumerGroupsReconciling"), 1);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumConsumerGroupsStable"), 2);
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumConsumerGroupsDead"), 0);
+        assertGaugeValue(metrics, metrics.metricName("consumer-groups-count", "group-coordinator-metrics"), 4);
+        assertGaugeValue(metrics, metrics.metricName("consumer-groups-count", "group-coordinator-metrics",
+            Collections.singletonMap("state", "empty")), 0);
+        assertGaugeValue(metrics, metrics.metricName("consumer-groups-count", "group-coordinator-metrics",
+            Collections.singletonMap("state", "assigning")), 1);
+        assertGaugeValue(metrics, metrics.metricName("consumer-groups-count", "group-coordinator-metrics",
+            Collections.singletonMap("state", "reconciling")), 1);
+        assertGaugeValue(metrics, metrics.metricName("consumer-groups-count", "group-coordinator-metrics",
+            Collections.singletonMap("state", "stable")), 2);
+        assertGaugeValue(metrics, metrics.metricName("consumer-groups-count", "group-coordinator-metrics",
+            Collections.singletonMap("state", "dead")), 0);
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
@@ -138,7 +138,7 @@ public class GroupCoordinatorMetricsShardTest {
 
         assertGaugeValue(
             metrics,
-            metrics.metricName("group-count", "group-coordinator-metrics", Collections.singletonMap("type", "generic")),
+            metrics.metricName("group-count", "group-coordinator-metrics", Collections.singletonMap("group-type", "generic")),
             4
         );
         assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroups"), 4);
@@ -225,7 +225,7 @@ public class GroupCoordinatorMetricsShardTest {
         assertEquals(2, shard.numConsumerGroups(ConsumerGroup.ConsumerGroupState.STABLE));
 
         assertGaugeValue(metrics, metrics.metricName("group-count", "group-coordinator-metrics",
-            Collections.singletonMap("type", "consumer")), 4);
+            Collections.singletonMap("group-type", "consumer")), 4);
         assertGaugeValue(metrics, metrics.metricName("consumer-group-count", "group-coordinator-metrics",
             Collections.singletonMap("state", "empty")), 0);
         assertGaugeValue(metrics, metrics.metricName("consumer-group-count", "group-coordinator-metrics",

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
@@ -67,31 +67,31 @@ public class GroupCoordinatorMetricsTest {
             metrics.metricName("consumer-group-rebalance-rate", GroupCoordinatorMetrics.METRICS_GROUP),
             metrics.metricName("consumer-group-rebalance-count", GroupCoordinatorMetrics.METRICS_GROUP),
             metrics.metricName(
-                "groups-count",
+                "group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
                 Collections.singletonMap("type", "generic")),
             metrics.metricName(
-                "groups-count",
+                "group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
                 Collections.singletonMap("type", "consumer")),
             metrics.metricName(
-                "consumer-groups-count",
+                "consumer-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
                 Collections.singletonMap("state", "empty")),
             metrics.metricName(
-                "consumer-groups-count",
+                "consumer-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
                 Collections.singletonMap("state", "assigning")),
             metrics.metricName(
-                "consumer-groups-count",
+                "consumer-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
                 Collections.singletonMap("state", "reconciling")),
             metrics.metricName(
-                "consumer-groups-count",
+                "consumer-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
                 Collections.singletonMap("state", "stable")),
             metrics.metricName(
-                "consumer-groups-count",
+                "consumer-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
                 Collections.singletonMap("state", "dead"))
         ));
@@ -151,7 +151,7 @@ public class GroupCoordinatorMetricsTest {
         assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroups"), 9);
         assertGaugeValue(
             metrics,
-            metrics.metricName("groups-count", METRICS_GROUP, Collections.singletonMap("type", "generic")),
+            metrics.metricName("group-count", METRICS_GROUP, Collections.singletonMap("type", "generic")),
             9
         );
 
@@ -166,7 +166,7 @@ public class GroupCoordinatorMetricsTest {
         assertEquals(1, shard1.numOffsets());
         assertGaugeValue(
             metrics,
-            metrics.metricName("groups-count", METRICS_GROUP, Collections.singletonMap("type", "consumer")),
+            metrics.metricName("group-count", METRICS_GROUP, Collections.singletonMap("type", "consumer")),
             7
         );
         assertGaugeValue(registry, metricName("GroupMetadataManager", "NumOffsets"), 7);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
@@ -69,11 +69,11 @@ public class GroupCoordinatorMetricsTest {
             metrics.metricName(
                 "group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Collections.singletonMap("type", "generic")),
+                Collections.singletonMap("group-type", "generic")),
             metrics.metricName(
                 "group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Collections.singletonMap("type", "consumer")),
+                Collections.singletonMap("group-type", "consumer")),
             metrics.metricName(
                 "consumer-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
@@ -151,7 +151,7 @@ public class GroupCoordinatorMetricsTest {
         assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroups"), 9);
         assertGaugeValue(
             metrics,
-            metrics.metricName("group-count", METRICS_GROUP, Collections.singletonMap("type", "generic")),
+            metrics.metricName("group-count", METRICS_GROUP, Collections.singletonMap("group-type", "generic")),
             9
         );
 
@@ -166,7 +166,7 @@ public class GroupCoordinatorMetricsTest {
         assertEquals(1, shard1.numOffsets());
         assertGaugeValue(
             metrics,
-            metrics.metricName("group-count", METRICS_GROUP, Collections.singletonMap("type", "consumer")),
+            metrics.metricName("group-count", METRICS_GROUP, Collections.singletonMap("group-type", "consumer")),
             7
         );
         assertGaugeValue(registry, metricName("GroupMetadataManager", "NumOffsets"), 7);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
@@ -69,11 +69,11 @@ public class GroupCoordinatorMetricsTest {
             metrics.metricName(
                 "group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Collections.singletonMap("group-type", "generic")),
+                Collections.singletonMap("protocol", "generic")),
             metrics.metricName(
                 "group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
-                Collections.singletonMap("group-type", "consumer")),
+                Collections.singletonMap("protocol", "consumer")),
             metrics.metricName(
                 "consumer-group-count",
                 GroupCoordinatorMetrics.METRICS_GROUP,
@@ -151,7 +151,7 @@ public class GroupCoordinatorMetricsTest {
         assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroups"), 9);
         assertGaugeValue(
             metrics,
-            metrics.metricName("group-count", METRICS_GROUP, Collections.singletonMap("group-type", "generic")),
+            metrics.metricName("group-count", METRICS_GROUP, Collections.singletonMap("protocol", "generic")),
             9
         );
 
@@ -166,7 +166,7 @@ public class GroupCoordinatorMetricsTest {
         assertEquals(1, shard1.numOffsets());
         assertGaugeValue(
             metrics,
-            metrics.metricName("group-count", METRICS_GROUP, Collections.singletonMap("group-type", "consumer")),
+            metrics.metricName("group-count", METRICS_GROUP, Collections.singletonMap("protocol", "consumer")),
             7
         );
         assertGaugeValue(registry, metricName("GroupMetadataManager", "NumOffsets"), 7);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/MetricsTestUtils.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/MetricsTestUtils.java
@@ -17,8 +17,9 @@
 package org.apache.kafka.coordinator.group.metrics;
 
 import com.yammer.metrics.core.Gauge;
-import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Metrics;
 
 import java.util.Set;
 import java.util.TreeSet;
@@ -44,14 +45,19 @@ public class MetricsTestUtils {
         assertEquals(new TreeSet<>(expected), actual);
     }
 
-    static void assertGaugeValue(MetricsRegistry registry, MetricName metricName, long count) {
+    static void assertGaugeValue(MetricsRegistry registry, com.yammer.metrics.core.MetricName metricName, long count) {
         Gauge gauge = (Gauge) registry.allMetrics().get(metricName);
 
         assertEquals(count, (long) gauge.value());
     }
 
-    static MetricName metricName(String type, String name) {
+    static void assertGaugeValue(Metrics metrics, MetricName metricName, long count) {
+        Long metricVal = (Long) metrics.metrics().get(metricName).metricValue();
+        assertEquals(count, metricVal);
+    }
+
+    static com.yammer.metrics.core.MetricName metricName(String type, String name) {
         String mBeanName = String.format("kafka.coordinator.group:type=%s,name=%s", type, name);
-        return new MetricName("kafka.coordinator.group", type, name, null, mBeanName);
+        return new com.yammer.metrics.core.MetricName("kafka.coordinator.group", type, name, null, mBeanName);
     }
 }


### PR DESCRIPTION
Move the following metrics from Yammer to Kafka metrics to continue with the migration from yammer to kafka metrics. These are not exposed and newly created metrics so there are no compatibility issues.

 * NumConsumerGroups (yammer) -> consumer-groups-count (kafka)
 * NumConsumerGroupsEmpty (yammer) -> consumer-groups-count, state=empty (kafka)
 * NumConsumerGroupsAssigning (yammer) -> consumer-groups-count, state=assigning (kafka)
 * NumConsumerGroupsReconciling (yammer) -> consumer-groups-count, state=reconciling (kafka)
 * NumConsumerGroupsStable (yammer) -> consumer-groups-count, state=stable(kafka)
 * NumConsumerGroupsDead (yammer) -> consumer-groups-count, state=dead (kafka)

Also, move generic group metrics from global to local, and follow the same pattern as consumer groups.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
