### PR TITLE
MINOR: DirectoryId.MIGRATING should be all zeros

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/common/DirectoryId.java
+++ b/server-common/src/main/java/org/apache/kafka/common/DirectoryId.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 public class DirectoryId {
     /**
-     * A Uuid that is used to represent and unspecified log directory,
+     * A Uuid that is used to represent an unspecified log directory,
      * that is expected to have been previously selected to host an
      * associated replica. This contrasts with {@code UNASSIGNED_DIR},
      * which is associated with (typically new) replicas that may not
@@ -33,7 +33,7 @@ public class DirectoryId {
     public static final Uuid MIGRATING = new Uuid(0L, 0L);
 
     /**
-     * A Uuid that is used to directories that are pending an assignment.
+     * A Uuid that is used to represent directories that are pending an assignment.
      */
     public static final Uuid UNASSIGNED = new Uuid(0L, 1L);
 

--- a/server-common/src/main/java/org/apache/kafka/common/DirectoryId.java
+++ b/server-common/src/main/java/org/apache/kafka/common/DirectoryId.java
@@ -23,17 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 public class DirectoryId {
-
-    /**
-     * A Uuid that is used to identify new or unknown dir assignments.
-     */
-    public static final Uuid UNASSIGNED = new Uuid(0L, 0L);
-
-    /**
-     * A Uuid that is used to represent unspecified offline dirs.
-     */
-    public static final Uuid LOST = new Uuid(0L, 1L);
-
     /**
      * A Uuid that is used to represent and unspecified log directory,
      * that is expected to have been previously selected to host an
@@ -41,7 +30,17 @@ public class DirectoryId {
      * which is associated with (typically new) replicas that may not
      * yet have been placed in any log directory.
      */
-    public static final Uuid MIGRATING = new Uuid(0L, 2L);
+    public static final Uuid MIGRATING = new Uuid(0L, 0L);
+
+    /**
+     * A Uuid that is used to directories that are pending an assignment.
+     */
+    public static final Uuid UNASSIGNED = new Uuid(0L, 1L);
+
+    /**
+     * A Uuid that is used to represent unspecified offline dirs.
+     */
+    public static final Uuid LOST = new Uuid(0L, 2L);
 
     /**
      * Static factory to generate a directory ID.


### PR DESCRIPTION
DirectoryId.MIGRATING should be all zeros, because all zeros is the default Uuid value in KPRC.