### PR TITLE
KAFKA-15922: Add a MetadataVersion for JBOD

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationRequest.java
@@ -45,10 +45,6 @@ public class BrokerRegistrationRequest extends AbstractRequest {
 
         @Override
         public BrokerRegistrationRequest build(short version) {
-            if (version < 2) {
-                // Reset the PreviousBrokerEpoch to default if not supported.
-                data.setPreviousBrokerEpoch(new BrokerRegistrationRequestData().previousBrokerEpoch());
-            }
             return new BrokerRegistrationRequest(data, version);
         }
 

--- a/clients/src/main/resources/common/message/BrokerRegistrationRequest.json
+++ b/clients/src/main/resources/common/message/BrokerRegistrationRequest.json
@@ -15,9 +15,9 @@
 
 // Version 1 adds Zk broker epoch to the request if the broker is migrating from Zk mode to KRaft mode.
 
-// Version 2 adds the PreviousBrokerEpoch for the KIP-966
+// Version 2 adds LogDirs for KIP-858
 
-// Version 3 adds LogDirs for KIP-858
+// Version 3 adds the PreviousBrokerEpoch for the KIP-966
 {
   "apiKey":62,
   "type": "request",
@@ -58,9 +58,9 @@
       "about": "The rack which this broker is in." },
     { "name": "IsMigratingZkBroker", "type": "bool", "versions": "1+", "default": "false",
       "about": "If the required configurations for ZK migration are present, this value is set to true" },
-    { "name": "PreviousBrokerEpoch", "type": "int64", "versions": "2+", "default": "-1",
-      "about": "The epoch before a clean shutdown." },
-    { "name": "LogDirs", "type":  "[]uuid", "versions":  "3+",
-      "about": "Log directories configured in this broker which are available." }
+    { "name": "LogDirs", "type":  "[]uuid", "versions":  "2+",
+      "about": "Log directories configured in this broker which are available." },
+    { "name": "PreviousBrokerEpoch", "type": "int64", "versions": "3+", "default": "-1",
+      "about": "The epoch before a clean shutdown." }
   ]
 }

--- a/clients/src/main/resources/common/message/BrokerRegistrationRequest.json
+++ b/clients/src/main/resources/common/message/BrokerRegistrationRequest.json
@@ -60,7 +60,7 @@
       "about": "If the required configurations for ZK migration are present, this value is set to true" },
     { "name": "LogDirs", "type":  "[]uuid", "versions":  "2+",
       "about": "Log directories configured in this broker which are available." },
-    { "name": "PreviousBrokerEpoch", "type": "int64", "versions": "3+", "default": "-1",
+    { "name": "PreviousBrokerEpoch", "type": "int64", "versions": "3+", "default": "-1", "ignorable": true,
       "about": "The epoch before a clean shutdown." }
   ]
 }

--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -18,7 +18,6 @@
 package kafka
 
 import java.util.Properties
-
 import joptsimple.OptionParser
 import kafka.server.{KafkaConfig, KafkaRaftServer, KafkaServer, Server}
 import kafka.utils.Implicits._

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -46,7 +46,7 @@ import org.apache.kafka.metadata.publisher.FeaturesPublisher
 import org.apache.kafka.raft.RaftConfig
 import org.apache.kafka.server.{ClientMetricsManager, NodeToControllerChannelManager}
 import org.apache.kafka.server.authorizer.Authorizer
-import org.apache.kafka.server.common.ApiMessageAndVersion
+import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
 import org.apache.kafka.server.metrics.{KafkaMetricsGroup, KafkaYammerMetrics}
 import org.apache.kafka.server.network.{EndpointReadyFutures, KafkaAuthorizerServerInfo}
 import org.apache.kafka.server.policy.{AlterConfigPolicy, CreateTopicPolicy}
@@ -84,7 +84,7 @@ case class ControllerMigrationSupport(
 class ControllerServer(
   val sharedServer: SharedServer,
   val configSchema: KafkaConfigSchema,
-  val bootstrapMetadata: BootstrapMetadata,
+  val bootstrapMetadata: BootstrapMetadata
 ) extends Logging {
 
   import kafka.server.Server._

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -46,7 +46,7 @@ import org.apache.kafka.metadata.publisher.FeaturesPublisher
 import org.apache.kafka.raft.RaftConfig
 import org.apache.kafka.server.{ClientMetricsManager, NodeToControllerChannelManager}
 import org.apache.kafka.server.authorizer.Authorizer
-import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
+import org.apache.kafka.server.common.ApiMessageAndVersion
 import org.apache.kafka.server.metrics.{KafkaMetricsGroup, KafkaYammerMetrics}
 import org.apache.kafka.server.network.{EndpointReadyFutures, KafkaAuthorizerServerInfo}
 import org.apache.kafka.server.policy.{AlterConfigPolicy, CreateTopicPolicy}
@@ -217,7 +217,7 @@ class ControllerServer(
         startupDeadline, time)
       val controllerNodes = RaftConfig.voterConnectionsToNodes(voterConnections)
       val quorumFeatures = new QuorumFeatures(config.nodeId,
-        QuorumFeatures.defaultFeatureMap(),
+        QuorumFeatures.defaultFeatureMap(config.unstableMetadataVersionsEnabled),
         controllerNodes.asScala.map(node => Integer.valueOf(node.id())).asJava)
 
       val delegationTokenKeyString = {
@@ -350,7 +350,7 @@ class ControllerServer(
         clusterId,
         time,
         s"controller-${config.nodeId}-",
-        QuorumFeatures.defaultFeatureMap(),
+        QuorumFeatures.defaultFeatureMap(config.unstableMetadataVersionsEnabled),
         config.migrationEnabled,
         incarnationId,
         listenerInfo)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -671,6 +671,7 @@ object KafkaConfig {
 
   /** Internal Configurations **/
   val UnstableApiVersionsEnableProp = "unstable.api.versions.enable"
+  val UnstableMetadataVersionsEnableProp = "unstable.metadata.versions.enable"
 
   /* Documentation */
   /** ********* Zookeeper Configuration ***********/
@@ -1519,8 +1520,10 @@ object KafkaConfig {
       .define(RaftConfig.QUORUM_RETRY_BACKOFF_MS_CONFIG, INT, Defaults.QuorumRetryBackoffMs, null, LOW, RaftConfig.QUORUM_RETRY_BACKOFF_MS_DOC)
 
       /** Internal Configurations **/
-      // This indicates whether unreleased APIs should be advertised by this broker.
-      .defineInternal(UnstableApiVersionsEnableProp, BOOLEAN, false, LOW)
+      // This indicates whether unreleased APIs should be advertised by this node.
+      .defineInternal(UnstableApiVersionsEnableProp, BOOLEAN, false, HIGH)
+      // This indicates whether unreleased MetadataVersions should be enabled on this node.
+      .defineInternal(UnstableMetadataVersionsEnableProp, BOOLEAN, false, HIGH)
   }
 
   /** ********* Remote Log Management Configuration *********/
@@ -2096,6 +2099,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
 
   /** Internal Configurations **/
   val unstableApiVersionsEnabled = getBoolean(KafkaConfig.UnstableApiVersionsEnableProp)
+  val unstableMetadataVersionsEnabled = getBoolean(KafkaConfig.UnstableMetadataVersionsEnableProp)
 
   def addReconfigurable(reconfigurable: Reconfigurable): Unit = {
     dynamicConfig.addReconfigurable(reconfigurable)

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -65,7 +65,11 @@ object StorageTool extends Logging {
             throw new TerseFailure(s"Must specify a valid KRaft metadata version of at least 3.0.")
           }
           if (!metadataVersion.isProduction()) {
-            throw new TerseFailure(s"Metadata version ${metadataVersion} is not ready for production use yet.")
+            if (config.get.unstableMetadataVersionsEnabled) {
+              System.out.println(s"WARNING: using pre-production metadata version ${metadataVersion}.")
+            } else {
+              throw new TerseFailure(s"Metadata version ${metadataVersion} is not ready for production use yet.")
+            }
           }
           val metaProperties = new MetaProperties.Builder().
             setVersion(MetaPropertiesVersion.V1).

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -59,9 +59,13 @@ object StorageTool extends Logging {
         case "format" =>
           val directories = configToLogDirectories(config.get)
           val clusterId = namespace.getString("cluster_id")
-          val metadataVersion = getMetadataVersion(namespace, Option(config.get.interBrokerProtocolVersionString))
+          val metadataVersion = getMetadataVersion(namespace,
+            Option(config.get.originals.get(KafkaConfig.InterBrokerProtocolVersionProp)).map(_.toString))
           if (!metadataVersion.isKRaftSupported) {
             throw new TerseFailure(s"Must specify a valid KRaft metadata version of at least 3.0.")
+          }
+          if (!metadataVersion.isProduction()) {
+            throw new TerseFailure(s"Metadata version ${metadataVersion} is not ready for production use yet.")
           }
           val metaProperties = new MetaProperties.Builder().
             setVersion(MetaPropertiesVersion.V1).
@@ -131,7 +135,7 @@ object StorageTool extends Logging {
       action(storeTrue())
     formatParser.addArgument("--release-version", "-r").
       action(store()).
-      help(s"A KRaft release version to use for the initial metadata version. The minimum is 3.0, the default is ${MetadataVersion.latest().version()}")
+      help(s"A KRaft release version to use for the initial metadata version. The minimum is 3.0, the default is ${MetadataVersion.LATEST_PRODUCTION.version()}")
 
     parser.parseArgsOrFail(args)
   }
@@ -151,7 +155,7 @@ object StorageTool extends Logging {
   ): MetadataVersion = {
     val defaultValue = defaultVersionString match {
       case Some(versionString) => MetadataVersion.fromVersionString(versionString)
-      case None => MetadataVersion.latest()
+      case None => MetadataVersion.LATEST_PRODUCTION
     }
 
     Option(namespace.getString("release_version"))

--- a/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
+++ b/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
@@ -117,6 +117,6 @@ public class ClusterTestExtensionsTest {
 
     @ClusterTest
     public void testDefaults(ClusterConfig config) {
-        Assertions.assertEquals(MetadataVersion.IBP_3_7_IV1, config.metadataVersion());
+        Assertions.assertEquals(MetadataVersion.IBP_3_7_IV3, config.metadataVersion());
     }
 }

--- a/core/src/test/java/kafka/test/annotation/ClusterTest.java
+++ b/core/src/test/java/kafka/test/annotation/ClusterTest.java
@@ -41,6 +41,6 @@ public @interface ClusterTest {
     String name() default "";
     SecurityProtocol securityProtocol() default SecurityProtocol.PLAINTEXT;
     String listener() default "";
-    MetadataVersion metadataVersion() default MetadataVersion.IBP_3_7_IV1;
+    MetadataVersion metadataVersion() default MetadataVersion.IBP_3_7_IV3;
     ClusterConfigProperty[] serverProperties() default {};
 }

--- a/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
@@ -198,6 +198,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
             if (brokerNode != null) {
                 props.putAll(brokerNode.propertyOverrides());
             }
+            props.putIfAbsent(KafkaConfig$.MODULE$.UnstableMetadataVersionsEnableProp(), "true");
             return new KafkaConfig(props, false, Option.empty());
         }
 

--- a/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/server/QuorumTestHarness.scala
@@ -312,6 +312,7 @@ abstract class QuorumTestHarness extends Logging {
     val props = propsList(0)
     props.setProperty(KafkaConfig.ServerMaxStartupTimeMsProp, TimeUnit.MINUTES.toMillis(10).toString)
     props.setProperty(KafkaConfig.ProcessRolesProp, "controller")
+    props.setProperty(KafkaConfig.UnstableMetadataVersionsEnableProp, "true")
     if (props.getProperty(KafkaConfig.NodeIdProp) == null) {
       props.setProperty(KafkaConfig.NodeIdProp, "1000")
     }

--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -72,7 +72,9 @@ object ZkMigrationIntegrationTest {
       MetadataVersion.IBP_3_5_IV2,
       MetadataVersion.IBP_3_6_IV2,
       MetadataVersion.IBP_3_7_IV0,
-      MetadataVersion.IBP_3_7_IV1
+      MetadataVersion.IBP_3_7_IV1,
+      MetadataVersion.IBP_3_7_IV2,
+      MetadataVersion.IBP_3_7_IV3
     ).foreach { mv =>
       val clusterConfig = ClusterConfig.defaultClusterBuilder()
         .metadataVersion(mv)

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -2191,7 +2191,7 @@ class PartitionTest extends AbstractPartitionTest {
     val partition = new Partition(
       topicPartition,
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
-      interBrokerProtocolVersion = MetadataVersion.IBP_3_7_IV1,
+      interBrokerProtocolVersion = MetadataVersion.IBP_3_7_IV2,
       localBrokerId = brokerId,
       () => defaultBrokerEpoch(brokerId),
       time,

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -33,6 +33,8 @@ import org.apache.kafka.common.metadata.UserScramCredentialRecord
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, MetaPropertiesVersion, PropertiesUtils}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertThrows, assertTrue}
 import org.junit.jupiter.api.{Test, Timeout}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -389,5 +391,46 @@ Found problem:
       assertTrue(metaProps.directoryId().isPresent())
       assertFalse(DirectoryId.reserved(metaProps.directoryId().get()))
     } finally Utils.delete(tempDir)
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = Array(false, true))
+  def testFormattingUnstableMetadataVersionBlocked(enableUnstable: Boolean): Unit = {
+    var exitString: String = ""
+    var exitStatus: Int = 1
+    def exitProcedure(status: Int, message: Option[String]) : Nothing = {
+      exitStatus = status
+      exitString = message.getOrElse("")
+      throw new StorageToolTestException(exitString)
+    }
+    Exit.setExitProcedure(exitProcedure)
+    val properties = newSelfManagedProperties()
+    val propsFile = TestUtils.tempFile()
+    val propsStream = Files.newOutputStream(propsFile.toPath)
+    try {
+      properties.setProperty(KafkaConfig.LogDirsProp, TestUtils.tempDir().toString)
+      properties.setProperty(KafkaConfig.UnstableMetadataVersionsEnableProp, enableUnstable.toString)
+      properties.store(propsStream, "config.props")
+    } finally {
+      propsStream.close()
+    }
+    val args = Array("format", "-c", s"${propsFile.toPath}",
+      "-t", "XcZZOzUqS4yHOjhMQB6JLQ",
+      "--release-version", MetadataVersion.latest().toString)
+    try {
+      StorageTool.main(args)
+    } catch {
+      case _: StorageToolTestException =>
+    } finally {
+      Exit.resetExitProcedure()
+    }
+    if (enableUnstable) {
+      assertEquals("", exitString)
+      assertEquals(0, exitStatus)
+    } else {
+      assertEquals(s"Metadata version ${MetadataVersion.latest().toString} is not ready for " +
+        "production use yet.", exitString)
+      assertEquals(1, exitStatus)
+    }
   }
 }

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -206,7 +206,7 @@ Found problem:
     val namespace = StorageTool.parseArguments(Array("format", "-c", "config.props", "-t", "XcZZOzUqS4yHOjhMQB6JLQ"))
     val mv = StorageTool.getMetadataVersion(namespace, defaultVersionString = None)
     assertEquals(MetadataVersion.LATEST_PRODUCTION.featureLevel(), mv.featureLevel(),
-      "Expected the default metadata.version to be the latest version")
+      "Expected the default metadata.version to be the latest production version")
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -203,7 +203,7 @@ Found problem:
   def testDefaultMetadataVersion(): Unit = {
     val namespace = StorageTool.parseArguments(Array("format", "-c", "config.props", "-t", "XcZZOzUqS4yHOjhMQB6JLQ"))
     val mv = StorageTool.getMetadataVersion(namespace, defaultVersionString = None)
-    assertEquals(MetadataVersion.latest().featureLevel(), mv.featureLevel(),
+    assertEquals(MetadataVersion.LATEST_PRODUCTION.featureLevel(), mv.featureLevel(),
       "Expected the default metadata.version to be the latest version")
   }
 

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -331,6 +331,7 @@ object TestUtils extends Logging {
     }.mkString(",")
 
     val props = new Properties
+    props.put(KafkaConfig.UnstableMetadataVersionsEnableProp, "true")
     if (zkConnect == null) {
       props.setProperty(KafkaConfig.ServerMaxStartupTimeMsProp, TimeUnit.MINUTES.toMillis(10).toString)
       props.put(KafkaConfig.NodeIdProp, nodeId.toString)

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumFeatures.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumFeatures.java
@@ -54,11 +54,13 @@ public final class QuorumFeatures {
         return Optional.empty();
     }
 
-    public static Map<String, VersionRange> defaultFeatureMap() {
+    public static Map<String, VersionRange> defaultFeatureMap(boolean enableUnstable) {
         Map<String, VersionRange> features = new HashMap<>(1);
         features.put(MetadataVersion.FEATURE_NAME, VersionRange.of(
                 MetadataVersion.MINIMUM_KRAFT_VERSION.featureLevel(),
-                MetadataVersion.LATEST_PRODUCTION.featureLevel()));
+                enableUnstable ?
+                    MetadataVersion.latest().featureLevel() :
+                    MetadataVersion.LATEST_PRODUCTION.featureLevel()));
         return features;
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumFeatures.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumFeatures.java
@@ -58,7 +58,7 @@ public final class QuorumFeatures {
         Map<String, VersionRange> features = new HashMap<>(1);
         features.put(MetadataVersion.FEATURE_NAME, VersionRange.of(
                 MetadataVersion.MINIMUM_KRAFT_VERSION.featureLevel(),
-                MetadataVersion.latest().featureLevel()));
+                MetadataVersion.LATEST_PRODUCTION.featureLevel()));
         return features;
     }
 

--- a/metadata/src/main/resources/common/metadata/PartitionChangeRecord.json
+++ b/metadata/src/main/resources/common/metadata/PartitionChangeRecord.json
@@ -17,8 +17,8 @@
   "apiKey": 5,
   "type": "metadata",
   "name": "PartitionChangeRecord",
-  // Version 1 implements Eligible Leader Replicas and LastKnownELR as described in KIP-966.
-  // Version 2 adds Directories for KIP-858
+  // Version 1 adds Directories for KIP-858.
+  // Version 2 implements Eligible Leader Replicas and LastKnownELR as described in KIP-966.
   "validVersions": "0-2",
   "flexibleVersions": "0+",
   "fields": [
@@ -43,14 +43,14 @@
       "about": "null if the adding replicas didn't change; the new adding replicas otherwise." },
     { "name": "LeaderRecoveryState", "type": "int8", "default": "-1", "versions": "0+", "taggedVersions": "0+", "tag": 5,
       "about": "-1 if it didn't change; 0 if the leader was elected from the ISR or recovered from an unclean election; 1 if the leader that was elected using unclean leader election and it is still recovering." },
+    { "name": "Directories", "type": "[]uuid", "default": "null",
+      "versions": "1+", "nullableVersions": "1+", "taggedVersions": "1+", "tag": 8,
+      "about": "null if the log dirs didn't change; the new log directory for each replica otherwise."},
     { "name": "EligibleLeaderReplicas", "type": "[]int32", "default": "null", "entityType": "brokerId",
-      "versions": "1+", "nullableVersions": "1+", "taggedVersions": "1+", "tag": 6,
+      "versions": "2+", "nullableVersions": "2+", "taggedVersions": "2+", "tag": 6,
       "about": "null if the ELR didn't change; the new eligible leader replicas otherwise." },
     { "name": "LastKnownELR", "type": "[]int32", "default": "null", "entityType": "brokerId",
-      "versions": "1+", "nullableVersions": "1+", "taggedVersions": "1+", "tag": 7,
-      "about": "null if the LastKnownELR didn't change; the last known eligible leader replicas otherwise." },
-    { "name": "Directories", "type": "[]uuid", "default": "null",
-      "versions": "2+", "nullableVersions": "2+", "taggedVersions": "2+", "tag": 8,
-      "about": "null if the log dirs didn't change; the new log directory for each replica otherwise."}
+      "versions": "2+", "nullableVersions": "2+", "taggedVersions": "2+", "tag": 7,
+      "about": "null if the LastKnownELR didn't change; the last known eligible leader replicas otherwise." }
   ]
 }

--- a/metadata/src/main/resources/common/metadata/PartitionRecord.json
+++ b/metadata/src/main/resources/common/metadata/PartitionRecord.json
@@ -17,8 +17,8 @@
   "apiKey": 3,
   "type": "metadata",
   "name": "PartitionRecord",
-  // Version 1 implements Eligible Leader Replicas and LastKnownELR as described in KIP-966.
-  // Version 2 adds Directories for KIP-858
+  // Version 1 adds Directories for KIP-858
+  // Version 2 implements Eligible Leader Replicas and LastKnownELR as described in KIP-966.
   "validVersions": "0-2",
   "flexibleVersions": "0+",
   "fields": [
@@ -42,13 +42,13 @@
       "about": "The epoch of the partition leader." },
     { "name": "PartitionEpoch", "type": "int32", "versions": "0+", "default": "-1",
       "about": "An epoch that gets incremented each time we change anything in the partition." },
+    { "name": "Directories", "type": "[]uuid", "versions": "1+",
+      "about": "The log directory hosting each replica, sorted in the same exact order as the Replicas field."},
     { "name": "EligibleLeaderReplicas", "type": "[]int32", "default": "null", "entityType": "brokerId",
-      "versions": "1+", "nullableVersions": "1+", "taggedVersions": "1+", "tag": 1,
+      "versions": "2+", "nullableVersions": "1+", "taggedVersions": "2+", "tag": 1,
       "about": "The eligible leader replicas of this partition." },
     { "name": "LastKnownELR", "type": "[]int32", "default": "null", "entityType": "brokerId",
-      "versions": "1+", "nullableVersions": "1+", "taggedVersions": "1+", "tag": 2,
-      "about": "The last known eligible leader replicas of this partition." },
-    { "name": "Directories", "type": "[]uuid", "versions": "2+",
-      "about": "The log directory hosting each replica, sorted in the same exact order as the Replicas field."}
+      "versions": "2+", "nullableVersions": "1+", "taggedVersions": "2+", "tag": 2,
+      "about": "The last known eligible leader replicas of this partition." }
   ]
 }

--- a/metadata/src/main/resources/common/metadata/PartitionRecord.json
+++ b/metadata/src/main/resources/common/metadata/PartitionRecord.json
@@ -45,10 +45,10 @@
     { "name": "Directories", "type": "[]uuid", "versions": "1+",
       "about": "The log directory hosting each replica, sorted in the same exact order as the Replicas field."},
     { "name": "EligibleLeaderReplicas", "type": "[]int32", "default": "null", "entityType": "brokerId",
-      "versions": "2+", "nullableVersions": "1+", "taggedVersions": "2+", "tag": 1,
+      "versions": "2+", "nullableVersions": "2+", "taggedVersions": "2+", "tag": 1,
       "about": "The eligible leader replicas of this partition." },
     { "name": "LastKnownELR", "type": "[]int32", "default": "null", "entityType": "brokerId",
-      "versions": "2+", "nullableVersions": "1+", "taggedVersions": "2+", "tag": 2,
+      "versions": "2+", "nullableVersions": "2+", "taggedVersions": "2+", "tag": 2,
       "about": "The last known eligible leader replicas of this partition." }
   ]
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
@@ -76,7 +76,7 @@ public class ClusterControlManagerTest {
         FeatureControlManager featureControl = new FeatureControlManager.Builder().
             setSnapshotRegistry(snapshotRegistry).
             setQuorumFeatures(new QuorumFeatures(0,
-                QuorumFeatures.defaultFeatureMap(),
+                QuorumFeatures.defaultFeatureMap(true),
                 Collections.singletonList(0))).
             setMetadataVersion(MetadataVersion.latest()).
             build();
@@ -137,7 +137,7 @@ public class ClusterControlManagerTest {
         FeatureControlManager featureControl = new FeatureControlManager.Builder().
             setSnapshotRegistry(snapshotRegistry).
             setQuorumFeatures(new QuorumFeatures(0,
-                QuorumFeatures.defaultFeatureMap(),
+                QuorumFeatures.defaultFeatureMap(true),
                 Collections.singletonList(0))).
             setMetadataVersion(MetadataVersion.latest()).
             build();
@@ -190,7 +190,7 @@ public class ClusterControlManagerTest {
         FeatureControlManager featureControl = new FeatureControlManager.Builder().
             setSnapshotRegistry(snapshotRegistry).
             setQuorumFeatures(new QuorumFeatures(0,
-                QuorumFeatures.defaultFeatureMap(),
+                QuorumFeatures.defaultFeatureMap(true),
                 Collections.singletonList(0))).
             setMetadataVersion(MetadataVersion.latest()).
             build();
@@ -245,7 +245,7 @@ public class ClusterControlManagerTest {
         FeatureControlManager featureControl = new FeatureControlManager.Builder().
             setSnapshotRegistry(snapshotRegistry).
             setQuorumFeatures(new QuorumFeatures(0,
-                QuorumFeatures.defaultFeatureMap(),
+                QuorumFeatures.defaultFeatureMap(true),
                 Collections.singletonList(0))).
             setMetadataVersion(MetadataVersion.latest()).
             build();
@@ -275,7 +275,7 @@ public class ClusterControlManagerTest {
         FeatureControlManager featureControl = new FeatureControlManager.Builder().
             setSnapshotRegistry(snapshotRegistry).
             setQuorumFeatures(new QuorumFeatures(0,
-                QuorumFeatures.defaultFeatureMap(),
+                QuorumFeatures.defaultFeatureMap(true),
                 Collections.singletonList(0))).
             setMetadataVersion(metadataVersion).
             build();
@@ -332,7 +332,7 @@ public class ClusterControlManagerTest {
         FeatureControlManager featureControl = new FeatureControlManager.Builder().
             setSnapshotRegistry(snapshotRegistry).
             setQuorumFeatures(new QuorumFeatures(0,
-                QuorumFeatures.defaultFeatureMap(),
+                QuorumFeatures.defaultFeatureMap(true),
                 Collections.singletonList(0))).
             setMetadataVersion(MetadataVersion.latest()).
             build();
@@ -371,7 +371,7 @@ public class ClusterControlManagerTest {
         FeatureControlManager featureControl = new FeatureControlManager.Builder().
             setSnapshotRegistry(snapshotRegistry).
             setQuorumFeatures(new QuorumFeatures(0,
-                QuorumFeatures.defaultFeatureMap(),
+                QuorumFeatures.defaultFeatureMap(true),
                 Collections.singletonList(0))).
             setMetadataVersion(MetadataVersion.latest()).
             build();
@@ -424,7 +424,7 @@ public class ClusterControlManagerTest {
         FeatureControlManager featureControl = new FeatureControlManager.Builder().
             setSnapshotRegistry(snapshotRegistry).
             setQuorumFeatures(new QuorumFeatures(0,
-                QuorumFeatures.defaultFeatureMap(),
+                QuorumFeatures.defaultFeatureMap(true),
                 Collections.singletonList(0))).
             setMetadataVersion(metadataVersion).
             build();

--- a/metadata/src/test/java/org/apache/kafka/controller/FeatureControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/FeatureControlManagerTest.java
@@ -76,7 +76,7 @@ public class FeatureControlManagerTest {
     }
 
     public static QuorumFeatures features(Object... args) {
-        Map<String, VersionRange> features = QuorumFeatures.defaultFeatureMap();
+        Map<String, VersionRange> features = QuorumFeatures.defaultFeatureMap(true);
         features.putAll(rangeMap(args));
         return new QuorumFeatures(0, features, emptyList());
     }

--- a/metadata/src/test/java/org/apache/kafka/controller/ProducerIdControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ProducerIdControlManagerTest.java
@@ -49,7 +49,7 @@ public class ProducerIdControlManagerTest {
         featureControl = new FeatureControlManager.Builder().
             setSnapshotRegistry(snapshotRegistry).
             setQuorumFeatures(new QuorumFeatures(0,
-                QuorumFeatures.defaultFeatureMap(),
+                QuorumFeatures.defaultFeatureMap(true),
                 Collections.singletonList(0))).
             setMetadataVersion(MetadataVersion.latest()).
             build();

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -191,7 +191,7 @@ public class QuorumControllerTest {
         ) {
             controlEnv.activeController().registerBroker(ANONYMOUS_CONTEXT,
                 new BrokerRegistrationRequestData().
-                setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV1)).
+                setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV3)).
                 setBrokerId(0).
                 setClusterId(logEnv.clusterId())).get();
             testConfigurationOperations(controlEnv.activeController());
@@ -234,7 +234,7 @@ public class QuorumControllerTest {
         ) {
             controlEnv.activeController().registerBroker(ANONYMOUS_CONTEXT,
                 new BrokerRegistrationRequestData().
-                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV1)).
+                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV3)).
                     setBrokerId(0).
                     setClusterId(logEnv.clusterId())).get();
             testDelayedConfigurationOperations(logEnv, controlEnv.activeController());
@@ -576,7 +576,7 @@ public class QuorumControllerTest {
                     setBrokerId(0).
                     setClusterId(active.clusterId()).
                     setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwBA")).
-                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV1)).
+                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV3)).
                     setListeners(listeners));
             assertEquals(5L, reply.get().epoch());
             CreateTopicsRequestData createTopicsRequestData =

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTestEnv.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTestEnv.java
@@ -103,7 +103,7 @@ public class QuorumControllerTestEnv implements AutoCloseable {
                 builder.setRaftClient(logEnv.logManagers().get(nodeId));
                 builder.setBootstrapMetadata(bootstrapMetadata);
                 builder.setLeaderImbalanceCheckIntervalNs(leaderImbalanceCheckIntervalNs);
-                builder.setQuorumFeatures(new QuorumFeatures(nodeId, QuorumFeatures.defaultFeatureMap(), nodeIds));
+                builder.setQuorumFeatures(new QuorumFeatures(nodeId, QuorumFeatures.defaultFeatureMap(true), nodeIds));
                 sessionTimeoutMillis.ifPresent(timeout -> {
                     builder.setSessionTimeoutNs(NANOSECONDS.convert(timeout, TimeUnit.MILLISECONDS));
                 });

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumFeaturesTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumFeaturesTest.java
@@ -50,6 +50,24 @@ public class QuorumFeaturesTest {
     }
 
     @Test
+    public void testDefaultFeatureMap() {
+        Map<String, VersionRange> expectedFeatures = new HashMap<>(1);
+        expectedFeatures.put(MetadataVersion.FEATURE_NAME, VersionRange.of(
+            MetadataVersion.MINIMUM_KRAFT_VERSION.featureLevel(),
+            MetadataVersion.LATEST_PRODUCTION.featureLevel()));
+        assertEquals(expectedFeatures, QuorumFeatures.defaultFeatureMap(false));
+    }
+
+    @Test
+    public void testDefaultFeatureMapWithUnstable() {
+        Map<String, VersionRange> expectedFeatures = new HashMap<>(1);
+        expectedFeatures.put(MetadataVersion.FEATURE_NAME, VersionRange.of(
+            MetadataVersion.MINIMUM_KRAFT_VERSION.featureLevel(),
+            MetadataVersion.latest().featureLevel()));
+        assertEquals(expectedFeatures, QuorumFeatures.defaultFeatureMap(true));
+    }
+
+    @Test
     public void testLocalSupportedFeature() {
         assertEquals(VersionRange.of(0, 3), QUORUM_FEATURES.localSupportedFeature("foo"));
         assertEquals(VersionRange.of(0, 4), QUORUM_FEATURES.localSupportedFeature("bar"));

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.controller;
 
+import org.apache.kafka.common.DirectoryId;
 import org.apache.kafka.common.ElectionType;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
@@ -1635,6 +1636,7 @@ public class ReplicationControlManagerTest {
                 setReplicas(asList(2, 1, 3)).
                 setLeader(3).
                 setRemovingReplicas(Collections.emptyList()).
+                setDirectories(Arrays.asList(DirectoryId.unassignedArray(3))).
                 setAddingReplicas(Collections.emptyList()), MetadataVersion.latest().partitionChangeRecordVersion())),
             new AlterPartitionReassignmentsResponseData().setErrorMessage(null).setResponses(asList(
                 new ReassignableTopicResponse().setName("foo").setPartitions(asList(
@@ -1986,6 +1988,7 @@ public class ReplicationControlManagerTest {
                     setLeader(4).
                     setReplicas(asList(2, 3, 4)).
                     setRemovingReplicas(null).
+                    setDirectories(Arrays.asList(DirectoryId.unassignedArray(3))).
                     setAddingReplicas(Collections.emptyList()), MetadataVersion.latest().partitionChangeRecordVersion())),
             new AlterPartitionReassignmentsResponseData().setErrorMessage(null).setResponses(asList(
                 new ReassignableTopicResponse().setName("foo").setPartitions(asList(

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -225,7 +225,7 @@ public class ReplicationControlManagerTest {
             this.featureControl = new FeatureControlManager.Builder().
                 setSnapshotRegistry(snapshotRegistry).
                 setQuorumFeatures(new QuorumFeatures(0,
-                    QuorumFeatures.defaultFeatureMap(),
+                    QuorumFeatures.defaultFeatureMap(true),
                     Collections.singletonList(0))).
                 setMetadataVersion(metadataVersion).
                 build();

--- a/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/migration/KRaftMigrationDriverTest.java
@@ -82,7 +82,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KRaftMigrationDriverTest {
     private final static QuorumFeatures QUORUM_FEATURES = new QuorumFeatures(4,
-        QuorumFeatures.defaultFeatureMap(),
+        QuorumFeatures.defaultFeatureMap(true),
         Arrays.asList(4, 5, 6));
 
     static class MockControllerMetrics extends QuorumControllerMetrics {

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -188,8 +188,14 @@ public enum MetadataVersion {
     // Implement KIP-919 controller registration.
     IBP_3_7_IV0(15, "3.7", "IV0", true),
 
+    // Reserved
+    IBP_3_7_IV1(16, "3.7", "IV1", false),
+
+    // Add JBOD support for KRaft.
+    IBP_3_7_IV2(17, "3.7", "IV2", true),
+
     // Add ELR related supports (KIP-966).
-    IBP_3_7_IV1(16, "3.7", "IV1", true);
+    IBP_3_7_IV3(18, "3.7", "IV3", true);
 
     // NOTES when adding a new version:
     //   Update the default version in @ClusterTest annotation to point to the latest version
@@ -207,6 +213,22 @@ public enum MetadataVersion {
      */
     public static final MetadataVersion MINIMUM_BOOTSTRAP_VERSION = IBP_3_3_IV0;
 
+    /**
+     * The latest production-ready MetadataVersion. This is the latest version that is stable
+     * and cannot be changed. MetadataVersions later than this can be tested via junit, but
+     * not deployed in production.
+     *
+     * <strong>Think carefully before you update this value. ONCE A METADATA VERSION IS PRODUCTION,
+     * IT CANNOT BE CHANGED.</strong>
+     */
+    public static final MetadataVersion LATEST_PRODUCTION = IBP_3_7_IV0;
+
+    /**
+     * An array containing all of the MetadataVersion entries.
+     *
+     * This is essentially a cached copy of MetadataVersion.values. Unlike that function, it doesn't
+     * allocate a new array each time.
+     */
     public static final MetadataVersion[] VERSIONS;
 
     private final short featureLevel;
@@ -289,12 +311,12 @@ public enum MetadataVersion {
         return this.isAtLeast(IBP_3_6_IV2);
     }
 
-    public boolean isElrSupported() {
-        return this.isAtLeast(IBP_3_7_IV1);
+    public boolean isDirectoryAssignmentSupported() {
+        return this.isAtLeast(IBP_3_7_IV2);
     }
 
-    public boolean isDirectoryAssignmentSupported() {
-        return false; // TODO: Bump IBP for JBOD support in KRaft
+    public boolean isElrSupported() {
+        return this.isAtLeast(IBP_3_7_IV3);
     }
 
     public boolean isKRaftSupported() {
@@ -351,9 +373,9 @@ public enum MetadataVersion {
     }
 
     public short partitionChangeRecordVersion() {
-        if (isDirectoryAssignmentSupported()) {
+        if (isElrSupported()) {
             return (short) 2;
-        } else if (isElrSupported()) {
+        } else if (isDirectoryAssignmentSupported()) {
             return (short) 1;
         } else {
             return (short) 0;
@@ -361,9 +383,9 @@ public enum MetadataVersion {
     }
 
     public short partitionRecordVersion() {
-        if (isDirectoryAssignmentSupported()) {
+        if (isElrSupported()) {
             return (short) 2;
-        } else if (isElrSupported()) {
+        } else if (isDirectoryAssignmentSupported()) {
             return (short) 1;
         } else {
             return (short) 0;
@@ -467,19 +489,24 @@ public enum MetadataVersion {
     }
 
     private static final Map<String, MetadataVersion> IBP_VERSIONS;
-    static {
-        {
-            MetadataVersion[] enumValues = MetadataVersion.values();
-            VERSIONS = Arrays.copyOf(enumValues, enumValues.length);
 
-            IBP_VERSIONS = new HashMap<>();
-            Map<String, MetadataVersion> maxInterVersion = new HashMap<>();
-            for (MetadataVersion metadataVersion : VERSIONS) {
+    static {
+        MetadataVersion[] enumValues = MetadataVersion.values();
+        VERSIONS = Arrays.copyOf(enumValues, enumValues.length);
+
+        IBP_VERSIONS = new HashMap<>();
+        Map<String, MetadataVersion> maxInterVersion = new HashMap<>();
+        for (MetadataVersion metadataVersion : VERSIONS) {
+            if (metadataVersion.isProduction()) {
                 maxInterVersion.put(metadataVersion.release, metadataVersion);
-                IBP_VERSIONS.put(metadataVersion.ibpVersion, metadataVersion);
             }
-            IBP_VERSIONS.putAll(maxInterVersion);
+            IBP_VERSIONS.put(metadataVersion.ibpVersion, metadataVersion);
         }
+        IBP_VERSIONS.putAll(maxInterVersion);
+    }
+
+    public boolean isProduction() {
+        return this.compareTo(MetadataVersion.LATEST_PRODUCTION) <= 0;
     }
 
     public String shortVersion() {

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -165,8 +165,13 @@ class MetadataVersionTest {
         assertEquals(IBP_3_6_IV1, MetadataVersion.fromVersionString("3.6-IV1"));
         assertEquals(IBP_3_6_IV2, MetadataVersion.fromVersionString("3.6-IV2"));
 
+        // 3.7-IV0 is the latest production version in the 3.7 line
+        assertEquals(IBP_3_7_IV0, MetadataVersion.fromVersionString("3.7"));
+
         assertEquals(IBP_3_7_IV0, MetadataVersion.fromVersionString("3.7-IV0"));
         assertEquals(IBP_3_7_IV1, MetadataVersion.fromVersionString("3.7-IV1"));
+        assertEquals(IBP_3_7_IV2, MetadataVersion.fromVersionString("3.7-IV2"));
+        assertEquals(IBP_3_7_IV3, MetadataVersion.fromVersionString("3.7-IV3"));
     }
 
     @Test
@@ -268,6 +273,8 @@ class MetadataVersionTest {
         assertEquals("3.6-IV2", IBP_3_6_IV2.version());
         assertEquals("3.7-IV0", IBP_3_7_IV0.version());
         assertEquals("3.7-IV1", IBP_3_7_IV1.version());
+        assertEquals("3.7-IV2", IBP_3_7_IV2.version());
+        assertEquals("3.7-IV3", IBP_3_7_IV3.version());
     }
 
     @Test
@@ -329,19 +336,44 @@ class MetadataVersionTest {
     @ParameterizedTest
     @EnumSource(value = MetadataVersion.class)
     public void testIsElrSupported(MetadataVersion metadataVersion) {
-        assertEquals(metadataVersion.equals(IBP_3_7_IV1),
-                metadataVersion.isElrSupported());
-        short expectPartitionRecordVersion = metadataVersion.equals(IBP_3_7_IV1) ? (short) 1 : (short) 0;
-        assertEquals(expectPartitionRecordVersion, metadataVersion.partitionRecordVersion());
-        short expectPartitionChangeRecordVersion = metadataVersion.equals(IBP_3_7_IV1) ? (short) 1 : (short) 0;
-        assertEquals(expectPartitionChangeRecordVersion, metadataVersion.partitionChangeRecordVersion());
+        assertEquals(metadataVersion.equals(IBP_3_7_IV3), metadataVersion.isElrSupported());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MetadataVersion.class)
+    public void testPartitionRecordVersion(MetadataVersion metadataVersion) {
+        final short expectedVersion;
+        if (metadataVersion.isElrSupported()) {
+            expectedVersion = (short) 2;
+        } else if (metadataVersion.isDirectoryAssignmentSupported()) {
+            expectedVersion = (short) 1;
+        } else {
+            expectedVersion = (short) 0;
+        }
+        assertEquals(expectedVersion, metadataVersion.partitionRecordVersion());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MetadataVersion.class)
+    public void testPartitionChangeRecordVersion(MetadataVersion metadataVersion) {
+        final short expectedVersion;
+        if (metadataVersion.isElrSupported()) {
+            expectedVersion = (short) 2;
+        } else if (metadataVersion.isDirectoryAssignmentSupported()) {
+            expectedVersion = (short) 1;
+        } else {
+            expectedVersion = (short) 0;
+        }
+        assertEquals(expectedVersion, metadataVersion.partitionChangeRecordVersion());
     }
 
     @ParameterizedTest
     @EnumSource(value = MetadataVersion.class)
     public void testRegisterBrokerRecordVersion(MetadataVersion metadataVersion) {
         final short expectedVersion;
-        if (metadataVersion.isAtLeast(MetadataVersion.IBP_3_4_IV0)) {
+        if (metadataVersion.isAtLeast(MetadataVersion.IBP_3_7_IV2)) {
+            expectedVersion = 3;
+        } else if (metadataVersion.isAtLeast(MetadataVersion.IBP_3_4_IV0)) {
             expectedVersion = 2;
         } else if (metadataVersion.isAtLeast(IBP_3_3_IV3)) {
             expectedVersion = 1;
@@ -385,5 +417,22 @@ class MetadataVersionTest {
     @EnumSource(value = MetadataVersion.class)
     public void testOffsetCommitValueVersionWithExpiredTimestamp(MetadataVersion metadataVersion) {
         assertEquals((short) 1, metadataVersion.offsetCommitValueVersion(true));
+    }
+
+    @Test
+    public void assertLatestProductionIsLessThanLatest() {
+        assertTrue(LATEST_PRODUCTION.ordinal() < MetadataVersion.latest().ordinal(),
+            "Expected LATEST_PRODUCTION " + LATEST_PRODUCTION +
+            " to be less than the latest of " + MetadataVersion.latest());
+    }
+
+    @Test
+    public void assertLatestProductionIsProduction() {
+        assertTrue(LATEST_PRODUCTION.isProduction());
+    }
+
+    @Test
+    public void assertLatestIsNotProduction() {
+        assertFalse(MetadataVersion.latest().isProduction());
     }
 }

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -335,8 +335,14 @@ class MetadataVersionTest {
 
     @ParameterizedTest
     @EnumSource(value = MetadataVersion.class)
+    public void testDirectoryAssignmentSupported(MetadataVersion metadataVersion) {
+        assertEquals(metadataVersion.isAtLeast(IBP_3_7_IV2), metadataVersion.isDirectoryAssignmentSupported());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MetadataVersion.class)
     public void testIsElrSupported(MetadataVersion metadataVersion) {
-        assertEquals(metadataVersion.equals(IBP_3_7_IV3), metadataVersion.isElrSupported());
+        assertEquals(metadataVersion.isAtLeast(IBP_3_7_IV3), metadataVersion.isElrSupported());
     }
 
     @ParameterizedTest

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -68,7 +68,7 @@ public class FeatureCommandTest {
         );
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 3.7-IV1\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(commandOutput));
+                "SupportedMaxVersion: 3.7-IV3\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(commandOutput));
     }
 
     @ClusterTest(clusterType = Type.KRAFT, metadataVersion = MetadataVersion.IBP_3_7_IV0)
@@ -78,7 +78,7 @@ public class FeatureCommandTest {
         );
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 3.7-IV1\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(commandOutput));
+                "SupportedMaxVersion: 3.7-IV3\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(commandOutput));
     }
 
     @ClusterTest(clusterType = Type.ZK, metadataVersion = MetadataVersion.IBP_3_3_IV1)
@@ -137,7 +137,7 @@ public class FeatureCommandTest {
         );
         // Change expected message to reflect possible MetadataVersion range 1-N (N increases when adding a new version)
         assertEquals("Could not disable metadata.version. Invalid update version 0 for feature " +
-                "metadata.version. Local controller 3000 only supports versions 1-16", commandOutput);
+                "metadata.version. Local controller 3000 only supports versions 1-18", commandOutput);
 
         commandOutput = ToolsTestUtils.captureStandardOut(() ->
                 assertEquals(1, FeatureCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(),


### PR DESCRIPTION
Assign MetadataVersion.IBP_3_7_IV2 to JBOD.

Move KIP-966 support to MetadataVersion.IBP_3_7_IV3.

Create MetadataVersion.LATEST_PRODUCTION as the latest metadata version that can be used when formatting a new cluster, or upgrading a cluster using kafka-features.sh. This will allow us to clearly distinguish between stable and unstable metadata versions for the first time.