### PR TITLE
KAFKA-15662: Add support for clientInstanceIds in Kafka Stream

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -411,7 +411,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
             throw new IllegalStateException("clientInstanceId not set");
         }
 
-        if (timeout.toMillis() > clientInstanceIdBlockingTime.toMillis()) {
+        if (timeout.toMillis() < clientInstanceIdBlockingTime.toMillis()) {
             throw new TimeoutException();
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -82,8 +82,9 @@ public class MockProducer<K, V> implements Producer<K, V> {
     public RuntimeException flushException = null;
     public RuntimeException partitionsForException = null;
     public RuntimeException closeException = null;
+    private boolean telemetryDisabled = false;
     private Uuid clientInstanceId;
-    private Duration clientInstanceIdBlockingTime;
+    private int injectTimeoutExceptionCounter;
 
     /**
      * Create a mock producer
@@ -392,25 +393,35 @@ public class MockProducer<K, V> implements Producer<K, V> {
         return this.cluster.partitionsForTopic(topic);
     }
 
-    public void setClientInstanceId(final Uuid instanceId, final Duration blockingTime) {
+    public void disableTelemetry() {
+        telemetryDisabled = true;
+    }
+
+    /**
+     * @param injectTimeoutExceptionCounter use -1 for infinite
+     */
+    public void injectTimeoutException(final int injectTimeoutExceptionCounter) {
+        this.injectTimeoutExceptionCounter = injectTimeoutExceptionCounter;
+    }
+
+    public void setClientInstanceId(final Uuid instanceId) {
         clientInstanceId = instanceId;
-        clientInstanceIdBlockingTime = blockingTime;
     }
 
     @Override
     public Uuid clientInstanceId(Duration timeout) {
+        if (telemetryDisabled) {
+            throw new IllegalStateException();
+        }
         if (clientInstanceId == null) {
-            throw new IllegalStateException("clientInstanceId not set");
+            throw new UnsupportedOperationException("clientInstanceId not set");
         }
-
-        if (timeout.toMillis() < clientInstanceIdBlockingTime.toMillis()) {
+        if (injectTimeoutExceptionCounter != 0) {
+            // -1 is used as "infinite"
+            if (injectTimeoutExceptionCounter > 0) {
+                --injectTimeoutExceptionCounter;
+            }
             throw new TimeoutException();
-        }
-
-        try {
-            Thread.sleep(clientInstanceIdBlockingTime.toMillis());
-        } catch (final InterruptedException error) {
-            throw new InterruptException(error);
         }
 
         return clientInstanceId;

--- a/streams/src/main/java/org/apache/kafka/streams/ClientInstanceIds.java
+++ b/streams/src/main/java/org/apache/kafka/streams/ClientInstanceIds.java
@@ -29,6 +29,8 @@ public interface ClientInstanceIds {
      * Returns the {@code client instance id} of the admin client.
      *
      * @return the {@code client instance id} of the admin client
+     *
+     * @throws IllegalStateException If telemetry is disabled on the admin client.
      */
     Uuid adminInstanceId();
 

--- a/streams/src/main/java/org/apache/kafka/streams/ClientInstanceIds.java
+++ b/streams/src/main/java/org/apache/kafka/streams/ClientInstanceIds.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams;
+
+import org.apache.kafka.common.Uuid;
+
+import java.util.Map;
+
+/**
+ * Encapsulates the {@code client instance id} used for metrics collection by
+ * producers, consumers, and the admin client used by Kafka Streams.
+ */
+public interface ClientInstanceIds {
+    /**
+     * Returns the {@code client instance id} of the admin client.
+     *
+     * @return the {@code client instance id} of the admin client
+     */
+    Uuid adminInstanceId();
+
+    /**
+     * Returns the {@code client instance id} of the consumers.
+     *
+     * @return a map from thread key to {@code client instance id}
+     */
+    Map<String, Uuid> consumerInstanceIds();
+
+    /**
+     * Returns the {@code client instance id} of the producers.
+     *
+     * @return a map from thread key to {@code client instance id}
+     */
+    Map<String, Uuid> producerInstanceIds();
+}

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -102,6 +102,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
@@ -1797,12 +1798,17 @@ public class KafkaStreams implements AutoCloseable {
     /**
      * Returns the internal clients' assigned {@code client instance ids}.
      *
-     * @return the internal clients' assigned instance ids used for metrics collection.
+     * @return The internal clients' assigned instance ids used for metrics collection.
      *
+     * @throws IllegalArgumentException If {@code timeout} is negative.
      * @throws IllegalStateException If {@code KafkaStreams} is not running.
      * @throws TimeoutException Indicates that a request timed out.
+     * @throws StreamsException For any other error that might occur.
      */
     public ClientInstanceIds clientInstanceIds(final Duration timeout) {
+        if (timeout.isNegative()) {
+            throw new IllegalArgumentException("The timeout cannot be negative.");
+        }
         if (state().hasNotStarted()) {
             throw new IllegalStateException("KafkaStreams has not been started, you can retry after calling start().");
         }
@@ -1812,54 +1818,121 @@ public class KafkaStreams implements AutoCloseable {
 
         final ClientInstanceIdsImpl clientInstanceIds = new ClientInstanceIdsImpl();
 
-        final Map<String, KafkaFuture<Uuid>> streamThreadFutures = new HashMap<>();
-        for (final StreamThread streamThread : threads) {
-            streamThreadFutures.putAll(streamThread.clientInstanceIds(timeout));
-        }
+        // (1) fan-out calls to threads
 
+        // StreamThread for main/restore consumers and producer(s)
+        final Map<String, KafkaFuture<Uuid>> consumerFutures = new HashMap<>();
+        final Map<String, KafkaFuture<Map<String, KafkaFuture<Uuid>>>> producerFutures = new HashMap<>();
+        for (final StreamThread streamThread : threads) {
+            consumerFutures.putAll(streamThread.consumerClientInstanceIds(timeout));
+            producerFutures.put(streamThread.getName(), streamThread.producersClientInstanceIds(timeout));
+        }
+        // GlobalThread
         KafkaFuture<Uuid> globalThreadFuture = null;
         if (globalStreamThread != null) {
             globalThreadFuture = globalStreamThread.globalConsumerInstanceId(timeout);
         }
 
+        // (2) get admin client instance id in a blocking fashion, while Stream/GlobalThreads work in parallel
         try {
             clientInstanceIds.setAdminInstanceId(adminClient.clientInstanceId(timeout));
+        } catch (final IllegalStateException telemetryDisabledError) {
+            // swallow
+            log.debug("Telemetry is disabled on the admin client.");
         } catch (final TimeoutException timeoutException) {
-            log.warn("Could not get admin client-instance-id due to timeout.");
+            throw timeoutException;
+        } catch (final Exception error) {
+            throw new StreamsException("Could not retrieve admin client instance id.", error);
         }
 
-        for (final Map.Entry<String, KafkaFuture<Uuid>> streamThreadFuture : streamThreadFutures.entrySet()) {
-            try {
+        // (3) collect client instance ids from threads
+
+        // (3a) collect consumers from StreamsThread
+        for (final Map.Entry<String, KafkaFuture<Uuid>> consumerFuture : consumerFutures.entrySet()) {
+            final Uuid instanceId = getOrThrowException(
+                consumerFuture.getValue(),
+                () -> String.format(
+                    "Could not retrieve consumer instance id for %s.",
+                    consumerFuture.getKey()
+                )
+            );
+
+            // could be `null` if telemetry is disabled on the consumer itself
+            if (instanceId != null) {
                 clientInstanceIds.addConsumerInstanceId(
-                    streamThreadFuture.getKey(),
-                    streamThreadFuture.getValue().get()
+                    consumerFuture.getKey(),
+                    instanceId
                 );
-            } catch (final ExecutionException exception) {
-                if (exception.getCause() instanceof TimeoutException) {
-                    log.warn("Could not get global consumer client-instance-id due to timeout.");
-                } else {
-                    log.error("Could not get global consumer client-instance-id", exception);
-                }
-            } catch (final InterruptedException error) {
-                log.error("Could not get global consumer client-instance-id", error);
+            } else {
+                log.debug(String.format("Telemetry is disabled for %s.", consumerFuture.getKey()));
             }
         }
+        // (3b) collect producers from StreamsThread
+        for (final Map.Entry<String, KafkaFuture<Map<String, KafkaFuture<Uuid>>>> threadProducerFuture : producerFutures.entrySet()) {
+            final Map<String, KafkaFuture<Uuid>> streamThreadProducerFutures = getOrThrowException(
+                threadProducerFuture.getValue(),
+                () -> String.format(
+                    "Could not retrieve producer instance id for %s.",
+                    threadProducerFuture.getKey()
+                )
+            );
 
-        if (globalThreadFuture != null) {
-            try {
-                clientInstanceIds.addConsumerInstanceId(globalStreamThread.getName(), globalThreadFuture.get());
-            } catch (final ExecutionException exception) {
-                if (exception.getCause() instanceof TimeoutException) {
-                    log.warn("Could not get global consumer client-instance-id due to timeout.");
+            for (final Map.Entry<String, KafkaFuture<Uuid>> producerFuture : streamThreadProducerFutures.entrySet()) {
+                final Uuid instanceId = getOrThrowException(
+                    producerFuture.getValue(),
+                    () -> String.format(
+                        "Could not retrieve producer instance id for %s.",
+                        producerFuture.getKey()
+                    )
+                );
+
+                // could be `null` if telemetry is disabled on the producer itself
+                if (instanceId != null) {
+                    clientInstanceIds.addProducerInstanceId(
+                        producerFuture.getKey(),
+                        instanceId
+                    );
                 } else {
-                    log.error("Could not get global consumer client-instance-id", exception);
+                    log.debug(String.format("Telemetry is disabled for %s.", producerFuture.getKey()));
                 }
-            } catch (final InterruptedException error) {
-                log.error("Could not get global consumer client-instance-id", error);
+            }
+        }
+        // (3c) collect from GlobalThread
+        if (globalThreadFuture != null) {
+            final Uuid instanceId = getOrThrowException(
+                globalThreadFuture,
+                () -> "Could not retrieve global consumer client instance id."
+            );
+
+            // could be `null` if telemetry is disabled on the client itself
+            if (instanceId != null) {
+                clientInstanceIds.addConsumerInstanceId(
+                    globalStreamThread.getName(),
+                    instanceId
+                );
+            } else {
+                log.debug("Telemetry is disabled for the global consumer.");
             }
         }
 
         return clientInstanceIds;
+    }
+
+    private <T> T getOrThrowException(final KafkaFuture<T> future, final Supplier<String> errorMessage) {
+        final Throwable cause;
+
+        try {
+            return future.get();
+        } catch (final ExecutionException exception) {
+            cause = exception.getCause();
+            if (cause instanceof TimeoutException) {
+                throw (TimeoutException) cause;
+            }
+        } catch (final InterruptedException error) {
+            cause = error;
+        }
+
+        throw new StreamsException(errorMessage.get(), cause);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -101,7 +101,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1802,16 +1802,12 @@ public class KafkaStreams implements AutoCloseable {
      * @throws IllegalStateException If {@code KafkaStreams} is not running.
      * @throws TimeoutException Indicates that a request timed out.
      */
-    public ClientInstanceIds clientInstanceIds(Duration timeout) {
+    public ClientInstanceIds clientInstanceIds(final Duration timeout) {
         if (state().hasNotStarted()) {
-            throw new IllegalStateException(
-                "KafkaStreams has not been started, you can retry after calling start()."
-            );
+            throw new IllegalStateException("KafkaStreams has not been started, you can retry after calling start().");
         }
         if (state().isShuttingDown() || state.hasCompletedShutdown()) {
-            throw new IllegalStateException(
-                "KafkaStreams has been stopped (" + state + ")."
-            );
+            throw new IllegalStateException("KafkaStreams has been stopped (" + state + ").");
         }
 
         final ClientInstanceIdsImpl clientInstanceIds = new ClientInstanceIdsImpl();

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -496,8 +496,13 @@ public class StreamsConfig extends AbstractConfig {
     /** {@code client.id} */
     @SuppressWarnings("WeakerAccess")
     public static final String CLIENT_ID_CONFIG = CommonClientConfigs.CLIENT_ID_CONFIG;
-    private static final String CLIENT_ID_DOC = "An ID prefix string used for the client IDs of internal consumer, producer and restore-consumer," +
-        " with pattern <code>&lt;client.id&gt;-StreamThread-&lt;threadSequenceNumber$gt;-&lt;consumer|producer|restore-consumer&gt;</code>.";
+    private static final String CLIENT_ID_DOC = "An ID prefix string used for the client IDs of internal [main-|restore-|global-]consumer, producer, and admin clients" +
+        " with pattern <code>&lt;client.id&gt;-[Global]StreamThread[-&lt;threadSequenceNumber$gt;]-&lt;consumer|producer|restore-consumer|global-consumer&gt;</code>.";
+
+    /** {@code enable.metrics.push} */
+    @SuppressWarnings("WeakerAccess")
+    public static  final String ENABLE_METRICS_PUSH_CONFIG = CommonClientConfigs.ENABLE_METRICS_PUSH_CONFIG;
+    public static final String ENABLE_METRICS_PUSH_DOC = "Whether to enable pushing of internal [main-|restore-|global]consumer, producer, and admin client metrics to the cluster, if the cluster has a client metrics subscription which matches a client.";
 
     /** {@code commit.interval.ms} */
     @SuppressWarnings("WeakerAccess")
@@ -999,6 +1004,11 @@ public class StreamsConfig extends AbstractConfig {
                     atLeast(0),
                     Importance.LOW,
                     COMMIT_INTERVAL_MS_DOC)
+            .define(ENABLE_METRICS_PUSH_CONFIG,
+                    Type.BOOLEAN,
+                    true,
+                    Importance.LOW,
+                    ENABLE_METRICS_PUSH_DOC)
             .define(REPARTITION_PURGE_INTERVAL_MS_CONFIG,
                     Type.LONG,
                     DEFAULT_COMMIT_INTERVAL_MS,

--- a/streams/src/main/java/org/apache/kafka/streams/internals/ClientInstanceIdsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/ClientInstanceIdsImpl.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.internals;
 
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.streams.ClientInstanceIds;
 
@@ -41,6 +42,11 @@ public class ClientInstanceIdsImpl implements ClientInstanceIds {
 
     @Override
     public Uuid adminInstanceId() {
+        if (adminInstanceId == null) {
+            throw new IllegalStateException(
+                "Telemetry is not enabled on the admin client." +
+                    " Set config `" + AdminClientConfig.ENABLE_METRICS_PUSH_CONFIG + "` to `true`.");
+        }
         return adminInstanceId;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/internals/ClientInstanceIdsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/ClientInstanceIdsImpl.java
@@ -1,0 +1,40 @@
+package org.apache.kafka.streams.internals;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.streams.ClientInstanceIds;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ClientInstanceIdsImpl implements ClientInstanceIds {
+    private final Map<String, Uuid> consumerInstanceIds = new HashMap<>();
+    private final Map<String, Uuid> producerInstanceIds = new HashMap<>();
+    private Uuid adminInstanceId;
+
+    public void addConsumerInstanceId(final String key, final Uuid instanceId) {
+        consumerInstanceIds.put(key, instanceId);
+    }
+
+    public void addProducerInstanceId(final String key, final Uuid instanceId) {
+        producerInstanceIds.put(key, instanceId);
+    }
+
+    public void setAdminInstanceId(final Uuid instanceId) {
+        adminInstanceId = instanceId;
+    }
+
+    @Override
+    public Uuid adminInstanceId() {
+        return adminInstanceId;
+    }
+
+    @Override
+    public Map<String, Uuid> consumerInstanceIds() {
+        return consumerInstanceIds;
+    }
+
+    @Override
+    public Map<String, Uuid> producerInstanceIds() {
+        return producerInstanceIds;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/internals/ClientInstanceIdsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/ClientInstanceIdsImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.streams.internals;
 
 import org.apache.kafka.common.Uuid;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -44,7 +44,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_ALPHA;
-import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.eosEnabled;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.processingMode;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.getTaskProducerClientId;
@@ -136,8 +135,8 @@ class ActiveTaskCreator {
     }
 
     StreamsProducer threadProducer() {
-        if (processingMode != EXACTLY_ONCE_V2) {
-            throw new IllegalStateException("Expected EXACTLY_ONCE_V2 to be enabled, but the processing mode was " + processingMode);
+        if (processingMode == EXACTLY_ONCE_ALPHA) {
+            throw new IllegalStateException("Expected AT_LEAST_ONCE or EXACTLY_ONCE_V2 to be enabled, but the processing mode was " + processingMode);
         }
         return threadProducer;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -45,9 +44,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.kafka.streams.processor.internals.GlobalStreamThread.State.CREATED;
@@ -75,7 +71,7 @@ public class GlobalStreamThread extends Thread {
     private java.util.function.Consumer<Throwable> streamsUncaughtExceptionHandler;
     private volatile Uuid globalConsumerClientInstanceId = null;
     private volatile long fetchDeadline = -1;
-    private KafkaFutureImpl<Uuid> clientInstanceIdFuture;
+    private volatile KafkaFutureImpl<Uuid> clientInstanceIdFuture;
 
     /**
      * The states that the global stream thread can be in

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -488,7 +488,7 @@ public class GlobalStreamThread extends Thread {
             return success;
         }
 
-        // need to set `clientInstancIdFuture` before `fetchDeadline`
+        // need to set `clientInstanceIdFuture` before `fetchDeadline`
         // to avoid a race condition potentially leading to a null-pointed-exception
         clientInstanceIdFuture = new KafkaFutureImpl<>();
         fetchDeadline = time.milliseconds() + timeout.toMillis();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -321,8 +321,8 @@ public class GlobalStreamThread extends Thread {
                 if (fetchDeadline != -1) {
                     if (fetchDeadline > time.milliseconds()) {
                         try {
-                            // pass in a timeout of zero, to just trigger the background RPC,
-                            // we don't want to block the global thread that can to useful work in the meantime
+                            // we pass in a timeout of zero, to just trigger the "get instance id" background RPC,
+                            // we don't want to block the global thread that can do useful work in the meantime
                             globalConsumerClientInstanceId = globalConsumer.clientInstanceId(Duration.ZERO);
                             clientInstanceIdFuture.complete(globalConsumerClientInstanceId);
                             fetchDeadline = -1;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -321,6 +321,8 @@ public class GlobalStreamThread extends Thread {
                 if (fetchDeadline != -1) {
                     if (fetchDeadline > time.milliseconds()) {
                         try {
+                            // pass in a timeout of zero, to just trigger the background RPC,
+                            // we don't want to block the global thread that can to useful work in the meantime
                             globalConsumerClientInstanceId = globalConsumer.clientInstanceId(Duration.ZERO);
                             clientInstanceIdFuture.complete(globalConsumerClientInstanceId);
                             fetchDeadline = -1;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1582,38 +1582,35 @@ public class StreamThread extends Thread {
 
         final Map<String, KafkaFuture<Uuid>> result = new HashMap<>();
 
+        KafkaFutureImpl<Uuid> future = new KafkaFutureImpl<>();
         if (mainConsumerClientInstanceId != null) {
-            final KafkaFutureImpl<Uuid> success = new KafkaFutureImpl<>();
-            success.complete(mainConsumerClientInstanceId);
-            result.put(getName() + "-consumer", success);
+            future.complete(mainConsumerClientInstanceId);
         } else {
-            mainConsumerInstanceIdFuture = new KafkaFutureImpl<>();
+            mainConsumerInstanceIdFuture = future;
             setDeadline = true;
-            result.put(getName() + "-consumer", mainConsumerInstanceIdFuture);
         }
+        result.put(getName() + "-consumer", future);
 
+        future = new KafkaFutureImpl<>();
         if (restoreConsumerClientInstanceId != null) {
-            final KafkaFutureImpl<Uuid> success = new KafkaFutureImpl<>();
-            success.complete(restoreConsumerClientInstanceId);
-            result.put(getName() + "-restore-consumer", success);
+            future.complete(restoreConsumerClientInstanceId);
         } else {
-            restoreConsumerInstanceIdFuture = new KafkaFutureImpl<>();
+            restoreConsumerInstanceIdFuture = future;
             setDeadline = true;
-            result.put(getName() + "-restore-consumer", restoreConsumerInstanceIdFuture);
         }
+        result.put(getName() + "-restore-consumer", future);
 
         if (processingMode.equals(StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_ALPHA)) {
             throw new UnsupportedOperationException("not implemented yet");
         } else {
+            future = new KafkaFutureImpl<>();
             if (threadProducerClientInstanceId != null) {
-                final KafkaFutureImpl<Uuid> success = new KafkaFutureImpl<>();
-                success.complete(threadProducerClientInstanceId);
-                result.put(getName() +"-producer", success);
+                future.complete(threadProducerClientInstanceId);
             } else {
-                threadProducerInstanceIdFuture = new KafkaFutureImpl<>();
+                threadProducerInstanceIdFuture = future;
                 setDeadline = true;
-                result.put(getName() +"-producer", threadProducerInstanceIdFuture);
             }
+            result.put(getName() + "-producer", future);
         }
 
         if (setDeadline) {

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -26,7 +26,6 @@ import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -82,6 +82,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -1472,6 +1473,104 @@ public class StreamsConfigTest {
                 throw new AssertionError("StreamsConfig did not accept `upgrade.from` config value `" + upgradeFrom + "`");
             }
         }
+    }
+
+    @Test
+    public void shouldNotSetEnableMetricCollectionByDefault() {
+        assertNull(
+            streamsConfig.getMainConsumerConfigs("groupId", "clientId", 0)
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+        assertNull(
+            streamsConfig.getRestoreConsumerConfigs("clientId")
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+        assertNull(
+            streamsConfig.getGlobalConsumerConfigs("clientId")
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+        assertNull(
+            streamsConfig.getProducerConfigs("clientId")
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+        assertNull(
+            streamsConfig.getAdminConfigs("clientId")
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+    }
+
+    @Test
+    public void shouldEnableMetricCollectionAllInternalClientsByDefault() {
+        props.put(StreamsConfig.ENABLE_METRICS_PUSH_CONFIG, true);
+        final StreamsConfig streamsConfig = new StreamsConfig(props);
+
+        assertTrue(
+            (Boolean) streamsConfig.getMainConsumerConfigs("groupId", "clientId", 0)
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+        assertTrue(
+            (Boolean) streamsConfig.getRestoreConsumerConfigs("clientId")
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+        assertTrue(
+            (Boolean) streamsConfig.getGlobalConsumerConfigs("clientId")
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+        assertTrue(
+            (Boolean) streamsConfig.getProducerConfigs("clientId")
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+        assertTrue(
+            (Boolean) streamsConfig.getAdminConfigs("clientId")
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+    }
+
+    @Test
+    public void shouldDisableMetricCollectionAllInternalClients() {
+        props.put(StreamsConfig.ENABLE_METRICS_PUSH_CONFIG, false);
+        final StreamsConfig streamsConfig = new StreamsConfig(props);
+
+        assertFalse(
+            (Boolean) streamsConfig.getMainConsumerConfigs("groupId", "clientId", 0)
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+        assertFalse(
+            (Boolean) streamsConfig.getRestoreConsumerConfigs("clientId")
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+        assertFalse(
+            (Boolean) streamsConfig.getGlobalConsumerConfigs("clientId")
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+        assertFalse(
+            (Boolean) streamsConfig.getProducerConfigs("clientId")
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+        assertFalse(
+            (Boolean) streamsConfig.getAdminConfigs("clientId")
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+    }
+
+    @Test
+    public void shouldDisableMetricCollectionAllMainConsumerOnly() {
+        props.put(StreamsConfig.mainConsumerPrefix(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG), false);
+
+        final StreamsConfig streamsConfig = new StreamsConfig(props);
+
+        assertFalse(
+            (Boolean) streamsConfig.getMainConsumerConfigs("groupId", "clientId", 0)
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+        assertNull(
+            streamsConfig.getRestoreConsumerConfigs("clientId")
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
+        assertNull(
+            streamsConfig.getGlobalConsumerConfigs("clientId")
+                .get(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG)
+        );
     }
 
     static class MisconfiguredSerde implements Serde<Object> {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -19,9 +19,12 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.clients.consumer.InvalidOffsetException;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
@@ -44,10 +47,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import static org.apache.kafka.streams.processor.internals.GlobalStreamThread.State.DEAD;
 import static org.apache.kafka.streams.processor.internals.GlobalStreamThread.State.RUNNING;
@@ -58,6 +63,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -296,6 +302,63 @@ public class GlobalStreamThreadTest {
         assertFalse(new File(baseDirectoryName + File.separator + "testAppId" + File.separator + "global").exists());
     }
 
+    @Test
+    public void shouldGetGlobalConsumerClientInstanceId() throws Exception {
+        initializeConsumer();
+        startAndSwallowError();
+
+        final Uuid instanceId = Uuid.randomUuid();
+        mockConsumer.setClientInstanceId(instanceId, Duration.ofMillis(1L));
+
+        try {
+            final KafkaFuture<Uuid> future = globalStreamThread.globalConsumerInstanceId(Duration.ofMillis(2L));
+            final Uuid result = future.get();
+
+            assertThat(result, equalTo(instanceId));
+        } finally {
+            globalStreamThread.shutdown();
+            globalStreamThread.join();
+
+        }
+    }
+
+    @Test
+    public void shouldReturnErrorIfInstanceIdNotInitialized() throws Exception {
+        initializeConsumer();
+        startAndSwallowError();
+
+        try {
+            final KafkaFuture<Uuid> future = globalStreamThread.globalConsumerInstanceId(Duration.ofMillis(2L));
+
+            final ExecutionException error = assertThrows(ExecutionException.class, future::get);
+            assertThat(error.getCause(), instanceOf(IllegalStateException.class));
+            assertThat(error.getCause().getMessage(), equalTo("clientInstanceId not set"));
+        } finally {
+            globalStreamThread.shutdown();
+            globalStreamThread.join();
+        }
+    }
+
+    @Test
+    public void shouldTimeOutOnGlobalConsumerInstanceId() throws Exception {
+        initializeConsumer();
+        startAndSwallowError();
+
+        final Uuid instanceId = Uuid.randomUuid();
+        mockConsumer.setClientInstanceId(instanceId, Duration.ofMillis(-1L));
+
+        try {
+            final KafkaFuture<Uuid> future = globalStreamThread.globalConsumerInstanceId(Duration.ofMillis(1L));
+            time.sleep(5L);
+
+            final ExecutionException error = assertThrows(ExecutionException.class, future::get);
+            assertThat(error.getCause(), instanceOf(TimeoutException.class));
+            assertThat(error.getCause().getMessage(), equalTo("Could not retrieve global consumer client-instance-id"));
+        } finally {
+            globalStreamThread.shutdown();
+            globalStreamThread.join();
+        }
+    }
     private void initializeConsumer() {
         mockConsumer.updatePartitions(
             GLOBAL_STORE_TOPIC_NAME,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -308,17 +308,16 @@ public class GlobalStreamThreadTest {
         startAndSwallowError();
 
         final Uuid instanceId = Uuid.randomUuid();
-        mockConsumer.setClientInstanceId(instanceId, Duration.ofMillis(1L));
+        mockConsumer.setClientInstanceId(instanceId, Duration.ZERO);
 
         try {
-            final KafkaFuture<Uuid> future = globalStreamThread.globalConsumerInstanceId(Duration.ofMillis(2L));
+            final KafkaFuture<Uuid> future = globalStreamThread.globalConsumerInstanceId(Duration.ofMillis(1L));
             final Uuid result = future.get();
 
             assertThat(result, equalTo(instanceId));
         } finally {
             globalStreamThread.shutdown();
             globalStreamThread.join();
-
         }
     }
 
@@ -328,7 +327,7 @@ public class GlobalStreamThreadTest {
         startAndSwallowError();
 
         try {
-            final KafkaFuture<Uuid> future = globalStreamThread.globalConsumerInstanceId(Duration.ofMillis(2L));
+            final KafkaFuture<Uuid> future = globalStreamThread.globalConsumerInstanceId(Duration.ofMillis(1L));
 
             final ExecutionException error = assertThrows(ExecutionException.class, future::get);
             assertThat(error.getCause(), instanceOf(IllegalStateException.class));
@@ -345,10 +344,10 @@ public class GlobalStreamThreadTest {
         startAndSwallowError();
 
         final Uuid instanceId = Uuid.randomUuid();
-        mockConsumer.setClientInstanceId(instanceId, Duration.ofMillis(-1L));
+        mockConsumer.setClientInstanceId(instanceId, Duration.ofMillis(1L));
 
         try {
-            final KafkaFuture<Uuid> future = globalStreamThread.globalConsumerInstanceId(Duration.ofMillis(1L));
+            final KafkaFuture<Uuid> future = globalStreamThread.globalConsumerInstanceId(Duration.ofMillis(2L));
             time.sleep(5L);
 
             final ExecutionException error = assertThrows(ExecutionException.class, future::get);


### PR DESCRIPTION
This PR is still WIP, but wanted to open it on time to collect initial feedback.

So far, I only added support for global-consumer client-instance-id.

Part of KIP-714