### PR TITLE
Update NOTICE-binary with latest additions

### DIFF
--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -98,6 +98,13 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 
+Apache Commons IO
+Copyright 2002-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+
 Apache Commons Lang
 Copyright 2001-2018 The Apache Software Foundation
 


### PR DESCRIPTION
This change mirrors the updates in `LICENSE-binary` and updates the newly added dependencies' notice messages when available.

- commons-io-2.11.0 (NOTICE available)
- error_prone_annotations-2.10.0 (no NOTICE available)
- opentelemetry-proto-1.0.0-alpha (no NOTICE available)
- checker-qual-3.19.0 (no NOTICE available)
- jsr305-3.0.2 (no NOTICE available)
- protobuf-java-3.23.4 (no NOTICE available)

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
