### PR TITLE
KAFKA-15690: Fix restoring tasks on partition loss, flaky EosIntegrationTest

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PendingUpdateAction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PendingUpdateAction.java
@@ -27,7 +27,7 @@ public class PendingUpdateAction {
         UPDATE_INPUT_PARTITIONS,
         RECYCLE,
         SUSPEND,
-        CLOSE_DIRTY,
+        ADD_BACK,
         CLOSE_CLEAN
     }
 
@@ -57,8 +57,8 @@ public class PendingUpdateAction {
         return new PendingUpdateAction(Action.SUSPEND);
     }
 
-    public static PendingUpdateAction createCloseDirty() {
-        return new PendingUpdateAction(Action.CLOSE_DIRTY);
+    public static PendingUpdateAction createAddBack() {
+        return new PendingUpdateAction(Action.ADD_BACK);
     }
 
     public static PendingUpdateAction createCloseClean() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
@@ -134,8 +134,8 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public boolean removePendingTaskToCloseDirty(final TaskId taskId) {
-        if (containsTaskIdWithAction(taskId, Action.CLOSE_DIRTY)) {
+    public boolean removePendingTaskToAddBack(final TaskId taskId) {
+        if (containsTaskIdWithAction(taskId, Action.ADD_BACK)) {
             pendingUpdateActions.remove(taskId);
             return true;
         }
@@ -143,8 +143,8 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public void addPendingTaskToCloseDirty(final TaskId taskId) {
-        pendingUpdateActions.put(taskId, PendingUpdateAction.createCloseDirty());
+    public void addPendingTaskToAddBack(final TaskId taskId) {
+        pendingUpdateActions.put(taskId, PendingUpdateAction.createAddBack());
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TasksRegistry.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TasksRegistry.java
@@ -45,9 +45,9 @@ public interface TasksRegistry {
 
     void addPendingTaskToUpdateInputPartitions(final TaskId taskId, final Set<TopicPartition> inputPartitions);
 
-    boolean removePendingTaskToCloseDirty(final TaskId taskId);
+    boolean removePendingTaskToAddBack(final TaskId taskId);
 
-    void addPendingTaskToCloseDirty(final TaskId taskId);
+    void addPendingTaskToAddBack(final TaskId taskId);
 
     boolean removePendingTaskToCloseClean(final TaskId taskId);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TasksTest.java
@@ -152,7 +152,7 @@ public class TasksTest {
         assertTrue(tasks.hasPendingTasksToRecycle());
 
         tasks.addPendingTaskToCloseClean(TASK_0_1);
-        tasks.addPendingTaskToCloseDirty(TASK_0_2);
+        tasks.addPendingTaskToAddBack(TASK_0_2);
         tasks.addPendingTaskToUpdateInputPartitions(TASK_1_1, mkSet(TOPIC_PARTITION_B_0));
         tasks.addPendingActiveTaskToSuspend(TASK_1_2);
         assertTrue(tasks.hasPendingTasksToRecycle());
@@ -177,7 +177,7 @@ public class TasksTest {
         assertTrue(tasks.hasPendingTasksToInit());
 
         tasks.addPendingTaskToCloseClean(TASK_0_1);
-        tasks.addPendingTaskToCloseDirty(TASK_0_2);
+        tasks.addPendingTaskToAddBack(TASK_0_2);
         tasks.addPendingTaskToUpdateInputPartitions(TASK_1_1, mkSet(TOPIC_PARTITION_B_0));
         tasks.addPendingActiveTaskToSuspend(TASK_1_2);
         assertTrue(tasks.hasPendingTasksToInit());
@@ -209,13 +209,13 @@ public class TasksTest {
     }
 
     @Test
-    public void shouldAddAndRemovePendingTaskToCloseDirty() {
-        assertFalse(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+    public void shouldAddAndRemovePendingTaskToAddBack() {
+        assertFalse(tasks.removePendingTaskToAddBack(TASK_0_0));
 
-        tasks.addPendingTaskToCloseDirty(TASK_0_0);
+        tasks.addPendingTaskToAddBack(TASK_0_0);
 
-        assertTrue(tasks.removePendingTaskToCloseDirty(TASK_0_0));
-        assertFalse(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+        assertTrue(tasks.removePendingTaskToAddBack(TASK_0_0));
+        assertFalse(tasks.removePendingTaskToAddBack(TASK_0_0));
     }
 
     @Test
@@ -232,7 +232,7 @@ public class TasksTest {
     public void onlyRemovePendingTaskToRecycleShouldRemoveTaskFromPendingUpdateActions() {
         tasks.addPendingTaskToRecycle(TASK_0_0, mkSet(TOPIC_PARTITION_A_0));
 
-        assertFalse(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+        assertFalse(tasks.removePendingTaskToAddBack(TASK_0_0));
         assertFalse(tasks.removePendingTaskToCloseClean(TASK_0_0));
         assertFalse(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
         assertNull(tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0));
@@ -243,7 +243,7 @@ public class TasksTest {
     public void onlyRemovePendingTaskToUpdateInputPartitionsShouldRemoveTaskFromPendingUpdateActions() {
         tasks.addPendingTaskToUpdateInputPartitions(TASK_0_0, mkSet(TOPIC_PARTITION_A_0));
 
-        assertFalse(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+        assertFalse(tasks.removePendingTaskToAddBack(TASK_0_0));
         assertFalse(tasks.removePendingTaskToCloseClean(TASK_0_0));
         assertFalse(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
         assertNull(tasks.removePendingTaskToRecycle(TASK_0_0));
@@ -254,7 +254,7 @@ public class TasksTest {
     public void onlyRemovePendingTaskToCloseCleanShouldRemoveTaskFromPendingUpdateActions() {
         tasks.addPendingTaskToCloseClean(TASK_0_0);
 
-        assertFalse(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+        assertFalse(tasks.removePendingTaskToAddBack(TASK_0_0));
         assertFalse(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
         assertNull(tasks.removePendingTaskToRecycle(TASK_0_0));
         assertNull(tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0));
@@ -262,14 +262,14 @@ public class TasksTest {
     }
 
     @Test
-    public void onlyRemovePendingTaskToCloseDirtyShouldRemoveTaskFromPendingUpdateActions() {
-        tasks.addPendingTaskToCloseDirty(TASK_0_0);
+    public void onlyRemovePendingTaskToAddBackShouldRemoveTaskFromPendingUpdateActions() {
+        tasks.addPendingTaskToAddBack(TASK_0_0);
 
         assertFalse(tasks.removePendingTaskToCloseClean(TASK_0_0));
         assertFalse(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
         assertNull(tasks.removePendingTaskToRecycle(TASK_0_0));
         assertNull(tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0));
-        assertTrue(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+        assertTrue(tasks.removePendingTaskToAddBack(TASK_0_0));
     }
 
     @Test
@@ -277,7 +277,7 @@ public class TasksTest {
         tasks.addPendingActiveTaskToSuspend(TASK_0_0);
 
         assertFalse(tasks.removePendingTaskToCloseClean(TASK_0_0));
-        assertFalse(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+        assertFalse(tasks.removePendingTaskToAddBack(TASK_0_0));
         assertNull(tasks.removePendingTaskToRecycle(TASK_0_0));
         assertNull(tasks.removePendingTaskToUpdateInputPartitions(TASK_0_0));
         assertTrue(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
@@ -296,13 +296,13 @@ public class TasksTest {
         assertTrue(tasks.removePendingTaskToCloseClean(TASK_0_0));
 
         tasks.addPendingTaskToCloseClean(TASK_0_0);
-        tasks.addPendingTaskToCloseDirty(TASK_0_0);
+        tasks.addPendingTaskToAddBack(TASK_0_0);
         assertFalse(tasks.removePendingTaskToCloseClean(TASK_0_0));
-        assertTrue(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+        assertTrue(tasks.removePendingTaskToAddBack(TASK_0_0));
 
-        tasks.addPendingTaskToCloseDirty(TASK_0_0);
+        tasks.addPendingTaskToAddBack(TASK_0_0);
         tasks.addPendingActiveTaskToSuspend(TASK_0_0);
-        assertFalse(tasks.removePendingTaskToCloseDirty(TASK_0_0));
+        assertFalse(tasks.removePendingTaskToAddBack(TASK_0_0));
         assertTrue(tasks.removePendingActiveTaskToSuspend(TASK_0_0));
 
         tasks.addPendingActiveTaskToSuspend(TASK_0_0);


### PR DESCRIPTION
The following race can happen in the state updater code path

 - Task is restoring, owned by state updater
 - We fall out of the consumer group, lose all partitions
 - We therefore register a "TaskManager.pendingUpdateAction", to CLOSE_DIRTY
 - We also register a "StateUpdater.taskAndAction" to remove the task
 - We get the same task reassigned. Since it's still owned by the state updater, we don't do much
 - The task completes restoration
 - The "StateUpdater.taskAndAction" to remove will be ignored, since it's already restored
 - Inside "handleRestoredTasksFromStateUpdater", we close the task dirty because of the pending update action
 - We now have the task assigned, but it's closed.

To fix this particular race, we cancel the "close" pending update action. Furthermore, since we may have made progress in other threads during the missed rebalance, we need to add the task back to the state updater, to at least check if we are still at the end of the changelog. Finally, it seems we do not need to close dirty here, it's enough to close clean when we lose the task, related to [KAFKA-10532](https://issues.apache.org/jira/browse/KAFKA-10532). 

This should fix the flaky EOSIntegrationTest.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
