### PR TITLE
KAFKA-14987 [2/2]; customize retry backoff for group/offsets expiration

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -533,7 +533,8 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
             }
         });
 
-        log.info("Generated {} tombstone records in {} milliseconds.", records.size(), time.milliseconds() - startMs);
+        log.info("Generated {} tombstone records while cleaning up group metadata in {} milliseconds.",
+            records.size(), time.milliseconds() - startMs);
         // Reschedule the next cycle.
         scheduleGroupMetadataExpiration();
         return new CoordinatorResult<>(records);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -537,6 +537,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<Record> {
             config.offsetsRetentionCheckIntervalMs,
             TimeUnit.MILLISECONDS,
             true,
+            config.offsetsRetentionCheckIntervalMs,
             this::cleanupGroupMetadata
         );
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -587,6 +587,7 @@ public class OffsetMetadataManager {
      * @return True if no offsets exist or if all offsets expired, false otherwise.
      */
     public boolean cleanupExpiredOffsets(String groupId, List<Record> records) {
+        Long startMs = time.milliseconds();
         TimelineHashMap<String, TimelineHashMap<Integer, OffsetAndMetadata>> offsetsByTopic = offsetsByGroup.get(groupId);
         if (offsetsByTopic == null) {
             return true;
@@ -620,8 +621,9 @@ public class OffsetMetadataManager {
         });
 
         if (!expiredPartitions.isEmpty()) {
-            log.info("[GroupId {}] Expiring offsets of partitions (allOffsetsExpired={}): {}",
-                groupId, allOffsetsExpired, String.join(", ", expiredPartitions));
+            log.info("[GroupId {}] Expiring {} offsets (allOffsetsExpired={}) in {} milliseconds.",
+                groupId, expiredPartitions.size(), allOffsetsExpired, time.milliseconds() - startMs);
+            log.debug("[GroupId {}] Expired partitions: {}", groupId, String.join(", ", expiredPartitions));
         }
         metrics.record(OFFSET_EXPIRED_SENSOR_NAME, expiredPartitions.size());
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -610,7 +610,7 @@ public class OffsetMetadataManager {
                 partitions.forEach((partition, offsetAndMetadata) -> {
                     if (condition.isOffsetExpired(offsetAndMetadata, currentTimestampMs, config.offsetsRetentionMs)) {
                         expiredPartitions.add(appendOffsetCommitTombstone(groupId, topic, partition, records).toString());
-                        log.debug("[GroupId {}] Expired offset for tp={}-{}", groupId, topic, partition);
+                        log.debug("[GroupId {}] Expired offset for partition={}-{}", groupId, topic, partition);
                     } else {
                         allOffsetsExpired.set(false);
                     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetMetadataManager.java
@@ -587,7 +587,6 @@ public class OffsetMetadataManager {
      * @return True if no offsets exist or if all offsets expired, false otherwise.
      */
     public boolean cleanupExpiredOffsets(String groupId, List<Record> records) {
-        Long startMs = time.milliseconds();
         TimelineHashMap<String, TimelineHashMap<Integer, OffsetAndMetadata>> offsetsByTopic = offsetsByGroup.get(groupId);
         if (offsetsByTopic == null) {
             return true;
@@ -611,6 +610,7 @@ public class OffsetMetadataManager {
                 partitions.forEach((partition, offsetAndMetadata) -> {
                     if (condition.isOffsetExpired(offsetAndMetadata, currentTimestampMs, config.offsetsRetentionMs)) {
                         expiredPartitions.add(appendOffsetCommitTombstone(groupId, topic, partition, records).toString());
+                        log.debug("[GroupId {}] Expired offset for tp={}-{}", groupId, topic, partition);
                     } else {
                         allOffsetsExpired.set(false);
                     }
@@ -619,12 +619,6 @@ public class OffsetMetadataManager {
                 allOffsetsExpired.set(false);
             }
         });
-
-        if (!expiredPartitions.isEmpty()) {
-            log.info("[GroupId {}] Expiring {} offsets (allOffsetsExpired={}) in {} milliseconds.",
-                groupId, expiredPartitions.size(), allOffsetsExpired, time.milliseconds() - startMs);
-            log.debug("[GroupId {}] Expired partitions: {}", groupId, String.join(", ", expiredPartitions));
-        }
         metrics.record(OFFSET_EXPIRED_SENSOR_NAME, expiredPartitions.size());
 
         return allOffsetsExpired.get();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -282,6 +282,18 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             boolean retry,
             TimeoutOperation<Void, U> operation
         ) {
+            schedule(key, delay, unit, retry, 500, operation);
+        }
+
+        @Override
+        public void schedule(
+            String key,
+            long delay,
+            TimeUnit unit,
+            boolean retry,
+            long retryBackoff,
+            TimeoutOperation<Void, U> operation
+        ) {
             // The TimerTask wraps the TimeoutOperation into a CoordinatorWriteEvent. When the TimerTask
             // expires, the event is pushed to the queue of the coordinator runtime to be executed. This
             // ensures that the threading model of the runtime is respected.
@@ -320,7 +332,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         if (retry) {
                             log.info("The write event {} for the timer {} failed due to {}. Rescheduling it. ",
                                 event.name, key, ex.getMessage());
-                            schedule(key, 500, TimeUnit.MILLISECONDS, retry, operation);
+                            schedule(key, retryBackoff, TimeUnit.MILLISECONDS, retry, operation);
                         } else {
                             log.error("The write event {} for the timer {} failed due to {}. Ignoring it. ",
                                 event.name, key, ex.getMessage());

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorTimer.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorTimer.java
@@ -61,7 +61,7 @@ public interface CoordinatorTimer<T, U> {
      * @param unit          The delay unit.
      * @param retry         A boolean indicating whether the operation should
      *                      be retried on failure.
-     * @param retryBackoff  The delay when rescheduled on retry.
+     * @param retryBackoff  The delay when rescheduled on retry. The same unit is used.
      * @param operation     The operation to perform upon expiration.
      */
     void schedule(String key, long delay, TimeUnit unit, boolean retry, long retryBackoff, TimeoutOperation<T, U> operation);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorTimer.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorTimer.java
@@ -53,6 +53,20 @@ public interface CoordinatorTimer<T, U> {
     void schedule(String key, long delay, TimeUnit unit, boolean retry, TimeoutOperation<T, U> operation);
 
     /**
+     * Add an operation to the timer. If an operation with the same key
+     * already exists, replace it with the new operation.
+     *
+     * @param key           The key to identify this operation.
+     * @param delay         The delay to wait before expiring.
+     * @param unit          The delay unit.
+     * @param retry         A boolean indicating whether the operation should
+     *                      be retried on failure.
+     * @param retryBackoff  The delay when rescheduled on retry.
+     * @param operation     The operation to perform upon expiration.
+     */
+    void schedule(String key, long delay, TimeUnit unit, boolean retry, long retryBackoff, TimeoutOperation<T, U> operation);
+
+    /**
      * Remove an operation corresponding to a given key.
      *
      * @param key The key.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -88,7 +88,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -119,7 +120,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -148,7 +150,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             mock(CoordinatorMetrics.class),
             mock(CoordinatorMetricsShard.class)
@@ -204,7 +207,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             mock(CoordinatorMetrics.class),
             mock(CoordinatorMetricsShard.class)
@@ -273,7 +277,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -305,7 +310,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -336,7 +342,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -363,7 +370,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -389,7 +397,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -416,7 +425,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -442,7 +452,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -469,7 +480,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -495,7 +507,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -522,7 +535,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -548,7 +562,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -575,7 +590,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -601,7 +617,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -628,7 +645,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -654,7 +672,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -673,7 +692,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -699,7 +719,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -725,7 +746,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -752,7 +774,8 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
-            new MockCoordinatorTimer<>(new MockTime()),
+            Time.SYSTEM,
+            new MockCoordinatorTimer<>(Time.SYSTEM),
             mock(GroupCoordinatorConfig.class),
             coordinatorMetrics,
             metricsShard
@@ -778,6 +801,7 @@ public class GroupCoordinatorShardTest {
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
+            mockTime,
             timer,
             GroupCoordinatorConfigTest.createGroupCoordinatorConfig(4096, 1000L, 24 * 60),
             mock(CoordinatorMetrics.class),
@@ -803,11 +827,13 @@ public class GroupCoordinatorShardTest {
     public void testCleanupGroupMetadata() {
         GroupMetadataManager groupMetadataManager = mock(GroupMetadataManager.class);
         OffsetMetadataManager offsetMetadataManager = mock(OffsetMetadataManager.class);
-        MockCoordinatorTimer<Void, Record> timer = new MockCoordinatorTimer<>(new MockTime());
+        Time mockTime = new MockTime();
+        MockCoordinatorTimer<Void, Record> timer = new MockCoordinatorTimer<>(mockTime);
         GroupCoordinatorShard coordinator = new GroupCoordinatorShard(
             new LogContext(),
             groupMetadataManager,
             offsetMetadataManager,
+            mockTime,
             timer,
             mock(GroupCoordinatorConfig.class),
             mock(CoordinatorMetrics.class),

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/MockCoordinatorTimer.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/MockCoordinatorTimer.java
@@ -127,7 +127,7 @@ public class MockCoordinatorTimer<T, U> implements CoordinatorTimer<T, U> {
         boolean retry,
         TimeoutOperation<T, U> operation
     ) {
-        schedule(key, delay, unit, retry, operation);
+        schedule(key, delay, unit, retry, 500L, operation);
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/MockCoordinatorTimer.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/MockCoordinatorTimer.java
@@ -108,6 +108,7 @@ public class MockCoordinatorTimer<T, U> implements CoordinatorTimer<T, U> {
         long delay,
         TimeUnit unit,
         boolean retry,
+        long retryBackoff,
         TimeoutOperation<T, U> operation
     ) {
         cancel(key);
@@ -116,6 +117,17 @@ public class MockCoordinatorTimer<T, U> implements CoordinatorTimer<T, U> {
         ScheduledTimeout<T, U> timeout = new ScheduledTimeout<>(key, deadlineMs, operation);
         timeoutQueue.add(timeout);
         timeoutMap.put(key, timeout);
+    }
+
+    @Override
+    public void schedule(
+        String key,
+        long delay,
+        TimeUnit unit,
+        boolean retry,
+        TimeoutOperation<T, U> operation
+    ) {
+        schedule(key, delay, unit, retry, operation);
     }
 
     /**


### PR DESCRIPTION
The group expiration log becomes noisy when we encounter a retry-able error as the retry backoff is fixed to 500 ms. Allow customizable retry backoff so that even in the case of failure we have a longer delay.

The current default for offsetsRetentionCheckIntervalMs is set to 10 minutes so even if the operation fails we will "retry" after 10 minutes. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
