### PR TITLE
KAFKA-14438: Throw if async consumer configured with invalid group ID

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -758,7 +758,7 @@ public class AsyncKafkaConsumerTest {
     }
 
     @Test
-    public void testGroupIdIsNull() {
+    public void testGroupIdNull() {
         final Properties props = requiredConsumerProperties();
         props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 10000);
         props.put(THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED, true);
@@ -774,7 +774,7 @@ public class AsyncKafkaConsumerTest {
     }
 
     @Test
-    public void testGroupIdIsNotNullAndValid() {
+    public void testGroupIdNotNullAndValid() {
         final Properties props = requiredConsumerProperties();
         props.put(ConsumerConfig.GROUP_ID_CONFIG, "consumerGroupA");
         props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 10000);
@@ -792,15 +792,15 @@ public class AsyncKafkaConsumerTest {
 
     @Test
     public void testGroupIdEmpty() {
-        testGroupId("");
+        testInvalidGroupId("");
     }
 
     @Test
     public void testGroupIdOnlyWhitespaces() {
-        testGroupId("       ");
+        testInvalidGroupId("       ");
     }
 
-    private void testGroupId(final String groupId) {
+    private void testInvalidGroupId(final String groupId) {
         final Properties props = requiredConsumerProperties();
         props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         final ConsumerConfig config = new ConsumerConfig(props);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.ClientResponse;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
@@ -49,6 +50,7 @@ import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.requests.OffsetCommitResponse;
 import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -62,6 +64,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
+import org.opentest4j.AssertionFailedError;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -72,6 +75,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -84,6 +88,7 @@ import java.util.stream.Stream;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -750,6 +755,70 @@ public class AsyncKafkaConsumerTest {
     public void testSubscriptionOnEmptyTopic() {
         String emptyTopic = "  ";
         assertThrows(IllegalArgumentException.class, () -> consumer.subscribe(singletonList(emptyTopic)));
+    }
+
+    @Test
+    public void testGroupIdIsNull() {
+        final Properties props = requiredConsumerProperties();
+        props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 10000);
+        props.put(THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED, true);
+        final ConsumerConfig config = new ConsumerConfig(props);
+
+        try (AsyncKafkaConsumer<String, String> consumer =
+                 new AsyncKafkaConsumer<>(config, new StringDeserializer(), new StringDeserializer())) {
+            assertFalse(config.unused().contains(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG));
+            assertFalse(config.unused().contains(THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED));
+        } catch (final Exception exception) {
+            throw new AssertionFailedError("The following exception was not expected:", exception);
+        }
+    }
+
+    @Test
+    public void testGroupIdIsNotNullAndValid() {
+        final Properties props = requiredConsumerProperties();
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "consumerGroupA");
+        props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 10000);
+        props.put(THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED, true);
+        final ConsumerConfig config = new ConsumerConfig(props);
+
+        try (AsyncKafkaConsumer<String, String> consumer =
+                 new AsyncKafkaConsumer<>(config, new StringDeserializer(), new StringDeserializer())) {
+            assertTrue(config.unused().contains(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG));
+            assertTrue(config.unused().contains(THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED));
+        } catch (final Exception exception) {
+            throw new AssertionFailedError("The following exception was not expected:", exception);
+        }
+    }
+
+    @Test
+    public void testGroupIdEmpty() {
+        testGroupId("");
+    }
+
+    @Test
+    public void testGroupIdOnlyWhitespaces() {
+        testGroupId("       ");
+    }
+
+    private void testGroupId(final String groupId) {
+        final Properties props = requiredConsumerProperties();
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        final ConsumerConfig config = new ConsumerConfig(props);
+
+        final Exception exception = assertThrows(
+            KafkaException.class,
+            () -> new AsyncKafkaConsumer<>(config, new StringDeserializer(), new StringDeserializer())
+        );
+
+        assertEquals("Failed to construct kafka consumer", exception.getMessage());
+    }
+
+    private Properties requiredConsumerProperties() {
+        final Properties props = new Properties();
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9091");
+        return props;
     }
 
     private void testUpdateFetchPositionsWithFetchCommittedOffsetsTimeout(boolean committedOffsetsEnabled) {

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -24,7 +24,7 @@ import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.admin.{NewPartitions, NewTopic}
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
-import org.apache.kafka.common.{MetricName, PartitionInfo, TopicPartition}
+import org.apache.kafka.common.{KafkaException, MetricName, PartitionInfo, TopicPartition}
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.errors.{InvalidGroupIdException, InvalidTopicException}
 import org.apache.kafka.common.header.Headers
@@ -2026,10 +2026,8 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer1Config.put(ConsumerConfig.GROUP_ID_CONFIG, "")
     consumer1Config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
     consumer1Config.put(ConsumerConfig.CLIENT_ID_CONFIG, "consumer1")
-    val consumer1 = createConsumer(configOverrides = consumer1Config)
 
-    consumer1.assign(List(tp).asJava)
-    assertThrows(classOf[InvalidGroupIdException], () => consumer1.commitSync())
+    assertThrows(classOf[KafkaException], () => createConsumer(configOverrides = consumer1Config))
   }
 
   // Static membership temporarily not supported in consumer group protocol


### PR DESCRIPTION
Verifies that the group ID passed into the async consumer is valid. That is, if the group ID is not null, it is not empty or it does not consist of only whitespaces.

This change stores the group ID in the group metadata because KAFKA-15281 about the group metadata API will build on that.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
