### PR TITLE
KAFKA-15818: ensure leave group on max poll interval

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -182,7 +182,6 @@ public class HeartbeatRequestManager implements RequestManager {
             membershipManager.onHeartbeatRequestSkipped();
             return NetworkClientDelegate.PollResult.EMPTY;
         }
-
         pollTimer.update(currentTimeMs);
         if (pollTimer.isExpired()) {
             logger.warn("consumer poll timeout has expired. This means the time between subsequent calls to poll() " +

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -561,17 +561,6 @@ public class HeartbeatRequestManager implements RequestManager {
                 serverAssignor = null;
                 topicPartitions = null;
             }
-
-            @Override
-            public String toString() {
-                return "SentFields(" +
-                        "instanceId='" + instanceId + '\'' +
-                        ", rebalanceTimeoutMs=" + rebalanceTimeoutMs +
-                        ", subscribedTopicNames=" + subscribedTopicNames +
-                        ", serverAssignor='" + serverAssignor + '\'' +
-                        ", topicPartitions=" + topicPartitions +
-                        ')';
-            }
         }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MemberState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MemberState.java
@@ -99,7 +99,14 @@ public enum MemberState {
      * unrecoverable state where the member won't send any requests to the broker and cannot
      * perform any other transition.
      */
-    FATAL;
+    FATAL,
+
+    /**
+     * An intermediate state indicating the consumer is staled because the user has not polled the consumer
+     * within the <code>max.poll.interval.ms</code> time bound; therefore causing the member to leave the
+     * group. The member rejoins on the next poll.
+     */
+    STALED;
 
     // Valid state transitions
     static {
@@ -116,7 +123,7 @@ public enum MemberState {
         FENCED.previousValidStates = Arrays.asList(JOINING, STABLE, RECONCILING, ACKNOWLEDGING,
                 PREPARE_LEAVING, LEAVING);
 
-        JOINING.previousValidStates = Arrays.asList(FENCED, UNSUBSCRIBED);
+        JOINING.previousValidStates = Arrays.asList(FENCED, UNSUBSCRIBED, STALED);
 
         PREPARE_LEAVING.previousValidStates = Arrays.asList(JOINING, STABLE, RECONCILING,
                 ACKNOWLEDGING, UNSUBSCRIBED, FENCED);
@@ -124,6 +131,8 @@ public enum MemberState {
         LEAVING.previousValidStates = Arrays.asList(PREPARE_LEAVING);
 
         UNSUBSCRIBED.previousValidStates = Arrays.asList(LEAVING);
+
+        STALED.previousValidStates = Arrays.asList(LEAVING);
     }
 
     private List<MemberState> previousValidStates;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MemberState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MemberState.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.common.protocol.Errors;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -132,7 +133,7 @@ public enum MemberState {
 
         UNSUBSCRIBED.previousValidStates = Arrays.asList(LEAVING);
 
-        STALED.previousValidStates = Arrays.asList(LEAVING);
+        STALED.previousValidStates = Arrays.asList(JOINING, RECONCILING, ACKNOWLEDGING, STABLE);
     }
 
     private List<MemberState> previousValidStates;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
@@ -151,8 +151,8 @@ public interface MembershipManager {
     void transitionToJoining();
 
     /**
-     * When the user stops polling the consumer, the member will be transitioned to LEAVING without revoking the
-     * partitions.
+     * When the user stops polling the consumer and the <code>max.poll.interval.ms</code> timer expires, we transition
+     * the member to STALE.
      */
     void transitionToStaled();
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
@@ -62,6 +62,11 @@ public interface MembershipManager {
     MemberState state();
 
     /**
+     * @return True if the member is staled due to expired poll timer.
+     */
+    boolean isStaled();
+
+    /**
      * Update member info and transition member state based on a successful heartbeat response.
      *
      * @param response Heartbeat response to extract member info and errors from.
@@ -149,5 +154,5 @@ public interface MembershipManager {
      * When the user stops polling the consumer, the member will be transitioned to LEAVING without revoking the
      * partitions.
      */
-    void onStaledMember();
+    void transitionToStaled();
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
@@ -139,4 +139,14 @@ public interface MembershipManager {
      * Note that list of topics of the subscription is taken from the shared subscription state.
      */
     void onSubscriptionUpdated();
+
+    /**
+     * @return Completable future of the current leave group operation.
+     */
+    Optional<CompletableFuture<Void>> leaveGroupFuture();
+
+    /**
+     * Transition to the {@link MemberState#JOINING} state to attempt joining a group.
+     */
+    void transitionToJoining();
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
@@ -141,12 +141,13 @@ public interface MembershipManager {
     void onSubscriptionUpdated();
 
     /**
-     * @return Completable future of the current leave group operation.
-     */
-    Optional<CompletableFuture<Void>> leaveGroupFuture();
-
-    /**
      * Transition to the {@link MemberState#JOINING} state to attempt joining a group.
      */
     void transitionToJoining();
+
+    /**
+     * When the user stops polling the consumer, the member will be transitioned to LEAVING without revoking the
+     * partitions.
+     */
+    void onStaledMember();
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -668,14 +668,13 @@ public class MembershipManagerImpl implements MembershipManager, ClusterResource
     }
 
     /**
-     * {@inheritDoc}
+     * Sets the epoch to the leave group epoch and clears the assignments. The member will rejoin with
+     * the existing subscriptions on the next time user polls.
      */
     @Override
     public void transitionToStaled() {
-        transitionTo(MemberState.PREPARE_LEAVING);
         memberEpoch = ConsumerGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH;
-        transitionTo(MemberState.LEAVING);
-        leaveGroupInProgress = Optional.of(CompletableFuture.completedFuture(null));
+        currentAssignment = new HashSet<>();
         transitionTo(MemberState.STALED);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -228,7 +228,7 @@ public class MembershipManagerImpl implements MembershipManager, ClusterResource
      * (callbacks executed and heartbeat request to leave is sent out). This will be empty is the
      * member is not leaving.
      */
-    private Optional<CompletableFuture<Void>> leaveGroupInProgress;
+    private Optional<CompletableFuture<Void>> leaveGroupInProgress = Optional.empty();
 
     /**
      * True if the member has registered to be notified when the cluster metadata is updated.
@@ -481,7 +481,8 @@ public class MembershipManagerImpl implements MembershipManager, ClusterResource
      * the user calls the subscribe API, or when the member wants to rejoin after getting fenced.
      * Visible for testing.
      */
-    void transitionToJoining() {
+    @Override
+    public void transitionToJoining() {
         if (state == MemberState.FATAL) {
             log.warn("No action taken to join the group with the updated subscription because " +
                     "the member is in FATAL state");
@@ -539,6 +540,11 @@ public class MembershipManagerImpl implements MembershipManager, ClusterResource
         // Return future to indicate that the leave group is done when the callbacks
         // complete, and the transition to send the heartbeat has been made.
         return leaveResult;
+    }
+
+    @Override
+    public Optional<CompletableFuture<Void>> leaveGroupFuture() {
+        return leaveGroupInProgress;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -479,6 +479,7 @@ public class MembershipManagerImpl implements MembershipManager, ClusterResource
      * Transition to the {@link MemberState#JOINING} state, indicating that the member will
      * try to join the group on the next heartbeat request. This is expected to be invoked when
      * the user calls the subscribe API, or when the member wants to rejoin after getting fenced.
+     * Visible for testing.
      */
     @Override
     public void transitionToJoining() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -674,7 +674,7 @@ public class MembershipManagerImpl implements MembershipManager, ClusterResource
     @Override
     public void transitionToStaled() {
         memberEpoch = ConsumerGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH;
-        currentAssignment = new HashSet<>();
+        currentAssignment.clear();
         transitionTo(MemberState.STALED);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.consumer.internals.CachedSupplier;
 import org.apache.kafka.clients.consumer.internals.CommitRequestManager;
 import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkThread;
+import org.apache.kafka.clients.consumer.internals.HeartbeatRequestManager;
 import org.apache.kafka.clients.consumer.internals.MembershipManager;
 import org.apache.kafka.clients.consumer.internals.RequestManagers;
 import org.apache.kafka.common.KafkaException;
@@ -128,8 +129,8 @@ public class ApplicationEventProcessor extends EventProcessor<ApplicationEvent> 
             return;
         }
 
-        CommitRequestManager manager = requestManagers.commitRequestManager.get();
-        manager.updateAutoCommitTimer(event.pollTimeMs());
+        requestManagers.commitRequestManager.ifPresent(m -> m.updateAutoCommitTimer(event.pollTimeMs()));
+        requestManagers.heartbeatRequestManager.ifPresent(HeartbeatRequestManager::ack);
     }
 
     private void process(final CommitApplicationEvent event) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/events/ApplicationEventProcessor.java
@@ -130,7 +130,7 @@ public class ApplicationEventProcessor extends EventProcessor<ApplicationEvent> 
         }
 
         requestManagers.commitRequestManager.ifPresent(m -> m.updateAutoCommitTimer(event.pollTimeMs()));
-        requestManagers.heartbeatRequestManager.ifPresent(HeartbeatRequestManager::ack);
+        requestManagers.heartbeatRequestManager.ifPresent(HeartbeatRequestManager::resetPollTimer);
     }
 
     private void process(final CommitApplicationEvent event) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -219,7 +219,7 @@ public class ConsumerTestBuilder implements Closeable {
                     gi.heartbeatJitterMs));
             HeartbeatRequestManager heartbeat = spy(new HeartbeatRequestManager(
                     logContext,
-                    time,
+                    time.timer(groupRebalanceConfig.rebalanceTimeoutMs),
                     config,
                     coordinator,
                     mm,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -35,6 +35,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Timer;
 
 import java.io.Closeable;
 import java.time.Duration;
@@ -80,6 +81,7 @@ public class ConsumerTestBuilder implements Closeable {
     final FetchConfig fetchConfig;
     final FetchBuffer fetchBuffer;
     final Metrics metrics;
+    final Timer pollTimer;
     final FetchMetricsManager metricsManager;
     final NetworkClientDelegate networkClientDelegate;
     final OffsetsRequestManager offsetsRequestManager;
@@ -148,6 +150,7 @@ public class ConsumerTestBuilder implements Closeable {
         this.subscriptions = spy(createSubscriptionState(config, logContext));
         this.metadata = spy(new ConsumerMetadata(config, subscriptions, logContext, new ClusterResourceListeners()));
         this.metricsManager = createFetchMetricsManager(metrics);
+        this.pollTimer = time.timer(groupRebalanceConfig.rebalanceTimeoutMs);
 
         this.client = new MockClient(time, metadata);
         MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWith(1, new HashMap<String, Integer>() {
@@ -219,7 +222,7 @@ public class ConsumerTestBuilder implements Closeable {
                     gi.heartbeatJitterMs));
             HeartbeatRequestManager heartbeat = spy(new HeartbeatRequestManager(
                     logContext,
-                    time.timer(groupRebalanceConfig.rebalanceTimeoutMs),
+                    pollTimer,
                     config,
                     coordinator,
                     mm,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -219,6 +219,7 @@ public class ConsumerTestBuilder implements Closeable {
                     gi.heartbeatJitterMs));
             HeartbeatRequestManager heartbeat = spy(new HeartbeatRequestManager(
                     logContext,
+                    time,
                     config,
                     coordinator,
                     mm,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
@@ -523,7 +523,7 @@ public class HeartbeatRequestManagerTest {
         assertTrue(heartbeatRequestManager.pollTimer().isExpired());
         // Poll again, ensure we heartbeat again.
         time.sleep(1);
-        heartbeatRequestManager.ack();
+        heartbeatRequestManager.resetPollTimer();
         assertHeartbeat(heartbeatRequestManager);
         assertFalse(heartbeatRequestManager.pollTimer().isExpired());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
@@ -513,26 +513,78 @@ public class HeartbeatRequestManagerTest {
     @Test
     public void testEnsureLeaveGroupWhenPollTimerExpires() {
         membershipManager.transitionToJoining();
-        time.sleep(1);
         // Sending first heartbeat and transitioning to stable
         assertHeartbeat(heartbeatRequestManager);
         assertInState(MemberState.STABLE);
-        assertFalse(heartbeatRequestManager.pollTimer().isExpired());
+        assertFalse(testBuilder.pollTimer.isExpired());
         // Expires the poll timer, ensure sending a leave group
         time.sleep(DEFAULT_MAX_POLL_INTERVAL_MS);
         NetworkClientDelegate.PollResult leaveGroupRequest = assertLeaveGroup(heartbeatRequestManager);
         assertInState(MemberState.JOINING);
-        assertTrue(heartbeatRequestManager.pollTimer().isExpired());
+        assertTrue(testBuilder.pollTimer.isExpired());
         time.sleep(100);
         assertNoHeartbeat(heartbeatRequestManager);
         assertInState(MemberState.JOINING);
-        time.sleep(1);
         heartbeatRequestManager.resetPollTimer();
         // Server respond to leave group. The manager heartbeats BAU.
         completingLeaveGroupRequest(leaveGroupRequest);
         // Join back to the group.
         assertHeartbeat(heartbeatRequestManager);
-        assertFalse(heartbeatRequestManager.pollTimer().isExpired());
+        assertFalse(testBuilder.pollTimer.isExpired());
+        assertInState(MemberState.STABLE);
+    }
+
+    private void assertInState(MemberState state) {
+        assertEquals(state, membershipManager.state());
+    }
+
+    private void assertHeartbeat(HeartbeatRequestManager hrm) {
+        NetworkClientDelegate.PollResult pollResult = hrm.poll(time.milliseconds());
+        assertEquals(1, pollResult.unsentRequests.size());
+        assertEquals(DEFAULT_HEARTBEAT_INTERVAL_MS, pollResult.timeUntilNextPollMs);
+        pollResult.unsentRequests.get(0).handler().onComplete(createHeartbeatResponse(pollResult.unsentRequests.get(0),
+            Errors.NONE));
+    }
+
+    private void assertNoHeartbeat(HeartbeatRequestManager hrm) {
+        NetworkClientDelegate.PollResult pollResult = hrm.poll(time.milliseconds());
+        assertEquals(0, pollResult.unsentRequests.size());
+    }
+
+    private NetworkClientDelegate.PollResult assertLeaveGroup(HeartbeatRequestManager hrm) {
+        NetworkClientDelegate.PollResult pollResult = hrm.poll(time.milliseconds());
+        assertEquals(1, pollResult.unsentRequests.size());
+        ConsumerGroupHeartbeatRequestData data = (ConsumerGroupHeartbeatRequestData) pollResult.unsentRequests.get(0).requestBuilder().build().data();
+        assertEquals(ConsumerGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH, data.memberEpoch());
+        assertEquals(MemberState.JOINING, membershipManager.state());
+        return pollResult;
+    }
+
+    private void completingLeaveGroupRequest(NetworkClientDelegate.PollResult leaveGroupRequest) {
+        leaveGroupRequest.unsentRequests.get(0).handler().onComplete(createHeartbeatResponse(leaveGroupRequest.unsentRequests.get(0), Errors.NONE));
+    }
+
+    @Test
+    public void testEnsureLeaveGroupWhenPollTimerExpires() {
+        membershipManager.transitionToJoining();
+        // Sending first heartbeat and transitioning to stable
+        assertHeartbeat(heartbeatRequestManager);
+        assertInState(MemberState.STABLE);
+        assertFalse(testBuilder.pollTimer.isExpired());
+        // Expires the poll timer, ensure sending a leave group
+        time.sleep(DEFAULT_MAX_POLL_INTERVAL_MS);
+        NetworkClientDelegate.PollResult leaveGroupRequest = assertLeaveGroup(heartbeatRequestManager);
+        assertInState(MemberState.JOINING);
+        assertTrue(testBuilder.pollTimer.isExpired());
+        time.sleep(100);
+        assertNoHeartbeat(heartbeatRequestManager);
+        assertInState(MemberState.JOINING);
+        heartbeatRequestManager.resetPollTimer();
+        // Server respond to leave group. The manager heartbeats BAU.
+        completingLeaveGroupRequest(leaveGroupRequest);
+        // Join back to the group.
+        assertHeartbeat(heartbeatRequestManager);
+        assertFalse(testBuilder.pollTimer.isExpired());
         assertInState(MemberState.STABLE);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
@@ -1047,9 +1047,10 @@ public class MembershipManagerImplTest {
 
     @Test
     public void testTransitionToStaled() {
-        MembershipManagerImpl membershipManager = createMemberInStableState();
+        MembershipManager membershipManager = memberJoinWithAssignment("topic", Uuid.randomUuid());
         membershipManager.transitionToStaled();
         assertEquals(LEAVE_GROUP_MEMBER_EPOCH, membershipManager.memberEpoch());
+        assertTrue(membershipManager.currentAssignment().isEmpty());
     }
 
     @Test
@@ -1398,5 +1399,15 @@ public class MembershipManagerImplTest {
                                 .setTopicId(topic2)
                                 .setPartitions(Arrays.asList(3, 4, 5))
                 ));
+    }
+
+    private MembershipManager memberJoinWithAssignment(String topicName, Uuid topicId) {
+        MembershipManagerImpl membershipManager = mockJoinAndReceiveAssignment(true);
+        membershipManager.onHeartbeatRequestSent();
+        when(metadata.topicNames()).thenReturn(Collections.singletonMap(topicId, topicName));
+        receiveAssignment(topicId, Collections.singletonList(0), membershipManager);
+        membershipManager.onHeartbeatRequestSent();
+        assertFalse(membershipManager.currentAssignment().isEmpty());
+        return membershipManager;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
@@ -1050,7 +1050,6 @@ public class MembershipManagerImplTest {
         MembershipManagerImpl membershipManager = createMemberInStableState();
         membershipManager.transitionToStaled();
         assertEquals(LEAVE_GROUP_MEMBER_EPOCH, membershipManager.memberEpoch());
-
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
@@ -42,6 +42,7 @@ import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.common.requests.ConsumerGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -1042,6 +1043,22 @@ public class MembershipManagerImplTest {
         assertNotEquals(0, membershipManager.memberEpoch());
         assertEquals(0, rebalanceListener.lostCount);
         assertEquals(0, rebalanceListener.revokedCount);
+    }
+
+    @Test
+    public void testTransitionToStaled() {
+        MembershipManagerImpl membershipManager = createMemberInStableState();
+        membershipManager.transitionToStaled();
+        assertEquals(LEAVE_GROUP_MEMBER_EPOCH, membershipManager.memberEpoch());
+
+    }
+
+    @Test
+    public void testHeartbeatSentOnStaledMember() {
+        MembershipManagerImpl membershipManager = createMemberInStableState();
+        membershipManager.transitionToStaled();
+        membershipManager.onHeartbeatRequestSent();
+        assertEquals(MemberState.JOINING, membershipManager.state());
     }
 
     private MembershipManagerImpl mockMemberSuccessfullyReceivesAndAcksAssignment(

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -948,6 +948,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // 1 consumer using range assignment
     this.consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "range-group")
     this.consumerConfig.setProperty(ConsumerConfig.GROUP_REMOTE_ASSIGNOR_CONFIG, "range")
+    this.consumerConfig.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "30000")
     val consumer = createConsumer()
 
     // create two new topics, each having 2 partitions


### PR DESCRIPTION
Currently, poll interval is not being respected during consumer#poll.  When the user stops polling the consumer, we should assume either the consumer is too slow to respond or is already dead.  In either case, we should let the group coordinator kick the member out of the group and reassign its partition after the rebalance timeout expires.  

If the consumer comes back alive, we should send a heartbeat and the member will be fenced and rejoin.  (and the partitions will be revoked).

This is the same behavior as the current implementation.