### PR TITLE
MINOR: Fix flaky `MetadataLoaderTest.testNoPublishEmptyImage`

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/image/loader/MetadataLoaderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/loader/MetadataLoaderTest.java
@@ -793,10 +793,10 @@ public class MetadataLoaderTest {
 
             @Override
             public void onMetadataUpdate(MetadataDelta delta, MetadataImage newImage, LoaderManifest manifest) {
+                capturedImages.add(newImage);
                 if (!firstPublish.isDone()) {
                     firstPublish.complete(null);
                 }
-                capturedImages.add(newImage);
             }
         };
 


### PR DESCRIPTION
There is a race in the assertion on `capturedImages`. Since the future is signaled first, it is still possible to see an empty list. By adding to the collection first, we can ensure the assertion will succeed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
