### PR TITLE
MINOR: Fix flaky test RefreshingHttpsJwksTest.testBasicScheduleRefresh

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/RefreshingHttpsJwksTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/RefreshingHttpsJwksTest.java
@@ -67,7 +67,7 @@ public class RefreshingHttpsJwksTest extends OAuthBearerTest {
 
        // we use mocktime here to ensure that scheduled refresh _doesn't_ run and update the invocation count
        // we expect httpsJwks.refresh() to be invoked twice, once from init() and maybeExpediteRefresh() each
-        try (RefreshingHttpsJwks refreshingHttpsJwks = getRefreshingHttpsJwks(time, httpsJwks, mockExecutorService(time))) {
+        try (RefreshingHttpsJwks refreshingHttpsJwks = getRefreshingHttpsJwks(time, httpsJwks)) {
             refreshingHttpsJwks.init();
             verify(httpsJwks, times(1)).refresh();
             assertTrue(refreshingHttpsJwks.maybeExpediteRefresh(keyId));
@@ -83,7 +83,7 @@ public class RefreshingHttpsJwksTest extends OAuthBearerTest {
     @Test
     public void testMaybeExpediteRefreshNoDelay() throws Exception {
         String keyId = "abc123";
-        Time time = new MockTime();
+        MockTime time = new MockTime();
         HttpsJwks httpsJwks = spyHttpsJwks();
 
         try (RefreshingHttpsJwks refreshingHttpsJwks = getRefreshingHttpsJwks(time, httpsJwks)) {
@@ -115,7 +115,7 @@ public class RefreshingHttpsJwksTest extends OAuthBearerTest {
         Arrays.fill(keyIdChars, '0');
         String keyId = new String(keyIdChars);
 
-        Time time = new MockTime();
+        MockTime time = new MockTime();
         HttpsJwks httpsJwks = spyHttpsJwks();
 
         try (RefreshingHttpsJwks refreshingHttpsJwks = getRefreshingHttpsJwks(time, httpsJwks)) {
@@ -137,7 +137,7 @@ public class RefreshingHttpsJwksTest extends OAuthBearerTest {
         MockTime time = new MockTime();
         HttpsJwks httpsJwks = spyHttpsJwks();
 
-        try (RefreshingHttpsJwks refreshingHttpsJwks = getRefreshingHttpsJwks(time, httpsJwks, mockExecutorService(time))) {
+        try (RefreshingHttpsJwks refreshingHttpsJwks = getRefreshingHttpsJwks(time, httpsJwks)) {
             refreshingHttpsJwks.init();
             // We refresh once at the initialization time from getJsonWebKeys.
             verify(httpsJwks, times(1)).refresh();
@@ -176,7 +176,7 @@ public class RefreshingHttpsJwksTest extends OAuthBearerTest {
 
     private void assertMaybeExpediteRefreshWithDelay(long sleepDelay, boolean shouldBeScheduled) throws Exception {
         String keyId = "abc123";
-        Time time = new MockTime();
+        MockTime time = new MockTime();
         HttpsJwks httpsJwks = spyHttpsJwks();
 
         try (RefreshingHttpsJwks refreshingHttpsJwks = getRefreshingHttpsJwks(time, httpsJwks)) {
@@ -187,12 +187,8 @@ public class RefreshingHttpsJwksTest extends OAuthBearerTest {
         }
     }
 
-    private RefreshingHttpsJwks getRefreshingHttpsJwks(final Time time, final HttpsJwks httpsJwks) {
-        return new RefreshingHttpsJwks(time, httpsJwks, REFRESH_MS, RETRY_BACKOFF_MS, RETRY_BACKOFF_MAX_MS);
-    }
-
-    private RefreshingHttpsJwks getRefreshingHttpsJwks(final Time time, final HttpsJwks httpsJwks, final ScheduledExecutorService executorService) {
-        return new RefreshingHttpsJwks(time, httpsJwks, REFRESH_MS, RETRY_BACKOFF_MS, RETRY_BACKOFF_MAX_MS, executorService);
+    private RefreshingHttpsJwks getRefreshingHttpsJwks(final MockTime time, final HttpsJwks httpsJwks) {
+        return new RefreshingHttpsJwks(time, httpsJwks, REFRESH_MS, RETRY_BACKOFF_MS, RETRY_BACKOFF_MAX_MS, mockExecutorService(time));
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/RefreshingHttpsJwksTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/RefreshingHttpsJwksTest.java
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
 import org.jose4j.http.SimpleResponse;
 import org.jose4j.jwk.HttpsJwks;
 import org.junit.jupiter.api.Test;

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/RefreshingHttpsJwksTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/RefreshingHttpsJwksTest.java
@@ -65,6 +65,8 @@ public class RefreshingHttpsJwksTest extends OAuthBearerTest {
         MockTime time = new MockTime();
         HttpsJwks httpsJwks = spyHttpsJwks();
 
+       // we use mocktime here to ensure that scheduled refresh _doesn't_ run and update the invocation count
+       // we expect httpsJwks.refresh() to be invoked twice, once from init() and maybeExpediteRefresh() each
         try (RefreshingHttpsJwks refreshingHttpsJwks = getRefreshingHttpsJwks(time, httpsJwks, mockExecutorService(time))) {
             refreshingHttpsJwks.init();
             verify(httpsJwks, times(1)).refresh();

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/RefreshingHttpsJwksTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/RefreshingHttpsJwksTest.java
@@ -62,14 +62,14 @@ public class RefreshingHttpsJwksTest extends OAuthBearerTest {
     @Test
     public void testBasicScheduleRefresh() throws Exception {
         String keyId = "abc123";
-        Time time = new MockTime();
+        MockTime time = new MockTime();
         HttpsJwks httpsJwks = spyHttpsJwks();
 
-        try (RefreshingHttpsJwks refreshingHttpsJwks = getRefreshingHttpsJwks(time, httpsJwks)) {
+        try (RefreshingHttpsJwks refreshingHttpsJwks = getRefreshingHttpsJwks(time, httpsJwks, mockExecutorService(time))) {
             refreshingHttpsJwks.init();
             verify(httpsJwks, times(1)).refresh();
             assertTrue(refreshingHttpsJwks.maybeExpediteRefresh(keyId));
-            verify(httpsJwks, times(1)).refresh();
+            verify(httpsJwks, times(2)).refresh();
         }
     }
 
@@ -134,6 +134,20 @@ public class RefreshingHttpsJwksTest extends OAuthBearerTest {
         String keyId = "abc123";
         MockTime time = new MockTime();
         HttpsJwks httpsJwks = spyHttpsJwks();
+
+        try (RefreshingHttpsJwks refreshingHttpsJwks = getRefreshingHttpsJwks(time, httpsJwks, mockExecutorService(time))) {
+            refreshingHttpsJwks.init();
+            // We refresh once at the initialization time from getJsonWebKeys.
+            verify(httpsJwks, times(1)).refresh();
+            assertTrue(refreshingHttpsJwks.maybeExpediteRefresh(keyId));
+            verify(httpsJwks, times(2)).refresh();
+            time.sleep(REFRESH_MS + 1);
+            verify(httpsJwks, times(3)).refresh();
+            assertFalse(refreshingHttpsJwks.maybeExpediteRefresh(keyId));
+        }
+    }
+
+    private ScheduledExecutorService mockExecutorService(MockTime time) {
         MockExecutorService mockExecutorService = new MockExecutorService(time);
         ScheduledExecutorService executorService = Mockito.mock(ScheduledExecutorService.class);
         Mockito.doAnswer(invocation -> {
@@ -155,17 +169,7 @@ public class RefreshingHttpsJwksTest extends OAuthBearerTest {
                 return null;
             }, unit.toMillis(initialDelay), period);
         }).when(executorService).scheduleAtFixedRate(Mockito.any(Runnable.class), Mockito.anyLong(), Mockito.anyLong(), Mockito.any(TimeUnit.class));
-
-        try (RefreshingHttpsJwks refreshingHttpsJwks = getRefreshingHttpsJwks(time, httpsJwks, executorService)) {
-            refreshingHttpsJwks.init();
-            // We refresh once at the initialization time from getJsonWebKeys.
-            verify(httpsJwks, times(1)).refresh();
-            assertTrue(refreshingHttpsJwks.maybeExpediteRefresh(keyId));
-            verify(httpsJwks, times(2)).refresh();
-            time.sleep(REFRESH_MS + 1);
-            verify(httpsJwks, times(3)).refresh();
-            assertFalse(refreshingHttpsJwks.maybeExpediteRefresh(keyId));
-        }
+        return executorService;
     }
 
     private void assertMaybeExpediteRefreshWithDelay(long sleepDelay, boolean shouldBeScheduled) throws Exception {


### PR DESCRIPTION
### What
This test is flaky because `maybeExpediteRefresh` schedules a refresh in a background thread. Instead pass through a mock executor service so that the refresh is executed directly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
