### PR TITLE
MINOR: Fix flaky `DescribeClusterRequestTest.testDescribeClusterRequestIncludingClusterAuthorizedOperations`

### DIFF
--- a/core/src/test/scala/unit/kafka/server/DescribeClusterRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DescribeClusterRequestTest.scala
@@ -83,6 +83,8 @@ class DescribeClusterRequestTest extends BaseRequestTest {
       Int.MinValue
     }
 
+    ensureConsistentKRaftMetadata()
+
     for (version <- ApiKeys.DESCRIBE_CLUSTER.oldestVersion to ApiKeys.DESCRIBE_CLUSTER.latestVersion) {
       val describeClusterRequest = new DescribeClusterRequest.Builder(new DescribeClusterRequestData()
         .setIncludeClusterAuthorizedOperations(includeClusterAuthorizedOperations))


### PR DESCRIPTION
Test startup does not assure that all brokers are registered. In flaky failures, the `DescribeCluster` API does not return a complete list of brokers. To fix the issue, we add a call to `ensureConsistentKRaftMetadata()` to ensure that all brokers are registered and have caught up to current metadata.

I could reproduce the failure locally once every 5-10 tries before the fix. I haven't seen any failures with the fix applied.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
