### PR TITLE
HOTFIX: Fix BrokerRegistrationRequestTest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationRequest.java
@@ -45,6 +45,10 @@ public class BrokerRegistrationRequest extends AbstractRequest {
 
         @Override
         public BrokerRegistrationRequest build(short version) {
+            if (version < 2) {
+                // Reset the PreviousBrokerEpoch to default if not supported.
+                data.setPreviousBrokerEpoch(new BrokerRegistrationRequestData().previousBrokerEpoch());
+            }
             return new BrokerRegistrationRequest(data, version);
         }
 


### PR DESCRIPTION
BrokerRegistrationRequestTest failed with 
```
org.opentest4j.AssertionFailedError: BrokerRegistrationRequestData(brokerId=0, clusterId='test', incarnationId=jMcpfICTSOiuxTik4-6cKw, listeners=[], features=[], rack='a', isMigratingZkBroker=false, logDirs=[], previousBrokerEpoch=1) ==> expected: <-1> but was: <1>
```

https://ci-builds.apache.org/job/Kafka/job/kafka/job/trunk/2435/testReport/junit/org.apache.kafka.common.requests/BrokerRegistrationRequestTest/Build___JDK_21_and_Scala_2_13____1__0/

We should reset `previousBrokerEpoch` to default value for version less than 2 like [before]https://github.com/apache/kafka/pull/14860/files#diff-ad10f923aec6f87a9809a00f9ec78ba58af8aa817395a2093732efe0c040e7bfL48). 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
