### PR TITLE
KAFKA-15945 : Flaky test - testSyncTopicConfigs() – org.apache.kafka.connect.mirror.integration.MirrorConnectorsIntegrationBaseTest

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -757,7 +757,7 @@ public class MirrorConnectorsIntegrationBaseTest {
         topicConfig.put("delete.retention.ms", "1000"); // should be excluded (default value is 86400000)
         topicConfig.put("retention.bytes", "1000"); // should be included, default value is -1
 
-        final String topic = "test-topic-with-config";
+        final String topic = "test-topic-with-config-new";
         final String backupTopic = remoteTopicName(topic, PRIMARY_CLUSTER_ALIAS);
 
         primary.kafka().createTopic(topic, NUM_PARTITIONS, 1, topicConfig);
@@ -772,7 +772,7 @@ public class MirrorConnectorsIntegrationBaseTest {
         // alter configs on target cluster
         backup.kafka().incrementalAlterConfigs(configOps);
         // wait until the configs are changed
-        waitForConfigValueChange(backup, backupTopic, "delete.retention.ms", "2000");
+        //waitForConfigValueChange(backup, backupTopic, "delete.retention.ms", "2000");
 
         waitForCondition(() -> {
             String primaryConfig, backupConfig;

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -101,6 +101,7 @@ import org.junit.jupiter.api.BeforeEach;
  */
 @Tag("integration")
 public class MirrorConnectorsIntegrationBaseTest {
+    private static final Object TOPIC_LOCK = new Object();
     private static final Logger log = LoggerFactory.getLogger(MirrorConnectorsIntegrationBaseTest.class);
 
     protected static final int NUM_RECORDS_PER_PARTITION = 10;
@@ -748,133 +749,139 @@ public class MirrorConnectorsIntegrationBaseTest {
 
     @Test
     public void testSyncTopicConfigs() throws InterruptedException {
-        mm2Config = new MirrorMakerConfig(mm2Props);
+        synchronized (TOPIC_LOCK) {
+            mm2Config = new MirrorMakerConfig(mm2Props);
 
-        waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);
+            waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);
 
-        // create topic with configuration to test:
-        final Map<String, String> topicConfig = new HashMap<>();
-        topicConfig.put("delete.retention.ms", "1000"); // should be excluded (default value is 86400000)
-        topicConfig.put("retention.bytes", "1000"); // should be included, default value is -1
+            // create topic with configuration to test:
+            final Map<String, String> topicConfig = new HashMap<>();
+            topicConfig.put("delete.retention.ms", "1000"); // should be excluded (default value is 86400000)
+            topicConfig.put("retention.bytes", "1000"); // should be included, default value is -1
 
-        final String topic = "test-topic-with-config-new";
-        final String backupTopic = remoteTopicName(topic, PRIMARY_CLUSTER_ALIAS);
+            final String topic = "test-topic-with-config-new";
+            final String backupTopic = remoteTopicName(topic, PRIMARY_CLUSTER_ALIAS);
 
-        primary.kafka().createTopic(topic, NUM_PARTITIONS, 1, topicConfig);
-        waitForTopicCreated(backup, backupTopic);
+            primary.kafka().createTopic(topic, NUM_PARTITIONS, 1, topicConfig);
+            waitForTopicCreated(backup, backupTopic);
 
-        // alter configs on the target topic
-        ConfigResource configResource = new ConfigResource(ConfigResource.Type.TOPIC, backupTopic);
-        Collection<AlterConfigOp> ops = new ArrayList<>();
-        ops.add(new AlterConfigOp(new ConfigEntry("delete.retention.ms", "2000"), AlterConfigOp.OpType.SET));
-        ops.add(new AlterConfigOp(new ConfigEntry("retention.bytes", "2000"), AlterConfigOp.OpType.SET));
-        Map<ConfigResource, Collection<AlterConfigOp>> configOps = Collections.singletonMap(configResource, ops);
-        // alter configs on target cluster
-        backup.kafka().incrementalAlterConfigs(configOps);
-        // wait until the configs are changed
-        //waitForConfigValueChange(backup, backupTopic, "delete.retention.ms", "2000");
+            // alter configs on the target topic
+            ConfigResource configResource = new ConfigResource(ConfigResource.Type.TOPIC, backupTopic);
+            Collection<AlterConfigOp> ops = new ArrayList<>();
+            ops.add(new AlterConfigOp(new ConfigEntry("delete.retention.ms", "2000"), AlterConfigOp.OpType.SET));
+            ops.add(new AlterConfigOp(new ConfigEntry("retention.bytes", "2000"), AlterConfigOp.OpType.SET));
+            Map<ConfigResource, Collection<AlterConfigOp>> configOps = Collections.singletonMap(configResource, ops);
+            // alter configs on target cluster
+            backup.kafka().incrementalAlterConfigs(configOps);
+            // wait until the configs are changed
+            //waitForConfigValueChange(backup, backupTopic, "delete.retention.ms", "2000");
 
-        waitForCondition(() -> {
-            String primaryConfig, backupConfig;
-            primaryConfig = getTopicConfig(primary.kafka(), topic, "delete.retention.ms");
-            backupConfig = getTopicConfig(backup.kafka(), backupTopic, "delete.retention.ms");
-            assertNotEquals(primaryConfig, backupConfig,
-                    "`delete.retention.ms` should be different, because it's in exclude filter! ");
-            assertEquals("2000", backupConfig, "`delete.retention.ms` should be 2000, because it's explicitly defined on the target topic! ");
+            waitForCondition(() -> {
+                String primaryConfig, backupConfig;
+                primaryConfig = getTopicConfig(primary.kafka(), topic, "delete.retention.ms");
+                backupConfig = getTopicConfig(backup.kafka(), backupTopic, "delete.retention.ms");
+                assertNotEquals(primaryConfig, backupConfig,
+                        "`delete.retention.ms` should be different, because it's in exclude filter! ");
+                assertEquals("2000", backupConfig, "`delete.retention.ms` should be 2000, because it's explicitly defined on the target topic! ");
 
-            // regression test for the config that are still supposed to be replicated
-            primaryConfig = getTopicConfig(primary.kafka(), topic, "retention.bytes");
-            backupConfig = getTopicConfig(backup.kafka(), backupTopic, "retention.bytes");
-            assertEquals(primaryConfig, backupConfig,
-                    "`retention.bytes` should be the same, because it isn't in exclude filter! ");
-            return true;
-        }, 30000, "Topic configurations were not synced");
+                // regression test for the config that are still supposed to be replicated
+                primaryConfig = getTopicConfig(primary.kafka(), topic, "retention.bytes");
+                backupConfig = getTopicConfig(backup.kafka(), backupTopic, "retention.bytes");
+                assertEquals(primaryConfig, backupConfig,
+                        "`retention.bytes` should be the same, because it isn't in exclude filter! ");
+                return true;
+            }, 30000, "Topic configurations were not synced");
+        }
     }
 
     @Test
     public void testReplicateSourceDefault() throws Exception {
-        mm2Props.put(DefaultConfigPropertyFilter.USE_DEFAULTS_FROM, "source");
-        mm2Config = new MirrorMakerConfig(mm2Props);
+        synchronized (TOPIC_LOCK) {
+            mm2Props.put(DefaultConfigPropertyFilter.USE_DEFAULTS_FROM, "source");
+            mm2Config = new MirrorMakerConfig(mm2Props);
 
-        waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);
+            waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);
 
-        // create topic with default configurations to test
-        final String topic = "test-topic-with-config";
-        final String backupTopic = remoteTopicName(topic, PRIMARY_CLUSTER_ALIAS);
+            // create topic with default configurations to test
+            final String topic = "test-topic-with-config";
+            final String backupTopic = remoteTopicName(topic, PRIMARY_CLUSTER_ALIAS);
 
-        primary.kafka().createTopic(topic, NUM_PARTITIONS, 1, new HashMap<>());
-        waitForTopicCreated(backup, backupTopic);
+            primary.kafka().createTopic(topic, NUM_PARTITIONS, 1, new HashMap<>());
+            waitForTopicCreated(backup, backupTopic);
 
-        // alter target topic configurations
-        ConfigResource configResource = new ConfigResource(ConfigResource.Type.TOPIC, backupTopic);
-        Collection<AlterConfigOp> ops = new ArrayList<>();
-        ops.add(new AlterConfigOp(new ConfigEntry("delete.retention.ms", "2000"), AlterConfigOp.OpType.SET));
-        ops.add(new AlterConfigOp(new ConfigEntry("retention.bytes", "2000"), AlterConfigOp.OpType.SET));
-        Map<ConfigResource, Collection<AlterConfigOp>> configOps = Collections.singletonMap(configResource, ops);
-        backup.kafka().incrementalAlterConfigs(configOps);
+            // alter target topic configurations
+            ConfigResource configResource = new ConfigResource(ConfigResource.Type.TOPIC, backupTopic);
+            Collection<AlterConfigOp> ops = new ArrayList<>();
+            ops.add(new AlterConfigOp(new ConfigEntry("delete.retention.ms", "2000"), AlterConfigOp.OpType.SET));
+            ops.add(new AlterConfigOp(new ConfigEntry("retention.bytes", "2000"), AlterConfigOp.OpType.SET));
+            Map<ConfigResource, Collection<AlterConfigOp>> configOps = Collections.singletonMap(configResource, ops);
+            backup.kafka().incrementalAlterConfigs(configOps);
 
-        waitForCondition(() -> {
-            String primaryConfig, backupConfig;
-            // altered configuration of the target topic should be synced with the source cluster's default
-            primaryConfig = getTopicConfig(primary.kafka(), topic, "retention.bytes");
-            backupConfig = getTopicConfig(backup.kafka(), backupTopic, "retention.bytes");
-            assertEquals(primaryConfig, backupConfig,
-                    "`retention.bytes` should be the same, because the source cluster default is being used! ");
-            assertEquals("-1", backupConfig,
-                    "`retention.bytes` should be synced with default value!");
+            waitForCondition(() -> {
+                String primaryConfig, backupConfig;
+                // altered configuration of the target topic should be synced with the source cluster's default
+                primaryConfig = getTopicConfig(primary.kafka(), topic, "retention.bytes");
+                backupConfig = getTopicConfig(backup.kafka(), backupTopic, "retention.bytes");
+                assertEquals(primaryConfig, backupConfig,
+                        "`retention.bytes` should be the same, because the source cluster default is being used! ");
+                assertEquals("-1", backupConfig,
+                        "`retention.bytes` should be synced with default value!");
 
-            // when using the source cluster's default, the excluded configuration should still not be changed
-            primaryConfig = getTopicConfig(primary.kafka(), topic, "delete.retention.ms");
-            backupConfig = getTopicConfig(backup.kafka(), backupTopic, "delete.retention.ms");
-            assertNotEquals(primaryConfig, backupConfig,
-                    "`delete.retention.ms` should be different, because it's in exclude filter! ");
-            assertEquals("2000", backupConfig, "`delete.retention.ms` should be 2000, because it's explicitly defined on the target topic! ");
-            return true;
-        }, 30000, "Topic configurations were not synced");
+                // when using the source cluster's default, the excluded configuration should still not be changed
+                primaryConfig = getTopicConfig(primary.kafka(), topic, "delete.retention.ms");
+                backupConfig = getTopicConfig(backup.kafka(), backupTopic, "delete.retention.ms");
+                assertNotEquals(primaryConfig, backupConfig,
+                        "`delete.retention.ms` should be different, because it's in exclude filter! ");
+                assertEquals("2000", backupConfig, "`delete.retention.ms` should be 2000, because it's explicitly defined on the target topic! ");
+                return true;
+            }, 30000, "Topic configurations were not synced");
+        }
     }
 
     @Test
     public void testReplicateTargetDefault() throws Exception {
-        mm2Config = new MirrorMakerConfig(mm2Props);
+        synchronized (TOPIC_LOCK) {
+            mm2Config = new MirrorMakerConfig(mm2Props);
 
-        waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);
+            waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);
 
-        // create topic with configuration to test:
-        final Map<String, String> topicConfig = new HashMap<>();
-        topicConfig.put("retention.bytes", "1000");
+            // create topic with configuration to test:
+            final Map<String, String> topicConfig = new HashMap<>();
+            topicConfig.put("retention.bytes", "1000");
 
-        final String topic = "test-topic-with-config";
-        final String backupTopic = remoteTopicName(topic, PRIMARY_CLUSTER_ALIAS);
+            final String topic = "test-topic-with-config";
+            final String backupTopic = remoteTopicName(topic, PRIMARY_CLUSTER_ALIAS);
 
-        primary.kafka().createTopic(topic, NUM_PARTITIONS, 1, topicConfig);
-        waitForTopicCreated(backup, backupTopic);
+            primary.kafka().createTopic(topic, NUM_PARTITIONS, 1, topicConfig);
+            waitForTopicCreated(backup, backupTopic);
 
-        waitForCondition(() -> {
-            String primaryConfig, backupConfig;
-            primaryConfig = getTopicConfig(primary.kafka(), topic, "retention.bytes");
-            backupConfig = getTopicConfig(backup.kafka(), backupTopic, "retention.bytes");
-            assertEquals(primaryConfig, backupConfig,
-                    "`retention.bytes` should be the same");
-            assertEquals("1000", backupConfig,
-                    "`retention.bytes` should be synced with default value!");
-            return true;
-        }, 30000, "Topic configurations were not synced");
+            waitForCondition(() -> {
+                String primaryConfig, backupConfig;
+                primaryConfig = getTopicConfig(primary.kafka(), topic, "retention.bytes");
+                backupConfig = getTopicConfig(backup.kafka(), backupTopic, "retention.bytes");
+                assertEquals(primaryConfig, backupConfig,
+                        "`retention.bytes` should be the same");
+                assertEquals("1000", backupConfig,
+                        "`retention.bytes` should be synced with default value!");
+                return true;
+            }, 30000, "Topic configurations were not synced");
 
-        // delete the previously altered configuration of the source topic
-        ConfigResource configResource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
-        Collection<AlterConfigOp> ops = new ArrayList<>();
-        ops.add(new AlterConfigOp(new ConfigEntry("retention.bytes", "1000"), AlterConfigOp.OpType.DELETE));
-        Map<ConfigResource, Collection<AlterConfigOp>> configOps = Collections.singletonMap(configResource, ops);
-        primary.kafka().incrementalAlterConfigs(configOps);
+            // delete the previously altered configuration of the source topic
+            ConfigResource configResource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
+            Collection<AlterConfigOp> ops = new ArrayList<>();
+            ops.add(new AlterConfigOp(new ConfigEntry("retention.bytes", "1000"), AlterConfigOp.OpType.DELETE));
+            Map<ConfigResource, Collection<AlterConfigOp>> configOps = Collections.singletonMap(configResource, ops);
+            primary.kafka().incrementalAlterConfigs(configOps);
 
-        waitForCondition(() -> {
-            String backupConfig;
-            // the configuration on the target topic should be changed to the target cluster's default
-            backupConfig = getTopicConfig(backup.kafka(), backupTopic, "retention.bytes");
-            assertEquals("-1", backupConfig,
-                    "`retention.bytes` should be synced with target's default value!");
-            return true;
-        }, 30000, "Topic configurations were not synced");
+            waitForCondition(() -> {
+                String backupConfig;
+                // the configuration on the target topic should be changed to the target cluster's default
+                backupConfig = getTopicConfig(backup.kafka(), backupTopic, "retention.bytes");
+                assertEquals("-1", backupConfig,
+                        "`retention.bytes` should be synced with target's default value!");
+                return true;
+            }, 30000, "Topic configurations were not synced");
+        }
     }
 
     private TopicPartition remoteTopicPartition(TopicPartition tp, String alias) {
@@ -886,30 +893,32 @@ public class MirrorConnectorsIntegrationBaseTest {
      */
     void createAndTestNewTopicWithConfigFilter() throws Exception {
         // create topic with configuration to test:
-        final Map<String, String> topicConfig = new HashMap<>();
-        topicConfig.put("delete.retention.ms", "1000"); // should be excluded (default value is 86400000)
-        topicConfig.put("retention.bytes", "1000"); // should be included, default value is -1
+        synchronized (TOPIC_LOCK) {
+            final Map<String, String> topicConfig = new HashMap<>();
+            topicConfig.put("delete.retention.ms", "1000"); // should be excluded (default value is 86400000)
+            topicConfig.put("retention.bytes", "1000"); // should be included, default value is -1
 
-        final String topic = "test-topic-with-config";
-        final String backupTopic = remoteTopicName(topic, PRIMARY_CLUSTER_ALIAS);
+            final String topic = "test-topic-with-config";
+            final String backupTopic = remoteTopicName(topic, PRIMARY_CLUSTER_ALIAS);
 
-        primary.kafka().createTopic(topic, NUM_PARTITIONS, 1, topicConfig);
-        waitForTopicCreated(backup, backupTopic);
+            primary.kafka().createTopic(topic, NUM_PARTITIONS, 1, topicConfig);
+            waitForTopicCreated(backup, backupTopic);
 
-        String primaryConfig, backupConfig;
+            String primaryConfig, backupConfig;
 
-        primaryConfig = getTopicConfig(primary.kafka(), topic, "delete.retention.ms");
-        backupConfig = getTopicConfig(backup.kafka(), backupTopic, "delete.retention.ms");
-        assertNotEquals(primaryConfig, backupConfig,
-                "`delete.retention.ms` should be different, because it's in exclude filter! ");
+            primaryConfig = getTopicConfig(primary.kafka(), topic, "delete.retention.ms");
+            backupConfig = getTopicConfig(backup.kafka(), backupTopic, "delete.retention.ms");
+            assertNotEquals(primaryConfig, backupConfig,
+                    "`delete.retention.ms` should be different, because it's in exclude filter! ");
 
-        // regression test for the config that are still supposed to be replicated
-        primaryConfig = getTopicConfig(primary.kafka(), topic, "retention.bytes");
-        backupConfig = getTopicConfig(backup.kafka(), backupTopic, "retention.bytes");
-        assertEquals(primaryConfig, backupConfig,
-                "`retention.bytes` should be the same, because it isn't in exclude filter! ");
-        assertEquals("1000", backupConfig,
-                "`retention.bytes` should be the same, because it's explicitly defined! ");
+            // regression test for the config that are still supposed to be replicated
+            primaryConfig = getTopicConfig(primary.kafka(), topic, "retention.bytes");
+            backupConfig = getTopicConfig(backup.kafka(), backupTopic, "retention.bytes");
+            assertEquals(primaryConfig, backupConfig,
+                    "`retention.bytes` should be the same, because it isn't in exclude filter! ");
+            assertEquals("1000", backupConfig,
+                    "`retention.bytes` should be the same, because it's explicitly defined! ");
+        }
     }
 
     /*

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -773,7 +773,6 @@ public class MirrorConnectorsIntegrationBaseTest {
         backup.kafka().incrementalAlterConfigs(configOps);
         // wait until the configs are changed
         waitForConfigValueChange(backup, backupTopic, "delete.retention.ms", "2000");
-        waitForConfigValueChange(backup, backupTopic, "retention.bytes", "2000");
 
         waitForCondition(() -> {
             String primaryConfig, backupConfig;

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -102,7 +102,7 @@ import org.junit.jupiter.api.BeforeEach;
 @Tag("integration")
 public class MirrorConnectorsIntegrationBaseTest {
     private static final Logger log = LoggerFactory.getLogger(MirrorConnectorsIntegrationBaseTest.class);
-    
+
     protected static final int NUM_RECORDS_PER_PARTITION = 10;
     protected static final int NUM_PARTITIONS = 10;
     protected static final int NUM_RECORDS_PRODUCED = NUM_PARTITIONS * NUM_RECORDS_PER_PARTITION;
@@ -113,6 +113,7 @@ public class MirrorConnectorsIntegrationBaseTest {
     private static final int RECORD_CONSUME_DURATION_MS = 20_000;
     private static final int OFFSET_SYNC_DURATION_MS = 30_000;
     private static final int TOPIC_SYNC_DURATION_MS = 60_000;
+    private static final int CONFIG_CHANGE_DURATION_MS = 60_000;
     private static final int REQUEST_TIMEOUT_DURATION_MS = 60_000;
     private static final int CHECKPOINT_INTERVAL_DURATION_MS = 1_000;
     private static final int NUM_WORKERS = 3;
@@ -138,7 +139,7 @@ public class MirrorConnectorsIntegrationBaseTest {
     protected Boolean createReplicatedTopicsUpfront = false; // enable to speed up the test cases
     protected Exit.Procedure exitProcedure;
     private Exit.Procedure haltProcedure;
-    
+
     protected Properties primaryBrokerProps = new Properties();
     protected Properties backupBrokerProps = new Properties();
     protected Map<String, String> primaryWorkerProps = new HashMap<>();
@@ -179,7 +180,7 @@ public class MirrorConnectorsIntegrationBaseTest {
         // we don't want to exit the JVM and instead simply want to fail the test
         Exit.setExitProcedure(exitProcedure);
         Exit.setHaltProcedure(haltProcedure);
-        
+
         primaryBrokerProps.put("auto.create.topics.enable", "false");
         backupBrokerProps.put("auto.create.topics.enable", "false");
 
@@ -196,7 +197,7 @@ public class MirrorConnectorsIntegrationBaseTest {
         mm2Config = new MirrorMakerConfig(mm2Props);
         primaryWorkerProps = mm2Config.workerConfig(new SourceAndTarget(BACKUP_CLUSTER_ALIAS, PRIMARY_CLUSTER_ALIAS));
         backupWorkerProps.putAll(mm2Config.workerConfig(new SourceAndTarget(PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS)));
-        
+
         primary = new EmbeddedConnectCluster.Builder()
                 .name(PRIMARY_CLUSTER_ALIAS + "-connect-cluster")
                 .numWorkers(NUM_WORKERS)
@@ -216,7 +217,7 @@ public class MirrorConnectorsIntegrationBaseTest {
                 .maskExitProcedures(false)
                 .clientProps(additionalBackupClusterClientsConfigs)
                 .build();
-        
+
         primary.start();
         primary.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS,
                 "Workers of " + PRIMARY_CLUSTER_ALIAS + "-connect-cluster did not start in time.");
@@ -240,17 +241,17 @@ public class MirrorConnectorsIntegrationBaseTest {
         waitForTopicCreated(backup, "test-topic-1");
         waitForTopicCreated(primary, "test-topic-1");
         warmUpConsumer(Collections.singletonMap("group.id", "consumer-group-dummy"));
-        
+
         log.info(PRIMARY_CLUSTER_ALIAS + " REST service: {}", primary.endpointForResource("connectors"));
         log.info(BACKUP_CLUSTER_ALIAS + " REST service: {}", backup.endpointForResource("connectors"));
         log.info(PRIMARY_CLUSTER_ALIAS + " brokers: {}", primary.kafka().bootstrapServers());
         log.info(BACKUP_CLUSTER_ALIAS + " brokers: {}", backup.kafka().bootstrapServers());
-        
+
         // now that the brokers are running, we can finish setting up the Connectors
         mm2Props.put(PRIMARY_CLUSTER_ALIAS + ".bootstrap.servers", primary.kafka().bootstrapServers());
         mm2Props.put(BACKUP_CLUSTER_ALIAS + ".bootstrap.servers", backup.kafka().bootstrapServers());
     }
-    
+
     @AfterEach
     public void shutdownClusters() throws Exception {
         try {
@@ -276,7 +277,7 @@ public class MirrorConnectorsIntegrationBaseTest {
             }
         }
     }
-    
+
     @Test
     public void testReplication() throws Exception {
         produceMessages(primaryProducer, "test-topic-1");
@@ -289,7 +290,7 @@ public class MirrorConnectorsIntegrationBaseTest {
         Map<String, Object> consumerProps = Collections.singletonMap("group.id", consumerGroupName);
         // warm up consumers before starting the connectors, so we don't need to wait for discovery
         warmUpConsumer(consumerProps);
-        
+
         mm2Config = new MirrorMakerConfig(mm2Props);
 
         waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);
@@ -332,7 +333,7 @@ public class MirrorConnectorsIntegrationBaseTest {
             assertTrue(primary.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "backup.heartbeats").count() > 0,
                     "Heartbeats were not replicated downstream to primary cluster.");
         }
-        
+
         assertTrue(backupClient.upstreamClusters().contains(PRIMARY_CLUSTER_ALIAS), "Did not find upstream primary cluster.");
         assertEquals(1, backupClient.replicationHops(PRIMARY_CLUSTER_ALIAS), "Did not calculate replication hops correctly.");
         assertTrue(backup.kafka().consume(1, CHECKPOINT_DURATION_MS, "primary.checkpoints.internal").count() > 0,
@@ -360,7 +361,7 @@ public class MirrorConnectorsIntegrationBaseTest {
         }
 
         assertMonotonicCheckpoints(backup, "primary.checkpoints.internal");
- 
+
         primaryClient.close();
         backupClient.close();
 
@@ -427,12 +428,12 @@ public class MirrorConnectorsIntegrationBaseTest {
         try (Consumer<byte[], byte[]> primaryConsumer = primary.kafka().createConsumerAndSubscribeTo(consumerProps, topic)) {
             waitForConsumingAllRecords(primaryConsumer, expectedRecords);
         }
-        
+
         // one way replication from primary to backup
         mm2Props.put(BACKUP_CLUSTER_ALIAS + "->" + PRIMARY_CLUSTER_ALIAS + ".enabled", "false");
         mm2Config = new MirrorMakerConfig(mm2Props);
         waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);
-        
+
         // sleep few seconds to have MM2 finish replication so that "end" consumer will consume some record
         Thread.sleep(TimeUnit.SECONDS.toMillis(3));
 
@@ -443,7 +444,7 @@ public class MirrorConnectorsIntegrationBaseTest {
                 backupTopic)) {
             waitForConsumingAllRecords(backupConsumer, expectedRecords);
         }
-        
+
         try (Admin backupClient = backup.kafka().createAdminClient()) {
             // retrieve the consumer group offset from backup cluster
             Map<TopicPartition, OffsetAndMetadata> remoteOffsets =
@@ -476,7 +477,7 @@ public class MirrorConnectorsIntegrationBaseTest {
                 put("auto.offset.reset", "earliest");
             }};
         // create consumers before starting the connectors, so we don't need to wait for discovery
-        try (Consumer<byte[], byte[]> primaryConsumer = primary.kafka().createConsumerAndSubscribeTo(consumerProps, 
+        try (Consumer<byte[], byte[]> primaryConsumer = primary.kafka().createConsumerAndSubscribeTo(consumerProps,
                 "test-topic-1")) {
             // we need to wait for consuming all the records for MM2 replicating the expected offsets
             waitForConsumingAllRecords(primaryConsumer, NUM_RECORDS_PRODUCED);
@@ -770,6 +771,9 @@ public class MirrorConnectorsIntegrationBaseTest {
         Map<ConfigResource, Collection<AlterConfigOp>> configOps = Collections.singletonMap(configResource, ops);
         // alter configs on target cluster
         backup.kafka().incrementalAlterConfigs(configOps);
+        // wait until the configs are changed
+        waitForConfigValueChange(backup, backupTopic, "delete.retention.ms", "2000");
+        waitForConfigValueChange(backup, backupTopic, "retention.bytes", "2000");
 
         waitForCondition(() -> {
             String primaryConfig, backupConfig;
@@ -920,13 +924,13 @@ public class MirrorConnectorsIntegrationBaseTest {
      * launch the connectors on kafka connect cluster and check if they are running
      */
     protected static void waitUntilMirrorMakerIsRunning(EmbeddedConnectCluster connectCluster,
-            List<Class<? extends Connector>> connectorClasses, MirrorMakerConfig mm2Config, 
+            List<Class<? extends Connector>> connectorClasses, MirrorMakerConfig mm2Config,
             String primary, String backup) throws InterruptedException {
         for (Class<? extends Connector> connector : connectorClasses) {
             connectCluster.configureConnector(connector.getSimpleName(), mm2Config.connectorBaseConfig(
                 new SourceAndTarget(primary, backup), connector));
         }
-        
+
         // we wait for the connector and tasks to come up for each connector, so that when we do the
         // actual testing, we are certain that the tasks are up and running; this will prevent
         // flaky tests where the connector and tasks didn't start up in time for the tests to be run
@@ -1045,6 +1049,15 @@ public class MirrorConnectorsIntegrationBaseTest {
                 "Topic: " + topicName + " didn't get created in the cluster"
             );
         }
+    }
+
+    /*
+     * wait for Config value change in a EmbeddedKafkaCluster
+     */
+    protected static void waitForConfigValueChange(EmbeddedConnectCluster cluster, String topic, String configName, String configValue) throws InterruptedException {
+        waitForCondition(() -> {
+            return getTopicConfig(cluster.kafka(), topic, configName).equals(configValue);
+        }, CONFIG_CHANGE_DURATION_MS, "Config: " + configName + " didn't get changed to: " + configValue + " on cluster: " + cluster.getName());
     }
 
     /*
@@ -1237,7 +1250,7 @@ public class MirrorConnectorsIntegrationBaseTest {
         }, RECORD_CONSUME_DURATION_MS, "Consumer cannot consume all records in time");
         consumer.commitSync();
     }
-   
+
     /*
      * MM2 config to use in integration tests
      */
@@ -1262,7 +1275,7 @@ public class MirrorConnectorsIntegrationBaseTest {
         mm2Props.put(BACKUP_CLUSTER_ALIAS + ".offset.flush.interval.ms", "5000");
         return mm2Props;
     }
-    
+
     private void createTopics() {
         // to verify topic config will be sync-ed across clusters
         Map<String, String> topicConfig = Collections.singletonMap(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT);

--- a/connect/mirror/src/test/resources/log4j.properties
+++ b/connect/mirror/src/test/resources/log4j.properties
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##
-log4j.rootLogger=ERROR, stdout
+log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
Added a method, waitForConfigValueChange, to wait for a configuration value change in an EmbeddedKafkaCluster after using the incrementalAlterConfigs API.

The test, testSyncTopicConfigs, appears to be flaky (as seen in https://ci-builds.apache.org/blue/organizations/jenkins/Kafka%2Fkafka-pr/detail/PR-14811/7/tests). This seems to be because we assert to check the updated values of the configuration before waiting for it to change.