### PR TITLE
KAFKA-15956: MetadataShell must take the log directory lock when reading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2092,6 +2092,11 @@ project(':shell') {
     implementation libs.jacksonJaxrsJsonProvider
 
     testImplementation project(':clients')
+    testImplementation project(':clients').sourceSets.test.output
+    testImplementation project(':core')
+    testImplementation project(':core').sourceSets.test.output
+    testImplementation project(':server-common')
+    testImplementation project(':server-common').sourceSets.test.output
     testImplementation libs.junitJupiter
 
     testRuntimeOnly libs.slf4jlog4j

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -275,6 +275,7 @@
     <allow pkg="kafka.raft"/>
     <allow pkg="kafka.server"/>
     <allow pkg="kafka.tools"/>
+    <allow pkg="kafka.utils"/>
     <allow pkg="net.sourceforge.argparse4j" />
     <allow pkg="org.apache.kafka.common"/>
     <allow pkg="org.apache.kafka.metadata"/>

--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataBatchLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataBatchLoader.java
@@ -135,7 +135,7 @@ public class MetadataBatchLoader {
                 replay(record);
             } catch (Throwable e) {
                 faultHandler.handleFault("Error loading metadata log record from offset " +
-                    batch.baseOffset() + indexWithinBatch, e);
+                    (batch.baseOffset() + indexWithinBatch), e);
             }
 
             // Emit the accumulated delta if a new transaction has been started and one of the following is true

--- a/shell/src/test/java/org/apache/kafka/shell/MetadataShellIntegrationTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/MetadataShellIntegrationTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.shell;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+
+import kafka.utils.FileLock;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.fault.MockFaultHandler;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@Timeout(120)
+@Tag("integration")
+public class MetadataShellIntegrationTest {
+    private final static Logger LOG = LoggerFactory.getLogger(MetadataShellIntegrationTest.class);
+
+    static class IntegrationEnv implements AutoCloseable {
+        File tempDir;
+        MetadataShell shell;
+        final MockFaultHandler faultHandler;
+
+        IntegrationEnv() throws IOException {
+            this.tempDir = Files.createTempDirectory("MetadataShellIntegrationTest").toFile();
+            this.shell = null;
+            this.faultHandler = new MockFaultHandler("testFailToGetLockOnSnapshotFile");
+        }
+
+        @Override
+        public void close() {
+            if (shell != null) {
+                try {
+                    shell.close();
+                } catch (Throwable e) {
+                    LOG.error("Error closing shell", e);
+                } finally {
+                    shell = null;
+                }
+            }
+            if (tempDir != null) {
+                try {
+                    Utils.delete(tempDir);
+                } catch (Throwable e) {
+                    LOG.error("Error deleting tempDir", e);
+                } finally {
+                    tempDir = null;
+                }
+            }
+            faultHandler.maybeRethrowFirstException();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testLock(boolean canLock) throws Exception {
+        try (IntegrationEnv env = new IntegrationEnv()) {
+            env.shell = new MetadataShell(null,
+                new File(new File(env.tempDir, "__cluster_metadata-0"), "00000000000122906351-0000000226.checkpoint").getAbsolutePath(),
+                    env.faultHandler);
+
+            if (canLock) {
+                assertEquals(NoSuchFileException.class,
+                    assertThrows(ExecutionException.class,
+                        () -> env.shell.run(Collections.emptyList())).
+                            getCause().getClass());
+            } else {
+                FileLock fileLock = new FileLock(new File(env.tempDir, ".lock"));
+                try {
+                    fileLock.lock();
+                    assertEquals("Unable to lock " + env.tempDir.getAbsolutePath() +
+                        ". Please ensure that no broker or controller process is using this " +
+                        "directory before proceeding.",
+                        assertThrows(RuntimeException.class,
+                            () -> env.shell.run(Collections.emptyList())).
+                                getMessage());
+                } finally {
+                    fileLock.destroy();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testParentParent() {
+        final File root = File.listRoots()[0];
+        assertEquals(root, MetadataShell.parentParent(new File(new File(root, "a"), "b")));
+    }
+
+    @Test
+    public void testParentParentOfRoot() {
+        final File root = File.listRoots()[0];
+        assertEquals(root, MetadataShell.parentParent(root));
+    }
+}


### PR DESCRIPTION
MetadataShell should take an advisory lock on the .lock file of the directory it is reading from. Add an integration test of this functionality in MetadataShellIntegrationTest.java.

Note: in build.gradle, I had to add some dependencies on server-common's test files in order to use MockFaultHandler, etc.

MetadataBatchLoader.java: fix a case where a log message was incorrect.  The intention was to print the number equivalent to (offset + index).  Instead it was printing the offset, followed by the index. So if the offset was 100 and the index was 1, 1001 would be printed rather than 101.