### PR TITLE
KAFKA-15527: Support ResultOrder to reverseRange and reverseAll query over kv-store in IQv2 

### DIFF
--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -135,10 +135,9 @@
 
     <h3><a id="streams_api_changes_370" href="#streams_api_changes_370">Streams API changes in 3.7.0</a></h3>
     <p>
-        IQv2 supports <code>RangeQuery</code> that allows to specify unbounded, bounded, or half-open key-ranges, which return data in ascending (byte[]-lexicographical) order (per partition).
-        <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-985%3A+Add+reverseRange+and+reverseAll+query+over+kv-store+in+IQv2">KIP-985</a> extends this functionality by adding <code>.withDescendingKeys()</code> to allow user to receive data in descending order.
+        IQv2 supports <code>RangeQuery</code> that allows to specify unbounded, bounded, or half-open key-ranges, which return data in unordered (byte[]-lexicographical) order (per partition).
+        <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-985%3A+Add+reverseRange+and+reverseAll+query+over+kv-store+in+IQv2">KIP-985</a> extends this functionality by adding <code>.withDescendingKeys()</code> and <code>.withAscendingKeys()</code>to allow user to receive data in descending or ascending order.
     </p>
-
     <p>
         The non-null key requirements for Kafka Streams join operators were relaxed as part of <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-962%3A+Relax+non-null+key+requirement+in+Kafka+Streams">KIP-962</a>.
         The behavior of the following operators changed.

--- a/streams/src/main/java/org/apache/kafka/streams/query/RangeQuery.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/RangeQuery.java
@@ -42,13 +42,12 @@ public final class RangeQuery<K, V> implements Query<KeyValueIterator<K, V>> {
 
     private final Optional<K> lower;
     private final Optional<K> upper;
+    private final ResultOrder order;
 
-    private final boolean isKeyAscending;
-
-    private RangeQuery(final Optional<K> lower, final Optional<K> upper, final boolean isKeyAscending) {
+    private RangeQuery(final Optional<K> lower, final Optional<K> upper, final ResultOrder order) {
         this.lower = lower;
         this.upper = upper;
-        this.isKeyAscending = isKeyAscending;
+        this.order = order;
     }
 
     /**
@@ -59,25 +58,34 @@ public final class RangeQuery<K, V> implements Query<KeyValueIterator<K, V>> {
      * @param <V> The value type
      */
     public static <K, V> RangeQuery<K, V> withRange(final K lower, final K upper) {
-        return new RangeQuery<>(Optional.ofNullable(lower), Optional.ofNullable(upper), true);
+        return new RangeQuery<>(Optional.ofNullable(lower), Optional.ofNullable(upper), ResultOrder.ANY);
     }
 
     /**
-     * Determines if the serialized byte[] of the keys in ascending order.
+     * Determines if the serialized byte[] of the keys in ascending or descending or unordered order.
      * Order is based on the serialized byte[] of the keys, not the 'logical' key order.
-     * @return true if ascending, false otherwise.
+     * @return return the order of returned records based on the serialized byte[] of the keys (can be unordered, or in ascending or in descending order).
      */
-    public boolean isKeyAscending() {
-        return isKeyAscending;
+    public ResultOrder resultOrder() {
+        return order;
     }
 
     /**
      * Set the query to return the serialized byte[] of the keys in descending order.
      * Order is based on the serialized byte[] of the keys, not the 'logical' key order.
-     * @return a new RangeQuery instance with descending flag set.
+     * @return a new RangeQuery instance with descending flag.
      */
     public RangeQuery<K, V> withDescendingKeys() {
-        return new RangeQuery<>(this.lower, this.upper, false);
+        return new RangeQuery<>(this.lower, this.upper, ResultOrder.DESCENDING);
+    }
+
+    /**
+     * Set the query to return the serialized byte[] of the keys in ascending order.
+     * Order is based on the serialized byte[] of the keys, not the 'logical' key order.
+     * @return a new RangeQuery instance with ascending flag.
+     */
+    public RangeQuery<K, V> withAscendingKeys() {
+        return new RangeQuery<>(this.lower, this.upper, ResultOrder.ASCENDING);
     }
 
     /**
@@ -88,7 +96,7 @@ public final class RangeQuery<K, V> implements Query<KeyValueIterator<K, V>> {
      * @param <V> The value type
      */
     public static <K, V> RangeQuery<K, V> withUpperBound(final K upper) {
-        return new RangeQuery<>(Optional.empty(), Optional.of(upper), true);
+        return new RangeQuery<>(Optional.empty(), Optional.of(upper), ResultOrder.ANY);
     }
 
     /**
@@ -98,7 +106,7 @@ public final class RangeQuery<K, V> implements Query<KeyValueIterator<K, V>> {
      * @param <V> The value type
      */
     public static <K, V> RangeQuery<K, V> withLowerBound(final K lower) {
-        return new RangeQuery<>(Optional.of(lower), Optional.empty(), true);
+        return new RangeQuery<>(Optional.of(lower), Optional.empty(), ResultOrder.ANY);
     }
 
     /**
@@ -107,7 +115,7 @@ public final class RangeQuery<K, V> implements Query<KeyValueIterator<K, V>> {
      * @param <V> The value type
      */
     public static <K, V> RangeQuery<K, V> withNoBounds() {
-        return new RangeQuery<>(Optional.empty(), Optional.empty(), true);
+        return new RangeQuery<>(Optional.empty(), Optional.empty(), ResultOrder.ANY);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/query/RangeQuery.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/RangeQuery.java
@@ -73,7 +73,7 @@ public final class RangeQuery<K, V> implements Query<KeyValueIterator<K, V>> {
     /**
      * Set the query to return the serialized byte[] of the keys in descending order.
      * Order is based on the serialized byte[] of the keys, not the 'logical' key order.
-     * @return a new RangeQuery instance with descending flag.
+     * @return a new RangeQuery instance with descending flag set.
      */
     public RangeQuery<K, V> withDescendingKeys() {
         return new RangeQuery<>(this.lower, this.upper, ResultOrder.DESCENDING);
@@ -82,7 +82,7 @@ public final class RangeQuery<K, V> implements Query<KeyValueIterator<K, V>> {
     /**
      * Set the query to return the serialized byte[] of the keys in ascending order.
      * Order is based on the serialized byte[] of the keys, not the 'logical' key order.
-     * @return a new RangeQuery instance with ascending flag.
+     * @return a new RangeQuery instance with ascending flag set.
      */
     public RangeQuery<K, V> withAscendingKeys() {
         return new RangeQuery<>(this.lower, this.upper, ResultOrder.ASCENDING);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -40,6 +40,7 @@ import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.RangeQuery;
+import org.apache.kafka.streams.query.ResultOrder;
 import org.apache.kafka.streams.query.internals.InternalQueryResultUtil;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -254,13 +255,16 @@ public class MeteredKeyValueStore<K, V>
         final QueryResult<R> result;
         final RangeQuery<K, V> typedQuery = (RangeQuery<K, V>) query;
         RangeQuery<Bytes, byte[]> rawRangeQuery;
-        final boolean isKeyAscending = typedQuery.isKeyAscending();
+        final ResultOrder order = typedQuery.resultOrder();
         rawRangeQuery = RangeQuery.withRange(
                 keyBytes(typedQuery.getLowerBound().orElse(null)),
                 keyBytes(typedQuery.getUpperBound().orElse(null))
         );
-        if (!isKeyAscending) {
+        if (order.equals(ResultOrder.DESCENDING)) {
             rawRangeQuery = rawRangeQuery.withDescendingKeys();
+        }
+        if (order.equals(ResultOrder.ASCENDING)) {
+            rawRangeQuery = rawRangeQuery.withAscendingKeys();
         }
         final QueryResult<KeyValueIterator<Bytes, byte[]>> rawResult =
             wrapped().query(rawRangeQuery, positionBound, config);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
@@ -29,6 +29,7 @@ import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.RangeQuery;
+import org.apache.kafka.streams.query.ResultOrder;
 import org.apache.kafka.streams.query.TimestampedKeyQuery;
 import org.apache.kafka.streams.query.TimestampedRangeQuery;
 import org.apache.kafka.streams.query.internals.InternalQueryResultUtil;
@@ -268,13 +269,16 @@ public class MeteredTimestampedKeyValueStore<K, V>
         final QueryResult<R> result;
         final RangeQuery<K, V> typedQuery = (RangeQuery<K, V>) query;
         RangeQuery<Bytes, byte[]> rawRangeQuery;
-        final boolean isKeyAscending = typedQuery.isKeyAscending();
+        final ResultOrder order = typedQuery.resultOrder();
         rawRangeQuery = RangeQuery.withRange(
                 keyBytes(typedQuery.getLowerBound().orElse(null)),
                 keyBytes(typedQuery.getUpperBound().orElse(null))
         );
-        if (!isKeyAscending) {
+        if (order.equals(ResultOrder.DESCENDING)) {
             rawRangeQuery = rawRangeQuery.withDescendingKeys();
+        }
+        if (order.equals(ResultOrder.ASCENDING)) {
+            rawRangeQuery = rawRangeQuery.withAscendingKeys();
         }
         final QueryResult<KeyValueIterator<Bytes, byte[]>> rawResult =
                 wrapped().query(rawRangeQuery, positionBound, config);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
@@ -34,6 +34,7 @@ import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.RangeQuery;
+import org.apache.kafka.streams.query.ResultOrder;
 import org.apache.kafka.streams.query.VersionedKeyQuery;
 import org.apache.kafka.streams.query.WindowKeyQuery;
 import org.apache.kafka.streams.query.WindowRangeQuery;
@@ -199,12 +200,12 @@ public final class StoreQueryUtils {
         final RangeQuery<Bytes, byte[]> rangeQuery = (RangeQuery<Bytes, byte[]>) query;
         final Optional<Bytes> lowerRange = rangeQuery.getLowerBound();
         final Optional<Bytes> upperRange = rangeQuery.getUpperBound();
-        final boolean isKeyAscending = rangeQuery.isKeyAscending();
+        final ResultOrder order = rangeQuery.resultOrder();
         final KeyValueIterator<Bytes, byte[]> iterator;
         try {
-            if (!lowerRange.isPresent() && !upperRange.isPresent() && isKeyAscending) {
+            if (!lowerRange.isPresent() && !upperRange.isPresent() && !order.equals(ResultOrder.DESCENDING)) {
                 iterator = kvStore.all();
-            } else if (isKeyAscending) {
+            } else if (!order.equals(ResultOrder.DESCENDING)) {
                 iterator = kvStore.range(lowerRange.orElse(null), upperRange.orElse(null));
             } else if (!lowerRange.isPresent() && !upperRange.isPresent()) {
                 iterator = kvStore.reverseAll();


### PR DESCRIPTION
Support `ResultOrder` to `reverseRange` and `reverseAll` query over kv-store in IQv2..

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
