### PR TITLE
KAFKA-14516: [3/3] New Group Coordinator IT for Static Member removed from Group upon Session timeout expiry

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
@@ -330,7 +330,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
     assertEquals(2, consumerGroupHeartbeatResponse.data.memberEpoch)
     assertEquals(expectedAssignment, consumerGroupHeartbeatResponse.data.assignment)
 
-    // A new static member tries to join the group with an inuse instanceid
+    // A new static member tries to join the group with an inuse instanceid.
     consumerGroupHeartbeatRequest = new ConsumerGroupHeartbeatRequest.Builder(
       new ConsumerGroupHeartbeatRequestData()
         .setGroupId("grp")
@@ -341,20 +341,22 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
         .setTopicPartitions(List.empty.asJava)
     ).build()
 
+    // Validating that trying to join with an in-use instanceId would throw an UnreleasedInstanceIdException.
+    consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
+    assertEquals(111, consumerGroupHeartbeatResponse.data.errorCode)
+
     // The new static member join group will keep failing with an UnreleasedInstanceIdException
-    // exception until eventually it gets through because the existing member will be kicked out
+    // until eventually it gets through because the existing member will be kicked out
     // because of not sending a heartbeat till session timeout expiry.
     TestUtils.waitUntilTrue(() => {
       consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
       consumerGroupHeartbeatResponse.data.errorCode == Errors.NONE.code &&
         consumerGroupHeartbeatResponse.data.assignment == expectedAssignment
-    }, msg = s"Could not get partitions assigned. Last response $consumerGroupHeartbeatResponse.")
+    }, msg = s"Could not re-join the group successfully. Last response $consumerGroupHeartbeatResponse.")
 
-    print(consumerGroupHeartbeatRequest)
-    // Verify the response. The group epoch bumps upto 4 which eventually reflects in the new member epoch
+    // Verify the response. The group epoch bumps upto 4 which eventually reflects in the new member epoch.
     assertEquals(4, consumerGroupHeartbeatResponse.data.memberEpoch)
     assertEquals(expectedAssignment, consumerGroupHeartbeatResponse.data.assignment)
-
   }
 
   private def connectAndReceive(request: ConsumerGroupHeartbeatRequest): ConsumerGroupHeartbeatResponse = {

--- a/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
@@ -343,7 +343,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
     // Validating that trying to join with an in-use instanceId would throw an UnreleasedInstanceIdException.
     consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
-    assertEquals(Errors.UNRELEASED_INSTANCE_ID.code(), consumerGroupHeartbeatResponse.data.errorCode)
+    assertEquals(Errors.UNRELEASED_INSTANCE_ID.code, consumerGroupHeartbeatResponse.data.errorCode)
 
     // The new static member join group will keep failing with an UnreleasedInstanceIdException
     // until eventually it gets through because the existing member will be kicked out

--- a/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
@@ -343,7 +343,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) {
 
     // Validating that trying to join with an in-use instanceId would throw an UnreleasedInstanceIdException.
     consumerGroupHeartbeatResponse = connectAndReceive(consumerGroupHeartbeatRequest)
-    assertEquals(111, consumerGroupHeartbeatResponse.data.errorCode)
+    assertEquals(Errors.UNRELEASED_INSTANCE_ID.code(), consumerGroupHeartbeatResponse.data.errorCode)
 
     // The new static member join group will keep failing with an UnreleasedInstanceIdException
     // until eventually it gets through because the existing member will be kicked out


### PR DESCRIPTION
Adding IT for the case when a static member gets removed from the group when the session timeout expires and it doesn't heartbeat within that.