### PR TITLE
MINOR: Fix ConsumerNetworkThread shutdown

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThread.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThread.java
@@ -78,13 +78,11 @@ public class ConsumerNetworkThread extends KafkaThread implements Closeable {
         this.applicationEventProcessorSupplier = applicationEventProcessorSupplier;
         this.networkClientDelegateSupplier = networkClientDelegateSupplier;
         this.requestManagersSupplier = requestManagersSupplier;
+        this.running = true;
     }
 
     @Override
     public void run() {
-        closer.assertOpen("Consumer network thread is already closed");
-        running = true;
-
         try {
             log.debug("Consumer network thread started");
 


### PR DESCRIPTION
There is a race condition in the shutdown logic. `running` could be set to `true` after `closeInternal` was called.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
