### PR TITLE
KAFKA-15760: Disable flaky test testTaskRequestWithOldStartMsGetsUpdated

### DIFF
--- a/trogdor/src/test/java/org/apache/kafka/trogdor/coordinator/CoordinatorTest.java
+++ b/trogdor/src/test/java/org/apache/kafka/trogdor/coordinator/CoordinatorTest.java
@@ -49,6 +49,7 @@ import org.apache.kafka.trogdor.rest.WorkerDone;
 import org.apache.kafka.trogdor.rest.WorkerRunning;
 import org.apache.kafka.trogdor.task.NoOpTaskSpec;
 import org.apache.kafka.trogdor.task.SampleTaskSpec;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -569,6 +570,7 @@ public class CoordinatorTest {
     }
 
     @Test
+    @Disabled("KAFKA-15760")
     public void testTaskRequestWithOldStartMsGetsUpdated() throws Exception {
         MockTime time = new MockTime(0, 0, 0);
         Scheduler scheduler = new MockScheduler(time);

--- a/trogdor/src/test/java/org/apache/kafka/trogdor/coordinator/CoordinatorTest.java
+++ b/trogdor/src/test/java/org/apache/kafka/trogdor/coordinator/CoordinatorTest.java
@@ -49,7 +49,6 @@ import org.apache.kafka.trogdor.rest.WorkerDone;
 import org.apache.kafka.trogdor.rest.WorkerRunning;
 import org.apache.kafka.trogdor.task.NoOpTaskSpec;
 import org.apache.kafka.trogdor.task.SampleTaskSpec;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;

--- a/trogdor/src/test/java/org/apache/kafka/trogdor/coordinator/CoordinatorTest.java
+++ b/trogdor/src/test/java/org/apache/kafka/trogdor/coordinator/CoordinatorTest.java
@@ -71,7 +71,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("integration")
-@Timeout(value = 120000, unit = MILLISECONDS)
+@Timeout(value = 240000, unit = MILLISECONDS)
 public class CoordinatorTest {
 
     private static final Logger log = LoggerFactory.getLogger(CoordinatorTest.class);
@@ -570,7 +570,6 @@ public class CoordinatorTest {
     }
 
     @Test
-    @Disabled("KAFKA-15760")
     public void testTaskRequestWithOldStartMsGetsUpdated() throws Exception {
         MockTime time = new MockTime(0, 0, 0);
         Scheduler scheduler = new MockScheduler(time);


### PR DESCRIPTION
### What
Disables `testTaskRequestWithOldStartMsGetsUpdated` which seems to flake in CI frequently. I tried to take a look and could not get the test failure to repro locally. The trogdor code is not production critical and is mostly stable as well, so disabling seems fine.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
