### PR TITLE
KAFKA-15968 Handle two specific ApiExceptions in EventHandlerExceptionInfo

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/errors/EventHandlerExceptionInfo.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/errors/EventHandlerExceptionInfo.java
@@ -17,7 +17,9 @@
 
 package org.apache.kafka.controller.errors;
 
+import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.errors.ApiException;
+import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.errors.NotControllerException;
 import org.apache.kafka.common.errors.PolicyViolationException;
 import org.apache.kafka.common.errors.TimeoutException;
@@ -70,7 +72,13 @@ public final class EventHandlerExceptionInfo {
         Throwable internal,
         Supplier<OptionalInt> latestControllerSupplier
     ) {
-        if (internal instanceof ApiException) {
+        if (internal instanceof CorruptRecordException) {
+            // Even though this is an ApiException, it's an indication of a problem at the log layer, so we treat it as a fault
+            return new EventHandlerExceptionInfo(true, true, internal);
+        } else if (internal instanceof InvalidRecordException) {
+            // Even though this is an ApiException, it's an indication of a problem at the log layer, so we treat it as a fault
+            return new EventHandlerExceptionInfo(true, true, internal);
+        } else if (internal instanceof ApiException) {
             // This exception is a standard API error response from the controller, which can pass
             // through without modification.
             return new EventHandlerExceptionInfo(false, false, internal);

--- a/metadata/src/test/java/org/apache/kafka/controller/errors/EventHandlerExceptionInfoTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/errors/EventHandlerExceptionInfoTest.java
@@ -21,11 +21,13 @@ import org.apache.kafka.common.errors.NotControllerException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.raft.errors.NotLeaderException;
 import org.apache.kafka.raft.errors.UnexpectedBaseOffsetException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.EnumSet;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.concurrent.RejectedExecutionException;
@@ -191,5 +193,23 @@ public class EventHandlerExceptionInfoTest {
     @Test
     public void testIsTimeoutException() {
         assertTrue(TIMEOUT.isTimeoutException());
+    }
+
+    @Test
+    public void testApiExceptions() {
+        for (Errors error : Errors.values()) {
+            if (error.equals(Errors.NONE)) {
+                continue;
+            }
+            EventHandlerExceptionInfo info = EventHandlerExceptionInfo.fromInternal(error.exception(), OptionalInt::empty);
+
+            if (EnumSet.of(Errors.CORRUPT_MESSAGE, Errors.INVALID_RECORD).contains(error)) {
+                assertTrue(info.causesFailover());
+                assertTrue(info.isFault());
+            } else {
+                assertFalse(info.causesFailover(), "Expected " + error.name() + " to not cause failover");
+                assertFalse(info.isFault(), "Expected " + error.name() + " to not be a fault");
+            }
+        }
     }
 }


### PR DESCRIPTION
This patch adds two cases to EventHandlerExceptionInfo for exceptions thrown by the log layer. Prior to this change, the log could throw a CorruptRecordException and the QuorumController would not treat it as a fatal exception. E.g., 

```
INFO [ControllerServer id=9990] handleCommit[baseOffset=192554233]: event failed with CorruptRecordException in 234 microseconds.
```

By treating these errors as non-fatal, the controller does not immediately crash itself which could lead to all kinds of problems with the metadata log since a batch of records was not processed.
