### PR TITLE
KAFKA-15696: Refactor AsyncConsumer close procedure

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1074,9 +1074,9 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
             return;
 
         try {
-            timer.update();
             // If the consumer is in a group, we will pause and revoke all assigned partitions
             onLeavePrepare().get(timer.remainingMs(), TimeUnit.MILLISECONDS);
+            timer.update();
         } catch (Exception e) {
             Exception exception = e;
             if (e instanceof ExecutionException)

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
@@ -118,6 +118,11 @@ public interface MembershipManager {
     CompletableFuture<Void> leaveGroup();
 
     /**
+     * Leaving the group when the user closes the consumer.
+     */
+    void leaveGroupOnClose();
+
+    /**
      * @return True if the member should send heartbeat to the coordinator without waiting for
      * the interval.
      */

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThreadTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkThreadTest.java
@@ -296,25 +296,8 @@ public class ConsumerNetworkThreadTest {
         prepareOffsetCommitRequest(singletonMap(tp, 100L), Errors.NONE, false);
         consumerNetworkThread.cleanup();
         assertTrue(coordinatorRequestManager.coordinator().isPresent());
-        assertFalse(client.hasPendingResponses());
-        assertFalse(client.hasInFlightRequests());
-    }
-
-    @Test
-    void testAutoCommitOnClose() {
-        TopicPartition tp = new TopicPartition("topic", 0);
-        Node node = metadata.fetch().nodes().get(0);
-        subscriptions.assignFromUser(singleton(tp));
-        subscriptions.seek(tp, 100);
-        coordinatorRequestManager.markCoordinatorUnknown("test", time.milliseconds());
-        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "group-id", node));
-        prepareOffsetCommitRequest(singletonMap(tp, 100L), Errors.NONE, false);
-        consumerNetworkThread.maybeAutocommitOnClose(time.timer(1000));
-        assertTrue(coordinatorRequestManager.coordinator().isPresent());
-        verify(commitRequestManager).createCommitAllConsumedRequest();
-
-        assertFalse(client.hasPendingResponses());
-        assertFalse(client.hasInFlightRequests());
+        assertFalse(client.hasPendingResponses(), "There should be no pending responses but found " + client.futureResponses());
+        assertFalse(client.hasInFlightRequests(), "There should be no pending requests, but found " + client.requests());
     }
 
     private void prepareTearDown() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -328,34 +328,35 @@ public class ConsumerTestBuilder implements Closeable {
             super(groupInfo, enableAutoCommit, enableAutoTick);
             String clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
             List<ConsumerPartitionAssignor> assignors = ConsumerPartitionAssignor.getAssignorInstances(
-                    config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG),
-                    config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId))
+                config.getList(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG),
+                config.originals(Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId))
             );
             Deserializers<String, String> deserializers = new Deserializers<>(new StringDeserializer(), new StringDeserializer());
             this.fetchCollector = spy(new FetchCollector<>(logContext,
-                    metadata,
-                    subscriptions,
-                    fetchConfig,
-                    deserializers,
-                    metricsManager,
-                    time));
+                metadata,
+                subscriptions,
+                fetchConfig,
+                deserializers,
+                metricsManager,
+                time));
             this.consumer = spy(new AsyncKafkaConsumer<>(
-                    logContext,
-                    clientId,
-                    deserializers,
-                    new FetchBuffer(logContext),
-                    fetchCollector,
-                    new ConsumerInterceptors<>(Collections.emptyList()),
-                    time,
-                    applicationEventHandler,
-                    backgroundEventQueue,
-                    metrics,
-                    subscriptions,
-                    metadata,
-                    retryBackoffMs,
-                    60000,
-                    assignors,
-                    groupInfo.map(groupInformation -> groupInformation.groupState.groupId).orElse(null)));
+                logContext,
+                clientId,
+                deserializers,
+                new FetchBuffer(logContext),
+                fetchCollector,
+                new ConsumerInterceptors<>(Collections.emptyList()),
+                time,
+                applicationEventHandler,
+                backgroundEventQueue,
+                metrics,
+                subscriptions,
+                metadata,
+                retryBackoffMs,
+                60000,
+                assignors,
+                groupInfo.map(groupInformation -> groupInformation.groupState.groupId).orElse(null),
+                enableAutoCommit));
         }
 
         @Override


### PR DESCRIPTION
This ticket encompasses several different tickets:
KAFKA-15696/KAFKA-15548

When closing the consumer we need to perform a few tasks
1. If auto-commit is enabled, send a commitSync and block until completed
2. Invoke all offsetCommitCallbacks and ensure all inflight commits are sent
3. Invoke partitionsRevoke callbacks
4. Unsubscribe from all partitions
5. LeaveGroup