### PR TITLE
KAFKA-15866:Refactor OffsetFetchRequestState Error handling

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -541,16 +541,22 @@ public class CommitRequestManager implements RequestManager {
                                final Errors responseError) {
             handleCoordinatorDisconnect(responseError.exception(), currentTimeMs);
             log.debug("Offset fetch failed: {}", responseError.message());
-            if (responseError == COORDINATOR_LOAD_IN_PROGRESS) {
-                retry(currentTimeMs);
-            } else if (responseError == Errors.NOT_COORDINATOR) {
-                // re-discover the coordinator and retry
-                coordinatorRequestManager.markCoordinatorUnknown("error response " + responseError.name(), currentTimeMs);
-                retry(currentTimeMs);
-            } else if (responseError == Errors.GROUP_AUTHORIZATION_FAILED) {
-                future.completeExceptionally(GroupAuthorizationException.forGroupId(groupState.groupId));
-            } else {
-                future.completeExceptionally(new KafkaException("Unexpected error in fetch offset response: " + responseError.message()));
+            switch (responseError) {
+                case COORDINATOR_LOAD_IN_PROGRESS:
+                    retry(currentTimeMs);
+                    break;
+                case NOT_COORDINATOR:
+                case COORDINATOR_NOT_AVAILABLE:
+                    // re-discover the coordinator and retry
+                    coordinatorRequestManager.markCoordinatorUnknown("error response " + responseError.name(), currentTimeMs);
+                    retry(currentTimeMs);
+                    break;
+                case GROUP_AUTHORIZATION_FAILED:
+                    future.completeExceptionally(GroupAuthorizationException.forGroupId(groupState.groupId));
+                    break;
+                default:
+                    future.completeExceptionally(new KafkaException("Unexpected error in fetch offset response: " + responseError.message()));
+                    break;
             }
         }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -421,7 +421,7 @@ public class CommitRequestManagerTest {
             Arguments.of(Errors.OFFSET_METADATA_TOO_LARGE, false),
             Arguments.of(Errors.INVALID_COMMIT_OFFSET_SIZE, false),
             Arguments.of(Errors.UNKNOWN_TOPIC_OR_PARTITION, false),
-            Arguments.of(Errors.COORDINATOR_NOT_AVAILABLE, false),
+            Arguments.of(Errors.COORDINATOR_NOT_AVAILABLE, true),
             Arguments.of(Errors.REQUEST_TIMED_OUT, false),
             Arguments.of(Errors.FENCED_INSTANCE_ID, false),
             Arguments.of(Errors.TOPIC_AUTHORIZATION_FAILED, false));


### PR DESCRIPTION
The PR resolve issue [KAFKA-15866](https://issues.apache.org/jira/browse/KAFKA-15866), the current OffsetFetchRequestState error handling uses nested if-else, which is quite different, stylistically, to the OffsetCommitRequestState using a switch statment.  The latter is a bit more readable so we should refactor the error handling using the same style to improve readability.

