### PR TITLE
KAFKA-15972: Add support to exclude labels for telemetry metrics (KIP-714)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryReporter.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.StringJoiner;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -103,6 +104,13 @@ import java.util.function.Predicate;
 public class ClientTelemetryReporter implements MetricsReporter {
 
     private static final Logger log = LoggerFactory.getLogger(ClientTelemetryReporter.class);
+    /*
+     Exclude client_id from the labels as the broker already knows the client_id from the request
+     context. These additional labels from the request context should be added by broker prior
+     exporting the metrics to the telemetry backend.
+    */
+    private static final Set<String> EXCLUDE_LABELS = Collections.singleton("client_id");
+
     public static final int DEFAULT_PUSH_INTERVAL_MS = 5 * 60 * 1000;
 
     private final ClientTelemetryProvider telemetryProvider;
@@ -226,7 +234,7 @@ public class ClientTelemetryReporter implements MetricsReporter {
     private void initCollectors() {
         kafkaMetricsCollector = new KafkaMetricsCollector(
             TelemetryMetricNamingConvention.getClientTelemetryMetricNamingStrategy(
-                telemetryProvider.domain()));
+                telemetryProvider.domain()), EXCLUDE_LABELS);
     }
 
     private ResourceMetrics buildMetric(Metric metric) {

--- a/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryEmitterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryEmitterTest.java
@@ -89,13 +89,13 @@ public class ClientTelemetryEmitterTest {
             Collections.singletonList("name"));
         ClientTelemetryEmitter emitter = new ClientTelemetryEmitter(selector, true);
 
-        SinglePointMetric gauge = SinglePointMetric.gauge(metricKey, Long.valueOf(1), now);
-        SinglePointMetric sum = SinglePointMetric.sum(metricKey, 1.0, true, now);
+        SinglePointMetric gauge = SinglePointMetric.gauge(metricKey, Long.valueOf(1), now, Collections.emptySet());
+        SinglePointMetric sum = SinglePointMetric.sum(metricKey, 1.0, true, now, Collections.emptySet());
         assertTrue(emitter.emitMetric(gauge));
         assertTrue(emitter.emitMetric(sum));
 
         MetricKey anotherKey = new MetricKey("io.name", Collections.emptyMap());
-        assertFalse(emitter.emitMetric(SinglePointMetric.gauge(anotherKey, Long.valueOf(1), now)));
+        assertFalse(emitter.emitMetric(SinglePointMetric.gauge(anotherKey, Long.valueOf(1), now, Collections.emptySet())));
 
         assertEquals(2, emitter.emittedMetrics().size());
         assertEquals(Arrays.asList(gauge, sum), emitter.emittedMetrics());


### PR DESCRIPTION
Changes in the PR are to support excluding `client_id` label when sending telemetry metrics.

Some of the labels/tags which are present in metric should be skipped while collecting telemetry as data might already be known to broker hence, we should minimize the data transfer. One of such labels is client_id which is already present in RequestContext hence broker can append that label prior emitting metrics to telemetry backend.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
