### PR TITLE
KAFKA-15971: Re-enable consumer integration tests for new consumer

### DIFF
--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -116,13 +116,13 @@ object BaseConsumerTest {
   // * ZooKeeper and the generic group protocol
   // * KRaft and the generic group protocol
   // * KRaft with the new group coordinator enabled and the generic group protocol
-  // * KRaft with the new group coordinator enabled and the consumer group protocol (temporarily disabled)
+  // * KRaft with the new group coordinator enabled and the consumer group protocol
   def getTestQuorumAndGroupProtocolParametersAll() : java.util.stream.Stream[Arguments] = {
     java.util.stream.Stream.of(
         Arguments.of("zk", "generic"),
         Arguments.of("kraft", "generic"),
-        Arguments.of("kraft+kip848", "generic"))
-//        Arguments.of("kraft+kip848", "consumer"))
+        Arguments.of("kraft+kip848", "generic"),
+        Arguments.of("kraft+kip848", "consumer"))
   }
 
   // In Scala 2.12, it is necessary to disambiguate the java.util.stream.Stream.of() method call


### PR DESCRIPTION
The consumer integration tests were experimentally disabled for the new `AsyncKafkaConsumer` variant with the aim of improving build stability. Several improvements have been made to the consumer code and other tests which seem to have made a difference. This PR re-enables the tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
