### PR TITLE
MINOR: fix zookeeper_migration_test system test in 3.5

### DIFF
--- a/tests/kafkatest/tests/core/zookeeper_migration_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_migration_test.py
@@ -28,7 +28,7 @@ from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.utils import is_int
-from kafkatest.version import DEV_BRANCH, V_3_4_0
+from kafkatest.version import DEV_BRANCH, V_3_4_1
 
 
 class TestMigration(ProduceConsumeValidateTest):
@@ -140,14 +140,14 @@ class TestMigration(ProduceConsumeValidateTest):
         This test ensures that even if we enable migrations after the upgrade to 3.5, that no migration
         is able to take place.
         """
-        self.zk = ZookeeperService(self.test_context, num_nodes=1, version=V_3_4_0)
+        self.zk = ZookeeperService(self.test_context, num_nodes=1, version=V_3_4_1)
         self.zk.start()
 
         self.kafka = KafkaService(self.test_context,
                                   num_nodes=3,
                                   zk=self.zk,
                                   allow_zk_with_kraft=True,
-                                  version=V_3_4_0,
+                                  version=V_3_4_1,
                                   server_prop_overrides=[["zookeeper.metadata.migration.enable", "false"]],
                                   topics={self.topic: {"partitions": self.partitions,
                                                        "replication-factor": self.replication_factor,
@@ -202,17 +202,17 @@ class TestMigration(ProduceConsumeValidateTest):
         the correct migration state in the log.
         """
         zk_quorum = partial(ServiceQuorumInfo, zk)
-        self.zk = ZookeeperService(self.test_context, num_nodes=1, version=V_3_4_0)
+        self.zk = ZookeeperService(self.test_context, num_nodes=1, version=V_3_4_1)
         self.kafka = KafkaService(self.test_context,
                                   num_nodes=3,
                                   zk=self.zk,
-                                  version=V_3_4_0,
+                                  version=V_3_4_1,
                                   quorum_info_provider=zk_quorum,
                                   allow_zk_with_kraft=True,
                                   server_prop_overrides=[["zookeeper.metadata.migration.enable", "true"]])
 
         remote_quorum = partial(ServiceQuorumInfo, isolated_kraft)
-        controller = KafkaService(self.test_context, num_nodes=1, zk=self.zk, version=V_3_4_0,
+        controller = KafkaService(self.test_context, num_nodes=1, zk=self.zk, version=V_3_4_1,
                                   allow_zk_with_kraft=True,
                                   isolated_kafka=self.kafka,
                                   server_prop_overrides=[["zookeeper.connect", self.zk.connect_setting()],

--- a/tests/kafkatest/tests/core/zookeeper_migration_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_migration_test.py
@@ -22,13 +22,13 @@ from ducktape.errors import TimeoutError
 
 from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.services.kafka import KafkaService
-from kafkatest.services.kafka.config_property import CLUSTER_ID
+from kafkatest.services.kafka.config_property import CLUSTER_ID, LOG_DIRS
 from kafkatest.services.kafka.quorum import isolated_kraft, ServiceQuorumInfo, zk
 from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.utils import is_int
-from kafkatest.version import DEV_BRANCH, V_3_4_1
+from kafkatest.version import DEV_BRANCH, LATEST_3_4
 
 
 class TestMigration(ProduceConsumeValidateTest):
@@ -57,7 +57,8 @@ class TestMigration(ProduceConsumeValidateTest):
                                   allow_zk_with_kraft=True,
                                   isolated_kafka=self.kafka,
                                   server_prop_overrides=[["zookeeper.connect", self.zk.connect_setting()],
-                                                         ["zookeeper.metadata.migration.enable", "true"]],
+                                                         ["zookeeper.metadata.migration.enable", "true"],
+                                                         [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]],
                                   quorum_info_provider=remote_quorum)
         controller.start()
 
@@ -95,7 +96,7 @@ class TestMigration(ProduceConsumeValidateTest):
                                   version=DEV_BRANCH,
                                   quorum_info_provider=zk_quorum,
                                   allow_zk_with_kraft=True,
-                                  server_prop_overrides=[["zookeeper.metadata.migration.enable", "false"]])
+                                  server_prop_overrides=[["zookeeper.metadata.migration.enable", "false"], [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]])
         self.kafka.security_protocol = "PLAINTEXT"
         self.kafka.interbroker_security_protocol = "PLAINTEXT"
         self.zk.start()
@@ -140,15 +141,15 @@ class TestMigration(ProduceConsumeValidateTest):
         This test ensures that even if we enable migrations after the upgrade to 3.5, that no migration
         is able to take place.
         """
-        self.zk = ZookeeperService(self.test_context, num_nodes=1, version=V_3_4_1)
+        self.zk = ZookeeperService(self.test_context, num_nodes=1, version=LATEST_3_4)
         self.zk.start()
 
         self.kafka = KafkaService(self.test_context,
                                   num_nodes=3,
                                   zk=self.zk,
                                   allow_zk_with_kraft=True,
-                                  version=V_3_4_1,
-                                  server_prop_overrides=[["zookeeper.metadata.migration.enable", "false"]],
+                                  version=LATEST_3_4,
+                                  server_prop_overrides=[["zookeeper.metadata.migration.enable", "false"], [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]],
                                   topics={self.topic: {"partitions": self.partitions,
                                                        "replication-factor": self.replication_factor,
                                                        'configs': {"min.insync.replicas": 2}}})
@@ -157,7 +158,7 @@ class TestMigration(ProduceConsumeValidateTest):
         # Now reconfigure the cluster as if we're trying to do a migration
         self.kafka.server_prop_overrides.clear()
         self.kafka.server_prop_overrides.extend([
-            ["zookeeper.metadata.migration.enable", "true"]
+            ["zookeeper.metadata.migration.enable", "true"], [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]
         ])
 
         self.logger.info("Performing rolling upgrade.")
@@ -202,21 +203,21 @@ class TestMigration(ProduceConsumeValidateTest):
         the correct migration state in the log.
         """
         zk_quorum = partial(ServiceQuorumInfo, zk)
-        self.zk = ZookeeperService(self.test_context, num_nodes=1, version=V_3_4_1)
+        self.zk = ZookeeperService(self.test_context, num_nodes=1, version=LATEST_3_4)
         self.kafka = KafkaService(self.test_context,
                                   num_nodes=3,
                                   zk=self.zk,
-                                  version=V_3_4_1,
+                                  version=LATEST_3_4,
                                   quorum_info_provider=zk_quorum,
                                   allow_zk_with_kraft=True,
-                                  server_prop_overrides=[["zookeeper.metadata.migration.enable", "true"]])
+                                  server_prop_overrides=[["zookeeper.metadata.migration.enable", "true"], [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]])
 
         remote_quorum = partial(ServiceQuorumInfo, isolated_kraft)
-        controller = KafkaService(self.test_context, num_nodes=1, zk=self.zk, version=V_3_4_1,
+        controller = KafkaService(self.test_context, num_nodes=1, zk=self.zk, version=LATEST_3_4,
                                   allow_zk_with_kraft=True,
                                   isolated_kafka=self.kafka,
                                   server_prop_overrides=[["zookeeper.connect", self.zk.connect_setting()],
-                                                         ["zookeeper.metadata.migration.enable", "true"]],
+                                                         ["zookeeper.metadata.migration.enable", "true"], [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]],
                                   quorum_info_provider=remote_quorum)
 
         self.kafka.security_protocol = "PLAINTEXT"
@@ -284,14 +285,14 @@ class TestMigration(ProduceConsumeValidateTest):
                                   version=DEV_BRANCH,
                                   quorum_info_provider=zk_quorum,
                                   allow_zk_with_kraft=True,
-                                  server_prop_overrides=[["zookeeper.metadata.migration.enable", "false"]])
+                                  server_prop_overrides=[["zookeeper.metadata.migration.enable", "false"], [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]])
 
         remote_quorum = partial(ServiceQuorumInfo, isolated_kraft)
         controller = KafkaService(self.test_context, num_nodes=1, zk=self.zk, version=DEV_BRANCH,
                                   allow_zk_with_kraft=True,
                                   isolated_kafka=self.kafka,
                                   server_prop_overrides=[["zookeeper.connect", self.zk.connect_setting()],
-                                                         ["zookeeper.metadata.migration.enable", "true"]],
+                                                         ["zookeeper.metadata.migration.enable", "true"], [LOG_DIRS, KafkaService.DATA_LOG_DIR_1]],
                                   quorum_info_provider=remote_quorum)
 
         self.kafka.security_protocol = "PLAINTEXT"


### PR DESCRIPTION
 zookeeper_migration_test in 3.5 branch failed with:
  1. "Kafka server didn't finish startup in 60 seconds" : This is because we added a constraint to ZK migrating to KRaft that we don't support JBOD in use. These system tests are fixed in this PR in trunk:
https://github.com/apache/kafka/pull/14654/files#diff-17b8c06d37fe43a3bd6ba5b89e08ff8f988ad5f4e5f7eda87844d51f7e5a5b96R61
  2. "Zookeeper node failed to start": This is because the ZK is pointing to 3.4.0 version, which should be 3.4.1. These system tests are fixed in this PR in trunk:
https://github.com/apache/kafka/pull/14208/files#diff-17b8c06d37fe43a3bd6ba5b89e08ff8f988ad5f4e5f7eda87844d51f7e5a5b96R143

After applying this patch, the system tests pass now.

```
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.11.4
session_id:       2023-12-05--004
run time:         8 minutes 19.409 seconds
tests run:        5
passed:           5
flaky:            0
failed:           0
ignored:          0
================================================================================
test_id:    kafkatest.tests.core.zookeeper_migration_test.TestMigration.test_online_migration.roll_controller=False
status:     PASS
run time:   2 minutes 58.323 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.core.zookeeper_migration_test.TestMigration.test_online_migration.roll_controller=True
status:     PASS
run time:   2 minutes 54.470 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.core.zookeeper_migration_test.TestMigration.test_pre_migration_mode_3_4.metadata_quorum=ISOLATED_KRAFT
status:     PASS
run time:   34.722 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.core.zookeeper_migration_test.TestMigration.test_reconcile_kraft_to_zk
status:     PASS
run time:   1 minute 13.468 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.core.zookeeper_migration_test.TestMigration.test_upgrade_after_3_4_migration
status:     PASS
run time:   38.313 seconds
--------------------------------------------------------------------------------

```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
