### PR TITLE
KAFKA-15880: Add Github Actions Workflow for promoting docker image

### DIFF
--- a/.github/workflows/docker_promote.yml
+++ b/.github/workflows/docker_promote.yml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Promote RC Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      rc_docker_image:
+        description: RC docker image that needs to be promoted to apache/kafka
+        required: true
+      promoted_docker_image:
+        description: Docker image name of the promoted image
+        required: true
+
+jobs:
+  promote:
+    if: github.repository == 'apache/kafka'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Copy RC Image to apache/kafka
+      uses: imjasonh/setup-crane@v0.1
+    - run: |
+        crane copy ${{ github.event.inputs.rc_docker_image }} ${{ github.event.inputs.promoted_docker_image }}


### PR DESCRIPTION
This PR adds Github Actions Workflow for promoting an RC docker image to final release. It makes the process of releasing docker image more streamlined, as discussed in [KIP-975](https://cwiki.apache.org/confluence/display/KAFKA/KIP-975%3A+Docker+Image+for+Apache+Kafka)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
