### PR TITLE
KAFKA-15358: Added QueuedReplicaToDirAssignments metric

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -849,6 +849,7 @@ project(':server') {
   dependencies {
     implementation project(':clients')
     implementation project(':server-common')
+    implementation libs.metrics
 
     implementation libs.slf4jApi
 

--- a/checkstyle/import-control-server.xml
+++ b/checkstyle/import-control-server.xml
@@ -58,6 +58,11 @@
   <!-- utilities and reusable classes from server-common -->
   <allow pkg="org.apache.kafka.queue" />
   <allow pkg="org.apache.kafka.server.common" />
+  <allow pkg="org.apache.kafka.server.metrics" />
+  <allow pkg="com.yammer.metrics" />
+
+  <!-- utilities for testing -->
+  <allow pkg="org.apache.kafka.test" />
 
   <!-- persistent collection factories/non-library-specific wrappers -->
   <allow pkg="org.apache.kafka.server.immutable" exact-match="true" />


### PR DESCRIPTION
Adds a new metric, QueuedReplicaToDirAssignments, which, when queried, will return the total number of replica to directory assignments that are currently queued in the AssignmentsManager.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
