### PR TITLE
KAFKA-15978: Update member information on HB response

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -225,6 +225,13 @@ public class CommitRequestManager implements RequestManager {
     }
 
     /**
+     * Updates the member ID and epoch upon receiving ConsumerGroupHeartbeatResponse.
+     */
+    void updateMemberInformation(String memberId, int memberEpoch) {
+        groupState.generation = new GroupState.Generation(memberEpoch, memberId, null);
+    }
+
+    /**
      * Returns an OffsetCommitRequest of all assigned topicPartitions and their current positions.
      */
     NetworkClientDelegate.UnsentRequest createCommitAllConsumedRequest() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -524,6 +524,7 @@ public class MembershipManagerImpl implements MembershipManager, ClusterResource
      */
     private void transitionToSendingLeaveGroup() {
         memberEpoch = ConsumerGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH;
+        commitRequestManager.updateMemberInformation(this.memberId, this.memberEpoch);
         currentAssignment = new HashSet<>();
         transitionTo(MemberState.LEAVING);
     }
@@ -1002,6 +1003,7 @@ public class MembershipManagerImpl implements MembershipManager, ClusterResource
 
     private void resetEpoch() {
         this.memberEpoch = ConsumerGroupHeartbeatRequest.JOIN_GROUP_MEMBER_EPOCH;
+        commitRequestManager.updateMemberInformation(this.memberId, this.memberEpoch);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -319,6 +319,7 @@ public class MembershipManagerImpl implements MembershipManager, ClusterResource
         }
         this.memberId = response.memberId();
         this.memberEpoch = response.memberEpoch();
+        commitRequestManager.updateMemberInformation(this.memberId, this.memberEpoch);
         ConsumerGroupHeartbeatResponseData.Assignment assignment = response.assignment();
 
         if (assignment != null) {

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -2338,4 +2338,24 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     assertEquals(numRecords, consumer.committed(Set(tp).asJava).get(tp).offset)
     assertEquals(numRecords, consumer.committed(Set(tp).asJava).get(tp).offset)
   }
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testConsumerAndCommitSync(quorum: String, groupProtocol: String): Unit = {
+    val numRecords = 1
+    val record = new ProducerRecord(tp.topic, tp.partition, null, "key".getBytes, "value".getBytes)
+
+    val producer = createProducer()
+    producer.send(record)
+
+    val consumer = createConsumer()
+    assertEquals(0, consumer.assignment.size)
+    consumer.subscribe(List(topic).asJava)
+    awaitAssignment(consumer, Set(tp, tp2))
+
+    val records = consumeRecords(consumer = consumer, numRecords = numRecords)
+    assertEquals(numRecords, records.size)
+
+    consumer.commitSync()
+  }
 }

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -2341,20 +2341,15 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
   @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
-  def testConsumerAndCommitSync(quorum: String, groupProtocol: String): Unit = {
-    val numRecords = 1
-    val record = new ProducerRecord(tp.topic, tp.partition, null, "key".getBytes, "value".getBytes)
-
-    val producer = createProducer()
-    producer.send(record)
-
+  def testSubscribeAndCommitSync(quorum: String, groupProtocol: String): Unit = {
+    // This test ensure that the member ID is propagated from the group coordinator when the
+    // assignment is received into a subsequent offset commit
     val consumer = createConsumer()
     assertEquals(0, consumer.assignment.size)
     consumer.subscribe(List(topic).asJava)
     awaitAssignment(consumer, Set(tp, tp2))
 
-    val records = consumeRecords(consumer = consumer, numRecords = numRecords)
-    assertEquals(numRecords, records.size)
+    consumer.seek(tp, 0)
 
     consumer.commitSync()
   }


### PR DESCRIPTION
In the new consumer, the commit request manager and the membership manager are separate components. The commit request manager is initialised with group information that it uses to construct `OffsetCommit` requests. However, the initial value of the member ID is `""` in some cases. When the consumer joins the group, it receives a `ConsumerGroupHeartbeat` response which tells it the member ID. The member ID was not being passed to the commit request manager, so it sent invalid `OffsetCommit` requests that failed with `UNKNOWN_MEMBER_ID`.

I've added an integration test that failed before the code change, and now passes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
