### PR TITLE
KAFKA-15662: Add support for clientInstanceIds in Kafka Stream

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/internals/StreamsConfigUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/StreamsConfigUtils.java
@@ -27,12 +27,13 @@ public class StreamsConfigUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamsConfigUtils.class);
 
+    @SuppressWarnings("deprecation")
     public enum ProcessingMode {
-        AT_LEAST_ONCE("AT_LEAST_ONCE"),
+        AT_LEAST_ONCE(StreamsConfig.AT_LEAST_ONCE),
 
-        EXACTLY_ONCE_ALPHA("EXACTLY_ONCE_ALPHA"),
+        EXACTLY_ONCE_ALPHA(StreamsConfig.EXACTLY_ONCE),
 
-        EXACTLY_ONCE_V2("EXACTLY_ONCE_V2");
+        EXACTLY_ONCE_V2(StreamsConfig.EXACTLY_ONCE_V2);
 
         public final String name;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -44,7 +44,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_ALPHA;
-import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.eosEnabled;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.processingMode;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.getTaskProducerClientId;
@@ -136,8 +135,8 @@ class ActiveTaskCreator {
     }
 
     StreamsProducer threadProducer() {
-        if (processingMode != EXACTLY_ONCE_V2) {
-            throw new IllegalStateException("Expected EXACTLY_ONCE_V2 to be enabled, but the processing mode was " + processingMode);
+        if (processingMode == EXACTLY_ONCE_ALPHA) {
+            throw new IllegalStateException("Expected AT_LEAST_ONCE or EXACTLY_ONCE_V2 to be enabled, but the processing mode was " + processingMode);
         }
         return threadProducer;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -46,6 +46,7 @@ import org.apache.kafka.streams.ThreadMetadata;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.internals.StreamsConfigUtils;
 import org.apache.kafka.streams.internals.metrics.ClientMetrics;
 import org.apache.kafka.streams.processor.StandbyUpdateListener;
 import org.apache.kafka.streams.processor.StateRestoreListener;
@@ -78,6 +79,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.eosEnabled;
+import static org.apache.kafka.streams.internals.StreamsConfigUtils.processingMode;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.getConsumerClientId;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.getRestoreConsumerClientId;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.getSharedAdminClientId;
@@ -338,11 +340,13 @@ public class StreamThread extends Thread implements ProcessingThread {
     private final AtomicLong cacheResizeSize = new AtomicLong(-1L);
     private final AtomicBoolean leaveGroupRequested = new AtomicBoolean(false);
     private final boolean eosEnabled;
+    private final StreamsConfigUtils.ProcessingMode processingMode;
     private final boolean stateUpdaterEnabled;
     private final boolean processingThreadsEnabled;
 
     private volatile long fetchDeadlineClientInstanceId = -1;
     private volatile KafkaFutureImpl<Uuid> mainConsumerInstanceIdFuture = new KafkaFutureImpl<>();
+    private volatile KafkaFutureImpl<Uuid> threadProducerInstanceIdFuture;
 
     public static StreamThread create(final TopologyMetadata topologyMetadata,
                                       final StreamsConfig config,
@@ -610,6 +614,7 @@ public class StreamThread extends Thread implements ProcessingThread {
 
         this.numIterations = 1;
         this.eosEnabled = eosEnabled(config);
+        this.processingMode = processingMode(config);
         this.stateUpdaterEnabled = InternalConfig.getStateUpdaterEnabled(config.originals());
         this.processingThreadsEnabled = InternalConfig.getProcessingThreadsEnabled(config.originals());
     }
@@ -751,13 +756,37 @@ public class StreamThread extends Thread implements ProcessingThread {
                         new TimeoutException("Could not retrieve main consumer client instance id.")
                     );
                 }
+
+
+            if (!processingMode.equals(StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_ALPHA) &&
+                    !threadProducerInstanceIdFuture.isDone()) {
+
+                if (fetchDeadlineClientInstanceId >= time.milliseconds()) {
+                    try {
+                        threadProducerClientInstanceId = taskManager.threadProducer().kafkaProducer().clientInstanceId(Duration.ZERO);
+                        threadProducerInstanceIdFuture.complete(threadProducerClientInstanceId);
+                        maybeResetFetchDeadline();
+                    } catch (final IllegalStateException disabledError) {
+                        threadProducerInstanceIdFuture.complete(null);
+                        threadProducerInstanceIdFuture.completeExceptionally(error);
+                        maybeResetFetchDeadline();
+                    }
+                } else {
+                    threadProducerInstanceIdFuture.completeExceptionally(
+                        new TimeoutException("Could not retrieve thread producer client instance id.")
             }
             maybeResetFetchDeadline();
         }
     }
 
     private void maybeResetFetchDeadline() {
-        final boolean reset = mainConsumerInstanceIdFuture.isDone();
+        boolean reset = mainConsumerInstanceIdFuture.isDone();
+
+        if (processingMode.equals(StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_ALPHA)) {
+            throw new UnsupportedOperationException("not implemented yet");
+        } else if (!threadProducerInstanceIdFuture.isDone()) {
+            reset = false;
+        }
 
         if (reset) {
             fetchDeadlineClientInstanceId = -1L;
@@ -1548,6 +1577,29 @@ public class StreamThread extends Thread implements ProcessingThread {
 
         if (setDeadline) {
             fetchDeadlineClientInstanceId = time.milliseconds() + timeout.toMillis();
+        }
+
+        return result;
+    }
+
+    // this method is NOT thread-safe (we rely on the callee to be `synchronized`)
+    public KafkaFuture<Map<String, KafkaFuture<Uuid>>> producersClientInstanceIds(final Duration timeout) {
+        final KafkaFutureImpl<Map<String, KafkaFuture<Uuid>>> result = new KafkaFutureImpl<>();
+
+        if (processingMode.equals(StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_ALPHA)) {
+            throw new UnsupportedOperationException("not yet implemented");
+        } else {
+            final KafkaFutureImpl<Uuid> producerFuture = new KafkaFutureImpl<>();
+            if (threadProducerClientInstanceId != null) {
+                producerFuture.complete(threadProducerClientInstanceId);
+            } else {
+                threadProducerInstanceIdFuture = producerFuture;
+                if (fetchDeadlineClientInstanceId == -1) {
+                    fetchDeadlineClientInstanceId = time.milliseconds() + timeout.toMillis();
+                }
+            }
+
+            result.complete(Collections.singletonMap(getName() + "-producer", producerFuture));
         }
 
         return result;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -141,15 +141,13 @@ public class ActiveTaskCreatorTest {
     }
 
     @Test
-    public void shouldFailOnGetThreadProducerIfEosDisabled() {
+    public void shouldReturnThreadProducerIfAtLeastOnceIsEnabled() {
         createTasks();
 
-        final IllegalStateException thrown = assertThrows(
-            IllegalStateException.class,
-            activeTaskCreator::threadProducer
-        );
+        final StreamsProducer threadProducer = activeTaskCreator.threadProducer();
 
-        assertThat(thrown.getMessage(), is("Expected EXACTLY_ONCE_V2 to be enabled, but the processing mode was AT_LEAST_ONCE"));
+        assertThat(mockClientSupplier.producers.size(), is(1));
+        assertThat(threadProducer.kafkaProducer(), is(mockClientSupplier.producers.get(0)));
     }
 
     @Test
@@ -291,7 +289,7 @@ public class ActiveTaskCreatorTest {
             activeTaskCreator::threadProducer
         );
 
-        assertThat(thrown.getMessage(), is("Expected EXACTLY_ONCE_V2 to be enabled, but the processing mode was EXACTLY_ONCE_ALPHA"));
+        assertThat(thrown.getMessage(), is("Expected AT_LEAST_ONCE or EXACTLY_ONCE_V2 to be enabled, but the processing mode was EXACTLY_ONCE_ALPHA"));
     }
 
     @SuppressWarnings("deprecation")

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -3387,7 +3387,7 @@ public class StreamThreadTest {
     }
 
     @Test
-    public void shouldReturnErrorIfProducerInstanceIdNotInitialized() {
+    public void shouldReturnErrorIfProducerInstanceIdNotInitialized() throws Exception {
         thread = createStreamThread("clientId");
         thread.setState(State.STARTING);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -3339,6 +3339,39 @@ public class StreamThreadTest {
     }
 
     @Test
+    public void shouldGetProducerInstanceId() throws Exception {
+        getProducerInstanceId(false);
+    }
+
+    @Test
+    public void shouldProducerInstanceIdAndInternalTimeout() throws Exception {
+        getProducerInstanceId(true);
+    }
+
+    private void getProducerInstanceId(final boolean injectTimeException) throws Exception {
+        final Uuid producerInstanceId = Uuid.randomUuid();
+        final MockProducer<byte[], byte[]> producer = new MockProducer<>();
+        producer.setClientInstanceId(producerInstanceId);
+        if (injectTimeException) {
+            producer.injectTimeoutException(1);
+        }
+        clientSupplier.prepareProducer(producer);
+
+        thread = createStreamThread("clientId");
+        thread.setState(State.STARTING);
+
+        final KafkaFuture<Map<String, KafkaFuture<Uuid>>> producerInstanceIdFutures =
+            thread.producersClientInstanceIds(Duration.ZERO);
+
+        thread.maybeGetClientInstanceIds(); // triggers internal timeout; should not crash
+        thread.maybeGetClientInstanceIds();
+
+        final KafkaFuture<Uuid> producerFuture = producerInstanceIdFutures.get().get("clientId-StreamThread-1-producer");
+        final Uuid producerUuid = producerFuture.get();
+        assertThat(producerUuid, equalTo(producerInstanceId));
+    }
+
+    @Test
     public void shouldReturnErrorIfMainConsumerInstanceIdNotInitialized() {
         thread = createStreamThread("clientId");
         thread.setState(State.STARTING);
@@ -3348,6 +3381,21 @@ public class StreamThreadTest {
         thread.maybeGetClientInstanceIds();
 
         final KafkaFuture<Uuid> future = consumerFutures.get("clientId-StreamThread-1-consumer");
+        final ExecutionException error = assertThrows(ExecutionException.class, future::get);
+        assertThat(error.getCause(), instanceOf(UnsupportedOperationException.class));
+        assertThat(error.getCause().getMessage(), equalTo("clientInstanceId not set"));
+    }
+
+    @Test
+    public void shouldReturnErrorIfProducerInstanceIdNotInitialized() {
+        thread = createStreamThread("clientId");
+        thread.setState(State.STARTING);
+
+        final Map<String, KafkaFuture<Uuid>> producerFutures = thread.producersClientInstanceIds(Duration.ZERO).get();
+
+        thread.maybeGetClientInstanceIds();
+
+        final KafkaFuture<Uuid> future = producerFutures.get("clientId-StreamThread-1-producer");
         final ExecutionException error = assertThrows(ExecutionException.class, future::get);
         assertThat(error.getCause(), instanceOf(UnsupportedOperationException.class));
         assertThat(error.getCause().getMessage(), equalTo("clientInstanceId not set"));
@@ -3364,6 +3412,24 @@ public class StreamThreadTest {
         thread.maybeGetClientInstanceIds();
 
         final KafkaFuture<Uuid> future = consumerFutures.get("clientId-StreamThread-1-consumer");
+        final Uuid clientInstanceId = future.get();
+        assertThat(clientInstanceId, equalTo(null));
+    }
+
+    @Test
+    public void shouldReturnNullIfProducerTelemetryDisabled() throws Exception {
+        final MockProducer<byte[], byte[]> producer = new MockProducer<>();
+        producer.disableTelemetry();
+        clientSupplier.prepareProducer(producer);
+
+        thread = createStreamThread("clientId");
+        thread.setState(State.STARTING);
+
+        final Map<String, KafkaFuture<Uuid>> producerFutures = thread.producersClientInstanceIds(Duration.ZERO).get();
+
+        thread.maybeGetClientInstanceIds();
+
+        final KafkaFuture<Uuid> future = producerFutures.get("clientId-StreamThread-1-producer");
         final Uuid clientInstanceId = future.get();
         assertThat(clientInstanceId, equalTo(null));
     }
@@ -3387,6 +3453,31 @@ public class StreamThreadTest {
         assertThat(
             error.getCause().getMessage(),
             equalTo("Could not retrieve main consumer client instance id.")
+        );
+    }
+
+    @Test
+    public void shouldTimeOutOnProducerInstanceId() throws Exception {
+        final MockProducer<byte[], byte[]> producer = new MockProducer<>();
+        producer.setClientInstanceId(Uuid.randomUuid());
+        producer.injectTimeoutException(-1);
+        clientSupplier.prepareProducer(producer);
+
+        thread = createStreamThread("clientId");
+        thread.setState(State.STARTING);
+
+        final Map<String, KafkaFuture<Uuid>> producerFutures = thread.producersClientInstanceIds(Duration.ZERO).get();
+
+        mockTime.sleep(1L);
+
+        thread.maybeGetClientInstanceIds();
+
+        final KafkaFuture<Uuid> future = producerFutures.get("clientId-StreamThread-1-producer");
+        final ExecutionException error = assertThrows(ExecutionException.class, future::get);
+        assertThat(error.getCause(), instanceOf(TimeoutException.class));
+        assertThat(
+            error.getCause().getMessage(),
+            equalTo("Could not retrieve thread producer client instance id.")
         );
     }
 


### PR DESCRIPTION
Part of KIP-714.

Adds support to expose producer client instance id. This PR only adds support for thread producer and state-updater disabled.