### PR TITLE
KAFKA-15662: Add support for clientInstanceIds in Kafka Stream 

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -182,7 +182,7 @@
 
     <!-- Streams -->
     <suppress checks="ClassFanOutComplexity"
-              files="(KafkaStreams|KStreamImpl|KTableImpl|InternalTopologyBuilder|StreamsPartitionAssignor|StreamThread|IQv2StoreIntegrationTest|KStreamImplTest|RocksDBStore).java"/>
+              files="(KafkaStreams|KStreamImpl|KTableImpl|InternalTopologyBuilder|StreamsPartitionAssignor|StreamThread|KStreamImplTest|RocksDBStore|TaskManager).java"/>
 
     <suppress checks="MethodLength"
               files="KTableImpl.java"/>
@@ -227,7 +227,7 @@
 
     <!-- Streams tests -->
     <suppress checks="ClassFanOutComplexity"
-              files="(RecordCollectorTest|StreamsPartitionAssignorTest|StreamThreadTest|StreamTaskTest|TaskManagerTest|TopologyTestDriverTest).java"/>
+              files="(RecordCollectorTest|StreamsPartitionAssignorTest|StreamThreadTest|StreamTaskTest|TaskManagerTest|TopologyTestDriverTest|KafkaStreamsTest|IQv2StoreIntegrationTest).java"/>
 
     <suppress checks="MethodLength"
               files="(EosIntegrationTest|EosV2UpgradeIntegrationTest|KStreamKStreamJoinTest|RocksDBWindowStoreTest|StreamStreamJoinIntegrationTest).java"/>

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -67,6 +67,7 @@ import java.util.stream.Collectors;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.token.delegation.DelegationToken;
 import org.apache.kafka.common.security.token.delegation.TokenInformation;
+import org.apache.kafka.common.utils.Time;
 
 public class MockAdminClient extends AdminClient {
     public static final String DEFAULT_CLUSTER_ID = "I4ZmrWqfT2e-upky_4fdPA";
@@ -99,7 +100,8 @@ public class MockAdminClient extends AdminClient {
     private boolean telemetryDisabled = false;
     private Uuid clientInstanceId;
     private int injectTimeoutExceptionCounter;
-
+    private Time mockTime;
+    private long blockingTimeMs;
     private KafkaException listConsumerGroupOffsetsException;
 
     private Map<MetricName, Metric> mockMetrics = new HashMap<>();
@@ -1370,6 +1372,11 @@ public class MockAdminClient extends AdminClient {
         this.injectTimeoutExceptionCounter = injectTimeoutExceptionCounter;
     }
 
+    public void advanceTimeOnClientInstanceId(final Time mockTime, final long blockingTimeMs) {
+        this.mockTime = mockTime;
+        this.blockingTimeMs = blockingTimeMs;
+    }
+
     public void setClientInstanceId(final Uuid instanceId) {
         clientInstanceId = instanceId;
     }
@@ -1388,6 +1395,10 @@ public class MockAdminClient extends AdminClient {
                 --injectTimeoutExceptionCounter;
             }
             throw new TimeoutException();
+        }
+
+        if (mockTime != null) {
+            mockTime.sleep(blockingTimeMs);
         }
 
         return clientInstanceId;

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -24,9 +24,11 @@ import org.apache.kafka.clients.admin.RemoveMembersFromConsumerGroupOptions;
 import org.apache.kafka.clients.admin.RemoveMembersFromConsumerGroupResult;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.annotation.InterfaceStability.Evolving;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
@@ -101,6 +103,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
@@ -1881,7 +1884,7 @@ public class KafkaStreams implements AutoCloseable {
      * @throws TimeoutException Indicates that a request timed out.
      * @throws StreamsException For any other error that might occur.
      */
-    public ClientInstanceIds clientInstanceIds(final Duration timeout) {
+    public synchronized ClientInstanceIds clientInstanceIds(final Duration timeout) {
         if (timeout.isNegative()) {
             throw new IllegalArgumentException("The timeout cannot be negative.");
         }
@@ -1892,17 +1895,26 @@ public class KafkaStreams implements AutoCloseable {
             throw new IllegalStateException("KafkaStreams has been stopped (" + state + ").");
         }
 
+        long remainingTimeMs = timeout.toMillis();
+        long startTimestampMs = time.milliseconds();
+
         final ClientInstanceIdsImpl clientInstanceIds = new ClientInstanceIdsImpl();
 
         // (1) fan-out calls to threads
 
         // StreamThread for main/restore consumers and producer(s)
-
+        final Map<String, KafkaFuture<Map<String, KafkaFuture<Uuid>>>> producerFutures = new HashMap<>();
+        for (final StreamThread streamThread : threads) {
+            producerFutures.put(streamThread.getName(), streamThread.producersClientInstanceIds(timeout));
+        }
         // GlobalThread
 
         // (2) get admin client instance id in a blocking fashion, while Stream/GlobalThreads work in parallel
         try {
             clientInstanceIds.setAdminInstanceId(adminClient.clientInstanceId(timeout));
+            final long nowMs = time.milliseconds();
+            remainingTimeMs -= nowMs - startTimestampMs;
+            startTimestampMs = nowMs;
         } catch (final IllegalStateException telemetryDisabledError) {
             // swallow
             log.debug("Telemetry is disabled on the admin client.");
@@ -1917,10 +1929,68 @@ public class KafkaStreams implements AutoCloseable {
         // (3a) collect consumers from StreamsThread
 
         // (3b) collect producers from StreamsThread
+        for (final Map.Entry<String, KafkaFuture<Map<String, KafkaFuture<Uuid>>>> threadProducerFuture : producerFutures.entrySet()) {
+            final Map<String, KafkaFuture<Uuid>> streamThreadProducerFutures = getOrThrowException(
+                threadProducerFuture.getValue(),
+                remainingTimeMs,
+                () -> String.format(
+                    "Could not retrieve producer instance id for %s.",
+                    threadProducerFuture.getKey()
+                )
+            );
+            long nowMs = time.milliseconds();
+            remainingTimeMs -= nowMs - startTimestampMs;
+            startTimestampMs = nowMs;
 
+            for (final Map.Entry<String, KafkaFuture<Uuid>> producerFuture : streamThreadProducerFutures.entrySet()) {
+                final Uuid instanceId = getOrThrowException(
+                    producerFuture.getValue(),
+                    remainingTimeMs,
+                    () -> String.format(
+                        "Could not retrieve producer instance id for %s.",
+                        producerFuture.getKey()
+                    )
+                );
+                nowMs = time.milliseconds();
+                remainingTimeMs -= nowMs - startTimestampMs;
+                startTimestampMs = nowMs;
+
+                // could be `null` if telemetry is disabled on the producer itself
+                if (instanceId != null) {
+                    clientInstanceIds.addProducerInstanceId(
+                        producerFuture.getKey(),
+                        instanceId
+                    );
+                } else {
+                    log.debug(String.format("Telemetry is disabled for %s.", producerFuture.getKey()));
+                }
+            }
+        }
         // (3c) collect from GlobalThread
 
         return clientInstanceIds;
+    }
+
+    private <T> T getOrThrowException(
+        final KafkaFuture<T> future,
+        final long timeoutMs,
+        final Supplier<String> errorMessage) {
+        final Throwable cause;
+
+        try {
+            return future.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (final java.util.concurrent.TimeoutException timeout) {
+            throw new TimeoutException(timeout);
+        } catch (final ExecutionException exception) {
+            cause = exception.getCause();
+            if (cause instanceof TimeoutException) {
+                throw (TimeoutException) cause;
+            }
+        } catch (final InterruptedException error) {
+            cause = error;
+        }
+
+        throw new StreamsException(errorMessage.get(), cause);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/internals/StreamsConfigUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/StreamsConfigUtils.java
@@ -27,12 +27,13 @@ public class StreamsConfigUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamsConfigUtils.class);
 
+    @SuppressWarnings("deprecation")
     public enum ProcessingMode {
-        AT_LEAST_ONCE("AT_LEAST_ONCE"),
+        AT_LEAST_ONCE(StreamsConfig.AT_LEAST_ONCE),
 
-        EXACTLY_ONCE_ALPHA("EXACTLY_ONCE_ALPHA"),
+        EXACTLY_ONCE_ALPHA(StreamsConfig.EXACTLY_ONCE),
 
-        EXACTLY_ONCE_V2("EXACTLY_ONCE_V2");
+        EXACTLY_ONCE_V2(StreamsConfig.EXACTLY_ONCE_V2);
 
         public final String name;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -44,7 +44,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_ALPHA;
-import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.eosEnabled;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.processingMode;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.getTaskProducerClientId;
@@ -120,6 +119,7 @@ class ActiveTaskCreator {
     }
 
     public void reInitializeThreadProducer() {
+        // need to invalidate producer client instance id future
         threadProducer.resetProducer();
     }
 
@@ -136,8 +136,8 @@ class ActiveTaskCreator {
     }
 
     StreamsProducer threadProducer() {
-        if (processingMode != EXACTLY_ONCE_V2) {
-            throw new IllegalStateException("Expected EXACTLY_ONCE_V2 to be enabled, but the processing mode was " + processingMode);
+        if (processingMode == EXACTLY_ONCE_ALPHA) {
+            throw new IllegalStateException("Expected AT_LEAST_ONCE or EXACTLY_ONCE_V2 to be enabled, but the processing mode was " + processingMode);
         }
         return threadProducer;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -22,8 +22,10 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
@@ -111,6 +113,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     private boolean commitRequested = false;
     private boolean hasPendingTxCommit = false;
     private Optional<Long> timeCurrentIdlingStarted;
+    KafkaFutureImpl<Uuid> producerInstanceId;
 
     @SuppressWarnings({"rawtypes", "this-escape", "checkstyle:ParameterNumber"})
     public StreamTask(final TaskId id,
@@ -715,6 +718,10 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         record = null;
         closeTaskSensor.record();
         partitionsToResume.clear();
+        if (producerInstanceId != null) {
+            producerInstanceId.complete(null);
+            producerInstanceId = null;
+        }
 
         transitionTo(State.CLOSED);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.TimeoutException;
@@ -91,13 +92,18 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.singletonList;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForApplicationState;
 import static org.apache.kafka.streams.state.QueryableStoreTypes.keyValueStore;
@@ -1380,6 +1386,94 @@ public class KafkaStreamsTest {
                 equalTo(instanceId)
             );
         }
+    }
+
+    @Test
+    public void shouldThrowTimeoutExceptionWhenThreadProducerFutureDoesNotComplete() {
+        final KafkaFutureImpl<Map<String, KafkaFuture<Uuid>>> producerFuture = new KafkaFutureImpl<>();
+        producerFuture.complete(Collections.singletonMap("threadProducer", new KafkaFutureImpl<>()));
+        when(streamThreadOne.producersClientInstanceIds(any())).thenReturn(producerFuture);
+        adminClient.setClientInstanceId(Uuid.randomUuid());
+
+        try (final KafkaStreams streams = new KafkaStreams(getBuilderWithSource().build(), props, supplier, time)) {
+            streams.start();
+            final TimeoutException timeoutException = assertThrows(
+                TimeoutException.class,
+                () -> streams.clientInstanceIds(Duration.ZERO)
+            );
+            assertThat(timeoutException.getCause(), instanceOf(java.util.concurrent.TimeoutException.class));
+        }
+    }
+
+    @Test
+    public void shouldCountDownTimeoutAcrossClient() {
+        adminClient.setClientInstanceId(Uuid.randomUuid());
+        adminClient.advanceTimeOnClientInstanceId(time, Duration.ofMillis(10L).toMillis());
+
+        final Time mockTime = time;
+        final AtomicLong expectedTimeout = new AtomicLong(20L);
+        final AtomicBoolean didAssertThreadProducer = new AtomicBoolean(false);
+        final AtomicBoolean didAssertTaskProducers = new AtomicBoolean(false);
+        final AtomicBoolean didAssertTask1 = new AtomicBoolean(false);
+        final AtomicBoolean didAssertTask2 = new AtomicBoolean(false);
+
+
+        // mimic thread producer on stream-thread-one
+        final KafkaFutureImpl<Map<String, KafkaFuture<Uuid>>> threadProducerFuture = new KafkaFutureImpl<>();
+        threadProducerFuture.complete(Collections.singletonMap("threadProducer", new KafkaFutureImpl<Uuid>() {
+            @Override
+            public Uuid get(final long timeout, final TimeUnit timeUnit) {
+                didAssertThreadProducer.set(true);
+                assertThat(timeout, equalTo(expectedTimeout.getAndAdd(-10L)));
+                mockTime.sleep(10L);
+                return null;
+            }
+        }));
+        when(streamThreadOne.producersClientInstanceIds(any())).thenReturn(threadProducerFuture);
+        // mimic task producer on stream-thread-two
+        final KafkaFutureImpl<Map<String, KafkaFuture<Uuid>>> taskProducersFuture = new KafkaFutureImpl<Map<String, KafkaFuture<Uuid>>>() {
+            @Override
+            public Map<String, KafkaFuture<Uuid>> get(final long timeout, final TimeUnit timeUnit)
+                throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {
+
+                didAssertTaskProducers.set(true);
+                assertThat(timeout, equalTo(expectedTimeout.getAndAdd(-10L)));
+                mockTime.sleep(10L);
+                return super.get(timeout, timeUnit);
+            }
+
+        };
+        taskProducersFuture.complete(mkMap(
+            mkEntry("task1", new KafkaFutureImpl<Uuid>() {
+                @Override
+                public Uuid get(final long timeout, final TimeUnit timeUnit) {
+                    didAssertTask1.set(true);
+                    assertThat(timeout, equalTo(expectedTimeout.getAndAdd(-5L)));
+                    mockTime.sleep(5L);
+                    return null;
+                }
+            }),
+            mkEntry("task2", new KafkaFutureImpl<Uuid>() {
+                @Override
+                public Uuid get(final long timeout, final TimeUnit timeUnit) {
+                    didAssertTask2.set(true);
+                    assertThat(timeout, equalTo(expectedTimeout.getAndAdd(-6L)));
+                    mockTime.sleep(6L);
+                    return null;
+                }
+            })
+        ));
+        when(streamThreadTwo.producersClientInstanceIds(any())).thenReturn(taskProducersFuture);
+
+        try (final KafkaStreams streams = new KafkaStreams(getBuilderWithSource().build(), props, supplier, time)) {
+            streams.start();
+            streams.clientInstanceIds(Duration.ofMillis(30L));
+        }
+
+        assertThat(didAssertThreadProducer.get(), equalTo(true));
+        assertThat(didAssertTaskProducers.get(), equalTo(true));
+        assertThat(didAssertTask1.get(), equalTo(true));
+        assertThat(didAssertTask2.get(), equalTo(true));
     }
 
     @Deprecated // testing old PAPI

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -1506,7 +1506,7 @@ public class StreamsConfigTest {
     }
 
     @Test
-    public void shouldEnableMetricCollectionForAllInternalClients() {
+    public void shouldEnableMetricCollectionForAllInternalClientsByDefault() {
         props.put(StreamsConfig.ENABLE_METRICS_PUSH_CONFIG, true);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -141,15 +141,13 @@ public class ActiveTaskCreatorTest {
     }
 
     @Test
-    public void shouldFailOnGetThreadProducerIfEosDisabled() {
+    public void shouldReturnThreadProducerIfAtLeastOnceIsEnabled() {
         createTasks();
 
-        final IllegalStateException thrown = assertThrows(
-            IllegalStateException.class,
-            activeTaskCreator::threadProducer
-        );
+        final StreamsProducer threadProducer = activeTaskCreator.threadProducer();
 
-        assertThat(thrown.getMessage(), is("Expected EXACTLY_ONCE_V2 to be enabled, but the processing mode was AT_LEAST_ONCE"));
+        assertThat(mockClientSupplier.producers.size(), is(1));
+        assertThat(threadProducer.kafkaProducer(), is(mockClientSupplier.producers.get(0)));
     }
 
     @Test
@@ -291,7 +289,7 @@ public class ActiveTaskCreatorTest {
             activeTaskCreator::threadProducer
         );
 
-        assertThat(thrown.getMessage(), is("Expected EXACTLY_ONCE_V2 to be enabled, but the processing mode was EXACTLY_ONCE_ALPHA"));
+        assertThat(thrown.getMessage(), is("Expected AT_LEAST_ONCE or EXACTLY_ONCE_V2 to be enabled, but the processing mode was EXACTLY_ONCE_ALPHA"));
     }
 
     @SuppressWarnings("deprecation")

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -2265,8 +2265,12 @@ public class TaskManagerTest {
     }
 
     @Test
-    public void shouldReInitializeThreadProducerOnHandleLostAllIfEosV2Enabled() {
+    public void shouldReInitializeThreadProducerOnHandleLostAllIfEosV2Enabled() throws Exception {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.EXACTLY_ONCE_V2, false);
+
+        final StreamThread mockThread = mock(StreamThread.class);
+        mockThread.threadProducerInstanceIdFuture = new KafkaFutureImpl<>();
+        taskManager.setStreamThread(mockThread);
 
         taskManager.handleLostAll();
 


### PR DESCRIPTION
Stacked on other PRs. 

Add support for EOSv1:
 - to setup the Futures for task producers, we need to delegate creating the Futurs to `StreamThread` (we cannot do it within `clientInstanceIds()` but push into the main processing loop via `maybeGetClientInstanceIds()` to avoid race conditions with rebalancing
 - We also need to take care for rebalancing and changing tasks
   - if we get new tasks, we just ignore it for now (what I think is not totally correct yet... -- not 100% sure right now what the best approach is)
   - if we lose a task, we just clean it out by completing the future inside `StreamTask#close()` (in the end, the user facing call will always timeout anyway, but completing the `Futures` with `null` seem to be a good idea in addition)