### PR TITLE
MINOR: Avoid leaking threads in DelegationTokenEndToEndAuthorizationWithOwnerTest.testDescribeTokenForOtherUserFails

### DIFF
--- a/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationWithOwnerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationWithOwnerTest.scala
@@ -104,17 +104,14 @@ class DelegationTokenEndToEndAuthorizationWithOwnerTest extends DelegationTokenE
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
   @ValueSource(strings = Array("kraft", "zk"))
   def testDescribeTokenForOtherUserFails(quorum: String): Unit = {
-    val describeTokenFailAdminClient = createScramAdminClient(kafkaClientSaslMechanism, describeTokenFailPrincipal.getName, describeTokenFailPassword)
-    val otherClientAdminClient = createScramAdminClient(kafkaClientSaslMechanism, otherClientPrincipal.getName, otherClientPassword)
-    try {
-      otherClientAdminClient.createDelegationToken().delegationToken().get()
-      val tokens = describeTokenFailAdminClient.describeDelegationToken(
-        new DescribeDelegationTokenOptions().owners(Collections.singletonList(otherClientPrincipal)))
-        .delegationTokens.get.asScala
-      assertTrue(tokens.isEmpty)
-    } finally {
-      describeTokenFailAdminClient.close()
-      otherClientAdminClient.close()
+    TestUtils.resource(createScramAdminClient(kafkaClientSaslMechanism, describeTokenFailPrincipal.getName, describeTokenFailPassword)) { describeTokenFailAdminClient =>
+      TestUtils.resource(createScramAdminClient(kafkaClientSaslMechanism, otherClientPrincipal.getName, otherClientPassword)) { otherClientAdminClient =>
+        otherClientAdminClient.createDelegationToken().delegationToken().get()
+        val tokens = describeTokenFailAdminClient.describeDelegationToken(
+          new DescribeDelegationTokenOptions().owners(Collections.singletonList(otherClientPrincipal))
+        ).delegationTokens.get.asScala
+        assertTrue(tokens.isEmpty)
+      }
     }
   }
 


### PR DESCRIPTION
I have seen a few builds failing with:

```
Build / JDK 17 and Scala 2.13 / executionError – kafka.api.DelegationTokenEndToEndAuthorizationWithOwnerTest
Error
org.opentest4j.AssertionFailedError: Found 1 unexpected threads during @AfterAll: `kafka-admin-client-thread | adminclient-254` ==> expected: <true> but was: <false>
Stacktrace
org.opentest4j.AssertionFailedError: Found 1 unexpected threads during @AfterAll: `kafka-admin-client-thread | adminclient-254` ==> expected: <true> but was: <false>
	at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at app//org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:63)
	at app//org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:36)
	at app//org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:210)
	at app//kafka.utils.TestUtils$.verifyNoUnexpectedThreads(TestUtils.scala:2441)
	at app//kafka.server.QuorumTestHarness.tearDownClass(QuorumTestHarness.scala:471)
	at java.base@17.0.7/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base@17.0.7/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base@17.0.7/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```

I think that the issue may be in testDescribeTokenForOtherUserFails where two admin clients are created. If the creation of the second one fails, the first one is not closed. This patch fixes this.

Example: https://ci-builds.apache.org/blue/organizations/jenkins/Kafka%2Fkafka-pr/detail/PR-14862/9/tests/.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
