### PR TITLE
KAFKA-15942: Implement ConsumerInterceptor

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -1059,7 +1059,8 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             public void onSuccess(Void value) {
                 inFlightAsyncCommits.decrementAndGet();
 
-                interceptors.onCommit(offsets);
+                if (interceptors != null)
+                    interceptors.onCommit(offsets);
                 completedOffsetCommits.add(new OffsetCommitCompletion(cb, offsets, null));
             }
 
@@ -1116,7 +1117,8 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             invokeCompletedOffsetCommitCallbacks();
 
             if (future.succeeded()) {
-                interceptors.onCommit(offsets);
+                if (interceptors != null)
+                    interceptors.onCommit(offsets);
                 return true;
             }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -1059,8 +1059,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             public void onSuccess(Void value) {
                 inFlightAsyncCommits.decrementAndGet();
 
-                if (interceptors != null)
-                    interceptors.onCommit(offsets);
+                interceptors.onCommit(offsets);
                 completedOffsetCommits.add(new OffsetCommitCompletion(cb, offsets, null));
             }
 
@@ -1117,8 +1116,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             invokeCompletedOffsetCommitCallbacks();
 
             if (future.succeeded()) {
-                if (interceptors != null)
-                    interceptors.onCommit(offsets);
+                interceptors.onCommit(offsets);
                 return true;
             }
 


### PR DESCRIPTION
When invoking `ConsumerInterceptor#onCommit` method in ConsumerCoordinator, there're some redundant if-nonNull branches.

`private final ConsumerInterceptors<?, ?> interceptors` is a non-null field because it'll be instantiate in the constructor, and this field is non-null when delivering from LegacyKafkaConsumer.

Some proofs:
There're 2 constructors in LegacyKafkaConsumer, both of them will instantiate `interceptors` field:
-  constructor1 in LegacyKafkaConsumer：`this.interceptors = new ConsumerInterceptors<>(interceptorList);`
-  constructor2 in LegacyKafkaConsumer:  `this.interceptors = new ConsumerInterceptors<>(Collections.emptyList());`

And this field can not set to null because it's private and no method to modify it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
