### PR TITLE
KAFKA-15986: Fix integration test failures

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1282,13 +1282,9 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
      */
     private boolean updateFetchPositions(final Timer timer) {
         try {
-            cachedSubscriptionHasAllFetchPositions = subscriptions.hasAllFetchPositions();
-            if (cachedSubscriptionHasAllFetchPositions) return true;
-
             // Validate positions using the partition leader end offsets, to detect if any partition
             // has been truncated due to a leader change. This will trigger an OffsetForLeaderEpoch
             // request, retrieve the partition end offsets, and validate the current position against it.
-            // If the timer is not expired, wait for the validation, otherwise, just request it.
             applicationEventHandler.addAndGet(new ValidatePositionsApplicationEvent(), timer);
 
             cachedSubscriptionHasAllFetchPositions = subscriptions.hasAllFetchPositions();
@@ -1312,7 +1308,6 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
             // which are awaiting reset. This will trigger a ListOffset request, retrieve the
             // partition offsets according to the strategy (ex. earliest, latest), and update the
             // positions.
-            // If the timer is not expired, wait for the reset, otherwise, just request it.
             applicationEventHandler.addAndGet(new ResetPositionsApplicationEvent(), timer);
             return true;
         } catch (TimeoutException e) {


### PR DESCRIPTION
A recent change in `AsyncKafkaConsumer.updateFetchPositions` has made fetching fail without returning records in some situations. Reverting the troublesome code.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
