### PR TITLE
KAFKA-15906: Emit latest MM2 offset syncs every offset.flush.interval.ms

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
@@ -431,6 +431,10 @@ public class MirrorSourceTaskTest {
         verify(producer, times(5)).send(any(), any());
         // Ack the latest sync immediately
         producerCallback.getValue().onCompletion(null, null);
+
+        mirrorSourceTask.commit();
+        // No more syncs should take place; we've been able to publish all of them so far
+        verify(producer, times(5)).send(any(), any());
     }
 
     private void compareHeaders(List<Header> expectedHeaders, List<org.apache.kafka.connect.header.Header> taskHeaders) {

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
@@ -407,10 +407,30 @@ public class MirrorSourceTaskTest {
         mirrorSourceTask.commitRecord(sourceRecord, recordMetadata);
         // We should have dispatched this sync to the producer
         verify(producer, times(4)).send(any(), any());
+        // Ack the latest sync immediately
+        producerCallback.getValue().onCompletion(null, null);
 
         mirrorSourceTask.commit();
         // No more syncs should take place; we've been able to publish all of them so far
         verify(producer, times(4)).send(any(), any());
+
+        // Don't skip the upstream record, so that the offset.lag.max determines whether the offset is emitted.
+        recordOffset = 7;
+        metadataOffset = 107;
+        recordMetadata = new RecordMetadata(sourceTopicPartition, metadataOffset, 0, 0, 0, recordPartition);
+        sourceRecord = mirrorSourceTask.convertRecord(new ConsumerRecord<>(topicName, recordPartition,
+                recordOffset, System.currentTimeMillis(), TimestampType.CREATE_TIME, recordKey.length,
+                recordValue.length, recordKey, recordValue, headers, Optional.empty()));
+
+        mirrorSourceTask.commitRecord(sourceRecord, recordMetadata);
+        // We should not have dispatched any more syncs to the producer; this sync was within offset.lag.max of the previous one.
+        verify(producer, times(4)).send(any(), any());
+
+        mirrorSourceTask.commit();
+        // We should dispatch the offset sync that was delayed until the next periodic offset commit.
+        verify(producer, times(5)).send(any(), any());
+        // Ack the latest sync immediately
+        producerCallback.getValue().onCompletion(null, null);
     }
 
     private void compareHeaders(List<Header> expectedHeaders, List<org.apache.kafka.connect.header.Header> taskHeaders) {


### PR DESCRIPTION
MirrorMaker2 defines the `offset.lag.max` configuration, which defines a target interval between offset syncs emitted to the offset syncs topics.

The actual number of offset syncs may be more frequent, if:
1. The connector restarts and hasn't emitted an offset sync yet.
2. The upstream topic has a gap in it (such as from a transaction marker)
3. The downstream topic experiences a truncation

And the actual number of offset syncs may be less frequent, if:
1. The throttling semaphore delays the sync long enough that it can't be emitted before another sync takes it's place.

This is insufficient for finite-length and low-throughput topics, where re-reading `offset.lag.max` records is undesirable.
In these situations, the replication & offset translation mechanisms may be healthy for hours, and still a persistent lag is present.

This PR adds "time-based" offset syncs: The latest offset sync that could be emitted for a topic is emitted every `offset.flush.interval.ms`, which has a default setting of 60 seconds. This means that if a record is mirrored, between 0 and 60 seconds later the connector will attempt to emit an offset sync for that record. 

This contributes N messages/minute to the offset syncs topic in addition to the existing sync throughput. These syncs will be fairly throttled within the existing budget set by the offset sync semaphore, so for MM2 clusters with high numbers of topics, this should still be a manageable sync volume.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
