### PR TITLE
KAFKA-15911: making sure the follower is making progress

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1342,7 +1342,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         UnalignedRecords records = snapshot.slice(partitionSnapshot.position(), Math.min(data.maxBytes(), maxSnapshotSize));
 
         LeaderState<T> state = quorum.leaderStateOrThrow();
-        state.updateCheckQuorumForFollowingVoter(data.replicaId(), currentTimeMs);
+        state.updateCheckQuorumForFollowingVoter(data.replicaId(), currentTimeMs, -1, partitionSnapshot.position());
 
         return FetchSnapshotResponse.singleton(
             log.topicPartition(),

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -60,6 +60,10 @@ public class LeaderState<T> implements EpochState {
     private final BatchAccumulator<T> accumulator;
     // The set includes all of the followers voters that FETCH or FETCH_SNAPSHOT during the current checkQuorumTimer interval.
     private final Set<Integer> fetchedVoters = new HashSet<>();
+    // The map includes all of the followers voters -> previous FETCH offset.
+    private final Map<Integer, Long> fetchedOffset = new HashMap<>();
+    // The map includes all of the followers voters -> previous FETCH_SNAPSHOT position.
+    private final Map<Integer, Long> fetchedPosition = new HashMap<>();
     private final Timer checkQuorumTimer;
     private final int checkQuorumTimeoutMs;
 
@@ -84,6 +88,8 @@ public class LeaderState<T> implements EpochState {
         for (int voterId : voters) {
             boolean hasAcknowledgedLeader = voterId == localId;
             this.voterStates.put(voterId, new ReplicaState(voterId, hasAcknowledgedLeader));
+            this.fetchedOffset.put(voterId, -1L);
+            this.fetchedPosition.put(voterId, -1L);
         }
         this.grantingVoters = Collections.unmodifiableSet(new HashSet<>(grantingVoters));
         this.log = logContext.logger(LeaderState.class);
@@ -118,8 +124,8 @@ public class LeaderState<T> implements EpochState {
      * @param id the node id
      * @param currentTimeMs the current timestamp in millisecond
      */
-    public void updateCheckQuorumForFollowingVoter(int id, long currentTimeMs) {
-        updateFetchedVoters(id);
+    public void updateCheckQuorumForFollowingVoter(int id, long currentTimeMs, long offset, long position) {
+        updateFetchedVoters(id, offset, position);
         // The majority number of the voters excluding the leader. Ex: 3 voters, the value will be 1
         int majority = voterStates.size() / 2;
         if (fetchedVoters.size() >= majority) {
@@ -129,14 +135,44 @@ public class LeaderState<T> implements EpochState {
         }
     }
 
-    private void updateFetchedVoters(int id) {
+    private void updateFetchedVoters(int id, long offset, long position) {
         if (id == localId) {
             throw new IllegalArgumentException("Received a FETCH/FETCH_SNAPSHOT request from the leader itself.");
         }
 
-        if (isVoter(id)) {
+        if (isVoter(id) && (isFetchOffsetAdvanced(id, offset) || isFetchSnapshotPositionAdvanced(id, position))) {
             fetchedVoters.add(id);
         }
+    }
+
+    /**
+     * We treat fetch offset is advanced when:
+     * 1. fetch offset is greater than or equal to leader end offset
+     * 2. if leader end offset is not set yet, we treat the follower is progressing
+     * 3. fetch offset is greater than previous fetch offset
+     *
+     * @param id the node id
+     * @param offset the fetch offset
+     */
+    private boolean isFetchOffsetAdvanced(int id, long offset) {
+        if (offset >= voterStates.get(localId).endOffset.orElse(new LogOffsetMetadata(-1)).offset ||
+                offset > fetchedOffset.get(id)) {
+            fetchedOffset.put(id, offset);
+        }
+        return false;
+    }
+
+    /**
+     * We treat fetch snapshot position is advanced when fetch snapshot position is greater than previous fetch snapshot position
+     *
+     * @param id the node id
+     * @param position the fetch snapshot position
+     */
+    private boolean isFetchSnapshotPositionAdvanced(int id, long position) {
+        if (position > fetchedPosition.get(id)) {
+            fetchedPosition.put(id, position);
+        }
+        return false;
     }
 
     public BatchAccumulator<T> accumulator() {
@@ -345,7 +381,7 @@ public class LeaderState<T> implements EpochState {
             fetchOffsetMetadata,
             leaderEndOffsetOpt
         );
-        updateCheckQuorumForFollowingVoter(replicaId, currentTimeMs);
+        updateCheckQuorumForFollowingVoter(replicaId, currentTimeMs, fetchOffsetMetadata.offset, -1, leaderEndOffsetOpt);
 
         return isVoter(state.nodeId) && maybeUpdateHighWatermark();
     }


### PR DESCRIPTION
Just because the leader returned a successful response to FETCH and FETCH_SNAPSHOT doesn't mean that the followers were able to handle the response correctly.

For example, imagine the case where the log end offset (LEO) is at 1000 and all of the followers are continuously fetching at offset 0 without ever increasing their fetch offset. This can happen if the followers encounter an error when processing the FETCH or FETCH_SNAPSHOT response.

This PR adds `isFetchOffsetAdvanced` and `isFetchSnapshotPositionAdvanced` to fix this potential issue.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
