### PR TITLE
MINOR: Use regctl in docker image promote workflow

### DIFF
--- a/.github/workflows/docker_promote.yml
+++ b/.github/workflows/docker_promote.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Copy RC Image to apache/kafka
-      uses: imjasonh/setup-crane@v0.1
+    - name: Copy RC Image to promoted image
+      uses: iarekylew00t/regctl-installer@v1
     - run: |
-        crane copy ${{ github.event.inputs.rc_docker_image }} ${{ github.event.inputs.promoted_docker_image }}
+        regctl image copy ${{ github.event.inputs.rc_docker_image }} ${{ github.event.inputs.promoted_docker_image }}


### PR DESCRIPTION
Docker Image Promote github Actions Workflow was using crane github action, which is not allowed to run in apache github actions. So now using [regctl](https://github.com/marketplace/actions/regctl-installer) which is in Github Marketplace.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
