### PR TITLE
MINOR: Fix descriptions of raft-metrics in docs/ops.html

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1923,74 +1923,74 @@ These metrics are reported on both Controllers and Brokers in a KRaft Cluster
     <th>Mbean name</th>
   </tr>
   <tr>
-    <td>Current State</td>
+    <td>current-state</td>
     <td>The current state of this member; possible values are leader, candidate, voted, follower, unattached, observer.</td>
-    <td>kafka.server:type=raft-metrics,name=current-state</td>
+    <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>
-    <td>Current Leader</td>
+    <td>current-leader</td>
     <td>The current quorum leader's id; -1 indicates unknown.</td>
-    <td>kafka.server:type=raft-metrics,name=current-leader</td>
+    <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>
-    <td>Current Voted</td>
+    <td>current-vote</td>
     <td>The current voted leader's id; -1 indicates not voted for anyone.</td>
-    <td>kafka.server:type=raft-metrics,name=current-vote</td>
+    <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>
-    <td>Current Epoch</td>
+    <td>current-epoch</td>
     <td>The current quorum epoch.</td>
-    <td>kafka.server:type=raft-metrics,name=current-epoch</td>
+    <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>
-    <td>High Watermark</td>
+    <td>high-watermark</td>
     <td>The high watermark maintained on this member; -1 if it is unknown.</td>
-    <td>kafka.server:type=raft-metrics,name=high-watermark</td>
+    <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>
-    <td>Log End Offset</td>
+    <td>log-end-offset</td>
     <td>The current raft log end offset.</td>
-    <td>kafka.server:type=raft-metrics,name=log-end-offset</td>
+    <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>
-    <td>Number of Unknown Voter Connections</td>
+    <td>number-unknown-voter-connections</td>
     <td>Number of unknown voters whose connection information is not cached. This value of this metric is always 0.</td>
-    <td>kafka.server:type=raft-metrics,name=number-unknown-voter-connections</td>
+    <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>
-    <td>Average Commit Latency</td>
+    <td>commit-latency-avg</td>
     <td>The average time in milliseconds to commit an entry in the raft log.</td>
-    <td>kafka.server:type=raft-metrics,name=commit-latency-avg</td>
+    <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>
-    <td>Maximum Commit Latency</td>
+    <td>commit-latency-max</td>
     <td>The maximum time in milliseconds to commit an entry in the raft log.</td>
-    <td>kafka.server:type=raft-metrics,name=commit-latency-max</td>
+    <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>
-    <td>Average Election Latency</td>
+    <td>election-latency-avg</td>
     <td>The average time in milliseconds spent on electing a new leader.</td>
-    <td>kafka.server:type=raft-metrics,name=election-latency-avg</td>
+    <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>
-    <td>Maximum Election Latency</td>
+    <td>election-latency-max</td>
     <td>The maximum time in milliseconds spent on electing a new leader.</td>
-    <td>kafka.server:type=raft-metrics,name=election-latency-max</td>
+    <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>
-    <td>Fetch Records Rate</td>
+    <td>fetch-records-rate</td>
     <td>The average number of records fetched from the leader of the raft quorum.</td>
-    <td>kafka.server:type=raft-metrics,name=fetch-records-rate</td>
+    <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>
-    <td>Append Records Rate</td>
+    <td>append-records-rate</td>
     <td>The average number of records appended per sec by the leader of the raft quorum.</td>
-    <td>kafka.server:type=raft-metrics,name=append-records-rate</td>
+    <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>
-    <td>Average Poll Idle Ratio</td>
+    <td>poll-idle-ratio-avg</td>
     <td>The average fraction of time the client's poll() is idle as opposed to waiting for the user code to process records.</td>
-    <td>kafka.server:type=raft-metrics,name=poll-idle-ratio-avg</td>
+    <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>
     <td>Current Metadata Version</td>


### PR DESCRIPTION
[The current documentation](https://kafka.apache.org/36/documentation/#kraft_quorum_monitoring
) has descriptions of raft-metrics like the following.

> kafka.server:type=raft-metrics,name=current-state

However, raft-metrics such as current-state are exposed as attributes, not as names.
To fix it, I removed "name=..." from the descriptions and updated "METRIC/ATTRIBUTE NAME" with reference to https://kafka.apache.org/36/documentation/#selector_monitoring.


Appendix:
Below are the results with Kafka 3.6.1.

```sh
$ JMX_PORT=9999 bin/kafka-server-start.sh -daemon config/kraft/server.properties

$ bin/kafka-jmx.sh --object-name kafka.server:type=raft-metrics,name=*
Trying to connect to JMX url: service:jmx:rmi:///jndi/rmi://:9999/jmxrmi
No matched attributes for the queried objects [kafka.server:type=raft-metrics,name=*].

$ bin/kafka-jmx.sh --object-name kafka.server:type=raft-metrics
Trying to connect to JMX url: service:jmx:rmi:///jndi/rmi://:9999/jmxrmi
"time","kafka.server:type=raft-metrics:append-records-rate","kafka.server:type=raft-metrics:commit-latency-avg","kafka.server:type=raft-metrics:commit-latency-max","kafka.server:type=raft-metrics:current-epoch","kafka.server:type=raft-metrics:current-leader","kafka.server:type=raft-metrics:current-state","kafka.server:type=raft-metrics:current-vote","kafka.server:type=raft-metrics:election-latency-avg","kafka.server:type=raft-metrics:election-latency-max","kafka.server:type=raft-metrics:fetch-records-rate","kafka.server:type=raft-metrics:high-watermark","kafka.server:type=raft-metrics:log-end-epoch","kafka.server:type=raft-metrics:log-end-offset","kafka.server:type=raft-metrics:number-unknown-voter-connections","kafka.server:type=raft-metrics:poll-idle-ratio-avg"
1702009513502,0.553877139979859,0.0,0.0,2.0,1.0,leader,1.0,NaN,NaN,0.0,760.0,2.0,760.0,0.0,1.0
^C
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
