### PR TITLE
MINOR: Use docker buildx to promote docker image

### DIFF
--- a/.github/workflows/docker_promote.yml
+++ b/.github/workflows/docker_promote.yml
@@ -30,12 +30,15 @@ jobs:
     if: github.repository == 'apache/kafka'
     runs-on: ubuntu-latest
     steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Copy RC Image to promoted image
-      uses: iarekylew00t/regctl-installer@v1
-    - run: |
-        regctl image copy ${{ github.event.inputs.rc_docker_image }} ${{ github.event.inputs.promoted_docker_image }}
+      run: |
+        docker buildx imagetools create --tag ${{ github.event.inputs.promoted_docker_image }} ${{ github.event.inputs.rc_docker_image }}


### PR DESCRIPTION
Use docker buildx to promote the image. This action is already being used in Release Candidate workflow.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
