### PR TITLE
KAFKA-15366: Modify LogDirFailureTest for KRaft

### DIFF
--- a/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
@@ -101,12 +101,6 @@ class LogDirFailureTest extends IntegrationTestHarness {
     }
   }
 
-  // TODO: depends on KAFKA-15893
-  @Test
-  def kraftBrokerWithOldInterBrokerProtocolShouldHaltOnLogDirFailure(): Unit = {
-    fail("KRaft broker should fail on log dir failure if inter-broker protocol < 3.7")
-  }
-
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
   @ValueSource(strings = Array("zk", "kraft"))
   def testProduceErrorFromFailureOnCheckpoint(quorum: String): Unit = {

--- a/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
@@ -73,7 +73,7 @@ class LogDirFailureTest extends IntegrationTestHarness {
   // Broker should halt on any log directory failure if inter-broker protocol < 1.0
   @nowarn("cat=deprecation")
   @Test
-  def zkBrokerWithOldInterBrokerProtocolShouldHaltOnLogDirFailure(): Unit = {
+  def testZkBrokerWithOldInterBrokerProtocolShouldHaltOnLogDirFailure(): Unit = {
     @volatile var statusCodeOption: Option[Int] = None
     Exit.setHaltProcedure { (statusCode, _) =>
       statusCodeOption = Some(statusCode)
@@ -195,7 +195,7 @@ class LogDirFailureTest extends IntegrationTestHarness {
       // ProduceResponse may contain KafkaStorageException and trigger metadata update
       producer.send(record)
       producer.partitionsFor(topic).asScala.find(_.partition() == 0).get.leader().id() != originalLeaderServerId
-    }, "Expected new leader for the partition", 6000L)
+    }, "Expected new leader for the partition")
 
     // Block on send to ensure that new leader accepts a message.
     producer.send(record).get(6000L, TimeUnit.MILLISECONDS)
@@ -218,7 +218,7 @@ class LogDirFailureTest extends IntegrationTestHarness {
             .getClusterMetadata(broker.clusterId, broker.config.interBrokerListenerName)
             .partition(new TopicPartition(topic, 0)).offlineReplicas().map(_.id()).contains(originalLeaderServerId)
         })
-      }, "Expected to find an offline log dir", 60000L)
+      }, "Expected to find an offline log dir")
     } else {
       // The controller should have marked the replica on the original leader as offline
       val controllerServer = servers.find(_.kafkaController.isActive).get

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1641,7 +1641,7 @@ object TestUtils extends Logging {
   }
 
 
-  def causeLogDirFailure(failureType: LogDirFailureType, leaderBroker: KafkaBroker, partition: TopicPartition): Unit = {
+  def causeLogDirFailure(failureType: LogDirFailureType, leaderBroker: KafkaBroker, partition: TopicPartition): File = {
     // Make log directory of the partition on the leader broker inaccessible by replacing it with a file
     val localLog = leaderBroker.replicaManager.localLogOrException(partition)
     val logDir = localLog.dir.getParentFile
@@ -1658,6 +1658,7 @@ object TestUtils extends Logging {
     // Wait for ReplicaHighWatermarkCheckpoint to happen so that the log directory of the topic will be offline
     waitUntilTrue(() => !leaderBroker.logManager.isLogDirOnline(logDir.getAbsolutePath), "Expected log directory offline", 3000L)
     assertTrue(leaderBroker.replicaManager.localLog(partition).isEmpty)
+    logDir
   }
 
   /**


### PR DESCRIPTION
This commit modifies LogDirFailureTest to be compatible with KRaft based JBOD functionality.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
