### PR TITLE
KAFKA-15556: Remove NetworkClientDelegate methods isUnavailable, maybeThrowAuthFailure, and tryConnect

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
@@ -70,8 +70,10 @@ public class FetchRequestManager extends AbstractFetch implements RequestManager
      */
     @Override
     public PollResult poll(long currentTimeMs) {
+        boolean checkNodeAvailability = false;
+
         return pollInternal(
-                prepareFetchRequests(),
+                prepareFetchRequests(checkNodeAvailability),
                 this::handleFetchSuccess,
                 this::handleFetchFailure
         );
@@ -82,8 +84,10 @@ public class FetchRequestManager extends AbstractFetch implements RequestManager
      */
     @Override
     public PollResult pollOnClose() {
+        boolean checkNodeAvailability = false;
+
         return pollInternal(
-                prepareCloseFetchSessionRequests(),
+                prepareCloseFetchSessionRequests(checkNodeAvailability),
                 this::handleCloseFetchSessionSuccess,
                 this::handleCloseFetchSessionFailure
         );

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -102,7 +102,9 @@ public class Fetcher<K, V> extends AbstractFetch {
      * @return number of fetches sent
      */
     public synchronized int sendFetches() {
-        final Map<Node, FetchSessionHandler.FetchRequestData> fetchRequests = prepareFetchRequests();
+        boolean checkNodeAvailability = true;
+
+        final Map<Node, FetchSessionHandler.FetchRequestData> fetchRequests = prepareFetchRequests(checkNodeAvailability);
         sendFetchesInternal(
                 fetchRequests,
                 (fetchTarget, data, clientResponse) -> {
@@ -119,8 +121,10 @@ public class Fetcher<K, V> extends AbstractFetch {
     }
 
     protected void maybeCloseFetchSessions(final Timer timer) {
+        boolean checkNodeAvailability = true;
+
         final List<RequestFuture<ClientResponse>> requestFutures = sendFetchesInternal(
-                prepareCloseFetchSessionRequests(),
+                prepareCloseFetchSessionRequests(checkNodeAvailability),
                 this::handleCloseFetchSessionSuccess,
                 this::handleCloseFetchSessionFailure
         );

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
@@ -780,10 +780,10 @@ public class FetchRequestManagerTest {
         Node node = initialUpdateResponse.brokers().iterator().next();
 
         client.backoff(node, 500);
-        assertEquals(0, sendFetches());
+        assertEquals(1, sendFetches());
 
         time.sleep(500);
-        assertEquals(1, sendFetches());
+        assertEquals(0, sendFetches());
     }
 
     @Test


### PR DESCRIPTION
Change:

*Refactored `AbstractFetch` so only `Fetcher` will check for node status when creating fetch requests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
