### PR TITLE
KAFKA-15922: Bump MetadataVersion to support JBOD with KRaft

### DIFF
--- a/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
+++ b/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
@@ -117,6 +117,6 @@ public class ClusterTestExtensionsTest {
 
     @ClusterTest
     public void testDefaults(ClusterConfig config) {
-        Assertions.assertEquals(MetadataVersion.IBP_3_7_IV3, config.metadataVersion());
+        Assertions.assertEquals(MetadataVersion.IBP_4_0_IV0, config.metadataVersion());
     }
 }

--- a/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
+++ b/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
@@ -117,6 +117,6 @@ public class ClusterTestExtensionsTest {
 
     @ClusterTest
     public void testDefaults(ClusterConfig config) {
-        Assertions.assertEquals(MetadataVersion.IBP_4_0_IV0, config.metadataVersion());
+        Assertions.assertEquals(MetadataVersion.IBP_3_8_IV0, config.metadataVersion());
     }
 }

--- a/core/src/test/java/kafka/test/annotation/ClusterTest.java
+++ b/core/src/test/java/kafka/test/annotation/ClusterTest.java
@@ -41,6 +41,6 @@ public @interface ClusterTest {
     String name() default "";
     SecurityProtocol securityProtocol() default SecurityProtocol.PLAINTEXT;
     String listener() default "";
-    MetadataVersion metadataVersion() default MetadataVersion.IBP_4_0_IV0;
+    MetadataVersion metadataVersion() default MetadataVersion.IBP_3_8_IV0;
     ClusterConfigProperty[] serverProperties() default {};
 }

--- a/core/src/test/java/kafka/test/annotation/ClusterTest.java
+++ b/core/src/test/java/kafka/test/annotation/ClusterTest.java
@@ -41,6 +41,6 @@ public @interface ClusterTest {
     String name() default "";
     SecurityProtocol securityProtocol() default SecurityProtocol.PLAINTEXT;
     String listener() default "";
-    MetadataVersion metadataVersion() default MetadataVersion.IBP_3_7_IV3;
+    MetadataVersion metadataVersion() default MetadataVersion.IBP_4_0_IV0;
     ClusterConfigProperty[] serverProperties() default {};
 }

--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -73,7 +73,9 @@ object ZkMigrationIntegrationTest {
       MetadataVersion.IBP_3_6_IV2,
       MetadataVersion.IBP_3_7_IV0,
       MetadataVersion.IBP_3_7_IV1,
-      MetadataVersion.IBP_3_7_IV2
+      MetadataVersion.IBP_3_7_IV2,
+      MetadataVersion.IBP_3_7_IV4,
+      MetadataVersion.IBP_3_8_IV0
     ).foreach { mv =>
       val clusterConfig = ClusterConfig.defaultClusterBuilder()
         .metadataVersion(mv)

--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -73,8 +73,7 @@ object ZkMigrationIntegrationTest {
       MetadataVersion.IBP_3_6_IV2,
       MetadataVersion.IBP_3_7_IV0,
       MetadataVersion.IBP_3_7_IV1,
-      MetadataVersion.IBP_3_7_IV2,
-      MetadataVersion.IBP_4_0_IV0
+      MetadataVersion.IBP_3_7_IV2
     ).foreach { mv =>
       val clusterConfig = ClusterConfig.defaultClusterBuilder()
         .metadataVersion(mv)

--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -74,7 +74,7 @@ object ZkMigrationIntegrationTest {
       MetadataVersion.IBP_3_7_IV0,
       MetadataVersion.IBP_3_7_IV1,
       MetadataVersion.IBP_3_7_IV2,
-      MetadataVersion.IBP_3_7_IV3
+      MetadataVersion.IBP_4_0_IV0
     ).foreach { mv =>
       val clusterConfig = ClusterConfig.defaultClusterBuilder()
         .metadataVersion(mv)

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -123,7 +123,7 @@ public class PartitionChangeBuilderTest {
             case (short) 1:
                 return MetadataVersion.IBP_3_7_IV2;
             case (short) 2:
-                return MetadataVersion.IBP_4_0_IV0;
+                return MetadataVersion.IBP_3_8_IV0;
             default:
                 throw new RuntimeException("Unknown PartitionChangeRecord version " + version);
         }

--- a/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/PartitionChangeBuilderTest.java
@@ -123,7 +123,7 @@ public class PartitionChangeBuilderTest {
             case (short) 1:
                 return MetadataVersion.IBP_3_7_IV2;
             case (short) 2:
-                return MetadataVersion.IBP_3_7_IV3;
+                return MetadataVersion.IBP_4_0_IV0;
             default:
                 throw new RuntimeException("Unknown PartitionChangeRecord version " + version);
         }

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -192,7 +192,7 @@ public class QuorumControllerTest {
         ) {
             controlEnv.activeController().registerBroker(ANONYMOUS_CONTEXT,
                 new BrokerRegistrationRequestData().
-                setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_4_0_IV0)).
+                setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_8_IV0)).
                 setBrokerId(0).
                 setLogDirs(Collections.singletonList(Uuid.fromString("iiaQjkRPQcuMULNII0MUeA"))).
                 setClusterId(logEnv.clusterId())).get();
@@ -236,7 +236,7 @@ public class QuorumControllerTest {
         ) {
             controlEnv.activeController().registerBroker(ANONYMOUS_CONTEXT,
                 new BrokerRegistrationRequestData().
-                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_4_0_IV0)).
+                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_8_IV0)).
                     setBrokerId(0).
                     setLogDirs(Collections.singletonList(Uuid.fromString("sTbzRAMnTpahIyIPNjiLhw"))).
                     setClusterId(logEnv.clusterId())).get();
@@ -579,7 +579,7 @@ public class QuorumControllerTest {
                     setBrokerId(0).
                     setClusterId(active.clusterId()).
                     setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwBA")).
-                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_4_0_IV0)).
+                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_8_IV0)).
                     setLogDirs(Collections.singletonList(Uuid.fromString("vBpaRsZVSaGsQT53wtYGtg"))).
                     setListeners(listeners));
             assertEquals(5L, reply.get().epoch());

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -192,7 +192,7 @@ public class QuorumControllerTest {
         ) {
             controlEnv.activeController().registerBroker(ANONYMOUS_CONTEXT,
                 new BrokerRegistrationRequestData().
-                setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV3)).
+                setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_4_0_IV0)).
                 setBrokerId(0).
                 setLogDirs(Collections.singletonList(Uuid.fromString("iiaQjkRPQcuMULNII0MUeA"))).
                 setClusterId(logEnv.clusterId())).get();
@@ -236,7 +236,7 @@ public class QuorumControllerTest {
         ) {
             controlEnv.activeController().registerBroker(ANONYMOUS_CONTEXT,
                 new BrokerRegistrationRequestData().
-                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV3)).
+                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_4_0_IV0)).
                     setBrokerId(0).
                     setLogDirs(Collections.singletonList(Uuid.fromString("sTbzRAMnTpahIyIPNjiLhw"))).
                     setClusterId(logEnv.clusterId())).get();
@@ -579,7 +579,7 @@ public class QuorumControllerTest {
                     setBrokerId(0).
                     setClusterId(active.clusterId()).
                     setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwBA")).
-                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_3_7_IV3)).
+                    setFeatures(brokerFeatures(MetadataVersion.IBP_3_0_IV1, MetadataVersion.IBP_4_0_IV0)).
                     setLogDirs(Collections.singletonList(Uuid.fromString("vBpaRsZVSaGsQT53wtYGtg"))).
                     setListeners(listeners));
             assertEquals(5L, reply.get().epoch());

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -283,7 +283,7 @@ public class PartitionRegistrationTest {
         return Arrays.asList(
             MetadataVersion.IBP_3_7_IV1,
             MetadataVersion.IBP_3_7_IV2,
-            MetadataVersion.IBP_4_0_IV0
+            MetadataVersion.IBP_3_8_IV0
         ).stream().map(mv -> Arguments.of(mv));
     }
 
@@ -369,7 +369,7 @@ public class PartitionRegistrationTest {
             setPartitionEpoch(0);
         List<UnwritableMetadataException> exceptions = new ArrayList<>();
         ImageWriterOptions options = new ImageWriterOptions.Builder().
-            setMetadataVersion(MetadataVersion.IBP_4_0_IV0).
+            setMetadataVersion(MetadataVersion.IBP_3_8_IV0).
             setLossHandler(exceptions::add).
             build();
         assertEquals(new ApiMessageAndVersion(expectRecord, (short) 2), partitionRegistration.toRecord(topicID, 0, options));

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -283,7 +283,7 @@ public class PartitionRegistrationTest {
         return Arrays.asList(
             MetadataVersion.IBP_3_7_IV1,
             MetadataVersion.IBP_3_7_IV2,
-            MetadataVersion.IBP_3_7_IV3
+            MetadataVersion.IBP_4_0_IV0
         ).stream().map(mv -> Arguments.of(mv));
     }
 
@@ -369,7 +369,7 @@ public class PartitionRegistrationTest {
             setPartitionEpoch(0);
         List<UnwritableMetadataException> exceptions = new ArrayList<>();
         ImageWriterOptions options = new ImageWriterOptions.Builder().
-            setMetadataVersion(MetadataVersion.IBP_3_7_IV3).
+            setMetadataVersion(MetadataVersion.IBP_4_0_IV0).
             setLossHandler(exceptions::add).
             build();
         assertEquals(new ApiMessageAndVersion(expectRecord, (short) 2), partitionRegistration.toRecord(topicID, 0, options));

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -194,8 +194,13 @@ public enum MetadataVersion {
     // Add JBOD support for KRaft.
     IBP_3_7_IV2(17, "3.7", "IV2", true),
 
+    // IBP_3_7_IV3 was ELR related supports (KIP-966) and has been moved forward
+
+    // Add new fetch request version for KIP-951
+    IBP_3_7_IV4(19, "3.7", "IV4", false),
+
     // Add ELR related supports (KIP-966).
-    IBP_4_0_IV0(18, "4.0", "IV0", true);
+    IBP_3_8_IV0(20, "3.8", "IV0", true);
 
     // NOTES when adding a new version:
     //   Update the default version in @ClusterTest annotation to point to the latest version
@@ -221,7 +226,7 @@ public enum MetadataVersion {
      * <strong>Think carefully before you update this value. ONCE A METADATA VERSION IS PRODUCTION,
      * IT CANNOT BE CHANGED.</strong>
      */
-    public static final MetadataVersion LATEST_PRODUCTION = IBP_3_7_IV2;
+    public static final MetadataVersion LATEST_PRODUCTION = IBP_3_7_IV4;
 
     /**
      * An array containing all of the MetadataVersion entries.
@@ -316,7 +321,7 @@ public enum MetadataVersion {
     }
 
     public boolean isElrSupported() {
-        return this.isAtLeast(IBP_4_0_IV0);
+        return this.isAtLeast(IBP_3_8_IV0);
     }
 
     public boolean isKRaftSupported() {
@@ -393,7 +398,7 @@ public enum MetadataVersion {
     }
 
     public short fetchRequestVersion() {
-        if (this.isAtLeast(IBP_3_7_IV0)) {
+        if (this.isAtLeast(IBP_3_7_IV4)) {
             return 16;
         } else if (this.isAtLeast(IBP_3_5_IV1)) {
             return 15;

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -195,7 +195,7 @@ public enum MetadataVersion {
     IBP_3_7_IV2(17, "3.7", "IV2", true),
 
     // Add ELR related supports (KIP-966).
-    IBP_3_7_IV3(18, "3.7", "IV3", true);
+    IBP_4_0_IV0(18, "4.0", "IV0", true);
 
     // NOTES when adding a new version:
     //   Update the default version in @ClusterTest annotation to point to the latest version
@@ -316,7 +316,7 @@ public enum MetadataVersion {
     }
 
     public boolean isElrSupported() {
-        return this.isAtLeast(IBP_3_7_IV3);
+        return this.isAtLeast(IBP_4_0_IV0);
     }
 
     public boolean isKRaftSupported() {

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -195,6 +195,7 @@ public enum MetadataVersion {
     IBP_3_7_IV2(17, "3.7", "IV2", true),
 
     // IBP_3_7_IV3 was ELR related supports (KIP-966) and has been moved forward
+    IBP_3_7_IV3(18, "3.7", "IV3", false),
 
     // Add new fetch request version for KIP-951
     IBP_3_7_IV4(19, "3.7", "IV4", false),

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -194,7 +194,8 @@ public enum MetadataVersion {
     // Add JBOD support for KRaft.
     IBP_3_7_IV2(17, "3.7", "IV2", true),
 
-    // IBP_3_7_IV3 was ELR related supports (KIP-966) and has been moved forward
+    // IBP_3_7_IV3 was reserved for ELR support (KIP-966) but has been moved forward to
+    // a later release requiring a new MetadataVersion. MVs are not reused.
     IBP_3_7_IV3(18, "3.7", "IV3", false),
 
     // Add new fetch request version for KIP-951

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -221,7 +221,7 @@ public enum MetadataVersion {
      * <strong>Think carefully before you update this value. ONCE A METADATA VERSION IS PRODUCTION,
      * IT CANNOT BE CHANGED.</strong>
      */
-    public static final MetadataVersion LATEST_PRODUCTION = IBP_3_7_IV0;
+    public static final MetadataVersion LATEST_PRODUCTION = IBP_3_7_IV2;
 
     /**
      * An array containing all of the MetadataVersion entries.

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -166,13 +166,12 @@ class MetadataVersionTest {
         assertEquals(IBP_3_6_IV2, MetadataVersion.fromVersionString("3.6-IV2"));
 
         // 3.7-IV0 is the latest production version in the 3.7 line
-        assertEquals(IBP_3_7_IV0, MetadataVersion.fromVersionString("3.7"));
+        assertEquals(IBP_3_7_IV2, MetadataVersion.fromVersionString("3.7"));
 
         assertEquals(IBP_3_7_IV0, MetadataVersion.fromVersionString("3.7-IV0"));
         assertEquals(IBP_3_7_IV1, MetadataVersion.fromVersionString("3.7-IV1"));
         assertEquals(IBP_3_7_IV2, MetadataVersion.fromVersionString("3.7-IV2"));
 
-        assertEquals(IBP_4_0_IV0, MetadataVersion.fromVersionString("4.0"));
         assertEquals(IBP_4_0_IV0, MetadataVersion.fromVersionString("4.0-IV0"));
     }
 

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -171,7 +171,9 @@ class MetadataVersionTest {
         assertEquals(IBP_3_7_IV0, MetadataVersion.fromVersionString("3.7-IV0"));
         assertEquals(IBP_3_7_IV1, MetadataVersion.fromVersionString("3.7-IV1"));
         assertEquals(IBP_3_7_IV2, MetadataVersion.fromVersionString("3.7-IV2"));
-        assertEquals(IBP_3_7_IV3, MetadataVersion.fromVersionString("3.7-IV3"));
+
+        assertEquals(IBP_4_0_IV0, MetadataVersion.fromVersionString("4.0"));
+        assertEquals(IBP_4_0_IV0, MetadataVersion.fromVersionString("4.0-IV0"));
     }
 
     @Test
@@ -274,7 +276,7 @@ class MetadataVersionTest {
         assertEquals("3.7-IV0", IBP_3_7_IV0.version());
         assertEquals("3.7-IV1", IBP_3_7_IV1.version());
         assertEquals("3.7-IV2", IBP_3_7_IV2.version());
-        assertEquals("3.7-IV3", IBP_3_7_IV3.version());
+        assertEquals("4.0-IV0", IBP_4_0_IV0.version());
     }
 
     @Test
@@ -342,7 +344,7 @@ class MetadataVersionTest {
     @ParameterizedTest
     @EnumSource(value = MetadataVersion.class)
     public void testIsElrSupported(MetadataVersion metadataVersion) {
-        assertEquals(metadataVersion.isAtLeast(IBP_3_7_IV3), metadataVersion.isElrSupported());
+        assertEquals(metadataVersion.isAtLeast(IBP_4_0_IV0), metadataVersion.isElrSupported());
     }
 
     @ParameterizedTest

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -165,7 +165,7 @@ class MetadataVersionTest {
         assertEquals(IBP_3_6_IV1, MetadataVersion.fromVersionString("3.6-IV1"));
         assertEquals(IBP_3_6_IV2, MetadataVersion.fromVersionString("3.6-IV2"));
 
-        // 3.7-IV0 is the latest production version in the 3.7 line
+        // 3.7-IV2 is the latest production version in the 3.7 line
         assertEquals(IBP_3_7_IV2, MetadataVersion.fromVersionString("3.7"));
 
         assertEquals(IBP_3_7_IV0, MetadataVersion.fromVersionString("3.7-IV0"));

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -165,12 +165,13 @@ class MetadataVersionTest {
         assertEquals(IBP_3_6_IV1, MetadataVersion.fromVersionString("3.6-IV1"));
         assertEquals(IBP_3_6_IV2, MetadataVersion.fromVersionString("3.6-IV2"));
 
-        // 3.7-IV2 is the latest production version in the 3.7 line
-        assertEquals(IBP_3_7_IV2, MetadataVersion.fromVersionString("3.7"));
+        // 3.7-IV4 is the latest production version in the 3.7 line
+        assertEquals(IBP_3_7_IV4, MetadataVersion.fromVersionString("3.7"));
 
         assertEquals(IBP_3_7_IV0, MetadataVersion.fromVersionString("3.7-IV0"));
         assertEquals(IBP_3_7_IV1, MetadataVersion.fromVersionString("3.7-IV1"));
         assertEquals(IBP_3_7_IV2, MetadataVersion.fromVersionString("3.7-IV2"));
+        assertEquals(IBP_3_7_IV3, MetadataVersion.fromVersionString("3.7-IV3"));
         assertEquals(IBP_3_7_IV4, MetadataVersion.fromVersionString("3.7-IV4"));
 
         assertEquals(IBP_3_8_IV0, MetadataVersion.fromVersionString("3.8-IV0"));
@@ -278,6 +279,7 @@ class MetadataVersionTest {
         assertEquals("3.7-IV0", IBP_3_7_IV0.version());
         assertEquals("3.7-IV1", IBP_3_7_IV1.version());
         assertEquals("3.7-IV2", IBP_3_7_IV2.version());
+        assertEquals("3.7-IV3", IBP_3_7_IV3.version());
         assertEquals("3.7-IV4", IBP_3_7_IV4.version());
         assertEquals("3.8-IV0", IBP_3_8_IV0.version());
     }

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -232,6 +232,7 @@ class MetadataVersionTest {
         assertEquals("3.7", IBP_3_7_IV0.shortVersion());
         assertEquals("3.7", IBP_3_7_IV1.shortVersion());
         assertEquals("3.7", IBP_3_7_IV2.shortVersion());
+        assertEquals("3.7", IBP_3_7_IV3.shortVersion());
         assertEquals("3.7", IBP_3_7_IV4.shortVersion());
     }
 

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -171,8 +171,9 @@ class MetadataVersionTest {
         assertEquals(IBP_3_7_IV0, MetadataVersion.fromVersionString("3.7-IV0"));
         assertEquals(IBP_3_7_IV1, MetadataVersion.fromVersionString("3.7-IV1"));
         assertEquals(IBP_3_7_IV2, MetadataVersion.fromVersionString("3.7-IV2"));
+        assertEquals(IBP_3_7_IV4, MetadataVersion.fromVersionString("3.7-IV4"));
 
-        assertEquals(IBP_4_0_IV0, MetadataVersion.fromVersionString("4.0-IV0"));
+        assertEquals(IBP_3_8_IV0, MetadataVersion.fromVersionString("3.8-IV0"));
     }
 
     @Test
@@ -229,6 +230,8 @@ class MetadataVersionTest {
         assertEquals("3.6", IBP_3_6_IV2.shortVersion());
         assertEquals("3.7", IBP_3_7_IV0.shortVersion());
         assertEquals("3.7", IBP_3_7_IV1.shortVersion());
+        assertEquals("3.7", IBP_3_7_IV2.shortVersion());
+        assertEquals("3.7", IBP_3_7_IV4.shortVersion());
     }
 
     @Test
@@ -275,7 +278,8 @@ class MetadataVersionTest {
         assertEquals("3.7-IV0", IBP_3_7_IV0.version());
         assertEquals("3.7-IV1", IBP_3_7_IV1.version());
         assertEquals("3.7-IV2", IBP_3_7_IV2.version());
-        assertEquals("4.0-IV0", IBP_4_0_IV0.version());
+        assertEquals("3.7-IV4", IBP_3_7_IV4.version());
+        assertEquals("3.8-IV0", IBP_3_8_IV0.version());
     }
 
     @Test
@@ -343,7 +347,7 @@ class MetadataVersionTest {
     @ParameterizedTest
     @EnumSource(value = MetadataVersion.class)
     public void testIsElrSupported(MetadataVersion metadataVersion) {
-        assertEquals(metadataVersion.isAtLeast(IBP_4_0_IV0), metadataVersion.isElrSupported());
+        assertEquals(metadataVersion.isAtLeast(IBP_3_8_IV0), metadataVersion.isElrSupported());
     }
 
     @ParameterizedTest

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -68,7 +68,7 @@ public class FeatureCommandTest {
         );
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 3.7-IV3\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(commandOutput));
+                "SupportedMaxVersion: 4.0-IV0\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(commandOutput));
     }
 
     @ClusterTest(clusterType = Type.KRAFT, metadataVersion = MetadataVersion.IBP_3_7_IV0)
@@ -78,7 +78,7 @@ public class FeatureCommandTest {
         );
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 3.7-IV3\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(commandOutput));
+                "SupportedMaxVersion: 4.0-IV0\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(commandOutput));
     }
 
     @ClusterTest(clusterType = Type.ZK, metadataVersion = MetadataVersion.IBP_3_3_IV1)

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -68,17 +68,17 @@ public class FeatureCommandTest {
         );
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 4.0-IV0\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(commandOutput));
+                "SupportedMaxVersion: 3.8-IV0\tFinalizedVersionLevel: 3.3-IV1\t", outputWithoutEpoch(commandOutput));
     }
 
-    @ClusterTest(clusterType = Type.KRAFT, metadataVersion = MetadataVersion.IBP_3_7_IV0)
+    @ClusterTest(clusterType = Type.KRAFT, metadataVersion = MetadataVersion.IBP_3_7_IV4)
     public void testDescribeWithKRaftAndBootstrapControllers() {
         String commandOutput = ToolsTestUtils.captureStandardOut(() ->
                 assertEquals(0, FeatureCommand.mainNoExit("--bootstrap-controller", cluster.bootstrapControllers(), "describe"))
         );
         // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
         assertEquals("Feature: metadata.version\tSupportedMinVersion: 3.0-IV1\t" +
-                "SupportedMaxVersion: 4.0-IV0\tFinalizedVersionLevel: 3.7-IV0\t", outputWithoutEpoch(commandOutput));
+                "SupportedMaxVersion: 3.8-IV0\tFinalizedVersionLevel: 3.7-IV4\t", outputWithoutEpoch(commandOutput));
     }
 
     @ClusterTest(clusterType = Type.ZK, metadataVersion = MetadataVersion.IBP_3_3_IV1)
@@ -137,7 +137,7 @@ public class FeatureCommandTest {
         );
         // Change expected message to reflect possible MetadataVersion range 1-N (N increases when adding a new version)
         assertEquals("Could not disable metadata.version. Invalid update version 0 for feature " +
-                "metadata.version. Local controller 3000 only supports versions 1-18", commandOutput);
+                "metadata.version. Local controller 3000 only supports versions 1-20", commandOutput);
 
         commandOutput = ToolsTestUtils.captureStandardOut(() ->
                 assertEquals(1, FeatureCommand.mainNoExit("--bootstrap-server", cluster.bootstrapServers(),


### PR DESCRIPTION
Update the LATEST_PRODUCTION to include JBOD and fetch request for KIP-951. 

Remove ELR MetadataVersion from 3.7 and push it to 3.8. Since it was not considered stable the MV is burned.

Add 3.8-IV0 as the next MetadataVersion which is currently not considered stable.

Fix tests to reflect this state.