### PR TITLE
MINOR: Allow Block.resetBlockLatch to release blocked operation for end-of-test cleanup

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -138,8 +138,8 @@ public class BlockingConnectorTest {
     @After
     public void close() {
         // stop all Connect, Kafka and Zk threads.
-        connect.stop();
         Block.resetBlockLatch();
+        connect.stop();
     }
 
     @Test
@@ -349,8 +349,9 @@ public class BlockingConnectorTest {
         connect.requestTimeout(ConnectResource.DEFAULT_REST_REQUEST_TIMEOUT_MS);
     }
 
-    private static class Block {
+    public static class Block {
         private static CountDownLatch blockLatch;
+        private static CountDownLatch clearLatch;
 
         private final String block;
 
@@ -392,6 +393,10 @@ public class BlockingConnectorTest {
                     blockLatch.countDown();
                     blockLatch = null;
                 }
+                if (clearLatch != null) {
+                    clearLatch.countDown();
+                    clearLatch = null;
+                }
             }
         }
 
@@ -406,6 +411,7 @@ public class BlockingConnectorTest {
                     blockLatch.countDown();
                 }
                 blockLatch = new CountDownLatch(1);
+                clearLatch = new CountDownLatch(1);
             }
         }
 
@@ -415,7 +421,8 @@ public class BlockingConnectorTest {
                 blockLatch.countDown();
                 while (true) {
                     try {
-                        Thread.sleep(Long.MAX_VALUE);
+                        clearLatch.await(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+                        return;
                     } catch (InterruptedException e) {
                         // No-op. Just keep blocking.
                     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
@@ -429,6 +429,7 @@ public class OffsetsApiIntegrationTest {
         ConnectRestException e = assertThrows(ConnectRestException.class,
                 () -> connect.alterConnectorOffsets(CONNECTOR_NAME, new ConnectorOffsets(offsetsToAlter)));
         assertThat(e.getMessage(), containsString("zombie sink task"));
+        BlockingConnectorTest.Block.resetBlockLatch();
     }
 
     @Test
@@ -785,6 +786,7 @@ public class OffsetsApiIntegrationTest {
         // Try to reset the offsets
         ConnectRestException e = assertThrows(ConnectRestException.class, () -> connect.resetConnectorOffsets(CONNECTOR_NAME));
         assertThat(e.getMessage(), containsString("zombie sink task"));
+        BlockingConnectorTest.Block.resetBlockLatch();
     }
 
     @Test


### PR DESCRIPTION
The kafka.utils.TestUtils.verifyNoUnexpectedThreads method used before and after core tests finds threads leaked by these tests. If these tests run before core tests, then those tests will all fail this assertion.

Instead of leaving the blocked connectors blocking indefinitely, they should block just long enough for the test to verify the desired behavior. After the test is complete, the test should signal to the blocked connector to exit the block and return control to the framework, which can then do it's cancellation operations.

In the future we can augment the tests to verify the behavior of the thread after cancellation by triggering the reset before the end of the test.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
