### PR TITLE
KAFKA-15981: update Group size only when groups size changes

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1758,8 +1758,7 @@ public class GroupMetadataManager {
 
     /**
      * The coordinator has been loaded. Session timeouts are registered
-     * for all members. Increment the group size metrics for each group
-     * that was successfully loaded.
+     * for all members.
      */
     public void onLoaded() {
         groups.forEach((groupId, group) -> {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -190,8 +190,6 @@ public class ConsumerGroup implements Group {
         this.targetAssignment = new TimelineHashMap<>(snapshotRegistry, 0);
         this.currentPartitionEpoch = new TimelineHashMap<>(snapshotRegistry, 0);
         this.metrics = Objects.requireNonNull(metrics);
-
-        metrics.onConsumerGroupStateTransition(null, this.state.get());
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/generic/GenericGroup.java
@@ -236,7 +236,6 @@ public class GenericGroup implements Group {
         this.protocolName = protocolName;
         this.leaderId = leaderId;
         this.currentStateTimestamp = currentStateTimestamp;
-        metrics.onGenericGroupStateTransition(null, initialState);
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -159,6 +159,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -10680,6 +10681,103 @@ public class GroupMetadataManagerTest {
                 .setTopicPartitions(Collections.emptyList()));
 
         verify(context.metrics).record(CONSUMER_GROUP_REBALANCES_SENSOR_NAME);
+    }
+
+    @Test
+    public void testOnGenericGroupStateTransition() {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+
+        // Creating a generic group should increment metric.
+        GenericGroup group = context.createGenericGroup("group-id");
+        verify(context.metrics, times(1)).onGenericGroupStateTransition(null, EMPTY);
+
+        // Replaying a new group should not increment metric as the group was already created.
+        context.replay(RecordHelpers.newGroupMetadataRecord(group, Collections.emptyMap(), MetadataVersion.LATEST_PRODUCTION));
+        verify(context.metrics, times(1)).onGenericGroupStateTransition(null, EMPTY);
+
+        // Loading a tombstone should remove group and decrement metric.
+        context.createGenericGroup("group-id");
+        context.replay(RecordHelpers.newGroupMetadataTombstoneRecord("group-id"));
+        verify(context.metrics, times(1)).onGenericGroupStateTransition(EMPTY, null);
+        assertThrows(GroupIdNotFoundException.class, () -> context.groupMetadataManager.group("group-id"));
+
+        // Replaying a tombstone for a group that has already been deleted should not decrement metric.
+        context.replay(RecordHelpers.newGroupMetadataTombstoneRecord("group-id"));
+        verify(context.metrics, times(1)).onGenericGroupStateTransition(EMPTY, null);
+    }
+
+    @Test
+    public void testOnGenericGroupStateTransitionOnLoading() {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+
+        GenericGroup group = new GenericGroup(
+            new LogContext(),
+            "group-id",
+            EMPTY,
+            context.time,
+            context.metrics
+        );
+
+        // Even if there are more group metadata records loaded than tombstone records, the last replayed record
+        // (tombstone in this test) is the latest state of the group. Hence, the overall metric count should be 0.
+        IntStream.range(0, 5).forEach(__ -> {
+            context.replay(RecordHelpers.newGroupMetadataRecord(group, Collections.emptyMap(), MetadataVersion.LATEST_PRODUCTION));
+        });
+        IntStream.range(0, 4).forEach(__ -> {
+            context.replay(RecordHelpers.newGroupMetadataTombstoneRecord("group-id"));
+        });
+
+        verify(context.metrics, times(1)).onGenericGroupStateTransition(null, EMPTY);
+        verify(context.metrics, times(1)).onGenericGroupStateTransition(EMPTY, null);
+    }
+
+    @Test
+    public void testOnConsumerGroupStateTransition() {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+
+        // Replaying a consumer group epoch record should increment metric.
+        context.replay(RecordHelpers.newGroupEpochRecord("group-id", 1));
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(null, ConsumerGroup.ConsumerGroupState.EMPTY);
+
+        // Replaying a consumer group epoch record for a group that has already been created should not increment metric.
+        context.replay(RecordHelpers.newGroupEpochRecord("group-id", 1));
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(null, ConsumerGroup.ConsumerGroupState.EMPTY);
+
+        // Creating and replaying tombstones for a group should remove group and decrement metric.
+        List<Record> tombstones = new ArrayList<>();
+        Group group = context.groupMetadataManager.group("group-id");
+        group.createGroupTombstoneRecords(tombstones);
+        tombstones.forEach(context::replay);
+        assertThrows(GroupIdNotFoundException.class, () -> context.groupMetadataManager.group("group-id"));
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.EMPTY, null);
+
+        // Replaying a tombstone for a group that has already been removed should not decrement metric.
+        tombstones.forEach(tombstone -> assertThrows(GroupIdNotFoundException.class, () -> context.replay(tombstone)));
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.EMPTY, null);
+    }
+
+    @Test
+    public void testOnConsumerGroupStateTransitionOnLoading() {
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+
+        // Even if there are more group epoch records loaded than tombstone records, the last replayed record
+        // (tombstone in this test) is the latest state of the group. Hence, the overall metric count should be 0.
+        IntStream.range(0, 5).forEach(__ -> {
+            context.replay(RecordHelpers.newGroupEpochRecord("group-id", 0));
+        });
+        context.replay(RecordHelpers.newTargetAssignmentEpochTombstoneRecord("group-id"));
+        context.replay(RecordHelpers.newGroupEpochTombstoneRecord("group-id"));
+        IntStream.range(0, 3).forEach(__ -> {
+            assertThrows(GroupIdNotFoundException.class, () -> context.replay(RecordHelpers.newTargetAssignmentEpochTombstoneRecord("group-id")));
+            assertThrows(GroupIdNotFoundException.class, () -> context.replay(RecordHelpers.newGroupEpochTombstoneRecord("group-id")));
+        });
+
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(null, ConsumerGroup.ConsumerGroupState.EMPTY);
+        verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.EMPTY, null);
     }
 
     private static void assertNoOrEmptyResult(List<ExpiredTimeout<Void, Record>> timeouts) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.timeline.SnapshotRegistry;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.stream.IntStream;
 
 import static org.apache.kafka.coordinator.group.generic.GenericGroupState.COMPLETING_REBALANCE;
 import static org.apache.kafka.coordinator.group.generic.GenericGroupState.DEAD;
@@ -130,6 +131,11 @@ public class GroupCoordinatorMetricsShardTest {
         GenericGroup group2 = new GenericGroup(logContext, "groupId2", EMPTY, Time.SYSTEM, shard);
         GenericGroup group3 = new GenericGroup(logContext, "groupId3", EMPTY, Time.SYSTEM, shard);
 
+        IntStream.range(0, 4).forEach(__ -> {
+            shard.incrementLocalGauge(NUM_GENERIC_GROUPS);
+            shard.incrementGlobalGauge(NUM_GENERIC_GROUPS_EMPTY);
+        });
+
         snapshotRegistry.getOrCreateSnapshot(1000);
         shard.commitUpTo(1000);
         assertEquals(4, shard.localGaugeValue(NUM_GENERIC_GROUPS));
@@ -197,6 +203,11 @@ public class GroupCoordinatorMetricsShardTest {
             "group-3",
             shard
         );
+
+        IntStream.range(0, 4).forEach(__ -> {
+            shard.incrementLocalGauge(NUM_CONSUMER_GROUPS);
+            shard.incrementLocalGauge(NUM_CONSUMER_GROUPS_EMPTY);
+        });
 
         snapshotRegistry.getOrCreateSnapshot(1000);
         shard.commitUpTo(1000);


### PR DESCRIPTION
Currently, we increment generic group metrics whenever we create a new Group object when we load a partition. This is incorrect as the partition may contain several records for the same group if in the active segment or if the segment has not yet been compacted. 

The same applies to removing groups; we can possibly have multiple group tombstone records. Instead, only increment the metric if we created a new group and only decrement the metric if the group exists.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
