### PR TITLE
MINOR: Give FETCH request own MetadataVersion for KIP-951

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -195,7 +195,10 @@ public enum MetadataVersion {
     IBP_3_7_IV2(17, "3.7", "IV2", true),
 
     // Add ELR related supports (KIP-966).
-    IBP_3_7_IV3(18, "3.7", "IV3", true);
+    IBP_3_7_IV3(18, "3.7", "IV3", true),
+
+    // Add new fetch request version for KIP-951
+    IBP_3_7_IV4(19, "3.7", "IV4", false);
 
     // NOTES when adding a new version:
     //   Update the default version in @ClusterTest annotation to point to the latest version
@@ -393,7 +396,7 @@ public enum MetadataVersion {
     }
 
     public short fetchRequestVersion() {
-        if (this.isAtLeast(IBP_3_7_IV0)) {
+        if (this.isAtLeast(IBP_3_7_IV4)) {
             return 16;
         } else if (this.isAtLeast(IBP_3_5_IV1)) {
             return 15;


### PR DESCRIPTION
https://github.com/apache/kafka/commit/c8f687ac1505456cb568de2b60df235eb1ceb5f0 was incorrect in reusing the same metadata version to enable the new fetch request. 

This fixes the issue by giving the version bump its own metadata version.

Note -- this is a no-op in running code. The fetch request to replica fetchers will be the same semantically. We just wanted to fix upgrades with MV 3_7_IV0 that could encounter unknown fetch versions when upgrading from a version that didn't contain this change to one that did.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
