### PR TITLE
MINOR: Client state machine fix for fencing while preparing to leave

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MemberState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MemberState.java
@@ -131,7 +131,7 @@ public enum MemberState {
 
         LEAVING.previousValidStates = Arrays.asList(PREPARE_LEAVING);
 
-        UNSUBSCRIBED.previousValidStates = Arrays.asList(LEAVING);
+        UNSUBSCRIBED.previousValidStates = Arrays.asList(PREPARE_LEAVING, LEAVING);
 
         STALED.previousValidStates = Arrays.asList(JOINING, RECONCILING, ACKNOWLEDGING, STABLE);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -401,7 +401,18 @@ public class MembershipManagerImpl implements MembershipManager, ClusterResource
      */
     @Override
     public void transitionToFenced() {
-        if (state == MemberState.PREPARE_LEAVING || state == MemberState.LEAVING) {
+        if (state == MemberState.PREPARE_LEAVING) {
+            log.debug("Member {} with epoch {} got fenced but it is already preparing to leave " +
+                    "the group, so it will stop sending heartbeat and won't attempt to rejoin.",
+                memberId, memberEpoch);
+            // Transition to UNSUBSCRIBED, ensuring that the member (that is not part of the
+            // group anymore from the broker point of view) will stop sending heartbeats while it
+            // completes the ongoing leaving operation.
+            transitionTo(MemberState.UNSUBSCRIBED);
+            return;
+        }
+
+        if (state == MemberState.LEAVING) {
             log.debug("Member {} with epoch {} got fenced but it is already leaving the group " +
                     "with state {}, so it won't attempt to rejoin.", memberId, memberEpoch, state);
             return;
@@ -591,6 +602,11 @@ public class MembershipManagerImpl implements MembershipManager, ClusterResource
         if (state == MemberState.FATAL) {
             log.warn("Member {} with epoch {} won't send leave group request because it is in " +
                     "FATAL state", memberId, memberEpoch);
+            return;
+        }
+        if (state == MemberState.UNSUBSCRIBED) {
+            log.warn("Member {} won't send leave group request because it is already out of the group.",
+                memberId);
             return;
         }
         memberEpoch = groupInstanceId.isPresent() ?


### PR DESCRIPTION
This includes a fix to better handle the case where a member gets fenced while preparing to leave the group. The logic was already making sure that the member ignores the fencing (no callbacks triggered or rejoin), but this PR adds the right transition to stop sending heartbeats while the leaving process completes (because the member is not part of the group anymore from the broker point of view).