### PR TITLE
MINOR: Fix thread leak in AuthorizerIntegrationTest

### DIFF
--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -60,7 +60,7 @@ import org.apache.kafka.common.{ElectionType, IsolationLevel, KafkaException, No
 import org.apache.kafka.metadata.authorizer.StandardAuthorizer
 import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
+import org.junit.jupiter.api.{BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{CsvSource, ValueSource}
 
@@ -341,12 +341,6 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     addAndVerifyAcls(Set(new AccessControlEntry(brokerPrincipal.toString, WildcardHost, CLUSTER_ACTION, ALLOW)), clusterResource)
 
     createOffsetsTopic(listenerName = interBrokerListenerName)
-  }
-
-  @AfterEach
-  override def tearDown(): Unit = {
-    removeAllClientAcls()
-    super.tearDown()
   }
 
   private def createMetadataRequest(allowAutoTopicCreation: Boolean) = {


### PR DESCRIPTION
Producers and consumers could be leaked in the AuthorizerIntegrationTest. In the teardown logic, `removeAllClientAcls()` is called before calling the super teardown method. If  `removeAllClientAcls()` fails, the super method does not have a change to close the producers and consumers. Example of such failure [here](https://ci-builds.apache.org/blue/organizations/jenkins/Kafka%2Fkafka-pr/detail/PR-14925/11/tests/).

As a new cluster is created for each test anyway, calling `removeAllClientAcls()` does not seem necessary. This patch removes it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
