### PR TITLE
MINOR: Update documentation.html with the 3.7 release

### DIFF
--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -33,7 +33,7 @@
     <!--//#include virtual="../includes/_docs_banner.htm" -->
     
     <h1>Documentation</h1>
-    <h3>Kafka 3.6 Documentation</h3>
+    <h3>Kafka 3.7 Documentation</h3>
     Prior releases: <a href="/07/documentation.html">0.7.x</a>, 
                     <a href="/08/documentation.html">0.8.0</a>, 
                     <a href="/081/documentation.html">0.8.1.X</a>, 
@@ -60,6 +60,7 @@
                     <a href="/33/documentation.html">3.3.X</a>.
                     <a href="/34/documentation.html">3.4.X</a>.
                     <a href="/35/documentation.html">3.5.X</a>.
+                    <a href="/36/documentation.html">3.6.X</a>.
 
    <h2 class="anchor-heading"><a id="gettingStarted" class="anchor-link"></a><a href="#gettingStarted">1. Getting Started</a></h2>
       <h3 class="anchor-heading"><a id="introduction" class="anchor-link"></a><a href="#introduction">1.1 Introduction</a></h3>


### PR DESCRIPTION
This patch updates the docs/documentation.html to mention the 3.7 release, as per the step in the Release Process:

> Make sure docs/documentation.html is referring to the next release and links and update docs/upgrade.html with upgrade instructions for next release. For a bugfix release, make sure to at least bump the version number in the ["Upgrading to ..."](https://github.com/apache/kafka/blob/2.8/docs/upgrade.html#L42) header in docs/upgrade.html. If this is a major or minor release #, it's a good idea to make this change now. If you end up doing it after cutting branches, be sure the commit lands on both trunk and your release branch. Note that this must be done before generating any artifacts because these docs are part of the content that gets voted on.