### PR TITLE
KAFKA-16005: ZooKeeper to KRaft migration rollback missing disabling controller and migration configuration on brokers

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3895,7 +3895,13 @@ controller.listener.names=CONTROLLER</pre>
   <h3>Reverting to ZooKeeper mode During the Migration</h3>
     While the cluster is still in migration mode, it is possible to revert to ZK mode. In order to do this:
     <ol>
-      <li>One by one, take each KRaft broker down. Remove the __cluster_metadata directory on the broker. Then, restart the broker in ZooKeeper mode.</li>
+      <li>
+        One by one, take each KRaft broker down.
+        Remove the __cluster_metadata directory on the broker.
+        Remove the zookeeper.metadata.migration.enable flag and the KRaft controllers related configuration like controller.quorum.voters
+        and controller.listener.names from the broker configuration properties file.
+        Then, restart the broker in ZooKeeper mode.
+      </li>
       <li>Take down the KRaft quorum.</li>
       <li>Using ZooKeeper shell, delete the controller node using <code>rmr /controller</code>, so that a ZooKeeper-based broker can become the next controller.</li>
     </ol>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3896,11 +3896,13 @@ controller.listener.names=CONTROLLER</pre>
     While the cluster is still in migration mode, it is possible to revert to ZK mode. In order to do this:
     <ol>
       <li>
-        One by one, take each KRaft broker down.
-        Remove the __cluster_metadata directory on the broker.
-        Remove the zookeeper.metadata.migration.enable flag and the KRaft controllers related configuration like controller.quorum.voters
-        and controller.listener.names from the broker configuration properties file.
-        Then, restart the broker in ZooKeeper mode.
+        For each KRaft broker:
+        <ul>
+          <li>Remove the __cluster_metadata directory on the broker.</li>
+          <li>Remove the <code>zookeeper.metadata.migration.enable</code> configuration and the KRaft controllers related configurations like <code>controller.quorum.voters</code>
+            and <code>controller.listener.names</code> from the broker configuration properties file.</li>
+          <li>Then, restart the broker in ZooKeeper mode.</li>
+        </ul>
       </li>
       <li>Take down the KRaft quorum.</li>
       <li>Using ZooKeeper shell, delete the controller node using <code>rmr /controller</code>, so that a ZooKeeper-based broker can become the next controller.</li>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3898,10 +3898,11 @@ controller.listener.names=CONTROLLER</pre>
       <li>
         For each KRaft broker:
         <ul>
+          <li>Stop the broker.</li>
           <li>Remove the __cluster_metadata directory on the broker.</li>
           <li>Remove the <code>zookeeper.metadata.migration.enable</code> configuration and the KRaft controllers related configurations like <code>controller.quorum.voters</code>
             and <code>controller.listener.names</code> from the broker configuration properties file.</li>
-          <li>Then, restart the broker in ZooKeeper mode.</li>
+          <li>Restart the broker in ZooKeeper mode.</li>
         </ul>
       </li>
       <li>Take down the KRaft quorum.</li>


### PR DESCRIPTION
Trivial PR  which adds more details about taking brokers down during migration rollback.
There is the need for removing some broker configurations like the ZooKeeper migration flag and information about the KRaft controllers (not used anymore).