### PR TITLE
KAFKA-16013: Add metric for expiration rate of delayed remote fetch

### DIFF
--- a/core/src/main/scala/kafka/server/DelayedRemoteFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedRemoteFetch.scala
@@ -82,7 +82,10 @@ class DelayedRemoteFetch(remoteFetchTask: Future[Void],
     val cancelled = remoteFetchTask.cancel(true)
     if (!cancelled) debug(s"Remote fetch task for for RemoteStorageFetchInfo: $remoteFetchInfo could not be cancelled and its isDone value is ${remoteFetchTask.isDone}")
 
-    DelayedRemoteFetchMetrics.expiredRequestMeter.mark()
+    if (fetchParams.isFromFollower)
+      warn(s"The follower should not invoke remote fetch. Fetch params are: $fetchParams")
+    else
+      DelayedRemoteFetchMetrics.expiredRequestMeter.mark()
   }
 
   /**

--- a/core/src/main/scala/kafka/server/DelayedRemoteFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedRemoteFetch.scala
@@ -80,7 +80,7 @@ class DelayedRemoteFetch(remoteFetchTask: Future[Void],
   override def onExpiration(): Unit = {
     // cancel the remote storage read task, if it has not been executed yet
     val cancelled = remoteFetchTask.cancel(true)
-    if (!cancelled) debug(s"Remote fetch task for for RemoteStorageFetchInfo: $remoteFetchInfo could not be cancelled and its isDone value is ${remoteFetchTask.isDone}")
+    if (!cancelled) debug(s"Remote fetch task for RemoteStorageFetchInfo: $remoteFetchInfo could not be cancelled and its isDone value is ${remoteFetchTask.isDone}")
 
     if (fetchParams.isFromFollower)
       warn(s"The follower should not invoke remote fetch. Fetch params are: $fetchParams")

--- a/core/src/test/scala/integration/kafka/server/DelayedRemoteFetchTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DelayedRemoteFetchTest.scala
@@ -22,15 +22,16 @@ import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record.MemoryRecords
 import org.apache.kafka.common.requests.FetchRequest
 import org.apache.kafka.common.{TopicIdPartition, Uuid}
+import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.storage.internals.log._
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.{mock, when}
+import org.mockito.Mockito.{mock, verify, when}
 
 import java.util.Optional
-import java.util.concurrent.CompletableFuture
-
+import java.util.concurrent.{CompletableFuture, Future}
 import scala.collection._
+import scala.jdk.CollectionConverters._
 
 class DelayedRemoteFetchTest {
   private val maxBytes = 1024
@@ -141,6 +142,52 @@ class DelayedRemoteFetchTest {
     assertEquals(topicIdPartition, actualTopicPartition.get)
     assertTrue(fetchResultOpt.isDefined)
     assertEquals(Errors.FENCED_LEADER_EPOCH, fetchResultOpt.get.error)
+  }
+
+  @Test
+  def testRequestExpiry(): Unit = {
+    var actualTopicPartition: Option[TopicIdPartition] = None
+    var fetchResultOpt: Option[FetchPartitionData] = None
+
+    def callback(responses: Seq[(TopicIdPartition, FetchPartitionData)]): Unit = {
+      assertEquals(1, responses.size)
+      actualTopicPartition = Some(responses.head._1)
+      fetchResultOpt = Some(responses.head._2)
+    }
+
+    val future: CompletableFuture[RemoteLogReadResult] = new CompletableFuture[RemoteLogReadResult]()
+    val fetchInfo: RemoteStorageFetchInfo = new RemoteStorageFetchInfo(0, false, topicIdPartition.topicPartition(), null, null, false)
+    val highWatermark = 100
+    val leaderLogStartOffset = 10
+    val logReadInfo = buildReadResult(Errors.NONE, highWatermark, leaderLogStartOffset)
+    val remoteFetchTask = mock(classOf[Future[Void]])
+
+    val delayedRemoteFetch = new DelayedRemoteFetch(remoteFetchTask, future, fetchInfo, Seq(topicIdPartition -> fetchStatus), fetchParams,
+      Seq(topicIdPartition -> logReadInfo), replicaManager, callback)
+
+    when(replicaManager.getPartitionOrException(topicIdPartition.topicPartition))
+      .thenReturn(mock(classOf[Partition]))
+
+    // Force the delayed remote fetch to expire
+    delayedRemoteFetch.run()
+
+    // Check that the task was cancelled and force-completed
+    verify(remoteFetchTask).cancel(true)
+    assertTrue(delayedRemoteFetch.isCompleted)
+
+    // Check that the ExpiresPerSec metric was incremented.
+    val metrics = KafkaYammerMetrics.defaultRegistry.allMetrics
+    assertEquals(1, metrics.keySet.asScala.count(_.getMBeanName == "kafka.server:type=DelayedRemoteFetchMetrics,name=ExpiresPerSec"))
+
+    // Fetch results should still include local read results
+    assertTrue(actualTopicPartition.isDefined)
+    assertEquals(topicIdPartition, actualTopicPartition.get)
+    assertTrue(fetchResultOpt.isDefined)
+
+    val fetchResult = fetchResultOpt.get
+    assertEquals(Errors.NONE, fetchResult.error)
+    assertEquals(highWatermark, fetchResult.highWatermark)
+    assertEquals(leaderLogStartOffset, fetchResult.logStartOffset)
   }
 
   private def buildFollowerFetchParams(replicaId: Int,


### PR DESCRIPTION
Add metric for the number of expired remote fetches per second, and corresponding unit test to verify that the metric is marked on expiration.

```
kafka.server:type=DelayedRemoteFetchMetrics,name=ExpiresPerSec
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
