### PR TITLE
MINOR: log new coordinator partition load schedule time

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/CoordinatorLoaderImpl.scala
+++ b/core/src/main/scala/kafka/coordinator/group/CoordinatorLoaderImpl.scala
@@ -79,7 +79,7 @@ class CoordinatorLoaderImpl[T](
     future: CompletableFuture[LoadSummary],
     startTimeMs: Long
   ): Unit = {
-    val schedulerTimeMs = time.milliseconds() - startTimeMs
+    val schedulerQueueTimeMs = time.milliseconds() - startTimeMs
     try {
       replicaManager.getLog(tp) match {
         case None =>
@@ -194,7 +194,7 @@ class CoordinatorLoaderImpl[T](
               s"Stopped loading records from $tp because the partition is not online or is no longer the leader."
             ))
           } else if (isRunning.get) {
-            future.complete(new LoadSummary(startTimeMs, endTimeMs, schedulerTimeMs, numRecords, numBytes))
+            future.complete(new LoadSummary(startTimeMs, endTimeMs, schedulerQueueTimeMs, numRecords, numBytes))
           } else {
             future.completeExceptionally(new RuntimeException("Coordinator loader is closed."))
           }

--- a/core/src/main/scala/kafka/coordinator/group/CoordinatorLoaderImpl.scala
+++ b/core/src/main/scala/kafka/coordinator/group/CoordinatorLoaderImpl.scala
@@ -188,9 +188,6 @@ class CoordinatorLoaderImpl[T](
           }
 
           val endTimeMs = time.milliseconds()
-          info(s"Finished loading offsets and group metadata from $tp "
-            + s"in ${endTimeMs - startTimeMs} milliseconds, of which " +
-            s"$schedulerTimeMs milliseconds was spent in the scheduler.")
 
           if (logEndOffset == -1L) {
             future.completeExceptionally(new NotLeaderOrFollowerException(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorLoader.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorLoader.java
@@ -53,16 +53,14 @@ public interface CoordinatorLoader<U> extends AutoCloseable {
     class LoadSummary {
         private final long startTimeMs;
         private final long endTimeMs;
-        private final long totalTimeMs;
-        private final long schedulerTimeMs;
+        private final long schedulerQueueTimeMs;
         private final long numRecords;
         private final long numBytes;
 
-        public LoadSummary(long startTimeMs, long endTimeMs, long schedulerTimeMs, long numRecords, long numBytes) {
+        public LoadSummary(long startTimeMs, long endTimeMs, long schedulerQueueTimeMs, long numRecords, long numBytes) {
             this.startTimeMs = startTimeMs;
             this.endTimeMs = endTimeMs;
-            this.totalTimeMs = endTimeMs - startTimeMs;
-            this.schedulerTimeMs = schedulerTimeMs;
+            this.schedulerQueueTimeMs = schedulerQueueTimeMs;
             this.numRecords = numRecords;
             this.numBytes = numBytes;
         }
@@ -75,12 +73,8 @@ public interface CoordinatorLoader<U> extends AutoCloseable {
             return endTimeMs;
         }
 
-        public long totalTimeMs() {
-            return totalTimeMs;
-        }
-
-        public long schedulerTimeMs() {
-            return schedulerTimeMs;
+        public long schedulerQueueTimeMs() {
+            return schedulerQueueTimeMs;
         }
 
         public long numRecords() {
@@ -96,8 +90,7 @@ public interface CoordinatorLoader<U> extends AutoCloseable {
             return "LoadSummary(" +
                 "startTimeMs=" + startTimeMs +
                 ", endTimeMs=" + endTimeMs +
-                ", totalTimeMs=" + totalTimeMs +
-                ", schedulerTimeMs=" + schedulerTimeMs +
+                ", schedulerQueueTimeMs=" + schedulerQueueTimeMs +
                 ", numRecords=" + numRecords +
                 ", numBytes=" + numBytes + ")";
         }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorLoader.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorLoader.java
@@ -53,12 +53,16 @@ public interface CoordinatorLoader<U> extends AutoCloseable {
     class LoadSummary {
         private final long startTimeMs;
         private final long endTimeMs;
+        private final long totalTimeMs;
+        private final long schedulerTimeMs;
         private final long numRecords;
         private final long numBytes;
 
-        public LoadSummary(long startTimeMs, long endTimeMs, long numRecords, long numBytes) {
+        public LoadSummary(long startTimeMs, long endTimeMs, long schedulerTimeMs, long numRecords, long numBytes) {
             this.startTimeMs = startTimeMs;
             this.endTimeMs = endTimeMs;
+            this.totalTimeMs = endTimeMs - startTimeMs;
+            this.schedulerTimeMs = schedulerTimeMs;
             this.numRecords = numRecords;
             this.numBytes = numBytes;
         }
@@ -69,6 +73,14 @@ public interface CoordinatorLoader<U> extends AutoCloseable {
 
         public long endTimeMs() {
             return endTimeMs;
+        }
+
+        public long totalTimeMs() {
+            return totalTimeMs;
+        }
+
+        public long schedulerTimeMs() {
+            return schedulerTimeMs;
         }
 
         public long numRecords() {
@@ -84,6 +96,8 @@ public interface CoordinatorLoader<U> extends AutoCloseable {
             return "LoadSummary(" +
                 "startTimeMs=" + startTimeMs +
                 ", endTimeMs=" + endTimeMs +
+                ", totalTimeMs=" + totalTimeMs +
+                ", schedulerTimeMs=" + schedulerTimeMs +
                 ", numRecords=" + numRecords +
                 ", numBytes=" + numBytes + ")";
         }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -1610,10 +1610,10 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                                             ctx.transitionTo(CoordinatorState.ACTIVE);
                                             if (summary != null) {
                                                 runtimeMetrics.recordPartitionLoadSensor(summary.startTimeMs(), summary.endTimeMs());
+                                                log.info("Finished loading of metadata from {} in {}ms with epoch {} and LoadSummary={}.",
+                                                    summary.endTimeMs() - summary.startTimeMs(), tp, partitionEpoch, summary
+                                                );
                                             }
-                                            log.info("Finished loading of metadata from {} with epoch {} and LoadSummary={}.",
-                                                tp, partitionEpoch, summary
-                                            );
                                         } catch (Throwable ex) {
                                             log.error("Failed to load metadata from {} with epoch {} due to {}.",
                                                 tp, partitionEpoch, ex.toString()

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -1610,8 +1610,10 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                                             ctx.transitionTo(CoordinatorState.ACTIVE);
                                             if (summary != null) {
                                                 runtimeMetrics.recordPartitionLoadSensor(summary.startTimeMs(), summary.endTimeMs());
-                                                log.info("Finished loading of metadata from {} in {}ms with epoch {} and LoadSummary={}.",
-                                                    summary.endTimeMs() - summary.startTimeMs(), tp, partitionEpoch, summary
+                                                log.info("Finished loading of metadata from {} in {}ms with epoch {} where {}ms " +
+                                                    "was spent in the scheduler. Loaded {} records which total to {} bytes.",
+                                                    summary.endTimeMs() - summary.startTimeMs(), tp, partitionEpoch,
+                                                    summary.schedulerQueueTimeMs(), summary.numRecords(), summary.numBytes()
                                                 );
                                             }
                                         } catch (Throwable ex) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntimeTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntimeTest.java
@@ -2116,6 +2116,7 @@ public class CoordinatorRuntimeTest {
                     new CoordinatorLoader.LoadSummary(
                         startTimeMs,
                         startTimeMs + 1000,
+                        startTimeMs + 500,
                         30,
                         3000),
                     Collections.emptyList(),
@@ -2170,6 +2171,7 @@ public class CoordinatorRuntimeTest {
                     new CoordinatorLoader.LoadSummary(
                         1000,
                         2000,
+                        1500,
                         30,
                         3000),
                     Arrays.asList(5L, 15L, 27L),
@@ -2225,6 +2227,7 @@ public class CoordinatorRuntimeTest {
                     new CoordinatorLoader.LoadSummary(
                         1000,
                         2000,
+                        1500,
                         30,
                         3000),
                     Collections.emptyList(),


### PR DESCRIPTION
The current load summary exposes the time from when the partition load operation is scheduled to when the load completes. We are missing the information of how long the scheduled operation stays in the scheduler. Log that information.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
