### PR TITLE
KAFKA-15556: Remove NetworkClientDelegate methods isUnavailable, maybeThrowAuthFailure, and tryConnect

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
@@ -56,7 +56,7 @@ public class FetchRequestManager extends AbstractFetch implements RequestManager
     }
 
     /**
-     * Node's availability will be checked at a later stage, so we default to return false;
+     * Node's availability will be checked at a later stage, so we default to return false.
      * @param node {@link Node} to check for availability
      * @return
      */
@@ -66,7 +66,7 @@ public class FetchRequestManager extends AbstractFetch implements RequestManager
     }
 
     /**
-     * Authentication failure will be checked at a later stage, so we do nothing here
+     * Authentication failure will be checked at a later stage, so we do nothing here.
      * @param node {@link Node} to check for a previous {@link AuthenticationException}; if found it is thrown
      */
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
@@ -55,15 +55,22 @@ public class FetchRequestManager extends AbstractFetch implements RequestManager
         this.networkClientDelegate = networkClientDelegate;
     }
 
+    /**
+     * Node's availability will be checked at a later stage, so we default to return false;
+     * @param node {@link Node} to check for availability
+     * @return
+     */
     @Override
     protected boolean isUnavailable(Node node) {
-        return networkClientDelegate.isUnavailable(node);
+        return false;
     }
 
+    /**
+     * Authentication failure will be checked at a later stage, so we do nothing here
+     * @param node {@link Node} to check for a previous {@link AuthenticationException}; if found it is thrown
+     */
     @Override
-    protected void maybeThrowAuthFailure(Node node) {
-        networkClientDelegate.maybeThrowAuthFailure(node);
-    }
+    protected void maybeThrowAuthFailure(Node node) {}
 
     /**
      * {@inheritDoc}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NetworkClientDelegate.java
@@ -82,27 +82,6 @@ public class NetworkClientDelegate implements AutoCloseable {
     }
 
     /**
-     * Check if the node is disconnected and unavailable for immediate reconnection (i.e. if it is in
-     * reconnect backoff window following the disconnect).
-     *
-     * @param node {@link Node} to check for availability
-     * @see NetworkClientUtils#isUnavailable(KafkaClient, Node, Time)
-     */
-    public boolean isUnavailable(Node node) {
-        return NetworkClientUtils.isUnavailable(client, node, time);
-    }
-
-    /**
-     * Checks for an authentication error on a given node and throws the exception if it exists.
-     *
-     * @param node {@link Node} to check for a previous {@link AuthenticationException}; if found it is thrown
-     * @see NetworkClientUtils#maybeThrowAuthFailure(KafkaClient, Node)
-     */
-    public void maybeThrowAuthFailure(Node node) {
-        NetworkClientUtils.maybeThrowAuthFailure(client, node);
-    }
-
-    /**
      * Initiate a connection if currently possible. This is only really useful for resetting
      * the failed status of a socket.
      *

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
@@ -781,10 +781,10 @@ public class FetchRequestManagerTest {
         Node node = initialUpdateResponse.brokers().iterator().next();
 
         client.backoff(node, 500);
-        assertEquals(0, sendFetches());
+        assertEquals(1, sendFetches());
 
         time.sleep(500);
-        assertEquals(1, sendFetches());
+        assertEquals(0, sendFetches());
     }
 
     @Test


### PR DESCRIPTION
Change:

*Refactored `AbstractFetch` so only `Fetcher` will check for node status when creating fetch requests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
