### PR TITLE
KAFKA-16021: Eagerly look up StringSerializer encoding during configure

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/StringDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/StringDeserializer.java
@@ -20,17 +20,19 @@ import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.utils.Utils;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.Map;
 
 /**
- *  String encoding defaults to UTF8 and can be customized by setting the property key.deserializer.encoding,
- *  value.deserializer.encoding or deserializer.encoding. The first two take precedence over the last.
+ * String encoding defaults to UTF8 and can be customized by setting the property key.deserializer.encoding,
+ * value.deserializer.encoding or deserializer.encoding. The first two take precedence over the last.
  */
 public class StringDeserializer implements Deserializer<String> {
-    private String encoding = StandardCharsets.UTF_8.name();
+    private Charset encoding = StandardCharsets.UTF_8;
 
     @Override
     public void configure(Map<String, ?> configs, boolean isKey) {
@@ -38,20 +40,22 @@ public class StringDeserializer implements Deserializer<String> {
         Object encodingValue = configs.get(propertyName);
         if (encodingValue == null)
             encodingValue = configs.get("deserializer.encoding");
-        if (encodingValue instanceof String)
-            encoding = (String) encodingValue;
+        if (encodingValue instanceof String) {
+            String encodingName = (String) encodingValue;
+            try {
+                encoding = Charset.forName(encodingName);
+            } catch (UnsupportedCharsetException | IllegalCharsetNameException e) {
+                throw new SerializationException("Unsupported encoding " + encodingName, e);
+            }
+        }
     }
 
     @Override
     public String deserialize(String topic, byte[] data) {
-        try {
-            if (data == null)
-                return null;
-            else
-                return new String(data, encoding);
-        } catch (UnsupportedEncodingException e) {
-            throw new SerializationException("Error when deserializing byte[] to string due to unsupported encoding " + encoding);
-        }
+        if (data == null)
+            return null;
+        else
+            return new String(data, encoding);
     }
 
     @Override
@@ -60,13 +64,9 @@ public class StringDeserializer implements Deserializer<String> {
             return null;
         }
 
-        try {
-            if (data.hasArray()) {
-                return new String(data.array(), data.position() + data.arrayOffset(), data.remaining(), encoding);
-            }
-            return new String(Utils.toArray(data), encoding);
-        } catch (UnsupportedEncodingException e) {
-            throw new SerializationException("Error when deserializing ByteBuffer to string due to unsupported encoding " + encoding);
+        if (data.hasArray()) {
+            return new String(data.array(), data.position() + data.arrayOffset(), data.remaining(), encoding);
         }
+        return new String(Utils.toArray(data), encoding);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/serialization/SerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/serialization/SerializationTest.java
@@ -129,6 +129,21 @@ public class SerializationTest {
         }
     }
 
+
+    @Test
+    public void stringSerdeConfigureThrowsOnUnknownEncoding() {
+        String encoding = "encoding-does-not-exist";
+        try (Serde<String> serDeser = Serdes.String()) {
+            Map<String, Object> serializerConfigs = new HashMap<>();
+            serializerConfigs.put("key.serializer.encoding", encoding);
+            assertThrows(SerializationException.class, () -> serDeser.serializer().configure(serializerConfigs, true));
+
+            Map<String, Object> deserializerConfigs = new HashMap<>();
+            deserializerConfigs.put("key.deserializer.encoding", encoding);
+            assertThrows(SerializationException.class, () -> serDeser.deserializer().configure(deserializerConfigs, true));
+        }
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void listSerdeShouldReturnEmptyCollection() {


### PR DESCRIPTION
The encoding for a StringSerializer doesn't change during the life of the serializer, so there isn't a good reason to look up the corresponding Charset every time a String needs to be serialized, which is what the getBytes(String) method does.

Looking it up once on construction is more efficient.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
