### PR TITLE
Revert "KAFKA-15764: Missing Tests for Transactions (#14702)"

### DIFF
--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1896,8 +1896,7 @@ object TestUtils extends Logging {
       maxBlockMs: Long = 60000,
       deliveryTimeoutMs: Int = 120000,
       requestTimeoutMs: Int = 30000,
-      maxInFlight: Int = 5,
-      compressionType: String = "none"): KafkaProducer[Array[Byte], Array[Byte]] = {
+      maxInFlight: Int = 5): KafkaProducer[Array[Byte], Array[Byte]] = {
     val props = new Properties()
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers(brokers))
     props.put(ProducerConfig.ACKS_CONFIG, "all")
@@ -1909,7 +1908,6 @@ object TestUtils extends Logging {
     props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, deliveryTimeoutMs.toString)
     props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, requestTimeoutMs.toString)
     props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, maxInFlight.toString)
-    props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, compressionType)
     new KafkaProducer[Array[Byte], Array[Byte]](props, new ByteArraySerializer, new ByteArraySerializer)
   }
 


### PR DESCRIPTION
This reverts commit ed7ad6d9d3d38940fbeb13324a186d3e5edd539e.

We have been seeing a lot of failures of `TransactionsWithTieredStoreTest.testTransactionsWithCompression` on trunk, and it seems to start with this PR. I see how this PR can influence the test via the change in `TestUtils`. The bad part is that sometimes seems to kill the Gradle Executors completely. So I'd suggest reverting the change before investigating further to stabilize CI.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
