### PR TITLE
MINOR: Use random cluster id for jsa file preparation

### DIFF
--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -39,7 +39,7 @@ COPY jsa_launch /etc/kafka/docker/jsa_launch
 RUN set -eux ; \
     apk update ; \
     apk upgrade ; \
-    apk add --no-cache wget gcompat gpg gpg-agent procps netcat-openbsd uuidgen; \
+    apk add --no-cache wget gcompat gpg gpg-agent procps netcat-openbsd; \
     mkdir opt/kafka; \
     wget -nv -O kafka.tgz "$kafka_url"; \
     wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \

--- a/docker/jvm/jsa_launch
+++ b/docker/jvm/jsa_launch
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KAFKA_CLUSTER_ID="5L6g3nShT-eMCtK--X86sw"
-TOPIC="$(uuidgen)"
+KAFKA_CLUSTER_ID="$(opt/kafka/bin/kafka-storage.sh random-uuid)"
+TOPIC=$KAFKA_CLUSTER_ID
 
 KAFKA_JVM_PERFORMANCE_OPTS="-XX:ArchiveClassesAtExit=storage.jsa" opt/kafka/bin/kafka-storage.sh format -t $KAFKA_CLUSTER_ID -c opt/kafka/config/kraft/server.properties
 

--- a/docker/jvm/jsa_launch
+++ b/docker/jvm/jsa_launch
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 KAFKA_CLUSTER_ID="$(opt/kafka/bin/kafka-storage.sh random-uuid)"
-TOPIC=$KAFKA_CLUSTER_ID
+TOPIC="test-topic"
 
 KAFKA_JVM_PERFORMANCE_OPTS="-XX:ArchiveClassesAtExit=storage.jsa" opt/kafka/bin/kafka-storage.sh format -t $KAFKA_CLUSTER_ID -c opt/kafka/config/kraft/server.properties
 


### PR DESCRIPTION
random-uuid command in storage script is better than uuidgen for topic names.
In some tests it was observed that using uuidgen command for topic name, does not result in successful creation of CDS jsa files

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
