### PR TITLE
MINOR: skip 'zinc' phase from gradle dependency-check plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -754,6 +754,7 @@ subprojects {
   dependencyCheck {
     suppressionFile = "$rootDir/gradle/resources/dependencycheck-suppressions.xml"
     skipProjects = [ ":jmh-benchmarks", ":trogdor" ]
+    skipConfigurations = [ "zinc" ]
   }
 }
 


### PR DESCRIPTION
This avoids `gradle dependencyCheckAggregate` from reporting on advisories in build-time dependencies (e.g. CVE-2023-46122) which typically should not affect us.

I checked that this does not prevent advisories in 'regular' dependencies from being reported (but there currently are none).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
