### PR TITLE
MINOR: Use --no-daemon when building with Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ def doValidation() {
   // Run all the tasks associated with `check` except for `test` - the latter is executed via `doTest`
   sh """
     ./retry_zinc ./gradlew -PscalaVersion=$SCALA_VERSION clean check -x test \
-        --profile --continue -PxmlSpotBugsReport=true -PkeepAliveMode="session"
+        --no-daemon --profile --continue -PxmlSpotBugsReport=true -PkeepAliveMode="session"
   """
 }
 
@@ -31,7 +31,7 @@ def isChangeRequest(env) {
 
 def doTest(env, target = "test") {
   sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
-      --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
+      --no-daemon --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
       -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""
   junit '**/build/test-results/**/TEST-*.xml'
 }


### PR DESCRIPTION
While investigating build instabilities, I saw a build failing with the following message:

```
The Daemon will expire after the build after running out of JVM heap space.
The project memory settings are likely not configured or are configured to an insufficient value.
The daemon will restart for the next build, which may increase subsequent build times.
These settings can be adjusted by setting 'org.gradle.jvmargs' in 'gradle.properties'.
The currently configured max heap space is '1.3 GiB' and the configured max metaspace is 'unknown'.
For more information on how to set these values, please refer to https://docs.gradle.org/8.5/userguide/build_environment.html#sec:configuring_jvm_memory in the Gradle documentation.
To disable this warning, set 'org.gradle.daemon.performance.disable-logging=true'.
```

This made me think about how we use daemons with gradle because we use `org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC` in `gradle.properties`. So why is the max heap reported as `1.3 GiB`? Could it be that we reuse gradle workers spawned by other projects? I also wonder that happen when previous tests leak resources. Do they stay for ever until the worker dies?

So, I would like to try using `--no-daemon` to see whether it improves our builds.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
