### PR TITLE
KAFKA-15388: Handling remote segment read in case of log compaction

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1351,7 +1351,7 @@ public class RemoteLogManager implements Closeable {
         }
     }
     // for testing
-    public RemoteLogInputStream getRemoteLogInputStream(InputStream in) {
+    RemoteLogInputStream getRemoteLogInputStream(InputStream in) {
         return new RemoteLogInputStream(in);
     }
 

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1289,15 +1289,21 @@ public class RemoteLogManager implements Closeable {
         }
 
         RemoteLogSegmentMetadata remoteLogSegmentMetadata = rlsMetadataOptional.get();
-        int startPos = lookupPositionForOffset(remoteLogSegmentMetadata, offset);
         InputStream remoteSegInputStream = null;
         try {
-            // Search forward for the position of the last offset that is greater than or equal to the target offset
-            remoteSegInputStream = remoteLogStorageManager.fetchLogSegment(remoteLogSegmentMetadata, startPos);
-            RemoteLogInputStream remoteLogInputStream = new RemoteLogInputStream(remoteSegInputStream);
-
-            RecordBatch firstBatch = findFirstBatch(remoteLogInputStream, offset);
-
+            int startPos = 0;
+            RecordBatch firstBatch = null;
+            while (firstBatch == null && rlsMetadataOptional.isPresent()) {
+                remoteLogSegmentMetadata = rlsMetadataOptional.get();
+                // Search forward for the position of the last offset that is greater than or equal to the target offset
+                startPos = lookupPositionForOffset(remoteLogSegmentMetadata, offset);
+                remoteSegInputStream = remoteLogStorageManager.fetchLogSegment(remoteLogSegmentMetadata, startPos);
+                RemoteLogInputStream remoteLogInputStream = getRemoteLogInputStream(remoteSegInputStream);
+                firstBatch = findFirstBatch(remoteLogInputStream, offset);
+                if (firstBatch == null) {
+                    rlsMetadataOptional = findNextSegmentMetadata(rlsMetadataOptional.get(), logOptional.get().leaderEpochCache());
+                }
+            }
             if (firstBatch == null)
                 return new FetchDataInfo(new LogOffsetMetadata(offset), MemoryRecords.EMPTY, false,
                         includeAbortedTxns ? Optional.of(Collections.emptyList()) : Optional.empty());
@@ -1339,6 +1345,10 @@ public class RemoteLogManager implements Closeable {
         } finally {
             Utils.closeQuietly(remoteSegInputStream, "RemoteLogSegmentInputStream");
         }
+    }
+    // for testing
+    public RemoteLogInputStream getRemoteLogInputStream(InputStream in) {
+        return new RemoteLogInputStream(in);
     }
 
     // Visible for testing
@@ -1412,8 +1422,8 @@ public class RemoteLogManager implements Closeable {
             }
         }
     }
-
-    private Optional<RemoteLogSegmentMetadata> findNextSegmentMetadata(RemoteLogSegmentMetadata segmentMetadata,
+    // visible for testing.
+    Optional<RemoteLogSegmentMetadata> findNextSegmentMetadata(RemoteLogSegmentMetadata segmentMetadata,
                                                                        Option<LeaderEpochFileCache> leaderEpochFileCacheOption) throws RemoteStorageException {
         if (leaderEpochFileCacheOption.isEmpty()) {
             return Optional.empty();

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1293,6 +1293,10 @@ public class RemoteLogManager implements Closeable {
         try {
             int startPos = 0;
             RecordBatch firstBatch = null;
+
+            //  Iteration over multiple RemoteSegmentMetadata is required in case of log compaction.
+            //  It may be possible the offset is log compacted in the current RemoteLogSegmentMetadata
+            //  And we need to iterate over the next segment metadata to fetch messages higher than the given offset.
             while (firstBatch == null && rlsMetadataOptional.isPresent()) {
                 remoteLogSegmentMetadata = rlsMetadataOptional.get();
                 // Search forward for the position of the last offset that is greater than or equal to the target offset

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1422,9 +1422,10 @@ public class RemoteLogManager implements Closeable {
             }
         }
     }
+
     // visible for testing.
     Optional<RemoteLogSegmentMetadata> findNextSegmentMetadata(RemoteLogSegmentMetadata segmentMetadata,
-                                                                       Option<LeaderEpochFileCache> leaderEpochFileCacheOption) throws RemoteStorageException {
+                                                               Option<LeaderEpochFileCache> leaderEpochFileCacheOption) throws RemoteStorageException {
         if (leaderEpochFileCacheOption.isEmpty()) {
             return Optional.empty();
         }

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -2191,7 +2191,6 @@ public class RemoteLogManagerTest {
         );
 
         when(rsmManager.fetchLogSegment(any(), anyInt())).thenReturn(fileInputStream);
-        when(remoteLogMetadataManager.remoteLogSegmentMetadata(any(), anyInt(), anyLong())).thenReturn(Optional.of(segmentMetadata), Optional.of(segmentMetadata));
         when(segmentMetadata.topicIdPartition()).thenReturn(new TopicIdPartition(Uuid.randomUuid(), tp));
         // Fetching first time  FirstBatch return null because of log compaction.
         // Fetching second time  FirstBatch return data.

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -87,6 +87,7 @@ import scala.collection.JavaConverters;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.InputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -2065,6 +2066,11 @@ public class RemoteLogManagerTest {
                 return Optional.of(segmentMetadata);
             }
 
+            public Optional<RemoteLogSegmentMetadata> findNextSegmentMetadata(RemoteLogSegmentMetadata segmentMetadata,
+                                                                              Option<LeaderEpochFileCache> leaderEpochFileCacheOption) {
+                return Optional.ofNullable(null);
+            }
+
             int lookupPositionForOffset(RemoteLogSegmentMetadata remoteLogSegmentMetadata, long offset) {
                 return 1;
             }
@@ -2158,6 +2164,86 @@ public class RemoteLogManagerTest {
                 verify(firstBatch, never()).writeTo(any(ByteBuffer.class));
                 assertEquals(MemoryRecords.EMPTY, fetchDataInfo.records);
             }
+        }
+    }
+
+    @Test
+    public void testReadForFirstBatchInLogCompaction() throws RemoteStorageException, IOException {
+        FileInputStream fileInputStream = mock(FileInputStream.class);
+        RemoteLogInputStream remoteLogInputStream = mock(RemoteLogInputStream.class);
+        ClassLoaderAwareRemoteStorageManager rsmManager = mock(ClassLoaderAwareRemoteStorageManager.class);
+        RemoteLogSegmentMetadata segmentMetadata = mock(RemoteLogSegmentMetadata.class);
+        LeaderEpochFileCache cache = mock(LeaderEpochFileCache.class);
+        when(cache.epochForOffset(anyLong())).thenReturn(OptionalInt.of(1));
+
+        when(remoteStorageManager.fetchLogSegment(any(RemoteLogSegmentMetadata.class), anyInt()))
+                .thenAnswer(a -> fileInputStream);
+        when(mockLog.leaderEpochCache()).thenReturn(Option.apply(cache));
+
+        int fetchOffset = 0;
+        int fetchMaxBytes = 10;
+        int recordBatchSizeInBytes = fetchMaxBytes + 1;
+        RecordBatch firstBatch = mock(RecordBatch.class);
+        ArgumentCaptor<ByteBuffer> capture = ArgumentCaptor.forClass(ByteBuffer.class);
+
+        FetchRequest.PartitionData partitionData = new FetchRequest.PartitionData(
+                Uuid.randomUuid(), fetchOffset, 0, fetchMaxBytes, Optional.empty()
+        );
+
+        when(rsmManager.fetchLogSegment(any(), anyInt())).thenReturn(fileInputStream);
+        when(remoteLogMetadataManager.remoteLogSegmentMetadata(any(), anyInt(), anyLong())).thenReturn(Optional.of(segmentMetadata), Optional.of(segmentMetadata));
+        when(segmentMetadata.topicIdPartition()).thenReturn(new TopicIdPartition(Uuid.randomUuid(), tp));
+        // Fetching first time  FirstBatch return null because of log compaction.
+        // Fetching second time  FirstBatch return data.
+        when(remoteLogInputStream.nextBatch()).thenReturn(null, firstBatch);
+        // Return last offset greater than the requested offset.
+        when(firstBatch.lastOffset()).thenReturn(2L);
+        when(firstBatch.sizeInBytes()).thenReturn(recordBatchSizeInBytes);
+        doNothing().when(firstBatch).writeTo(capture.capture());
+        RemoteStorageFetchInfo fetchInfo = new RemoteStorageFetchInfo(
+                0, true, tp, partitionData, FetchIsolation.HIGH_WATERMARK, false
+        );
+
+
+        try (RemoteLogManager remoteLogManager = new RemoteLogManager(
+                remoteLogManagerConfig,
+                brokerId,
+                logDir,
+                clusterId,
+                time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> {
+                },
+                brokerTopicStats) {
+            public RemoteStorageManager createRemoteStorageManager() {
+                return rsmManager;
+            }
+
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+
+            public Optional<RemoteLogSegmentMetadata> fetchRemoteLogSegmentMetadata(TopicPartition topicPartition,
+                                                                                    int epochForOffset, long offset) {
+                return Optional.of(segmentMetadata);
+            }
+            public RemoteLogInputStream getRemoteLogInputStream(InputStream in) {
+                return remoteLogInputStream;
+            }
+
+            int lookupPositionForOffset(RemoteLogSegmentMetadata remoteLogSegmentMetadata, long offset) {
+                return 1;
+            }
+        }) {
+            FetchDataInfo fetchDataInfo = remoteLogManager.read(fetchInfo);
+            // Common assertions
+            assertEquals(fetchOffset, fetchDataInfo.fetchOffsetMetadata.messageOffset);
+            assertFalse(fetchDataInfo.firstEntryIncomplete);
+            // FetchIsolation is HIGH_WATERMARK
+            assertEquals(Optional.empty(), fetchDataInfo.abortedTransactions);
+            // Verify that the byte buffer has capacity equal to the size of the first batch
+            assertEquals(recordBatchSizeInBytes, capture.getValue().capacity());
+
         }
     }
 

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -2068,7 +2068,7 @@ public class RemoteLogManagerTest {
 
             public Optional<RemoteLogSegmentMetadata> findNextSegmentMetadata(RemoteLogSegmentMetadata segmentMetadata,
                                                                               Option<LeaderEpochFileCache> leaderEpochFileCacheOption) {
-                return Optional.ofNullable(null);
+                return Optional.empty();
             }
 
             int lookupPositionForOffset(RemoteLogSegmentMetadata remoteLogSegmentMetadata, long offset) {
@@ -2175,9 +2175,6 @@ public class RemoteLogManagerTest {
         RemoteLogSegmentMetadata segmentMetadata = mock(RemoteLogSegmentMetadata.class);
         LeaderEpochFileCache cache = mock(LeaderEpochFileCache.class);
         when(cache.epochForOffset(anyLong())).thenReturn(OptionalInt.of(1));
-
-        when(remoteStorageManager.fetchLogSegment(any(RemoteLogSegmentMetadata.class), anyInt()))
-                .thenAnswer(a -> fileInputStream);
         when(mockLog.leaderEpochCache()).thenReturn(Option.apply(cache));
 
         int fetchOffset = 0;


### PR DESCRIPTION
**Problem**
Fetching from remote log segment implementation does not handled log compaction cases. It always assumes record batch will exist in the required segment for the requested offset. But there is a possibility where the requested offset is the last offset of the segment and has been removed due to log compaction. Then it requires to iterate over the next higher segment for further data as it has been done for local segment[ fetch request. ](https://github.com/apache/kafka/blob/317f61dfd9a7f1443cf75b6a32568d1c81984d08/core/src/main/scala/kafka/log/LocalLog.scala#L425)
**Fixes**
1. Iterating over the higher remote segment  if there is no relevant batch in the current remotelogsegment.

**Testing Strategy:**

- Tested through unit test.
- Reproduced Issue locally
 _Steps followed for testing manually_
1. Created topic 
`bin/kafka-topics.sh --bootstrap-server localhost:9092 --create --topic arpit`
2. Add bunch of config to enable quick creation of segments and enable log compaction. 
` bin/kafka-configs.sh --bootstrap-server localhost:9092 --alter --entity-type topics --entity-name arpit  --add-config segment.bytes=100
 bin/kafka-configs.sh --bootstrap-server localhost:9092 --alter --entity-type topics --entity-name arpit  --add-config cleanup.policy=compact
`
3. Produce item into the topic 
<img width="1119" alt="Screenshot 2023-12-21 at 11 24 21 PM" src="https://github.com/apache/kafka/assets/59436466/9803547c-a0ed-4a69-9784-3388e70ea848">

4. Remote log is not enabled yet, and successfully fetch data from the local segments. 
<img width="1315" alt="Screenshot 2023-12-21 at 11 24 41 PM" src="https://github.com/apache/kafka/assets/59436466/2e0e0df6-1027-490e-a1d3-1aafdaa593d5">
5. Enable remote log storage.

`bin/kafka-configs.sh --bootstrap-server localhost:9092 --alter --entity-type topics --entity-name arpit  --delete-config cleanup.policy=compact`

`bin/kafka-configs.sh --bootstrap-server localhost:9092 --alter --entity-type topics --entity-name arpit  --add-config remote.storage.enable=true`

6. When rerun the consumer script with remote storage enable , consumer does not return any data. The remote log segment  0.log does not have any data because of log compaction but the current logic returns null instead of checking data on the higher segment.Screenshot for the reference. 
<img width="1359" alt="Screenshot 2023-12-21 at 11 27 14 PM" src="https://github.com/apache/kafka/assets/59436466/46a6f7a3-9007-4a76-bec2-bba5465b311a">
<img width="916" alt="Screenshot 2023-12-21 at 11 29 55 PM" src="https://github.com/apache/kafka/assets/59436466/1787fc7e-7a4a-4221-bbea-809d5a965932">
7. After fixing the logic , The remote fetch successfully iterate over  the segments in order until it fetches the first batch available. 
<img width="1321" alt="Screenshot 2023-12-21 at 11 31 30 PM" src="https://github.com/apache/kafka/assets/59436466/f8ba7158-e66c-40c3-8867-141bfb6f74f1">


cc @divijvaidya  @satishd  @showuon 


