### PR TITLE
KAFKA-16046: fix stream-stream-join store types

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowStoreMaterializer.java
@@ -65,6 +65,7 @@ public class SlidingWindowStoreMaterializer<K, V> extends MaterializedStoreFacto
                         Duration.ofMillis(windows.timeDifferenceMs()),
                         false,
                         emitStrategy,
+                        true,
                         true
                 ))
                 : (WindowBytesStoreSupplier) materialized.storeSupplier();

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/StreamJoinedStoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/StreamJoinedStoreFactory.java
@@ -88,6 +88,7 @@ public class StreamJoinedStoreFactory<K, V1, V2> extends AbstractConfigurableSto
                         Duration.ofMillis(windows.size()),
                         true,
                         EmitStrategy.onWindowUpdate(),
+                        false,
                         false
                 ))
                 : storeSupplier;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowStoreMaterializer.java
@@ -63,7 +63,8 @@ public class WindowStoreMaterializer<K, V> extends MaterializedStoreFactory<K, V
                         Duration.ofMillis(windows.size()),
                         false,
                         emitStrategy,
-                        false
+                        false,
+                        true
                 ))
                 : (WindowBytesStoreSupplier) materialized.storeSupplier();
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/BuiltInDslStoreSuppliers.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/BuiltInDslStoreSuppliers.java
@@ -50,11 +50,19 @@ public class BuiltInDslStoreSuppliers {
                         params.isSlidingWindow());
             }
 
-            return Stores.persistentTimestampedWindowStore(
-                    params.name(),
-                    params.retentionPeriod(),
-                    params.windowSize(),
-                    params.retainDuplicates());
+            if (params.isTimestamped()) {
+                return Stores.persistentTimestampedWindowStore(
+                        params.name(),
+                        params.retentionPeriod(),
+                        params.windowSize(),
+                        params.retainDuplicates());
+            } else {
+                return Stores.persistentWindowStore(
+                        params.name(),
+                        params.retentionPeriod(),
+                        params.windowSize(),
+                        params.retainDuplicates());
+            }
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/DslWindowParams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/DslWindowParams.java
@@ -32,6 +32,7 @@ public class DslWindowParams {
     private final boolean retainDuplicates;
     private final EmitStrategy emitStrategy;
     private final boolean isSlidingWindow;
+    private final boolean isTimestamped;
 
     /**
      * @param name             name of the store (cannot be {@code null})
@@ -44,6 +45,7 @@ public class DslWindowParams {
      *                         caching and means that null values will be ignored.
      * @param emitStrategy     defines how to emit results
      * @param isSlidingWindow  whether the requested store is a sliding window
+     * @param isTimestamped    whether the requested store should be timestamped (see {@link TimestampedWindowStore}
      */
     public DslWindowParams(
             final String name,
@@ -51,8 +53,10 @@ public class DslWindowParams {
             final Duration windowSize,
             final boolean retainDuplicates,
             final EmitStrategy emitStrategy,
-            final boolean isSlidingWindow
+            final boolean isSlidingWindow,
+            final boolean isTimestamped
     ) {
+        this.isTimestamped = isTimestamped;
         Objects.requireNonNull(name);
         this.name = name;
         this.retentionPeriod = retentionPeriod;
@@ -84,6 +88,10 @@ public class DslWindowParams {
 
     public boolean isSlidingWindow() {
         return isSlidingWindow;
+    }
+
+    public boolean isTimestamped() {
+        return isTimestamped;
     }
 
     @Override


### PR DESCRIPTION
Before #14648, the `KStreamImplJoin` class would always create non-timestamped persistent windowed stores. After that PR, the default was changed to create timestamped stores. This wasn't compatible because, during restoration, timestamped stores have their values transformed to prepend the timestamp to the value. This caused serialization errors when trying to read from the store because the deserializers did not expect the timestamp to be prepended.

To fix this, we allow creating non-timestamped stores using the `DslWindowParams`

Testing was done both manually as well as adding a unit test to ensure that the stores created are not timestamped. I also confirmed that the only place in the code `persistentWindowStore` was used before #14648 was in the `StreamJoined` code.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
