### PR TITLE
MINOR: Close RemoteLogManager in RemoteLogManagerTest

### DIFF
--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -73,6 +73,7 @@ import org.apache.kafka.storage.internals.log.RemoteStorageFetchInfo;
 import org.apache.kafka.storage.internals.log.TimeIndex;
 import org.apache.kafka.storage.internals.log.TransactionIndex;
 import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -225,6 +226,14 @@ public class RemoteLogManagerTest {
                 return 0L;
             }
         };
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (remoteLogManager != null) {
+            remoteLogManager.close();
+            remoteLogManager = null;
+        }
     }
 
     @Test


### PR DESCRIPTION
I was inspecting heap dumps to chase the OOM errors that we see in builds and I have noticed that `remote-log-index-cleaner` threads were still running. This may be one of the sources.

We should ensure that the RemoteLogManager is closed in RemoteLogManagerTest.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
