### PR TITLE
MINOR: set test global timeout as 10 mins

### DIFF
--- a/connect/file/src/test/resources/junit-platform.properties
+++ b/connect/file/src/test/resources/junit-platform.properties
@@ -12,5 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
 junit.jupiter.execution.timeout.default = 10 m

--- a/connect/mirror/src/test/resources/junit-platform.properties
+++ b/connect/mirror/src/test/resources/junit-platform.properties
@@ -12,5 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
 junit.jupiter.execution.timeout.default = 10 m

--- a/connect/runtime/src/test/resources/junit-platform.properties
+++ b/connect/runtime/src/test/resources/junit-platform.properties
@@ -12,5 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
 junit.jupiter.execution.timeout.default = 10 m

--- a/core/src/test/resources/junit-platform.properties
+++ b/core/src/test/resources/junit-platform.properties
@@ -12,5 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
 junit.jupiter.execution.timeout.default = 10 m

--- a/group-coordinator/src/test/resources/junit-platform.properties
+++ b/group-coordinator/src/test/resources/junit-platform.properties
@@ -12,5 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
 junit.jupiter.execution.timeout.default = 10 m

--- a/metadata/src/test/resources/junit-platform.properties
+++ b/metadata/src/test/resources/junit-platform.properties
@@ -12,5 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
 junit.jupiter.execution.timeout.default = 10 m

--- a/raft/src/test/resources/junit-platform.properties
+++ b/raft/src/test/resources/junit-platform.properties
@@ -12,5 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
 junit.jupiter.execution.timeout.default = 10 m

--- a/server-common/src/test/resources/junit-platform.properties
+++ b/server-common/src/test/resources/junit-platform.properties
@@ -13,3 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
+junit.jupiter.execution.timeout.default = 10 m

--- a/shell/src/test/resources/junit-platform.properties
+++ b/shell/src/test/resources/junit-platform.properties
@@ -12,5 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
 junit.jupiter.execution.timeout.default = 10 m

--- a/storage/src/test/resources/junit-platform.properties
+++ b/storage/src/test/resources/junit-platform.properties
@@ -12,5 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
 junit.jupiter.execution.timeout.default = 10 m

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
@@ -42,7 +42,9 @@ import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.MockReducer;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -63,6 +65,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class KTableKTableLeftJoinTest {
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(600);
     private final String topic1 = "topic1";
     private final String topic2 = "topic2";
     private final String output = "output";

--- a/streams/src/test/resources/junit-platform.properties
+++ b/streams/src/test/resources/junit-platform.properties
@@ -12,5 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
 junit.jupiter.execution.timeout.default = 10 m

--- a/streams/streams-scala/src/test/resources/junit-platform.properties
+++ b/streams/streams-scala/src/test/resources/junit-platform.properties
@@ -12,5 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
 junit.jupiter.execution.timeout.default = 10 m

--- a/streams/test-utils/src/test/resources/junit-platform.properties
+++ b/streams/test-utils/src/test/resources/junit-platform.properties
@@ -12,5 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
 junit.jupiter.execution.timeout.default = 10 m

--- a/tools/src/test/resources/junit-platform.properties
+++ b/tools/src/test/resources/junit-platform.properties
@@ -12,5 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
 junit.jupiter.execution.timeout.default = 10 m


### PR DESCRIPTION
As @stanislavkozlovski found [here](https://gist.github.com/stanislavkozlovski/8959f7ee59434f774841f4ae2f5228c2), there are some tests ran more than 1 ~ 2 hours, which make our CI build meet 8 hours timeout. We should set a timeout for each test as 10 mins using a junit5 feature [here](https://junit.org/junit5/docs/current/user-guide/#writing-tests-declarative-timeouts-default-timeouts). If it exceeds 10m, it doesn't make sense to keep waiting and we should fail them, and investigate/improve them. This way, we can resolve the CI timeout issue.

If it exceeds the timeout, it'll fail with the exception:
```
Gradle Test Run :storage:test > Gradle Test Executor 21 > TransactionsWithTieredStoreTest > testDelayedFetchIncludesAbortedTransaction(String) > testDelayedFetchIncludesAbortedTransaction(String).quorum=zk FAILED
    java.util.concurrent.TimeoutException: testDelayedFetchIncludesAbortedTransaction(java.lang.String) timed out after 10 seconds
        at org.junit.jupiter.engine.extension.TimeoutExceptionFactory.create(TimeoutExceptionFactory.java:29)
        at org.junit.jupiter.engine.extension.SameThreadTimeoutInvocation.proceed(SameThreadTimeoutInvocation.java:58)
        at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
```

However, the stream tests are still using junit4, we can only set timeout for each test suite. I added timeout for `KTableKTableLeftJoinTest` separately as highlighted [here](https://gist.github.com/stanislavkozlovski/8959f7ee59434f774841f4ae2f5228c2).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
