### PR TITLE
MINOR: New year code clean up - misc

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
@@ -42,7 +42,7 @@ public class DeleteConsumerGroupsResult {
      */
     public Map<String, KafkaFuture<Void>> deletedGroups() {
         Map<String, KafkaFuture<Void>> deletedGroups = new HashMap<>(futures.size());
-        futures.forEach((key, future) -> deletedGroups.put(key, future));
+        deletedGroups.putAll(futures);
         return deletedGroups;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
@@ -45,7 +45,7 @@ public class DescribeConsumerGroupsResult {
      */
     public Map<String, KafkaFuture<ConsumerGroupDescription>> describedGroups() {
         Map<String, KafkaFuture<ConsumerGroupDescription>> describedGroups = new HashMap<>();
-        futures.forEach((key, future) -> describedGroups.put(key, future));
+        describedGroups.putAll(futures);
         return describedGroups;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3389,7 +3389,7 @@ public class KafkaAdminClient extends AdminClient {
                             String protocolType = group.protocolType();
                             if (protocolType.equals(ConsumerProtocol.PROTOCOL_TYPE) || protocolType.isEmpty()) {
                                 final String groupId = group.groupId();
-                                final Optional<ConsumerGroupState> state = group.groupState().equals("")
+                                final Optional<ConsumerGroupState> state = group.groupState().isEmpty()
                                         ? Optional.empty()
                                         : Optional.of(ConsumerGroupState.parse(group.groupState()));
                                 final ConsumerGroupListing groupListing = new ConsumerGroupListing(groupId, protocolType.isEmpty(), state);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -285,8 +285,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     @Override
     public synchronized void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) {
         ensureNotClosed();
-        for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : offsets.entrySet())
-            committed.put(entry.getKey(), entry.getValue());
+        committed.putAll(offsets);
         if (callback != null) {
             callback.onComplete(offsets, null);
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
@@ -862,7 +862,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
 
             List<TopicPartition> unassignedPartitions = new ArrayList<>(totalPartitionsCount - sortedAssignedPartitions.size());
 
-            Collections.sort(sortedAssignedPartitions, Comparator.comparing(TopicPartition::topic).thenComparing(TopicPartition::partition));
+            sortedAssignedPartitions.sort(Comparator.comparing(TopicPartition::topic).thenComparing(TopicPartition::partition));
 
             boolean shouldAddDirectly = false;
             Iterator<TopicPartition> sortedAssignedPartitionsIter = sortedAssignedPartitions.iterator();
@@ -961,7 +961,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
                     currentPartitionConsumer.put(topicPartition, entry.getKey());
 
             List<String> sortedAllTopics = new ArrayList<>(topic2AllPotentialConsumers.keySet());
-            Collections.sort(sortedAllTopics, new TopicComparator(topic2AllPotentialConsumers));
+            sortedAllTopics.sort(new TopicComparator(topic2AllPotentialConsumers));
             sortedAllPartitions = getAllTopicPartitions(sortedAllTopics);
 
             sortedCurrentSubscriptions = new TreeSet<>(new SubscriptionComparator(currentAssignment));
@@ -1054,7 +1054,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
 
             List<TopicPartition> unassignedPartitions = new ArrayList<>();
 
-            Collections.sort(sortedAssignedPartitions, new PartitionComparator(topic2AllPotentialConsumers));
+            sortedAssignedPartitions.sort(new PartitionComparator(topic2AllPotentialConsumers));
 
             boolean shouldAddDirectly = false;
             Iterator<TopicPartition> sortedAssignedPartitionsIter = sortedAssignedPartitions.iterator();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -1018,7 +1018,6 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
          * backoff on failed attempt. See {@link RequestState}.
          */
         List<NetworkClientDelegate.UnsentRequest> drain(final long currentTimeMs) {
-            List<NetworkClientDelegate.UnsentRequest> unsentRequests = new ArrayList<>();
 
             // not ready to sent request
             List<OffsetCommitRequestState> unreadyCommitRequests = unsentOffsetCommits.stream()
@@ -1028,12 +1027,11 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
             failAndRemoveExpiredCommitRequests(currentTimeMs);
 
             // Add all unsent offset commit requests to the unsentRequests list
-            unsentRequests.addAll(
-                    unsentOffsetCommits.stream()
-                        .filter(request -> request.canSendRequest(currentTimeMs))
-                        .peek(request -> request.onSendAttempt(currentTimeMs))
-                        .map(OffsetCommitRequestState::toUnsentRequest)
-                        .collect(Collectors.toList()));
+            List<NetworkClientDelegate.UnsentRequest> unsentRequests = new ArrayList<>(unsentOffsetCommits.stream()
+                .filter(request -> request.canSendRequest(currentTimeMs))
+                .peek(request -> request.onSendAttempt(currentTimeMs))
+                .map(OffsetCommitRequestState::toUnsentRequest)
+                .collect(Collectors.toList()));
 
             // Partition the unsent offset fetch requests into sendable and non-sendable lists
             Map<Boolean, List<OffsetFetchRequestState>> partitionedBySendability =
@@ -1079,8 +1077,7 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
         }
 
         private List<NetworkClientDelegate.UnsentRequest> drainPendingCommits() {
-            ArrayList<NetworkClientDelegate.UnsentRequest> res = new ArrayList<>();
-            res.addAll(unsentOffsetCommits.stream().map(OffsetCommitRequestState::toUnsentRequest).collect(Collectors.toList()));
+            ArrayList<NetworkClientDelegate.UnsentRequest> res = new ArrayList<>(unsentOffsetCommits.stream().map(OffsetCommitRequestState::toUnsentRequest).collect(Collectors.toList()));
             clearAll();
             return res;
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -1077,7 +1077,7 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
         }
 
         private List<NetworkClientDelegate.UnsentRequest> drainPendingCommits() {
-            ArrayList<NetworkClientDelegate.UnsentRequest> res = new ArrayList<>(unsentOffsetCommits.stream().map(OffsetCommitRequestState::toUnsentRequest).collect(Collectors.toList()));
+            List<NetworkClientDelegate.UnsentRequest> res = new ArrayList<>(unsentOffsetCommits.stream().map(OffsetCommitRequestState::toUnsentRequest).collect(Collectors.toList()));
             clearAll();
             return res;
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -708,12 +708,7 @@ public class ConsumerNetworkClient implements Closeable {
             // the lock protects removal from a concurrent put which could otherwise mutate the
             // queue after it has been removed from the map
             synchronized (unsent) {
-                Iterator<ConcurrentLinkedQueue<ClientRequest>> iterator = unsent.values().iterator();
-                while (iterator.hasNext()) {
-                    ConcurrentLinkedQueue<ClientRequest> requests = iterator.next();
-                    if (requests.isEmpty())
-                        iterator.remove();
-                }
+                unsent.values().removeIf(ConcurrentLinkedQueue::isEmpty);
             }
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -380,7 +380,7 @@ public class HeartbeatRequestManager implements RequestManager {
                 break;
 
             case FENCED_MEMBER_EPOCH:
-                message = String.format("GroupHeartbeatRequest failed for member %s because epoch %s is fenced.",
+                message = String.format("GroupHeartbeatRequest failed for member %s because epoch %d is fenced.",
                         membershipManager.memberId(), membershipManager.memberEpoch());
                 logInfo(message, response, currentTimeMs);
                 membershipManager.transitionToFenced();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/LegacyKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/LegacyKafkaConsumer.java
@@ -518,7 +518,7 @@ public class LegacyKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
      */
     private void subscribeInternal(Pattern pattern, Optional<ConsumerRebalanceListener> listener) {
         maybeThrowInvalidGroupIdException();
-        if (pattern == null || pattern.toString().equals(""))
+        if (pattern == null || pattern.toString().isEmpty())
             throw new IllegalArgumentException("Topic pattern to subscribe to cannot be " + (pattern == null ?
                     "null" : "empty"));
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MemberState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MemberState.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.protocol.Errors;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public enum MemberState {
@@ -116,7 +117,7 @@ public enum MemberState {
 
         RECONCILING.previousValidStates = Arrays.asList(STABLE, JOINING, ACKNOWLEDGING, RECONCILING);
 
-        ACKNOWLEDGING.previousValidStates = Arrays.asList(RECONCILING);
+        ACKNOWLEDGING.previousValidStates = Collections.singletonList(RECONCILING);
 
         FATAL.previousValidStates = Arrays.asList(JOINING, STABLE, RECONCILING, ACKNOWLEDGING,
                 PREPARE_LEAVING, LEAVING, UNSUBSCRIBED);
@@ -129,7 +130,7 @@ public enum MemberState {
         PREPARE_LEAVING.previousValidStates = Arrays.asList(JOINING, STABLE, RECONCILING,
                 ACKNOWLEDGING, UNSUBSCRIBED, FENCED);
 
-        LEAVING.previousValidStates = Arrays.asList(PREPARE_LEAVING);
+        LEAVING.previousValidStates = Collections.singletonList(PREPARE_LEAVING);
 
         UNSUBSCRIBED.previousValidStates = Arrays.asList(PREPARE_LEAVING, LEAVING);
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -1079,7 +1079,7 @@ public class MembershipManagerImpl implements MembershipManager, ClusterResource
         // while waiting for the commit to complete. Check if that's the case and abort the
         // revocation.
         if (state == MemberState.FATAL) {
-            String errorMsg = String.format("Member %s with epoch %s received a fatal error " +
+            String errorMsg = String.format("Member %s with epoch %d received a fatal error " +
                 "while waiting for a revocation commit to complete. Will abort revocation " +
                 "without triggering user callback.", memberId, memberEpoch);
             log.debug(errorMsg);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/StickyPartitionCache.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/StickyPartitionCache.java
@@ -52,7 +52,7 @@ public class StickyPartitionCache {
         if (oldPart == null || oldPart == prevPartition) {
             List<PartitionInfo> availablePartitions = cluster.availablePartitionsForTopic(topic);
             if (availablePartitions.size() < 1) {
-                Integer random = Utils.toPositive(ThreadLocalRandom.current().nextInt());
+                int random = Utils.toPositive(ThreadLocalRandom.current().nextInt());
                 newPart = random % partitions.size();
             } else if (availablePartitions.size() == 1) {
                 newPart = availablePartitions.get(0).partition();

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -111,9 +111,7 @@ public class AbstractConfig {
         this.originals = resolveConfigVariables(configProviderProps, (Map<String, Object>) originals);
         this.values = definition.parse(this.originals);
         Map<String, Object> configUpdates = postProcessParsedConfig(Collections.unmodifiableMap(this.values));
-        for (Map.Entry<String, Object> update : configUpdates.entrySet()) {
-            this.values.put(update.getKey(), update.getValue());
-        }
+        this.values.putAll(configUpdates);
         definition.parse(this.values);
         this.definition = definition;
         if (doLog)
@@ -521,11 +519,10 @@ public class AbstractConfig {
     private Map<String, ?> resolveConfigVariables(Map<String, ?> configProviderProps, Map<String, Object> originals) {
         Map<String, String> providerConfigString;
         Map<String, ?> configProperties;
-        Map<String, Object> resolvedOriginals = new HashMap<>();
         // As variable configs are strings, parse the originals and obtain the potential variable configs.
         Map<String, String> indirectVariables = extractPotentialVariables(originals);
 
-        resolvedOriginals.putAll(originals);
+        Map<String, Object> resolvedOriginals = new HashMap<>(originals);
         if (configProviderProps == null || configProviderProps.isEmpty()) {
             providerConfigString = indirectVariables;
             configProperties = originals;

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -1488,7 +1488,7 @@ public class ConfigDef {
         }
 
         List<ConfigKey> configs = new ArrayList<>(configKeys.values());
-        Collections.sort(configs, (k1, k2) -> compare(k1, k2, groupOrd));
+        configs.sort((k1, k2) -> compare(k1, k2, groupOrd));
         return configs;
     }
 
@@ -1668,10 +1668,7 @@ public class ConfigDef {
     }
 
     private static void addConfigDetail(StringBuilder builder, String name, String value) {
-        builder.append("<tr>" +
-                "<th>" + name + ":</th>" +
-                "<td>" + value + "</td>" +
-                "</tr>\n");
+        builder.append("<tr>" + "<th>").append(name).append(":</th>").append("<td>").append(value).append("</td>").append("</tr>\n");
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -275,7 +275,7 @@ public enum ApiKeys {
         for (ApiKeys key : clientApis()) {
             b.append("<tr>\n");
             b.append("<td>");
-            b.append("<a href=\"#The_Messages_" + key.name + "\">" + key.name + "</a>");
+            b.append("<a href=\"#The_Messages_").append(key.name).append("\">").append(key.name).append("</a>");
             b.append("</td>");
             b.append("<td>");
             b.append(key.id);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -136,7 +136,7 @@ public class Protocol {
         for (ApiKeys key : ApiKeys.clientApis()) {
             // Key
             b.append("<h5>");
-            b.append("<a name=\"The_Messages_" + key.name + "\">");
+            b.append("<a name=\"The_Messages_").append(key.name).append("\">");
             b.append(key.name);
             b.append(" API (Key: ");
             b.append(key.id);

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/HttpAccessTokenRetriever.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/HttpAccessTokenRetriever.java
@@ -305,7 +305,7 @@ public class HttpAccessTokenRetriever implements AccessTokenRetriever {
     static String formatErrorMessage(String errorResponseBody) {
         // See https://www.ietf.org/rfc/rfc6749.txt, section 5.2 for the format
         // of this error message.
-        if (errorResponseBody == null || errorResponseBody.trim().equals("")) {
+        if (errorResponseBody == null || errorResponseBody.trim().isEmpty()) {
             return "{}";
         }
         ObjectMapper mapper = new ObjectMapper();

--- a/clients/src/main/java/org/apache/kafka/common/security/scram/ScramLoginModule.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/ScramLoginModule.java
@@ -46,7 +46,7 @@ public class ScramLoginModule implements LoginModule {
         if (password != null)
             subject.getPrivateCredentials().add(password);
 
-        Boolean useTokenAuthentication = "true".equalsIgnoreCase((String) options.get(TOKEN_AUTH_CONFIG));
+        boolean useTokenAuthentication = "true".equalsIgnoreCase((String) options.get(TOKEN_AUTH_CONFIG));
         if (useTokenAuthentication) {
             Map<String, String> scramExtensions = Collections.singletonMap(TOKEN_AUTH_CONFIG, "true");
             subject.getPublicCredentials().add(scramExtensions);

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -220,8 +220,8 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
         }
         log.warn("Unrecognized client authentication configuration {}.  Falling " +
                 "back to NONE.  Recognized client authentication configurations are {}.",
-                key, String.join(", ", SslClientAuth.VALUES.stream().
-                        map(Enum::name).collect(Collectors.toList())));
+                key, SslClientAuth.VALUES.stream().
+                        map(Enum::name).collect(Collectors.joining(", ")));
         return SslClientAuth.NONE;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollection.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollection.java
@@ -689,8 +689,6 @@ public class ImplicitLinkedHashCollection<E extends ImplicitLinkedHashCollection
             array.add(e);
         }
         array.sort(comparator);
-        for (E e : array) {
-            add(e);
-        }
+        this.addAll(array);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/utils/SecurityUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/SecurityUtils.java
@@ -76,7 +76,7 @@ public class SecurityUtils {
 
     public static void addConfiguredSecurityProviders(Map<String, ?> configs) {
         String securityProviderClassesStr = (String) configs.get(SecurityConfig.SECURITY_PROVIDERS_CONFIG);
-        if (securityProviderClassesStr == null || securityProviderClassesStr.equals("")) {
+        if (securityProviderClassesStr == null || securityProviderClassesStr.isEmpty()) {
             return;
         }
         try {

--- a/clients/src/main/java/org/apache/kafka/common/utils/Shell.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Shell.java
@@ -103,7 +103,7 @@ abstract public class Shell {
                     String line = errReader.readLine();
                     while ((line != null) && !Thread.currentThread().isInterrupted()) {
                         errMsg.append(line);
-                        errMsg.append(System.getProperty("line.separator"));
+                        errMsg.append(System.lineSeparator());
                         line = errReader.readLine();
                     }
                 } catch (IOException ioe) {

--- a/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/MirrorClientConfig.java
+++ b/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/MirrorClientConfig.java
@@ -110,8 +110,7 @@ public class MirrorClientConfig extends AbstractConfig {
     }
     
     private Map<String, Object> clientConfig(String prefix) {
-        Map<String, Object> props = new HashMap<>();
-        props.putAll(valuesWithPrefixOverride(prefix));
+        Map<String, Object> props = new HashMap<>(valuesWithPrefixOverride(prefix));
         props.keySet().retainAll(CLIENT_CONFIG_DEF.names());
         props.entrySet().removeIf(x -> x.getValue() == null);
         return props;

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -147,8 +147,7 @@ public abstract class MirrorConnectorConfig extends AbstractConfig {
     }
 
     Map<String, Object> sourceProducerConfig(String role) {
-        Map<String, Object> props = new HashMap<>();
-        props.putAll(originalsWithPrefix(SOURCE_CLUSTER_PREFIX));
+        Map<String, Object> props = new HashMap<>(originalsWithPrefix(SOURCE_CLUSTER_PREFIX));
         props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         props.putAll(originalsWithPrefix(PRODUCER_CLIENT_PREFIX));
         props.putAll(originalsWithPrefix(SOURCE_PREFIX + PRODUCER_CLIENT_PREFIX));
@@ -163,8 +162,7 @@ public abstract class MirrorConnectorConfig extends AbstractConfig {
     }
 
     static Map<String, Object> sourceConsumerConfig(Map<String, ?> props) {
-        Map<String, Object> result = new HashMap<>();
-        result.putAll(Utils.entriesWithPrefix(props, SOURCE_CLUSTER_PREFIX));
+        Map<String, Object> result = new HashMap<>(Utils.entriesWithPrefix(props, SOURCE_CLUSTER_PREFIX));
         result.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         result.putAll(Utils.entriesWithPrefix(props, CONSUMER_CLIENT_PREFIX));
         result.putAll(Utils.entriesWithPrefix(props, SOURCE_PREFIX + CONSUMER_CLIENT_PREFIX));
@@ -174,8 +172,7 @@ public abstract class MirrorConnectorConfig extends AbstractConfig {
     }
 
     Map<String, Object> targetAdminConfig(String role) {
-        Map<String, Object> props = new HashMap<>();
-        props.putAll(originalsWithPrefix(TARGET_CLUSTER_PREFIX));
+        Map<String, Object> props = new HashMap<>(originalsWithPrefix(TARGET_CLUSTER_PREFIX));
         props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         props.putAll(originalsWithPrefix(ADMIN_CLIENT_PREFIX));
         props.putAll(originalsWithPrefix(TARGET_PREFIX + ADMIN_CLIENT_PREFIX));
@@ -184,8 +181,7 @@ public abstract class MirrorConnectorConfig extends AbstractConfig {
     }
 
     Map<String, Object> targetProducerConfig(String role) {
-        Map<String, Object> props = new HashMap<>();
-        props.putAll(originalsWithPrefix(TARGET_CLUSTER_PREFIX));
+        Map<String, Object> props = new HashMap<>(originalsWithPrefix(TARGET_CLUSTER_PREFIX));
         props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         props.putAll(originalsWithPrefix(PRODUCER_CLIENT_PREFIX));
         props.putAll(originalsWithPrefix(TARGET_PREFIX + PRODUCER_CLIENT_PREFIX));
@@ -194,8 +190,7 @@ public abstract class MirrorConnectorConfig extends AbstractConfig {
     }
 
     Map<String, Object> targetConsumerConfig(String role) {
-        Map<String, Object> props = new HashMap<>();
-        props.putAll(originalsWithPrefix(TARGET_CLUSTER_PREFIX));
+        Map<String, Object> props = new HashMap<>(originalsWithPrefix(TARGET_CLUSTER_PREFIX));
         props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         props.putAll(originalsWithPrefix(CONSUMER_CLIENT_PREFIX));
         props.putAll(originalsWithPrefix(TARGET_PREFIX + CONSUMER_CLIENT_PREFIX));
@@ -206,8 +201,7 @@ public abstract class MirrorConnectorConfig extends AbstractConfig {
     }
 
     Map<String, Object> sourceAdminConfig(String role) {
-        Map<String, Object> props = new HashMap<>();
-        props.putAll(originalsWithPrefix(SOURCE_CLUSTER_PREFIX));
+        Map<String, Object> props = new HashMap<>(originalsWithPrefix(SOURCE_CLUSTER_PREFIX));
         props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         props.putAll(originalsWithPrefix(ADMIN_CLIENT_PREFIX));
         props.putAll(originalsWithPrefix(SOURCE_PREFIX + ADMIN_CLIENT_PREFIX));

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
@@ -151,9 +151,8 @@ public class MirrorMakerConfig extends AbstractConfig {
 
     // loads properties of the form cluster.x.y.z
     Map<String, String> clusterProps(String cluster) {
-        Map<String, String> props = new HashMap<>();
 
-        props.putAll(stringsWithPrefixStripped(cluster + "."));
+        Map<String, String> props = new HashMap<>(stringsWithPrefixStripped(cluster + "."));
 
         for (String k : MirrorClientConfig.CLIENT_CONFIG_DEF.names()) {
             String v = props.get(k);
@@ -230,9 +229,8 @@ public class MirrorMakerConfig extends AbstractConfig {
 
     // loads properties of the form cluster.x.y.z and source->target.x.y.z
     public Map<String, String> connectorBaseConfig(SourceAndTarget sourceAndTarget, Class<?> connectorClass) {
-        Map<String, String> props = new HashMap<>();
 
-        props.putAll(rawProperties);
+        Map<String, String> props = new HashMap<>(rawProperties);
         props.keySet().retainAll(allConfigNames());
         
         props.putAll(stringsWithPrefix(CONFIG_PROVIDERS_CONFIG));

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/rest/MirrorRestServer.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/rest/MirrorRestServer.java
@@ -26,7 +26,6 @@ import org.glassfish.hk2.api.TypeLiteral;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -48,7 +47,7 @@ public class MirrorRestServer extends RestServer {
 
     @Override
     protected Collection<Class<?>> regularResources() {
-        return Arrays.asList(
+        return Collections.singletonList(
                 InternalMirrorResource.class
         );
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -80,8 +80,7 @@ public class ConnectMetrics {
                 .timeWindow(sampleWindowMs, TimeUnit.MILLISECONDS).recordLevel(
                         Sensor.RecordingLevel.forName(metricsRecordingLevel));
 
-        Map<String, Object> contextLabels = new HashMap<>();
-        contextLabels.putAll(config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
+        Map<String, Object> contextLabels = new HashMap<>(config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
         contextLabels.put(WorkerConfig.CONNECT_KAFKA_CLUSTER_ID, clusterId);
         Object groupId = config.originals().get(DistributedConfig.GROUP_ID_CONFIG);
         if (groupId != null) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -87,8 +87,7 @@ public class WorkerGroupMember {
                     .tags(metricsTags);
             List<MetricsReporter> reporters = CommonClientConfigs.metricsReporters(clientId, config);
 
-            Map<String, Object> contextLabels = new HashMap<>();
-            contextLabels.putAll(config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
+            Map<String, Object> contextLabels = new HashMap<>(config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX));
             contextLabels.put(WorkerConfig.CONNECT_KAFKA_CLUSTER_ID, config.kafkaClusterId());
             contextLabels.put(WorkerConfig.CONNECT_GROUP_ID, config.getString(DistributedConfig.GROUP_ID_CONFIG));
             MetricsContext metricsContext = new KafkaMetricsContext(JMX_PREFIX, contextLabels);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/ConnectRestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/ConnectRestServer.java
@@ -27,6 +27,7 @@ import org.glassfish.jersey.server.ResourceConfig;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 public class ConnectRestServer extends RestServer {
@@ -56,7 +57,7 @@ public class ConnectRestServer extends RestServer {
 
     @Override
     protected Collection<Class<?>> adminResources() {
-        return Arrays.asList(
+        return Collections.singletonList(
                 LoggingResource.class
         );
     }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/TimestampConverter.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/TimestampConverter.java
@@ -161,7 +161,7 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
             public Date toRaw(Config config, Object orig) {
                 if (!(orig instanceof Long))
                     throw new DataException("Expected Unix timestamp to be a Long, but found " + orig.getClass());
-                Long unixTime = (Long) orig;
+                long unixTime = (Long) orig;
                 switch (config.unixPrecision) {
                     case UNIX_PRECISION_SECONDS:
                         return Timestamp.toLogical(Timestamp.SCHEMA, TimeUnit.SECONDS.toMillis(unixTime));
@@ -182,7 +182,7 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
 
             @Override
             public Long toType(Config config, Date orig) {
-                Long unixTimeMillis = Timestamp.fromLogical(Timestamp.SCHEMA, orig);
+                long unixTimeMillis = Timestamp.fromLogical(Timestamp.SCHEMA, orig);
                 switch (config.unixPrecision) {
                     case UNIX_PRECISION_SECONDS:
                         return TimeUnit.MILLISECONDS.toSeconds(unixTimeMillis);
@@ -280,10 +280,10 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
             this.format = format;
             this.unixPrecision = unixPrecision;
         }
-        String field;
-        String type;
-        SimpleDateFormat format;
-        String unixPrecision;
+        final String field;
+        final String type;
+        final SimpleDateFormat format;
+        final String unixPrecision;
     }
     private Config config;
     private Cache<Schema, Schema> schemaUpdateCache;

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -368,8 +368,9 @@ public class RemoteLogManager implements Closeable {
         for (StopPartition stopPartition: stopPartitions) {
             TopicPartition tp = stopPartition.topicPartition();
             try {
-                if (topicIdByPartitionMap.containsKey(tp)) {
-                    TopicIdPartition tpId = new TopicIdPartition(topicIdByPartitionMap.get(tp), tp);
+                final Uuid topicId = topicIdByPartitionMap.get(tp);
+                if (topicId != null) {
+                    TopicIdPartition tpId = new TopicIdPartition(topicId, tp);
                     RLMTaskWithFuture task = leaderOrFollowerTasks.remove(tpId);
                     if (task != null) {
                         LOGGER.info("Cancelling the RLM task for tpId: {}", tpId);

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -820,7 +820,7 @@ object ConfigCommand extends Logging {
       .ofType(classOf[String])
     val entityDefault = parser.accepts("entity-default", "Default entity name for clients/users/brokers/ips (applies to corresponding entity type in command line)")
 
-    val nl = System.getProperty("line.separator")
+    val nl = java.lang.System.lineSeparator()
     val addConfig = parser.accepts("add-config", "Key Value pairs of configs to add. Square brackets can be used to group values which contain commas: 'k1=v1,k2=[v1,v2,v2],k3=v3'. The following is a list of valid configurations: " +
       "For entity-type '" + ConfigType.TOPIC + "': " + LogConfig.configNames.asScala.map("\t" + _).mkString(nl, nl, nl) +
       "For entity-type '" + ConfigType.BROKER + "': " + DynamicConfig.Broker.names.asScala.toSeq.sorted.map("\t" + _).mkString(nl, nl, nl) +

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -986,7 +986,7 @@ object ConsumerGroupCommand extends Logging {
     val ListDoc = "List all consumer groups."
     val DescribeDoc = "Describe consumer group and list offset lag (number of messages not yet processed) related to given group."
     val AllGroupsDoc = "Apply to all consumer groups."
-    val nl = System.getProperty("line.separator")
+    val nl = java.lang.System.lineSeparator()
     val DeleteDoc = "Pass in groups to delete topic partition offsets and ownership information " +
       "over the entire consumer group. For instance --group g1 --group g2"
     val TimeoutMsDoc = "The timeout that can be set for some use cases. For example, it can be used when describing the group " +

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1802,7 +1802,7 @@ class Partition(val topicPartition: TopicPartition,
       } else {
         val replica = remoteReplicasMap.get(brokerId)
         val brokerEpoch = if (replica == null) Option.empty else replica.stateSnapshot.brokerEpoch
-        if (!brokerEpoch.isDefined) {
+        if (brokerEpoch.isEmpty) {
           // There are two cases where the broker epoch can be missing:
           // 1. During ISR expansion, we already held lock for the partition and did the broker epoch check, so the new
           //   ISR replica should have a valid broker epoch. Then, the missing broker epoch can only happen to the

--- a/core/src/main/scala/kafka/metrics/LinuxIoMetricsCollector.scala
+++ b/core/src/main/scala/kafka/metrics/LinuxIoMetricsCollector.scala
@@ -71,9 +71,9 @@ class LinuxIoMetricsCollector(procRoot: String, val time: Time, val logger: Logg
       val lines = Files.readAllLines(path, StandardCharsets.UTF_8).asScala
       lines.foreach(line => {
         if (line.startsWith(READ_BYTES_PREFIX)) {
-          cachedReadBytes = line.substring(READ_BYTES_PREFIX.size).toLong
+          cachedReadBytes = line.substring(READ_BYTES_PREFIX.length).toLong
         } else if (line.startsWith(WRITE_BYTES_PREFIX)) {
-          cachedWriteBytes = line.substring(WRITE_BYTES_PREFIX.size).toLong
+          cachedWriteBytes = line.substring(WRITE_BYTES_PREFIX.length).toLong
         }
       })
       lastUpdateMs = now

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -314,7 +314,7 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
   }
 
   private def verifyReconfigurableConfigs(configNames: Set[String]): Unit = CoreUtils.inWriteLock(lock) {
-    val nonDynamic = configNames.filter(DynamicConfig.Broker.nonDynamicProps.contains)
+    val nonDynamic = configNames.intersect(DynamicConfig.Broker.nonDynamicProps)
     require(nonDynamic.isEmpty, s"Reconfigurable contains non-dynamic configs $nonDynamic")
   }
 

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -661,7 +661,7 @@ class ZkAdminManager(val config: KafkaConfig,
     val exactUser = wantExact(userComponent)
     val exactClientId = wantExact(clientIdComponent)
 
-    def wantExcluded(component: Option[ClientQuotaFilterComponent]): Boolean = strict && !component.isDefined
+    def wantExcluded(component: Option[ClientQuotaFilterComponent]): Boolean = strict && component.isEmpty
     val excludeUser = wantExcluded(userComponent)
     val excludeClientId = wantExcluded(clientIdComponent)
 
@@ -803,7 +803,7 @@ class ZkAdminManager(val config: KafkaConfig,
   private val attemptToDescribeUserThatDoesNotExist = "Attempt to describe a user credential that does not exist"
 
   def describeUserScramCredentials(users: Option[Seq[String]]): DescribeUserScramCredentialsResponseData = {
-    val describingAllUsers = !users.isDefined || users.get.isEmpty
+    val describingAllUsers = users.isEmpty || users.get.isEmpty
     val retval = new DescribeUserScramCredentialsResponseData()
     val userResults = mutable.Map[String, DescribeUserScramCredentialsResponseData.DescribeUserScramCredentialsResult]()
 
@@ -954,7 +954,7 @@ class ZkAdminManager(val config: KafkaConfig,
       ).toMap ++ illegalUpsertions.map(requestStatus =>
         if (requestStatus.user.isEmpty) {
           (requestStatus.user, usernameMustNotBeEmptyMsg)
-        } else if (requestStatus.mechanism == Some(ScramMechanism.UNKNOWN)) {
+        } else if (requestStatus.mechanism.contains(ScramMechanism.UNKNOWN)) {
           (requestStatus.user, unknownScramMechanismMsg)
         } else {
           (requestStatus.user, if (requestStatus.iterations > maxIterations) {tooManyIterationsMsg} else {tooFewIterationsMsg})

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -235,7 +235,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
           case Code.OK =>
             info(s"Successfully registered KRaft controller $kraftControllerId with ZK epoch $newControllerEpoch")
             // First op is always SetData on /controller_epoch
-            val setDataResult = response.zkOpResults(0).rawOpResult.asInstanceOf[SetDataResult]
+            val setDataResult = response.zkOpResults.head.rawOpResult.asInstanceOf[SetDataResult]
             SuccessfulRegistrationResult(newControllerEpoch, setDataResult.getStat.getVersion)
           case Code.BADVERSION =>
             info(s"The ZK controller epoch changed $failureSuffix")

--- a/core/src/main/scala/kafka/zk/migration/ZkTopicMigrationClient.scala
+++ b/core/src/main/scala/kafka/zk/migration/ZkTopicMigrationClient.scala
@@ -339,7 +339,7 @@ class ZkTopicMigrationClient(zkClient: KafkaZkClient) extends TopicMigrationClie
       DeleteRequest(DeleteTopicsTopicZNode.path(topicName), ZkVersion.MatchAnyVersion)
     }.toSeq
 
-    val (migrationZkVersion, responses) = zkClient.retryMigrationRequestsUntilConnected(deleteRequests.toSeq, state)
+    val (migrationZkVersion, responses) = zkClient.retryMigrationRequestsUntilConnected(deleteRequests, state)
     val resultCodes = responses.map { response => response.path -> response.resultCode }.toMap
     if (resultCodes.forall { case (_, code) => code.equals(Code.OK) }) {
       state.withMigrationZkVersion(migrationZkVersion)

--- a/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatManager.java
@@ -131,13 +131,7 @@ public class BrokerHeartbeatManager {
                 return -1;
             } else if (a.metadataOffset > b.metadataOffset) {
                 return 1;
-            } else if (a.id < b.id) {
-                return -1;
-            } else if (a.id > b.id) {
-                return 1;
-            } else {
-                return 0;
-            }
+            } else return Integer.compare(a.id, b.id);
         }
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/BrokersToIsrs.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokersToIsrs.java
@@ -258,8 +258,7 @@ public class BrokersToIsrs {
         } else {
             int[] newPartitions = new int[partitions.length - 1];
             int j = 0;
-            for (int i = 0; i < partitions.length; i++) {
-                int partition = partitions[i];
+            for (int partition : partitions) {
                 if (partition != removedPartition) {
                     newPartitions[j++] = partition;
                 }

--- a/metadata/src/main/java/org/apache/kafka/controller/ControllerResult.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ControllerResult.java
@@ -69,7 +69,7 @@ class ControllerResult<T> {
     public String toString() {
         return String.format(
             "ControllerResult(records=%s, response=%s, isAtomic=%s)",
-            String.join(",", records.stream().map(ApiMessageAndVersion::toString).collect(Collectors.toList())),
+            records.stream().map(ApiMessageAndVersion::toString).collect(Collectors.joining(",")),
             response,
             isAtomic
         );

--- a/metadata/src/main/java/org/apache/kafka/controller/ControllerResultAndOffset.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ControllerResultAndOffset.java
@@ -56,7 +56,7 @@ final class ControllerResultAndOffset<T> extends ControllerResult<T> {
     public String toString() {
         return String.format(
             "ControllerResultAndOffset(records=%s, response=%s, isAtomic=%s, offset=%d)",
-            String.join(",", records().stream().map(ApiMessageAndVersion::toString).collect(Collectors.toList())),
+            records().stream().map(ApiMessageAndVersion::toString).collect(Collectors.joining(",")),
             response(),
             isAtomic(),
             offset

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -492,7 +492,7 @@ public class PartitionChangeBuilder {
         if (record.isr() != null && record.isr().isEmpty() && (partition.lastKnownElr.length != 1 ||
             partition.lastKnownElr[0] != partition.leader)) {
             // Only update the last known leader when the first time the partition becomes leaderless.
-            record.setLastKnownELR(Arrays.asList(partition.leader));
+            record.setLastKnownELR(Collections.singletonList(partition.leader));
         }
     }
 
@@ -548,7 +548,7 @@ public class PartitionChangeBuilder {
 
         // Calculate the new last known ELR. Includes any ISR members since the ISR size drops below min ISR.
         // In order to reduce the metadata usage, the last known ELR excludes the members in ELR and current ISR.
-        targetLastKnownElr.forEach(ii -> candidateSet.add(ii));
+        candidateSet.addAll(targetLastKnownElr);
         targetLastKnownElr = candidateSet.stream()
             .filter(replica -> !targetIsrSet.contains(replica))
             .filter(replica -> !targetElr.contains(replica))

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -130,7 +130,6 @@ import org.apache.kafka.timeline.SnapshotRegistry;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1410,7 +1410,7 @@ public final class QuorumController implements Controller {
                     maybeScheduleNextWriteNoOpRecord();
 
                     return ControllerResult.of(
-                        Arrays.asList(new ApiMessageAndVersion(new NoOpRecord(), (short) 0)),
+                        Collections.singletonList(new ApiMessageAndVersion(new NoOpRecord(), (short) 0)),
                         null
                     );
                 },

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumFeatures.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumFeatures.java
@@ -141,7 +141,7 @@ public final class QuorumFeatures {
     @Override
     public String toString() {
         List<String> features = new ArrayList<>();
-        localSupportedFeatures.entrySet().forEach(f -> features.add(f.getKey() + ": " + f.getValue()));
+        localSupportedFeatures.forEach((key, value) -> features.add(key + ": " + value));
         features.sort(String::compareTo);
         List<String> nodeIds = new ArrayList<>();
         quorumNodeIds.forEach(id -> nodeIds.add("" + id));

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -721,8 +721,8 @@ public class ReplicationControlManager {
             }
             ApiError error = maybeCheckCreateTopicPolicy(() -> {
                 Map<Integer, List<Integer>> assignments = new HashMap<>();
-                newParts.entrySet().forEach(e -> assignments.put(e.getKey(),
-                    Replicas.toList(e.getValue().replicas)));
+                newParts.forEach((key, value) -> assignments.put(key,
+                    Replicas.toList(value.replicas)));
                 return new CreateTopicPolicy.RequestMetadata(
                     topic.name(), null, null, assignments, creationConfigs);
             });

--- a/metadata/src/main/java/org/apache/kafka/image/DelegationTokenImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/DelegationTokenImage.java
@@ -54,8 +54,8 @@ public final class DelegationTokenImage {
         } else {
             if (!tokens.isEmpty()) {
                 List<String> tokenIds = new ArrayList<>(tokens.keySet());
-                StringBuffer delegationTokenImageString = new StringBuffer("DelegationTokenImage(");
-                delegationTokenImageString.append(tokenIds.stream().collect(Collectors.joining(", ")));
+                StringBuilder delegationTokenImageString = new StringBuilder("DelegationTokenImage(");
+                delegationTokenImageString.append(String.join(", ", tokenIds));
                 delegationTokenImageString.append(")");
                 options.handleLoss(delegationTokenImageString.toString());
             } 

--- a/metadata/src/main/java/org/apache/kafka/image/DelegationTokenImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/DelegationTokenImage.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 
 /**

--- a/metadata/src/main/java/org/apache/kafka/image/ScramImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ScramImage.java
@@ -61,12 +61,12 @@ public final class ScramImage {
             }
         } else {
             boolean isEmpty = true;
-            StringBuffer scramImageString = new StringBuffer("ScramImage({");
+            StringBuilder scramImageString = new StringBuilder("ScramImage({");
             for (Entry<ScramMechanism, Map<String, ScramCredentialData>> mechanismEntry : mechanisms.entrySet()) {
                 if (!mechanismEntry.getValue().isEmpty()) {
-                    scramImageString.append(mechanismEntry.getKey() + ":");
+                    scramImageString.append(mechanismEntry.getKey()).append(":");
                     List<String> users = new ArrayList<>(mechanismEntry.getValue().keySet());
-                    scramImageString.append(users.stream().collect(Collectors.joining(", ")));
+                    scramImageString.append(String.join(", ", users));
                     scramImageString.append("},{");
                     isEmpty = false;
                 }

--- a/metadata/src/main/java/org/apache/kafka/image/ScramImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ScramImage.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 
 /**

--- a/metadata/src/main/java/org/apache/kafka/image/node/ClientQuotasImageNode.java
+++ b/metadata/src/main/java/org/apache/kafka/image/node/ClientQuotasImageNode.java
@@ -63,14 +63,18 @@ public class ClientQuotasImageNode implements MetadataNode {
         String ip = null;
         String user = null;
         for (Map.Entry<String, String> entry : entity.entries().entrySet()) {
-            if (entry.getKey().equals(CLIENT_ID)) {
-                clientId = entry.getValue();
-            } else if (entry.getKey().equals(IP)) {
-                ip = entry.getValue();
-            } else if (entry.getKey().equals(USER)) {
-                user = entry.getValue();
-            } else {
-                throw new RuntimeException("Invalid entity type " + entry.getKey());
+            switch (entry.getKey()) {
+                case CLIENT_ID:
+                    clientId = entry.getValue();
+                    break;
+                case IP:
+                    ip = entry.getValue();
+                    break;
+                case USER:
+                    user = entry.getValue();
+                    break;
+                default:
+                    throw new RuntimeException("Invalid entity type " + entry.getKey());
             }
         }
         StringBuilder bld = new StringBuilder();
@@ -106,7 +110,7 @@ public class ClientQuotasImageNode implements MetadataNode {
     static ClientQuotaEntity decodeEntity(String input) {
         Map<String, String> entries = new HashMap<>();
         String type = null;
-        String value = "";
+        StringBuilder value = new StringBuilder();
         boolean escaping = false;
         int i = 0;
         while (true) {
@@ -127,20 +131,20 @@ public class ClientQuotasImageNode implements MetadataNode {
             } else {
                 char c = input.charAt(i++);
                 if (escaping) {
-                    value += c;
+                    value.append(c);
                     escaping = false;
                 } else {
                     switch (c) {
                         case ')':
-                            entries.put(type, value);
+                            entries.put(type, value.toString());
                             type = null;
-                            value = "";
+                            value = new StringBuilder();
                             break;
                         case '\\':
                             escaping = true;
                             break;
                         default:
-                            value += c;
+                            value.append(c);
                             break;
                     }
                 }

--- a/metadata/src/main/java/org/apache/kafka/image/node/TopicImageNode.java
+++ b/metadata/src/main/java/org/apache/kafka/image/node/TopicImageNode.java
@@ -52,7 +52,7 @@ public final class TopicImageNode implements MetadataNode {
         } else if (name.equals("id")) {
             return new MetadataLeafNode(image.id().toString());
         } else {
-            Integer partitionId;
+            int partitionId;
             try {
                 partitionId = Integer.parseInt(name);
             } catch (NumberFormatException e) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/properties/MetaPropertiesEnsemble.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/properties/MetaPropertiesEnsemble.java
@@ -101,9 +101,7 @@ public final class MetaPropertiesEnsemble {
         private Optional<String> metadataLogDir = Optional.empty();
 
         public Loader addLogDirs(Collection<String> logDirs) {
-            for (String logDir : logDirs) {
-                this.logDirs.add(logDir);
-            }
+            this.logDirs.addAll(logDirs);
             return this;
         }
 
@@ -607,8 +605,7 @@ public final class MetaPropertiesEnsemble {
         TreeMap<String, String> outputMap = new TreeMap<>();
         emptyLogDirs.forEach(e -> outputMap.put(e, "EMPTY"));
         errorLogDirs.forEach(e -> outputMap.put(e, "ERROR"));
-        logDirProps.entrySet().forEach(
-            e -> outputMap.put(e.getKey(), e.getValue().toString()));
+        logDirProps.forEach((key, value) -> outputMap.put(key, value.toString()));
         return "MetaPropertiesEnsemble" +
             "(metadataLogDir=" + metadataLogDir +
             ", dirs={" + outputMap.entrySet().stream().

--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerTopicConfigSynonyms.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerTopicConfigSynonyms.java
@@ -112,23 +112,23 @@ public final class ServerTopicConfigSynonyms {
     }
 
     private static Entry<String, List<ConfigSynonym>> sameName(String configName) {
-        return Utils.mkEntry(configName, asList(new ConfigSynonym(configName)));
+        return Utils.mkEntry(configName, Collections.singletonList(new ConfigSynonym(configName)));
     }
 
     private static Entry<String, List<ConfigSynonym>> sameNameWithLogPrefix(String configName) {
-        return Utils.mkEntry(configName, asList(new ConfigSynonym(LOG_PREFIX + configName)));
+        return Utils.mkEntry(configName, Collections.singletonList(new ConfigSynonym(LOG_PREFIX + configName)));
     }
 
     private static Entry<String, List<ConfigSynonym>> sameNameWithLogCleanerPrefix(String configName) {
-        return Utils.mkEntry(configName, asList(new ConfigSynonym(LOG_CLEANER_PREFIX + configName)));
+        return Utils.mkEntry(configName, Collections.singletonList(new ConfigSynonym(LOG_CLEANER_PREFIX + configName)));
     }
 
     private static Entry<String, List<ConfigSynonym>> singleWithLogPrefix(String topicConfigName, String brokerConfigName) {
-        return Utils.mkEntry(topicConfigName, asList(new ConfigSynonym(LOG_PREFIX + brokerConfigName)));
+        return Utils.mkEntry(topicConfigName, Collections.singletonList(new ConfigSynonym(LOG_PREFIX + brokerConfigName)));
     }
 
     private static Entry<String, List<ConfigSynonym>> singleWithLogCleanerPrefix(String topicConfigName, String brokerConfigName) {
-        return Utils.mkEntry(topicConfigName, asList(new ConfigSynonym(LOG_CLEANER_PREFIX + brokerConfigName)));
+        return Utils.mkEntry(topicConfigName, Collections.singletonList(new ConfigSynonym(LOG_CLEANER_PREFIX + brokerConfigName)));
     }
 
     private static Entry<String, List<ConfigSynonym>> listWithLogPrefix(String topicConfigName, ConfigSynonym... synonyms) {
@@ -139,6 +139,6 @@ public final class ServerTopicConfigSynonyms {
     }
 
     private static Entry<String, List<ConfigSynonym>> single(String topicConfigName, String brokerConfigName) {
-        return Utils.mkEntry(topicConfigName, asList(new ConfigSynonym(brokerConfigName)));
+        return Utils.mkEntry(topicConfigName, Collections.singletonList(new ConfigSynonym(brokerConfigName)));
     }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerTopicConfigSynonyms.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerTopicConfigSynonyms.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.server.config;
 
-import static java.util.Arrays.asList;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/server-common/src/main/java/org/apache/kafka/server/metrics/KafkaMetricsGroup.java
+++ b/server-common/src/main/java/org/apache/kafka/server/metrics/KafkaMetricsGroup.java
@@ -117,7 +117,7 @@ public class KafkaMetricsGroup {
 
     private static Optional<String> toMBeanName(Map<String, String> tags) {
         List<Map.Entry<String, String>> filteredTags = tags.entrySet().stream()
-                .filter(entry -> !entry.getValue().equals(""))
+                .filter(entry -> !entry.getValue().isEmpty())
                 .collect(Collectors.toList());
         if (!filteredTags.isEmpty()) {
             String tagsString = filteredTags.stream()
@@ -131,7 +131,7 @@ public class KafkaMetricsGroup {
 
     private static Optional<String> toScope(Map<String, String> tags) {
         List<Map.Entry<String, String>> filteredTags = tags.entrySet().stream()
-                .filter(entry -> !entry.getValue().equals(""))
+                .filter(entry -> !entry.getValue().isEmpty())
                 .collect(Collectors.toList());
         if (!filteredTags.isEmpty()) {
             // convert dot to _ since reporters like Graphite typically use dot to represent hierarchy

--- a/server-common/src/main/java/org/apache/kafka/server/util/FutureUtils.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/FutureUtils.java
@@ -60,12 +60,13 @@ public class FutureUtils {
             timeout.setStackTrace(t.getStackTrace());
             throw timeout;
         } catch (Throwable t)  {
-            if (t instanceof ExecutionException) {
-                ExecutionException executionException = (ExecutionException) t;
-                t = executionException.getCause();
+            Throwable throwable = t;
+            if (throwable instanceof ExecutionException) {
+                ExecutionException executionException = (ExecutionException) throwable;
+                throwable = executionException.getCause();
             }
-            log.error("{}Received a fatal error while waiting for {}", prefix, action, t);
-            throw new RuntimeException("Received a fatal error while waiting for " + action, t);
+            log.error("{}Received a fatal error while waiting for {}", prefix, action, throwable);
+            throw new RuntimeException("Received a fatal error while waiting for " + action, throwable);
         }
     }
 

--- a/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
@@ -51,8 +51,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.metadata.AssignmentsHelper.buildRequestData;
-
 public class AssignmentsManager {
 
     private static final Logger log = LoggerFactory.getLogger(AssignmentsManager.class);

--- a/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
@@ -367,7 +367,7 @@ public class ClientMetricsManager implements Closeable {
         }
 
         if (request.data().metrics() != null && request.data().metrics().length > clientTelemetryMaxBytes) {
-            String msg = String.format("Telemetry request from [%s] is larger than the maximum allowed size [%s]",
+            String msg = String.format("Telemetry request from [%s] is larger than the maximum allowed size [%d]",
                 request.data().clientInstanceId(), clientTelemetryMaxBytes);
             throw new TelemetryTooLargeException(msg);
         }

--- a/server/src/main/java/org/apache/kafka/server/metrics/ClientMetricsConfigs.java
+++ b/server/src/main/java/org/apache/kafka/server/metrics/ClientMetricsConfigs.java
@@ -135,7 +135,7 @@ public class ClientMetricsConfigs extends AbstractConfig {
         if (properties.containsKey(PUSH_INTERVAL_MS)) {
             int pushIntervalMs = Integer.parseInt(properties.getProperty(PUSH_INTERVAL_MS));
             if (pushIntervalMs < MIN_INTERVAL_MS || pushIntervalMs > MAX_INTERVAL_MS) {
-                String msg = String.format("Invalid value %s for %s, interval must be between 100 and 3600000 (1 hour)",
+                String msg = String.format("Invalid value %d for %s, interval must be between 100 and 3600000 (1 hour)",
                     pushIntervalMs, PUSH_INTERVAL_MS);
                 throw new InvalidRequestException(msg);
             }

--- a/shell/src/main/java/org/apache/kafka/shell/command/LsCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/LsCommandHandler.java
@@ -115,8 +115,7 @@ public final class LsCommandHandler implements Commands.Handler {
                     MetadataNodeInfo info = entryOption.get();
                     MetadataNode node = info.node();
                     if (node.isDirectory()) {
-                        List<String> children = new ArrayList<>();
-                        children.addAll(node.childNames());
+                        List<String> children = new ArrayList<>(node.childNames());
                         children.sort(String::compareTo);
                         targetDirectories.add(
                             new TargetDirectory(info.lastPathComponent(), children));

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataSnapshotFile.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataSnapshotFile.java
@@ -23,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataSnapshotFile.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataSnapshotFile.java
@@ -145,7 +145,7 @@ public class RemoteLogMetadataSnapshotFile {
             return Optional.empty();
         }
 
-        try (ReadableByteChannel channel = Channels.newChannel(new FileInputStream(metadataStoreFile))) {
+        try (ReadableByteChannel channel = Channels.newChannel(Files.newInputStream(metadataStoreFile.toPath()))) {
 
             // header: <version:short><metadata-partition:int><metadata-partition-offset:long>
             // Read header

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -469,7 +469,7 @@ public class LogConfig extends AbstractConfig {
      */
     public static LogConfig fromProps(Map<?, ?> defaults, Properties overrides) {
         Properties props = new Properties();
-        defaults.forEach((k, v) -> props.put(k, v));
+        props.putAll(defaults);
         props.putAll(overrides);
         Set<String> overriddenKeys = overrides.keySet().stream().map(k -> (String) k).collect(Collectors.toSet());
         return new LogConfig(props, overriddenKeys);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphGraceSearchUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphGraceSearchUtil.java
@@ -47,7 +47,7 @@ public final class GraphGraceSearchUtil {
             }
         }
 
-        final String newChain = chain.equals("") ? graphNode.nodeName() : graphNode.nodeName() + "->" + chain;
+        final String newChain = chain.isEmpty() ? graphNode.nodeName() : graphNode.nodeName() + "->" + chain;
 
         if (graphNode.parentNodes().isEmpty()) {
             // error base case: we traversed to the end of the graph without finding a window definition

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -462,7 +462,7 @@ public class ProcessorStateManager implements StateManager {
 
         if (!restoreRecords.isEmpty()) {
             // restore states from changelog records and update the snapshot offset as the batch end record's offset
-            final Long batchEndOffset = restoreRecords.get(restoreRecords.size() - 1).offset();
+            final long batchEndOffset = restoreRecords.get(restoreRecords.size() - 1).offset();
             final RecordBatchingStateRestoreCallback restoreCallback = adapt(storeMetadata.restoreCallback);
             final List<ConsumerRecord<byte[], byte[]>> convertedRecords = restoreRecords.stream()
                 .map(storeMetadata.recordConverter::convert)

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -314,10 +314,9 @@ public class StreamsMetadataState {
                                final Map<HostInfo, Set<TopicPartition>> standbyPartitionHostMap,
                                final Map<TopicPartition, PartitionInfo> topicPartitionInfo) {
         this.partitionsByTopic = new HashMap<>();
-        topicPartitionInfo.entrySet().forEach(entry -> this.partitionsByTopic
-                .computeIfAbsent(entry.getKey().topic(), topic -> new ArrayList<>())
-                .add(entry.getValue())
-        );
+        topicPartitionInfo.forEach((key, value) -> this.partitionsByTopic
+            .computeIfAbsent(key.topic(), topic -> new ArrayList<>())
+            .add(value));
 
         rebuildMetadata(activePartitionHostMap, standbyPartitionHostMap);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWindowStoreKeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWindowStoreKeyValueIterator.java
@@ -76,7 +76,9 @@ class MergedSortedCacheWindowStoreKeyValueIterator
     @Override
     Windowed<Bytes> deserializeCacheKey(final Bytes cacheKey) {
         final byte[] binaryKey = cacheFunction.key(cacheKey).get();
-        return storeKeyToWindowKey.toWindowKey(binaryKey, windowSize, serdes.keyDeserializer(), serdes.topic());
+        try (final Deserializer<Bytes> keyDeserializer = serdes.keyDeserializer()) {
+            return storeKeyToWindowKey.toWindowKey(binaryKey, windowSize, keyDeserializer, serdes.topic());
+        }
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/tools/ClientMetricsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClientMetricsCommand.java
@@ -244,7 +244,7 @@ public class ClientMetricsCommand {
                 .describedAs("push interval")
                 .ofType(java.lang.Integer.class);
 
-            nl = System.getProperty("line.separator");
+            nl = System.lineSeparator();
 
             String[] matchSelectors = new String[] {
                 "client_id", "client_instance_id", "client_software_name",

--- a/tools/src/main/java/org/apache/kafka/tools/DelegationTokenCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/DelegationTokenCommand.java
@@ -92,7 +92,7 @@ public class DelegationTokenCommand {
 
     public static DelegationToken createToken(Admin adminClient, DelegationTokenCommandOptions opts) throws ExecutionException, InterruptedException {
         List<KafkaPrincipal> renewerPrincipals = getPrincipals(opts, opts.renewPrincipalsOpt);
-        Long maxLifeTimeMs = opts.maxLifeTime();
+        long maxLifeTimeMs = opts.maxLifeTime();
 
         System.out.println("Calling create token operation with renewers :" + renewerPrincipals + " , max-life-time-period :" + maxLifeTimeMs);
         CreateDelegationTokenOptions createDelegationTokenOptions = new CreateDelegationTokenOptions().maxlifeTimeMs(maxLifeTimeMs).renewers(renewerPrincipals);
@@ -140,7 +140,7 @@ public class DelegationTokenCommand {
 
     public static Long renewToken(Admin adminClient, DelegationTokenCommandOptions opts) throws ExecutionException, InterruptedException {
         String hmac = opts.hmac();
-        Long renewTimePeriodMs = opts.renewTimePeriod();
+        long renewTimePeriodMs = opts.renewTimePeriod();
 
         System.out.println("Calling renew token operation with hmac :" + hmac + " , renew-time-period :" + renewTimePeriodMs);
         RenewDelegationTokenResult renewResult = adminClient.renewDelegationToken(Base64.getDecoder().decode(hmac), new RenewDelegationTokenOptions().renewTimePeriodMs(renewTimePeriodMs));
@@ -152,7 +152,7 @@ public class DelegationTokenCommand {
 
     public static void expireToken(Admin adminClient, DelegationTokenCommandOptions opts) throws ExecutionException, InterruptedException {
         String hmac = opts.hmac();
-        Long expiryTimePeriodMs = opts.expiryTimePeriod();
+        long expiryTimePeriodMs = opts.expiryTimePeriod();
 
         System.out.println("Calling expire token operation with hmac :" + hmac + " , expire-time-period :" + expiryTimePeriodMs);
         ExpireDelegationTokenResult renewResult = adminClient.expireDelegationToken(Base64.getDecoder().decode(hmac), new ExpireDelegationTokenOptions().expiryTimePeriodMs(expiryTimePeriodMs));

--- a/tools/src/main/java/org/apache/kafka/tools/LeaderElectionCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/LeaderElectionCommand.java
@@ -168,10 +168,10 @@ public class LeaderElectionCommand {
         if (!failed.isEmpty()) {
             AdminCommandFailedException rootException =
                 new AdminCommandFailedException(String.format("%d replica(s) could not be elected", failed.size()));
-            failed.entrySet().forEach(entry -> {
+            failed.forEach((key, value) -> {
                 System.out.println(String.format("Error completing leader election (%s) for partition: %s: %s",
-                    electionType, entry.getKey(), entry.getValue()));
-                rootException.addSuppressed(entry.getValue());
+                    electionType, key, value));
+                rootException.addSuppressed(value);
             });
             throw rootException;
         }

--- a/tools/src/main/java/org/apache/kafka/tools/LeaderElectionCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/LeaderElectionCommand.java
@@ -167,7 +167,7 @@ public class LeaderElectionCommand {
 
         if (!failed.isEmpty()) {
             AdminCommandFailedException rootException =
-                new AdminCommandFailedException(String.format("%s replica(s) could not be elected", failed.size()));
+                new AdminCommandFailedException(String.format("%d replica(s) could not be elected", failed.size()));
             failed.entrySet().forEach(entry -> {
                 System.out.println(String.format("Error completing leader election (%s) for partition: %s: %s",
                     electionType, entry.getKey(), entry.getValue()));
@@ -220,7 +220,7 @@ public class LeaderElectionCommand {
             .filter(i -> Collections.frequency(partitions, i) > 1)
             .collect(Collectors.toSet());
 
-        if (duplicatePartitions.size() > 0) {
+        if (!duplicatePartitions.isEmpty()) {
             throw new AdminOperationException(String.format(
                 "Replica election data contains duplicate partitions: %s", String.join(",", duplicatePartitions.toString()))
             );

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -507,7 +507,7 @@ public abstract class TopicCommand {
             String topicName) {
             if (topic.hasReplicaAssignment()) {
                 try {
-                    Integer startPartitionId = topicsInfo.get(topicName).get().partitions().size();
+                    int startPartitionId = topicsInfo.get(topicName).get().partitions().size();
                     Map<Integer, List<Integer>> replicaMap = topic.replicaAssignment.entrySet().stream()
                         .skip(startPartitionId)
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -540,7 +540,7 @@ public abstract class TopicCommand {
             // If topicId is provided and not zero, will use topicId regardless of topic name
             Optional<Uuid> inputTopicId = opts.topicId()
                 .map(Uuid::fromString).filter(uuid -> uuid != Uuid.ZERO_UUID);
-            Boolean useTopicId = inputTopicId.isPresent();
+            boolean useTopicId = inputTopicId.isPresent();
 
             List<Uuid> topicIds;
             List<String> topics;
@@ -752,7 +752,7 @@ public abstract class TopicCommand {
                 .withRequiredArg()
                 .describedAs("topic-id")
                 .ofType(String.class);
-            nl = System.getProperty("line.separator");
+            nl = System.lineSeparator();
 
             String logConfigNames = LogConfig.configNames().stream().map(config -> "\t" + config).collect(Collectors.joining(nl));
             configOpt = parser.accepts("config",  "A topic configuration override for the topic being created." +
@@ -954,7 +954,7 @@ public abstract class TopicCommand {
                 CommandLineUtils.checkRequiredArgs(parser, options, topicOpt);
             if (has(alterOpt)) {
                 Set<OptionSpec<?>> usedOptions = new HashSet<>(Arrays.asList(bootstrapServerOpt, configOpt));
-                Set<OptionSpec<?>> invalidOptions = new HashSet<>(Arrays.asList(alterOpt));
+                Set<OptionSpec<?>> invalidOptions = new HashSet<>(Collections.singletonList(alterOpt));
                 CommandLineUtils.checkInvalidArgsSet(parser, options, usedOptions, invalidOptions, Optional.of(KAFKA_CONFIGS_CLI_SUPPORTS_ALTERING_TOPIC_CONFIGS_WITH_A_BOOTSTRAP_SERVER));
                 CommandLineUtils.checkRequiredArgs(parser, options, partitionsOpt);
             }
@@ -964,9 +964,9 @@ public abstract class TopicCommand {
             // check invalid args
             CommandLineUtils.checkInvalidArgs(parser, options, configOpt, invalidOptions(Arrays.asList(alterOpt, createOpt)));
             CommandLineUtils.checkInvalidArgs(parser, options, deleteConfigOpt,
-                invalidOptions(new HashSet<>(Arrays.asList(bootstrapServerOpt)), Arrays.asList(alterOpt)));
+                invalidOptions(new HashSet<>(Collections.singletonList(bootstrapServerOpt)), Collections.singletonList(alterOpt)));
             CommandLineUtils.checkInvalidArgs(parser, options, partitionsOpt, invalidOptions(Arrays.asList(alterOpt, createOpt)));
-            CommandLineUtils.checkInvalidArgs(parser, options, replicationFactorOpt, invalidOptions(Arrays.asList(createOpt)));
+            CommandLineUtils.checkInvalidArgs(parser, options, replicationFactorOpt, invalidOptions(Collections.singletonList(createOpt)));
             CommandLineUtils.checkInvalidArgs(parser, options, replicaAssignmentOpt, invalidOptions(Arrays.asList(alterOpt, createOpt)));
             if (options.has(createOpt)) {
                 CommandLineUtils.checkInvalidArgs(parser, options, replicaAssignmentOpt, partitionsOpt, replicationFactorOpt);
@@ -982,10 +982,10 @@ public abstract class TopicCommand {
             CommandLineUtils.checkInvalidArgs(parser, options, reportUnavailablePartitionsOpt,
                 invalidOptions(Collections.singleton(topicsWithOverridesOpt), Arrays.asList(describeOpt, reportUnavailablePartitionsOpt)));
             CommandLineUtils.checkInvalidArgs(parser, options, topicsWithOverridesOpt,
-                invalidOptions(new HashSet<>(allReplicationReportOpts), Arrays.asList(describeOpt)));
+                invalidOptions(new HashSet<>(allReplicationReportOpts), Collections.singletonList(describeOpt)));
             CommandLineUtils.checkInvalidArgs(parser, options, ifExistsOpt,
                 invalidOptions(Arrays.asList(alterOpt, deleteOpt, describeOpt)));
-            CommandLineUtils.checkInvalidArgs(parser, options, ifNotExistsOpt, invalidOptions(Arrays.asList(createOpt)));
+            CommandLineUtils.checkInvalidArgs(parser, options, ifNotExistsOpt, invalidOptions(Collections.singletonList(createOpt)));
             CommandLineUtils.checkInvalidArgs(parser, options, excludeInternalTopicOpt, invalidOptions(Arrays.asList(listOpt, describeOpt)));
         }
 

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorRestResource.java
@@ -113,7 +113,7 @@ public class CoordinatorRestResource {
             @DefaultValue("0") @QueryParam("firstEndMs") long firstEndMs,
             @DefaultValue("0") @QueryParam("lastEndMs") long lastEndMs,
             @DefaultValue("") @QueryParam("state") String state) throws Throwable {
-        boolean isEmptyState = state.equals("");
+        boolean isEmptyState = state.isEmpty();
         if (!isEmptyState && !TaskStateType.Constants.VALUES.contains(state)) {
             return Response.status(400).entity(
                 String.format("State %s is invalid. Must be one of %s",

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/fault/NetworkPartitionFaultWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/fault/NetworkPartitionFaultWorker.java
@@ -70,9 +70,7 @@ public class NetworkPartitionFaultWorker implements TaskWorker {
         TreeSet<String> toBlock = new TreeSet<>();
         for (Set<String> partitionSet : partitionSets) {
             if (!partitionSet.contains(curNode.name())) {
-                for (String nodeName : partitionSet) {
-                    toBlock.add(nodeName);
-                }
+                toBlock.addAll(partitionSet);
             }
         }
         for (String nodeName : toBlock) {

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/Histogram.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/Histogram.java
@@ -152,14 +152,14 @@ public class Histogram {
         }
         // Verify that the percentiles array is sorted and positive.
         float prev = 0f;
-        for (int i = 0; i < percentiles.length; i++) {
-            if (percentiles[i] < prev) {
+        for (float percentile : percentiles) {
+            if (percentile < prev) {
                 throw new RuntimeException("Invalid percentiles fraction array.  Bad element " +
-                    percentiles[i] + ".  The array must be sorted and non-negative.");
+                    percentile + ".  The array must be sorted and non-negative.");
             }
-            if (percentiles[i] > 1.0f) {
+            if (percentile > 1.0f) {
                 throw new RuntimeException("Invalid percentiles fraction array.  Bad element " +
-                    percentiles[i] + ".  Elements must be less than or equal to 1.");
+                    percentile + ".  Elements must be less than or equal to 1.");
             }
         }
         // Find out how many total samples we have, and what the average is.

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/TopicsSpec.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/TopicsSpec.java
@@ -67,8 +67,7 @@ public class TopicsSpec extends Message {
     }
 
     public TopicsSpec immutableCopy() {
-        HashMap<String, PartitionsSpec> mapCopy = new HashMap<>();
-        mapCopy.putAll(map);
+        HashMap<String, PartitionsSpec> mapCopy = new HashMap<>(map);
         return new TopicsSpec(Collections.unmodifiableMap(mapCopy));
     }
 

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/TopicsSpec.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/TopicsSpec.java
@@ -67,7 +67,7 @@ public class TopicsSpec extends Message {
     }
 
     public TopicsSpec immutableCopy() {
-        HashMap<String, PartitionsSpec> mapCopy = new HashMap<>(map);
+        Map<String, PartitionsSpec> mapCopy = new HashMap<>(map);
         return new TopicsSpec(Collections.unmodifiableMap(mapCopy));
     }
 
@@ -77,7 +77,7 @@ public class TopicsSpec extends Message {
      * @return      A map from topic names to PartitionsSpec objects.
      */
     public Map<String, PartitionsSpec> materialize() {
-        HashMap<String, PartitionsSpec> all = new HashMap<>();
+        Map<String, PartitionsSpec> all = new HashMap<>();
         for (Map.Entry<String, PartitionsSpec> entry : map.entrySet()) {
             String topicName = entry.getKey();
             PartitionsSpec partitions = entry.getValue();

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -79,7 +79,7 @@ task bootstrapWrapper() {
 wrapper.finalizedBy bootstrapWrapper
 
 // Remove the generated batch file since we don't test building in the Windows environment.
-task removeWindowsScript(type: Delete) {
+tasks.register('removeWindowsScript', Delete) {
     delete "$rootDir/gradlew.bat"
 }
 wrapper.finalizedBy removeWindowsScript


### PR DESCRIPTION
Multiple clean ups for `warn` discovered via automatic tooling (different ones). No logic change.

Types of clean up:
1. Remove redundant imports
2. Use bulk collection operations such as `putAll` instead of iteration
3. Replace `Arrays.asList()` with `Collections.singletonList()`
4. Remove String concatenation in a loop, use StringBuilder instead
5. Replace `if` with `switch`
6. Use `compare()` to compare integers
7. Loop is replaces with `Collection.removeIf()`
8. Replace StringBuffer with StringBuilder
9. Replace `for` with enhanced `for` loop
10. Replace redundant `Collection.addAll()` with parameterized constructor call
11. Use `%d` with integers instead of `%s`
12. Replace `String.equals("")` with `String.isEmpty()`
13. Replace `Collections.sort()` with `List.sort()` where applicable
14. Replace `System.getProperty("line.separator")` with `System.lineSeparator()`