### PR TITLE
MINOR: New year code cleanup - include final keyword

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -44,9 +44,9 @@ final class ClusterConnectionStates {
     private final Map<String, NodeConnectionState> nodeState;
     private final Logger log;
     private final HostResolver hostResolver;
-    private Set<String> connectingNodes;
-    private ExponentialBackoff reconnectBackoff;
-    private ExponentialBackoff connectionSetupTimeout;
+    private final Set<String> connectingNodes;
+    private final ExponentialBackoff reconnectBackoff;
+    private final ExponentialBackoff connectionSetupTimeout;
 
     public ClusterConnectionStates(long reconnectBackoffMs, long reconnectBackoffMaxMs,
                                    long connectionSetupTimeoutMs, long connectionSetupTimeoutMaxMs,
@@ -479,7 +479,7 @@ final class ClusterConnectionStates {
         private final String host;
         private final HostResolver hostResolver;
         private InetAddress lastAttemptedAddress;
-        private Logger log;
+        private final Logger log;
 
         private NodeConnectionState(ConnectionState state, long lastConnectAttemptMs, long reconnectBackoffMs,
                 long connectionSetupTimeoutMs, String host, HostResolver hostResolver, Logger log) {

--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -464,6 +464,9 @@ final class ClusterConnectionStates {
      * The state of our connection to a node.
      */
     private static class NodeConnectionState {
+        private final String host;
+        private final HostResolver hostResolver;
+        private final Logger log;
 
         ConnectionState state;
         AuthenticationException authenticationException;
@@ -476,10 +479,7 @@ final class ClusterConnectionStates {
         long throttleUntilTimeMs;
         private List<InetAddress> addresses;
         private int addressIndex;
-        private final String host;
-        private final HostResolver hostResolver;
         private InetAddress lastAttemptedAddress;
-        private final Logger log;
 
         private NodeConnectionState(ConnectionState state, long lastConnectAttemptMs, long reconnectBackoffMs,
                 long connectionSetupTimeoutMs, String host, HostResolver hostResolver, Logger log) {

--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -228,6 +228,8 @@ public class FetchSessionHandler {
     }
 
     public class Builder {
+        private final Map<Uuid, String> topicNames;
+        private final boolean copySessionPartitions;
         /**
          * The next partitions which we want to fetch.
          *
@@ -242,8 +244,6 @@ public class FetchSessionHandler {
          * incremental fetch requests (see below).
          */
         private LinkedHashMap<TopicPartition, PartitionData> next;
-        private final Map<Uuid, String> topicNames;
-        private final boolean copySessionPartitions;
         private int partitionsWithoutTopicIds = 0;
 
         Builder() {

--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -242,7 +242,7 @@ public class FetchSessionHandler {
          * incremental fetch requests (see below).
          */
         private LinkedHashMap<TopicPartition, PartitionData> next;
-        private Map<Uuid, String> topicNames;
+        private final Map<Uuid, String> topicNames;
         private final boolean copySessionPartitions;
         private int partitionsWithoutTopicIds = 0;
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitions.java
@@ -30,9 +30,9 @@ import java.util.Map;
 @InterfaceStability.Evolving
 public class NewPartitions {
 
-    private int totalCount;
+    private final int totalCount;
 
-    private List<List<Integer>> newAssignments;
+    private final List<List<Integer>> newAssignments;
 
     private NewPartitions(int totalCount, List<List<Integer>> newAssignments) {
         this.totalCount = totalCount;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/RecordsToDelete.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/RecordsToDelete.java
@@ -29,7 +29,7 @@ import java.util.Map;
 @InterfaceStability.Evolving
 public class RecordsToDelete {
 
-    private long offset;
+    private final long offset;
 
     private RecordsToDelete(long offset) {
         this.offset = offset;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/RemoveMembersFromConsumerGroupOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/RemoveMembersFromConsumerGroupOptions.java
@@ -32,7 +32,7 @@ import java.util.Set;
 @InterfaceStability.Evolving
 public class RemoveMembersFromConsumerGroupOptions extends AbstractOptions<RemoveMembersFromConsumerGroupOptions> {
 
-    private Set<MemberToRemove> members;
+    private final Set<MemberToRemove> members;
     private String reason;
 
     public RemoveMembersFromConsumerGroupOptions(Collection<MemberToRemove> members) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java
@@ -172,8 +172,8 @@ public interface ConsumerPartitionAssignor {
     }
 
     final class Assignment {
-        private List<TopicPartition> partitions;
-        private ByteBuffer userData;
+        private final List<TopicPartition> partitions;
+        private final ByteBuffer userData;
 
         public Assignment(List<TopicPartition> partitions, ByteBuffer userData) {
             this.partitions = partitions;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
@@ -101,7 +101,7 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
         @Override
         public Iterator<ConsumerRecord<K, V>> iterator() {
             return new AbstractIterator<ConsumerRecord<K, V>>() {
-                Iterator<? extends Iterable<ConsumerRecord<K, V>>> iters = iterables.iterator();
+                final Iterator<? extends Iterable<ConsumerRecord<K, V>>> iters = iterables.iterator();
                 Iterator<ConsumerRecord<K, V>> current;
 
                 protected ConsumerRecord<K, V> makeNext() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -65,10 +65,10 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     private final Queue<Runnable> pollTasks;
     private final Set<TopicPartition> paused;
 
-    private Map<TopicPartition, List<ConsumerRecord<K, V>>> records;
+    private final Map<TopicPartition, List<ConsumerRecord<K, V>>> records;
     private KafkaException pollException;
     private KafkaException offsetsException;
-    private AtomicBoolean wakeup;
+    private final AtomicBoolean wakeup;
     private Duration lastPollTimeout;
     private boolean closed;
     private boolean shouldRebalance;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -64,11 +64,11 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     private final Map<TopicPartition, OffsetAndMetadata> committed;
     private final Queue<Runnable> pollTasks;
     private final Set<TopicPartition> paused;
+    private final AtomicBoolean wakeup;
 
     private final Map<TopicPartition, List<ConsumerRecord<K, V>>> records;
     private KafkaException pollException;
     private KafkaException offsetsException;
-    private final AtomicBoolean wakeup;
     private Duration lastPollTimeout;
     private boolean closed;
     private boolean shouldRebalance;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -67,6 +67,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     private final AtomicBoolean wakeup;
 
     private final Map<TopicPartition, List<ConsumerRecord<K, V>>> records;
+
     private KafkaException pollException;
     private KafkaException offsetsException;
     private Duration lastPollTimeout;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -117,7 +117,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
     private MetadataSnapshot metadataSnapshot;
     private MetadataSnapshot assignmentSnapshot;
     private Timer nextAutoCommitTimer;
-    private AtomicBoolean asyncCommitFenced;
+    private final AtomicBoolean asyncCommitFenced;
     private ConsumerGroupMetadata groupMetadata;
     private final boolean throwOnFetchStableOffsetsUnsupported;
     private final Optional<String> rackId;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -111,17 +111,15 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
     // this collection must be thread-safe because it is modified from the response handler
     // of offset commit requests, which may be invoked from the heartbeat thread
     private final ConcurrentLinkedQueue<OffsetCommitCompletion> completedOffsetCommits;
-
+    private final AtomicBoolean asyncCommitFenced;
+    private final boolean throwOnFetchStableOffsetsUnsupported;
+    private final Optional<String> rackId;
     private boolean isLeader = false;
     private Set<String> joinedSubscription;
     private MetadataSnapshot metadataSnapshot;
     private MetadataSnapshot assignmentSnapshot;
     private Timer nextAutoCommitTimer;
-    private final AtomicBoolean asyncCommitFenced;
     private ConsumerGroupMetadata groupMetadata;
-    private final boolean throwOnFetchStableOffsetsUnsupported;
-    private final Optional<String> rackId;
-
     // hold onto request&future for committed offset requests to enable async calls.
     private PendingCommittedOffsetRequest pendingCommittedOffsetRequest = null;
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Heartbeat.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Heartbeat.java
@@ -40,7 +40,7 @@ public final class Heartbeat {
     private volatile long lastHeartbeatSend = 0L;
     private volatile boolean heartbeatInFlight = false;
     private volatile long heartbeatAttempts = 0L;
-    private ExponentialBackoff retryBackoff;
+    private final ExponentialBackoff retryBackoff;
 
     public Heartbeat(GroupRebalanceConfig config,
                      Time time) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Heartbeat.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Heartbeat.java
@@ -36,11 +36,11 @@ public final class Heartbeat {
     private final Timer sessionTimer;
     private final Timer pollTimer;
     private final Logger log;
+    private final ExponentialBackoff retryBackoff;
 
     private volatile long lastHeartbeatSend = 0L;
     private volatile boolean heartbeatInFlight = false;
     private volatile long heartbeatAttempts = 0L;
-    private final ExponentialBackoff retryBackoff;
 
     public Heartbeat(GroupRebalanceConfig config,
                      Time time) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -61,7 +61,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
     private Map<String, Map<TopicPartition, OffsetAndMetadata>> uncommittedConsumerGroupOffsets;
     private final Serializer<K> keySerializer;
     private final Serializer<V> valueSerializer;
-    private boolean autoComplete;
+    private final boolean autoComplete;
     private boolean closed;
     private boolean transactionInitialized;
     private boolean transactionInFlight;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -58,10 +58,11 @@ public class MockProducer<K, V> implements Producer<K, V> {
     private final Deque<Completion> completions;
     private final Map<TopicPartition, Long> offsets;
     private final List<Map<String, Map<TopicPartition, OffsetAndMetadata>>> consumerGroupOffsets;
-    private Map<String, Map<TopicPartition, OffsetAndMetadata>> uncommittedConsumerGroupOffsets;
+    private final Map<MetricName, Metric> mockMetrics;
     private final Serializer<K> keySerializer;
     private final Serializer<V> valueSerializer;
     private final boolean autoComplete;
+    private Map<String, Map<TopicPartition, OffsetAndMetadata>> uncommittedConsumerGroupOffsets;
     private boolean closed;
     private boolean transactionInitialized;
     private boolean transactionInFlight;
@@ -70,7 +71,6 @@ public class MockProducer<K, V> implements Producer<K, V> {
     private boolean producerFenced;
     private boolean sentOffsets;
     private long commitCount = 0L;
-    private final Map<MetricName, Metric> mockMetrics;
 
     public RuntimeException initTransactionException = null;
     public RuntimeException beginTransactionException = null;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ErrorLoggingCallback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ErrorLoggingCallback.java
@@ -27,10 +27,9 @@ public class ErrorLoggingCallback implements Callback {
     private static final Logger log = LoggerFactory.getLogger(ErrorLoggingCallback.class);
     private final String topic;
     private final byte[] key;
-    private byte[] value;
     private final int valueLength;
     private final boolean logAsString;
-
+    private byte[] value;
     public ErrorLoggingCallback(String topic, byte[] key, byte[] value, boolean logAsString) {
         this.topic = topic;
         this.key = key;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ErrorLoggingCallback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ErrorLoggingCallback.java
@@ -25,11 +25,11 @@ import java.nio.charset.StandardCharsets;
 
 public class ErrorLoggingCallback implements Callback {
     private static final Logger log = LoggerFactory.getLogger(ErrorLoggingCallback.class);
-    private String topic;
-    private byte[] key;
+    private final String topic;
+    private final byte[] key;
     private byte[] value;
-    private int valueLength;
-    private boolean logAsString;
+    private final int valueLength;
+    private final boolean logAsString;
 
     public ErrorLoggingCallback(String topic, byte[] key, byte[] value, boolean logAsString) {
         this.topic = topic;

--- a/clients/src/main/java/org/apache/kafka/common/MetricName.java
+++ b/clients/src/main/java/org/apache/kafka/common/MetricName.java
@@ -65,7 +65,7 @@ public final class MetricName {
     private final String name;
     private final String group;
     private final String description;
-    private Map<String, String> tags;
+    private final Map<String, String> tags;
     private int hash = 0;
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/MetricNameTemplate.java
+++ b/clients/src/main/java/org/apache/kafka/common/MetricNameTemplate.java
@@ -32,7 +32,7 @@ public class MetricNameTemplate {
     private final String name;
     private final String group;
     private final String description;
-    private LinkedHashSet<String> tags;
+    private final LinkedHashSet<String> tags;
 
     /**
      * Create a new template. Note that the order of the tags will be preserved if the supplied

--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.utils.Time;
 
 public final class KafkaMetric implements Metric {
 
-    private MetricName metricName;
+    private final MetricName metricName;
     private final Object lock;
     private final Time time;
     private final MetricValueProvider<?> metricValueProvider;

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/SampledStat.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/SampledStat.java
@@ -34,7 +34,7 @@ import org.apache.kafka.common.metrics.MetricConfig;
  */
 public abstract class SampledStat implements MeasurableStat {
 
-    private double initialValue;
+    private final double initialValue;
     private int current = 0;
     protected List<Sample> samples;
 

--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -93,8 +93,8 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
     private final String sslClientAuthOverride;
 
     private KerberosShortNamer kerberosShortNamer;
-    private Map<String, AuthenticateCallbackHandler> saslCallbackHandlers;
-    private Map<String, Long> connectionsMaxReauthMsByMechanism;
+    private final Map<String, AuthenticateCallbackHandler> saslCallbackHandlers;
+    private final Map<String, Long> connectionsMaxReauthMsByMechanism;
     private final Time time;
     private final LogContext logContext;
     private final Logger log;

--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -87,17 +87,16 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
     private final Map<String, LoginManager> loginManagers;
     private final Map<String, Subject> subjects;
     private final Supplier<ApiVersionsResponse> apiVersionSupplier;
-
-    private SslFactory sslFactory;
-    private Map<String, ?> configs;
     private final String sslClientAuthOverride;
-
-    private KerberosShortNamer kerberosShortNamer;
     private final Map<String, AuthenticateCallbackHandler> saslCallbackHandlers;
     private final Map<String, Long> connectionsMaxReauthMsByMechanism;
     private final Time time;
     private final LogContext logContext;
     private final Logger log;
+
+    private SslFactory sslFactory;
+    private Map<String, ?> configs;
+    private KerberosShortNamer kerberosShortNamer;
 
     public SaslChannelBuilder(Mode mode,
                               Map<String, JaasContext> jaasContexts,

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -94,7 +94,7 @@ public class Selector implements Selectable, AutoCloseable {
         NOTIFY_ONLY(true),         // discard any outstanding receives, notify disconnect
         DISCARD_NO_NOTIFY(false);  // discard any outstanding receives, no disconnect notification
 
-        boolean notifyDisconnect;
+        final boolean notifyDisconnect;
 
         CloseMode(boolean notifyDisconnect) {
             this.notifyDisconnect = notifyDisconnect;

--- a/clients/src/main/java/org/apache/kafka/common/network/SslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslChannelBuilder.java
@@ -44,7 +44,7 @@ public class SslChannelBuilder implements ChannelBuilder, ListenerReconfigurable
     private final ListenerName listenerName;
     private final boolean isInterBrokerListener;
     private SslFactory sslFactory;
-    private Mode mode;
+    private final Mode mode;
     private Map<String, ?> configs;
     private SslPrincipalMapper sslPrincipalMapper;
     private final Logger log;

--- a/clients/src/main/java/org/apache/kafka/common/network/SslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslChannelBuilder.java
@@ -43,11 +43,11 @@ import java.util.function.Supplier;
 public class SslChannelBuilder implements ChannelBuilder, ListenerReconfigurable {
     private final ListenerName listenerName;
     private final boolean isInterBrokerListener;
-    private SslFactory sslFactory;
     private final Mode mode;
+    private final Logger log;
+    private SslFactory sslFactory;
     private Map<String, ?> configs;
     private SslPrincipalMapper sslPrincipalMapper;
-    private final Logger log;
 
     /**
      * Constructs an SSL channel builder. ListenerName is provided only

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -396,8 +396,8 @@ public enum Errors {
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 
-    private static Map<Class<?>, Errors> classToError = new HashMap<>();
-    private static Map<Short, Errors> codeToError = new HashMap<>();
+    private static final Map<Class<?>, Errors> classToError = new HashMap<>();
+    private static final Map<Short, Errors> codeToError = new HashMap<>();
 
     static {
         for (Errors error : Errors.values()) {

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -396,17 +396,17 @@ public enum Errors {
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 
-    private static final Map<Class<?>, Errors> classToError = new HashMap<>();
-    private static final Map<Short, Errors> codeToError = new HashMap<>();
+    private static final Map<Class<?>, Errors> CLASS_TO_ERROR = new HashMap<>();
+    private static final Map<Short, Errors> CODE_TO_ERROR = new HashMap<>();
 
     static {
         for (Errors error : Errors.values()) {
-            if (codeToError.put(error.code(), error) != null)
+            if (CODE_TO_ERROR.put(error.code(), error) != null)
                 throw new ExceptionInInitializerError("Code " + error.code() + " for error " +
                         error + " has already been used");
 
             if (error.exception != null)
-                classToError.put(error.exception.getClass(), error);
+                CLASS_TO_ERROR.put(error.exception.getClass(), error);
         }
     }
 
@@ -479,7 +479,7 @@ public enum Errors {
      * Throw the exception if there is one
      */
     public static Errors forCode(short code) {
-        Errors error = codeToError.get(code);
+        Errors error = CODE_TO_ERROR.get(code);
         if (error != null) {
             return error;
         } else {
@@ -496,7 +496,7 @@ public enum Errors {
         Throwable cause = maybeUnwrapException(t);
         Class<?> clazz = cause.getClass();
         while (clazz != null) {
-            Errors error = classToError.get(clazz);
+            Errors error = CLASS_TO_ERROR.get(clazz);
             if (error != null)
                 return error;
             clazz = clazz.getSuperclass();

--- a/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecordsSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecordsSend.java
@@ -37,8 +37,9 @@ public final class LazyDownConversionRecordsSend extends RecordsSend<LazyDownCon
     static final int MIN_OVERFLOW_MESSAGE_LENGTH = Records.LOG_OVERHEAD;
 
     private final RecordValidationStats recordValidationStats;
-    private RecordsSend convertedRecordsWriter;
     private final Iterator<ConvertedRecords<?>> convertedRecordsIterator;
+
+    private RecordsSend convertedRecordsWriter;
 
     public LazyDownConversionRecordsSend(LazyDownConversionRecords records) {
         super(records, records.sizeInBytes());

--- a/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecordsSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecordsSend.java
@@ -36,9 +36,9 @@ public final class LazyDownConversionRecordsSend extends RecordsSend<LazyDownCon
     private static final int MAX_READ_SIZE = 128 * 1024;
     static final int MIN_OVERFLOW_MESSAGE_LENGTH = Records.LOG_OVERHEAD;
 
-    private RecordValidationStats recordValidationStats;
+    private final RecordValidationStats recordValidationStats;
     private RecordsSend convertedRecordsWriter;
-    private Iterator<ConvertedRecords<?>> convertedRecordsIterator;
+    private final Iterator<ConvertedRecords<?>> convertedRecordsIterator;
 
     public LazyDownConversionRecordsSend(LazyDownConversionRecords records) {
         super(records, records.sizeInBytes());

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
@@ -80,7 +80,7 @@ public class MemoryRecordsBuilder implements AutoCloseable {
     private int numRecords = 0;
     private float actualCompressionRatio = 1;
     private long maxTimestamp = RecordBatch.NO_TIMESTAMP;
-    private long deleteHorizonMs;
+    private final long deleteHorizonMs;
     private long offsetOfMaxTimestamp = -1;
     private Long lastOffset = null;
     private Long baseTimestamp = null;

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
@@ -65,6 +65,7 @@ public class MemoryRecordsBuilder implements AutoCloseable {
     private final int partitionLeaderEpoch;
     private final int writeLimit;
     private final int batchHeaderSizeInBytes;
+    private final long deleteHorizonMs;
 
     // Use a conservative estimate of the compression ratio. The producer overrides this using statistics
     // from previous batches before appending any records.
@@ -80,7 +81,6 @@ public class MemoryRecordsBuilder implements AutoCloseable {
     private int numRecords = 0;
     private float actualCompressionRatio = 1;
     private long maxTimestamp = RecordBatch.NO_TIMESTAMP;
-    private final long deleteHorizonMs;
     private long offsetOfMaxTimestamp = -1;
     private Long lastOffset = null;
     private Long baseTimestamp = null;

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteRecordsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteRecordsRequest.java
@@ -34,7 +34,7 @@ public class DeleteRecordsRequest extends AbstractRequest {
     private final DeleteRecordsRequestData data;
 
     public static class Builder extends AbstractRequest.Builder<DeleteRecordsRequest> {
-        private DeleteRecordsRequestData data;
+        private final DeleteRecordsRequestData data;
 
         public Builder(DeleteRecordsRequestData data) {
             super(ApiKeys.DELETE_RECORDS);

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsRequest.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 public class DeleteTopicsRequest extends AbstractRequest {
 
     public static class Builder extends AbstractRequest.Builder<DeleteTopicsRequest> {
-        private DeleteTopicsRequestData data;
+        private final DeleteTopicsRequestData data;
 
         public Builder(DeleteTopicsRequestData data) {
             super(ApiKeys.DELETE_TOPICS);
@@ -62,7 +62,7 @@ public class DeleteTopicsRequest extends AbstractRequest {
         }
     }
 
-    private DeleteTopicsRequestData data;
+    private final DeleteTopicsRequestData data;
 
     private DeleteTopicsRequest(DeleteTopicsRequestData data, short version) {
         super(ApiKeys.DELETE_TOPICS, version);

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListPartitionReassignmentsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListPartitionReassignmentsRequest.java
@@ -51,7 +51,7 @@ public class ListPartitionReassignmentsRequest extends AbstractRequest {
         }
     }
 
-    private ListPartitionReassignmentsRequestData data;
+    private final ListPartitionReassignmentsRequestData data;
 
     private ListPartitionReassignmentsRequest(ListPartitionReassignmentsRequestData data, short version) {
         super(ApiKeys.LIST_PARTITION_REASSIGNMENTS, version);

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponse.java
@@ -41,7 +41,7 @@ public class OAuthBearerClientInitialResponse {
 
     private final String tokenValue;
     private final String authorizationId;
-    private SaslExtensions saslExtensions;
+    private final SaslExtensions saslExtensions;
 
     public static final Pattern EXTENSION_KEY_PATTERN = Pattern.compile(KEY);
     public static final Pattern EXTENSION_VALUE_PATTERN = Pattern.compile(VALUE);

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapper.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/CommonNameLoggingTrustManagerFactoryWrapper.java
@@ -56,7 +56,7 @@ class CommonNameLoggingTrustManagerFactoryWrapper {
 
     private static final Logger log = LoggerFactory.getLogger(CommonNameLoggingTrustManagerFactoryWrapper.class);
 
-    private TrustManagerFactory origTmf;
+    private final TrustManagerFactory origTmf;
 
     /**
      * Create a wrapped trust manager factory
@@ -270,7 +270,7 @@ class CommonNameLoggingTrustManagerFactoryWrapper {
 
     static class NeverExpiringX509Certificate extends X509Certificate {
 
-        private X509Certificate origCertificate;
+        private final X509Certificate origCertificate;
 
         public NeverExpiringX509Certificate(X509Certificate origCertificate) {
             this.origCertificate = origCertificate;

--- a/clients/src/main/java/org/apache/kafka/common/security/token/delegation/DelegationToken.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/token/delegation/DelegationToken.java
@@ -29,8 +29,8 @@ import java.util.Objects;
  */
 @InterfaceStability.Evolving
 public class DelegationToken {
-    private TokenInformation tokenInformation;
-    private byte[] hmac;
+    private final TokenInformation tokenInformation;
+    private final byte[] hmac;
 
     public DelegationToken(TokenInformation tokenInformation, byte[] hmac) {
         this.tokenInformation = tokenInformation;

--- a/clients/src/main/java/org/apache/kafka/common/security/token/delegation/internals/DelegationTokenCache.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/token/delegation/internals/DelegationTokenCache.java
@@ -31,16 +31,16 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class DelegationTokenCache {
 
-    private CredentialCache credentialCache = new CredentialCache();
+    private final CredentialCache credentialCache = new CredentialCache();
 
     //Cache to hold all the tokens
-    private Map<String, TokenInformation> tokenCache = new ConcurrentHashMap<>();
+    private final Map<String, TokenInformation> tokenCache = new ConcurrentHashMap<>();
 
     //Cache to hold hmac->tokenId mapping. This is required for renew, expire requests
-    private Map<String, String> hmacTokenIdCache = new ConcurrentHashMap<>();
+    private final Map<String, String> hmacTokenIdCache = new ConcurrentHashMap<>();
 
     //Cache to hold tokenId->hmac mapping. This is required for removing entry from hmacTokenIdCache using tokenId.
-    private Map<String, String> tokenIdHmacCache = new ConcurrentHashMap<>();
+    private final Map<String, String> tokenIdHmacCache = new ConcurrentHashMap<>();
 
     public DelegationTokenCache(Collection<String> scramMechanisms) {
         //Create caches for scramMechanisms

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/SchemaProjector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/SchemaProjector.java
@@ -37,13 +37,13 @@ import java.util.Set;
 
 public class SchemaProjector {
 
-    private static final Set<AbstractMap.SimpleImmutableEntry<Type, Type>> promotable = new HashSet<>();
+    private static final Set<AbstractMap.SimpleImmutableEntry<Type, Type>> PROMOTABLE = new HashSet<>();
 
     static {
         Type[] promotableTypes = {Type.INT8, Type.INT16, Type.INT32, Type.INT64, Type.FLOAT32, Type.FLOAT64};
         for (int i = 0; i < promotableTypes.length; ++i) {
             for (int j = i; j < promotableTypes.length; ++j) {
-                promotable.add(new AbstractMap.SimpleImmutableEntry<>(promotableTypes[i], promotableTypes[j]));
+                PROMOTABLE.add(new AbstractMap.SimpleImmutableEntry<>(promotableTypes[i], promotableTypes[j]));
             }
         }
     }
@@ -191,6 +191,6 @@ public class SchemaProjector {
     }
 
     private static boolean isPromotable(Type sourceType, Type targetType) {
-        return promotable.contains(new AbstractMap.SimpleImmutableEntry<>(sourceType, targetType));
+        return PROMOTABLE.contains(new AbstractMap.SimpleImmutableEntry<>(sourceType, targetType));
     }
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/SchemaProjector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/SchemaProjector.java
@@ -37,7 +37,7 @@ import java.util.Set;
 
 public class SchemaProjector {
 
-    private static Set<AbstractMap.SimpleImmutableEntry<Type, Type>> promotable = new HashSet<>();
+    private static final Set<AbstractMap.SimpleImmutableEntry<Type, Type>> promotable = new HashSet<>();
 
     static {
         Type[] promotableTypes = {Type.INT8, Type.INT16, Type.INT32, Type.INT64, Type.FLOAT32, Type.FLOAT64};

--- a/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/PropertyFileLoginModule.java
+++ b/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/PropertyFileLoginModule.java
@@ -48,9 +48,9 @@ import javax.security.auth.spi.LoginModule;
  */
 public class PropertyFileLoginModule implements LoginModule {
     private static final Logger log = LoggerFactory.getLogger(PropertyFileLoginModule.class);
-
-    private CallbackHandler callbackHandler;
+    private static final Map<String, Properties> CREDENTIAL_PROPERTIES_MAP = new ConcurrentHashMap<>();
     private static final String FILE_OPTIONS = "file";
+    private CallbackHandler callbackHandler;
     private String fileName;
     private boolean authenticated;
 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -91,6 +91,8 @@ public class MirrorSourceConnector extends SourceConnector {
     private static final String READ_COMMITTED = IsolationLevel.READ_COMMITTED.toString().toLowerCase(Locale.ROOT);
     private static final String EXACTLY_ONCE_SUPPORT_CONFIG = "exactly.once.support";
 
+    private final AtomicBoolean noAclAuthorizer = new AtomicBoolean(false);
+
     private Scheduler scheduler;
     private MirrorSourceConfig config;
     private SourceAndTarget sourceAndTarget;
@@ -105,7 +107,6 @@ public class MirrorSourceConnector extends SourceConnector {
     private Admin targetAdminClient;
     private Admin offsetSyncsAdminClient;
     private volatile boolean useIncrementalAlterConfigs;
-    private final AtomicBoolean noAclAuthorizer = new AtomicBoolean(false);
 
     public MirrorSourceConnector() {
         // nop

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -105,7 +105,7 @@ public class MirrorSourceConnector extends SourceConnector {
     private Admin targetAdminClient;
     private Admin offsetSyncsAdminClient;
     private volatile boolean useIncrementalAlterConfigs;
-    private AtomicBoolean noAclAuthorizer = new AtomicBoolean(false);
+    private final AtomicBoolean noAclAuthorizer = new AtomicBoolean(false);
 
     public MirrorSourceConnector() {
         // nop

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
@@ -210,7 +210,7 @@ public class DistributedConfig extends WorkerConfig {
         + "which must include the algorithm used for the " + INTER_WORKER_SIGNATURE_ALGORITHM_CONFIG + " property. "
         + "The algorithm(s) '" + INTER_WORKER_VERIFICATION_ALGORITHMS_DEFAULT + "' will be used as a default on JVMs that provide them; "
         + "on other JVMs, no default is used and a value for this property must be manually specified in the worker config.";
-    private Crypto crypto;
+    private final Crypto crypto;
 
     public enum ExactlyOnceSourceSupport {
         DISABLED(false),

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
@@ -104,7 +104,7 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
 
     private Operation operation;
 
-    private Cache<Schema, Schema> moveSchemaCache = new SynchronizedCache<>(new LRUCache<>(16));
+    private final Cache<Schema, Schema> moveSchemaCache = new SynchronizedCache<>(new LRUCache<>(16));
 
     @Override
     public R apply(R record) {

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
@@ -72,6 +72,7 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
                     "Either <code>move</code> if the fields are to be moved to the headers (removed from the key/value), " +
                             "or <code>copy</code> if the fields are to be copied to the headers (retained in the key/value).");
 
+    private final Cache<Schema, Schema> moveSchemaCache = new SynchronizedCache<>(new LRUCache<>(16));
     enum Operation {
         MOVE(MOVE_OPERATION),
         COPY(COPY_OPERATION);
@@ -103,8 +104,6 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
     private List<String> headers;
 
     private Operation operation;
-
-    private final Cache<Schema, Schema> moveSchemaCache = new SynchronizedCache<>(new LRUCache<>(16));
 
     @Override
     public R apply(R record) {

--- a/core/src/main/java/kafka/server/builders/LogManagerBuilder.java
+++ b/core/src/main/java/kafka/server/builders/LogManagerBuilder.java
@@ -47,7 +47,7 @@ public class LogManagerBuilder {
     private long retentionCheckMs = 1000L;
     private int maxTransactionTimeoutMs = 15 * 60 * 1000;
     private ProducerStateManagerConfig producerStateManagerConfig = new ProducerStateManagerConfig(60000, false);
-    private int producerIdExpirationCheckIntervalMs = 600000;
+    private final int producerIdExpirationCheckIntervalMs = 600000;
     private MetadataVersion interBrokerProtocolVersion = MetadataVersion.latest();
     private Scheduler scheduler = null;
     private BrokerTopicStats brokerTopicStats = null;

--- a/core/src/main/java/kafka/server/builders/LogManagerBuilder.java
+++ b/core/src/main/java/kafka/server/builders/LogManagerBuilder.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 
 public class LogManagerBuilder {
+    private static final int PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS = 600000;
     private List<File> logDirs = null;
     private List<File> initialOfflineDirs = Collections.emptyList();
     private ConfigRepository configRepository = null;
@@ -47,7 +48,6 @@ public class LogManagerBuilder {
     private long retentionCheckMs = 1000L;
     private int maxTransactionTimeoutMs = 15 * 60 * 1000;
     private ProducerStateManagerConfig producerStateManagerConfig = new ProducerStateManagerConfig(60000, false);
-    private final int producerIdExpirationCheckIntervalMs = 600000;
     private MetadataVersion interBrokerProtocolVersion = MetadataVersion.latest();
     private Scheduler scheduler = null;
     private BrokerTopicStats brokerTopicStats = null;
@@ -172,7 +172,7 @@ public class LogManagerBuilder {
                               retentionCheckMs,
                               maxTransactionTimeoutMs,
                               producerStateManagerConfig,
-                              producerIdExpirationCheckIntervalMs,
+                              PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS,
                               interBrokerProtocolVersion,
                               scheduler,
                               brokerTopicStats,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
@@ -72,12 +72,12 @@ public class GroupCoordinatorRuntimeMetrics implements CoordinatorRuntimeMetrics
     /**
      * The partition load sensor.
      */
-    private Sensor partitionLoadSensor;
+    private final Sensor partitionLoadSensor;
 
     /**
      * The thread idle sensor.
      */
-    private Sensor threadIdleRatioSensor;
+    private final Sensor threadIdleRatioSensor;
 
     public GroupCoordinatorRuntimeMetrics(Metrics metrics) {
         this.metrics = Objects.requireNonNull(metrics);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AuthorizerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AuthorizerBenchmark.java
@@ -81,7 +81,7 @@ public class AuthorizerBenchmark {
         ACL(AclAuthorizer::new),
         KRAFT(StandardAuthorizer::new);
 
-        private Supplier<Authorizer> supplier;
+        private final Supplier<Authorizer> supplier;
 
         AuthorizerType(Supplier<Authorizer> supplier) {
             this.supplier = supplier;
@@ -111,9 +111,9 @@ public class AuthorizerBenchmark {
     private List<Action> actions = new ArrayList<>();
     private RequestContext authorizeContext;
     private RequestContext authorizeByResourceTypeContext;
-    private String authorizeByResourceTypeHostName = "127.0.0.2";
+    private final String authorizeByResourceTypeHostName = "127.0.0.2";
 
-    private HashMap<ResourcePattern, AclAuthorizer.VersionedAcls> aclToUpdate = new HashMap<>();
+    private final HashMap<ResourcePattern, AclAuthorizer.VersionedAcls> aclToUpdate = new HashMap<>();
 
     Random rand = new Random(System.currentTimeMillis());
     double eps = 1e-9;

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AuthorizerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AuthorizerBenchmark.java
@@ -107,13 +107,12 @@ public class AuthorizerBenchmark {
     private final int hostPreCount = 1000;
     private final String resourceNamePrefix = "foo-bar35_resource-";
     private final KafkaPrincipal principal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "test-user");
+    private final String authorizeByResourceTypeHostName = "127.0.0.2";
+    private final HashMap<ResourcePattern, AclAuthorizer.VersionedAcls> aclToUpdate = new HashMap<>();
     private Authorizer authorizer;
     private List<Action> actions = new ArrayList<>();
     private RequestContext authorizeContext;
     private RequestContext authorizeByResourceTypeContext;
-    private final String authorizeByResourceTypeHostName = "127.0.0.2";
-
-    private final HashMap<ResourcePattern, AclAuthorizer.VersionedAcls> aclToUpdate = new HashMap<>();
 
     Random rand = new Random(System.currentTimeMillis());
     double eps = 1e-9;

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/StandardAuthorizerUpdateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/StandardAuthorizerUpdateBenchmark.java
@@ -59,17 +59,15 @@ import static org.apache.kafka.common.acl.AclPermissionType.ALLOW;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class StandardAuthorizerUpdateBenchmark {
-    @Param({"25000", "50000", "75000", "100000"})
-    private int aclCount;
+    private static final Random RANDOM = new Random(System.currentTimeMillis());
     private final String resourceNamePrefix = "foo-bar35_resource-";
     private static final KafkaPrincipal PRINCIPAL = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "test-user");
-    private StandardAuthorizer authorizer;
     private final Set<Uuid> ids = new HashSet<>();
-
     private final List<StandardAclWithId> aclsToAdd = prepareAcls();
-
+    private StandardAuthorizer authorizer;
+    @Param({"25000", "50000", "75000", "100000"})
+    private int aclCount;
     int index = 0;
-    private static final Random RANDOM = new Random(System.currentTimeMillis());
 
     @Setup(Level.Trial)
     public void setup() throws Exception {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/StandardAuthorizerUpdateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/StandardAuthorizerUpdateBenchmark.java
@@ -60,10 +60,12 @@ import static org.apache.kafka.common.acl.AclPermissionType.ALLOW;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class StandardAuthorizerUpdateBenchmark {
     private static final Random RANDOM = new Random(System.currentTimeMillis());
-    private final String resourceNamePrefix = "foo-bar35_resource-";
     private static final KafkaPrincipal PRINCIPAL = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "test-user");
+
+    private final String resourceNamePrefix = "foo-bar35_resource-";
     private final Set<Uuid> ids = new HashSet<>();
     private final List<StandardAclWithId> aclsToAdd = prepareAcls();
+
     private StandardAuthorizer authorizer;
     @Param({"25000", "50000", "75000", "100000"})
     private int aclCount;

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/StandardAuthorizerUpdateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/StandardAuthorizerUpdateBenchmark.java
@@ -66,7 +66,7 @@ public class StandardAuthorizerUpdateBenchmark {
     private StandardAuthorizer authorizer;
     private final Set<Uuid> ids = new HashSet<>();
 
-    private List<StandardAclWithId> aclsToAdd = prepareAcls();
+    private final List<StandardAclWithId> aclsToAdd = prepareAcls();
 
     int index = 0;
     private static final Random RANDOM = new Random(System.currentTimeMillis());

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -115,13 +115,13 @@ public class ReplicaFetcherThreadBenchmark {
 
     private ReplicaFetcherBenchThread fetcher;
     private LogManager logManager;
-    private File logDir = new File(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
-    private KafkaScheduler scheduler = new KafkaScheduler(1, true, "scheduler");
-    private Pool<TopicPartition, Partition> pool = new Pool<TopicPartition, Partition>(Option.empty());
-    private Metrics metrics = new Metrics();
+    private final File logDir = new File(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
+    private final KafkaScheduler scheduler = new KafkaScheduler(1, true, "scheduler");
+    private final Pool<TopicPartition, Partition> pool = new Pool<TopicPartition, Partition>(Option.empty());
+    private final Metrics metrics = new Metrics();
     private ReplicaManager replicaManager;
     private ReplicaQuota replicaQuota;
-    private Option<Uuid> topicId = Option.apply(Uuid.randomUuid());
+    private final Option<Uuid> topicId = Option.apply(Uuid.randomUuid());
 
     @Setup(Level.Trial)
     public void setup() throws IOException {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -110,18 +110,17 @@ import scala.collection.Map;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class ReplicaFetcherThreadBenchmark {
-    @Param({"100", "500", "1000", "5000"})
-    private int partitionCount;
-
-    private ReplicaFetcherBenchThread fetcher;
-    private LogManager logManager;
     private final File logDir = new File(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
     private final KafkaScheduler scheduler = new KafkaScheduler(1, true, "scheduler");
     private final Pool<TopicPartition, Partition> pool = new Pool<TopicPartition, Partition>(Option.empty());
     private final Metrics metrics = new Metrics();
+    private final Option<Uuid> topicId = Option.apply(Uuid.randomUuid());
+    @Param({"100", "500", "1000", "5000"})
+    private int partitionCount;
+    private ReplicaFetcherBenchThread fetcher;
+    private LogManager logManager;
     private ReplicaManager replicaManager;
     private ReplicaQuota replicaQuota;
-    private final Option<Uuid> topicId = Option.apply(Uuid.randomUuid());
 
     @Setup(Level.Trial)
     public void setup() throws IOException {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
@@ -99,26 +99,26 @@ public class KRaftMetadataRequestBenchmark {
     @Param({"10", "20", "50"})
     private int partitionCount;
 
-    private RequestChannel requestChannel = Mockito.mock(RequestChannel.class, Mockito.withSettings().stubOnly());
-    private RequestChannel.Metrics requestChannelMetrics = Mockito.mock(RequestChannel.Metrics.class);
-    private ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
-    private GroupCoordinator groupCoordinator = Mockito.mock(GroupCoordinator.class);
-    private TransactionCoordinator transactionCoordinator = Mockito.mock(TransactionCoordinator.class);
-    private AutoTopicCreationManager autoTopicCreationManager = Mockito.mock(AutoTopicCreationManager.class);
-    private Metrics metrics = new Metrics();
-    private int brokerId = 1;
-    private ForwardingManager forwardingManager = Mockito.mock(ForwardingManager.class);
-    private KRaftMetadataCache metadataCache = MetadataCache.kRaftMetadataCache(brokerId);
-    private ClientQuotaManager clientQuotaManager = Mockito.mock(ClientQuotaManager.class);
-    private ClientRequestQuotaManager clientRequestQuotaManager = Mockito.mock(ClientRequestQuotaManager.class);
-    private ControllerMutationQuotaManager controllerMutationQuotaManager = Mockito.mock(ControllerMutationQuotaManager.class);
-    private ReplicationQuotaManager replicaQuotaManager = Mockito.mock(ReplicationQuotaManager.class);
-    private QuotaFactory.QuotaManagers quotaManagers = new QuotaFactory.QuotaManagers(clientQuotaManager,
+    private final RequestChannel requestChannel = Mockito.mock(RequestChannel.class, Mockito.withSettings().stubOnly());
+    private final RequestChannel.Metrics requestChannelMetrics = Mockito.mock(RequestChannel.Metrics.class);
+    private final ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+    private final GroupCoordinator groupCoordinator = Mockito.mock(GroupCoordinator.class);
+    private final TransactionCoordinator transactionCoordinator = Mockito.mock(TransactionCoordinator.class);
+    private final AutoTopicCreationManager autoTopicCreationManager = Mockito.mock(AutoTopicCreationManager.class);
+    private final Metrics metrics = new Metrics();
+    private final int brokerId = 1;
+    private final ForwardingManager forwardingManager = Mockito.mock(ForwardingManager.class);
+    private final KRaftMetadataCache metadataCache = MetadataCache.kRaftMetadataCache(brokerId);
+    private final ClientQuotaManager clientQuotaManager = Mockito.mock(ClientQuotaManager.class);
+    private final ClientRequestQuotaManager clientRequestQuotaManager = Mockito.mock(ClientRequestQuotaManager.class);
+    private final ControllerMutationQuotaManager controllerMutationQuotaManager = Mockito.mock(ControllerMutationQuotaManager.class);
+    private final ReplicationQuotaManager replicaQuotaManager = Mockito.mock(ReplicationQuotaManager.class);
+    private final QuotaFactory.QuotaManagers quotaManagers = new QuotaFactory.QuotaManagers(clientQuotaManager,
             clientQuotaManager, clientRequestQuotaManager, controllerMutationQuotaManager, replicaQuotaManager,
             replicaQuotaManager, replicaQuotaManager, Option.empty());
-    private FetchManager fetchManager = Mockito.mock(FetchManager.class);
-    private BrokerTopicStats brokerTopicStats = new BrokerTopicStats(Optional.empty());
-    private KafkaPrincipal principal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "test-user");
+    private final FetchManager fetchManager = Mockito.mock(FetchManager.class);
+    private final BrokerTopicStats brokerTopicStats = new BrokerTopicStats(Optional.empty());
+    private final KafkaPrincipal principal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "test-user");
     private KafkaApis kafkaApis;
     private RequestChannel.Request allTopicMetadataRequest;
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
@@ -94,11 +94,6 @@ import java.util.stream.IntStream;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 
 public class KRaftMetadataRequestBenchmark {
-    @Param({"500", "1000",  "5000"})
-    private int topicCount;
-    @Param({"10", "20", "50"})
-    private int partitionCount;
-
     private final RequestChannel requestChannel = Mockito.mock(RequestChannel.class, Mockito.withSettings().stubOnly());
     private final RequestChannel.Metrics requestChannelMetrics = Mockito.mock(RequestChannel.Metrics.class);
     private final ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
@@ -119,6 +114,10 @@ public class KRaftMetadataRequestBenchmark {
     private final FetchManager fetchManager = Mockito.mock(FetchManager.class);
     private final BrokerTopicStats brokerTopicStats = new BrokerTopicStats(Optional.empty());
     private final KafkaPrincipal principal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "test-user");
+    @Param({"500", "1000",  "5000"})
+    private int topicCount;
+    @Param({"10", "20", "50"})
+    private int partitionCount;
     private KafkaApis kafkaApis;
     private RequestChannel.Request allTopicMetadataRequest;
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
@@ -101,29 +101,29 @@ public class MetadataRequestBenchmark {
     @Param({"10", "20", "50"})
     private int partitionCount;
 
-    private RequestChannel requestChannel = Mockito.mock(RequestChannel.class, Mockito.withSettings().stubOnly());
-    private RequestChannel.Metrics requestChannelMetrics = Mockito.mock(RequestChannel.Metrics.class);
-    private ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
-    private GroupCoordinator groupCoordinator = Mockito.mock(GroupCoordinator.class);
-    private ZkAdminManager adminManager = Mockito.mock(ZkAdminManager.class);
-    private TransactionCoordinator transactionCoordinator = Mockito.mock(TransactionCoordinator.class);
-    private KafkaController kafkaController = Mockito.mock(KafkaController.class);
-    private AutoTopicCreationManager autoTopicCreationManager = Mockito.mock(AutoTopicCreationManager.class);
-    private KafkaZkClient kafkaZkClient = Mockito.mock(KafkaZkClient.class);
-    private Metrics metrics = new Metrics();
-    private int brokerId = 1;
-    private ZkMetadataCache metadataCache = MetadataCache.zkMetadataCache(brokerId,
+    private final RequestChannel requestChannel = Mockito.mock(RequestChannel.class, Mockito.withSettings().stubOnly());
+    private final RequestChannel.Metrics requestChannelMetrics = Mockito.mock(RequestChannel.Metrics.class);
+    private final ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+    private final GroupCoordinator groupCoordinator = Mockito.mock(GroupCoordinator.class);
+    private final ZkAdminManager adminManager = Mockito.mock(ZkAdminManager.class);
+    private final TransactionCoordinator transactionCoordinator = Mockito.mock(TransactionCoordinator.class);
+    private final KafkaController kafkaController = Mockito.mock(KafkaController.class);
+    private final AutoTopicCreationManager autoTopicCreationManager = Mockito.mock(AutoTopicCreationManager.class);
+    private final KafkaZkClient kafkaZkClient = Mockito.mock(KafkaZkClient.class);
+    private final Metrics metrics = new Metrics();
+    private final int brokerId = 1;
+    private final ZkMetadataCache metadataCache = MetadataCache.zkMetadataCache(brokerId,
         MetadataVersion.latest(), BrokerFeatures.createEmpty(), null, false);
-    private ClientQuotaManager clientQuotaManager = Mockito.mock(ClientQuotaManager.class);
-    private ClientRequestQuotaManager clientRequestQuotaManager = Mockito.mock(ClientRequestQuotaManager.class);
-    private ControllerMutationQuotaManager controllerMutationQuotaManager = Mockito.mock(ControllerMutationQuotaManager.class);
-    private ReplicationQuotaManager replicaQuotaManager = Mockito.mock(ReplicationQuotaManager.class);
-    private QuotaFactory.QuotaManagers quotaManagers = new QuotaFactory.QuotaManagers(clientQuotaManager,
+    private final ClientQuotaManager clientQuotaManager = Mockito.mock(ClientQuotaManager.class);
+    private final ClientRequestQuotaManager clientRequestQuotaManager = Mockito.mock(ClientRequestQuotaManager.class);
+    private final ControllerMutationQuotaManager controllerMutationQuotaManager = Mockito.mock(ControllerMutationQuotaManager.class);
+    private final ReplicationQuotaManager replicaQuotaManager = Mockito.mock(ReplicationQuotaManager.class);
+    private final QuotaFactory.QuotaManagers quotaManagers = new QuotaFactory.QuotaManagers(clientQuotaManager,
         clientQuotaManager, clientRequestQuotaManager, controllerMutationQuotaManager, replicaQuotaManager,
         replicaQuotaManager, replicaQuotaManager, Option.empty());
-    private FetchManager fetchManager = Mockito.mock(FetchManager.class);
-    private BrokerTopicStats brokerTopicStats = new BrokerTopicStats(Optional.empty());
-    private KafkaPrincipal principal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "test-user");
+    private final FetchManager fetchManager = Mockito.mock(FetchManager.class);
+    private final BrokerTopicStats brokerTopicStats = new BrokerTopicStats(Optional.empty());
+    private final KafkaPrincipal principal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "test-user");
     private KafkaApis kafkaApis;
     private RequestChannel.Request allTopicMetadataRequest;
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
@@ -96,11 +96,6 @@ import java.util.stream.IntStream;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 
 public class MetadataRequestBenchmark {
-    @Param({"500", "1000", "5000"})
-    private int topicCount;
-    @Param({"10", "20", "50"})
-    private int partitionCount;
-
     private final RequestChannel requestChannel = Mockito.mock(RequestChannel.class, Mockito.withSettings().stubOnly());
     private final RequestChannel.Metrics requestChannelMetrics = Mockito.mock(RequestChannel.Metrics.class);
     private final ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
@@ -124,6 +119,10 @@ public class MetadataRequestBenchmark {
     private final FetchManager fetchManager = Mockito.mock(FetchManager.class);
     private final BrokerTopicStats brokerTopicStats = new BrokerTopicStats(Optional.empty());
     private final KafkaPrincipal principal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "test-user");
+    @Param({"500", "1000", "5000"})
+    private int topicCount;
+    @Param({"10", "20", "50"})
+    private int partitionCount;
     private KafkaApis kafkaApis;
     private RequestChannel.Request allTopicMetadataRequest;
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -77,13 +77,13 @@ import scala.compat.java8.OptionConverters;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class PartitionMakeFollowerBenchmark {
     private LogManager logManager;
-    private File logDir = new File(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
-    private KafkaScheduler scheduler = new KafkaScheduler(1, true, "scheduler");
+    private final File logDir = new File(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
+    private final KafkaScheduler scheduler = new KafkaScheduler(1, true, "scheduler");
     private Partition partition;
-    private List<Integer> replicas = Arrays.asList(0, 1, 2);
-    private OffsetCheckpoints offsetCheckpoints = Mockito.mock(OffsetCheckpoints.class);
-    private DelayedOperations delayedOperations  = Mockito.mock(DelayedOperations.class);
-    private ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final List<Integer> replicas = Arrays.asList(0, 1, 2);
+    private final OffsetCheckpoints offsetCheckpoints = Mockito.mock(OffsetCheckpoints.class);
+    private final DelayedOperations delayedOperations  = Mockito.mock(DelayedOperations.class);
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private Option<Uuid> topicId;
 
     @Setup(Level.Trial)

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -78,12 +78,12 @@ import scala.compat.java8.OptionConverters;
 public class PartitionMakeFollowerBenchmark {
     private final File logDir = new File(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
     private final KafkaScheduler scheduler = new KafkaScheduler(1, true, "scheduler");
-    private Partition partition;
     private final List<Integer> replicas = Arrays.asList(0, 1, 2);
     private final OffsetCheckpoints offsetCheckpoints = Mockito.mock(OffsetCheckpoints.class);
     private final DelayedOperations delayedOperations  = Mockito.mock(DelayedOperations.class);
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private Option<Uuid> topicId;
+    private Partition partition;
     private LogManager logManager;
 
     @Setup(Level.Trial)

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -76,7 +76,6 @@ import scala.compat.java8.OptionConverters;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class PartitionMakeFollowerBenchmark {
-    private LogManager logManager;
     private final File logDir = new File(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
     private final KafkaScheduler scheduler = new KafkaScheduler(1, true, "scheduler");
     private Partition partition;
@@ -85,6 +84,7 @@ public class PartitionMakeFollowerBenchmark {
     private final DelayedOperations delayedOperations  = Mockito.mock(DelayedOperations.class);
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private Option<Uuid> topicId;
+    private LogManager logManager;
 
     @Setup(Level.Trial)
     public void setup() throws IOException {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -70,12 +70,12 @@ import scala.compat.java8.OptionConverters;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class UpdateFollowerFetchStateBenchmark {
-    private TopicPartition topicPartition = new TopicPartition(UUID.randomUUID().toString(), 0);
-    private Option<Uuid> topicId = OptionConverters.toScala(Optional.of(Uuid.randomUuid()));
-    private File logDir = new File(System.getProperty("java.io.tmpdir"), topicPartition.toString());
-    private KafkaScheduler scheduler = new KafkaScheduler(1, true, "scheduler");
-    private BrokerTopicStats brokerTopicStats = new BrokerTopicStats(Optional.empty());
-    private LogDirFailureChannel logDirFailureChannel = Mockito.mock(LogDirFailureChannel.class);
+    private final TopicPartition topicPartition = new TopicPartition(UUID.randomUUID().toString(), 0);
+    private final Option<Uuid> topicId = OptionConverters.toScala(Optional.of(Uuid.randomUuid()));
+    private final File logDir = new File(System.getProperty("java.io.tmpdir"), topicPartition.toString());
+    private final KafkaScheduler scheduler = new KafkaScheduler(1, true, "scheduler");
+    private final BrokerTopicStats brokerTopicStats = new BrokerTopicStats(Optional.empty());
+    private final LogDirFailureChannel logDirFailureChannel = Mockito.mock(LogDirFailureChannel.class);
     private long nextOffset = 0;
     private LogManager logManager;
     private Partition partition;

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/BaseRecordBatchBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/BaseRecordBatchBenchmark.java
@@ -56,19 +56,19 @@ public abstract class BaseRecordBatchBenchmark {
     }
 
     @Param(value = {"1", "2", "10", "50", "200", "500"})
-    private int maxBatchSize = 200;
+    private final int maxBatchSize = 200;
 
     @Param(value = {"1", "2"})
     byte messageVersion = CURRENT_MAGIC_VALUE;
 
     @Param(value = {"100", "1000", "10000", "100000"})
-    private int messageSize = 1000;
+    private final int messageSize = 1000;
 
     @Param(value = {"RANDOM", "ONES"})
-    private Bytes bytes = Bytes.RANDOM;
+    private final Bytes bytes = Bytes.RANDOM;
 
     @Param(value = {"NO_CACHING", "CREATE"})
-    private String bufferSupplierStr = "NO_CACHING";
+    private final String bufferSupplierStr = "NO_CACHING";
 
     // zero starting offset is much faster for v1 batches, but that will almost never happen
     int startingOffset;

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/BaseRecordBatchBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/BaseRecordBatchBenchmark.java
@@ -56,19 +56,19 @@ public abstract class BaseRecordBatchBenchmark {
     }
 
     @Param(value = {"1", "2", "10", "50", "200", "500"})
-    private final int maxBatchSize = 200;
+    private int maxBatchSize = 200;
 
     @Param(value = {"1", "2"})
     byte messageVersion = CURRENT_MAGIC_VALUE;
 
     @Param(value = {"100", "1000", "10000", "100000"})
-    private final int messageSize = 1000;
+    private int messageSize = 1000;
 
     @Param(value = {"RANDOM", "ONES"})
-    private final Bytes bytes = Bytes.RANDOM;
+    private Bytes bytes = Bytes.RANDOM;
 
     @Param(value = {"NO_CACHING", "CREATE"})
-    private final String bufferSupplierStr = "NO_CACHING";
+    private String bufferSupplierStr = "NO_CACHING";
 
     // zero starting offset is much faster for v1 batches, but that will almost never happen
     int startingOffset;

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/CompressedRecordBatchValidationBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/CompressedRecordBatchValidationBenchmark.java
@@ -41,7 +41,7 @@ import org.openjdk.jmh.infra.Blackhole;
 public class CompressedRecordBatchValidationBenchmark extends BaseRecordBatchBenchmark {
 
     @Param(value = {"LZ4", "SNAPPY", "GZIP", "ZSTD"})
-    private final CompressionType compressionType = CompressionType.LZ4;
+    private CompressionType compressionType = CompressionType.LZ4;
 
     @Override
     CompressionType compressionType() {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/CompressedRecordBatchValidationBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/CompressedRecordBatchValidationBenchmark.java
@@ -41,7 +41,7 @@ import org.openjdk.jmh.infra.Blackhole;
 public class CompressedRecordBatchValidationBenchmark extends BaseRecordBatchBenchmark {
 
     @Param(value = {"LZ4", "SNAPPY", "GZIP", "ZSTD"})
-    private CompressionType compressionType = CompressionType.LZ4;
+    private final CompressionType compressionType = CompressionType.LZ4;
 
     @Override
     CompressionType compressionType() {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/RecordBatchIterationBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/RecordBatchIterationBenchmark.java
@@ -39,7 +39,7 @@ import org.openjdk.jmh.infra.Blackhole;
 public class RecordBatchIterationBenchmark extends BaseRecordBatchBenchmark {
 
     @Param(value = {"LZ4", "SNAPPY", "GZIP", "ZSTD", "NONE"})
-    private final CompressionType compressionType = CompressionType.NONE;
+    private CompressionType compressionType = CompressionType.NONE;
 
     @Override
     CompressionType compressionType() {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/RecordBatchIterationBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/RecordBatchIterationBenchmark.java
@@ -39,7 +39,7 @@ import org.openjdk.jmh.infra.Blackhole;
 public class RecordBatchIterationBenchmark extends BaseRecordBatchBenchmark {
 
     @Param(value = {"LZ4", "SNAPPY", "GZIP", "ZSTD", "NONE"})
-    private CompressionType compressionType = CompressionType.NONE;
+    private final CompressionType compressionType = CompressionType.NONE;
 
     @Override
     CompressionType compressionType() {

--- a/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DelegationTokenControlManager.java
@@ -59,7 +59,7 @@ import static org.apache.kafka.common.protocol.Errors.UNSUPPORTED_VERSION;
  * Manages DelegationTokens.
  */
 public class DelegationTokenControlManager {
-    private Time time = Time.SYSTEM;
+    private final Time time = Time.SYSTEM;
 
     static class Builder {
         private LogContext logContext = null;

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -96,8 +96,8 @@ public class PartitionChangeBuilder {
     private LeaderRecoveryState targetLeaderRecoveryState;
     private boolean zkMigrationEnabled;
     private boolean eligibleLeaderReplicasEnabled;
-    private int minISR;
-    private Map<Integer, Uuid> targetDirectories;
+    private final int minISR;
+    private final Map<Integer, Uuid> targetDirectories;
     private DefaultDirProvider defaultDirProvider;
 
     // Whether allow electing last known leader in a Balanced recovery. Note, the last known leader will be stored in the

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -85,6 +85,8 @@ public class PartitionChangeBuilder {
     private final int partitionId;
     private final IntPredicate isAcceptableLeader;
     private final MetadataVersion metadataVersion;
+    private final int minISR;
+    private final Map<Integer, Uuid> targetDirectories;
     private List<Integer> targetIsr;
     private List<Integer> targetReplicas;
     private List<Integer> targetRemoving;
@@ -96,8 +98,6 @@ public class PartitionChangeBuilder {
     private LeaderRecoveryState targetLeaderRecoveryState;
     private boolean zkMigrationEnabled;
     private boolean eligibleLeaderReplicasEnabled;
-    private final int minISR;
-    private final Map<Integer, Uuid> targetDirectories;
     private DefaultDirProvider defaultDirProvider;
 
     // Whether allow electing last known leader in a Balanced recovery. Note, the last known leader will be stored in the

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1715,7 +1715,7 @@ public final class QuorumController implements Controller {
      * from this callbacks need to compare against this value to verify that the event
      * was not from a previous registration.
      */
-    private QuorumMetaLogListener metaLogListener;
+    private final QuorumMetaLogListener metaLogListener;
 
     /**
      * If this controller is active, this is the non-negative controller epoch.

--- a/metadata/src/main/java/org/apache/kafka/metadata/properties/MetaPropertiesEnsemble.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/properties/MetaPropertiesEnsemble.java
@@ -173,11 +173,11 @@ public final class MetaPropertiesEnsemble {
         };
 
         private final MetaPropertiesEnsemble prev;
-        private Random random = new Random();
         private final Set<String> emptyLogDirs;
         private final Set<String> errorLogDirs;
         private final Map<String, MetaProperties> logDirProps;
         private Optional<String> metaLogDir;
+        private Random random = new Random();
 
         private PreWriteHandler preWriteHandler = (logDir, isNew, metaProperties) -> {
             LOG.info("Writing out {} {}{}meta.properties file containing {}",

--- a/metadata/src/main/java/org/apache/kafka/metadata/properties/MetaPropertiesEnsemble.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/properties/MetaPropertiesEnsemble.java
@@ -174,9 +174,9 @@ public final class MetaPropertiesEnsemble {
 
         private final MetaPropertiesEnsemble prev;
         private Random random = new Random();
-        private Set<String> emptyLogDirs;
-        private Set<String> errorLogDirs;
-        private Map<String, MetaProperties> logDirProps;
+        private final Set<String> emptyLogDirs;
+        private final Set<String> errorLogDirs;
+        private final Map<String, MetaProperties> logDirProps;
         private Optional<String> metaLogDir;
 
         private PreWriteHandler preWriteHandler = (logDir, isNew, metaProperties) -> {
@@ -432,8 +432,8 @@ public final class MetaPropertiesEnsemble {
      */
     public Iterator<Entry<String, Optional<MetaProperties>>> nonFailedDirectoryProps() {
         return new Iterator<Entry<String, Optional<MetaProperties>>>() {
-            private Iterator<String> emptyLogDirsIterator = emptyLogDirs.iterator();
-            private Iterator<Entry<String, MetaProperties>> logDirsIterator =
+            private final Iterator<String> emptyLogDirsIterator = emptyLogDirs.iterator();
+            private final Iterator<Entry<String, MetaProperties>> logDirsIterator =
                     logDirProps.entrySet().iterator();
 
             @Override

--- a/shell/src/main/java/org/apache/kafka/shell/InteractiveShell.java
+++ b/shell/src/main/java/org/apache/kafka/shell/InteractiveShell.java
@@ -145,8 +145,8 @@ public final class InteractiveShell implements AutoCloseable {
     }
 
     public class HistoryIterator implements  Iterator<Entry<Integer, String>> {
-        private int index;
         private final int last;
+        private int index;
 
         HistoryIterator(int index, int last) {
             this.index = index;

--- a/shell/src/main/java/org/apache/kafka/shell/InteractiveShell.java
+++ b/shell/src/main/java/org/apache/kafka/shell/InteractiveShell.java
@@ -146,7 +146,7 @@ public final class InteractiveShell implements AutoCloseable {
 
     public class HistoryIterator implements  Iterator<Entry<Integer, String>> {
         private int index;
-        private int last;
+        private final int last;
 
         HistoryIterator(int index, int last) {
             this.index = index;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -114,7 +114,7 @@ public class RemoteIndexCache implements Closeable {
      *
      * We use {@link Caffeine} cache instead of implementing a thread safe LRU cache on our own.
      */
-    private Cache<Uuid, Entry> internalCache;
+    private final Cache<Uuid, Entry> internalCache;
 
     /**
      * Creates RemoteIndexCache with the given configs.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -166,7 +166,7 @@ public class ProcessorStateManager implements StateManager {
     private static final String STATE_CHANGELOG_TOPIC_SUFFIX = "-changelog";
 
     private Logger log;
-    private String logPrefix;
+    private final String logPrefix;
 
     private final TaskId taskId;
     private Task.State taskState;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -165,11 +165,9 @@ public class ProcessorStateManager implements StateManager {
 
     private static final String STATE_CHANGELOG_TOPIC_SUFFIX = "-changelog";
 
-    private Logger log;
     private final String logPrefix;
 
     private final TaskId taskId;
-    private Task.State taskState;
     private final boolean eosEnabled;
     private final ChangelogRegister changelogReader;
     private final Collection<TopicPartition> sourcePartitions;
@@ -181,9 +179,11 @@ public class ProcessorStateManager implements StateManager {
 
     private final File baseDir;
     private final OffsetCheckpoint checkpointFile;
+    private final boolean stateUpdaterEnabled;
 
     private TaskType taskType;
-    private final boolean stateUpdaterEnabled;
+    private Logger log;
+    private Task.State taskState;
 
     public static String storeChangelogTopic(final String prefix, final String storeName, final String namedTopology) {
         if (namedTopology == null) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -57,9 +57,8 @@ public class ClientState {
     private final ClientStateTask previousActiveTasks = new ClientStateTask(null, new TreeMap<>());
     private final ClientStateTask previousStandbyTasks = new ClientStateTask(null, null);
     private final ClientStateTask revokingActiveTasks = new ClientStateTask(null, new TreeMap<>());
-
-    private int capacity;
     private final UUID processId;
+    private int capacity;
 
     public ClientState() {
         this(null, 0);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -59,7 +59,7 @@ public class ClientState {
     private final ClientStateTask revokingActiveTasks = new ClientStateTask(null, new TreeMap<>());
 
     private int capacity;
-    private UUID processId;
+    private final UUID processId;
 
     public ClientState() {
         this(null, 0);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueToTimestampedKeyValueByteStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueToTimestampedKeyValueByteStoreAdapter.java
@@ -209,7 +209,7 @@ public class KeyValueToTimestampedKeyValueByteStoreAdapter implements KeyValueSt
 
     private static class KeyValueToTimestampedKeyValueAdapterIterator implements ManagedKeyValueIterator<Bytes, byte[]> {
 
-        private RocksDbIterator rocksDbIterator;
+        private final RocksDbIterator rocksDbIterator;
 
         public KeyValueToTimestampedKeyValueAdapterIterator(final RocksDbIterator rocksDbIterator) {
             this.rocksDbIterator = rocksDbIterator;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryLRUCache.java
@@ -41,8 +41,6 @@ import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTEN
  * An in-memory LRU cache store based on HashSet and HashMap.
  */
 public class MemoryLRUCache implements KeyValueStore<Bytes, byte[]> {
-
-    protected StateStoreContext context;
     private final Position position = Position.emptyPosition();
 
     public interface EldestEntryRemovalListener {
@@ -55,6 +53,7 @@ public class MemoryLRUCache implements KeyValueStore<Bytes, byte[]> {
     private boolean restoring = false; // TODO: this is a sub-optimal solution to avoid logging during restoration.
                                        // in the future we should augment the StateRestoreCallback with onComplete etc to better resolve this.
     private volatile boolean open = true;
+    protected StateStoreContext context;
 
     private EldestEntryRemovalListener listener;
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryLRUCache.java
@@ -43,7 +43,7 @@ import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTEN
 public class MemoryLRUCache implements KeyValueStore<Bytes, byte[]> {
 
     protected StateStoreContext context;
-    private Position position = Position.emptyPosition();
+    private final Position position = Position.emptyPosition();
 
     public interface EldestEntryRemovalListener {
         void apply(Bytes key, byte[] value);

--- a/tools/src/main/java/org/apache/kafka/tools/ClientMetricsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClientMetricsCommand.java
@@ -104,7 +104,7 @@ public class ClientMetricsCommand {
     }
 
     public static class ClientMetricsService implements AutoCloseable {
-        private Admin adminClient;
+        private final Admin adminClient;
 
         public ClientMetricsService(Properties config) {
             this.adminClient = Admin.create(config);

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -336,10 +336,10 @@ public class ProducerPerformance {
 
     // Visible for testing
     static class Stats {
-        private long start;
+        private final long start;
         private long windowStart;
-        private int[] latencies;
-        private long sampling;
+        private final int[] latencies;
+        private final long sampling;
         private long iteration;
         private int index;
         private long count;
@@ -350,7 +350,7 @@ public class ProducerPerformance {
         private int windowMaxLatency;
         private long windowTotalLatency;
         private long windowBytes;
-        private long reportingInterval;
+        private final long reportingInterval;
 
         public Stats(long numRecords, int reportingInterval) {
             this.start = System.currentTimeMillis();

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -337,9 +337,9 @@ public class ProducerPerformance {
     // Visible for testing
     static class Stats {
         private final long start;
-        private long windowStart;
         private final int[] latencies;
         private final long sampling;
+        private final long reportingInterval;
         private long iteration;
         private int index;
         private long count;
@@ -350,7 +350,7 @@ public class ProducerPerformance {
         private int windowMaxLatency;
         private long windowTotalLatency;
         private long windowBytes;
-        private final long reportingInterval;
+        private long windowStart;
 
         public Stats(long numRecords, int reportingInterval) {
             this.start = System.currentTimeMillis();

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -420,7 +420,7 @@ public abstract class TopicCommand {
     }
 
     public static class TopicService implements AutoCloseable {
-        private Admin adminClient;
+        private final Admin adminClient;
 
         public TopicService(Properties commandConfig, Optional<String> bootstrapServer) {
             this.adminClient = createAdminClient(commandConfig, bootstrapServer);

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -95,9 +95,8 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
     private final boolean useAsyncCommit;
     private final boolean verbose;
     private final int maxMessages;
-    private int consumedMessages = 0;
-
     private final CountDownLatch shutdownLatch = new CountDownLatch(1);
+    private int consumedMessages = 0;
 
     public VerifiableConsumer(KafkaConsumer<String, String> consumer,
                               PrintStream out,

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -97,7 +97,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
     private final int maxMessages;
     private int consumedMessages = 0;
 
-    private CountDownLatch shutdownLatch = new CountDownLatch(1);
+    private final CountDownLatch shutdownLatch = new CountDownLatch(1);
 
     public VerifiableConsumer(KafkaConsumer<String, String> consumer,
                               PrintStream out,

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -346,9 +346,9 @@ public class VerifiableProducer implements AutoCloseable {
 
     private static class SuccessfulSend extends ProducerEvent {
 
-        private String key;
-        private String value;
-        private RecordMetadata recordMetadata;
+        private final String key;
+        private final String value;
+        private final RecordMetadata recordMetadata;
 
         public SuccessfulSend(String key, String value, RecordMetadata recordMetadata) {
             assert recordMetadata != null : "Expected non-null recordMetadata object.";
@@ -390,10 +390,10 @@ public class VerifiableProducer implements AutoCloseable {
 
     private static class FailedSend extends ProducerEvent {
 
-        private String topic;
-        private String key;
-        private String value;
-        private Exception exception;
+        private final String topic;
+        private final String key;
+        private final String value;
+        private final Exception exception;
 
         public FailedSend(String key, String value, String topic, Exception exception) {
             assert exception != null : "Expected non-null exception.";
@@ -436,10 +436,10 @@ public class VerifiableProducer implements AutoCloseable {
 
     private static class ToolData extends ProducerEvent {
 
-        private long sent;
-        private long acked;
-        private long targetThroughput;
-        private double avgThroughput;
+        private final long sent;
+        private final long acked;
+        private final long targetThroughput;
+        private final double avgThroughput;
 
         public ToolData(long sent, long acked, long targetThroughput, double avgThroughput) {
             this.sent = sent;
@@ -485,8 +485,8 @@ public class VerifiableProducer implements AutoCloseable {
     /** Callback which prints errors to stdout when the producer fails to send. */
     private class PrintInfoCallback implements Callback {
 
-        private String key;
-        private String value;
+        private final String key;
+        private final String value;
 
         PrintInfoCallback(String key, String value) {
             this.key = key;

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/TaskManager.java
@@ -120,7 +120,7 @@ public final class TaskManager {
     /**
      * True if the TaskManager is shut down.
      */
-    private AtomicBoolean shutdown = new AtomicBoolean(false);
+    private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
     /**
      * The ID to use for the next worker.  Only accessed by the state change thread.

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/rest/UptimeResponse.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/rest/UptimeResponse.java
@@ -25,8 +25,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class UptimeResponse extends Message {
 
-    private long serverStartMs;
-    private long nowMs;
+    private final long serverStartMs;
+    private final long nowMs;
 
     @JsonCreator
     public UptimeResponse(@JsonProperty("serverStartMs") long serverStartMs,

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -188,7 +188,7 @@ public class ProduceBenchWorker implements TaskWorker {
         private final Throttle throttle;
         private final AtomicLong transactionsCommitted;
         private final boolean enableTransactions;
-        
+
         private Iterator<TopicPartition> partitionsIterator;
         private Future<RecordMetadata> sendFuture;
 

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -189,8 +189,8 @@ public class ProduceBenchWorker implements TaskWorker {
 
         private Iterator<TopicPartition> partitionsIterator;
         private Future<RecordMetadata> sendFuture;
-        private AtomicLong transactionsCommitted;
-        private boolean enableTransactions;
+        private final AtomicLong transactionsCommitted;
+        private final boolean enableTransactions;
 
         SendRecords(HashSet<TopicPartition> activePartitions) {
             this.activePartitions = activePartitions;

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -186,11 +186,11 @@ public class ProduceBenchWorker implements TaskWorker {
         private final Optional<TransactionGenerator> transactionGenerator;
 
         private final Throttle throttle;
-
-        private Iterator<TopicPartition> partitionsIterator;
-        private Future<RecordMetadata> sendFuture;
         private final AtomicLong transactionsCommitted;
         private final boolean enableTransactions;
+        
+        private Iterator<TopicPartition> partitionsIterator;
+        private Future<RecordMetadata> sendFuture;
 
         SendRecords(HashSet<TopicPartition> activePartitions) {
             this.activePartitions = activePartitions;


### PR DESCRIPTION
Changes:

1. Code cleanup to include `final` keyword where ever required. Detected via automatic tooling.
2. Change the casing of variables to SNAKE_CASE which are now `static final`
3. Re-order fields so that fields with `final` qualifier are grouped together