### PR TITLE
KAFKA-16046: also fix stores for outer join

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
@@ -45,7 +45,7 @@ public class KeyValueStoreMaterializer<K, V> extends MaterializedStoreFactory<K,
     @Override
     public StateStore build() {
         final KeyValueBytesStoreSupplier supplier = materialized.storeSupplier() == null
-                ? dslStoreSuppliers().keyValueStore(new DslKeyValueParams(materialized.storeName()))
+                ? dslStoreSuppliers().keyValueStore(new DslKeyValueParams(materialized.storeName(), true))
                 : (KeyValueBytesStoreSupplier) materialized.storeSupplier();
 
         final StoreBuilder<?> builder;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/OuterStreamJoinStoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/OuterStreamJoinStoreFactory.java
@@ -95,11 +95,12 @@ public class OuterStreamJoinStoreFactory<K, V1, V2> extends AbstractConfigurable
         final TimestampedKeyAndJoinSideSerde<K> timestampedKeyAndJoinSideSerde = new TimestampedKeyAndJoinSideSerde<>(streamJoined.keySerde());
         final LeftOrRightValueSerde<V1, V2> leftOrRightValueSerde = new LeftOrRightValueSerde<>(streamJoined.valueSerde(), streamJoined.otherValueSerde());
 
+        final DslKeyValueParams dslKeyValueParams = new DslKeyValueParams(name, false);
         final KeyValueBytesStoreSupplier supplier;
 
         if (passedInDslStoreSuppliers != null) {
             // case 1: dslStoreSuppliers was explicitly passed in
-            supplier = passedInDslStoreSuppliers.keyValueStore(new DslKeyValueParams(name));
+            supplier = passedInDslStoreSuppliers.keyValueStore(dslKeyValueParams);
         } else if (streamJoined.thisStoreSupplier() != null) {
             // case 2: thisStoreSupplier was explicitly passed in, we match
             // the type for that one
@@ -110,12 +111,12 @@ public class OuterStreamJoinStoreFactory<K, V1, V2> extends AbstractConfigurable
             } else {
                 // couldn't determine the type of bytes store for thisStoreSupplier,
                 // fallback to the default
-                supplier = dslStoreSuppliers().keyValueStore(new DslKeyValueParams(name));
+                supplier = dslStoreSuppliers().keyValueStore(dslKeyValueParams);
             }
         } else {
             // case 3: nothing was explicitly passed in, fallback to default which
             // was configured via either the TopologyConfig or StreamsConfig globally
-            supplier = dslStoreSuppliers().keyValueStore(new DslKeyValueParams(name));
+            supplier = dslStoreSuppliers().keyValueStore(dslKeyValueParams);
         }
 
         final StoreBuilder<KeyValueStore<TimestampedKeyAndJoinSide<K>, LeftOrRightValue<V1, V2>>>

--- a/streams/src/main/java/org/apache/kafka/streams/state/BuiltInDslStoreSuppliers.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/BuiltInDslStoreSuppliers.java
@@ -36,7 +36,9 @@ public class BuiltInDslStoreSuppliers {
 
         @Override
         public KeyValueBytesStoreSupplier keyValueStore(final DslKeyValueParams params) {
-            return Stores.persistentTimestampedKeyValueStore(params.name());
+            return params.isTimestamped()
+                    ? Stores.persistentTimestampedKeyValueStore(params.name())
+                    : Stores.persistentKeyValueStore(params.name());
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/DslKeyValueParams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/DslKeyValueParams.java
@@ -25,17 +25,24 @@ import java.util.Objects;
 public class DslKeyValueParams {
 
     private final String name;
+    private final boolean isTimestamped;
 
     /**
-     * @param name the name of the store (cannot be {@code null})
+     * @param name          the name of the store (cannot be {@code null})
+     * @param isTimestamped whether the returned stores should be timestamped, see ({@link TimestampedKeyValueStore}
      */
-    public DslKeyValueParams(final String name) {
+    public DslKeyValueParams(final String name, final boolean isTimestamped) {
         Objects.requireNonNull(name);
         this.name = name;
+        this.isTimestamped = isTimestamped;
     }
 
     public String name() {
         return name;
+    }
+
+    public boolean isTimestamped() {
+        return isTimestamped;
     }
 
     @Override
@@ -47,18 +54,20 @@ public class DslKeyValueParams {
             return false;
         }
         final DslKeyValueParams that = (DslKeyValueParams) o;
-        return Objects.equals(name, that.name);
+        return isTimestamped == that.isTimestamped
+                && Objects.equals(name, that.name);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name);
+        return Objects.hash(name, isTimestamped);
     }
 
     @Override
     public String toString() {
         return "DslKeyValueParams{" +
                 "name='" + name + '\'' +
+                "isTimestamped=" + isTimestamped +
                 '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/DslWindowParams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/DslWindowParams.java
@@ -108,7 +108,8 @@ public class DslWindowParams {
                 && Objects.equals(retentionPeriod, that.retentionPeriod)
                 && Objects.equals(windowSize, that.windowSize)
                 && Objects.equals(emitStrategy, that.emitStrategy)
-                && Objects.equals(isSlidingWindow, that.isSlidingWindow);
+                && Objects.equals(isSlidingWindow, that.isSlidingWindow)
+                && Objects.equals(isTimestamped, that.isTimestamped);
     }
 
     @Override
@@ -119,7 +120,8 @@ public class DslWindowParams {
                 windowSize,
                 retainDuplicates,
                 emitStrategy,
-                isSlidingWindow
+                isSlidingWindow,
+                isTimestamped
         );
     }
 
@@ -132,6 +134,7 @@ public class DslWindowParams {
                 ", retainDuplicates=" + retainDuplicates +
                 ", emitStrategy=" + emitStrategy +
                 ", isSlidingWindow=" + isSlidingWindow +
+                ", isTimestamped=" + isTimestamped +
                 '}';
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -52,7 +52,7 @@ import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.internals.InMemoryKeyValueStore;
 import org.apache.kafka.streams.state.internals.InMemorySessionStore;
 import org.apache.kafka.streams.state.internals.InMemoryWindowStore;
-import org.apache.kafka.streams.state.internals.RocksDBTimestampedStore;
+import org.apache.kafka.streams.state.internals.RocksDBStore;
 import org.apache.kafka.streams.state.internals.RocksDBWindowStore;
 import org.apache.kafka.streams.state.internals.WrappedStateStore;
 import org.apache.kafka.test.MockApiProcessorSupplier;
@@ -1299,7 +1299,7 @@ public class StreamsBuilderTest {
         assertTypesForStateStore(topology.stateStores(),
                 InMemoryWindowStore.class,
                 RocksDBWindowStore.class,
-                RocksDBTimestampedStore.class);
+                RocksDBStore.class);
     }
 
     @Test


### PR DESCRIPTION
This is the corollary to https://github.com/apache/kafka/pull/15061 for outer joins, which don't use timestamped KV stores either (compared to just window stores).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

cc @lucasbru @ableegoldman 