### PR TITLE
KAFKA-16047: Leverage the fenceProducers timeout in the InitProducerId

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4394,7 +4394,10 @@ public class KafkaAdminClient extends AdminClient {
     public FenceProducersResult fenceProducers(Collection<String> transactionalIds, FenceProducersOptions options) {
         AdminApiFuture.SimpleAdminApiFuture<CoordinatorKey, ProducerIdAndEpoch> future =
             FenceProducersHandler.newFuture(transactionalIds);
-        FenceProducersHandler handler = new FenceProducersHandler(logContext);
+        if (options.timeoutMs() == null) {
+            options.timeoutMs(defaultApiTimeoutMs);
+        }
+        FenceProducersHandler handler = new FenceProducersHandler(options, logContext);
         invokeDriver(handler, future, options.timeoutMs);
         return new FenceProducersResult(future.all());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -7031,6 +7031,7 @@ public class KafkaAdminClientTest {
         try (AdminClientUnitTestEnv env = mockClientEnv()) {
             String transactionalId = "copyCat";
             Node transactionCoordinator = env.cluster().nodes().iterator().next();
+            final FenceProducersOptions options = new FenceProducersOptions().timeoutMs(10000);
 
             // fail to find the coordinator at first with a retriable error
             env.kafkaClient().prepareResponse(prepareFindCoordinatorResponse(Errors.COORDINATOR_NOT_AVAILABLE, transactionalId, transactionCoordinator));
@@ -7060,7 +7061,7 @@ public class KafkaAdminClientTest {
                     transactionCoordinator
             );
 
-            FenceProducersResult result = env.adminClient().fenceProducers(Collections.singleton(transactionalId));
+            FenceProducersResult result = env.adminClient().fenceProducers(Collections.singleton(transactionalId), options);
             assertNull(result.all().get());
             assertEquals(4761, result.producerId(transactionalId).get());
             assertEquals((short) 489, result.epochId(transactionalId).get());


### PR DESCRIPTION
KAFKA-16047: Leverage the fenceProducers timeout in the InitProducerId

This is expected to respect the timeout that fenceProducers have, in the InitProducerId request.


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)


cc. @gharris1727 
