### PR TITLE
KAFKA-16053: Fix leaks of KDC server in tests

### DIFF
--- a/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
+++ b/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
@@ -78,6 +78,7 @@ class CustomQuotaCallbackTest extends IntegrationTestHarness with SaslSetup {
     adminClients.foreach(_.close())
     GroupedUserQuotaCallback.tearDown()
     super.tearDown()
+    closeSasl()
   }
 
   override def configureSecurityBeforeServersStart(testInfo: TestInfo): Unit = {

--- a/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerWithZkSaslTest.scala
+++ b/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerWithZkSaslTest.scala
@@ -91,6 +91,7 @@ class AclAuthorizerWithZkSaslTest extends QuorumTestHarness with SaslSetup {
     aclAuthorizer.close()
     aclAuthorizer2.close()
     super.tearDown()
+    closeSasl()
   }
 
   @Test


### PR DESCRIPTION
# Problem
We are facing OOM while running test suite for Apache Kafka as discussed in https://lists.apache.org/thread/d5js0xpsrsvhgjb10mbzo9cwsy8087x4 

# Changes

This JIRA fixes ~123MB of heap leak caused by DefaultDirectoryService objects in the heap memory. The `DefaultDirectoryService` is used by `MiniKdc.scala`. This change fixes a couple of leaks where the kdc service is not closed at the end of test run.

<img width="873" alt="Screenshot 2023-12-27 at 13 18 33" src="https://github.com/apache/kafka/assets/71267/4489a6ea-b55f-4ad9-9907-0749be1dfaf3">

