### PR TITLE
KAFKA-16051: Fixed deadlock in StandaloneHerder

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -483,7 +483,7 @@ public class StandaloneHerder extends AbstractHerder {
         }
     }
 
-    private void updateConnectorTasks(String connName) {
+    private synchronized void updateConnectorTasks(String connName) {
         if (!worker.isRunning(connName)) {
             log.info("Skipping update of tasks for connector {} since it is not running", connName);
             return;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -1047,8 +1047,6 @@ public class StandaloneHerderTest {
         expectConfigValidation(connectorMock, false, newConfig);
         herder.putConnectorConfig(CONNECTOR_NAME, newConfig, true, reconfigureCallback);
 
-        Thread.sleep(10);
-
         // Reconfigure the tasks
         herder.requestTaskReconfiguration(CONNECTOR_NAME);
 


### PR DESCRIPTION
*Description of the change*
Changed StandaloneHerder to always synchronize on itself before invoking any methods on MemoryConfigBackingStore. This helped the situation as the order of acquiring locks is always the same. First on the herder and then on the config backing store.

*Testing strategy*
Manually tested StandaloneHerder from Kafka 2.6.3 and Kafka 3.6.1 and both have the same issue. 9 times out of 10 startup ends in deadlock. Tested after fixing (3.8.0-SNAPSHOT) and the deadlock is not happening anymore.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
