### PR TITLE
KAFKA-16042: Add byte-rate metrics for topic and partition 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
@@ -127,8 +127,7 @@ public class ProduceRequest extends AbstractRequest {
         this.transactionalId = data.transactionalId();
     }
 
-    // visible for testing
-    Map<TopicPartition, Integer> partitionSizes() {
+    public Map<TopicPartition, Integer> partitionSizes() {
         if (partitionSizes == null) {
             // this method may be called by different thread (see the comment on data)
             synchronized (this) {

--- a/clients/src/main/java/org/apache/kafka/server/quota/ClientQuotaCallback.java
+++ b/clients/src/main/java/org/apache/kafka/server/quota/ClientQuotaCallback.java
@@ -18,6 +18,7 @@ package org.apache.kafka.server.quota;
 
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 import java.util.Map;
@@ -38,6 +39,22 @@ public interface ClientQuotaCallback extends Configurable {
      * @return quota metric tags that indicate which other clients share this quota
      */
     Map<String, String> quotaMetricTags(ClientQuotaType quotaType, KafkaPrincipal principal, String clientId);
+
+    /**
+     * Quota callback invoked to determine the quota metric tags to be applied an individual topic partition of a request
+     * Quota limits are associated with quota metrics and all clients which use the same
+     * metric tags share the quota limit.
+     *
+     * @param quotaType Type of quota requested
+     * @param principal The user principal of the connection for which quota is requested
+     * @param clientId  The client id associated with the request
+     * @param ignoredTopicPartition topicPartition for the topic-partition based quota
+     * @return quota metric tags that indicate which other clients share this quota
+     */
+    default Map<String, String> quotaMetricTags(ClientQuotaType quotaType, KafkaPrincipal principal, String clientId, TopicPartition ignoredTopicPartition) {
+        // the default implementation of this method signature is using the original implementation for backward compatibility
+        return quotaMetricTags(quotaType, principal, clientId);
+    }
 
     /**
      * Returns the quota limit associated with the provided metric tags. These tags were returned from

--- a/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
@@ -65,7 +65,7 @@ class ClientRequestQuotaManager(private val config: ClientQuotaManagerConfig,
     if (quotasEnabled) {
       request.recordNetworkThreadTimeCallback = Some(timeNanos => recordNoThrottle(
         request.session, request.header.clientId, nanosToPercentage(timeNanos)))
-      recordAndGetThrottleTimeMs(request.session, request.header.clientId,
+      recordAndGetThrottleTimeMs(request.session, request.header.clientId, None,
         nanosToPercentage(request.requestThreadTimeNanos), timeMs)
     } else {
       0

--- a/core/src/main/scala/kafka/server/ControllerMutationQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ControllerMutationQuotaManager.scala
@@ -18,7 +18,7 @@ package kafka.server
 
 import kafka.network.RequestChannel
 import kafka.network.RequestChannel.Session
-import org.apache.kafka.common.MetricName
+import org.apache.kafka.common.{MetricName, TopicPartition}
 import org.apache.kafka.common.errors.ThrottlingQuotaExceededException
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.metrics.QuotaViolationException
@@ -203,7 +203,8 @@ class ControllerMutationQuotaManager(private val config: ClientQuotaManagerConfi
    * @return The throttle time in milliseconds defines as the time to wait until the average
    *         rate gets back to the defined quota
    */
-  override def recordAndGetThrottleTimeMs(session: Session, clientId: String, value: Double, timeMs: Long): Int = {
+  override def recordAndGetThrottleTimeMs(session: Session, clientId: String,
+                                          topicPartitions: Option[TopicPartition] = null, value: Double, timeMs: Long): Int = {
     val clientSensors = getOrCreateQuotaSensors(session, clientId)
     val quotaSensor = clientSensors.quotaSensor
     try {

--- a/core/src/test/scala/unit/kafka/server/BaseClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseClientQuotaManagerTest.scala
@@ -77,6 +77,10 @@ class BaseClientQuotaManagerTest {
     quotaManager.maybeRecordAndGetThrottleTimeMs(buildSession(user), clientId, value, time.milliseconds)
   }
 
+  protected def maybeRecord(quotaManager: ClientQuotaManager, user: String, clientId: String, topicPartitions: Map[TopicPartition, Integer]): Int = {
+    quotaManager.maybeRecordAndGetThrottleTimeMs(buildSession(user), clientId, topicPartitions, time.milliseconds)
+  }
+
   protected def throttle(quotaManager: ClientQuotaManager, user: String, clientId: String, throttleTimeMs: Int,
                          channelThrottlingCallback: ThrottleCallback): Unit = {
     val (_, request) = buildRequest(FetchRequest.Builder.forConsumer(ApiKeys.FETCH.latestVersion, 0, 1000, new util.HashMap[TopicPartition, PartitionData]))

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -2473,7 +2473,7 @@ class KafkaApisTest extends Logging {
       when(clientRequestQuotaManager.maybeRecordAndGetThrottleTimeMs(any[RequestChannel.Request](),
         any[Long])).thenReturn(0)
       when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
-        any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
+        any[RequestChannel.Request](), anyDouble, any, anyLong)).thenReturn(0)
       kafkaApis = createKafkaApis()
       kafkaApis.handleProduceRequest(request, RequestLocal.withThreadConfinedCaching)
 
@@ -2536,7 +2536,7 @@ class KafkaApisTest extends Logging {
       when(clientRequestQuotaManager.maybeRecordAndGetThrottleTimeMs(any[RequestChannel.Request](),
         any[Long])).thenReturn(0)
       when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
-        any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
+        any[RequestChannel.Request](), anyDouble, any, anyLong)).thenReturn(0)
       kafkaApis = createKafkaApis()
       kafkaApis.handleProduceRequest(request, RequestLocal.withThreadConfinedCaching)
 
@@ -2600,7 +2600,7 @@ class KafkaApisTest extends Logging {
       when(clientRequestQuotaManager.maybeRecordAndGetThrottleTimeMs(any[RequestChannel.Request](),
         any[Long])).thenReturn(0)
       when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
-        any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
+        any[RequestChannel.Request](), anyDouble, any, anyLong)).thenReturn(0)
       kafkaApis = createKafkaApis()
       kafkaApis.handleProduceRequest(request, RequestLocal.withThreadConfinedCaching)
 
@@ -2665,7 +2665,7 @@ class KafkaApisTest extends Logging {
       when(clientRequestQuotaManager.maybeRecordAndGetThrottleTimeMs(any[RequestChannel.Request](),
         any[Long])).thenReturn(0)
       when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
-        any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
+        any[RequestChannel.Request](), anyDouble, any, anyLong)).thenReturn(0)
       when(metadataCache.contains(tp)).thenAnswer(_ => true)
       when(metadataCache.getPartitionInfo(tp.topic(), tp.partition())).thenAnswer(_ => Option.empty)
       when(metadataCache.getAliveBrokerNode(any(), any())).thenReturn(Option.empty)
@@ -4138,7 +4138,7 @@ class KafkaApisTest extends Logging {
       any[util.Map[Uuid, String]])).thenReturn(fetchContext)
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
-      any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
+      any[RequestChannel.Request](), anyDouble, any, anyLong)).thenReturn(0)
 
     val fetchRequest = new FetchRequest.Builder(9, 9, -1, -1, 100, 0, fetchDataBuilder)
       .build()
@@ -4192,7 +4192,7 @@ class KafkaApisTest extends Logging {
     ).thenReturn(fetchContext)
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
-      any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
+      any[RequestChannel.Request](), anyDouble, any, anyLong)).thenReturn(0)
 
     // If replicaId is -1 we will build a consumer request. Any non-negative replicaId will build a follower request.
     val replicaEpoch = if (replicaId < 0) -1 else 1
@@ -4261,7 +4261,7 @@ class KafkaApisTest extends Logging {
       any[util.Map[Uuid, String]])).thenReturn(fetchContext)
 
     when(clientQuotaManager.maybeRecordAndGetThrottleTimeMs(
-      any[RequestChannel.Request](), anyDouble, anyLong)).thenReturn(0)
+      any[RequestChannel.Request](), anyDouble, any, anyLong)).thenReturn(0)
 
     val fetchRequest = new FetchRequest.Builder(16, 16, -1, -1, 100, 0, fetchDataBuilder)
       .build()


### PR DESCRIPTION
Jira: [KAFKA-16042](https://issues.apache.org/jira/browse/KAFKA-16042)
# Changes
- Expose the individual partition size in fetch response and produce request
- Record topic partition size in quota manager with metric tags

# To discuss
- [ ] Should we add a configuration to enable/disable the new metric?
- [ ] Add tests

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
