### PR TITLE
KAFKA-16052: Create a real dummy replicaManager instance to save heap memory

### DIFF
--- a/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
@@ -17,54 +17,62 @@
 
 package kafka.coordinator
 
-import java.util.concurrent.{ConcurrentHashMap, Executors}
+import java.util.concurrent.{ConcurrentHashMap, ExecutorService, Executors}
 import java.util.{Collections, Random}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.Lock
 import kafka.coordinator.AbstractCoordinatorConcurrencyTest._
-import kafka.log.UnifiedLog
-import kafka.server._
+import kafka.log.{LogManager, UnifiedLog}
+import kafka.server.QuotaFactory.QuotaManagers
+import kafka.server.{DelayedOperationPurgatory, KafkaConfig, _}
 import kafka.utils._
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.{MemoryRecords, RecordBatch, RecordValidationStats}
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
+import org.apache.kafka.common.utils.Time
 import org.apache.kafka.server.util.timer.MockTimer
-import org.apache.kafka.server.util.{MockScheduler, MockTime}
+import org.apache.kafka.server.util.{MockScheduler, MockTime, Scheduler}
 import org.apache.kafka.storage.internals.log.{AppendOrigin, LogConfig, VerificationGuard}
 import org.junit.jupiter.api.{AfterEach, BeforeEach}
-import org.mockito.Mockito.{CALLS_REAL_METHODS, mock, withSettings}
+import org.mockito.Mockito.{mock, when, withSettings}
 
 import scala.collection._
 import scala.jdk.CollectionConverters._
 
-abstract class AbstractCoordinatorConcurrencyTest[M <: CoordinatorMember] {
-
+abstract class AbstractCoordinatorConcurrencyTest[M <: CoordinatorMember] extends Logging {
   val nThreads = 5
-
-  val time = new MockTime
-  val timer = new MockTimer
-  val executor = Executors.newFixedThreadPool(nThreads)
-  val scheduler = new MockScheduler(time)
-  var replicaManager: TestReplicaManager = _
-  var zkClient: KafkaZkClient = _
   val serverProps = TestUtils.createBrokerConfig(nodeId = 0, zkConnect = "")
   val random = new Random
+  var replicaManager: TestReplicaManager = _
+  var zkClient: KafkaZkClient = _
+  var time: MockTime = _
+  var timer: MockTimer = _
+  var executor: ExecutorService = _
+  var scheduler: MockScheduler = _
 
   @BeforeEach
   def setUp(): Unit = {
-
-    replicaManager = mock(classOf[TestReplicaManager], withSettings().defaultAnswer(CALLS_REAL_METHODS))
-    replicaManager.createDelayedProducePurgatory(timer)
-
-    zkClient = mock(classOf[KafkaZkClient])
+    time = new MockTime
+    timer = new MockTimer(time)
+    scheduler = new MockScheduler(time)
+    executor = Executors.newFixedThreadPool(nThreads)
+    val mockLogMger = mock(classOf[LogManager])
+    when(mockLogMger.liveLogDirs).thenReturn(Seq.empty)
+    val producePurgatory = new DelayedOperationPurgatory[DelayedProduce]("Produce", timer, 1, reaperEnabled = false)
+    val watchKeys = Collections.newSetFromMap(new ConcurrentHashMap[TopicPartitionOperationKey, java.lang.Boolean]()).asScala
+    replicaManager = TestReplicaManager(KafkaConfig.fromProps(serverProps), time, scheduler, mockLogMger, mock(classOf[QuotaManagers], withSettings().stubOnly()), producePurgatory, watchKeys)
+    zkClient = mock(classOf[KafkaZkClient], withSettings().stubOnly())
   }
 
   @AfterEach
   def tearDown(): Unit = {
-    if (executor != null)
-      executor.shutdownNow()
+    CoreUtils.swallow(replicaManager.shutdown(false), this)
+    CoreUtils.swallow(executor.shutdownNow(), this)
+    CoreUtils.swallow(timer.close(), this)
+    CoreUtils.swallow(scheduler.shutdown(), this)
+    CoreUtils.swallow(time.scheduler.shutdown(), this)
   }
 
   /**
@@ -148,7 +156,6 @@ abstract class AbstractCoordinatorConcurrencyTest[M <: CoordinatorMember] {
 }
 
 object AbstractCoordinatorConcurrencyTest {
-
   trait Action extends Runnable {
     def await(): Unit
   }
@@ -156,17 +163,27 @@ object AbstractCoordinatorConcurrencyTest {
   trait CoordinatorMember {
   }
 
-  class TestReplicaManager extends ReplicaManager(
-    null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, None, null) {
+  class TestReplicaManager(config: KafkaConfig,
+                           mtime: Time,
+                           scheduler: Scheduler,
+                           logManager: LogManager,
+                           quotaManagers: QuotaManagers,
+                           val watchKeys: mutable.Set[TopicPartitionOperationKey],
+                           val producePurgatory: DelayedOperationPurgatory[DelayedProduce])
+    extends ReplicaManager(
+      config,
+      metrics = null,
+      mtime,
+      scheduler,
+      logManager,
+      None,
+      quotaManagers,
+      null,
+      null,
+      null,
+      delayedProducePurgatoryParam = Some(producePurgatory)) {
 
     @volatile var logs: mutable.Map[TopicPartition, (UnifiedLog, Long)] = _
-    var producePurgatory: DelayedOperationPurgatory[DelayedProduce] = _
-    var watchKeys: mutable.Set[TopicPartitionOperationKey] = _
-
-    def createDelayedProducePurgatory(timer: MockTimer): Unit = {
-      producePurgatory = new DelayedOperationPurgatory[DelayedProduce]("Produce", timer, 1, reaperEnabled = false)
-      watchKeys = Collections.newSetFromMap(new ConcurrentHashMap[TopicPartitionOperationKey, java.lang.Boolean]()).asScala
-    }
 
     override def maybeStartTransactionVerificationForPartition(
       topicPartition: TopicPartition,
@@ -256,5 +273,17 @@ object AbstractCoordinatorConcurrencyTest {
 
     override def getLogEndOffset(topicPartition: TopicPartition): Option[Long] =
       getOrCreateLogs().get(topicPartition).map(l => l._2)
+  }
+
+  object TestReplicaManager {
+    def apply(config: KafkaConfig,
+              time: Time,
+              scheduler: Scheduler,
+              logManager: LogManager,
+              quotaManagers: QuotaManagers,
+              producePurgatory: DelayedOperationPurgatory[DelayedProduce],
+              watchKeys: mutable.Set[TopicPartitionOperationKey]): TestReplicaManager = {
+      new TestReplicaManager(config, time, scheduler, logManager, quotaManagers, watchKeys, producePurgatory)
+    }
   }
 }

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -47,7 +47,7 @@ import scala.jdk.CollectionConverters._
 /**
  * Unit tests for the log cleaning logic
  */
-class LogCleanerTest {
+class LogCleanerTest extends Logging {
 
   val tmpdir = TestUtils.tempDir()
   val dir = TestUtils.randomPartitionLogDir(tmpdir)
@@ -64,6 +64,7 @@ class LogCleanerTest {
 
   @AfterEach
   def teardown(): Unit = {
+    CoreUtils.swallow(time.scheduler.shutdown(), this)
     Utils.delete(tmpdir)
   }
 


### PR DESCRIPTION
For more detail, please check [KAFKA-16052](https://issues.apache.org/jira/browse/KAFKA-16052).

The mockito will keep the invocation history in the test suite and cause the huge heap usage. Since the mock replicaManager is only used to bypass the replicaManager constructor without verifying/mocking anything, we can create a real dummy replicaManager to avoid the mockito invocation history in memory.

Co-authored-by: Luke Chen <showuon@gmail.com>