### PR TITLE
KAFKA-16070: move setReadOnly to Headers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -52,8 +52,6 @@ import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
 import org.apache.kafka.common.metrics.MetricConfig;
@@ -1026,7 +1024,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             // take into account broker load, the amount of data produced to each partition, etc.).
             int partition = partition(record, serializedKey, serializedValue, cluster);
 
-            setReadOnly(record.headers());
+            record.headers().setReadOnly();
             Header[] headers = record.headers().toArray();
 
             int serializedSize = AbstractRecords.estimateSizeInBytesUpperBound(apiVersions.maxUsableProduceMagic(),
@@ -1096,12 +1094,6 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             // we notify interceptor about all exceptions, since onSend is called before anything else in this method
             this.interceptors.onSendError(record, appendCallbacks.topicPartition(), e);
             throw e;
-        }
-    }
-
-    private void setReadOnly(Headers headers) {
-        if (headers instanceof RecordHeaders) {
-            ((RecordHeaders) headers).setReadOnly();
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/header/Headers.java
+++ b/clients/src/main/java/org/apache/kafka/common/header/Headers.java
@@ -69,4 +69,10 @@ public interface Headers extends Iterable<Header> {
      */
     Header[] toArray();
 
+    /**
+     * Set Header to readonly.
+     */
+    default void setReadOnly() {
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeaders.java
+++ b/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeaders.java
@@ -104,6 +104,7 @@ public class RecordHeaders implements Headers {
         return closeAware(headers.iterator());
     }
 
+    @Override
     public void setReadOnly() {
         this.isReadOnly = true;
     }

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class RecordHeadersTest {
 
@@ -129,40 +128,22 @@ public class RecordHeadersTest {
 
     @Test
     public void testReadOnly() {
-        RecordHeaders headers = new RecordHeaders();
+        Headers headers = new RecordHeaders();
         headers.add(new RecordHeader("key", "value".getBytes()));
         Iterator<Header> headerIteratorBeforeClose = headers.iterator();
         headers.setReadOnly();
-        try {
-            headers.add(new RecordHeader("key", "value".getBytes()));
-            fail("IllegalStateException expected as headers are closed");
-        } catch (IllegalStateException ise) {
-            //expected  
-        }
 
-        try {
-            headers.remove("key");
-            fail("IllegalStateException expected as headers are closed");
-        } catch (IllegalStateException ise) {
-            //expected  
-        }
-
-        try {
+        assertThrows(IllegalStateException.class, () -> headers.add(new RecordHeader("key", "value".getBytes())));
+        assertThrows(IllegalStateException.class, () -> headers.remove("key"));
+        assertThrows(IllegalStateException.class, () -> {
             Iterator<Header> headerIterator = headers.iterator();
             headerIterator.next();
             headerIterator.remove();
-            fail("IllegalStateException expected as headers are closed");
-        } catch (IllegalStateException ise) {
-            //expected  
-        }
-        
-        try {
+        });
+        assertThrows(IllegalStateException.class, () -> {
             headerIteratorBeforeClose.next();
             headerIteratorBeforeClose.remove();
-            fail("IllegalStateException expected as headers are closed");
-        } catch (IllegalStateException ise) {
-            //expected  
-        }
+        });
     }
 
     @Test


### PR DESCRIPTION
Promote the setReadOnly function to Headers instead of only in RecordHeaders.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
