### PR TITLE
MINOR: Fixing flaky test GroupMetadataManagerTest.testStaticMemberGetsBackAssignmentUponRejoin

### DIFF
--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -2191,6 +2191,7 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(-2)
             .build();
 
+        assertEquals(1, result.records().size());
         assertRecordEquals(result.records().get(0), RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch));
 
         // Member 2 rejoins the group with the same instance id.
@@ -2340,6 +2341,7 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH)
             .build();
 
+        assertEquals(1, result.records().size());
         assertRecordEquals(result.records().get(0), RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch));
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -2191,11 +2191,7 @@ public class GroupMetadataManagerTest {
             .setMemberEpoch(-2)
             .build();
 
-        List<Record> expectedRecords = Collections.singletonList(
-            RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch)
-        );
-
-        assertEquals(result.records(), expectedRecords);
+        assertRecordEquals(result.records().get(0), RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch));
 
         // Member 2 rejoins the group with the same instance id.
         CoordinatorResult<ConsumerGroupHeartbeatResponseData, Record> rejoinResult = context.consumerGroupHeartbeat(
@@ -2343,11 +2339,8 @@ public class GroupMetadataManagerTest {
             .Builder(member2)
             .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH)
             .build();
-        List<Record> expectedRecords = Collections.singletonList(
-            RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch)
-        );
 
-        assertEquals(result.records(), expectedRecords);
+        assertRecordEquals(result.records().get(0), RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch));
     }
 
     @Test


### PR DESCRIPTION
Noticed 2 cases of Flaky unit tests. One in this build: https://ci-builds.apache.org/blue/organizations/jenkins/Kafka%2Fkafka-pr/detail/PR-15080/1/tests/ `testStaticMemberGetsBackAssignmentUponRejoin` and this link: https://github.com/apache/kafka/pull/14988#issuecomment-1853155239 which mentions `testNoGroupEpochBumpWhenStaticMemberTemporarilyLeaves` as flaky. The main reason for the flakiness is that the order of topic-partitions in the assigned partitions is inverted in expected v/s actual. This PR aims to correct the 2.

I ran all the 182 tests in `GroupMetadataManagerTest` 30 times via a script and all the tests passed on all occasions. 