### PR TITLE
KAFKA-16063: Prevent memory leak by Disabling shutdownhook

### DIFF
--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -178,6 +178,7 @@ class MiniKdc(config: Properties, workDir: File) extends Logging {
 
     // And start the ds
     ds.setInstanceId(config.getProperty(MiniKdc.Instance))
+    ds.setShutdownHookEnabled(false)
     ds.startup()
 
     // context entry, after ds.startup()


### PR DESCRIPTION
It seems to be a well known leak over the internet. 
https://blog.creekorful.org/2020/03/classloader-and-memory-leaks/
https://stackoverflow.com/questions/6385018/memory-leaks-with-addshutdownhook

We already calling DirectoryService shutdown during kdc stop method. We explicitly not required ApplicationShutDownHook for the same.

**Testing**:
Generated HeapDump and found no object leak related to ApplicationShutDownHook/DefaultDirectoryService.

<img width="1344" alt="Screenshot 2024-01-02 at 1 15 08 PM" src="https://github.com/apache/kafka/assets/59436466/85a173f4-8dfc-42c1-b92d-21bf2c6155ba">


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
