### PR TITLE
MINOR: Fix flaky test RemoteIndexCacheTest.testClose()

### DIFF
--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -357,7 +357,13 @@ class RemoteIndexCacheTest {
     verify(spyEntry.timeIndex, times(0)).deleteIfExists()
 
     // verify cleaner thread is shutdown
-    assertTrue(cache.cleanerThread.isShutdownComplete)
+    TestUtils.waitUntilTrue(() => {
+      try {
+        cache.cleanerThread.isShutdownComplete
+      } catch {
+        case e: InterruptedException => true
+      }
+    }, "Failed while waiting for cleaner thread to shutdown")
   }
 
   @Test


### PR DESCRIPTION
Test fails 2% of the time.

https://ge.apache.org/scans/tests?search.timeZoneId=Europe/Berlin&tests.container=kafka.log.remote.RemoteIndexCacheTest&tests.test=testClose()

This test should be modified to test 
assertTrue(cache.cleanerThread.isShutdownComplete) in a TestUtils.waitUntilTrue condition which will catch the InterruptedException and exit successfully on it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
