### PR TITLE
MINOR: Enable Gradle Remote Build Cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -31,3 +31,4 @@ swaggerVersion=2.2.8
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC
 org.gradle.parallel=true
+org.gradle.caching=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
 def isGithubActions = System.getenv('GITHUB_ACTIONS') != null
 def isJenkins = System.getenv('JENKINS_URL') != null
 def isCI = isGithubActions || isJenkins
-def isTrunk = System.getenv("BRANCH_NAME") == "trunk" || System.getenv("GITHUB_REF") == "trunk"
+def isTrunk = System.getenv("BRANCH_NAME") == "gradle-remote-build-cache" || System.getenv("GITHUB_REF") == "trunk"
 
 gradleEnterprise {
     server = "https://ge.apache.org"
@@ -44,7 +44,7 @@ buildCache {
     }
 
     remote(gradleEnterprise.buildCache) {
-        enabled = true
+        enabled = isTrunk
         push = isCI && isTrunk
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
 def isGithubActions = System.getenv('GITHUB_ACTIONS') != null
 def isJenkins = System.getenv('JENKINS_URL') != null
 def isCI = isGithubActions || isJenkins
-def isTrunk = System.getenv("BRANCH_NAME") == "gradle-remote-build-cache" || System.getenv("GITHUB_REF") == "trunk"
+def isTrunk = System.getenv("BRANCH_NAME") == "PR-15109" || System.getenv("GITHUB_REF") == "trunk"
 
 gradleEnterprise {
     server = "https://ge.apache.org"

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,7 @@ plugins {
 def isGithubActions = System.getenv('GITHUB_ACTIONS') != null
 def isJenkins = System.getenv('JENKINS_URL') != null
 def isCI = isGithubActions || isJenkins
+def isTrunk = System.getenv("BRANCH_NAME") == "trunk" || System.getenv("GITHUB_REF") == "trunk"
 
 gradleEnterprise {
     server = "https://ge.apache.org"
@@ -43,7 +44,8 @@ buildCache {
     }
 
     remote(gradleEnterprise.buildCache) {
-        enabled = false
+        enabled = true
+        push = isCI && isTrunk
     }
 }
 


### PR DESCRIPTION
We enable the remote build cache, hosted by the ASF Gradle Enterprise instance.

We only cache tasks during builds on `trunk`, to ensure that pushes to PRs always re-run all Tasks needed by that PR.

PRs will read from the build cache, enabling tasks for modules that haven't been changed in the PR to be read from the cache.

This should ensure that changes "leaf" modules (e.g. connect, streams, etc.) don't run the entire test suite from dependent modules (i.e. core, clients, storage, etc.), which can be very costly.
