### PR TITLE
KAFKA-16076: Interrupting the currentThread fix

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
@@ -170,6 +170,7 @@ public class RestClient {
             }
         } catch (IOException | InterruptedException | TimeoutException | ExecutionException e) {
             log.error("IO error forwarding REST request: ", e);
+            Thread.currentThread().interrupt();
             throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR, "IO Error trying to forward REST request: " + e.getMessage(), e);
         } catch (ConnectRestException e) {
             // catching any explicitly thrown ConnectRestException-s to preserve its status code


### PR DESCRIPTION
In RestClient class, httpRequest is being called with different threads. An InterruptedException in case of failure is used to handle its specific exceptions, nevertheless it's forgot to call Thread.currentThread().interrupt().

In general, it's a good practice to call this so the rest of code know the thread was interrupted already.
Note:
Some methods that cause a thread to wait or sleep (like Thread.sleep()) will check this flag. If they see it’s set, they’ll stop waiting/sleeping and throw an InterruptedException.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
