### PR TITLE
KAFKA-16070: Extract the setReadOnly method into Headers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1026,7 +1026,6 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             // take into account broker load, the amount of data produced to each partition, etc.).
             int partition = partition(record, serializedKey, serializedValue, cluster);
 
-            setReadOnly(record.headers());
             Header[] headers = record.headers().toArray();
 
             int serializedSize = AbstractRecords.estimateSizeInBytesUpperBound(apiVersions.maxUsableProduceMagic(),
@@ -1096,12 +1095,6 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             // we notify interceptor about all exceptions, since onSend is called before anything else in this method
             this.interceptors.onSendError(record, appendCallbacks.topicPartition(), e);
             throw e;
-        }
-    }
-
-    private void setReadOnly(Headers headers) {
-        if (headers instanceof RecordHeaders) {
-            ((RecordHeaders) headers).setReadOnly();
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/header/Headers.java
+++ b/clients/src/main/java/org/apache/kafka/common/header/Headers.java
@@ -69,4 +69,9 @@ public interface Headers extends Iterable<Header> {
      */
     Header[] toArray();
 
+    /**
+     * Set a field to show if headers are in read-only state or not.
+     */
+    default void setReadOnly() {
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeaders.java
+++ b/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeaders.java
@@ -104,6 +104,7 @@ public class RecordHeaders implements Headers {
         return closeAware(headers.iterator());
     }
 
+    @Override
     public void setReadOnly() {
         this.isReadOnly = true;
     }


### PR DESCRIPTION
TODO unit tests.

This PR abstracts the setReadOnly function into the Headers Interface and provides a default implementation.

The setReadOnly function in Headers can be rewritten by RecordHeaders, so that the setReadOnly function in KafkaProducer can be removed and the code can be cleaned up.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
