### PR TITLE
MINOR: Add reviewers GitHub action

### DIFF
--- a/.github/workflows/pr_reviews.yml
+++ b/.github/workflows/pr_reviews.yml
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Adding Reviewers
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  add_reviewers:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Add Reviewers
+      run: |
+        user_json=$(gh api users/${{ github.event.review.user.login }})
+        user_name=$(echo "$user_json" | jq -r '.name')
+        user_email=$(echo "$user_json" | jq -r '.email')
+        if [[ "${{ github.event.pull_request.body }}" =~ ^.*Reviewers:\ .*${user_name}.*$ ]]; then
+            echo "Reviewer already added: ${user_name} <${user_email}>"
+        elif [[ "${{ github.event.pull_request.body }}" =~ ^.*Reviewers:\ .*$ ]]; then
+          pr_body="${{ github.event.pull_request.body }}, ${user_name} <${user_email}>"
+          gh pr edit ${{ github.event.pull_request.number }} --body "${pr_body}"
+          echo "Added reviewer: ${user_name} <${user_email}>"
+        else
+          pr_body="${{ github.event.pull_request.body }}
+
+        Reviewers: ${user_name} <${user_email}>"
+          gh pr edit ${{ github.event.pull_request.number }} --body "${pr_body}"
+          echo "Added reviewer: ${user_name} <${user_email}>"
+        fi
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr_reviews.yml
+++ b/.github/workflows/pr_reviews.yml
@@ -24,8 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Add Reviewers
       run: |
         user_json=$(gh api users/${{ github.event.review.user.login }})

--- a/.github/workflows/pr_reviews.yml
+++ b/.github/workflows/pr_reviews.yml
@@ -26,19 +26,19 @@ jobs:
     - uses: actions/checkout@v3
     - name: Add Reviewers
       run: |
-        user_json=$(gh api users/${{ github.event.review.user.login }})
+        user_json=$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" users/${{ github.event.review.user.login }})
         user_name=$(echo "$user_json" | jq -r '.name')
         user_email=$(echo "$user_json" | jq -r '.email')
-        if [[ "${{ github.event.pull_request.body }}" =~ ^.*Reviewers:\ .*${user_name}.*$ ]]; then
+        if [[ '${{ github.event.pull_request.body }}' =~ ^.*Reviewers:\ .*${user_name}.*$ ]]; then
             echo "Reviewer already added: ${user_name} <${user_email}>"
-        elif [[ "${{ github.event.pull_request.body }}" =~ ^.*Reviewers:\ .*$ ]]; then
-          pr_body="${{ github.event.pull_request.body }}, ${user_name} <${user_email}>"
+        elif [[ '${{ github.event.pull_request.body }}' =~ ^.*Reviewers:\ .*$ ]]; then
+          pr_body=$(echo '${{ github.event.pull_request.body }}'", ${user_name} <${user_email}>")
           gh pr edit ${{ github.event.pull_request.number }} --body "${pr_body}"
           echo "Added reviewer: ${user_name} <${user_email}>"
         else
-          pr_body="${{ github.event.pull_request.body }}
+          pr_body=$(echo '${{ github.event.pull_request.body }}'"
 
-        Reviewers: ${user_name} <${user_email}>"
+        Reviewers: ${user_name} <${user_email}>")
           gh pr edit ${{ github.event.pull_request.number }} --body "${pr_body}"
           echo "Added reviewer: ${user_name} <${user_email}>"
         fi


### PR DESCRIPTION
This PR adds a github action that is triggered when a GitHub review is submitted.
The action does the following:
- if there is no "Reviewers" line at the end of the description, then appends it with the current reviewer name and email that is set in their GitHub account.
- if there is a "Reviewers" line at the end, then appends the reviewer name and email. It uses the "Name \<email@provider.domain\>" format.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
