### PR TITLE
KAFKA-16055: Thread unsafe use of HashMap stored in QueryableStoreProvider#storeProviders

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
@@ -20,7 +20,7 @@ import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
 
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -36,7 +36,7 @@ public class QueryableStoreProvider {
     private final GlobalStateStoreProvider globalStoreProvider;
 
     public QueryableStoreProvider(final GlobalStateStoreProvider globalStateStoreProvider) {
-        this.storeProviders = new HashMap<>();
+        this.storeProviders = new ConcurrentHashMap<>();
         this.globalStoreProvider = globalStateStoreProvider;
     }
 


### PR DESCRIPTION
This PR replaces a HashMap by a ConcurrentHashMap so that the local state store queries can be made from multiple threads. This is based on a discussion in the kafka-users mailing list. See this for additional context: https://lists.apache.org/thread/gpct1275bfqovlckptn3lvf683qpoxol

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
