### PR TITLE
KAFKA-16079: fix threads leak threads in LocalLeaderEndPointTest and other tests

### DIFF
--- a/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
+++ b/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
@@ -20,7 +20,7 @@ package kafka.server
 import kafka.cluster.BrokerEndPoint
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server.checkpoints.LazyOffsetCheckpoints
-import kafka.utils.TestUtils
+import kafka.utils.{CoreUtils, Logging, TestUtils}
 import org.apache.kafka.common.{Node, TopicPartition, Uuid}
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderPartition
@@ -42,7 +42,7 @@ import java.util.Collections
 import scala.collection.{Map, Seq}
 import scala.jdk.CollectionConverters._
 
-class LocalLeaderEndPointTest {
+class LocalLeaderEndPointTest extends Logging {
 
   val time = new MockTime
   val topicId: Uuid = Uuid.randomUuid()
@@ -84,8 +84,8 @@ class LocalLeaderEndPointTest {
 
   @AfterEach
   def tearDown(): Unit = {
-    replicaManager.shutdown(checkpointHW = false)
-    quotaManager.shutdown()
+    CoreUtils.swallow(replicaManager.shutdown(checkpointHW = false), this)
+    CoreUtils.swallow(quotaManager.shutdown(), this)
   }
 
   @Test

--- a/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
+++ b/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
@@ -18,6 +18,7 @@
 package kafka.server
 
 import kafka.cluster.BrokerEndPoint
+import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server.checkpoints.LazyOffsetCheckpoints
 import kafka.utils.TestUtils
 import org.apache.kafka.common.{Node, TopicPartition, Uuid}
@@ -32,7 +33,7 @@ import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.server.common.OffsetAndEpoch
 import org.apache.kafka.server.util.{MockScheduler, MockTime}
 import org.apache.kafka.storage.internals.log.{AppendOrigin, LogDirFailureChannel}
-import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.api.Assertions._
 import org.mockito.Mockito.mock
 
@@ -50,6 +51,7 @@ class LocalLeaderEndPointTest {
   val sourceBroker: BrokerEndPoint = BrokerEndPoint(0, "localhost", 9092)
   var replicaManager: ReplicaManager = _
   var endPoint: LeaderEndPoint = _
+  var quotaManager: QuotaManagers = _
 
   @BeforeEach
   def setUp(): Unit = {
@@ -58,7 +60,7 @@ class LocalLeaderEndPointTest {
     val mockLogMgr = TestUtils.createLogManager(config.logDirs.map(new File(_)))
     val alterPartitionManager = mock(classOf[AlterPartitionManager])
     val metrics = new Metrics
-    val quotaManager = QuotaFactory.instantiate(config, metrics, time, "")
+    quotaManager = QuotaFactory.instantiate(config, metrics, time, "")
     replicaManager = new ReplicaManager(
       metrics = metrics,
       config = config,
@@ -78,6 +80,12 @@ class LocalLeaderEndPointTest {
     replicaManager.getPartitionOrException(topicPartition)
       .localLogOrException
     endPoint = new LocalLeaderEndPoint(sourceBroker, config, replicaManager, QuotaFactory.UnboundedQuota)
+  }
+
+  @AfterEach
+  def tearDown(): Unit = {
+    replicaManager.shutdown(checkpointHW = false)
+    quotaManager.shutdown()
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -1390,7 +1390,6 @@ class KafkaApisTest extends Logging {
         val request = buildRequest(new MetadataRequest(metadataRequestData, version.toShort))
         val kafkaApis = createKafkaApis()
         try {
-
           val capturedResponse: ArgumentCaptor[AbstractResponse] = ArgumentCaptor.forClass(classOf[AbstractResponse])
           kafkaApis.handle(request, RequestLocal.withThreadConfinedCaching)
           verify(requestChannel).sendResponse(

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -1388,20 +1388,24 @@ class KafkaApisTest extends Logging {
       topics.foreach(topic => {
         val metadataRequestData = new MetadataRequestData().setTopics(Collections.singletonList(topic))
         val request = buildRequest(new MetadataRequest(metadataRequestData, version.toShort))
-        kafkaApis = createKafkaApis()
+        val kafkaApis = createKafkaApis()
+        try {
 
-        val capturedResponse: ArgumentCaptor[AbstractResponse] = ArgumentCaptor.forClass(classOf[AbstractResponse])
-        kafkaApis.handle(request, RequestLocal.withThreadConfinedCaching)
-        verify(requestChannel).sendResponse(
-          ArgumentMatchers.eq(request),
-          capturedResponse.capture(),
-          any()
-        )
-        val response = capturedResponse.getValue.asInstanceOf[MetadataResponse]
-        assertEquals(1, response.topicMetadata.size)
-        assertEquals(1, response.errorCounts.get(Errors.INVALID_REQUEST))
-        response.data.topics.forEach(topic => assertNotEquals(null, topic.name))
-        reset(requestChannel)
+          val capturedResponse: ArgumentCaptor[AbstractResponse] = ArgumentCaptor.forClass(classOf[AbstractResponse])
+          kafkaApis.handle(request, RequestLocal.withThreadConfinedCaching)
+          verify(requestChannel).sendResponse(
+            ArgumentMatchers.eq(request),
+            capturedResponse.capture(),
+            any()
+          )
+          val response = capturedResponse.getValue.asInstanceOf[MetadataResponse]
+          assertEquals(1, response.topicMetadata.size)
+          assertEquals(1, response.errorCounts.get(Errors.INVALID_REQUEST))
+          response.data.topics.forEach(topic => assertNotEquals(null, topic.name))
+          reset(requestChannel)
+        } finally {
+          kafkaApis.close()
+        }
       })
     )
   }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -75,6 +75,7 @@ class ReplicaManagerConcurrencyTest extends Logging {
     CoreUtils.swallow(replicaManager.shutdown(checkpointHW = false), this)
     CoreUtils.swallow(quotaManagers.shutdown(), this)
     CoreUtils.swallow(metrics.close(), this)
+    CoreUtils.swallow(time.scheduler.shutdown(), this)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -21,10 +21,11 @@ import java.util
 import java.util.concurrent.{CompletableFuture, Executors, LinkedBlockingQueue, TimeUnit}
 import java.util.{Optional, Properties}
 import kafka.api.LeaderAndIsr
+import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server.metadata.KRaftMetadataCache
 import kafka.server.metadata.MockConfigRepository
 import kafka.utils.TestUtils.waitUntilTrue
-import kafka.utils.TestUtils
+import kafka.utils.{CoreUtils, Logging, TestUtils}
 import org.apache.kafka.common.metadata.RegisterBrokerRecord
 import org.apache.kafka.common.metadata.{PartitionChangeRecord, PartitionRecord, TopicRecord}
 import org.apache.kafka.common.metrics.Metrics
@@ -50,12 +51,15 @@ import scala.collection.{immutable, mutable}
 import scala.jdk.CollectionConverters._
 import scala.util.Random
 
-class ReplicaManagerConcurrencyTest {
+class ReplicaManagerConcurrencyTest extends Logging {
 
   private val time = new MockTime()
   private val metrics = new Metrics()
   private val executor = Executors.newScheduledThreadPool(8)
   private val tasks = mutable.Buffer.empty[ShutdownableThread]
+  private var channel: ControllerChannel = _
+  private var quotaManagers: QuotaManagers = _
+  private var replicaManager: ReplicaManager = _
 
   private def submit(task: ShutdownableThread): Unit = {
     tasks += task
@@ -64,10 +68,13 @@ class ReplicaManagerConcurrencyTest {
 
   @AfterEach
   def cleanup(): Unit = {
-    tasks.foreach(_.shutdown())
-    executor.shutdownNow()
-    executor.awaitTermination(5, TimeUnit.SECONDS)
-    metrics.close()
+    CoreUtils.swallow(tasks.foreach(_.shutdown()), this)
+    CoreUtils.swallow(executor.shutdownNow(), this)
+    CoreUtils.swallow(executor.awaitTermination(5, TimeUnit.SECONDS), this)
+    CoreUtils.swallow(channel.shutdown(), this)
+    CoreUtils.swallow(replicaManager.shutdown(checkpointHW = false), this)
+    CoreUtils.swallow(quotaManagers.shutdown(), this)
+    CoreUtils.swallow(metrics.close(), this)
   }
 
   @Test
@@ -75,8 +82,8 @@ class ReplicaManagerConcurrencyTest {
     val localId = 0
     val remoteId = 1
     val metadataCache = MetadataCache.kRaftMetadataCache(localId)
-    val channel = new ControllerChannel
-    val replicaManager = buildReplicaManager(localId, channel, metadataCache)
+    channel = new ControllerChannel
+    replicaManager = buildReplicaManager(localId, channel, metadataCache)
 
     // Start with the remote replica out of the ISR
     val initialPartitionRegistration = registration(
@@ -173,13 +180,15 @@ class ReplicaManagerConcurrencyTest {
       time = time
     )
 
+    quotaManagers = QuotaFactory.instantiate(config, metrics, time, "")
+
     new ReplicaManager(
       metrics = metrics,
       config = config,
       time = time,
       scheduler = time.scheduler,
       logManager = logManager,
-      quotaManagers = QuotaFactory.instantiate(config, metrics, time, ""),
+      quotaManagers = quotaManagers,
       metadataCache = metadataCache,
       logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size),
       alterPartitionManager = new MockAlterPartitionManager(channel)


### PR DESCRIPTION
Fix threads leak in LocalLeaderEndPointTest/FinalizedFeatureChangeListenerTest/KafkaApisTest/ReplicaManagerConcurrencyTest

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
