### PR TITLE
MINOR: Fix shadow jar publishing for the clients module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -303,7 +303,7 @@ subprojects {
             from components.java
           } else {
             apply plugin: 'com.github.johnrengelman.shadow'
-            project.shadow.component(mavenJava)
+            artifact shadowJar
           }
 
           afterEvaluate {


### PR DESCRIPTION
## What
The PR fixes the publishing of `kafka-clients` artifact to remote maven. The `kafka-clients` jar is recently been shadowed which does publish the artifacts to local maven successfully but errors when publishing to remote maven. The issue triggers only with `publishMavenJavaPublicationToMavenRepository` and `signing` but `publishToMavenLocal` works correctly with earlier changes. Generating signed `asc` files error out for shadowed release artifacts as the module name (`clients`) differs from the artifact name (`kafka-clients`).

The fix is basically to explicitly define `artifact` of `shadowJar` to `signing` and `publish` plugin. `project.shadow.component(mavenJava)` previously outputs the name as `client-<version>-all.jar` though the `classifier` and `archivesBaseName` are already defined correctly in `:clients` and `shadowJar` construction. 

Below is another way where the artifact details can be overridden post construction in `afterEvaluate` to let `publish` plugin know about the correct `artifactId` but it doesn't solve the `signing` plugin issue where `signing` plugin is unaware of `kafka-client-<version>.jar` and skips signing. For `signing` plugin the `artifact` should be explicitly defined as well.

```
            project.shadow.component(mavenJava)
        
            afterEvaluate {
              pom.withXml {
                asNode().dependencies.dependency.findAll() {
                  def projectName = it.artifactId.text()
                  if (['clients'].contains(projectName)) {
                    it.artifactId*.value = 'kafka-clients'
                  }
                }
              }
            }
```  

## Tests:
- I created person `gpg` secrets locally for signing and private maven repo to upload the artifacts. I ran the release pipeline pointing to custom repo and can successfully push the `kafka-clients` artifacts.

![Screenshot 2024-01-04 at 3 46 06 PM](https://github.com/apache/kafka/assets/2861565/e8f71eb9-905f-4838-afa1-99929d613e2d)

- Testing shaded dependencies generated successfully. I can see no difference in the previous and release shaded jars, and can also see shaded dependencies in the jar.

![Screenshot 2024-01-04 at 3 50 11 PM](https://github.com/apache/kafka/assets/2861565/e334e51c-ec00-419a-97a1-62c0315bfefe)

## Query:

- I compared the 3.6.1 kafka release artifacts [here](https://repo1.maven.org/maven2/org/apache/kafka/kafka-clients/3.6.1/) with generated artifacts in my personal repo, and can find `module` metadata artifact is missing. Debugged the issue and it seems `gradle publish` - `from components.java` actually registers both `jar` and `module` for publish which is not there in case of `shadowJar` hence the question is that do we require to publish `module` metadata information or are we good?

cc: @stanislavkozlovski @xvrl @AndrewJSchofield


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
