### PR TITLE
KAFKA-16083: Exclude throttle time when expiring inflight requests on a connection

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -589,7 +589,7 @@ public class NetworkClientTest {
         client.poll(0, time.milliseconds());
 
         assertEquals(1, client.inFlightRequestCount(node.idString()));
-        assertFalse(client.connectionFailed(node), "Connection failed after throttling.");
+        assertFalse(client.connectionFailed(node), "Connection should not have failed due to the extra time spent throttling.");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -561,6 +561,38 @@ public class NetworkClientTest {
     }
 
     @Test
+    public void testConnectionTimeoutAfterThrottling() {
+        awaitReady(client, node);
+        short requestVersion = PRODUCE.latestVersion();
+        int timeoutMs = 1000;
+        ProduceRequest.Builder builder = new ProduceRequest.Builder(
+            requestVersion,
+            requestVersion,
+            new ProduceRequestData()
+                .setAcks((short) 1)
+                .setTimeoutMs(timeoutMs));
+        TestCallbackHandler handler = new TestCallbackHandler();
+        ClientRequest r1 = client.newClientRequest(node.idString(), builder, time.milliseconds(), true,
+                defaultRequestTimeoutMs, handler);
+
+        client.send(r1, time.milliseconds());
+        client.poll(0, time.milliseconds());
+
+        // Throttle long enough to ensure other inFlight requests timeout.
+        ProduceResponse pr = new ProduceResponse(new ProduceResponseData().setThrottleTimeMs(timeoutMs));
+        ByteBuffer buffer = RequestTestUtils.serializeResponseWithHeader(pr, requestVersion, r1.correlationId());
+        selector.delayedReceive(new DelayedReceive(node.idString(), new NetworkReceive(node.idString(), buffer)));
+        ClientRequest r2 = client.newClientRequest(node.idString(), builder, time.milliseconds(), true,
+                defaultRequestTimeoutMs, handler);
+        client.send(r2, time.milliseconds());
+        time.sleep(timeoutMs);
+        client.poll(0, time.milliseconds());
+
+        assertEquals(1, client.inFlightRequestCount(node.idString()));
+        assertFalse(client.connectionFailed(node), "Connection failed after throttling.");
+    }
+
+    @Test
     public void testConnectionThrottling() {
         // Instrument the test to return a response with a 100ms throttle delay.
         awaitReady(client, node);


### PR DESCRIPTION
When expiring inflight requests, the network client does not take throttle time into account. If a connection has multiple inflight requests (default of 5) and each request is throttled then some of the requests can incorrectly marked as expired. Subsequently the connection is closed and the client establishes a new connection to the broker. This behavior leads to unnecessary connections to the broker, leads to connection storms and increases latencies. 

### Testing
Unit tests

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
