### PR TITLE
MINOR: Address occasional UnnecessaryStubbingException in StreamThreadTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -774,7 +774,7 @@ public class StreamThreadTest {
             mockTime
         );
 
-        when(consumer.poll(any())).thenReturn(ConsumerRecords.empty());
+        lenient().when(consumer.poll(any())).thenReturn(ConsumerRecords.empty());
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());


### PR DESCRIPTION
This pull request should address the occasional failures of the StreamThreadTest such as https://ci-builds.apache.org/blue/organizations/jenkins/Kafka%2Fkafka-pr/detail/PR-15116/1/tests

A similar problem occurred https://github.com/apache/kafka/blob/trunk/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java#L714

The poll() method does not need to called for the test to pass, but when it is called it should return empty ConsumerRecords.