### PR TITLE
KAFKA-16086: Fix memory leak in RocksDBStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -308,8 +308,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         allDescriptors.add(defaultColumnFamilyDescriptor);
         allDescriptors.addAll(extraDescriptors);
 
-        try {
-            final Options options = new Options(dbOptions, defaultColumnFamilyDescriptor.getOptions());
+        try (final Options options = new Options(dbOptions, defaultColumnFamilyDescriptor.getOptions())) {
             final List<byte[]> allExisting = RocksDB.listColumnFamilies(options, absolutePath);
 
             final List<ColumnFamilyDescriptor> existingDescriptors = new LinkedList<>();


### PR DESCRIPTION
We allocate an `Options` in order to list column families while opening the `RocksDBStore`, but never explicitly `close()` it.

`Options` is a RocksDB native object, which needs to be explicitly closed to free the resources it allocates in native memory.

Failing to close this causes a memory leak when repeatedly opening/closing stores.

It's an `AutoCloseable`, and all usage of it is confined to the surrounding `try` block, so we can just hook it out to the `try` to auto-close it when done.