### PR TITLE
KAFKA-16073: [Tiered] Update localLogStartOffset before deleting segments in memory t…

### DIFF
--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1510,10 +1510,21 @@ class UnifiedLog(@volatile var logStartOffset: Long,
           }
         }
         localLog.checkIfMemoryMappedBufferClosed()
-        // remove the segments for lookups
-        localLog.removeAndDeleteSegments(segmentsToDelete, asyncDelete = true, reason)
-        deleteProducerSnapshots(deletable, asyncDelete = true)
-        incrementStartOffset(localLog.segments.firstSegmentBaseOffset.getAsLong, LogStartOffsetIncrementReason.SegmentDeletion)
+        if (remoteLogEnabled()) {
+          /**
+           * See @link{https://issues.apache.org/jira/browse/KAFKA-16073} for the background of this fix
+           */
+          val newLocalLogStartOffset = localLog.segments.higherSegment(deletable.last.baseOffset()).get().baseOffset()
+          incrementStartOffset(newLocalLogStartOffset, LogStartOffsetIncrementReason.SegmentDeletion)
+          // remove the segments for lookups
+          localLog.removeAndDeleteSegments(segmentsToDelete, asyncDelete = true, reason)
+          deleteProducerSnapshots(deletable, asyncDelete = true)
+        } else {
+          // remove the segments for lookups
+          localLog.removeAndDeleteSegments(segmentsToDelete, asyncDelete = true, reason)
+          deleteProducerSnapshots(deletable, asyncDelete = true)
+          incrementStartOffset(localLog.segments.firstSegmentBaseOffset.getAsLong, LogStartOffsetIncrementReason.SegmentDeletion)
+        }
       }
       numToDelete
     }


### PR DESCRIPTION
### Problem
https://issues.apache.org/jira/browse/KAFKA-16073

The consumer will receive 'OutOfRangeException' in the following case:

In a specific concurrent scenario, imagine sequential offsets: offset1 < offset2 < offset3. A client requests data at offset2. While a background deletion process removes segments from memory, it hasn't yet updated the LocalLogStartOffset from offset1 to offset3. Consequently, when the fetch offset (offset2) is evaluated against the stale offset1 in ReplicaManager.handleOffsetOutOfRangeError, it incorrectly triggers an OffsetOutOfRangeException. This issue arises from the out-of-sync update of localLogStartOffset, leading to incorrect handling of consumer fetch requests and potential data access errors.

Summarizing the example scenario from the JIRA [comment](https://issues.apache.org/jira/browse/KAFKA-16073?focusedCommentId=17801663&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17801663) 

Let us assume each segment has one offset in this example:
log start offset 0
log end offset 10
local log start offset 4
fetch offset 6
new local log start offset 7

Deletion based on retention configs is started and eventually updating the local log start offset as 7.

There is a race condition here where the segments list is updated by removing 4, 5, and 6 offset segments in LocalLog and then updates the local-log-start-offset. But fetch offset is being served concurrently and it may throw OffsetOutOfRangeException if the inmemory segments are already removed in LocalLog and local-log-start-offset is not yet updated as 7 when it executes the [code](https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/ReplicaManager.scala#L1866) as it fails the condition because fetch offset(6) < old local-log-start-offset(4).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
