### PR TITLE
KAFKA-14505; [4/N] Wire transaction verification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1314,6 +1314,7 @@ project(':group-coordinator') {
     implementation project(':server-common')
     implementation project(':clients')
     implementation project(':metadata')
+    implementation project(':storage')
     implementation libs.slf4jApi
     implementation libs.metrics
 

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -248,6 +248,7 @@
       <allow pkg="org.apache.kafka.server.common"/>
       <allow pkg="org.apache.kafka.server.record"/>
       <allow pkg="org.apache.kafka.server.util"/>
+      <allow pkg="org.apache.kafka.storage.internals.log"/>
       <allow pkg="org.apache.kafka.test" />
       <allow pkg="org.apache.kafka.timeline" />
       <subpackage name="metrics">

--- a/core/src/main/scala/kafka/coordinator/group/CoordinatorPartitionWriter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/CoordinatorPartitionWriter.scala
@@ -27,7 +27,7 @@ import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.TransactionResult
 import org.apache.kafka.common.utils.{BufferSupplier, Time}
 import org.apache.kafka.coordinator.group.runtime.PartitionWriter
-import org.apache.kafka.storage.internals.log.{VerificationGuard}
+import org.apache.kafka.storage.internals.log.VerificationGuard
 
 import java.util
 import java.util.concurrent.CompletableFuture

--- a/core/src/main/scala/kafka/coordinator/group/CoordinatorPartitionWriter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/CoordinatorPartitionWriter.scala
@@ -82,10 +82,7 @@ class CoordinatorPartitionWriter[T](
   }
 
   /**
-   * Register a PartitionWriter.Listener.
-   *
-   * @param tp       The partition to register the listener to.
-   * @param listener The listener.
+   * {@inheritDoc}
    */
   override def registerListener(
     tp: TopicPartition,
@@ -95,10 +92,7 @@ class CoordinatorPartitionWriter[T](
   }
 
   /**
-   * Deregister a PartitionWriter.Listener.
-   *
-   * @param tp       The partition to deregister the listener from.
-   * @param listener The listener.
+   * {@inheritDoc}
    */
   override def deregisterListener(
     tp: TopicPartition,
@@ -108,15 +102,7 @@ class CoordinatorPartitionWriter[T](
   }
 
   /**
-   * Write records to the partitions. Records are written in one batch so
-   * atomicity is guaranteed.
-   *
-   * @param tp            The partition to write records to.
-   * @param producerId    The producer id.
-   * @param producerEpoch The producer epoch.
-   * @param records       The list of records. The records are written in a single batch.
-   * @return The log end offset right after the written records.
-   * @throws KafkaException Any KafkaException caught during the write operation.
+   * {@inheritDoc}
    */
   override def append(
     tp: TopicPartition,
@@ -174,15 +160,7 @@ class CoordinatorPartitionWriter[T](
   }
 
   /**
-   * Write the transaction end marker.
-   *
-   * @param tp                The partition to write records to.
-   * @param producerId        The producer id.
-   * @param producerEpoch     The producer epoch.
-   * @param coordinatorEpoch  The epoch of the transaction coordinator.
-   * @param result            The transaction result.
-   * @return The log end offset right after the written records.
-   * @throws KafkaException Any KafkaException caught during the write operation.
+   * {@inheritDoc}
    */
   override def appendEndTransactionMarker(
     tp: TopicPartition,
@@ -204,16 +182,7 @@ class CoordinatorPartitionWriter[T](
   }
 
   /**
-   * Verify the transaction.
-   *
-   * @param tp              The partition to write records to.
-   * @param transactionalId The transactional id.
-   * @param producerId      The producer id.
-   * @param producerEpoch   The producer epoch.
-   * @return A future containing the {@link VerificationGuard} or an exception if the
-   *         transaction requires a verification; or {@link VerificationGuard#SENTINEL}
-   *         if the transaction has already been verified.
-   * @throws KafkaException Any KafkaException caught during the operation.
+   * {@inheritDoc}
    */
   override def maybeStartTransactionVerification(
     tp: TopicPartition,

--- a/core/src/main/scala/kafka/coordinator/group/CoordinatorPartitionWriter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/CoordinatorPartitionWriter.scala
@@ -17,7 +17,7 @@
 package kafka.coordinator.group
 
 import kafka.cluster.PartitionListener
-import kafka.server.{ActionQueue, ReplicaManager}
+import kafka.server.{ActionQueue, ReplicaManager, RequestLocal}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.RecordTooLargeException
 import org.apache.kafka.common.protocol.Errors
@@ -27,9 +27,10 @@ import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.TransactionResult
 import org.apache.kafka.common.utils.{BufferSupplier, Time}
 import org.apache.kafka.coordinator.group.runtime.PartitionWriter
-import org.apache.kafka.storage.internals.log.AppendOrigin
+import org.apache.kafka.storage.internals.log.{VerificationGuard}
 
 import java.util
+import java.util.concurrent.CompletableFuture
 import scala.collection.Map
 
 /**
@@ -121,6 +122,7 @@ class CoordinatorPartitionWriter[T](
     tp: TopicPartition,
     producerId: Long,
     producerEpoch: Short,
+    verificationGuard: VerificationGuard,
     records: util.List[T]
   ): Long = {
     if (records.isEmpty) throw new IllegalStateException("records must be non-empty.")
@@ -161,7 +163,7 @@ class CoordinatorPartitionWriter[T](
               s"in append to partition $tp which exceeds the maximum configured size of $maxBatchSize.")
           }
 
-          internalAppend(tp, recordsBuilder.build())
+          internalAppend(tp, recordsBuilder.build(), verificationGuard)
         } finally {
           bufferSupplier.release(buffer)
         }
@@ -201,18 +203,55 @@ class CoordinatorPartitionWriter[T](
     ))
   }
 
+  /**
+   * Verify the transaction.
+   *
+   * @param tp              The partition to write records to.
+   * @param transactionalId The transactional id.
+   * @param producerId      The producer id.
+   * @param producerEpoch   The producer epoch.
+   * @return A future containing the {@link VerificationGuard} or an exception.
+   * @throws KafkaException Any KafkaException caught during the operation.
+   */
+  override def maybeStartTransactionVerification(
+    tp: TopicPartition,
+    transactionalId: String,
+    producerId: Long,
+    producerEpoch: Short
+  ): CompletableFuture[VerificationGuard] = {
+    val future = new CompletableFuture[VerificationGuard]()
+    replicaManager.maybeStartTransactionVerificationForPartition(
+      topicPartition = tp,
+      transactionalId = transactionalId,
+      producerId = producerId,
+      producerEpoch = producerEpoch,
+      baseSequence = RecordBatch.NO_SEQUENCE,
+      requestLocal = RequestLocal.NoCaching,
+      callback = (error, _, verificationGuard) => {
+        if (error != Errors.NONE) {
+          future.completeExceptionally(error.exception)
+        } else {
+          future.complete(verificationGuard)
+        }
+      }
+    )
+    future
+  }
+
   private def internalAppend(
     tp: TopicPartition,
-    memoryRecords: MemoryRecords
+    memoryRecords: MemoryRecords,
+    verificationGuard: VerificationGuard = VerificationGuard.SENTINEL
   ): Long = {
     var appendResults: Map[TopicPartition, PartitionResponse] = Map.empty
-    replicaManager.appendRecords(
+    replicaManager.appendForGroup(
       timeout = 0L,
       requiredAcks = 1,
-      internalTopicsAllowed = true,
-      origin = AppendOrigin.COORDINATOR,
       entriesPerPartition = Map(tp -> memoryRecords),
       responseCallback = results => appendResults = results,
+      requestLocal = RequestLocal.NoCaching,
+      verificationGuards = Map(tp -> verificationGuard),
+      delayedProduceLock = None,
       // We can directly complete the purgatories here because we don't hold
       // any conflicting locks.
       actionQueue = directActionQueue

--- a/core/src/main/scala/kafka/coordinator/group/CoordinatorPartitionWriter.scala
+++ b/core/src/main/scala/kafka/coordinator/group/CoordinatorPartitionWriter.scala
@@ -210,7 +210,9 @@ class CoordinatorPartitionWriter[T](
    * @param transactionalId The transactional id.
    * @param producerId      The producer id.
    * @param producerEpoch   The producer epoch.
-   * @return A future containing the {@link VerificationGuard} or an exception.
+   * @return A future containing the {@link VerificationGuard} or an exception if the
+   *         transaction requires a verification; or {@link VerificationGuard#SENTINEL}
+   *         if the transaction has already been verified.
    * @throws KafkaException Any KafkaException caught during the operation.
    */
   override def maybeStartTransactionVerification(

--- a/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
@@ -215,7 +215,8 @@ object AbstractCoordinatorConcurrencyTest {
                                 responseCallback: Map[TopicPartition, PartitionResponse] => Unit,
                                 delayedProduceLock: Option[Lock] = None,
                                 requestLocal: RequestLocal = RequestLocal.NoCaching,
-                                verificationGuards: Map[TopicPartition, VerificationGuard] = Map.empty): Unit = {
+                                verificationGuards: Map[TopicPartition, VerificationGuard] = Map.empty,
+                                actionQueue: ActionQueue = null): Unit = {
       appendRecords(timeout, requiredAcks, true, AppendOrigin.COORDINATOR, entriesPerPartition, responseCallback,
         delayedProduceLock, requestLocal = requestLocal)
     }

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -19,7 +19,7 @@ package kafka.coordinator.group
 
 import java.util.{Optional, OptionalInt}
 import kafka.common.OffsetAndMetadata
-import kafka.server.{DelayedOperationPurgatory, HostedPartition, KafkaConfig, ReplicaManager, RequestLocal}
+import kafka.server.{ActionQueue, DelayedOperationPurgatory, HostedPartition, KafkaConfig, ReplicaManager, RequestLocal}
 import kafka.utils._
 import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.protocol.Errors
@@ -3902,7 +3902,8 @@ class GroupCoordinatorTest {
       capturedArgument.capture(),
       any[Option[ReentrantLock]],
       any(classOf[RequestLocal]),
-      any[Map[TopicPartition, VerificationGuard]]
+      any[Map[TopicPartition, VerificationGuard]],
+      any[ActionQueue]
     )).thenAnswer(_ => {
       capturedArgument.getValue.apply(
         Map(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, groupPartitionId) ->
@@ -3934,7 +3935,8 @@ class GroupCoordinatorTest {
       capturedArgument.capture(),
       any[Option[ReentrantLock]],
       any(classOf[RequestLocal]),
-      any[Map[TopicPartition, VerificationGuard]]
+      any[Map[TopicPartition, VerificationGuard]],
+      any[ActionQueue]
     )).thenAnswer(_ => {
         capturedArgument.getValue.apply(
           Map(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, groupPartitionId) ->
@@ -4077,7 +4079,8 @@ class GroupCoordinatorTest {
       capturedArgument.capture(),
       any[Option[ReentrantLock]],
       any(classOf[RequestLocal]),
-      any[Map[TopicPartition, VerificationGuard]]
+      any[Map[TopicPartition, VerificationGuard]],
+      any[ActionQueue]
     )).thenAnswer(_ => {
       capturedArgument.getValue.apply(
         Map(new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, groupPartitionId) ->
@@ -4119,7 +4122,8 @@ class GroupCoordinatorTest {
       capturedArgument.capture(),
       any[Option[ReentrantLock]],
       any(classOf[RequestLocal]),
-      any[Map[TopicPartition, VerificationGuard]]
+      any[Map[TopicPartition, VerificationGuard]],
+      any[ActionQueue]
     )).thenAnswer(_ => {
       capturedArgument.getValue.apply(
         Map(offsetTopicPartition ->

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
@@ -1181,6 +1181,7 @@ class GroupMetadataManagerTest {
       any(),
       any[Option[ReentrantLock]],
       any(),
+      any(),
       any())
     verify(replicaManager).getMagic(any())
   }
@@ -1214,6 +1215,7 @@ class GroupMetadataManagerTest {
       any(),
       any(),
       any[Option[ReentrantLock]],
+      any(),
       any(),
       any())
     verify(replicaManager).getMagic(any())
@@ -1288,6 +1290,7 @@ class GroupMetadataManagerTest {
       any(),
       any[Option[ReentrantLock]],
       any(),
+      any(),
       any())
     // Will update sensor after commit
     assertEquals(1, TestUtils.totalMetricValue(metrics, "offset-commit-count"))
@@ -1328,7 +1331,8 @@ class GroupMetadataManagerTest {
       capturedResponseCallback.capture(),
       any[Option[ReentrantLock]],
       any(),
-      ArgumentMatchers.eq(Map(offsetTopicPartition -> verificationGuard)))
+      ArgumentMatchers.eq(Map(offsetTopicPartition -> verificationGuard)),
+      any())
     verify(replicaManager).getMagic(any())
     capturedResponseCallback.getValue.apply(Map(groupTopicPartition ->
       new PartitionResponse(Errors.NONE, 0L, RecordBatch.NO_TIMESTAMP, 0L)))
@@ -1386,7 +1390,8 @@ class GroupMetadataManagerTest {
       any(),
       any[Option[ReentrantLock]],
       any(),
-      ArgumentMatchers.eq(Map(offsetTopicPartition -> verificationGuard)))
+      ArgumentMatchers.eq(Map(offsetTopicPartition -> verificationGuard)),
+      any())
     verify(replicaManager).getMagic(any())
   }
 
@@ -1434,7 +1439,8 @@ class GroupMetadataManagerTest {
       any(),
       any[Option[ReentrantLock]],
       any(),
-      ArgumentMatchers.eq(Map(offsetTopicPartition -> verificationGuard)))
+      ArgumentMatchers.eq(Map(offsetTopicPartition -> verificationGuard)),
+      any())
     verify(replicaManager).getMagic(any())
   }
 
@@ -1585,6 +1591,7 @@ class GroupMetadataManagerTest {
       any(),
       any[Option[ReentrantLock]],
       any(),
+      any(),
       any())
     verify(replicaManager).getMagic(any())
     assertEquals(1, TestUtils.totalMetricValue(metrics, "offset-commit-count"))
@@ -1689,6 +1696,7 @@ class GroupMetadataManagerTest {
       any(),
       any(),
       any[Option[ReentrantLock]],
+      any(),
       any(),
       any())
     verify(replicaManager, times(2)).getMagic(any())
@@ -2797,6 +2805,7 @@ class GroupMetadataManagerTest {
       capturedArgument.capture(),
       any[Option[ReentrantLock]],
       any(),
+      any(),
       any())
     capturedArgument
   }
@@ -2809,6 +2818,7 @@ class GroupMetadataManagerTest {
       capturedRecords.capture(),
       capturedCallback.capture(),
       any[Option[ReentrantLock]],
+      any(),
       any(),
       any()
     )).thenAnswer(_ => {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -1106,6 +1106,8 @@ public class GroupCoordinatorService implements GroupCoordinator {
      * @return The Errors instance associated with the given exception.
      */
     private static Errors normalizeException(Throwable exception) {
+        exception = Errors.maybeUnwrapException(exception);
+
         if (exception instanceof UnknownTopicOrPartitionException ||
             exception instanceof NotEnoughReplicasException ||
             exception instanceof TimeoutException) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/PartitionWriter.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/PartitionWriter.java
@@ -128,9 +128,9 @@ public interface PartitionWriter<T> {
      * @param transactionalId   The transactional id.
      * @param producerId        The producer id.
      * @param producerEpoch     The producer epoch.
-     * @return A future containing the {@link VerificationGuard} or an exception if the
-     *         transaction requires a verification; or {@link VerificationGuard#SENTINEL}
-     *         if the transaction has already been verified.
+     * @return A future failed with any error encountered; or the {@link VerificationGuard}
+     *         if the transaction required verification and {@link VerificationGuard#SENTINEL}
+     *         if it did not.
      * @throws KafkaException Any KafkaException caught during the operation.
      */
     CompletableFuture<VerificationGuard> maybeStartTransactionVerification(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/PartitionWriter.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/PartitionWriter.java
@@ -128,7 +128,9 @@ public interface PartitionWriter<T> {
      * @param transactionalId   The transactional id.
      * @param producerId        The producer id.
      * @param producerEpoch     The producer epoch.
-     * @return A future containing the {@link VerificationGuard} or an exception.
+     * @return A future containing the {@link VerificationGuard} or an exception if the
+     *         transaction requires a verification; or {@link VerificationGuard#SENTINEL}
+     *         if the transaction has already been verified.
      * @throws KafkaException Any KafkaException caught during the operation.
      */
     CompletableFuture<VerificationGuard> maybeStartTransactionVerification(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/PartitionWriter.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/PartitionWriter.java
@@ -19,8 +19,10 @@ package org.apache.kafka.coordinator.group.runtime;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.requests.TransactionResult;
+import org.apache.kafka.storage.internals.log.VerificationGuard;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * A simple interface to write records to Partitions/Logs. It contains the minimum
@@ -84,10 +86,11 @@ public interface PartitionWriter<T> {
      * Write records to the partitions. Records are written in one batch so
      * atomicity is guaranteed.
      *
-     * @param tp            The partition to write records to.
-     * @param producerId    The producer id.
-     * @param producerEpoch The producer epoch.
-     * @param records       The list of records. The records are written in a single batch.
+     * @param tp                The partition to write records to.
+     * @param producerId        The producer id.
+     * @param producerEpoch     The producer epoch.
+     * @param verificationGuard The verification guard.
+     * @param records           The list of records. The records are written in a single batch.
      * @return The log end offset right after the written records.
      * @throws KafkaException Any KafkaException caught during the write operation.
      */
@@ -95,6 +98,7 @@ public interface PartitionWriter<T> {
         TopicPartition tp,
         long producerId,
         short producerEpoch,
+        VerificationGuard verificationGuard,
         List<T> records
     ) throws KafkaException;
 
@@ -115,5 +119,22 @@ public interface PartitionWriter<T> {
         short producerEpoch,
         int coordinatorEpoch,
         TransactionResult result
+    ) throws KafkaException;
+
+    /**
+     * Verify the transaction.
+     *
+     * @param tp                The partition to write records to.
+     * @param transactionalId   The transactional id.
+     * @param producerId        The producer id.
+     * @param producerEpoch     The producer epoch.
+     * @return A future containing the {@link VerificationGuard} or an exception.
+     * @throws KafkaException Any KafkaException caught during the operation.
+     */
+    CompletableFuture<VerificationGuard> maybeStartTransactionVerification(
+        TopicPartition tp,
+        String transactionalId,
+        long producerId,
+        short producerEpoch
     ) throws KafkaException;
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -87,6 +87,7 @@ import java.util.List;
 import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -1899,6 +1900,56 @@ public class GroupCoordinatorServiceTest {
             ArgumentMatchers.eq(Duration.ofMillis(5000)),
             ArgumentMatchers.any()
         )).thenReturn(CompletableFuture.completedFuture(response));
+
+        CompletableFuture<TxnOffsetCommitResponseData> future = service.commitTransactionalOffsets(
+            requestContext(ApiKeys.TXN_OFFSET_COMMIT),
+            request,
+            BufferSupplier.NO_CACHING
+        );
+
+        assertEquals(response, future.get());
+    }
+
+    @Test
+    public void testCommitTransactionalOffsetsWithWrappedError() throws ExecutionException, InterruptedException {
+        CoordinatorRuntime<GroupCoordinatorShard, Record> runtime = mockRuntime();
+        GroupCoordinatorService service = new GroupCoordinatorService(
+            new LogContext(),
+            createConfig(),
+            runtime,
+            new GroupCoordinatorMetrics()
+        );
+        service.startup(() -> 1);
+
+        TxnOffsetCommitRequestData request = new TxnOffsetCommitRequestData()
+            .setGroupId("foo")
+            .setTransactionalId("transactional-id")
+            .setProducerId(10L)
+            .setProducerEpoch((short) 5)
+            .setMemberId("member-id")
+            .setGenerationId(10)
+            .setTopics(Collections.singletonList(new TxnOffsetCommitRequestData.TxnOffsetCommitRequestTopic()
+                .setName("topic")
+                .setPartitions(Collections.singletonList(new TxnOffsetCommitRequestData.TxnOffsetCommitRequestPartition()
+                    .setPartitionIndex(0)
+                    .setCommittedOffset(100)))));
+
+        TxnOffsetCommitResponseData response = new TxnOffsetCommitResponseData()
+            .setTopics(Collections.singletonList(new TxnOffsetCommitResponseData.TxnOffsetCommitResponseTopic()
+                .setName("topic")
+                .setPartitions(Collections.singletonList(new TxnOffsetCommitResponseData.TxnOffsetCommitResponsePartition()
+                    .setPartitionIndex(0)
+                    .setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code())))));
+
+        when(runtime.scheduleTransactionalWriteOperation(
+            ArgumentMatchers.eq("txn-commit-offset"),
+            ArgumentMatchers.eq(new TopicPartition("__consumer_offsets", 0)),
+            ArgumentMatchers.eq("transactional-id"),
+            ArgumentMatchers.eq(10L),
+            ArgumentMatchers.eq((short) 5),
+            ArgumentMatchers.eq(Duration.ofMillis(5000)),
+            ArgumentMatchers.any()
+        )).thenReturn(FutureUtils.failedFuture(new CompletionException(Errors.NOT_ENOUGH_REPLICAS.exception())));
 
         CompletableFuture<TxnOffsetCommitResponseData> future = service.commitTransactionalOffsets(
             requestContext(ApiKeys.TXN_OFFSET_COMMIT),

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/InMemoryPartitionWriter.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/InMemoryPartitionWriter.java
@@ -20,12 +20,14 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.TransactionResult;
+import org.apache.kafka.storage.internals.log.VerificationGuard;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -223,6 +225,7 @@ public class InMemoryPartitionWriter<T> implements PartitionWriter<T> {
         TopicPartition tp,
         long producerId,
         short producerEpoch,
+        VerificationGuard verificationGuard,
         List<T> records
     ) throws KafkaException {
         PartitionState state = partitionState(tp);
@@ -264,6 +267,16 @@ public class InMemoryPartitionWriter<T> implements PartitionWriter<T> {
         } finally {
             state.lock.unlock();
         }
+    }
+
+    @Override
+    public CompletableFuture<VerificationGuard> maybeStartTransactionVerification(
+        TopicPartition tp,
+        String transactionalId,
+        long producerId,
+        short producerEpoch
+    ) throws KafkaException {
+        return CompletableFuture.completedFuture(new VerificationGuard());
     }
 
     public void commit(

--- a/tests/kafkatest/tests/core/transactions_test.py
+++ b/tests/kafkatest/tests/core/transactions_test.py
@@ -257,7 +257,7 @@ class TransactionsTest(Test):
         check_order=[True, False],
         use_group_metadata=[True, False],
         metadata_quorum=quorum.all_kraft,
-        use_new_coordinator=[False]
+        use_new_coordinator=[True, False]
     )
     def test_transactions(self, failure_mode, bounce_target, check_order, use_group_metadata, metadata_quorum=quorum.zk, use_new_coordinator=False):
         security_protocol = 'PLAINTEXT'


### PR DESCRIPTION
This patch wires the transaction verification in the new group coordinator. It basically calls the verification path before scheduling the write operation. If the verification fails, the error is returned to the caller.

Note that the patch uses `appendForGroup`. I suppose that we will move away from using it when https://github.com/apache/kafka/pull/15087 is merged.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
