### PR TITLE
KAFKA-16094: BrokerRegistrationRequest.logDirs field must be ignorable

### DIFF
--- a/clients/src/main/resources/common/message/BrokerRegistrationRequest.json
+++ b/clients/src/main/resources/common/message/BrokerRegistrationRequest.json
@@ -59,7 +59,7 @@
     { "name": "IsMigratingZkBroker", "type": "bool", "versions": "1+", "default": "false",
       "about": "If the required configurations for ZK migration are present, this value is set to true" },
     { "name": "LogDirs", "type":  "[]uuid", "versions":  "2+",
-      "about": "Log directories configured in this broker which are available." },
+      "about": "Log directories configured in this broker which are available.", "ignorable": true },
     { "name": "PreviousBrokerEpoch", "type": "int64", "versions": "3+", "default": "-1", "ignorable": true,
       "about": "The epoch before a clean shutdown." }
   ]

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -3502,7 +3502,9 @@ public class RequestResponseTest {
                         new BrokerRegistrationRequestData.Feature()).iterator()))
                 .setListeners(new BrokerRegistrationRequestData.ListenerCollection(singletonList(
                         new BrokerRegistrationRequestData.Listener()).iterator()))
-                .setIncarnationId(Uuid.randomUuid());
+                .setIncarnationId(Uuid.randomUuid())
+                .setLogDirs(Arrays.asList(Uuid.fromString("qaJjNJ05Q36kEgeTBDcj0Q")))
+                .setPreviousBrokerEpoch(123L);
         return new BrokerRegistrationRequest.Builder(data).build(v);
     }
 


### PR DESCRIPTION
3.7 brokers must be able to register with 3.6 and earlier controllers. Currently, this is broken because we will unconditionally try to set logDirs, but this field cannot be sent with BrokerRegistrationRequest versions older than v2. This PR marks the logDirs field as "ignorable." Marking the field as "ignorable" means that we will still be able to send the BrokerRegistrationRequest even if the schema doesn't support logDirs.