### PR TITLE
[KAFKA-15735] Adding KRaft test

### DIFF
--- a/core/src/test/scala/integration/kafka/api/SaslMultiMechanismConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslMultiMechanismConsumerTest.scala
@@ -13,9 +13,11 @@
 package kafka.api
 
 import kafka.server.KafkaConfig
-import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo, Timeout}
-import kafka.utils.{JaasTestUtils, TestUtils}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo, Timeout}
+import kafka.utils.{JaasTestUtils, TestInfoUtils, TestUtils}
 import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 import scala.jdk.CollectionConverters._
 
@@ -42,8 +44,9 @@ class SaslMultiMechanismConsumerTest extends BaseConsumerTest with SaslSetup {
     closeSasl()
   }
 
-  @Test
-  def testMultipleBrokerMechanisms(): Unit = {
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)
+  @ValueSource(strings = Array("zk", "kraft"))
+  def testMultipleBrokerMechanisms(quorum: String): Unit = {
     val plainSaslProducer = createProducer()
     val plainSaslConsumer = createConsumer()
 


### PR DESCRIPTION
Adding the KRaft test for `testMultipleBrokerMechanisms()` in `SaslMultiMechanismConsumerTest` class
Ref: [KAFKA-15735](https://issues.apache.org/jira/browse/KAFKA-15735?jql=status%20%3D%20Open%20AND%20labels%20%3D%20kraft-test%20AND%20assignee%20in%20(EMPTY))

Testing: 
All Tests passed on CLI
<img width="1728" alt="Screenshot 2024-01-09 at 3 10 06 PM" src="https://github.com/apache/kafka/assets/122860866/a7bdd5c4-f6b7-4424-9064-c63136ef2607">


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
