### PR TITLE
MINOR: bump dev version for system tests to 3.8

### DIFF
--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -122,9 +122,9 @@ def get_version(node=None):
         return DEV_BRANCH
 
 DEV_BRANCH = KafkaVersion("dev")
-DEV_VERSION = KafkaVersion("3.7.0-SNAPSHOT")
+DEV_VERSION = KafkaVersion("3.8.0-SNAPSHOT")
 
-LATEST_METADATA_VERSION = "3.7"
+LATEST_METADATA_VERSION = "3.8"
 
 # 0.8.2.x versions
 V_0_8_2_1 = KafkaVersion("0.8.2.1")


### PR DESCRIPTION
The original PR bumping version to 3.8 was incomplete (cf https://github.com/apache/kafka/pull/14993)