### PR TITLE
KAFKA-14404: fix overlap of streams-config sections & describe additional parameters

### DIFF
--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -414,7 +414,7 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
           <tr class="row-even"><td>retry.backoff.ms</td>
             <td>Medium</td>
             <td colspan="2">The amount of time in milliseconds, before a request is retried. This applies if the <code class="docutils literal"><span class="pre">retries</span></code> parameter is configured to be greater than 0. </td>
-            <td>100 milliseconds</td>
+            <td><code class="docutils literal"><span class="pre">100</span></code></td>
           </tr>
           <tr class="row-odd"><td>rocksdb.config.setter</td>
             <td>Medium</td>
@@ -1097,8 +1097,8 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
     <div class="section" id="default-values">
       <h4><a class="toc-backref" href="#id18">Default Values</a><a class="headerlink" href="#default-values" title="Permalink to this headline"></a></h4>
       <p>Kafka Streams uses different default values for some of the underlying client configs, which are summarized below. For detailed descriptions
-        of these configs, see <a class="reference external" href="http://kafka.apache.org/0100/documentation.html#producerconfigs">Producer Configs</a>
-        and <a class="reference external" href="http://kafka.apache.org/0100/documentation.html#newconsumerconfigs">Consumer Configs</a>.</p>
+        of these configs, see <a class="reference external" href="http://kafka.apache.org/documentation.html#producerconfigs">Producer Configs</a>
+        and <a class="reference external" href="http://kafka.apache.org/documentation.html#newconsumerconfigs">Consumer Configs</a>.</p>
       <table border="1" class="non-scrolling-table docutils">
         <thead valign="bottom">
         <tr class="row-odd"><th class="head">Parameter Name</th>
@@ -1109,25 +1109,41 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
         <tbody valign="top">
         <tr class="row-even"><td>auto.offset.reset</td>
           <td>Consumer</td>
-          <td>earliest</td>
+          <td><code class="docutils literal"><span class="pre">earliest</span></code></td>
         </tr>
         <tr class="row-odd"><td>linger.ms</td>
           <td>Producer</td>
-          <td>100</td>
+          <td><code class="docutils literal"><span class="pre">100</span></code></td>
         </tr>
         <tr class="row-even"><td>max.poll.records</td>
           <td>Consumer</td>
-          <td>1000</td>
-        </tr>
-        <tr class="row-odd">
-          <td>transaction.timeout.ms</td>
-          <td>Producer</td>
-          <td><code class="docutils literal"><span class="pre">10000</span></code></td>
+          <td><code class="docutils literal"><span class="pre">1000</span></code></td>
         </tr>
         <tr class="row-even">
           <td>client.id</td>
           <td>-</td>
           <td><code class="docutils literal"><span class="pre">&lt;application.id&gt;-&lt;random-UUID&gt;</span></code></td>
+        </tr>
+        </tbody>
+      </table>
+      <p>If EOS is enabled, other parameters have the following default values.</p>
+      <table border="1" class="non-scrolling-table docutils">
+        <thead valign="bottom">
+        <tr class="row-odd"><th class="head">Parameter Name</th>
+          <th class="head">Corresponding Client</th>
+          <th class="head">Streams Default</th>
+        </tr>
+        </thead>
+        <tbody valign="top">
+        <tr class="row-even">
+          <td>transaction.timeout.ms</td>
+          <td>Producer</td>
+          <td><code class="docutils literal"><span class="pre">10000</span></code></td>
+        </tr>
+        <tr class="row-odd">
+          <td>delivery.timeout.ms</td>
+          <td>Producer</td>
+          <td><code class="docutils literal"><span class="pre">Integer.MAX_VALUE</span></code></td>
         </tr>
         </tbody>
       </table>
@@ -1164,6 +1180,32 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
         <tr class="row-even"><td>partition.assignment.strategy</td>
           <td>Consumer</td>
           <td><code class="docutils literal"><span class="pre">StreamsPartitionAssignor</span></code></td>
+        </tr>
+        </tbody>
+      </table>
+      <p>If EOS is enabled, other parameters are set with the following values.</p>
+      <table border="1" class="non-scrolling-table docutils">
+        <colgroup>
+          <col width="50%">
+          <col width="19%">
+          <col width="31%">
+        </colgroup>
+        <thead valign="bottom">
+        <tr class="row-odd"><th class="head">Parameter Name</th>
+          <th class="head">Corresponding Client</th>
+          <th class="head">Streams Default</th>
+        </tr>
+        </thead>
+        <tbody valign="top">
+        <tr class="row-even">
+          <td>isolation.level</td>
+          <td>Consumer</td>
+          <td><code class="docutils literal"><span class="pre">READ_COMMITTED</span></code></td>
+        </tr>
+        <tr class="row-odd">
+          <td>enable.idempotence</td>
+          <td>Producer</td>
+          <td><code class="docutils literal"><span class="pre">true</span></code></td>
         </tr>
         </tbody>
       </table>

--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -243,7 +243,7 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
           <tr class="row-odd"><td>acceptable.recovery.lag</td>
             <td>Medium</td>
             <td colspan="2">The maximum acceptable lag (number of offsets to catch up) for an instance to be considered caught-up and ready for the active task.</td>
-            <td>10000</td>
+            <td><code class="docutils literal"><span class="pre">10000</span></code></td>
           </tr>
           <tr class="row-even"><td>application.server</td>
             <td>Low</td>
@@ -255,7 +255,7 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
           <tr class="row-odd"><td>buffered.records.per.partition</td>
             <td>Low</td>
             <td colspan="2">The maximum number of records to buffer per partition.</td>
-            <td>1000</td>
+            <td><code class="docutils literal"><span class="pre">1000</span></code></td>
           </tr>
           <tr class="row-even"><td>cache.max.bytes.buffering</td>
             <td>Medium</td>
@@ -303,12 +303,12 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
           <tr class="row-even"><td>default.windowed.key.serde.inner</td>
             <td>Medium</td>
             <td colspan="2">Default serializer/deserializer for the inner class of windowed keys, implementing the <code class="docutils literal"><span class="pre">Serde</span></code> interface.</td>
-            <td>null</td>
+            <td><code class="docutils literal"><span class="pre">null</span></code></td>
           </tr>
           <tr class="row-odd"><td>default.windowed.value.serde.inner</td>
             <td>Medium</td>
             <td colspan="2">Default serializer/deserializer for the inner class of windowed values, implementing the <code class="docutils literal"><span class="pre">Serde</span></code> interface.</td>
-            <td>null</td>
+            <td><code class="docutils literal"><span class="pre">null</span></code></td>
           </tr>
           <tr class="row-even"><td>default.dsl.store</td>
             <td>Low</td>
@@ -349,7 +349,7 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
           <tr class="row-odd"><td>max.warmup.replicas</td>
             <td>Medium</td>
             <td colspan="2">The maximum number of warmup replicas (extra standbys beyond the configured num.standbys) that can be assigned at once.</td>
-            <td>2</td>
+            <td><code class="docutils literal"><span class="pre">2</span></code></td>
           </tr>
           <tr class="row-even"><td>metric.reporters</td>
             <td>Low</td>
@@ -359,7 +359,7 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
           <tr class="row-odd"><td>metrics.num.samples</td>
             <td>Low</td>
             <td colspan="2">The number of samples maintained to compute metrics.</td>
-            <td>2</td>
+            <td><code class="docutils literal"><span class="pre">2</span></code></td>
           </tr>
           <tr class="row-even"><td>metrics.recording.level</td>
             <td>Low</td>
@@ -374,12 +374,12 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
           <tr class="row-even"><td>num.standby.replicas</td>
             <td>High</td>
             <td colspan="2">The number of standby replicas for each task.</td>
-            <td>0</td>
+            <td><code class="docutils literal"><span class="pre">0</span></code></td>
           </tr>
           <tr class="row-odd"><td>num.stream.threads</td>
             <td>Medium</td>
             <td colspan="2">The number of threads to execute stream processing.</td>
-            <td>1</td>
+            <td><code class="docutils literal"><span class="pre">1</span></code></td>
           </tr>
           <tr class="row-odd"><td>probing.rebalance.interval.ms</td>
             <td>Low</td>
@@ -409,12 +409,12 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
             <td>Medium</td>
             <td colspan="2">The replication factor for changelog topics and repartition topics created by the application.
               The default of <code>-1</code> (meaning: use broker default replication factor) requires broker version 2.4 or newer.</td>
-            <td>-1</td>
+            <td><code class="docutils literal"><span class="pre">-1</span></code></td>
           </tr>
           <tr class="row-even"><td>retry.backoff.ms</td>
-              <td>Medium</td>
-              <td colspan="2">The amount of time in milliseconds, before a request is retried. This applies if the <code class="docutils literal"><span class="pre">retries</span></code> parameter is configured to be greater than 0. </td>
-              <td>100 milliseconds</td>
+            <td>Medium</td>
+            <td colspan="2">The amount of time in milliseconds, before a request is retried. This applies if the <code class="docutils literal"><span class="pre">retries</span></code> parameter is configured to be greater than 0. </td>
+            <td>100 milliseconds</td>
           </tr>
           <tr class="row-odd"><td>rocksdb.config.setter</td>
             <td>Medium</td>
@@ -439,7 +439,7 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
           <tr class="row-even"><td>topology.optimization</td>
             <td>Medium</td>
             <td colspan="2">A configuration telling Kafka Streams if it should optimize the topology and what optimizations to apply. Acceptable values are: <code>StreamsConfig.NO_OPTIMIZATION</code> (<code>none</code>), <code>StreamsConfig.OPTIMIZE</code> (<code>all</code>) or a comma separated list of specific optimizations: (<code>StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS</code> (<code>reuse.ktable.source.topics</code>), <code>StreamsConfig.MERGE_REPARTITION_TOPICS</code> (<code>merge.repartition.topics</code>)). </td>
-            <td><code> NO_OPTIMIZATION</code></td>
+            <td><code>NO_OPTIMIZATION</code></td>
           </tr>
           <tr class="row-odd"><td>upgrade.from</td>
             <td>Medium</td>
@@ -452,9 +452,9 @@ streamsSettings.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);</code></pre>
             <td>86400000 milliseconds (1 day)</td>
           </tr>
           <tr class="row-even"><td>window.size.ms</td>
-              <td>Low</td>
-              <td colspan="2">Sets window size for the deserializer in order to calculate window end times.</td>
-              <td>null</td>
+            <td>Low</td>
+            <td colspan="2">Sets window size for the deserializer in order to calculate window end times.</td>
+            <td><code class="docutils literal"><span class="pre">null</span></code></td>
           </tr>
           </tbody>
         </table>

--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -1097,8 +1097,8 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
     <div class="section" id="default-values">
       <h4><a class="toc-backref" href="#id18">Default Values</a><a class="headerlink" href="#default-values" title="Permalink to this headline"></a></h4>
       <p>Kafka Streams uses different default values for some of the underlying client configs, which are summarized below. For detailed descriptions
-        of these configs, see <a class="reference external" href="http://kafka.apache.org/documentation.html#producerconfigs">Producer Configs</a>
-        and <a class="reference external" href="http://kafka.apache.org/documentation.html#newconsumerconfigs">Consumer Configs</a>.</p>
+        of these configs, see <a class="reference external" href="https://kafka.apache.org/documentation.html#producerconfigs">Producer Configs</a>
+        and <a class="reference external" href="https://kafka.apache.org/documentation.html#consumerconfigs">Consumer Configs</a>.</p>
       <table border="1" class="non-scrolling-table docutils">
         <thead valign="bottom">
         <tr class="row-odd"><th class="head">Parameter Name</th>

--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -1151,7 +1151,7 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
     <div class="section" id="parameters-controlled-by-kafka-streams">
       <h3><a class="toc-backref" href="#id26">Parameters controlled by Kafka Streams</a><a class="headerlink" href="#parameters-controlled-by-kafka-streams" title="Permalink to this headline"></a></h3>
       <p>Some parameters are not configurable by the user. If you supply a value that is different from the default value,
-        your value is ignored. Below is a list of some of these parameters.
+        your value is ignored. Below is a list of some of these parameters.</p>
       <table border="1" class="non-scrolling-table docutils">
         <colgroup>
           <col width="50%">
@@ -1159,7 +1159,8 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
           <col width="31%">
         </colgroup>
         <thead valign="bottom">
-        <tr class="row-odd"><th class="head">Parameter Name</th>
+        <tr class="row-odd">
+          <th class="head">Parameter Name</th>
           <th class="head">Corresponding Client</th>
           <th class="head">Streams Default</th>
         </tr>
@@ -1191,7 +1192,8 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
           <col width="31%">
         </colgroup>
         <thead valign="bottom">
-        <tr class="row-odd"><th class="head">Parameter Name</th>
+        <tr class="row-odd">
+          <th class="head">Parameter Name</th>
           <th class="head">Corresponding Client</th>
           <th class="head">Streams Default</th>
         </tr>
@@ -1209,6 +1211,51 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
         </tr>
         </tbody>
       </table>
+      <div class="section" id="client-id">
+        <h3><a class="toc-backref" href="#id38">client.id</a><a class="headerlink" href="#client-id" title="Permalink to this headline"></a></h3>
+        <p>Kafka Streams uses the <code class="docutils literal"><span class="pre">client.id</span></code>
+        parameter to compute derived client IDs for internal clients. If you don't set
+        <code class="docutils literal"><span class="pre">client.id</span></code>, Kafka Streams sets it to
+        <code class="docutils literal"><span class="pre">&lt;application.id&gt;-&lt;random-UUID&gt;</span></code>.</p>
+
+        <p>This value will be used to derive the client IDs of the following internal clients.</p>
+
+        <table border="1" class="non-scrolling-table docutils">
+          <thead valign="bottom">
+          <tr class="row-odd">
+            <th class="head">Client</th>
+            <th class="head">client.id</th>
+          </tr>
+          </thead>
+          <tbody valign="top">
+          <tr class="row-even">
+            <td>Consumer</td>
+            <td><code class="docutils literal"><span class="pre">&lt;client.id&gt;-StreamThread-&lt;threadIdx&gt;-consumer</span></code></td>
+          </tr>
+          <tr class="row-odd">
+            <td>Restore consumer</td>
+            <td><code class="docutils literal"><span class="pre">&lt;client.id&gt;-StreamThread-&lt;threadIdx&gt;-restore-consumer</span></code></td>
+          </tr>
+          <tr class="row-even">
+            <td>Global consumer</td>
+            <td><code class="docutils literal"><span class="pre">&lt;client.id&gt;-global-consumer</span></code></td>
+          </tr>
+          </tbody>
+          <tr class="row-odd">
+            <td>Producer</td>
+            <td>
+              <ul class="simple">
+                <li><strong>For Non-EOS and EOS v2: </strong><code class="docutils literal"><span class="pre">&lt;client.id&gt;-StreamThread-&lt;threadIdx&gt;-producer</span></code></li>
+                <li><strong>For EOS v1: </strong><code class="docutils literal"><span class="pre">&lt;client.id&gt;-StreamThread-&lt;threadIdx&gt;-&lt;taskId&gt;-producer</span></code></li>
+              </ul>
+            </td>
+          </tr>
+          <tr class="row-even">
+            <td>Admin</td>
+            <td><code class="docutils literal"><span class="pre">&lt;client.id&gt;-admin</span></code></td>
+          </tr>
+        </table>
+      </div>
       <div class="section" id="enable-auto-commit">
         <span id="streams-developer-guide-consumer-auto-commit"></span><h4><a class="toc-backref" href="#id19">enable.auto.commit</a><a class="headerlink" href="#enable-auto-commit" title="Permalink to this headline"></a></h4>
         <blockquote>

--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -1111,7 +1111,7 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
           <td>Consumer</td>
           <td>earliest</td>
         </tr>
-        <tr class="row-even"><td>linger.ms</td>
+        <tr class="row-odd"><td>linger.ms</td>
           <td>Producer</td>
           <td>100</td>
         </tr>
@@ -1119,20 +1119,23 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
           <td>Consumer</td>
           <td>1000</td>
         </tr>
+        <tr class="row-odd">
+          <td>transaction.timeout.ms</td>
+          <td>Producer</td>
+          <td><code class="docutils literal"><span class="pre">10000</span></code></td>
+        </tr>
+        <tr class="row-even">
+          <td>client.id</td>
+          <td>-</td>
+          <td><code class="docutils literal"><span class="pre">&lt;application.id&gt;-&lt;random-UUID&gt;</span></code></td>
+        </tr>
         </tbody>
       </table>
     </div>
     <div class="section" id="parameters-controlled-by-kafka-streams">
       <h3><a class="toc-backref" href="#id26">Parameters controlled by Kafka Streams</a><a class="headerlink" href="#parameters-controlled-by-kafka-streams" title="Permalink to this headline"></a></h3>
-      <p>Kafka Streams assigns the following configuration parameters. If you try to change
-        <code class="docutils literal"><span class="pre">allow.auto.create.topics</span></code>, your value
-        is ignored and setting it has no effect in a Kafka Streams application. You can set the other parameters.
-        Kafka Streams sets them to different default values than a plain
-        <code class="docutils literal"><span class="pre">KafkaConsumer</span></code>.
-      <p>Kafka Streams uses the <code class="docutils literal"><span class="pre">client.id</span></code>
-        parameter to compute derived client IDs for internal clients. If you don't set
-        <code class="docutils literal"><span class="pre">client.id</span></code>, Kafka Streams sets it to
-        <code class="docutils literal"><span class="pre">&lt;application.id&gt;-&lt;random-UUID&gt;</span></code>.
+      <p>Some parameters are not configurable by the user. If you supply a value that is different from the default value,
+        your value is ignored. Below is a list of some of these parameters.
       <table border="1" class="non-scrolling-table docutils">
         <colgroup>
           <col width="50%">
@@ -1150,17 +1153,17 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
           <td>Consumer</td>
           <td><code class="docutils literal"><span class="pre">false</span></code></td>
         </tr>
-        <tr class="row-even"><td>auto.offset.reset</td>
+        <tr class="row-even"><td>group.id</td>
           <td>Consumer</td>
-          <td><code class="docutils literal"><span class="pre">earliest</span></code></td>
+          <td><code class="docutils literal"><span class="pre">application.id</span></code></td>
         </tr>
-        <tr class="row-odd"><td>linger.ms</td>
-          <td>Producer</td>
-          <td><code class="docutils literal"><span class="pre">100</span></code></td>
-        </tr>
-        <tr class="row-odd"><td>max.poll.records</td>
+        <tr class="row-odd"><td>enable.auto.commit</td>
           <td>Consumer</td>
-          <td><code class="docutils literal"><span class="pre">1000</span></code></td>
+          <td><code class="docutils literal"><span class="pre">false</span></code></td>
+        </tr>
+        <tr class="row-even"><td>partition.assignment.strategy</td>
+          <td>Consumer</td>
+          <td><code class="docutils literal"><span class="pre">StreamsPartitionAssignor</span></code></td>
         </tr>
         </tbody>
       </table>

--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -1153,11 +1153,6 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
       <p>Some parameters are not configurable by the user. If you supply a value that is different from the default value,
         your value is ignored. Below is a list of some of these parameters.</p>
       <table border="1" class="non-scrolling-table docutils">
-        <colgroup>
-          <col width="50%">
-          <col width="19%">
-          <col width="31%">
-        </colgroup>
         <thead valign="bottom">
         <tr class="row-odd">
           <th class="head">Parameter Name</th>
@@ -1186,11 +1181,6 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
       </table>
       <p>If EOS is enabled, other parameters are set with the following values.</p>
       <table border="1" class="non-scrolling-table docutils">
-        <colgroup>
-          <col width="50%">
-          <col width="19%">
-          <col width="31%">
-        </colgroup>
         <thead valign="bottom">
         <tr class="row-odd">
           <th class="head">Parameter Name</th>
@@ -1221,6 +1211,10 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
         <p>This value will be used to derive the client IDs of the following internal clients.</p>
 
         <table border="1" class="non-scrolling-table docutils">
+          <colgroup>
+            <col width="30%">
+            <col width="70%">
+          </colgroup>
           <thead valign="bottom">
           <tr class="row-odd">
             <th class="head">Client</th>
@@ -1242,12 +1236,14 @@ streamsSettings.put(StreamsConfig.topicPrefix("PARAMETER_NAME"), "topic-value");
           </tr>
           </tbody>
           <tr class="row-odd">
-            <td>Producer</td>
+            <td rowspan="2">Producer</td>
             <td>
-              <ul class="simple">
-                <li><strong>For Non-EOS and EOS v2: </strong><code class="docutils literal"><span class="pre">&lt;client.id&gt;-StreamThread-&lt;threadIdx&gt;-producer</span></code></li>
-                <li><strong>For EOS v1: </strong><code class="docutils literal"><span class="pre">&lt;client.id&gt;-StreamThread-&lt;threadIdx&gt;-&lt;taskId&gt;-producer</span></code></li>
-              </ul>
+              <strong>For Non-EOS and EOS v2: </strong><code class="docutils literal"><span class="pre">&lt;client.id&gt;-StreamThread-&lt;threadIdx&gt;-producer</span></code>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <strong>For EOS v1: </strong><code class="docutils literal"><span class="pre">&lt;client.id&gt;-StreamThread-&lt;threadIdx&gt;-&lt;taskId&gt;-producer</span></code>
             </td>
           </tr>
           <tr class="row-even">


### PR DESCRIPTION
*There is an overlap between two sections in the current version of streams-config.html as described in KAFKA-14404.
The goal of this fix is to remove the overlap as well as describing some other parameters and their default values*


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
