### PR TITLE
KAFKA-16097: Add suspended tasks back to the state updater when reassigned

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PendingUpdateAction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PendingUpdateAction.java
@@ -29,7 +29,8 @@ public class PendingUpdateAction {
         RECYCLE,
         SUSPEND,
         ADD_BACK,
-        CLOSE_CLEAN
+        CLOSE_CLEAN,
+        EMPTY
     }
 
     private final Set<TopicPartition> inputPartitions;
@@ -70,6 +71,9 @@ public class PendingUpdateAction {
     public static PendingUpdateAction createCloseClean() {
         return new PendingUpdateAction(Action.CLOSE_CLEAN);
     }
+    public static PendingUpdateAction createEmpty() {
+        return new PendingUpdateAction(Action.EMPTY);
+    }
 
     public Set<TopicPartition> getInputPartitions() {
         if (action != Action.UPDATE_INPUT_PARTITIONS && action != Action.CLOSE_REVIVE_AND_UPDATE_INPUT_PARTITIONS && action != Action.RECYCLE) {
@@ -82,5 +86,11 @@ public class PendingUpdateAction {
         return action;
     }
 
-
+    @Override
+    public String toString() {
+        return "PendingUpdateAction{" +
+            "inputPartitions=" + inputPartitions +
+            ", action=" + action +
+            '}';
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PendingUpdateAction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PendingUpdateAction.java
@@ -29,8 +29,7 @@ public class PendingUpdateAction {
         RECYCLE,
         SUSPEND,
         ADD_BACK,
-        CLOSE_CLEAN,
-        EMPTY
+        CLOSE_CLEAN
     }
 
     private final Set<TopicPartition> inputPartitions;
@@ -70,9 +69,6 @@ public class PendingUpdateAction {
 
     public static PendingUpdateAction createCloseClean() {
         return new PendingUpdateAction(Action.CLOSE_CLEAN);
-    }
-    public static PendingUpdateAction createEmpty() {
-        return new PendingUpdateAction(Action.EMPTY);
     }
 
     public Set<TopicPartition> getInputPartitions() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -550,10 +550,9 @@ public class TaskManager {
                         stateUpdater.remove(taskId);
                     }
                 } else if (task.isActive()) {
-                    tasks.removePendingActiveTaskToSuspend(taskId);
-                    if (tasks.removePendingTaskToCloseClean(taskId)) {
+                    if (tasks.removePendingActiveTaskToSuspend(taskId) || tasks.removePendingTaskToCloseClean(taskId)) {
                         log.info(
-                            "We were planning on closing task {} because we lost one of its partitions." +
+                            "We were planning on suspending or closing task {} because we lost one of its partitions." +
                             "The task got reassigned to this thread, so cancel closing  of the task, but add it back to the " +
                             "state updater, since we may have to catch up on the changelog.",
                             taskId);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -561,7 +561,7 @@ public class TaskManager {
                     }
                     if (tasks.removePendingTaskToCloseClean(taskId)) {
                         log.info(
-                            "We were planning on suspending or closing task {} because we lost one of its partitions." +
+                            "We were planning on closing task {} because we lost one of its partitions." +
                             "The task got reassigned to this thread, so cancel closing  of the task, but add it back to the " +
                             "state updater, since we may have to catch up on the changelog.",
                             taskId);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -550,7 +550,16 @@ public class TaskManager {
                         stateUpdater.remove(taskId);
                     }
                 } else if (task.isActive()) {
-                    if (tasks.removePendingActiveTaskToSuspend(taskId) || tasks.removePendingTaskToCloseClean(taskId)) {
+                    if (tasks.removePendingActiveTaskToSuspend(taskId)) {
+                        log.info(
+                            "We were planning on suspending a task {} because it was revoked " +
+                                "The task got reassigned to this thread, so we cancel suspending " +
+                                "of the task, but add it back to the state updater, since we do not know " +
+                                "if it is fully restored yet.",
+                            taskId);
+                        tasks.addPendingTaskToAddBack(taskId);
+                    }
+                    if (tasks.removePendingTaskToCloseClean(taskId)) {
                         log.info(
                             "We were planning on suspending or closing task {} because we lost one of its partitions." +
                             "The task got reassigned to this thread, so cancel closing  of the task, but add it back to the " +

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
@@ -94,17 +94,20 @@ class Tasks implements TasksRegistry {
 
     @Override
     public void addPendingActiveTasksToCreate(final Map<TaskId, Set<TopicPartition>> pendingTasks) {
+        log.info("addPendingActiveTasksToCreate {}", pendingTasks);
         pendingActiveTasksToCreate.putAll(pendingTasks);
     }
 
     @Override
     public void addPendingStandbyTasksToCreate(final Map<TaskId, Set<TopicPartition>> pendingTasks) {
+        log.info("addPendingStandbyTasksToCreate {}", pendingTasks);
         pendingStandbyTasksToCreate.putAll(pendingTasks);
     }
 
     @Override
     public Set<TopicPartition> removePendingTaskToRecycle(final TaskId taskId) {
         if (containsTaskIdWithAction(taskId, Action.RECYCLE)) {
+            log.info("Removing pending update action RECYCLE for task {}", taskId);
             return pendingUpdateActions.remove(taskId).getInputPartitions();
         }
         return null;
@@ -112,6 +115,8 @@ class Tasks implements TasksRegistry {
 
     @Override
     public void addPendingTaskToRecycle(final TaskId taskId, final Set<TopicPartition> inputPartitions) {
+        log.info("Adding pending update action RECYCLE for task {}, previous state was {}", taskId,
+            pendingUpdateActions.getOrDefault(taskId, PendingUpdateAction.createEmpty()).toString());
         pendingUpdateActions.put(taskId, PendingUpdateAction.createRecycleTask(inputPartitions));
     }
 
@@ -123,6 +128,7 @@ class Tasks implements TasksRegistry {
     @Override
     public Set<TopicPartition> removePendingTaskToCloseReviveAndUpdateInputPartitions(final TaskId taskId) {
         if (containsTaskIdWithAction(taskId, Action.CLOSE_REVIVE_AND_UPDATE_INPUT_PARTITIONS)) {
+            log.info("Removing pending update action CLOSE_REVIVE_AND_UPDATE_INPUT_PARTITIONS for task {}", taskId);
             return pendingUpdateActions.remove(taskId).getInputPartitions();
         }
         return null;
@@ -130,12 +136,15 @@ class Tasks implements TasksRegistry {
 
     @Override
     public void addPendingTaskToCloseReviveAndUpdateInputPartitions(final TaskId taskId, final Set<TopicPartition> inputPartitions) {
+        log.info("Adding pending update action CLOSE_REVIVE_AND_UPDATE_INPUT_PARTITIONS for task {}, previous state was {}", taskId,
+            pendingUpdateActions.getOrDefault(taskId, PendingUpdateAction.createEmpty()).toString());
         pendingUpdateActions.put(taskId, PendingUpdateAction.createCloseReviveAndUpdateInputPartition(inputPartitions));
     }
 
     @Override
     public Set<TopicPartition> removePendingTaskToUpdateInputPartitions(final TaskId taskId) {
         if (containsTaskIdWithAction(taskId, Action.UPDATE_INPUT_PARTITIONS)) {
+            log.info("Removing pending update action UPDATE_INPUT_PARTITIONS for task {}", taskId);
             return pendingUpdateActions.remove(taskId).getInputPartitions();
         }
         return null;
@@ -143,12 +152,15 @@ class Tasks implements TasksRegistry {
 
     @Override
     public void addPendingTaskToUpdateInputPartitions(final TaskId taskId, final Set<TopicPartition> inputPartitions) {
+        log.info("Adding pending update action UPDATE_INPUT_PARTITIONS for task {}, previous state was {}", taskId,
+            pendingUpdateActions.getOrDefault(taskId, PendingUpdateAction.createEmpty()).toString());
         pendingUpdateActions.put(taskId, PendingUpdateAction.createUpdateInputPartition(inputPartitions));
     }
 
     @Override
     public boolean removePendingTaskToAddBack(final TaskId taskId) {
         if (containsTaskIdWithAction(taskId, Action.ADD_BACK)) {
+            log.info("Removing pending update action ADD_BACK for task {}", taskId);
             pendingUpdateActions.remove(taskId);
             return true;
         }
@@ -157,12 +169,15 @@ class Tasks implements TasksRegistry {
 
     @Override
     public void addPendingTaskToAddBack(final TaskId taskId) {
+        log.info("Adding pending update action ADD_BACK for task {}, previous state was {}", taskId,
+            pendingUpdateActions.getOrDefault(taskId, PendingUpdateAction.createEmpty()).toString());
         pendingUpdateActions.put(taskId, PendingUpdateAction.createAddBack());
     }
 
     @Override
     public boolean removePendingTaskToCloseClean(final TaskId taskId) {
         if (containsTaskIdWithAction(taskId, Action.CLOSE_CLEAN)) {
+            log.info("Removing pending update action CLOSE_CLEAN for task {}", taskId);
             pendingUpdateActions.remove(taskId);
             return true;
         }
@@ -171,12 +186,15 @@ class Tasks implements TasksRegistry {
 
     @Override
     public void addPendingTaskToCloseClean(final TaskId taskId) {
+        log.info("Adding pending update action CLOSE_CLEAN for task {}, previous state was {}", taskId,
+            pendingUpdateActions.getOrDefault(taskId, PendingUpdateAction.createEmpty()).toString());
         pendingUpdateActions.put(taskId, PendingUpdateAction.createCloseClean());
     }
 
     @Override
     public boolean removePendingActiveTaskToSuspend(final TaskId taskId) {
         if (containsTaskIdWithAction(taskId, Action.SUSPEND)) {
+            log.info("Removing pending update action SUSPEND for task {}", taskId);
             pendingUpdateActions.remove(taskId);
             return true;
         }
@@ -185,6 +203,8 @@ class Tasks implements TasksRegistry {
 
     @Override
     public void addPendingActiveTaskToSuspend(final TaskId taskId) {
+        log.info("Adding pending update action SUSPEND for task {}, previous state was {}", taskId,
+            pendingUpdateActions.getOrDefault(taskId, PendingUpdateAction.createEmpty()).toString());
         pendingUpdateActions.put(taskId, PendingUpdateAction.createSuspend());
     }
 
@@ -196,12 +216,16 @@ class Tasks implements TasksRegistry {
     @Override
     public Set<Task> drainPendingTasksToInit() {
         final Set<Task> result = new HashSet<>(pendingTasksToInit);
+        if (!pendingTasksToInit.isEmpty()) {
+            log.info("drainPendingTasksToInit {}", result);
+        }
         pendingTasksToInit.clear();
         return result;
     }
 
     @Override
     public void addPendingTasksToInit(final Collection<Task> tasks) {
+        log.info("addPendingTasksToInit {}", tasks);
         pendingTasksToInit.addAll(tasks);
     }
 


### PR DESCRIPTION
When a partition is revoked, the corresponding task gets a pending action
"SUSPEND". This pending action may overwrite a previous pending action.

If the task was previously removed from the state updater, e.g. because
we were fenced, the pending action is overwritten with suspend, and in
handleAssigned, upon reassignment of that task, then SUSPEND action is
removed.

Then, once the state updater executes the removal, no pending action
is registered anymore, and we run into an IllegalStateException.

This commit solves the problem by adding back reassigned tasks to the
state updater, since they may have been removed from the state updater
for another reason than being restored completely.

We also add logging to make these kinds of state transitions obvious
in the logs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
