### PR TITLE
KAFKA-16098: Verify pending recycle action when standby is re-assigned

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -574,6 +574,15 @@ public class TaskManager {
             } else if (standbyTasksToCreate.containsKey(taskId)) {
                 if (task.isActive()) {
                     removeTaskToRecycleFromStateUpdater(taskId, standbyTasksToCreate.get(taskId));
+                } else {
+                    if (tasks.removePendingTaskToRecycle(taskId) != null) {
+                        log.info(
+                            "We were planning on recycling standby task {} to an active task." +
+                                "The task got reassigned to this thread as a standby task, so cancel recycling of the task, " +
+                                "but add it back to the state updater, since we may have to catch up on the changelog.",
+                            taskId);
+                        tasks.addPendingTaskToAddBack(taskId);
+                    }
                 }
                 standbyTasksToCreate.remove(taskId);
             } else {


### PR DESCRIPTION
When a standby is recycled to an active and then re-assigned as a standby again, it might happen that the recycling is still pending when the standby is reassigned. That causes an illegal state exception from the main consumer since the active task that results from the recycling is actually not assigned to the main consumer anymore, but it was re-assigned as a standby in the most recent rebalance.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
