### PR TITLE
MINOR: Disalow using a group id with only whitespaces in the new consumer group protocol

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -702,6 +702,7 @@ public class GroupMetadataManager {
 
     /**
      * Throws an InvalidRequestException if the value is non-null and empty.
+     * A string containing only whitespaces is also considered empty.
      *
      * @param value The value.
      * @param error The error message.
@@ -711,7 +712,7 @@ public class GroupMetadataManager {
         String value,
         String error
     ) throws InvalidRequestException {
-        if (value != null && value.isEmpty()) {
+        if (value != null && value.trim().isEmpty()) {
             throw new InvalidRequestException(error);
         }
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -1263,6 +1263,12 @@ public class GroupMetadataManagerTest {
             new ConsumerGroupHeartbeatRequestData()));
         assertEquals("GroupId can't be empty.", ex.getMessage());
 
+        // GroupId can't be all whitespaces.
+        ex = assertThrows(InvalidRequestException.class, () -> context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId("   ")));
+        assertEquals("GroupId can't be empty.", ex.getMessage());
+
         // RebalanceTimeoutMs must be present in the first request (epoch == 0).
         ex = assertThrows(InvalidRequestException.class, () -> context.consumerGroupHeartbeat(
             new ConsumerGroupHeartbeatRequestData()


### PR DESCRIPTION
This patch strengthen the validation of the group id when the new consumer group protocol is used.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
