### PR TITLE
KAFKA-16089: Fix memory leak in RocksDBStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -308,8 +308,8 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         allDescriptors.add(defaultColumnFamilyDescriptor);
         allDescriptors.addAll(extraDescriptors);
 
-        try (final Options options = new Options(dbOptions, defaultColumnFamilyDescriptor.getOptions())) {
-            final List<byte[]> allExisting = RocksDB.listColumnFamilies(options, absolutePath);
+        try {
+            final List<byte[]> allExisting = RocksDB.listColumnFamilies(userSpecifiedOptions, absolutePath);
 
             final List<ColumnFamilyDescriptor> existingDescriptors = new LinkedList<>();
             existingDescriptors.add(defaultColumnFamilyDescriptor);
@@ -344,10 +344,10 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         while (existing + created < allDescriptors.size()) {
             final ColumnFamilyHandle existingHandle = existing < existingColumnFamilyHandles.size() ? existingColumnFamilyHandles.get(existing) : null;
             final ColumnFamilyHandle createdHandle = created < createdColumnFamilyHandles.size() ? createdColumnFamilyHandles.get(created) : null;
-            if (existingHandle != null && Arrays.equals(existingHandle.getDescriptor().getName(), allDescriptors.get(existing + created).getName())) {
+            if (existingHandle != null && Arrays.equals(existingHandle.getName(), allDescriptors.get(existing + created).getName())) {
                 columnFamilies.add(existingHandle);
                 existing++;
-            } else if (createdHandle != null && Arrays.equals(createdHandle.getDescriptor().getName(), allDescriptors.get(existing + created).getName())) {
+            } else if (createdHandle != null && Arrays.equals(createdHandle.getName(), allDescriptors.get(existing + created).getName())) {
                 columnFamilies.add(createdHandle);
                 created++;
             } else {


### PR DESCRIPTION
`ColumnFamilyDescriptor` is _not_ a `RocksObject`, which in theory means it's not backed by any native memory allocated by RocksDB.

However, in practice, `ColumnFamilyHandle#getDescriptor()`, which returns a `ColumnFamilyDescriptor`, allocates an internal `rocksdb::db::ColumnFamilyDescriptor`, copying the name and options of the column family into it.

Since the Java `ColumnFamilyDescriptor` is not a `RocksObject`, it's not possible to track this allocation and free it from Java.

Fortunately, in our case, we can simply avoid calling `ColumnFamilyHandle#getDescriptor()`, since we're only interested in the column family name, which is already available on
`ColumnFamilyHandle#getName()`, which does not leak memory.

We can also optimize away the temporary `Options`, which was previously a source of memory leaks, because `userSpecifiedOptions` is an instance of `Options`.