### PR TITLE
MINOR: Change Connect integration StopStartLatch::await to throw TimeoutException on timeout

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -246,9 +246,12 @@ public class ConnectWorkerIntegrationTest {
         Thread.sleep(TimeUnit.SECONDS.toMillis(10));
 
         // Wait for the connector to be stopped
-        assertTrue("Failed to stop connector and tasks after coordinator failure within "
+        stopLatch.await(
+                "Failed to stop connector and tasks after coordinator failure within "
                         + CONNECTOR_SETUP_DURATION_MS + "ms",
-                stopLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS));
+                CONNECTOR_SETUP_DURATION_MS,
+                TimeUnit.MILLISECONDS
+        );
 
         StartAndStopLatch startLatch = connectorHandle.expectedStarts(1, false);
         connect.kafka().startOnlyKafkaOnSamePorts();
@@ -265,10 +268,12 @@ public class ConnectWorkerIntegrationTest {
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, numTasks,
                 "Connector tasks did not start in time.");
 
-        // Expect that the connector has started again
-        assertTrue("Failed to stop connector and tasks after coordinator failure within "
+        startLatch.await(
+                "Failed to stop connector and tasks after coordinator failure within "
                         + CONNECTOR_SETUP_DURATION_MS + "ms",
-                startLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS));
+                CONNECTOR_SETUP_DURATION_MS,
+                TimeUnit.MILLISECONDS
+        );
     }
 
     /**
@@ -341,7 +346,7 @@ public class ConnectWorkerIntegrationTest {
         StartAndStopLatch stopCounter = connector.expectedStops(1);
         connect.deleteConnector(CONNECTOR_NAME);
 
-        assertTrue("Connector and all tasks were not stopped in time", stopCounter.await(1, TimeUnit.MINUTES));
+        stopCounter.await(1, TimeUnit.MINUTES);
     }
 
     /**

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
@@ -41,7 +41,7 @@ public class ConnectorHandle {
 
     private final String connectorName;
     private final Map<String, TaskHandle> taskHandles = new ConcurrentHashMap<>();
-    private final StartAndStopCounter startAndStopCounter = new StartAndStopCounter();
+    private final StartAndStopCounter startAndStopCounter;
 
     private CountDownLatch recordsRemainingLatch;
     private CountDownLatch recordsToCommitLatch;
@@ -50,6 +50,7 @@ public class ConnectorHandle {
 
     public ConnectorHandle(String connectorName) {
         this.connectorName = connectorName;
+        this.startAndStopCounter = new StartAndStopCounter("connector " + connectorName);
     }
 
     /**

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
@@ -270,16 +270,12 @@ public class ConnectorRestartApiIntegrationTest {
         }
 
         // Wait for the connector to be stopped
-        assertTrue("Failed to stop connector and tasks within "
-                        + CONNECTOR_SETUP_DURATION_MS + "ms",
-                stopLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS));
+        stopLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS);
 
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(connectorName, NUM_TASKS,
                 "Connector tasks are not all in running state.");
         // Expect that the connector has started again
-        assertTrue("Failed to start connector and tasks within "
-                        + CONNECTOR_SETUP_DURATION_MS + "ms",
-                startLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS));
+        startLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS);
         StartsAndStops afterSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
 
         assertEquals(beforeSnapshot.starts() + expectedConnectorRestarts, afterSnapshot.starts());
@@ -323,9 +319,12 @@ public class ConnectorRestartApiIntegrationTest {
         connect.assertions().assertConnectorIsFailedAndTasksHaveFailed(connectorName, 0,
                 "Connector tasks are not all in running state.");
         // Expect that the connector has started again
-        assertTrue("Failed to start connector and tasks after coordinator failure within "
+        startLatch.await(
+                "Failed to start connector and tasks after coordinator failure within "
                         + CONNECTOR_SETUP_DURATION_MS + "ms",
-                startLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS));
+                CONNECTOR_SETUP_DURATION_MS,
+                TimeUnit.MILLISECONDS
+        );
         StartsAndStops afterSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
 
         assertEquals(beforeSnapshot.starts() + expectedConnectorRestarts, afterSnapshot.starts());
@@ -358,16 +357,12 @@ public class ConnectorRestartApiIntegrationTest {
         }
 
         // Wait for the connector to be stopped
-        assertTrue("Failed to stop connector and tasks within "
-                        + CONNECTOR_SETUP_DURATION_MS + "ms",
-                stopLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS));
+        stopLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS);
 
         connect.assertions().assertConnectorIsRunningAndNumTasksHaveFailed(connectorName, NUM_TASKS, tasksToFail.size(),
                 "Connector tasks are not all in running state.");
         // Expect that the connector has started again
-        assertTrue("Failed to start connector and tasks within "
-                        + CONNECTOR_SETUP_DURATION_MS + "ms",
-                startLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS));
+        startLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS);
 
         StartsAndStops afterSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
@@ -70,6 +70,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -1097,22 +1098,17 @@ public class ExactlyOnceSourceIntegrationTest {
         return connectorHandle.expectedStarts(1, true);
     }
 
-    private void assertConnectorStarted(StartAndStopLatch connectorStart) throws InterruptedException {
-        assertTrue("Connector and tasks did not finish startup in time",
-                connectorStart.await(
-                        ConnectAssertions.CONNECTOR_SETUP_DURATION_MS,
-                        TimeUnit.MILLISECONDS
-                )
+    private void assertConnectorStarted(StartAndStopLatch connectorStart) throws InterruptedException, TimeoutException {
+        connectorStart.await(
+                ConnectAssertions.CONNECTOR_SETUP_DURATION_MS,
+                TimeUnit.MILLISECONDS
         );
     }
 
-    private void assertConnectorStopped(StartAndStopLatch connectorStop) throws InterruptedException {
-        assertTrue(
-                "Connector and tasks did not finish shutdown in time",
-                connectorStop.await(
-                        ConnectAssertions.CONNECTOR_SHUTDOWN_DURATION_MS,
-                        TimeUnit.MILLISECONDS
-                )
+    private void assertConnectorStopped(StartAndStopLatch connectorStop) throws InterruptedException, TimeoutException {
+        connectorStop.await(
+                ConnectAssertions.CONNECTOR_SHUTDOWN_DURATION_MS,
+                TimeUnit.MILLISECONDS
         );
     }
 
@@ -1120,7 +1116,7 @@ public class ExactlyOnceSourceIntegrationTest {
             int currentNumTasks,
             int newNumTasks,
             String topic,
-            Map<String, String> baseConnectorProps) throws InterruptedException {
+            Map<String, String> baseConnectorProps) throws InterruptedException, TimeoutException {
 
         // create a collection of producers that simulate the producers used for the existing tasks
         List<KafkaProducer<byte[], byte[]>> producers = IntStream.range(0, currentNumTasks)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
@@ -172,9 +172,12 @@ public class RebalanceSourceConnectorsIntegrationTest {
         connect.configureConnector(CONNECTOR_NAME, props);
 
         // Wait for the connector *and tasks* to be restarted
-        assertTrue("Failed to alter connector configuration and see connector and tasks restart "
-                   + "within " + CONNECTOR_SETUP_DURATION_MS + "ms",
-                restartLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS));
+        restartLatch.await(
+                "Failed to alter connector configuration and see connector and tasks restart "
+                        + "within " + CONNECTOR_SETUP_DURATION_MS + "ms",
+                CONNECTOR_SETUP_DURATION_MS,
+                TimeUnit.MILLISECONDS
+        );
 
         // And wait for the Connect to show the connectors and tasks are running
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestExtensionIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestExtensionIntegrationTest.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
@@ -61,7 +62,7 @@ public class RestExtensionIntegrationTest {
     private EmbeddedConnectCluster connect;
 
     @Test
-    public void testRestExtensionApi() throws InterruptedException {
+    public void testRestExtensionApi() throws InterruptedException, TimeoutException {
         // setup Connect worker properties
         Map<String, String> workerProps = new HashMap<>();
         workerProps.put(REST_EXTENSION_CLASSES_CONFIG, IntegrationTestRestExtension.class.getName());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopCounter.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopCounter.java
@@ -28,13 +28,15 @@ public class StartAndStopCounter {
     private final AtomicInteger startCounter = new AtomicInteger(0);
     private final AtomicInteger stopCounter = new AtomicInteger(0);
     private final List<StartAndStopLatch> restartLatches = new CopyOnWriteArrayList<>();
+    private final String name;
     private final Time clock;
 
-    public StartAndStopCounter() {
-        this(Time.SYSTEM);
+    public StartAndStopCounter(String name) {
+        this(name, Time.SYSTEM);
     }
 
-    public StartAndStopCounter(Time clock) {
+    public StartAndStopCounter(String name, Time clock) {
+        this.name = name;
         this.clock = clock != null ? clock : Time.SYSTEM;
     }
 
@@ -99,7 +101,7 @@ public class StartAndStopCounter {
      * @return the latch; never null
      */
     public StartAndStopLatch expectedRestarts(int expectedStarts, int expectedStops, List<StartAndStopLatch> dependents) {
-        StartAndStopLatch latch = new StartAndStopLatch(expectedStarts, expectedStops, this::remove, dependents, clock);
+        StartAndStopLatch latch = new StartAndStopLatch(expectedStarts, expectedStops, this::remove, dependents, name, clock);
         restartLatches.add(latch);
         return latch;
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopCounterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopCounterTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
@@ -45,7 +46,7 @@ public class StartAndStopCounterTest {
     @Before
     public void setup() {
         clock = new MockTime();
-        counter = new StartAndStopCounter(clock);
+        counter = new StartAndStopCounter("test", clock);
     }
 
     @After
@@ -109,9 +110,12 @@ public class StartAndStopCounterTest {
     private Future<Boolean> asyncAwait(long duration, TimeUnit unit) {
         return waiters.submit(() -> {
             try {
-                return latch.await(duration, unit);
+                latch.await(duration, unit);
+                return true;
             } catch (InterruptedException e) {
                 Thread.interrupted();
+                return false;
+            } catch (TimeoutException e) {
                 return false;
             }
         });

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopLatch.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopLatch.java
@@ -153,16 +153,16 @@ public class StartAndStopLatch {
             throw new TimeoutException(detailMessage +
                     "Timed out while awaiting " + expectedStarts
                             + " start(s) for " + name +
-                            "; there are currently " + startLatch.getCount()
-                            + " left"
+                            "; currently, " + startLatch.getCount()
+                            + " remain(s)"
             );
         }
         if (!stopLatch.await(end - clock.milliseconds(), TimeUnit.MILLISECONDS)) {
             throw new TimeoutException(detailMessage +
                     "Timed out while awaiting " + expectedStops
                             + " stop(s) for " + name +
-                            "; there are currently " + stopLatch.getCount()
-                            + " left"
+                            "; currently, " + stopLatch.getCount()
+                            + " remain(s)"
             );
         }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopLatch.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopLatch.java
@@ -152,17 +152,17 @@ public class StartAndStopLatch {
         if (!startLatch.await(end - start, TimeUnit.MILLISECONDS)) {
             throw new TimeoutException(detailMessage +
                     "Timed out while awaiting " + expectedStarts
-                            + " starts for " + name +
+                            + " start(s) for " + name +
                             "; there are currently " + startLatch.getCount()
-                            + "left"
+                            + " left"
             );
         }
         if (!stopLatch.await(end - clock.milliseconds(), TimeUnit.MILLISECONDS)) {
             throw new TimeoutException(detailMessage +
                     "Timed out while awaiting " + expectedStops
-                            + " stops for " + name +
-                            "; there are currently " + startLatch.getCount()
-                            + "left"
+                            + " stop(s) for " + name +
+                            "; there are currently " + stopLatch.getCount()
+                            + " left"
             );
         }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TaskHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TaskHandle.java
@@ -42,7 +42,7 @@ public class TaskHandle {
     private final String taskId;
     private final ConnectorHandle connectorHandle;
     private final ConcurrentMap<TopicPartition, PartitionHistory> partitions = new ConcurrentHashMap<>();
-    private final StartAndStopCounter startAndStopCounter = new StartAndStopCounter();
+    private final StartAndStopCounter startAndStopCounter;
     private final Consumer<SinkRecord> consumer;
 
     private CountDownLatch recordsRemainingLatch;
@@ -54,6 +54,7 @@ public class TaskHandle {
         this.taskId = taskId;
         this.connectorHandle = connectorHandle;
         this.consumer = consumer;
+        this.startAndStopCounter = new StartAndStopCounter("task " + taskId);
     }
 
     public String taskId() {


### PR DESCRIPTION
Currently, [StartAndStopLatch::await](https://github.com/apache/kafka/blob/6ff21ee1e009a5a2729bb105591a9bfa16c6c4c5/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopLatch.java#L96) returns a boolean that indicates whether the operation completed within the specified timeout or not. This is similar to the variant of [CountdownLatch::await](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CountDownLatch.html#await(long,java.util.concurrent.TimeUnit)) with the same signature.

However, every single call site for this method either throws an exception when the return value is false with the intent to fail the test, or should do so but doesn't (i.e., the rest of the test operates under the assumption that after `StartAndStopLatch::await` has returned, the operation has completed successfully). Examples of the latter include [here](https://github.com/apache/kafka/blob/6ff21ee1e009a5a2729bb105591a9bfa16c6c4c5/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestExtensionIntegrationTest.java#L107) and [here](https://github.com/apache/kafka/blob/6ff21ee1e009a5a2729bb105591a9bfa16c6c4c5/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SessionedProtocolIntegrationTest.java), and examples of the former include most other invocations of that method.

In order to simplify the API, the contract for the method is altered to have a `void` return type, and throw a `TimeoutException` if the timeout elapses before the operation completes, instead of return true/false depending on whether the operation completed successfully within the timeout.

In addition, some extra granularity is added to the error messages in these `TimeoutException` instances that may aid in debugging some flaky integration tests, such as the `ConnectorRestartApiIntegrationTest::testMultiWorkerRestartOnlyConnector` case reported in [KAFKA-15675](https://issues.apache.org/jira/browse/KAFKA-15675).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
