### PR TITLE
KAFKA-16123: KStreamKStreamJoinProcessor does not drop late records.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -132,8 +132,10 @@ class KStreamKStreamJoin<K, V1, V2, VOut> implements ProcessorSupplier<K, V1, K,
 
             sharedTimeTracker.advanceStreamTime(inputRecordTimestamp);
             if (sharedTimeTracker.streamTime > inputRecordTimestamp + joinBeforeMs + joinAfterMs + joinGraceMs) {
-                // Join window for this record is too old.
-                StreamStreamJoinUtil.logSkip("Record arrived after window close", LOG, droppedRecordsSensor, context());
+                StreamStreamJoinUtil.logSkip(
+                    "Record is too old. It's own window and any matching window on the other input stream are closed.",
+                    LOG, droppedRecordsSensor, context()
+                );
                 return;
             }
             if (outer && record.key() == null && record.value() != null) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/StreamStreamJoinUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/StreamStreamJoinUtil.java
@@ -40,7 +40,7 @@ public final class StreamStreamJoinUtil {
         // furthermore, on left/outer joins 'null' in ValueJoiner#apply() indicates a missing record --
         // thus, to be consistent and to avoid ambiguous null semantics, null values are ignored
         if (record.key() == null || record.value() == null) {
-            logSkip("Skipping record due to null key or value.", logger, droppedRecordsSensor, context);
+            logSkip("null key or value", logger, droppedRecordsSensor, context);
             return true;
         } else {
             return false;
@@ -56,13 +56,14 @@ public final class StreamStreamJoinUtil {
         if (context.recordMetadata().isPresent()) {
             final RecordMetadata recordMetadata = context.recordMetadata().get();
             logger.warn(
-                reason + " topic=[{}] partition=[{}] offset=[{}]",
+                "Skipping record. reason=[{}] topic=[{}] partition=[{}] offset=[{}]",
+                reason,
                 recordMetadata.topic(),
                 recordMetadata.partition(),
                 recordMetadata.offset()
             );
         } else {
-            logger.warn(reason + " topic, partition, and offset not known.");
+            logger.warn("Skipping record. reason=[{}] topic, partition, and offset not known.", reason);
         }
         droppedRecordsSensor.record();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/StreamStreamJoinUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/StreamStreamJoinUtil.java
@@ -56,7 +56,7 @@ public final class StreamStreamJoinUtil {
         if (context.recordMetadata().isPresent()) {
             final RecordMetadata recordMetadata = context.recordMetadata().get();
             logger.warn(
-                "Skipping record. reason=[{}] topic=[{}] partition=[{}] offset=[{}]",
+                "Skipping record. Reason=[{}] topic=[{}] partition=[{}] offset=[{}]",
                 reason,
                 recordMetadata.topic(),
                 recordMetadata.partition(),

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RelaxedNullKeyRequirementJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RelaxedNullKeyRequirementJoinTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RelaxedNullKeyRequirementJoinTest {
 
-    private static final JoinWindows WINDOW = ofTimeDifferenceAndGrace(Duration.ofSeconds(60), Duration.ofSeconds(10));
+    private static final JoinWindows WINDOW_60MS_GRACE_10MS = ofTimeDifferenceAndGrace(Duration.ofMillis(60), Duration.ofMillis(10));
     private static final ValueJoiner<String, String, String> JOINER = (lv, rv) -> lv + "|" + rv;
     private static final String LEFT = "left";
     private static final String RIGHT = "right";
@@ -71,11 +71,21 @@ public class RelaxedNullKeyRequirementJoinTest {
     @Test
     void testRelaxedLeftStreamStreamJoin() {
         leftStream
-            .leftJoin(rightStream, JOINER, WINDOW)
+            .leftJoin(rightStream, JOINER, WINDOW_60MS_GRACE_10MS)
             .to(OUT);
         initTopology();
-        left.pipeInput(null, "leftValue", 1);
-        assertEquals(Collections.singletonList(new KeyValue<>(null, "leftValue|null")), out.readKeyValuesToList());
+        left.pipeInput(null, "leftValue1", 1);
+        left.pipeInput(null, "leftValue2", 90);
+        left.pipeInput(null, "lateArrival-Dropped", 19);
+        left.pipeInput(null, "lateArrivalWithinGrace", 20);
+        assertEquals(
+            Arrays.asList(
+                new KeyValue<>(null, "leftValue1|null"),
+                new KeyValue<>(null, "leftValue2|null"),
+                new KeyValue<>(null, "lateArrivalWithinGrace|null")
+            ),
+            out.readKeyValuesToList()
+        );
     }
 
     @Test
@@ -91,13 +101,22 @@ public class RelaxedNullKeyRequirementJoinTest {
     @Test
     void testRelaxedOuterStreamStreamJoin() {
         leftStream
-            .outerJoin(rightStream, JOINER, WINDOW)
+            .outerJoin(rightStream, JOINER, WINDOW_60MS_GRACE_10MS)
             .to(OUT);
         initTopology();
         right.pipeInput(null, "rightValue", 1);
-        left.pipeInput(null, "leftValue");
+        left.pipeInput(null, "leftValue", 90);
+        left.pipeInput(null, "lateArrival-dropped", 19);
+        right.pipeInput(null, "lateArrival-dropped", 19);
+        right.pipeInput(null, "lateArrivalWithinGrace", 20);
+        left.pipeInput(null, "lateArrivalWithinGrace", 20);
         assertEquals(
-            Arrays.asList(new KeyValue<>(null, "null|rightValue"), new KeyValue<>(null, "leftValue|null")),
+            Arrays.asList(
+                new KeyValue<>(null, "null|rightValue"),
+                new KeyValue<>(null, "leftValue|null"),
+                new KeyValue<>(null, "null|lateArrivalWithinGrace"),
+                new KeyValue<>(null, "lateArrivalWithinGrace|null")
+            ),
             out.readKeyValuesToList()
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -128,7 +128,7 @@ public class KStreamKStreamJoinTest {
 
             assertThat(
                 appender.getMessages(),
-                hasItem("Skipping record. reason=[null key or value] topic=[left] partition=[0] offset=[0]")
+                hasItem("Skipping record. Reason=[null key or value] topic=[left] partition=[0] offset=[0]")
             );
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -130,7 +130,7 @@ public class KStreamKStreamJoinTest {
 
             assertThat(
                 appender.getMessages(),
-                hasItem("Skipping record due to null key or value. topic=[left] partition=[0] offset=[0]")
+                hasItem("Skipping record. reason=[null key or value] topic=[left] partition=[0] offset=[0]")
             );
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -16,23 +16,15 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-
-import org.apache.kafka.common.Metric;
-import org.apache.kafka.common.MetricName;
-import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyWrapper;
@@ -63,7 +55,6 @@ import org.apache.kafka.streams.state.internals.LeftOrRightValueSerde;
 import org.apache.kafka.streams.state.internals.LeftOrRightValue;
 import org.apache.kafka.streams.state.internals.InMemoryWindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.WrappedStateStore;
-import org.apache.kafka.streams.test.TestRecord;
 import org.apache.kafka.test.MockApiProcessor;
 import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.MockValueJoiner;
@@ -71,13 +62,13 @@ import org.apache.kafka.test.MockInternalNewProcessorContext;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.GenericInMemoryKeyValueStore;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -93,11 +84,7 @@ import java.util.stream.StreamSupport;
 import static java.time.Duration.ofHours;
 import static java.time.Duration.ofMillis;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-import static java.util.Arrays.asList;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_0;
-import static org.apache.kafka.test.StreamsTestUtils.getMetricByName;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
@@ -141,7 +128,7 @@ public class KStreamKStreamJoinTest {
 
             assertThat(
                 appender.getMessages(),
-                hasItem("Skipping record. Reason=[null key or value] topic=[left] partition=[0] offset=[0]")
+                hasItem("Skipping record. reason=[null key or value] topic=[left] partition=[0] offset=[0]")
             );
         }
     }
@@ -1912,82 +1899,6 @@ public class KStreamKStreamJoinTest {
             }
             processor.checkAndClearProcessResult();
         }
-    }
-
-
-    @Test
-    public void recordsArrivingPostWindowCloseShouldBeDropped() {
-        final int key = 0;
-        final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
-        final Consumed<Integer, String> serde = Consumed.with(Serdes.Integer(), Serdes.String());
-        final StreamsBuilder builder = new StreamsBuilder();
-        builder
-            .stream("left", serde)
-            .join(
-                builder.stream("right", serde),
-                MockValueJoiner.TOSTRING_JOINER,
-                JoinWindows.ofTimeDifferenceAndGrace(ofMillis(10), ofMillis(5)),
-                StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
-            )
-            .to("out");
-        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(props), props)) {
-            final TestInputTopic<Integer, String> left = driver.createInputTopic("left", new IntegerSerializer(), new StringSerializer());
-            final TestInputTopic<Integer, String> right = driver.createInputTopic("right", new IntegerSerializer(), new StringSerializer());
-            final TestOutputTopic<Integer, String> out = driver.createOutputTopic("out", new IntegerDeserializer(), new StringDeserializer());
-
-            left.pipeInput(key, "l15", 15); // l15 window {5:25,5} open, closes at 31
-            assertRecordDropCount(0.0, driver.metrics());
-
-            left.pipeInput(-1, "bump time", 30);
-            right.pipeInput(key, "r4", 4); // gets dropped
-            right.pipeInput(key, "r5", 5);
-            right.pipeInput(key, "r25-0", 25);
-            Assertions.assertEquals(
-                asList(
-                    new TestRecord<>(key, "l15+r5", null, 15L),
-                    new TestRecord<>(key, "l15+r25-0", null, 25L)
-                ),
-                out.readRecordsToList()
-            );
-            assertRecordDropCount(1.0, driver.metrics());
-            left.pipeInput(-1, "bump time", 31); // l15 is now closed
-
-            right.pipeInput(key, "r5", 5); // gets dropped
-            assertRecordDropCount(2.0, driver.metrics());
-            Assertions.assertEquals(emptyList(), out.readRecordsToList());
-
-            right.pipeInput(key, "r6", 6); // Doesn't get dropped, but all involved windows are closed.
-            assertRecordDropCount(2.0, driver.metrics());
-            Assertions.assertEquals(emptyList(), out.readRecordsToList());
-
-            right.pipeInput(key, "r25-1", 25);
-            // r25-1 still joins with l15 (despite l15 window closed) because r25-1 window {15:35,5} is open, closes at 41.
-
-            Assertions.assertEquals(
-                singletonList(new TestRecord<>(key, "l15+r25-1", null, 25L)),
-                out.readRecordsToList()
-            );
-
-            left.pipeInput(key, "l16", 16);
-            Assertions.assertEquals(
-                asList(
-                    new TestRecord<>(key, "l16+r6", null, 16L),
-                    new TestRecord<>(key, "l16+r25-0", null, 25L),
-                    new TestRecord<>(key, "l16+r25-1", null, 25L)
-                ),
-                out.readRecordsToList()
-            );
-            assertRecordDropCount(2.0, driver.metrics());
-        }
-    }
-
-    static void assertRecordDropCount(final double expected, final Map<MetricName, ? extends Metric> metrics) {
-        final String metricGroup = "stream-task-metrics";
-        final String metricName = "dropped-records-total";
-        Assertions.assertEquals(
-            expected,
-            getMetricByName(metrics, metricName, metricGroup).metricValue()
-        );
     }
 
     private void buildStreamsJoinThatShouldThrow(final StreamJoined<String, Integer, Integer> streamJoined,

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -16,15 +16,16 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyWrapper;
@@ -38,29 +39,27 @@ import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.InternalTopicConfig;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
-import org.apache.kafka.common.utils.LogCaptureAppender;
-import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.state.BuiltInDslStoreSuppliers;
 import org.apache.kafka.streams.state.DslWindowParams;
+import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
-import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.internals.KeyValueStoreBuilder;
-import org.apache.kafka.streams.state.internals.TimestampedKeyAndJoinSide;
 import org.apache.kafka.streams.state.internals.InMemoryKeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.internals.InMemoryWindowBytesStoreSupplier;
+import org.apache.kafka.streams.state.internals.KeyValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.LeftOrRightValue;
+import org.apache.kafka.streams.state.internals.LeftOrRightValueSerde;
+import org.apache.kafka.streams.state.internals.TimestampedKeyAndJoinSide;
 import org.apache.kafka.streams.state.internals.TimestampedKeyAndJoinSideSerde;
 import org.apache.kafka.streams.state.internals.WindowStoreBuilder;
-import org.apache.kafka.streams.state.internals.LeftOrRightValueSerde;
-import org.apache.kafka.streams.state.internals.LeftOrRightValue;
-import org.apache.kafka.streams.state.internals.InMemoryWindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.WrappedStateStore;
+import org.apache.kafka.test.GenericInMemoryKeyValueStore;
 import org.apache.kafka.test.MockApiProcessor;
 import org.apache.kafka.test.MockApiProcessorSupplier;
-import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.MockInternalNewProcessorContext;
+import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
-import org.apache.kafka.test.GenericInMemoryKeyValueStore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -72,18 +71,18 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.Optional;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static java.time.Duration.ofHours;
 import static java.time.Duration.ofMillis;
-
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_0;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -817,7 +816,7 @@ public class KStreamKStreamJoinTest {
         stream2 = builder.stream(topic2, consumed);
 
         final Duration timeDifference = ofMillis(100L);
-        final Duration grace = ofMillis(104);
+        final Duration grace = ofMillis(150);
         joined = stream1.join(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
@@ -1368,9 +1367,10 @@ public class KStreamKStreamJoinTest {
 
             //push two items with timestamp at grace edge; this should produce one join item, M0 is 'too late'
             final long currentStreamTime = 2104;
-            final long lowerBound = currentStreamTime - timeDifference.toMillis() - grace.toMillis();
-            inputTopic1.pipeInput(0, "M0", lowerBound - 1);
-            inputTopic1.pipeInput(1, "M1", lowerBound + 1);
+            final long graceBound = currentStreamTime - timeDifference.toMillis() - grace.toMillis();
+            inputTopic1.pipeInput(0, "M0", graceBound - 1);
+            final long windowL1LowerBound = 2001 - timeDifference.toMillis();
+            inputTopic1.pipeInput(1, "M1", Math.max(graceBound, windowL1LowerBound));
 
             processor.checkAndClearProcessResult(
                 new KeyValueTimestamp<>(1, "M1+l1", 2001L)

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -1940,7 +1940,6 @@ public class KStreamKStreamJoinTest {
             assertRecordDropCount(2.0, processor);
             processor.checkAndClearProcessResult();
 
-
             right.pipeInput(1, "right", 115);
             left.pipeInput(-1, "bumpTime", 140);
             left.pipeInput(1, "closesAt139", 124);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
@@ -1354,7 +1354,6 @@ public class KStreamKStreamLeftJoinTest {
             processor.checkAndClearProcessResult();
             assertRecordDropCount(2.0, processor);
 
-
             right.pipeInput(1, "right", 115);
             left.pipeInput(-1, "bumpTime", 140);
             left.pipeInput(1, "closesAt139", 124);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamSelfJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamSelfJoinTest.java
@@ -274,7 +274,7 @@ public class KStreamKStreamSelfJoinTest {
         final KStream<String, String> innerJoin = stream3.join(
             stream4,
             valueJoiner,
-            JoinWindows.ofTimeDifferenceWithNoGrace(ofSeconds(10)),
+            JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofSeconds(30000L)),
             StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String())
         );
         innerJoin.process(innerJoinSupplier);
@@ -308,7 +308,7 @@ public class KStreamKStreamSelfJoinTest {
         final KStream<String, String> selfJoin = stream1.join(
             stream2,
             valueJoiner,
-            JoinWindows.ofTimeDifferenceWithNoGrace(ofSeconds(10)),
+            JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofSeconds(30000L)),
             StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String())
         );
         selfJoin.process(selfJoinSupplier);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamWindowCloseTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamWindowCloseTest.java
@@ -194,7 +194,7 @@ public class KStreamKStreamWindowCloseTest {
             assertRecordDropCount(2.0, driver.metrics());
             Assertions.assertEquals(emptyList(), out.readRecordsToList());
 
-            right.pipeInput(key, "r6", 6); // Doesn't get dropped, but all involved windows are closed.
+            right.pipeInput(key, "r6", 6); // Doesn't get dropped, but all involved windows are closed. r6 window {1:16:5} closes at 21
             assertRecordDropCount(2.0, driver.metrics());
             Assertions.assertEquals(emptyList(), out.readRecordsToList());
 
@@ -205,7 +205,7 @@ public class KStreamKStreamWindowCloseTest {
                 out.readRecordsToList()
             );
 
-            left.pipeInput(key, "l16", 16);
+            left.pipeInput(key, "l16", 16); // l15 window {6:21,5} open, closes at 27
             Assertions.assertEquals(
                 asList(
                     new TestRecord<>(key, "l16+r6", null, 16L),

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamWindowCloseTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamWindowCloseTest.java
@@ -89,7 +89,7 @@ public class KStreamKStreamWindowCloseTest {
 
     private static Arguments outerJoin() {
         final StreamsBuilder builder = new StreamsBuilder();
-        final KStream<Integer, String> stream = builder.stream(LEFT, CONSUMED).leftJoin(
+        final KStream<Integer, String> stream = builder.stream(LEFT, CONSUMED).outerJoin(
             builder.stream(RIGHT, CONSUMED),
             MockValueJoiner.TOSTRING_JOINER,
             WINDOW,

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamWindowCloseTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamWindowCloseTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.test.MockApiProcessor;
+import org.apache.kafka.test.MockApiProcessorSupplier;
+import org.apache.kafka.test.MockValueJoiner;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import static java.time.Duration.ofMillis;
+import static org.apache.kafka.test.StreamsTestUtils.getMetricByName;
+
+public class KStreamKStreamWindowCloseTest {
+
+    private static final String LEFT = "left";
+    private static final String RIGHT = "right";
+    private final static Properties PROPS = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+    private static final Consumed<Integer, String> CONSUMED = Consumed.with(Serdes.Integer(), Serdes.String());
+    private static final JoinWindows WINDOW = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(10), ofMillis(5));
+
+    static List<Arguments> streams() {
+        return Arrays.asList(
+            innerJoin(),
+            leftJoin(),
+            outerJoin()
+        );
+    }
+
+    private static Arguments innerJoin() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KStream<Integer, String> stream = builder.stream(LEFT, CONSUMED).join(
+            builder.stream(RIGHT, CONSUMED),
+            MockValueJoiner.TOSTRING_JOINER,
+            WINDOW,
+            StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
+        );
+        final MockApiProcessorSupplier<Integer, String, Object, Object> processorSupplier = new MockApiProcessorSupplier<>();
+        stream.process(processorSupplier);
+        return Arguments.of(builder.build(PROPS), processorSupplier);
+    }
+
+    private static Arguments leftJoin() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KStream<Integer, String> stream = builder.stream(LEFT, CONSUMED).leftJoin(
+            builder.stream(RIGHT, CONSUMED),
+            MockValueJoiner.TOSTRING_JOINER,
+            WINDOW,
+            StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
+        );
+        final MockApiProcessorSupplier<Integer, String, Object, Object> processorSupplier = new MockApiProcessorSupplier<>();
+        stream.process(processorSupplier);
+        return Arguments.of(builder.build(PROPS), processorSupplier);
+    }
+
+    private static Arguments outerJoin() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KStream<Integer, String> stream = builder.stream(LEFT, CONSUMED).leftJoin(
+            builder.stream(RIGHT, CONSUMED),
+            MockValueJoiner.TOSTRING_JOINER,
+            WINDOW,
+            StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
+        );
+        final MockApiProcessorSupplier<Integer, String, Object, Object> supplier = new MockApiProcessorSupplier<>();
+        stream.process(supplier);
+        return Arguments.of(builder.build(PROPS), supplier);
+    }
+
+    @ParameterizedTest
+    @MethodSource("streams")
+    public void recordsArrivingPostWindowCloseShouldBeDropped(
+        final Topology topology,
+        final MockApiProcessorSupplier<Integer, String, Void, Void> supplier) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(topology, PROPS)) {
+            final TestInputTopic<Integer, String> left =
+                driver.createInputTopic(KStreamKStreamWindowCloseTest.LEFT, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+            final TestInputTopic<Integer, String> right =
+                driver.createInputTopic(KStreamKStreamWindowCloseTest.RIGHT, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+            final MockApiProcessor<Integer, String, Void, Void> processor = supplier.theCapturedProcessor();
+
+            left.pipeInput(0, "left", 15);
+            right.pipeInput(-1, "bumpTime", 40);
+            assertRecordDropCount(0.0, processor);
+
+            right.pipeInput(0, "closesAt39", 24);
+            assertRecordDropCount(1.0, processor);
+
+            right.pipeInput(0, "closesAt40", 25);
+            assertRecordDropCount(1.0, processor);
+
+            right.pipeInput(-1, "bumpTime", 41);
+            right.pipeInput(0, "closesAt40", 25);
+            assertRecordDropCount(2.0, processor);
+
+            right.pipeInput(1, "right", 115);
+            left.pipeInput(-1, "bumpTime", 140);
+            left.pipeInput(1, "closesAt139", 124);
+            assertRecordDropCount(3.0, processor);
+            left.pipeInput(1, "closesAt140", 125);
+            assertRecordDropCount(3.0, processor);
+
+            left.pipeInput(-1, "bumpTime", 141);
+            left.pipeInput(1, "closesAt140", 125);
+            assertRecordDropCount(4.0, processor);
+        }
+    }
+
+    static void assertRecordDropCount(final double expected, final MockApiProcessor<Integer, String, Void, Void> processor) {
+        final String metricGroup = "stream-task-metrics";
+        final String metricName = "dropped-records-total";
+        Assertions.assertEquals(
+            expected,
+            getMetricByName(processor.context().metrics().metrics(), metricName, metricGroup).metricValue()
+        );
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamWindowCloseTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamWindowCloseTest.java
@@ -116,25 +116,25 @@ public class KStreamKStreamWindowCloseTest {
             right.pipeInput(-1, "bumpTime", 40);
             assertRecordDropCount(0.0, processor);
 
-            right.pipeInput(0, "closesAt39", 24);
+            right.pipeInput(0, "closedAt40", 24);
             assertRecordDropCount(1.0, processor);
 
-            right.pipeInput(0, "closesAt40", 25);
+            right.pipeInput(0, "closedAt41", 25);
             assertRecordDropCount(1.0, processor);
 
             right.pipeInput(-1, "bumpTime", 41);
-            right.pipeInput(0, "closesAt40", 25);
+            right.pipeInput(0, "closedAt41", 25);
             assertRecordDropCount(2.0, processor);
 
             right.pipeInput(1, "right", 115);
             left.pipeInput(-1, "bumpTime", 140);
-            left.pipeInput(1, "closesAt139", 124);
+            left.pipeInput(1, "closedAt140", 124);
             assertRecordDropCount(3.0, processor);
-            left.pipeInput(1, "closesAt140", 125);
+            left.pipeInput(1, "closedAt141", 125);
             assertRecordDropCount(3.0, processor);
 
             left.pipeInput(-1, "bumpTime", 141);
-            left.pipeInput(1, "closesAt140", 125);
+            left.pipeInput(1, "closedAt141", 125);
             assertRecordDropCount(4.0, processor);
         }
     }


### PR DESCRIPTION
KStreamKStreamJoinProcessor forwards null records for left/outer joins unconditionally of the join window.
