### PR TITLE
KAFKA-15811: Enhance request context with client socket port information (KIP-714)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -369,6 +369,16 @@ public class KafkaChannel implements AutoCloseable {
         return transportLayer.socketChannel().socket().getInetAddress();
     }
 
+    /**
+     * Returns the port to which this channel's socket is connected or `null` if the socket has never been connected.
+     *
+     * If the socket was connected prior to being closed, then this method will continue to return the
+     * connected port number after the socket is closed.
+     */
+    public int socketPort() {
+        return transportLayer.socketChannel().socket().getPort();
+    }
+
     public String socketDescription() {
         Socket socket = transportLayer.socketChannel().socket();
         if (socket.getInetAddress() == null)

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -370,7 +370,7 @@ public class KafkaChannel implements AutoCloseable {
     }
 
     /**
-     * Returns the port to which this channel's socket is connected or `null` if the socket has never been connected.
+     * Returns the port to which this channel's socket is connected or 0 if the socket has never been connected.
      *
      * If the socket was connected prior to being closed, then this method will continue to return the
      * connected port number after the socket is closed.

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
@@ -37,6 +37,7 @@ public class RequestContext implements AuthorizableRequestContext {
     public final RequestHeader header;
     public final String connectionId;
     public final InetAddress clientAddress;
+    public final Optional<Integer> clientPort;
     public final KafkaPrincipal principal;
     public final ListenerName listenerName;
     public final SecurityProtocol securityProtocol;
@@ -55,6 +56,28 @@ public class RequestContext implements AuthorizableRequestContext {
         this(header,
             connectionId,
             clientAddress,
+            Optional.empty(),
+            principal,
+            listenerName,
+            securityProtocol,
+            clientInformation,
+            fromPrivilegedListener,
+            Optional.empty());
+    }
+
+    public RequestContext(RequestHeader header,
+        String connectionId,
+        InetAddress clientAddress,
+        Optional<Integer> clientPort,
+        KafkaPrincipal principal,
+        ListenerName listenerName,
+        SecurityProtocol securityProtocol,
+        ClientInformation clientInformation,
+        boolean fromPrivilegedListener) {
+        this(header,
+            connectionId,
+            clientAddress,
+            clientPort,
             principal,
             listenerName,
             securityProtocol,
@@ -66,6 +89,7 @@ public class RequestContext implements AuthorizableRequestContext {
     public RequestContext(RequestHeader header,
                           String connectionId,
                           InetAddress clientAddress,
+                          Optional<Integer> clientPort,
                           KafkaPrincipal principal,
                           ListenerName listenerName,
                           SecurityProtocol securityProtocol,
@@ -75,6 +99,7 @@ public class RequestContext implements AuthorizableRequestContext {
         this.header = header;
         this.connectionId = connectionId;
         this.clientAddress = clientAddress;
+        this.clientPort = clientPort;
         this.principal = principal;
         this.listenerName = listenerName;
         this.securityProtocol = securityProtocol;

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -416,6 +416,10 @@ public class SaslServerAuthenticator implements Authenticator {
         return transportLayer.socketChannel().socket().getInetAddress();
     }
 
+    private int clientPort() {
+        return transportLayer.socketChannel().socket().getPort();
+    }
+
     private void handleSaslToken(byte[] clientToken) throws IOException {
         if (!enableKafkaSaslAuthenticateHeaders) {
             byte[] response = saslServer.evaluateResponse(clientToken);
@@ -433,7 +437,7 @@ public class SaslServerAuthenticator implements Authenticator {
             RequestHeader header = RequestHeader.parse(requestBuffer);
             ApiKeys apiKey = header.apiKey();
             short version = header.apiVersion();
-            RequestContext requestContext = new RequestContext(header, connectionId, clientAddress(),
+            RequestContext requestContext = new RequestContext(header, connectionId, clientAddress(), Optional.of(clientPort()),
                     KafkaPrincipal.ANONYMOUS, listenerName, securityProtocol, ClientInformation.EMPTY, false);
             RequestAndSize requestAndSize = requestContext.parseRequest(requestBuffer);
             if (apiKey != ApiKeys.SASL_AUTHENTICATE) {
@@ -519,7 +523,7 @@ public class SaslServerAuthenticator implements Authenticator {
             LOG.debug("Handling Kafka request {} during {}", apiKey, reauthInfo.authenticationOrReauthenticationText());
 
 
-            RequestContext requestContext = new RequestContext(header, connectionId, clientAddress(),
+            RequestContext requestContext = new RequestContext(header, connectionId, clientAddress(), Optional.of(clientPort()),
                     KafkaPrincipal.ANONYMOUS, listenerName, securityProtocol, ClientInformation.EMPTY, false);
             RequestAndSize requestAndSize = requestContext.parseRequest(requestBuffer);
             if (apiKey == ApiKeys.API_VERSIONS)

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -22,6 +22,7 @@ import java.net._
 import java.nio.ByteBuffer
 import java.nio.channels.{Selector => NSelector, _}
 import java.util
+import java.util.Optional
 import java.util.concurrent._
 import java.util.concurrent.atomic._
 import kafka.cluster.{BrokerEndPoint, EndPoint}
@@ -1140,9 +1141,9 @@ private[kafka] class Processor(
                 expiredConnectionsKilledCount.record(null, 1, 0)
               } else {
                 val connectionId = receive.source
-                val context = new RequestContext(header, connectionId, channel.socketAddress,
-                  channel.principal, listenerName, securityProtocol,
-                  channel.channelMetadataRegistry.clientInformation, isPrivilegedListener, channel.principalSerde)
+                val context = new RequestContext(header, connectionId, channel.socketAddress, Optional.of(channel.socketPort()),
+                  channel.principal, listenerName, securityProtocol, channel.channelMetadataRegistry.clientInformation,
+                  isPrivilegedListener, channel.principalSerde)
 
                 val req = new RequestChannel.Request(processor = id, context = context,
                   startTimeNanos = nowNanos, memoryPool, receive.payload, requestChannel.metrics, None)

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -333,7 +333,7 @@ class AutoTopicCreationManagerTest {
 
     val requestHeader = new RequestHeader(ApiKeys.METADATA, ApiKeys.METADATA.latestVersion,
       "clientId", 0)
-    new RequestContext(requestHeader, "1", InetAddress.getLocalHost,
+    new RequestContext(requestHeader, "1", InetAddress.getLocalHost, Optional.empty(),
       kafkaPrincipal, ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
       SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY, false, principalSerde)
   }

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -229,6 +229,7 @@ class ForwardingManagerTest {
       requestHeader,
       "1",
       InetAddress.getLocalHost,
+      Optional.empty(),
       principal,
       new ListenerName("client"),
       SecurityProtocol.SASL_PLAINTEXT,

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -6103,9 +6103,9 @@ class KafkaApisTest extends Logging {
     // and have a non KafkaPrincipal.ANONYMOUS principal. This test is done before the check
     // for forwarding because after forwarding the context will have a different context. 
     // We validate the context authenticated failure case in other integration tests.
-    val context = new RequestContext(header, "1", InetAddress.getLocalHost, new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "Alice"),
-      listenerName, SecurityProtocol.SSL, ClientInformation.EMPTY, fromPrivilegedListener,
-      Optional.of(kafkaPrincipalSerde))
+    val context = new RequestContext(header, "1", InetAddress.getLocalHost, Optional.empty(),
+      new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "Alice"), listenerName, SecurityProtocol.SSL,
+      ClientInformation.EMPTY, fromPrivilegedListener, Optional.of(kafkaPrincipalSerde))
     new RequestChannel.Request(processor = 1, context = context, startTimeNanos = 0, MemoryPool.NONE, buffer,
       requestMetrics, envelope = None)
   }

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -2407,7 +2407,7 @@ object TestUtils extends Logging {
 
     RequestHeader.parse(envelopeBuffer)
 
-    val envelopeContext = new RequestContext(envelopeHeader, "1", InetAddress.getLocalHost,
+    val envelopeContext = new RequestContext(envelopeHeader, "1", InetAddress.getLocalHost, Optional.empty(),
       KafkaPrincipal.ANONYMOUS, listenerName, SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY,
       fromPrivilegedListener, Optional.of(principalSerde))
 

--- a/server/src/main/java/org/apache/kafka/server/metrics/ClientMetricsInstanceMetadata.java
+++ b/server/src/main/java/org/apache/kafka/server/metrics/ClientMetricsInstanceMetadata.java
@@ -45,13 +45,7 @@ public class ClientMetricsInstanceMetadata {
             requestContext.clientInformation.softwareVersion() : null);
         attributesMap.put(ClientMetricsConfigs.CLIENT_SOURCE_ADDRESS, requestContext.clientAddress != null ?
             requestContext.clientAddress.getHostAddress() : null);
-        // KIP-714 mentions client source port should be the client connection's source port from the
-        // broker's point of view. But the broker does not have this information rather the port could be
-        // the broker's port where the client connection is established. We might want to consider removing
-        // the client source port from the KIP or use broker port if that can be helpful.
-        // TODO: fix port
-        attributesMap.put(ClientMetricsConfigs.CLIENT_SOURCE_PORT, requestContext.clientAddress != null ?
-            requestContext.clientAddress.getHostAddress() : null);
+        attributesMap.put(ClientMetricsConfigs.CLIENT_SOURCE_PORT, requestContext.clientPort.map(String::valueOf).orElse(null));
     }
 
     public boolean isMatch(Map<String, Pattern> patterns) {

--- a/server/src/test/java/org/apache/kafka/server/metrics/ClientMetricsInstanceMetadataTest.java
+++ b/server/src/test/java/org/apache/kafka/server/metrics/ClientMetricsInstanceMetadataTest.java
@@ -54,7 +54,8 @@ public class ClientMetricsInstanceMetadataTest {
             Collections.singletonMap(ClientMetricsConfigs.CLIENT_SOURCE_ADDRESS, Pattern.compile(
                 InetAddress.getLocalHost().getHostAddress()))));
         assertTrue(instanceMetadata.isMatch(
-            Collections.singletonMap(ClientMetricsConfigs.CLIENT_SOURCE_PORT, Pattern.compile("56078"))));
+            Collections.singletonMap(ClientMetricsConfigs.CLIENT_SOURCE_PORT, Pattern.compile(
+                String.valueOf(ClientMetricsTestUtils.CLIENT_PORT)))));
     }
 
     @Test
@@ -69,7 +70,7 @@ public class ClientMetricsInstanceMetadataTest {
         patternMap.put(ClientMetricsConfigs.CLIENT_SOFTWARE_NAME, Pattern.compile("apache-kafka-.*"));
         patternMap.put(ClientMetricsConfigs.CLIENT_SOFTWARE_VERSION, Pattern.compile("3.5.2"));
         patternMap.put(ClientMetricsConfigs.CLIENT_SOURCE_ADDRESS, Pattern.compile(InetAddress.getLocalHost().getHostAddress()));
-        patternMap.put(ClientMetricsConfigs.CLIENT_SOURCE_PORT, Pattern.compile("56078"));
+        patternMap.put(ClientMetricsConfigs.CLIENT_SOURCE_PORT, Pattern.compile(String.valueOf(ClientMetricsTestUtils.CLIENT_PORT)));
 
         assertTrue(instanceMetadata.isMatch(patternMap));
     }

--- a/server/src/test/java/org/apache/kafka/server/metrics/ClientMetricsInstanceMetadataTest.java
+++ b/server/src/test/java/org/apache/kafka/server/metrics/ClientMetricsInstanceMetadataTest.java
@@ -53,6 +53,8 @@ public class ClientMetricsInstanceMetadataTest {
         assertTrue(instanceMetadata.isMatch(
             Collections.singletonMap(ClientMetricsConfigs.CLIENT_SOURCE_ADDRESS, Pattern.compile(
                 InetAddress.getLocalHost().getHostAddress()))));
+        assertTrue(instanceMetadata.isMatch(
+            Collections.singletonMap(ClientMetricsConfigs.CLIENT_SOURCE_PORT, Pattern.compile("56078"))));
     }
 
     @Test
@@ -67,6 +69,7 @@ public class ClientMetricsInstanceMetadataTest {
         patternMap.put(ClientMetricsConfigs.CLIENT_SOFTWARE_NAME, Pattern.compile("apache-kafka-.*"));
         patternMap.put(ClientMetricsConfigs.CLIENT_SOFTWARE_VERSION, Pattern.compile("3.5.2"));
         patternMap.put(ClientMetricsConfigs.CLIENT_SOURCE_ADDRESS, Pattern.compile(InetAddress.getLocalHost().getHostAddress()));
+        patternMap.put(ClientMetricsConfigs.CLIENT_SOURCE_PORT, Pattern.compile("56078"));
 
         assertTrue(instanceMetadata.isMatch(patternMap));
     }
@@ -105,6 +108,11 @@ public class ClientMetricsInstanceMetadataTest {
         // Source address is different.
         patternMap.put(ClientMetricsConfigs.CLIENT_SOFTWARE_VERSION, Pattern.compile("3.5.2"));
         patternMap.put(ClientMetricsConfigs.CLIENT_SOURCE_ADDRESS, Pattern.compile("1.2.3.4"));
+        assertFalse(instanceMetadata.isMatch(patternMap));
+
+        // Source port is different.
+        patternMap.put(ClientMetricsConfigs.CLIENT_SOURCE_ADDRESS, Pattern.compile(InetAddress.getLocalHost().getHostAddress()));
+        patternMap.put(ClientMetricsConfigs.CLIENT_SOURCE_PORT, Pattern.compile("8080"));
         assertFalse(instanceMetadata.isMatch(patternMap));
     }
 

--- a/server/src/test/java/org/apache/kafka/server/metrics/ClientMetricsTestUtils.java
+++ b/server/src/test/java/org/apache/kafka/server/metrics/ClientMetricsTestUtils.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 
 public class ClientMetricsTestUtils {
@@ -59,6 +60,7 @@ public class ClientMetricsTestUtils {
             new RequestHeader(ApiKeys.GET_TELEMETRY_SUBSCRIPTIONS, (short) 0, "producer-1", 0),
             "1",
             InetAddress.getLocalHost(),
+            Optional.of(56078),
             KafkaPrincipal.ANONYMOUS,
             ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
             SecurityProtocol.PLAINTEXT,
@@ -71,6 +73,7 @@ public class ClientMetricsTestUtils {
             new RequestHeader(ApiKeys.GET_TELEMETRY_SUBSCRIPTIONS, (short) 0, "producer-1", 0),
              "1",
             InetAddress.getLocalHost(),
+            Optional.of(56078),
             KafkaPrincipal.ANONYMOUS,
             ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
             SecurityProtocol.PLAINTEXT,

--- a/server/src/test/java/org/apache/kafka/server/metrics/ClientMetricsTestUtils.java
+++ b/server/src/test/java/org/apache/kafka/server/metrics/ClientMetricsTestUtils.java
@@ -46,6 +46,7 @@ public class ClientMetricsTestUtils {
         ClientMetricsConfigs.CLIENT_SOFTWARE_NAME + "=apache-kafka-java",
         ClientMetricsConfigs.CLIENT_SOFTWARE_VERSION + "=3.5.*"
     ));
+    public static final int CLIENT_PORT = 56078;
 
     public static Properties defaultProperties() {
         Properties props = new Properties();
@@ -60,7 +61,7 @@ public class ClientMetricsTestUtils {
             new RequestHeader(ApiKeys.GET_TELEMETRY_SUBSCRIPTIONS, (short) 0, "producer-1", 0),
             "1",
             InetAddress.getLocalHost(),
-            Optional.of(56078),
+            Optional.of(CLIENT_PORT),
             KafkaPrincipal.ANONYMOUS,
             ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
             SecurityProtocol.PLAINTEXT,
@@ -73,7 +74,7 @@ public class ClientMetricsTestUtils {
             new RequestHeader(ApiKeys.GET_TELEMETRY_SUBSCRIPTIONS, (short) 0, "producer-1", 0),
              "1",
             InetAddress.getLocalHost(),
-            Optional.of(56078),
+            Optional.of(CLIENT_PORT),
             KafkaPrincipal.ANONYMOUS,
             ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
             SecurityProtocol.PLAINTEXT,


### PR DESCRIPTION
PR adds support to capture client socket port information in Request Context. The port from request context is used as matching criteria in filtering clients and shall be used by metrics plugin to fetch port from request context.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
