### PR TITLE
KAFKA-16131: Only update directoryIds if the metadata version supports DirectoryAssignment

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2798,6 +2798,7 @@ class ReplicaManager(val config: KafkaConfig,
   def applyDelta(delta: TopicsDelta, newImage: MetadataImage): Unit = {
     // Before taking the lock, compute the local changes
     val localChanges = delta.localChanges(config.nodeId)
+    val metadataVersion = newImage.features().metadataVersion()
 
     replicaStateChangeLock.synchronized {
       // Handle deleted partitions. We need to do this first because we might subsequently
@@ -2845,7 +2846,12 @@ class ReplicaManager(val config: KafkaConfig,
         remoteLogManager.foreach(rlm => rlm.onLeadershipChange(leaderChangedPartitions.asJava, followerChangedPartitions.asJava, localChanges.topicIds()))
       }
 
-      localChanges.directoryIds.forEach(maybeUpdateTopicAssignment)
+      if (metadataVersion.isDirectoryAssignmentSupported()) {
+        println("We are here");
+        localChanges.directoryIds.forEach(maybeUpdateTopicAssignment)
+      } else {
+        println("Not updating directoryIds");
+      }
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2847,10 +2847,8 @@ class ReplicaManager(val config: KafkaConfig,
       }
 
       if (metadataVersion.isDirectoryAssignmentSupported()) {
-        println("We are here");
+        // We only want to update the directoryIds if DirectoryAssignment is supported!
         localChanges.directoryIds.forEach(maybeUpdateTopicAssignment)
-      } else {
-        println("Not updating directoryIds");
       }
     }
   }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -6173,7 +6173,7 @@ class ReplicaManagerTest {
   private def imageFromTopics(topicsImage: TopicsImage): MetadataImage = {
     new MetadataImage(
       new MetadataProvenance(100L, 10, 1000L),
-      FeaturesImage.EMPTY,
+      FeaturesImage.LATEST,
       ClusterImageTest.IMAGE1,
       topicsImage,
       ConfigurationsImage.EMPTY,

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -57,7 +57,9 @@ import org.apache.kafka.common.{DirectoryId, IsolationLevel, Node, TopicIdPartit
 import org.apache.kafka.image._
 import org.apache.kafka.metadata.LeaderConstants.NO_LEADER
 import org.apache.kafka.metadata.LeaderRecoveryState
+import org.apache.kafka.metadata.migration.ZkMigrationState
 import org.apache.kafka.server.common.{DirectoryEventHandler, OffsetAndEpoch}
+import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.common.MetadataVersion.IBP_2_6_IV0
 import org.apache.kafka.server.log.remote.storage.{NoOpRemoteLogMetadataManager, NoOpRemoteStorageManager, RemoteLogManagerConfig, RemoteLogSegmentMetadata, RemoteStorageException, RemoteStorageManager}
 import org.apache.kafka.server.metrics.{KafkaMetricsGroup, KafkaYammerMetrics}
@@ -6171,9 +6173,13 @@ class ReplicaManagerTest {
   }
 
   private def imageFromTopics(topicsImage: TopicsImage): MetadataImage = {
+    val featuresImageLatest = new FeaturesImage(
+      Collections.emptyMap(),
+      MetadataVersion.latest(),
+      ZkMigrationState.NONE)
     new MetadataImage(
       new MetadataProvenance(100L, 10, 1000L),
-      FeaturesImage.LATEST,
+      featuresImageLatest,
       ClusterImageTest.IMAGE1,
       topicsImage,
       ConfigurationsImage.EMPTY,

--- a/metadata/src/main/java/org/apache/kafka/image/FeaturesImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/FeaturesImage.java
@@ -46,6 +46,18 @@ public final class FeaturesImage {
         ZkMigrationState.NONE
     );
 
+    public static final FeaturesImage LATEST = new FeaturesImage(
+        Collections.emptyMap(),
+        MetadataVersion.latest(),
+        ZkMigrationState.NONE
+    );
+
+    public static final FeaturesImage LATEST_PRODUCTION = new FeaturesImage(
+        Collections.emptyMap(),
+        MetadataVersion.LATEST_PRODUCTION,
+        ZkMigrationState.NONE
+    );
+
     private final Map<String, Short> finalizedVersions;
 
     private final MetadataVersion metadataVersion;

--- a/metadata/src/main/java/org/apache/kafka/image/FeaturesImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/FeaturesImage.java
@@ -46,18 +46,6 @@ public final class FeaturesImage {
         ZkMigrationState.NONE
     );
 
-    public static final FeaturesImage LATEST = new FeaturesImage(
-        Collections.emptyMap(),
-        MetadataVersion.latest(),
-        ZkMigrationState.NONE
-    );
-
-    public static final FeaturesImage LATEST_PRODUCTION = new FeaturesImage(
-        Collections.emptyMap(),
-        MetadataVersion.LATEST_PRODUCTION,
-        ZkMigrationState.NONE
-    );
-
     private final Map<String, Short> finalizedVersions;
 
     private final MetadataVersion metadataVersion;


### PR DESCRIPTION

We only want to send directory assignments if the metadata version supports it.