### PR TITLE
MINOR: populate TopicName in ConsumerGroupDescribe

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -483,7 +483,11 @@ public class GroupMetadataManager {
         final List<ConsumerGroupDescribeResponseData.DescribedGroup> describedGroups = new ArrayList<>();
         groupIds.forEach(groupId -> {
             try {
-                describedGroups.add(consumerGroup(groupId, committedOffset).asDescribedGroup(committedOffset, defaultAssignor.name()));
+                describedGroups.add(consumerGroup(groupId, committedOffset).asDescribedGroup(
+                    committedOffset,
+                    defaultAssignor.name(),
+                    metadataImage.topics()
+                ));
             } catch (GroupIdNotFoundException exception) {
                 describedGroups.add(new ConsumerGroupDescribeResponseData.DescribedGroup()
                     .setGroupId(groupId)

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -953,7 +953,11 @@ public class ConsumerGroup implements Group {
         return value == null ? 1 : value + 1;
     }
 
-    public ConsumerGroupDescribeResponseData.DescribedGroup asDescribedGroup(long committedOffset, String defaultAssignor) {
+    public ConsumerGroupDescribeResponseData.DescribedGroup asDescribedGroup(
+        long committedOffset,
+        String defaultAssignor,
+        TopicsImage topicsImage
+    ) {
         ConsumerGroupDescribeResponseData.DescribedGroup describedGroup = new ConsumerGroupDescribeResponseData.DescribedGroup()
             .setGroupId(groupId)
             .setAssignorName(preferredServerAssignor(committedOffset).orElse(defaultAssignor))
@@ -964,7 +968,7 @@ public class ConsumerGroup implements Group {
             entry -> describedGroup.members().add(
                 entry.getValue().asConsumerGroupDescribeMember(
                     targetAssignment.get(entry.getValue().memberId(), committedOffset),
-                    subscriptionMetadata()
+                    topicsImage
                 )
             )
         );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -962,7 +962,10 @@ public class ConsumerGroup implements Group {
             .setAssignmentEpoch(targetAssignmentEpoch.get(committedOffset));
         members.entrySet(committedOffset).forEach(
             entry -> describedGroup.members().add(
-                entry.getValue().asConsumerGroupDescribeMember(targetAssignment.get(entry.getValue().memberId(), committedOffset))
+                entry.getValue().asConsumerGroupDescribeMember(
+                    targetAssignment.get(entry.getValue().memberId(), committedOffset),
+                    subscriptionMetadata()
+                )
             )
         );
         return describedGroup;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
@@ -562,7 +562,7 @@ public class ConsumerGroupMember {
             .setMemberEpoch(memberEpoch)
             .setMemberId(memberId)
             .setAssignment(new ConsumerGroupDescribeResponseData.Assignment()
-            .setTopicPartitions(topicPartitionsFromMap(assignedPartitions, topicsImage)))
+                .setTopicPartitions(topicPartitionsFromMap(assignedPartitions, topicsImage)))
             .setTargetAssignment(new ConsumerGroupDescribeResponseData.Assignment()
                 .setTopicPartitions(topicPartitionsFromMap(
                     targetAssignment != null ? targetAssignment.partitions() : Collections.emptyMap(),
@@ -584,7 +584,6 @@ public class ConsumerGroupMember {
         for (Map.Entry<Uuid, Set<Integer>> entry : partitions.entrySet()) {
             Uuid topicId = entry.getKey();
             Set<Integer> partitionSet = partitions.get(topicId);
-//        partitions.forEach((topicId, partitionSet) -> {
             String topicName = lookupTopicNameById(topicId, topicsImage);
             if (topicName != null) {
                 topicPartitions.add(new ConsumerGroupDescribeResponseData.TopicPartitions()

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMember.java
@@ -581,21 +581,15 @@ public class ConsumerGroupMember {
         TopicsImage topicsImage
     ) {
         List<ConsumerGroupDescribeResponseData.TopicPartitions> topicPartitions = new ArrayList<>();
-        for (Map.Entry<Uuid, Set<Integer>> entry : partitions.entrySet()) {
-            Uuid topicId = entry.getKey();
-            Set<Integer> partitionSet = partitions.get(topicId);
+        partitions.forEach((topicId, partitionSet) -> {
             String topicName = lookupTopicNameById(topicId, topicsImage);
             if (topicName != null) {
                 topicPartitions.add(new ConsumerGroupDescribeResponseData.TopicPartitions()
                     .setTopicId(topicId)
                     .setTopicName(topicName)
                     .setPartitions(new ArrayList<>(partitionSet)));
-            } else {
-                // When the topic has been deleted and the group/member hasn't updated,
-                // directly remove the topic from the assignment.
-                partitions.remove(topicId, partitionSet);
             }
-        }
+        });
         return topicPartitions;
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMemberTest.java
@@ -17,10 +17,11 @@
 package org.apache.kafka.coordinator.group.consumer;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.errors.UnknownTopicIdException;
 import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
+import org.apache.kafka.coordinator.group.GroupMetadataManagerTest;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
+import org.apache.kafka.image.MetadataImage;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
@@ -39,8 +40,6 @@ import java.util.stream.Collectors;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 public class ConsumerGroupMemberTest {
 
     @Test
@@ -321,6 +320,12 @@ public class ConsumerGroupMemberTest {
         Uuid topicId2 = Uuid.randomUuid();
         Uuid topicId3 = Uuid.randomUuid();
         Uuid topicId4 = Uuid.randomUuid();
+        MetadataImage metadataImage = new GroupMetadataManagerTest.MetadataImageBuilder()
+            .addTopic(topicId1, "topic1", 3)
+            .addTopic(topicId2, "topic2", 3)
+            .addTopic(topicId3, "topic3", 3)
+            .addTopic(topicId4, "topic4", 3)
+            .build();
         List<Integer> assignedPartitions = Arrays.asList(0, 1, 2);
         int epoch = 10;
         ConsumerGroupCurrentMemberAssignmentValue record = new ConsumerGroupCurrentMemberAssignmentValue()
@@ -356,10 +361,7 @@ public class ConsumerGroupMemberTest {
             .setSubscribedTopicRegex(subscribedTopicRegex)
             .build();
 
-        Map<String, TopicMetadata> subscriptionMetadata = new HashMap<>();
-        subscriptionMetadata.put("topic1", new TopicMetadata(topicId1, "topic1", 1, new HashMap<>()));
-        subscriptionMetadata.put("topic4", new TopicMetadata(topicId4, "topic4", 1, new HashMap<>()));
-        ConsumerGroupDescribeResponseData.Member actual = member.asConsumerGroupDescribeMember(targetAssignment, subscriptionMetadata);
+        ConsumerGroupDescribeResponseData.Member actual = member.asConsumerGroupDescribeMember(targetAssignment, metadataImage.topics());
         ConsumerGroupDescribeResponseData.Member expected = new ConsumerGroupDescribeResponseData.Member()
             .setMemberId(memberId)
             .setMemberEpoch(epoch)
@@ -395,23 +397,32 @@ public class ConsumerGroupMemberTest {
         ConsumerGroupMember member = new ConsumerGroupMember.Builder(Uuid.randomUuid().toString())
             .build();
 
-        ConsumerGroupDescribeResponseData.Member consumerGroupDescribeMember = member.asConsumerGroupDescribeMember(null, new HashMap<>());
+        ConsumerGroupDescribeResponseData.Member consumerGroupDescribeMember = member.asConsumerGroupDescribeMember(
+            null, new GroupMetadataManagerTest.MetadataImageBuilder().build().topics());
 
         assertEquals(new ConsumerGroupDescribeResponseData.Assignment(), consumerGroupDescribeMember.targetAssignment());
     }
 
     @Test
     public void testAsConsumerGroupDescribeWithTopicNameNotFound() {
+        Uuid memberId = Uuid.randomUuid();
         ConsumerGroupCurrentMemberAssignmentValue record = new ConsumerGroupCurrentMemberAssignmentValue()
             .setAssignedPartitions(Collections.singletonList(new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
                 .setTopicId(Uuid.randomUuid())
                 .setPartitions(Arrays.asList(0, 1, 2))));
-        ConsumerGroupMember member = new ConsumerGroupMember.Builder(Uuid.randomUuid().toString())
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder(memberId.toString())
             .updateWith(record)
             .build();
 
-        Map<String, TopicMetadata> subscriptionMetadata = new HashMap<>();
-        subscriptionMetadata.put("foo", new TopicMetadata(Uuid.randomUuid(), "foo", 1, new HashMap<>()));
-        assertThrows(UnknownTopicIdException.class, () -> member.asConsumerGroupDescribeMember(null, subscriptionMetadata));
+        ConsumerGroupDescribeResponseData.Member expected = new ConsumerGroupDescribeResponseData.Member()
+            .setMemberId(memberId.toString())
+            .setSubscribedTopicRegex("");
+        ConsumerGroupDescribeResponseData.Member actual = member.asConsumerGroupDescribeMember(null,
+            new GroupMetadataManagerTest.MetadataImageBuilder()
+                .addTopic(Uuid.randomUuid(), "foo", 3)
+                .build().topics()
+        );
+        assertEquals(expected, actual);
+        assertEquals(Collections.emptyMap(), member.assignedPartitions());
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMemberTest.java
@@ -423,6 +423,5 @@ public class ConsumerGroupMemberTest {
                 .build().topics()
         );
         assertEquals(expected, actual);
-        assertEquals(Collections.emptyMap(), member.assignedPartitions());
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
@@ -872,7 +872,8 @@ public class ConsumerGroupTest {
                 new ConsumerGroupDescribeResponseData.Member().setMemberId("member2")
                     .setSubscribedTopicRegex("")
             ));
-        ConsumerGroupDescribeResponseData.DescribedGroup actual = group.asDescribedGroup(1, "");
+        ConsumerGroupDescribeResponseData.DescribedGroup actual = group.asDescribedGroup(1, "",
+            new GroupMetadataManagerTest.MetadataImageBuilder().build().topics());
 
         assertEquals(expected, actual);
     }


### PR DESCRIPTION
The patch populates the topic name of `ConsumerGroupDescribeResponseData.TopicPartitions` with the corresponding topic id in `ConsumerGroupDescribe`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
