### PR TITLE
KAFKA-16137: Add missing RPC field descriptions

### DIFF
--- a/clients/src/main/resources/common/message/ListClientMetricsResourcesResponse.json
+++ b/clients/src/main/resources/common/message/ListClientMetricsResourcesResponse.json
@@ -22,9 +22,12 @@
   "fields": [
       { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
         "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
-      { "name": "ErrorCode", "type": "int16", "versions": "0+" },
-      { "name": "ClientMetricsResources", "type": "[]ClientMetricsResource", "versions": "0+", "fields": [
-        { "name": "Name", "type": "string", "versions": "0+" }
+      { "name": "ErrorCode", "type": "int16", "versions": "0+",
+        "about": "The error code, or 0 if there was no error." },
+      { "name": "ClientMetricsResources", "type": "[]ClientMetricsResource", "versions": "0+",
+        "about": "Each client metrics resource in the response.", "fields": [
+        { "name": "Name", "type": "string", "versions": "0+",
+          "about": "The resource name." }
     ]}
   ]
 }


### PR DESCRIPTION
The `ListClientMetricsResourcesResponse` definition is missing several `"about"` descriptions. The main effect of this is that the Kafka protocol documentation misses the descriptions of these fields which are blank.