### PR TITLE
MINOR: Fix compilation issue in ReplicaManagerTest

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -6175,7 +6175,7 @@ class ReplicaManagerTest {
   private def imageFromTopics(topicsImage: TopicsImage): MetadataImage = {
     val featuresImageLatest = new FeaturesImage(
       Collections.emptyMap(),
-      MetadataVersion.latest(),
+      MetadataVersion.latestProduction(),
       ZkMigrationState.NONE)
     new MetadataImage(
       new MetadataProvenance(100L, 10, 1000L),


### PR DESCRIPTION
Fixes the compilation issue on trunk:
```
> Task :core:compileTestScala
[Error] /Users/mickael/github/kafka/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala:6178:23: value latest is not a member of object org.apache.kafka.server.common.MetadataVersion
one error found

> Task :core:compileTestScala FAILED
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
