### PR TITLE
KAFKA-15712: Added KRaft support to MultipleListenersWithSameSecurityProtocolBaseTest

### DIFF
--- a/core/src/test/scala/integration/kafka/server/MultipleListenersWithSameSecurityProtocolBaseTest.scala
+++ b/core/src/test/scala/integration/kafka/server/MultipleListenersWithSameSecurityProtocolBaseTest.scala
@@ -41,10 +41,11 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 import java.util
+import scala.collection._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.Seq
-import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.jdk.CollectionConverters._
 
 object MultipleListenersWithSameSecurityProtocolBaseTest {
   val SecureInternal = "SECURE_INTERNAL"


### PR DESCRIPTION
### What
* Added support for KRaft mode in MultipleListenersWithSameSecurityProtocolBaseTest.

### Why
* MultipleListenersWithSameSecurityProtocolBaseTest currently only supports zk mode.
* To add support for KRaft mode, new advertised listener configs and additional mechanism to create topics was needed, which is addressed in the PR.

### Testing
* Ran affected unit tests
```
➜  ak git:(smjn-KAFKA-15712) ./gradlew :core:test --tests kafka.server.MultipleListenersWithDefaultJaasContextTest                                                                      
> Configure project :
Starting build with version 3.8.0-SNAPSHOT (commit id 3c4da20e) using Gradle 8.5, Java 17 and Scala 2.13.12
Build properties: maxParallelForks=10, maxScalacThreads=8, maxTestRetries=0

> Task :core:test

Gradle Test Run :core:test > Gradle Test Executor 9 > MultipleListenersWithDefaultJaasContextTest > testProduceConsume(String) > testProduceConsume(String).quorum=zk PASSED

Gradle Test Run :core:test > Gradle Test Executor 9 > MultipleListenersWithDefaultJaasContextTest > testProduceConsume(String) > testProduceConsume(String).quorum=kraft PASSED
...

BUILD SUCCESSFUL in 38s
```

```
➜  ak git:(smjn-KAFKA-15712) ./gradlew :core:test --tests kafka.server.MultipleListenersWithAdditionalJaasContextTest                                                                                 

> Configure project :
Starting build with version 3.8.0-SNAPSHOT (commit id 3c4da20e) using Gradle 8.5, Java 17 and Scala 2.13.12
Build properties: maxParallelForks=10, maxScalacThreads=8, maxTestRetries=0

> Task :core:test

Gradle Test Run :core:test > Gradle Test Executor 10 > MultipleListenersWithAdditionalJaasContextTest > testProduceConsume(String) > testProduceConsume(String).quorum=zk PASSED

Gradle Test Run :core:test > Gradle Test Executor 10 > MultipleListenersWithAdditionalJaasContextTest > testProduceConsume(String) > testProduceConsume(String).quorum=kraft PASSED
...

BUILD SUCCESSFUL in 36s
59 actionable tasks: 1 executed, 58 up-to-date
```
* clean build
```
➜  ak git:(smjn-KAFKA-15712) ./gradlew clean jar                                                                                                                                                       [15:17:10]

> Configure project :
Starting build with version 3.8.0-SNAPSHOT (commit id 3c4da20e) using Gradle 8.5, Java 17 and Scala 2.13.12
Build properties: maxParallelForks=10, maxScalacThreads=8, maxTestRetries=0

> Task :core:compileScala
[Warn] /Users/smahajan/.gradle/workers/warning:[options] bootstrap class path not set in conjunction with -source 8
/Users/smahajan/ws/ak/core/src/main/java/kafka/log/remote/RemoteLogManager.java:235:  [removal] AccessController in java.security has been deprecated and marked for removal
[Warn] /Users/smahajan/ws/ak/core/src/main/java/kafka/log/remote/RemoteLogManager.java:257:  [removal] AccessController in java.security has been deprecated and marked for removal

> Task :core:compileTestScala
Unexpected javac output: warning: [options] bootstrap class path not set in conjunction with -source 8
Note: /Users/smahajan/ws/ak/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 warning.

...

BUILD SUCCESSFUL in 1m 32s
199 actionable tasks: 190 executed, 9 up-to-date
```