### PR TITLE
KAFKA-16164: Pre-Vote, modifying vote RPCs [part 1]

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/VoteRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/VoteRequest.java
@@ -70,22 +70,22 @@ public class VoteRequest extends AbstractRequest {
     }
 
     public static VoteRequestData singletonRequest(TopicPartition topicPartition,
-                                                   int candidateEpoch,
-                                                   int candidateId,
+                                                   int replicaEpoch,
+                                                   int replicaId,
                                                    int lastEpoch,
                                                    long lastEpochEndOffset) {
         return singletonRequest(topicPartition,
             null,
-            candidateEpoch,
-            candidateId,
+            replicaEpoch,
+            replicaId,
             lastEpoch,
             lastEpochEndOffset);
     }
 
     public static VoteRequestData singletonRequest(TopicPartition topicPartition,
                                                    String clusterId,
-                                                   int candidateEpoch,
-                                                   int candidateId,
+                                                   int replicaEpoch,
+                                                   int replicaId,
                                                    int lastEpoch,
                                                    long lastEpochEndOffset) {
         return new VoteRequestData()
@@ -96,8 +96,8 @@ public class VoteRequest extends AbstractRequest {
                            .setPartitions(Collections.singletonList(
                                new VoteRequestData.PartitionData()
                                    .setPartitionIndex(topicPartition.partition())
-                                   .setCandidateEpoch(candidateEpoch)
-                                   .setCandidateId(candidateId)
+                                   .setReplicaEpoch(replicaEpoch)
+                                   .setReplicaId(replicaId)
                                    .setLastOffsetEpoch(lastEpoch)
                                    .setLastOffset(lastEpochEndOffset))
                            )));

--- a/clients/src/main/java/org/apache/kafka/common/requests/VoteResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/VoteResponse.java
@@ -54,7 +54,8 @@ public class VoteResponse extends AbstractResponse {
                                                      Errors partitionLevelError,
                                                      int leaderEpoch,
                                                      int leaderId,
-                                                     boolean voteGranted) {
+                                                     boolean voteGranted,
+                                                     boolean preVote) {
         return new VoteResponseData()
             .setErrorCode(topLevelError.code())
             .setTopics(Collections.singletonList(
@@ -65,7 +66,8 @@ public class VoteResponse extends AbstractResponse {
                             .setErrorCode(partitionLevelError.code())
                             .setLeaderId(leaderId)
                             .setLeaderEpoch(leaderEpoch)
-                            .setVoteGranted(voteGranted)))));
+                            .setVoteGranted(voteGranted)
+                            .setPreVote(preVote)))));
     }
 
     @Override

--- a/clients/src/main/resources/common/message/VoteRequest.json
+++ b/clients/src/main/resources/common/message/VoteRequest.json
@@ -18,6 +18,7 @@
   "type": "request",
   "listeners": ["controller"],
   "name": "VoteRequest",
+  // Version 1 adds the PreVote field and renames CandidateEpoch and CandidateId to ReplicaEpoch and ReplicaId
   "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [

--- a/clients/src/main/resources/common/message/VoteRequest.json
+++ b/clients/src/main/resources/common/message/VoteRequest.json
@@ -18,7 +18,7 @@
   "type": "request",
   "listeners": ["controller"],
   "name": "VoteRequest",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "ClusterId", "type": "string", "versions": "0+",
@@ -31,14 +31,16 @@
         "versions": "0+", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },
-        { "name": "CandidateEpoch", "type": "int32", "versions": "0+",
-          "about": "The bumped epoch of the candidate sending the request"},
-        { "name": "CandidateId", "type": "int32", "versions": "0+", "entityType": "brokerId",
-          "about": "The ID of the voter sending the request"},
+        { "name": "ReplicaEpoch", "type": "int32", "versions": "0+",
+          "about": "The bumped epoch of the replica sending the request"},
+        { "name": "ReplicaId", "type": "int32", "versions": "0+", "entityType": "brokerId",
+          "about": "The ID of the replica sending the request"},
         { "name": "LastOffsetEpoch", "type": "int32", "versions": "0+",
           "about": "The epoch of the last record written to the metadata log"},
         { "name": "LastOffset", "type": "int64", "versions": "0+",
-          "about": "The offset of the last record written to the metadata log"}
+          "about": "The offset of the last record written to the metadata log"},
+        { "name": "PreVote", "type": "bool", "versions": "1+",
+          "about": "Whether the request is a PreVote request (no epoch increase) or not."}
       ]
       }
     ]

--- a/clients/src/main/resources/common/message/VoteResponse.json
+++ b/clients/src/main/resources/common/message/VoteResponse.json
@@ -17,7 +17,7 @@
   "apiKey": 52,
   "type": "response",
   "name": "VoteResponse",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
@@ -36,7 +36,9 @@
         { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
           "about": "The latest known leader epoch"},
         { "name": "VoteGranted", "type": "bool", "versions": "0+",
-          "about": "True if the vote was granted and false otherwise"}
+          "about": "True if the vote was granted and false otherwise"},
+        { "name": "PreVote", "type": "bool", "versions": "1+",
+          "about": "Whether the response is a PreVote response or not."}
       ]
       }
     ]

--- a/clients/src/main/resources/common/message/VoteResponse.json
+++ b/clients/src/main/resources/common/message/VoteResponse.json
@@ -17,6 +17,7 @@
   "apiKey": 52,
   "type": "response",
   "name": "VoteResponse",
+  // Version 1 adds the PreVote field
   "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1443,8 +1443,8 @@ public class RequestResponseTest {
                 .setTopics(singletonList(new VoteRequestData.TopicData()
                         .setPartitions(singletonList(new VoteRequestData.PartitionData()
                                 .setPartitionIndex(0)
-                                .setCandidateEpoch(1)
-                                .setCandidateId(2)
+                                .setReplicaEpoch(1)
+                                .setReplicaId(2)
                                 .setLastOffset(3L)
                                 .setLastOffsetEpoch(4)))
                         .setTopicName("topic1")));

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1135,7 +1135,7 @@ public class RequestResponseTest {
             case ALTER_CLIENT_QUOTAS: return createAlterClientQuotasResponse();
             case DESCRIBE_USER_SCRAM_CREDENTIALS: return createDescribeUserScramCredentialsResponse();
             case ALTER_USER_SCRAM_CREDENTIALS: return createAlterUserScramCredentialsResponse();
-            case VOTE: return createVoteResponse();
+            case VOTE: return createVoteResponse(version);
             case BEGIN_QUORUM_EPOCH: return createBeginQuorumEpochResponse();
             case END_QUORUM_EPOCH: return createEndQuorumEpochResponse();
             case DESCRIBE_QUORUM: return createDescribeQuorumResponse();
@@ -1438,29 +1438,39 @@ public class RequestResponseTest {
     }
 
     private VoteRequest createVoteRequest(short version) {
+        VoteRequestData.PartitionData partitionData = new VoteRequestData.PartitionData()
+            .setPartitionIndex(0)
+            .setReplicaEpoch(1)
+            .setReplicaId(2)
+            .setLastOffset(3L)
+            .setLastOffsetEpoch(4);
+        if (version >= 1) {
+            // v1 and above contains PreVote field
+            partitionData.setPreVote(true);
+        }
         VoteRequestData data = new VoteRequestData()
                 .setClusterId("clusterId")
                 .setTopics(singletonList(new VoteRequestData.TopicData()
-                        .setPartitions(singletonList(new VoteRequestData.PartitionData()
-                                .setPartitionIndex(0)
-                                .setReplicaEpoch(1)
-                                .setReplicaId(2)
-                                .setLastOffset(3L)
-                                .setLastOffsetEpoch(4)))
+                        .setPartitions(singletonList(partitionData))
                         .setTopicName("topic1")));
         return new VoteRequest.Builder(data).build(version);
     }
 
-    private VoteResponse createVoteResponse() {
+    private VoteResponse createVoteResponse(short version) {
+        VoteResponseData.PartitionData partitionData = new VoteResponseData.PartitionData()
+            .setErrorCode(Errors.NONE.code())
+            .setLeaderEpoch(0)
+            .setPartitionIndex(1)
+            .setLeaderId(2)
+            .setVoteGranted(false);
+        if (version >= 1) {
+            // v1 and above contains PreVote field
+            partitionData.setPreVote(true);
+        }
         VoteResponseData data = new VoteResponseData()
                 .setErrorCode(Errors.NONE.code())
                 .setTopics(singletonList(new VoteResponseData.TopicData()
-                        .setPartitions(singletonList(new VoteResponseData.PartitionData()
-                                .setErrorCode(Errors.NONE.code())
-                                .setLeaderEpoch(0)
-                                .setPartitionIndex(1)
-                                .setLeaderId(2)
-                                .setVoteGranted(false)))));
+                        .setPartitions(singletonList(partitionData))));
         return new VoteResponse(data);
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaNetworkChannelTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaNetworkChannelTest.java
@@ -286,7 +286,7 @@ public class KafkaNetworkChannelTest {
             case END_QUORUM_EPOCH:
                 return new EndQuorumEpochResponseData().setErrorCode(error.code());
             case VOTE:
-                return VoteResponse.singletonResponse(error, topicPartition, Errors.NONE, 1, 5, false);
+                return VoteResponse.singletonResponse(error, topicPartition, Errors.NONE, 1, 5, false, false);
             case FETCH:
                 return new FetchResponseData().setErrorCode(error.code());
             default:

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -670,7 +670,7 @@ public class KafkaRaftClientTest {
         context.assertVotedCandidate(1, localId);
 
         int correlationId = context.assertSentVoteRequest(1, 0, 0L, 1);
-        context.deliverResponse(correlationId, otherNodeId, context.voteResponse(true, Optional.empty(), 1));
+        context.deliverResponse(correlationId, otherNodeId, context.standardVoteResponse(true, Optional.empty(), 1));
 
         // Become leader after receiving the vote
         context.pollUntil(() -> context.log.endOffset().offset == 1L);
@@ -710,7 +710,7 @@ public class KafkaRaftClientTest {
         context.assertVotedCandidate(1, localId);
 
         int correlationId = context.assertSentVoteRequest(1, 0, 0L, 2);
-        context.deliverResponse(correlationId, firstNodeId, context.voteResponse(true, Optional.empty(), 1));
+        context.deliverResponse(correlationId, firstNodeId, context.standardVoteResponse(true, Optional.empty(), 1));
 
         // Become leader after receiving the vote
         context.pollUntil(() -> context.log.endOffset().offset == 1L);
@@ -1099,12 +1099,12 @@ public class KafkaRaftClientTest {
         int retryCorrelationId = context.assertSentVoteRequest(epoch, 0, 0L, 1);
 
         // We will ignore the timed out response if it arrives late
-        context.deliverResponse(correlationId, otherNodeId, context.voteResponse(true, Optional.empty(), 1));
+        context.deliverResponse(correlationId, otherNodeId, context.standardVoteResponse(true, Optional.empty(), 1));
         context.client.poll();
         context.assertVotedCandidate(epoch, localId);
 
         // Become leader after receiving the retry response
-        context.deliverResponse(retryCorrelationId, otherNodeId, context.voteResponse(true, Optional.empty(), 1));
+        context.deliverResponse(retryCorrelationId, otherNodeId, context.standardVoteResponse(true, Optional.empty(), 1));
         context.client.poll();
         context.assertElectedLeader(epoch, localId);
     }
@@ -1329,7 +1329,7 @@ public class KafkaRaftClientTest {
 
         // Quorum size is two. If the other member rejects, then we need to schedule a revote.
         int correlationId = context.assertSentVoteRequest(epoch, 0, 0L, 1);
-        context.deliverResponse(correlationId, otherNodeId, context.voteResponse(false, Optional.empty(), 1));
+        context.deliverResponse(correlationId, otherNodeId, context.standardVoteResponse(false, Optional.empty(), 1));
 
         context.client.poll();
 
@@ -1904,10 +1904,10 @@ public class KafkaRaftClientTest {
         context.assertElectedLeader(epoch, voter3);
 
         // The vote requests now return and should be ignored
-        VoteResponseData voteResponse1 = context.voteResponse(false, Optional.empty(), epoch);
+        VoteResponseData voteResponse1 = context.standardVoteResponse(false, Optional.empty(), epoch);
         context.deliverResponse(voteRequests.get(0).correlationId, voter2, voteResponse1);
 
-        VoteResponseData voteResponse2 = context.voteResponse(false, Optional.of(voter3), epoch);
+        VoteResponseData voteResponse2 = context.standardVoteResponse(false, Optional.of(voter3), epoch);
         context.deliverResponse(voteRequests.get(1).correlationId, voter3, voteResponse2);
 
         context.client.poll();

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -394,7 +394,7 @@ public final class RaftClientTestContext {
             log.lastFetchedEpoch(), log.endOffset().offset);
 
         for (RaftRequest.Outbound request : voteRequests) {
-            VoteResponseData voteResponse = voteResponse(true, Optional.empty(), epoch);
+            VoteResponseData voteResponse = standardVoteResponse(true, Optional.empty(), epoch);
             deliverResponse(request.correlationId, request.destinationId(), voteResponse);
         }
 
@@ -530,8 +530,8 @@ public final class RaftClientTestContext {
                 VoteRequestData request = (VoteRequestData) raftMessage.data();
                 VoteRequestData.PartitionData partitionRequest = unwrap(request);
 
-                assertEquals(epoch, partitionRequest.candidateEpoch());
-                assertEquals(localIdOrThrow(), partitionRequest.candidateId());
+                assertEquals(epoch, partitionRequest.replicaEpoch());
+                assertEquals(localIdOrThrow(), partitionRequest.replicaId());
                 assertEquals(lastEpoch, partitionRequest.lastOffsetEpoch());
                 assertEquals(lastEpochOffset, partitionRequest.lastOffset());
                 voteRequests.add((RaftRequest.Outbound) raftMessage);
@@ -914,14 +914,15 @@ public final class RaftClientTestContext {
         );
     }
 
-    VoteResponseData voteResponse(boolean voteGranted, Optional<Integer> leaderId, int epoch) {
+    VoteResponseData standardVoteResponse(boolean voteGranted, Optional<Integer> leaderId, int epoch) {
         return VoteResponse.singletonResponse(
             Errors.NONE,
             metadataPartition,
             Errors.NONE,
             epoch,
             leaderId.orElse(-1),
-            voteGranted
+            voteGranted,
+            false
         );
     }
 


### PR DESCRIPTION
Modifying vote RPCs according to https://cwiki.apache.org/confluence/display/KAFKA/KIP-996%3A+Pre-Vote
- new PreVote field
- renaming fields to refer to "replica" vs "candidate" since Prospective will start to use vote RPCs 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
