### PR TITLE
streams-scala: remove collections-compat dependency when on Scala 2.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2315,6 +2315,11 @@ project(':streams:streams-scala') {
 
     api libs.scalaLibrary
     if ( versions.baseScala == '2.12' ) {
+      // Scala-Collection-Compat isn't required when compiling with Scala 2.13 or later,
+      // and having it in the dependencies could lead to classpath conflicts in Scala 3
+      // projects that use kafka-streams-kafka_2.13 (because we don't have a Scala 3 version yet)
+      // but also pull in scala-collection-compat_3 via another dependency.
+      // So we make sure to not include it in the dependencies.
       api libs.scalaCollectionCompat
     }
     testImplementation project(':core')

--- a/build.gradle
+++ b/build.gradle
@@ -2314,8 +2314,9 @@ project(':streams:streams-scala') {
     api project(':streams')
 
     api libs.scalaLibrary
-    api libs.scalaCollectionCompat
-
+    if ( versions.baseScala == '2.12' ) {
+      api libs.scalaCollectionCompat
+    }
     testImplementation project(':core')
     testImplementation project(':core').sourceSets.test.output
     testImplementation project(':server-common').sourceSets.test.output


### PR DESCRIPTION
Hey there,

The motivation for this PR is that we're trying to migrate our codebase to Scala 3. Since Scala 3 is able to consume Scala 2.13 libraries, we can use the Scala 2.13 version of kafka-streams-scala, but that pulls in the scala-collections-compat_2.13 library as a dependency. Another one of our dependencies pulls in scala-collections-compat_3, and you can't have both on the classpath at the same time. Luckily this library is actually not required at all when compiling with Scala 2.13, so that dependency should just be removed. 