### PR TITLE
KAFKA-15931: Reopen TransactionIndex if channel is closed

### DIFF
--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -947,26 +947,22 @@ class RemoteIndexCacheTest {
   }
 
   @Test
-  def testCheckTxnIndexIsEmpty(): Unit = {
+  def testReopenClosedTxnIndex(): Unit = {
     val tpId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 0))
     val metadataList = generateRemoteLogSegmentMetadata(size = 1, tpId)
 
+    assertCacheSize(0)
     // getIndex for first time will call rsm#fetchIndex
     val cacheEntry = cache.getIndexEntry(metadataList.head)
-    assertFalse(cacheEntry.hasTxnIndex)
-  }
-
-  @Test
-  def testReopenClosedTxnIndex(): Unit = {
-    val cacheEntry = generateSpyCacheEntry()
-    assertTrue(cacheEntry.hasTxnIndex)
-    cacheEntry.completeAbortedTxnsSearch(0L, 1L, _ => {})
+    assertCacheSize(1)
+    assertTrue(getIndexFileFromRemoteCacheDir(cache, LogFileUtils.INDEX_FILE_SUFFIX).isPresent)
+    assertTrue(getIndexFileFromRemoteCacheDir(cache, LogFileUtils.TXN_INDEX_FILE_SUFFIX).isPresent)
+    assertTrue(getIndexFileFromRemoteCacheDir(cache, LogFileUtils.TIME_INDEX_FILE_SUFFIX).isPresent)
 
     // Close cached transaction index
     cacheEntry.txnIndex.close()
 
-    // Index is reopened if accessed again, as when searching for aborted txns
-    cacheEntry.completeAbortedTxnsSearch(0L, 1L, _ => {})
+    // Reopen cached transaction index
     assertFalse(cacheEntry.txnIndex.isClosed)
   }
 

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -947,22 +947,26 @@ class RemoteIndexCacheTest {
   }
 
   @Test
-  def testReopenClosedTxnIndex(): Unit = {
+  def testCheckTxnIndexIsEmpty(): Unit = {
     val tpId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 0))
     val metadataList = generateRemoteLogSegmentMetadata(size = 1, tpId)
 
-    assertCacheSize(0)
     // getIndex for first time will call rsm#fetchIndex
     val cacheEntry = cache.getIndexEntry(metadataList.head)
-    assertCacheSize(1)
-    assertTrue(getIndexFileFromRemoteCacheDir(cache, LogFileUtils.INDEX_FILE_SUFFIX).isPresent)
-    assertTrue(getIndexFileFromRemoteCacheDir(cache, LogFileUtils.TXN_INDEX_FILE_SUFFIX).isPresent)
-    assertTrue(getIndexFileFromRemoteCacheDir(cache, LogFileUtils.TIME_INDEX_FILE_SUFFIX).isPresent)
+    assertFalse(cacheEntry.hasTxnIndex)
+  }
+
+  @Test
+  def testReopenClosedTxnIndex(): Unit = {
+    val cacheEntry = generateSpyCacheEntry()
+    assertTrue(cacheEntry.hasTxnIndex)
+    cacheEntry.completeAbortedTxnsSearch(0L, 1L, _ => {})
 
     // Close cached transaction index
     cacheEntry.txnIndex.close()
 
-    // Reopen cached transaction index
+    // Index is reopened if accessed again, as when searching for aborted txns
+    cacheEntry.completeAbortedTxnsSearch(0L, 1L, _ => {})
     assertFalse(cacheEntry.txnIndex.isClosed)
   }
 

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -947,26 +947,6 @@ class RemoteIndexCacheTest {
   }
 
   @Test
-  def testReopenClosedTxnIndex(): Unit = {
-    val tpId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 0))
-    val metadataList = generateRemoteLogSegmentMetadata(size = 1, tpId)
-
-    assertCacheSize(0)
-    // getIndex for first time will call rsm#fetchIndex
-    val cacheEntry = cache.getIndexEntry(metadataList.head)
-    assertCacheSize(1)
-    assertTrue(getIndexFileFromRemoteCacheDir(cache, LogFileUtils.INDEX_FILE_SUFFIX).isPresent)
-    assertTrue(getIndexFileFromRemoteCacheDir(cache, LogFileUtils.TXN_INDEX_FILE_SUFFIX).isPresent)
-    assertTrue(getIndexFileFromRemoteCacheDir(cache, LogFileUtils.TIME_INDEX_FILE_SUFFIX).isPresent)
-
-    // Close cached transaction index
-    cacheEntry.txnIndex.close()
-
-    // Reopen cached transaction index
-    assertFalse(cacheEntry.txnIndex.isClosed)
-  }
-
-  @Test
   def testDeleteInvalidIndexFilesOnInit(): Unit = {
     val cacheDir = new File(logDir, RemoteIndexCache.DIR_NAME)
     val baseOffset: Long = 100L

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -947,6 +947,26 @@ class RemoteIndexCacheTest {
   }
 
   @Test
+  def testReopenClosedTxnIndex(): Unit = {
+    val tpId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 0))
+    val metadataList = generateRemoteLogSegmentMetadata(size = 1, tpId)
+
+    assertCacheSize(0)
+    // getIndex for first time will call rsm#fetchIndex
+    val cacheEntry = cache.getIndexEntry(metadataList.head)
+    assertCacheSize(1)
+    assertTrue(getIndexFileFromRemoteCacheDir(cache, LogFileUtils.INDEX_FILE_SUFFIX).isPresent)
+    assertTrue(getIndexFileFromRemoteCacheDir(cache, LogFileUtils.TXN_INDEX_FILE_SUFFIX).isPresent)
+    assertTrue(getIndexFileFromRemoteCacheDir(cache, LogFileUtils.TIME_INDEX_FILE_SUFFIX).isPresent)
+
+    // Close cached transaction index
+    cacheEntry.txnIndex.close()
+
+    // Reopen cached transaction index
+    assertFalse(cacheEntry.txnIndex.isClosed)
+  }
+
+  @Test
   def testDeleteInvalidIndexFilesOnInit(): Unit = {
     val cacheDir = new File(logDir, RemoteIndexCache.DIR_NAME)
     val baseOffset: Long = 100L

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -492,7 +492,7 @@ public class RemoteIndexCache implements Closeable {
 
         private final OffsetIndex offsetIndex;
         private final TimeIndex timeIndex;
-        private final TransactionIndex txnIndex;
+        private TransactionIndex txnIndex;
 
         // This lock is used to synchronize cleanup methods and read methods. This ensures that cleanup (which changes the
         // underlying files of the index) isn't performed while a read is in-progress for the entry. This is required in
@@ -525,6 +525,18 @@ public class RemoteIndexCache implements Closeable {
 
         // Visible for testing
         public TransactionIndex txnIndex() {
+            if (txnIndex.isClosed()) {
+                // Reopen txn index if closed
+                final File txnIndexFile = txnIndex.file();
+                try {
+                    final String indexFileName = txnIndexFile.getName();
+                    final long offset = offsetFromRemoteIndexFileName(indexFileName);
+                    txnIndex = new TransactionIndex(offset, txnIndexFile);
+                    txnIndex.sanityCheck();
+                } catch (IOException e) {
+                    throw new KafkaException("Failed to reopen transaction index " + txnIndexFile, e);
+                }
+            }
             return txnIndex;
         }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -53,7 +53,6 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -524,7 +523,7 @@ public class RemoteIndexCache implements Closeable {
             return timeIndex;
         }
 
-        // Use to reopen txn index if channel is closed.
+        // Visible for testing
         public TransactionIndex txnIndex() {
             if (txnIndex.isClosed()) {
                 // Reopen txn index if closed
@@ -629,17 +628,6 @@ public class RemoteIndexCache implements Closeable {
             }
         }
 
-        public boolean completeAbortedTxnsSearch(
-            long startOffset,
-            long upperBoundOffset,
-            Consumer<List<AbortedTxn>> accumulator
-        ) {
-            TransactionIndex transactionIndex = txnIndex();
-            TxnIndexSearchResult searchResult = transactionIndex.collectAbortedTxns(startOffset, upperBoundOffset);
-            accumulator.accept(searchResult.abortedTransactions);
-            return searchResult.isComplete;
-        }
-
         @Override
         public void close() {
             entryLock.writeLock().lock();
@@ -659,10 +647,6 @@ public class RemoteIndexCache implements Closeable {
                     ", timeIndex=" + timeIndex.file().getName() +
                     ", txnIndex=" + txnIndex.file().getName() +
                     '}';
-        }
-
-        public boolean hasTxnIndex() {
-            return txnIndex.file().length() == 0;
         }
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -492,7 +492,7 @@ public class RemoteIndexCache implements Closeable {
 
         private final OffsetIndex offsetIndex;
         private final TimeIndex timeIndex;
-        private TransactionIndex txnIndex;
+        private final TransactionIndex txnIndex;
 
         // This lock is used to synchronize cleanup methods and read methods. This ensures that cleanup (which changes the
         // underlying files of the index) isn't performed while a read is in-progress for the entry. This is required in
@@ -525,18 +525,6 @@ public class RemoteIndexCache implements Closeable {
 
         // Visible for testing
         public TransactionIndex txnIndex() {
-            if (txnIndex.isClosed()) {
-                // Reopen txn index if closed
-                final File txnIndexFile = txnIndex.file();
-                try {
-                    final String indexFileName = txnIndexFile.getName();
-                    final long offset = offsetFromRemoteIndexFileName(indexFileName);
-                    txnIndex = new TransactionIndex(offset, txnIndexFile);
-                    txnIndex.sanityCheck();
-                } catch (IOException e) {
-                    throw new KafkaException("Failed to reopen transaction index " + txnIndexFile, e);
-                }
-            }
             return txnIndex;
         }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -546,7 +546,7 @@ public class RemoteIndexCache implements Closeable {
         private long estimatedEntrySize() {
             entryLock.readLock().lock();
             try {
-                return offsetIndex.sizeInBytes() + timeIndex.sizeInBytes() + Files.size(txnIndex.file().toPath());
+                return offsetIndex.sizeInBytes() + timeIndex.sizeInBytes() + Files.size(txnIndex.path());
             } catch (IOException e) {
                 log.warn("Error occurred when estimating remote index cache entry bytes size, just set 0 firstly.", e);
                 return 0L;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -53,6 +53,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -523,7 +524,7 @@ public class RemoteIndexCache implements Closeable {
             return timeIndex;
         }
 
-        // Visible for testing
+        // Use to reopen txn index if channel is closed.
         public TransactionIndex txnIndex() {
             if (txnIndex.isClosed()) {
                 // Reopen txn index if closed
@@ -628,6 +629,17 @@ public class RemoteIndexCache implements Closeable {
             }
         }
 
+        public boolean completeAbortedTxnsSearch(
+            long startOffset,
+            long upperBoundOffset,
+            Consumer<List<AbortedTxn>> accumulator
+        ) {
+            TransactionIndex transactionIndex = txnIndex();
+            TxnIndexSearchResult searchResult = transactionIndex.collectAbortedTxns(startOffset, upperBoundOffset);
+            accumulator.accept(searchResult.abortedTransactions);
+            return searchResult.isComplete;
+        }
+
         @Override
         public void close() {
             entryLock.writeLock().lock();
@@ -647,6 +659,10 @@ public class RemoteIndexCache implements Closeable {
                     ", timeIndex=" + timeIndex.file().getName() +
                     ", txnIndex=" + txnIndex.file().getName() +
                     '}';
+        }
+
+        public boolean hasTxnIndex() {
+            return txnIndex.file().length() == 0;
         }
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/RemoteIndexCache.java
@@ -509,6 +509,7 @@ public class RemoteIndexCache implements Closeable {
         public Entry(OffsetIndex offsetIndex, TimeIndex timeIndex, TransactionIndex txnIndex) {
             this.offsetIndex = offsetIndex;
             this.timeIndex = timeIndex;
+            // If txn index does not exist on the source, it's an empty file on the index entry
             this.txnIndex = txnIndex;
             this.entrySizeBytes = estimatedEntrySize();
         }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
@@ -115,6 +115,11 @@ public class TransactionIndex implements Closeable {
         maybeChannel = Optional.empty();
     }
 
+    public boolean isClosed() {
+        final boolean isOpen = maybeChannel.map(FileChannel::isOpen).orElse(false);
+        return !isOpen;
+    }
+
     /**
      * Delete this index.
      *

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
@@ -115,11 +115,6 @@ public class TransactionIndex implements Closeable {
         maybeChannel = Optional.empty();
     }
 
-    public boolean isClosed() {
-        final boolean isOpen = maybeChannel.map(FileChannel::isOpen).orElse(false);
-        return !isOpen;
-    }
-
     /**
      * Delete this index.
      *

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
@@ -122,7 +122,7 @@ public class TransactionIndex implements Closeable {
                     + txnFile.path().toAbsolutePath());
         }
         lastOffset = abortedTxn.lastOffset();
-        Utils.writeFully(txnFile.channel(), abortedTxn.buffer.duplicate());
+        txnFile.write(abortedTxn.buffer.duplicate());
     }
 
     public void truncateTo(long offset) throws IOException {
@@ -199,54 +199,48 @@ public class TransactionIndex implements Closeable {
         if (!txnFile.exists())
             return Collections.emptyList();
 
-        try {
-            FileChannel channel = txnFile.channel();
-            PrimitiveRef.IntRef position = PrimitiveRef.ofInt(0);
+        PrimitiveRef.IntRef position = PrimitiveRef.ofInt(0);
 
-            return () -> new Iterator<AbortedTxnWithPosition>() {
+        return () -> new Iterator<AbortedTxnWithPosition>() {
 
-                @Override
-                public boolean hasNext() {
-                    try {
-                        return channel.position() - position.value >= AbortedTxn.TOTAL_SIZE;
-                    } catch (IOException e) {
-                        throw new KafkaException("Failed read position from the transaction index " + txnFile.path().toAbsolutePath(), e);
-                    }
+            @Override
+            public boolean hasNext() {
+                try {
+                    return txnFile.currentPosition() - position.value >= AbortedTxn.TOTAL_SIZE;
+                } catch (IOException e) {
+                    throw new KafkaException("Failed read position from the transaction index " + txnFile.path().toAbsolutePath(), e);
                 }
+            }
 
-                @Override
-                public AbortedTxnWithPosition next() {
-                    try {
-                        ByteBuffer buffer = allocate.get();
-                        Utils.readFully(channel, buffer, position.value);
-                        buffer.flip();
+            @Override
+            public AbortedTxnWithPosition next() {
+                try {
+                    ByteBuffer buffer = allocate.get();
+                    txnFile.read(buffer, position.value);
+                    buffer.flip();
 
-                        AbortedTxn abortedTxn = new AbortedTxn(buffer);
-                        if (abortedTxn.version() > AbortedTxn.CURRENT_VERSION)
-                            throw new KafkaException("Unexpected aborted transaction version " + abortedTxn.version()
-                                + " in transaction index " + txnFile.path().toAbsolutePath() + ", current version is "
-                                + AbortedTxn.CURRENT_VERSION);
-                        AbortedTxnWithPosition nextEntry = new AbortedTxnWithPosition(abortedTxn, position.value);
-                        position.value += AbortedTxn.TOTAL_SIZE;
-                        return nextEntry;
-                    } catch (IOException e) {
-                        // We received an unexpected error reading from the index file. We propagate this as an
-                        // UNKNOWN error to the consumer, which will cause it to retry the fetch.
-                        throw new KafkaException("Failed to read from the transaction index " + txnFile.path().toAbsolutePath(), e);
-                    }
+                    AbortedTxn abortedTxn = new AbortedTxn(buffer);
+                    if (abortedTxn.version() > AbortedTxn.CURRENT_VERSION)
+                        throw new KafkaException("Unexpected aborted transaction version " + abortedTxn.version()
+                            + " in transaction index " + txnFile.path().toAbsolutePath() + ", current version is "
+                            + AbortedTxn.CURRENT_VERSION);
+                    AbortedTxnWithPosition nextEntry = new AbortedTxnWithPosition(abortedTxn, position.value);
+                    position.value += AbortedTxn.TOTAL_SIZE;
+                    return nextEntry;
+                } catch (IOException e) {
+                    // We received an unexpected error reading from the index file. We propagate this as an
+                    // UNKNOWN error to the consumer, which will cause it to retry the fetch.
+                    throw new KafkaException("Failed to read from the transaction index " + txnFile.path().toAbsolutePath(), e);
                 }
+            }
 
-            };
-
-        } catch (IOException e) {
-            throw new KafkaException("Failed to read from the transaction index " + txnFile.path().toAbsolutePath(), e);
-        }
+        };
     }
 
     // Visible for testing
     static class TransactionIndexFile {
         // note that the file is not created until we need it
-        private Path path;
+        private volatile Path path;
         // channel is reopened as long as there are reads and writes
         private FileChannel channel;
 
@@ -271,28 +265,7 @@ public class TransactionIndex implements Closeable {
             this.path = parentDir.resolve(path.getFileName());
         }
 
-        /**
-         * Use to read or write values to the index.
-         * The file is the source of truth and if available values should be read from or written to.
-         *
-         * @return an open file channel with the position at the end of the file
-         * @throws IOException if any I/O error happens, but not if existing channel is closed.
-         *                     In that case, it is reopened.
-         */
-        FileChannel channel() throws IOException {
-            if (channel == null) {
-                openChannel();
-            } else {
-                // as channel is exposed, it could be closed without setting it to null
-                if (!channel.isOpen())  {
-                    log.debug("Transaction index channel was closed directly and is going to be reopened");
-                    openChannel();
-                }
-            }
-            return channel;
-        }
-
-        void renameTo(Path other) throws IOException {
+        synchronized void renameTo(Path other) throws IOException {
             try {
                 if (Files.exists(path))
                     Utils.atomicMoveWithFallback(path, other, false);
@@ -327,6 +300,39 @@ public class TransactionIndex implements Closeable {
         boolean deleteIfExists() throws IOException {
             closeChannel();
             return Files.deleteIfExists(path());
+        }
+
+        void write(ByteBuffer buffer) throws IOException {
+            Utils.writeFully(channel(), buffer);
+        }
+
+        void read(ByteBuffer buffer, int position) throws IOException {
+            Utils.readFully(channel(), buffer, position);
+        }
+
+        long currentPosition() throws IOException {
+            return channel().position();
+        }
+
+        /**
+         * Use to read or write values to the index.
+         * The file is the source of truth and if available values should be read from or written to.
+         *
+         * @return an open file channel with the position at the end of the file
+         * @throws IOException if any I/O error happens, but not if existing channel is closed.
+         *                     In that case, it is reopened.
+         */
+        private FileChannel channel() throws IOException {
+            if (channel == null) {
+                openChannel();
+            } else {
+                // as channel is exposed, it could be closed without setting it to null
+                if (!channel.isOpen())  {
+                    log.debug("Transaction index channel was closed directly and is going to be reopened");
+                    openChannel();
+                }
+            }
+            return channel;
         }
     }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
@@ -19,6 +19,7 @@ package org.apache.kafka.storage.internals.log;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.utils.PrimitiveRef;
 import org.apache.kafka.common.utils.Utils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -274,21 +275,25 @@ public class TransactionIndex implements Closeable {
             }
         }
 
-        void flush() throws IOException {
+        synchronized void flush() throws IOException {
             if (channel != null)
                 channel.force(true);
         }
 
-        void closeChannel() throws IOException {
+        synchronized void closeChannel() throws IOException {
             if (channel != null)
                 channel.close();
+        }
+        
+        synchronized boolean isChannelOpen() {
+            return channel != null && channel.isOpen();
         }
 
         Path path() {
             return path;
         }
 
-        void truncate(long position) throws IOException {
+        synchronized void truncate(long position) throws IOException {
             if (channel != null)
                 channel.truncate(position);
         }
@@ -322,12 +327,12 @@ public class TransactionIndex implements Closeable {
          * @throws IOException if any I/O error happens, but not if existing channel is closed.
          *                     In that case, it is reopened.
          */
-        private FileChannel channel() throws IOException {
+        private synchronized FileChannel channel() throws IOException {
             if (channel == null) {
                 openChannel();
             } else {
                 // as channel is exposed, it could be closed without setting it to null
-                if (!channel.isOpen())  {
+                if (!isChannelOpen())  {
                     log.debug("Transaction index channel was closed directly and is going to be reopened");
                     openChannel();
                 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
@@ -19,6 +19,8 @@ package org.apache.kafka.storage.internals.log;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.utils.PrimitiveRef;
 import org.apache.kafka.common.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.File;
@@ -26,13 +28,12 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.function.Supplier;
 
 /**
@@ -48,6 +49,8 @@ import java.util.function.Supplier;
  */
 public class TransactionIndex implements Closeable {
 
+    private static final Logger log = LoggerFactory.getLogger(TransactionIndex.class);
+
     private static class AbortedTxnWithPosition {
         final AbortedTxn txn;
         final int position;
@@ -59,60 +62,37 @@ public class TransactionIndex implements Closeable {
 
     private final long startOffset;
 
-    private volatile File file;
+    final TransactionIndexFile txnFile;
 
-    // note that the file is not created until we need it
-    private Optional<FileChannel> maybeChannel = Optional.empty();
-    private OptionalLong lastOffset = OptionalLong.empty();
+    private Long lastOffset = null;
 
     public TransactionIndex(long startOffset, File file) throws IOException {
         this.startOffset = startOffset;
-        this.file = file;
-
-        if (file.exists())
-            openChannel();
+        this.txnFile = new TransactionIndexFile(file);
     }
 
     public File file() {
-        return file;
+        return txnFile.path().toFile();
     }
 
     public void updateParentDir(File parentDir) {
-        this.file = new File(parentDir, file.getName());
-    }
-
-    public void append(AbortedTxn abortedTxn) throws IOException {
-        lastOffset.ifPresent(offset -> {
-            if (offset >= abortedTxn.lastOffset())
-                throw new IllegalArgumentException("The last offset of appended transactions must increase sequentially, but "
-                    + abortedTxn.lastOffset() + " is not greater than current last offset " + offset + " of index "
-                    + file.getAbsolutePath());
-        });
-        lastOffset = OptionalLong.of(abortedTxn.lastOffset());
-        Utils.writeFully(channel(), abortedTxn.buffer.duplicate());
+        txnFile.updateParentDir(parentDir);
     }
 
     public void flush() throws IOException {
-        FileChannel channel = channelOrNull();
-        if (channel != null)
-            channel.force(true);
+        txnFile.flush();
     }
 
     /**
      * Remove all the entries from the index. Unlike `AbstractIndex`, this index is not resized ahead of time.
      */
     public void reset() throws IOException {
-        FileChannel channel = channelOrNull();
-        if (channel != null)
-            channel.truncate(0);
-        lastOffset = OptionalLong.empty();
+        txnFile.truncate(0);
+        lastOffset = null;
     }
 
     public void close() throws IOException {
-        FileChannel channel = channelOrNull();
-        if (channel != null)
-            channel.close();
-        maybeChannel = Optional.empty();
+        txnFile.closeChannel();
     }
 
     /**
@@ -123,31 +103,36 @@ public class TransactionIndex implements Closeable {
      *         not exist
      */
     public boolean deleteIfExists() throws IOException {
-        close();
-        return Files.deleteIfExists(file.toPath());
+        return txnFile.deleteIfExists();
     }
 
     public void renameTo(File f) throws IOException {
-        try {
-            if (file.exists())
-                Utils.atomicMoveWithFallback(file.toPath(), f.toPath(), false);
-        } finally {
-            this.file = f;
+        txnFile.renameTo(f);
+    }
+
+    public void append(AbortedTxn abortedTxn) throws IOException {
+        if (lastOffset != null) {
+            if (lastOffset >= abortedTxn.lastOffset())
+                throw new IllegalArgumentException("The last offset of appended transactions must increase sequentially, but "
+                    + abortedTxn.lastOffset() + " is not greater than current last offset " + lastOffset + " of index "
+                    + txnFile.path().toAbsolutePath());
         }
+        lastOffset = abortedTxn.lastOffset();
+        Utils.writeFully(txnFile.channel(), abortedTxn.buffer.duplicate());
     }
 
     public void truncateTo(long offset) throws IOException {
         ByteBuffer buffer = ByteBuffer.allocate(AbortedTxn.TOTAL_SIZE);
-        OptionalLong newLastOffset = OptionalLong.empty();
+        Long newLastOffset = null;
         for (AbortedTxnWithPosition txnWithPosition : iterable(() -> buffer)) {
             AbortedTxn abortedTxn = txnWithPosition.txn;
             long position = txnWithPosition.position;
             if (abortedTxn.lastOffset() >= offset) {
-                channel().truncate(position);
+                txnFile.truncate(position);
                 lastOffset = newLastOffset;
                 return;
             }
-            newLastOffset = OptionalLong.of(abortedTxn.lastOffset());
+            newLastOffset = abortedTxn.lastOffset();
         }
     }
 
@@ -190,7 +175,7 @@ public class TransactionIndex implements Closeable {
             AbortedTxn abortedTxn = txnWithPosition.txn;
             if (abortedTxn.lastOffset() < startOffset)
                 throw new CorruptIndexException("Last offset of aborted transaction " + abortedTxn + " in index "
-                    + file.getAbsolutePath() + " is less than start offset " + startOffset);
+                    + txnFile.path().toAbsolutePath() + " is less than start offset " + startOffset);
         }
     }
 
@@ -202,71 +187,141 @@ public class TransactionIndex implements Closeable {
         return !iterable().iterator().hasNext();
     }
 
-    private FileChannel openChannel() throws IOException {
-        FileChannel channel = FileChannel.open(file.toPath(), StandardOpenOption.CREATE,
-                StandardOpenOption.READ, StandardOpenOption.WRITE);
-        maybeChannel = Optional.of(channel);
-        channel.position(channel.size());
-        return channel;
-    }
-
-    private FileChannel channel() throws IOException {
-        FileChannel channel = channelOrNull();
-        if (channel == null)
-            return openChannel();
-        else
-            return channel;
-    }
-
-    private FileChannel channelOrNull() {
-        return maybeChannel.orElse(null);
-    }
-
     private Iterable<AbortedTxnWithPosition> iterable() {
         return iterable(() -> ByteBuffer.allocate(AbortedTxn.TOTAL_SIZE));
     }
 
     private Iterable<AbortedTxnWithPosition> iterable(Supplier<ByteBuffer> allocate) {
-        FileChannel channel = channelOrNull();
-        if (channel == null)
+        if (!txnFile.exists())
             return Collections.emptyList();
 
-        PrimitiveRef.IntRef position = PrimitiveRef.ofInt(0);
+        try {
+            FileChannel channel = txnFile.channel();
+            PrimitiveRef.IntRef position = PrimitiveRef.ofInt(0);
 
-        return () -> new Iterator<AbortedTxnWithPosition>() {
+            return () -> new Iterator<AbortedTxnWithPosition>() {
 
-            @Override
-            public boolean hasNext() {
-                try {
-                    return channel.position() - position.value >= AbortedTxn.TOTAL_SIZE;
-                } catch (IOException e) {
-                    throw new KafkaException("Failed read position from the transaction index " + file.getAbsolutePath(), e);
+                @Override
+                public boolean hasNext() {
+                    try {
+                        return channel.position() - position.value >= AbortedTxn.TOTAL_SIZE;
+                    } catch (IOException e) {
+                        throw new KafkaException("Failed read position from the transaction index " + txnFile.path().toAbsolutePath(), e);
+                    }
                 }
-            }
 
-            @Override
-            public AbortedTxnWithPosition next() {
-                try {
-                    ByteBuffer buffer = allocate.get();
-                    Utils.readFully(channel, buffer, position.value);
-                    buffer.flip();
+                @Override
+                public AbortedTxnWithPosition next() {
+                    try {
+                        ByteBuffer buffer = allocate.get();
+                        Utils.readFully(channel, buffer, position.value);
+                        buffer.flip();
 
-                    AbortedTxn abortedTxn = new AbortedTxn(buffer);
-                    if (abortedTxn.version() > AbortedTxn.CURRENT_VERSION)
-                        throw new KafkaException("Unexpected aborted transaction version " + abortedTxn.version()
-                            + " in transaction index " + file.getAbsolutePath() + ", current version is "
-                            + AbortedTxn.CURRENT_VERSION);
-                    AbortedTxnWithPosition nextEntry = new AbortedTxnWithPosition(abortedTxn, position.value);
-                    position.value += AbortedTxn.TOTAL_SIZE;
-                    return nextEntry;
-                } catch (IOException e) {
-                    // We received an unexpected error reading from the index file. We propagate this as an
-                    // UNKNOWN error to the consumer, which will cause it to retry the fetch.
-                    throw new KafkaException("Failed to read from the transaction index " + file.getAbsolutePath(), e);
+                        AbortedTxn abortedTxn = new AbortedTxn(buffer);
+                        if (abortedTxn.version() > AbortedTxn.CURRENT_VERSION)
+                            throw new KafkaException("Unexpected aborted transaction version " + abortedTxn.version()
+                                + " in transaction index " + txnFile.path().toAbsolutePath() + ", current version is "
+                                + AbortedTxn.CURRENT_VERSION);
+                        AbortedTxnWithPosition nextEntry = new AbortedTxnWithPosition(abortedTxn, position.value);
+                        position.value += AbortedTxn.TOTAL_SIZE;
+                        return nextEntry;
+                    } catch (IOException e) {
+                        // We received an unexpected error reading from the index file. We propagate this as an
+                        // UNKNOWN error to the consumer, which will cause it to retry the fetch.
+                        throw new KafkaException("Failed to read from the transaction index " + txnFile.path().toAbsolutePath(), e);
+                    }
                 }
-            }
 
-        };
+            };
+
+        } catch (IOException e) {
+            throw new KafkaException("Failed to read from the transaction index " + txnFile.path().toAbsolutePath(), e);
+        }
     }
 
+    public static class TransactionIndexFile {
+        // note that the file is not created until we need it
+        private volatile File file;
+        // channel is reopened as long as there are reads and writes
+        private FileChannel channel;
+
+        TransactionIndexFile(File file) throws IOException {
+            this.file = file;
+
+            if (file.exists())
+                openChannel();
+        }
+
+        private void openChannel() throws IOException {
+            channel = FileChannel.open(
+                file.toPath(),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.READ,
+                StandardOpenOption.WRITE
+            );
+            channel.position(channel.size());
+        }
+
+        /**
+         * Use to read or write values to the index.
+         * The file is the source of truth and if available values should be read from or written to.
+         *
+         * @return an open file channel with the position at the end of the file
+         * @throws IOException if any I/O error happens, but not if existing channel is closed.
+         *                     In that case, it is reopened.
+         */
+        public FileChannel channel() throws IOException {
+            if (channel == null) {
+                openChannel();
+            } else {
+                // as channel is exposed, it could be closed without setting it to null
+                if (!channel.isOpen())  {
+                    log.debug("Transaction index channel was closed directly and is going to be reopened");
+                    openChannel();
+                }
+            }
+            return channel;
+        }
+
+        public synchronized void updateParentDir(File parentDir) {
+            file = new File(parentDir, file.getName());
+        }
+
+        public void flush() throws IOException {
+            if (channel != null)
+                channel.force(true);
+        }
+
+        public void closeChannel() throws IOException {
+            if (channel != null)
+                channel.close();
+        }
+
+        public Path path() {
+            return file.toPath();
+        }
+
+        public void renameTo(File f) throws IOException {
+            try {
+                if (file.exists())
+                    Utils.atomicMoveWithFallback(file.toPath(), f.toPath(), false);
+            } finally {
+                this.file = f;
+            }
+        }
+
+        public void truncate(long position) throws IOException {
+            if (channel != null)
+                channel.truncate(position);
+        }
+
+        public boolean exists() {
+            return file.exists();
+        }
+
+        public boolean deleteIfExists() throws IOException {
+            closeChannel();
+            return Files.deleteIfExists(path());
+        }
+    }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
@@ -239,7 +239,8 @@ public class TransactionIndex implements Closeable {
         }
     }
 
-    public static class TransactionIndexFile {
+    // Visible for testing
+    static class TransactionIndexFile {
         // note that the file is not created until we need it
         private volatile File file;
         // channel is reopened as long as there are reads and writes
@@ -270,7 +271,7 @@ public class TransactionIndex implements Closeable {
          * @throws IOException if any I/O error happens, but not if existing channel is closed.
          *                     In that case, it is reopened.
          */
-        public FileChannel channel() throws IOException {
+        FileChannel channel() throws IOException {
             if (channel == null) {
                 openChannel();
             } else {
@@ -283,25 +284,25 @@ public class TransactionIndex implements Closeable {
             return channel;
         }
 
-        public synchronized void updateParentDir(File parentDir) {
+        synchronized void updateParentDir(File parentDir) {
             file = new File(parentDir, file.getName());
         }
 
-        public void flush() throws IOException {
+        void flush() throws IOException {
             if (channel != null)
                 channel.force(true);
         }
 
-        public void closeChannel() throws IOException {
+        void closeChannel() throws IOException {
             if (channel != null)
                 channel.close();
         }
 
-        public Path path() {
+        Path path() {
             return file.toPath();
         }
 
-        public void renameTo(File f) throws IOException {
+        void renameTo(File f) throws IOException {
             try {
                 if (file.exists())
                     Utils.atomicMoveWithFallback(file.toPath(), f.toPath(), false);
@@ -310,16 +311,16 @@ public class TransactionIndex implements Closeable {
             }
         }
 
-        public void truncate(long position) throws IOException {
+        void truncate(long position) throws IOException {
             if (channel != null)
                 channel.truncate(position);
         }
 
-        public boolean exists() {
+        boolean exists() {
             return file.exists();
         }
 
-        public boolean deleteIfExists() throws IOException {
+        boolean deleteIfExists() throws IOException {
             closeChannel();
             return Files.deleteIfExists(path());
         }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
@@ -68,7 +68,11 @@ public class TransactionIndex implements Closeable {
 
     public TransactionIndex(long startOffset, File file) throws IOException {
         this.startOffset = startOffset;
-        this.txnFile = new TransactionIndexFile(file);
+        this.txnFile = new TransactionIndexFile(file.toPath());
+    }
+
+    public Path path() {
+        return txnFile.path();
     }
 
     public File file() {
@@ -76,7 +80,11 @@ public class TransactionIndex implements Closeable {
     }
 
     public void updateParentDir(File parentDir) {
-        txnFile.updateParentDir(parentDir);
+        txnFile.updateParentDir(parentDir.toPath());
+    }
+
+    public void renameTo(File f) throws IOException {
+        txnFile.renameTo(f.toPath());
     }
 
     public void flush() throws IOException {
@@ -104,10 +112,6 @@ public class TransactionIndex implements Closeable {
      */
     public boolean deleteIfExists() throws IOException {
         return txnFile.deleteIfExists();
-    }
-
-    public void renameTo(File f) throws IOException {
-        txnFile.renameTo(f);
     }
 
     public void append(AbortedTxn abortedTxn) throws IOException {
@@ -242,25 +246,29 @@ public class TransactionIndex implements Closeable {
     // Visible for testing
     static class TransactionIndexFile {
         // note that the file is not created until we need it
-        private volatile File file;
+        private Path path;
         // channel is reopened as long as there are reads and writes
         private FileChannel channel;
 
-        TransactionIndexFile(File file) throws IOException {
-            this.file = file;
+        TransactionIndexFile(Path path) throws IOException {
+            this.path = path;
 
-            if (file.exists())
+            if (Files.exists(path))
                 openChannel();
         }
 
         private void openChannel() throws IOException {
             channel = FileChannel.open(
-                file.toPath(),
+                path,
                 StandardOpenOption.CREATE,
                 StandardOpenOption.READ,
                 StandardOpenOption.WRITE
             );
             channel.position(channel.size());
+        }
+
+        synchronized void updateParentDir(Path parentDir) {
+            this.path = parentDir.resolve(path.getFileName());
         }
 
         /**
@@ -284,8 +292,13 @@ public class TransactionIndex implements Closeable {
             return channel;
         }
 
-        synchronized void updateParentDir(File parentDir) {
-            file = new File(parentDir, file.getName());
+        void renameTo(Path other) throws IOException {
+            try {
+                if (Files.exists(path))
+                    Utils.atomicMoveWithFallback(path, other, false);
+            } finally {
+                this.path = other;
+            }
         }
 
         void flush() throws IOException {
@@ -299,16 +312,7 @@ public class TransactionIndex implements Closeable {
         }
 
         Path path() {
-            return file.toPath();
-        }
-
-        void renameTo(File f) throws IOException {
-            try {
-                if (file.exists())
-                    Utils.atomicMoveWithFallback(file.toPath(), f.toPath(), false);
-            } finally {
-                this.file = f;
-            }
+            return path;
         }
 
         void truncate(long position) throws IOException {
@@ -317,7 +321,7 @@ public class TransactionIndex implements Closeable {
         }
 
         boolean exists() {
-            return file.exists();
+            return Files.exists(path);
         }
 
         boolean deleteIfExists() throws IOException {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
@@ -217,7 +217,7 @@ public class TransactionIndex implements Closeable {
             public AbortedTxnWithPosition next() {
                 try {
                     ByteBuffer buffer = allocate.get();
-                    txnFile.read(buffer, position.value);
+                    txnFile.readFully(buffer, position.value);
                     buffer.flip();
 
                     AbortedTxn abortedTxn = new AbortedTxn(buffer);
@@ -284,7 +284,7 @@ public class TransactionIndex implements Closeable {
             if (channel != null)
                 channel.close();
         }
-        
+
         synchronized boolean isChannelOpen() {
             return channel != null && channel.isOpen();
         }
@@ -311,7 +311,7 @@ public class TransactionIndex implements Closeable {
             Utils.writeFully(channel(), buffer);
         }
 
-        void read(ByteBuffer buffer, int position) throws IOException {
+        void readFully(ByteBuffer buffer, int position) throws IOException {
             Utils.readFully(channel(), buffer, position);
         }
 

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/TransactionIndexTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/TransactionIndexTest.java
@@ -23,15 +23,20 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedByInterruptException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -264,5 +269,56 @@ public class TransactionIndexTest {
         abortedTxns = assertDoesNotThrow(() ->
             index.collectAbortedTxns(0L, 100L).abortedTransactions);
         assertEquals(2, abortedTxns.size());
+    }
+
+    @Test
+    void testAppendAndCollectAfterInterrupted() throws Exception {
+        // Given the index
+        // When closed
+        index.close();
+        // Then it should still append data
+        index.append(new AbortedTxn(0L, 0, 10, 2));
+
+        // Given a thread reading from the channel
+        final CountDownLatch ready = new CountDownLatch(1);
+        final Exception[] exceptionHolder = new Exception[1];
+
+        Thread t = new Thread(() -> {
+            try {
+                ByteBuffer buffer = ByteBuffer.allocate(100);
+
+                while (index.txnFile.isChannelOpen()) {
+                    index.txnFile.read(buffer, 0);
+                    buffer.clear();
+                    // wait until first reading happens to mark it as ready
+                    if (ready.getCount() > 0) ready.countDown();
+                }
+            } catch (ClosedByInterruptException e) {
+                // Expected exception
+                exceptionHolder[0] = e;
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        t.start();
+        
+        assertTrue(ready.await(5, TimeUnit.SECONDS), "Timeout waiting for thread to finish");
+        
+        // When thread is interrupted
+        t.interrupt();
+
+        t.join();
+
+        // Check if ClosedByInterruptException was thrown
+        assertNotNull(exceptionHolder[0], "An exception should have been thrown");
+        assertTrue(exceptionHolder[0] instanceof ClosedByInterruptException,
+                "Expected ClosedByInterruptException, but got: " + exceptionHolder[0].getClass().getName());
+
+        assertFalse(index.txnFile.isChannelOpen());
+
+        // Then it should still read data
+        List<AbortedTxn> abortedTxns = assertDoesNotThrow(() ->
+            index.collectAbortedTxns(0L, 100L).abortedTransactions);
+        assertEquals(1, abortedTxns.size());
     }
 }

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/TransactionIndexTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/TransactionIndexTest.java
@@ -222,4 +222,47 @@ public class TransactionIndexTest {
         index.append(new AbortedTxn(0L, 0, 10, 2));
         assertFalse(index.isEmpty());
     }
+
+    public void testDoNotCreateFileUntilNeeded() throws IOException {
+        // Given that index file does not exist yet
+        file.delete();
+        // When index is created, reset, or flushed
+        // Then it is not created
+        final TransactionIndex index = assertDoesNotThrow(() -> new TransactionIndex(0, file));
+        assertFalse(file.exists());
+        index.reset();
+        assertFalse(file.exists());
+        index.flush();
+        assertFalse(file.exists());
+        // only when modifying it, it gets created
+        index.append(new AbortedTxn(0L, 0, 10, 2));
+        assertTrue(file.exists());
+    }
+
+    @Test
+    void testAppendAndCollectAfterClose() throws IOException {
+        // Given the index
+        // When closed
+        index.close();
+        // Then it should still append data
+        index.append(new AbortedTxn(0L, 0, 10, 2));
+        // When channel is closed
+        index.txnFile.channel().close();
+        // Then it should still append data
+        assertDoesNotThrow(() -> index.append(new AbortedTxn(1L, 5, 15, 16)));
+        // When closed
+        index.close();
+        // Then it should still read data
+        List<AbortedTxn> abortedTxns = assertDoesNotThrow(() ->
+            index.collectAbortedTxns(0L, 100L).abortedTransactions);
+        assertEquals(2, abortedTxns.size());
+        assertEquals(0, abortedTxns.get(0).firstOffset());
+        assertEquals(5, abortedTxns.get(1).firstOffset());
+        // When channel is closed
+        index.txnFile.channel().close();
+        // Then it should still read data
+        abortedTxns = assertDoesNotThrow(() ->
+            index.collectAbortedTxns(0L, 100L).abortedTransactions);
+        assertEquals(2, abortedTxns.size());
+    }
 }

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/TransactionIndexTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/TransactionIndexTest.java
@@ -247,7 +247,7 @@ public class TransactionIndexTest {
         // Then it should still append data
         index.append(new AbortedTxn(0L, 0, 10, 2));
         // When channel is closed
-        index.txnFile.channel().close();
+        index.txnFile.closeChannel();
         // Then it should still append data
         assertDoesNotThrow(() -> index.append(new AbortedTxn(1L, 5, 15, 16)));
         // When closed
@@ -259,7 +259,7 @@ public class TransactionIndexTest {
         assertEquals(0, abortedTxns.get(0).firstOffset());
         assertEquals(5, abortedTxns.get(1).firstOffset());
         // When channel is closed
-        index.txnFile.channel().close();
+        index.txnFile.closeChannel();
         // Then it should still read data
         abortedTxns = assertDoesNotThrow(() ->
             index.collectAbortedTxns(0L, 100L).abortedTransactions);

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/TransactionIndexTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/TransactionIndexTest.java
@@ -288,7 +288,7 @@ public class TransactionIndexTest {
                 ByteBuffer buffer = ByteBuffer.allocate(100);
 
                 while (index.txnFile.isChannelOpen()) {
-                    index.txnFile.read(buffer, 0);
+                    index.txnFile.readFully(buffer, 0);
                     buffer.clear();
                     // wait until first reading happens to mark it as ready
                     if (ready.getCount() > 0) ready.countDown();
@@ -301,9 +301,9 @@ public class TransactionIndexTest {
             }
         });
         t.start();
-        
+
         assertTrue(ready.await(5, TimeUnit.SECONDS), "Timeout waiting for thread to finish");
-        
+
         // When thread is interrupted
         t.interrupt();
 


### PR DESCRIPTION
Cached TransactionIndex may get closed if interrupted, causing following calls to always fail with ClosedChannelException, and forcing process to be restarted. In order to avoid this issue, a new method is exposed by TransactionIndex to validate state of channel; and index is reopened if closed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
