### PR TITLE
KAFKA-16179; Stop processing requests before stopping publishing

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -481,6 +481,8 @@ class ControllerServer(
         CoreUtils.swallow(registrationChannelManager.shutdown(), this)
         registrationChannelManager = null
       }
+      if (socketServer != null)
+        CoreUtils.swallow(socketServer.stopProcessingRequests(), this)
       metadataPublishers.forEach(p => sharedServer.loader.removeAndClosePublisher(p).get())
       metadataPublishers.clear()
       if (metadataCache != null) {
@@ -498,8 +500,6 @@ class ControllerServer(
         registrationsPublisher.close()
         registrationsPublisher = null
       }
-      if (socketServer != null)
-        CoreUtils.swallow(socketServer.stopProcessingRequests(), this)
       migrationSupport.foreach(_.shutdown(this))
       if (controller != null)
         controller.beginShutdown()


### PR DESCRIPTION
An NPE can be raised from `SimpleApiVersionManager.features` because of the dependency on `FeaturesPublisher` which is shutdown and nulled first when `ControllerServer` is stopped. To fix the issue, we stop processing requests first before shutting down publishers.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
