### PR TITLE
MINOR: Fix "No suitable checks publisher found" message during CI build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ def doTest(env, target = "test") {
   sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
       --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
       -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""
-  junit '**/build/test-results/**/TEST-*.xml'
+  junit skipPublishingChecks: true, testResults: '**/build/test-results/**/TEST-*.xml'
 }
 
 def doStreamsArchetype() {


### PR DESCRIPTION
This message keeps popping up in our CI builds during the "Archive JUnit-formatted test results" step, and can be misleading since it appears to indicate that something is wrong.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
