### PR TITLE
KAFKA-15675: Improve worker liveness check during Connect integration tests

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -138,11 +138,6 @@ public class BlockingConnectorTest {
                 NUM_WORKERS,
                 "Initial group of workers did not start in time"
         );
-
-        try (Response response = connect.requestGet(connect.endpointForResource("connectors/nonexistent"))) {
-            // hack: make sure the worker is actually up (has joined the cluster, created and read to the end of internal topics, etc.)
-            assertEquals(404, response.getStatus());
-        }
     }
 
     @After

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -238,9 +238,6 @@ public class ConnectWorkerIntegrationTest {
 
         connect.kafka().stopOnlyKafka();
 
-        connect.assertions().assertExactlyNumWorkersAreUp(NUM_WORKERS,
-                "Group of workers did not remain the same after broker shutdown");
-
         // Allow for the workers to discover that the coordinator is unavailable, wait is
         // heartbeat timeout * 2 + 4sec
         Thread.sleep(TimeUnit.SECONDS.toMillis(10));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExactlyOnceSourceIntegrationTest.java
@@ -500,7 +500,7 @@ public class ExactlyOnceSourceIntegrationTest {
         connectorHandle.expectedCommits(MINIMUM_MESSAGES);
 
         // make sure the worker is actually up (otherwise, it may fence out our simulated zombie leader, instead of the other way around)
-        assertEquals(404, connect.requestGet(connect.endpointForResource("connectors/nonexistent")).getStatus());
+        connect.assertions().assertExactlyNumWorkersAreUp(1, "Connect worker did not complete startup in time");
 
         // fence out the leader of the cluster
         Producer<?, ?> zombieLeader = transactionalProducer(

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnect.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnect.java
@@ -962,7 +962,7 @@ abstract class EmbeddedConnect {
         return workers().stream()
                 .filter(w -> {
                     try {
-                        String endpoint = w.url().resolve("/connectors/liveness-check/status").toString();
+                        String endpoint = w.url().resolve("/connectors/liveness-check").toString();
                         Response response = requestGet(endpoint);
                         boolean live = response.getStatus() == Response.Status.NOT_FOUND.getStatusCode()
                                 || response.getStatus() == Response.Status.OK.getStatusCode();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnect.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnect.java
@@ -958,7 +958,6 @@ abstract class EmbeddedConnect {
      * @return the list of handles of the online workers
      */
     public Set<WorkerHandle> activeWorkers() {
-        ObjectMapper mapper = new ObjectMapper();
         return workers().stream()
                 .filter(w -> {
                     try {


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-15675)

The current liveness check for workers is not very effective, as it does not guarantee that workers have actually joined the cluster, read to the end of the config topic, etc. This has the effect that some REST requests are made against workers that haven't fully completed startup, which can result in 409 responses. By improving our worker liveness check, we ensure that the cluster is stable before issuing REST requests against it.

Note that this check should be replaced by pinging a dedicated health check endpoint if/when one is introduced. I've published [KIP-1017](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1017%3A+Health+check+endpoint+for+Kafka+Connect) to add a health check endpoint to the REST API, but I'm hoping we can settle on this (somewhat hacky) approach in the meantime.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
