### PR TITLE
KAFKA-16186: Broker metrics for client telemetry (KIP-714)

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -235,7 +235,7 @@ class BrokerServer(
       )
       clientToControllerChannelManager.start()
       forwardingManager = new ForwardingManagerImpl(clientToControllerChannelManager)
-      clientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, config.clientTelemetryMaxBytes, time)
+      clientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, config.clientTelemetryMaxBytes, time, metrics)
 
       val apiVersionManager = ApiVersionManager(
         ListenerType.BROKER,

--- a/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
@@ -212,6 +212,7 @@ public class ClientMetricsManager implements AutoCloseable {
             } catch (Exception exception) {
                 clientMetricsStats.recordPluginErrorCount(clientInstanceId);
                 clientInstance.lastKnownError(Errors.INVALID_RECORD);
+                log.error("Error exporting client metrics to the plugin for client instance id: {}", clientInstanceId, exception);
                 return request.errorResponse(0, Errors.INVALID_RECORD);
             }
         }

--- a/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
@@ -206,9 +206,9 @@ public class ClientMetricsManager implements AutoCloseable {
         byte[] metrics = request.data().metrics();
         if (metrics != null && metrics.length > 0) {
             try {
-                long exportTimeStartMs = time.milliseconds();
+                long exportTimeStartMs = time.hiResClockMs();
                 receiverPlugin.exportMetrics(requestContext, request);
-                clientMetricsStats.recordPluginExport(clientInstanceId, time.milliseconds() - exportTimeStartMs);
+                clientMetricsStats.recordPluginExport(clientInstanceId, time.hiResClockMs() - exportTimeStartMs);
             } catch (Exception exception) {
                 clientMetricsStats.recordPluginErrorCount(clientInstanceId);
                 clientInstance.lastKnownError(Errors.INVALID_RECORD);
@@ -545,7 +545,7 @@ public class ClientMetricsManager implements AutoCloseable {
         ClientMetricsStats() {
             Measurable instanceCount = (config, now) -> clientInstanceCache.size();
             MetricName instanceCountMetric = metrics.metricName(INSTANCE_COUNT, GROUP_NAME,
-                "The current number of client metric instances being managed by the broker");
+                "The current number of client metrics instances being managed by the broker");
             metrics.addMetric(instanceCountMetric, instanceCount);
             registeredMetricNames.add(instanceCountMetric);
         }
@@ -617,6 +617,7 @@ public class ClientMetricsManager implements AutoCloseable {
             for (String name : sensorsName) {
                 metrics.removeSensor(name);
             }
+            sensorsName.clear();
         }
 
         private Meter createMeter(Metrics metrics, SampledStat stat, String name, Map<String, String> metricTags) {

--- a/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.server;
 
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.cache.Cache;
 import org.apache.kafka.common.cache.LRUCache;
@@ -28,6 +29,14 @@ import org.apache.kafka.common.errors.UnknownSubscriptionIdException;
 import org.apache.kafka.common.errors.UnsupportedCompressionTypeException;
 import org.apache.kafka.common.message.GetTelemetrySubscriptionsResponseData;
 import org.apache.kafka.common.message.PushTelemetryResponseData;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Meter;
+import org.apache.kafka.common.metrics.stats.SampledStat;
+import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.requests.GetTelemetrySubscriptionsRequest;
@@ -63,6 +72,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Handles client telemetry metrics requests/responses, subscriptions and instance information.
@@ -84,17 +95,19 @@ public class ClientMetricsManager implements AutoCloseable {
     private final Time time;
     private final int cacheExpiryMs;
     private final AtomicLong lastCacheErrorLogMs;
+    private final Metrics metrics;
+    private final ClientMetricsStats clientMetricsStats;
 
     // The latest subscription version is used to determine if subscription has changed and needs
     // to re-evaluate the client instance subscription id as per changed subscriptions.
     private final AtomicInteger subscriptionUpdateVersion;
 
-    public ClientMetricsManager(ClientMetricsReceiverPlugin receiverPlugin, int clientTelemetryMaxBytes, Time time) {
-        this(receiverPlugin, clientTelemetryMaxBytes, time, DEFAULT_CACHE_EXPIRY_MS);
+    public ClientMetricsManager(ClientMetricsReceiverPlugin receiverPlugin, int clientTelemetryMaxBytes, Time time, Metrics metrics) {
+        this(receiverPlugin, clientTelemetryMaxBytes, time, DEFAULT_CACHE_EXPIRY_MS, metrics);
     }
 
     // Visible for testing
-    ClientMetricsManager(ClientMetricsReceiverPlugin receiverPlugin, int clientTelemetryMaxBytes, Time time, int cacheExpiryMs) {
+    ClientMetricsManager(ClientMetricsReceiverPlugin receiverPlugin, int clientTelemetryMaxBytes, Time time, int cacheExpiryMs, Metrics metrics) {
         this.receiverPlugin = receiverPlugin;
         this.subscriptionMap = new ConcurrentHashMap<>();
         this.subscriptionUpdateVersion = new AtomicInteger(0);
@@ -104,6 +117,8 @@ public class ClientMetricsManager implements AutoCloseable {
         this.time = time;
         this.cacheExpiryMs = cacheExpiryMs;
         this.lastCacheErrorLogMs = new AtomicLong(0);
+        this.metrics = metrics;
+        this.clientMetricsStats = new ClientMetricsStats();
     }
 
     public Set<String> listClientMetricsResources() {
@@ -191,8 +206,11 @@ public class ClientMetricsManager implements AutoCloseable {
         byte[] metrics = request.data().metrics();
         if (metrics != null && metrics.length > 0) {
             try {
+                long exportTimeStartMs = time.milliseconds();
                 receiverPlugin.exportMetrics(requestContext, request);
+                clientMetricsStats.recordPluginExport(clientInstanceId, time.milliseconds() - exportTimeStartMs);
             } catch (Exception exception) {
+                clientMetricsStats.recordPluginErrorCount(clientInstanceId);
                 clientInstance.lastKnownError(Errors.INVALID_RECORD);
                 return request.errorResponse(0, Errors.INVALID_RECORD);
             }
@@ -210,6 +228,7 @@ public class ClientMetricsManager implements AutoCloseable {
     public void close() throws Exception {
         subscriptionMap.clear();
         expirationTimer.close();
+        clientMetricsStats.unregisterMetrics();
     }
 
     private void updateClientSubscription(String subscriptionName, ClientMetricsConfigs configs) {
@@ -288,6 +307,9 @@ public class ClientMetricsManager implements AutoCloseable {
         ClientMetricsInstanceMetadata instanceMetadata) {
 
         ClientMetricsInstance clientInstance = createClientInstance(clientInstanceId, instanceMetadata);
+        // Maybe add client metrics, if metrics not already added. Metrics might be already added
+        // if the client instance was evicted from the cache because of size limit.
+        clientMetricsStats.maybeAddClientInstanceMetrics(clientInstanceId);
         clientInstanceCache.put(clientInstanceId, clientInstance);
         return clientInstance;
     }
@@ -357,6 +379,7 @@ public class ClientMetricsManager implements AutoCloseable {
 
         if (!clientInstance.maybeUpdateGetRequestTimestamp(timestamp) && (clientInstance.lastKnownError() != Errors.UNKNOWN_SUBSCRIPTION_ID
             || clientInstance.lastKnownError() != Errors.UNSUPPORTED_COMPRESSION_TYPE)) {
+            clientMetricsStats.recordThrottleCount(clientInstance.clientInstanceId());
             String msg = String.format("Request from the client [%s] arrived before the next push interval time",
                 request.data().clientInstanceId());
             throw new ThrottlingQuotaExceededException(msg);
@@ -373,12 +396,14 @@ public class ClientMetricsManager implements AutoCloseable {
         }
 
         if (!clientInstance.maybeUpdatePushRequestTimestamp(timestamp) && !request.data().terminating()) {
+            clientMetricsStats.recordThrottleCount(clientInstance.clientInstanceId());
             String msg = String.format("Request from the client [%s] arrived before the next push interval time",
                 request.data().clientInstanceId());
             throw new ThrottlingQuotaExceededException(msg);
         }
 
         if (request.data().subscriptionId() != clientInstance.subscriptionId()) {
+            clientMetricsStats.recordUnknownSubscriptionCount(clientInstance.clientInstanceId());
             String msg = String.format("Unknown client subscription id for the client [%s]",
                 request.data().clientInstanceId());
             throw new UnknownSubscriptionIdException(msg);
@@ -477,6 +502,7 @@ public class ClientMetricsManager implements AutoCloseable {
         @Override
         public void run() {
             log.trace("Expiration timer task run for client instance id: {}, after delay ms: {}", clientInstanceId, delayMs);
+            clientMetricsStats.unregisterClientInstanceMetrics(clientInstanceId);
             if (!clientInstanceCache.remove(clientInstanceId)) {
                 /*
                  This can only happen if the client instance is removed from the cache by the LRU
@@ -490,6 +516,125 @@ public class ClientMetricsManager implements AutoCloseable {
                     log.warn("Client metrics instance cache cannot find the client instance id: {}. The cache"
                         + " must be at capacity, size: {} ", clientInstanceId, clientInstanceCache.size());
                 }
+            }
+        }
+    }
+
+    // Visible for testing
+    final class ClientMetricsStats {
+
+        private static final String GROUP_NAME = "ClientMetrics";
+
+        // Visible for testing
+        static final String INSTANCE_COUNT = "ClientMetricsInstanceCount";
+        static final String UNKNOWN_SUBSCRIPTION_REQUEST = "ClientMetricsUnknownSubscriptionRequest";
+        static final String THROTTLE = "ClientMetricsThrottle";
+        static final String PLUGIN_EXPORT = "ClientMetricsPluginExport";
+        static final String PLUGIN_ERROR = "ClientMetricsPluginError";
+        static final String PLUGIN_EXPORT_TIME = "ClientMetricsPluginExportTime";
+
+        // Names of sensors that are registered through client instances.
+        private final Set<String> sensorsName = ConcurrentHashMap.newKeySet();
+        // List of metric names which are not specific to a client instance. Do not require thread
+        // safe structure as it will be populated only in constructor.
+        private final List<MetricName> registeredMetricNames = new ArrayList<>();
+
+        private final Set<String> instanceMetrics = Stream.of(UNKNOWN_SUBSCRIPTION_REQUEST,
+            THROTTLE, PLUGIN_EXPORT, PLUGIN_ERROR, PLUGIN_EXPORT_TIME).collect(Collectors.toSet());
+
+        ClientMetricsStats() {
+            Measurable instanceCount = (config, now) -> clientInstanceCache.size();
+            MetricName instanceCountMetric = metrics.metricName(INSTANCE_COUNT, GROUP_NAME,
+                "The current number of client metric instances being managed by the broker");
+            metrics.addMetric(instanceCountMetric, instanceCount);
+            registeredMetricNames.add(instanceCountMetric);
+        }
+
+        public void maybeAddClientInstanceMetrics(Uuid clientInstanceId) {
+            // If one sensor of the metrics has been registered for the client instance,
+            // then all other sensors should have been registered; and vice versa.
+            if (metrics.getSensor(PLUGIN_EXPORT + "-" + clientInstanceId) != null) {
+                return;
+            }
+
+            Map<String, String> tags = Collections.singletonMap(ClientMetricsConfigs.CLIENT_INSTANCE_ID, clientInstanceId.toString());
+
+            Sensor unknownSubscriptionRequestCountSensor = metrics.sensor(
+                ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST + "-" + clientInstanceId);
+            unknownSubscriptionRequestCountSensor.add(createMeter(metrics, new WindowedCount(),
+                ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST, tags));
+            sensorsName.add(unknownSubscriptionRequestCountSensor.name());
+
+            Sensor throttleCount = metrics.sensor(ClientMetricsStats.THROTTLE + "-" + clientInstanceId);
+            throttleCount.add(createMeter(metrics, new WindowedCount(), ClientMetricsStats.THROTTLE, tags));
+            sensorsName.add(throttleCount.name());
+
+            Sensor pluginExportCount = metrics.sensor(ClientMetricsStats.PLUGIN_EXPORT + "-" + clientInstanceId);
+            pluginExportCount.add(createMeter(metrics, new WindowedCount(), ClientMetricsStats.PLUGIN_EXPORT, tags));
+            sensorsName.add(pluginExportCount.name());
+
+            Sensor pluginErrorCount = metrics.sensor(ClientMetricsStats.PLUGIN_ERROR + "-" + clientInstanceId);
+            pluginErrorCount.add(createMeter(metrics, new WindowedCount(), ClientMetricsStats.PLUGIN_ERROR, tags));
+            sensorsName.add(pluginErrorCount.name());
+
+            Sensor pluginExportTime = metrics.sensor(ClientMetricsStats.PLUGIN_EXPORT_TIME + "-" + clientInstanceId);
+            pluginExportTime.add(metrics.metricName(ClientMetricsStats.PLUGIN_EXPORT_TIME + "Avg",
+                ClientMetricsStats.GROUP_NAME, "Average time broker spent in invoking plugin exportMetrics call", tags), new Avg());
+            pluginExportTime.add(metrics.metricName(ClientMetricsStats.PLUGIN_EXPORT_TIME + "Max",
+                ClientMetricsStats.GROUP_NAME, "Maximum time broker spent in invoking plugin exportMetrics call", tags), new Max());
+            sensorsName.add(pluginExportTime.name());
+        }
+
+        public void recordUnknownSubscriptionCount(Uuid clientInstanceId) {
+            record(UNKNOWN_SUBSCRIPTION_REQUEST, clientInstanceId);
+        }
+
+        public void recordThrottleCount(Uuid clientInstanceId) {
+            record(THROTTLE, clientInstanceId);
+        }
+
+        public void recordPluginExport(Uuid clientInstanceId, long timeMs) {
+            record(PLUGIN_EXPORT, clientInstanceId);
+            record(PLUGIN_EXPORT_TIME, clientInstanceId, timeMs);
+        }
+
+        public void recordPluginErrorCount(Uuid clientInstanceId) {
+            record(PLUGIN_ERROR, clientInstanceId);
+        }
+
+        public void unregisterClientInstanceMetrics(Uuid clientInstanceId) {
+            for (String name : instanceMetrics) {
+                String sensorName = name + "-" + clientInstanceId;
+                metrics.removeSensor(sensorName);
+                sensorsName.remove(sensorName);
+            }
+        }
+
+        public void unregisterMetrics() {
+            for (MetricName metricName : registeredMetricNames) {
+                metrics.removeMetric(metricName);
+            }
+            for (String name : sensorsName) {
+                metrics.removeSensor(name);
+            }
+        }
+
+        private Meter createMeter(Metrics metrics, SampledStat stat, String name, Map<String, String> metricTags) {
+            MetricName rateMetricName = metrics.metricName(name + "Rate", ClientMetricsStats.GROUP_NAME,
+                String.format("The number of %s per second", name), metricTags);
+            MetricName totalMetricName = metrics.metricName(name + "Count", ClientMetricsStats.GROUP_NAME,
+                String.format("The total number of %s", name), metricTags);
+            return new Meter(stat, rateMetricName, totalMetricName);
+        }
+
+        private void record(String metricName, Uuid clientInstanceId) {
+            record(metricName, clientInstanceId, 1);
+        }
+
+        private void record(String metricName, Uuid clientInstanceId, long value) {
+            Sensor sensor = metrics.getSensor(metricName + "-" + clientInstanceId);
+            if (sensor != null) {
+                sensor.record(value);
             }
         }
     }

--- a/server/src/test/java/org/apache/kafka/server/ClientMetricsManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/ClientMetricsManagerTest.java
@@ -16,10 +16,13 @@
  */
 package org.apache.kafka.server;
 
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.message.GetTelemetrySubscriptionsRequestData;
 import org.apache.kafka.common.message.PushTelemetryRequestData;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.requests.GetTelemetrySubscriptionsRequest;
@@ -32,8 +35,10 @@ import org.apache.kafka.server.metrics.ClientMetricsConfigs;
 import org.apache.kafka.server.metrics.ClientMetricsInstance;
 import org.apache.kafka.server.metrics.ClientMetricsReceiverPlugin;
 import org.apache.kafka.server.metrics.ClientMetricsTestUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +49,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -51,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -62,18 +70,26 @@ public class ClientMetricsManagerTest {
     private static final Logger LOG = LoggerFactory.getLogger(ClientMetricsManagerTest.class);
 
     private MockTime time;
+    private Metrics kafkaMetrics;
     private ClientMetricsReceiverPlugin clientMetricsReceiverPlugin;
     private ClientMetricsManager clientMetricsManager;
 
     @BeforeEach
     public void setUp() {
         time = new MockTime();
+        kafkaMetrics = new Metrics();
         clientMetricsReceiverPlugin = new ClientMetricsReceiverPlugin();
-        clientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time, 100);
+        clientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time, 100, kafkaMetrics);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        clientMetricsManager.close();
+        kafkaMetrics.close();
     }
 
     @Test
-    public void testUpdateSubscription() {
+    public void testUpdateSubscription() throws Exception {
         assertTrue(clientMetricsManager.subscriptions().isEmpty());
 
         assertEquals(0, clientMetricsManager.subscriptionUpdateVersion());
@@ -102,6 +118,10 @@ public class ClientMetricsManagerTest {
             assertEquals(split[1], subscriptionInfo.matchPattern().get(split[0]).pattern());
         });
         assertEquals(1, clientMetricsManager.subscriptionUpdateVersion());
+        // Validate metrics should have instance count metric and kafka metrics count registered i.e. 2 metrics.
+        assertEquals(2, kafkaMetrics.metrics().size());
+        // Metrics should not have any instance while updating the subscriptions.
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
     }
 
     @Test
@@ -153,7 +173,7 @@ public class ClientMetricsManagerTest {
     }
 
     @Test
-    public void testGetTelemetry() throws UnknownHostException {
+    public void testGetTelemetry() throws Exception {
         clientMetricsManager.updateSubscription("sub-1", ClientMetricsTestUtils.defaultProperties());
         assertEquals(1, clientMetricsManager.subscriptions().size());
 
@@ -184,6 +204,16 @@ public class ClientMetricsManagerTest {
         ClientMetricsInstance instance = clientMetricsManager.clientInstance(response.data().clientInstanceId());
         assertNotNull(instance);
         assertEquals(Errors.NONE, instance.lastKnownError());
+        // Validate metrics should have instance count metric, kafka metrics count and 5 sensors with 10 metrics
+        // registered i.e. 12 metrics.
+        assertEquals(12, kafkaMetrics.metrics().size());
+        // Metrics should only have one instance.
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.THROTTLE + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "Count").metricValue());
+        assertEquals(Double.NaN, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "Max").metricValue());
     }
 
     @Test
@@ -265,7 +295,7 @@ public class ClientMetricsManagerTest {
     }
 
     @Test
-    public void testGetTelemetrySameClientImmediateRetryFail() throws UnknownHostException {
+    public void testGetTelemetrySameClientImmediateRetryFail() throws Exception {
         GetTelemetrySubscriptionsRequest request = new GetTelemetrySubscriptionsRequest.Builder(
             new GetTelemetrySubscriptionsRequestData(), true).build();
 
@@ -282,10 +312,13 @@ public class ClientMetricsManagerTest {
             request, ClientMetricsTestUtils.requestContext());
 
         assertEquals(Errors.THROTTLING_QUOTA_EXCEEDED, response.error());
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
+        // Should register 1 throttle metric.
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.THROTTLE + "Count").metricValue());
     }
 
     @Test
-    public void testGetTelemetrySameClientImmediateRetryAfterPushFail() throws UnknownHostException {
+    public void testGetTelemetrySameClientImmediateRetryAfterPushFail() throws Exception {
         GetTelemetrySubscriptionsRequest request = new GetTelemetrySubscriptionsRequest.Builder(
             new GetTelemetrySubscriptionsRequestData(), true).build();
 
@@ -299,8 +332,8 @@ public class ClientMetricsManagerTest {
         // Create new client metrics manager which simulates a new server as it will not have any
         // last request information but request should succeed as subscription id should match
         // the one with new client instance.
-
-        ClientMetricsManager newClientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time);
+        kafkaMetrics = new Metrics();
+        ClientMetricsManager newClientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time, kafkaMetrics);
 
         PushTelemetryRequest pushRequest = new Builder(
             new PushTelemetryRequestData()
@@ -321,6 +354,8 @@ public class ClientMetricsManagerTest {
             request, ClientMetricsTestUtils.requestContext());
 
         assertEquals(Errors.THROTTLING_QUOTA_EXCEEDED, response.error());
+        // Should register 1 throttle metric.
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.THROTTLE + "Count").metricValue());
     }
 
     @Test
@@ -359,7 +394,7 @@ public class ClientMetricsManagerTest {
     }
 
     @Test
-    public void testGetTelemetryConcurrentRequestNewClientInstance() throws InterruptedException {
+    public void testGetTelemetryConcurrentRequestNewClientInstance() throws Exception {
         GetTelemetrySubscriptionsRequest request = new GetTelemetrySubscriptionsRequest.Builder(
             new GetTelemetrySubscriptionsRequestData().setClientInstanceId(Uuid.randomUuid()), true).build();
 
@@ -409,11 +444,12 @@ public class ClientMetricsManagerTest {
         }
         // 1 request should fail with throttling error.
         assertEquals(1, throttlingErrorCount);
+        // Should register 1 throttle metric.
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.THROTTLE + "Count").metricValue());
     }
 
     @Test
-    public void testGetTelemetryConcurrentRequestAfterSubscriptionUpdate()
-        throws InterruptedException, UnknownHostException {
+    public void testGetTelemetryConcurrentRequestAfterSubscriptionUpdate() throws Exception {
         GetTelemetrySubscriptionsRequest request = new GetTelemetrySubscriptionsRequest.Builder(
             new GetTelemetrySubscriptionsRequestData().setClientInstanceId(Uuid.randomUuid()), true).build();
 
@@ -472,10 +508,12 @@ public class ClientMetricsManagerTest {
         }
         // 1 request should fail with throttling error.
         assertEquals(1, throttlingErrorCount);
+        // Should register 1 throttle metric.
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.THROTTLE + "Count").metricValue());
     }
 
     @Test
-    public void testPushTelemetry() throws UnknownHostException {
+    public void testPushTelemetry() throws Exception {
         clientMetricsManager.updateSubscription("sub-1", ClientMetricsTestUtils.defaultProperties());
         assertEquals(1, clientMetricsManager.subscriptions().size());
 
@@ -501,10 +539,21 @@ public class ClientMetricsManagerTest {
         assertEquals(Errors.NONE, response.error());
         assertFalse(instance.terminating());
         assertEquals(Errors.NONE, instance.lastKnownError());
+        // Validate metrics should have instance count metric, kafka metrics count and 5 sensors with 10 metrics
+        // registered i.e. 12 metrics.
+        assertEquals(12, kafkaMetrics.metrics().size());
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.THROTTLE + "Count").metricValue());
+        // Should have 1 successful export and 0 error metrics.
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "Count").metricValue());
+        // Should not have default NaN value, must register actual export time.
+        assertNotEquals(Double.NaN, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "Max").metricValue());
     }
 
     @Test
-    public void testPushTelemetryOnNewServer() throws UnknownHostException {
+    public void testPushTelemetryOnNewServer() throws Exception {
         GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
             new GetTelemetrySubscriptionsRequestData(), true).build();
 
@@ -514,18 +563,30 @@ public class ClientMetricsManagerTest {
         // Create new client metrics manager which simulates a new server as it will not have any
         // client instance information but request should succeed as subscription id should match
         // the one with new client instance.
-
-        ClientMetricsManager newClientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time);
+        kafkaMetrics = new Metrics();
+        ClientMetricsManager newClientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time, kafkaMetrics);
 
         PushTelemetryRequest request = new PushTelemetryRequest.Builder(
             new PushTelemetryRequestData()
                 .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
-                .setSubscriptionId(subscriptionsResponse.data().subscriptionId()), true).build();
+                .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
+                .setMetrics("test-data".getBytes(StandardCharsets.UTF_8)), true).build();
 
         PushTelemetryResponse response = newClientMetricsManager.processPushTelemetryRequest(
             request, ClientMetricsTestUtils.requestContext());
 
         assertEquals(Errors.NONE, response.error());
+        // Validate metrics should have instance count metric, kafka metrics count and 5 sensors with 10 metrics
+        // registered i.e. 12 metrics.
+        assertEquals(12, kafkaMetrics.metrics().size());
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.THROTTLE + "Count").metricValue());
+        // Should have 1 successful export and 0 error metrics.
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "Count").metricValue());
+        // Should not have default NaN value, must register actual export time metrics.
+        assertNotEquals(Double.NaN, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "Max").metricValue());
     }
 
     @Test
@@ -581,7 +642,7 @@ public class ClientMetricsManagerTest {
     }
 
     @Test
-    public void testPushTelemetryThrottleError() throws UnknownHostException {
+    public void testPushTelemetryThrottleError() throws Exception {
         GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
             new GetTelemetrySubscriptionsRequestData(), true).build();
 
@@ -591,7 +652,8 @@ public class ClientMetricsManagerTest {
         PushTelemetryRequest request = new PushTelemetryRequest.Builder(
             new PushTelemetryRequestData()
                 .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
-                .setSubscriptionId(subscriptionsResponse.data().subscriptionId()), true).build();
+                .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
+                .setMetrics("test-data".getBytes(StandardCharsets.UTF_8)), true).build();
 
         PushTelemetryResponse response = clientMetricsManager.processPushTelemetryRequest(
             request, ClientMetricsTestUtils.requestContext());
@@ -607,10 +669,16 @@ public class ClientMetricsManagerTest {
         assertNotNull(instance);
         assertFalse(instance.terminating());
         assertEquals(Errors.THROTTLING_QUOTA_EXCEEDED, instance.lastKnownError());
+        // Should have 1 throttle error metrics.
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.THROTTLE + "Count").metricValue());
+        // Should have 1 successful export metrics as well.
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "Count").metricValue());
+        assertNotEquals(Double.NaN, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "Max").metricValue());
     }
 
     @Test
-    public void testPushTelemetryTerminatingFlag() throws UnknownHostException {
+    public void testPushTelemetryTerminatingFlag() throws Exception {
         GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
             new GetTelemetrySubscriptionsRequestData(), true).build();
 
@@ -620,7 +688,8 @@ public class ClientMetricsManagerTest {
         PushTelemetryRequest request = new PushTelemetryRequest.Builder(
             new PushTelemetryRequestData()
                 .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
-                .setSubscriptionId(subscriptionsResponse.data().subscriptionId()), true).build();
+                .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
+                .setMetrics("test-data".getBytes(StandardCharsets.UTF_8)), true).build();
 
         PushTelemetryResponse response = clientMetricsManager.processPushTelemetryRequest(
             request, ClientMetricsTestUtils.requestContext());
@@ -632,6 +701,7 @@ public class ClientMetricsManagerTest {
             new PushTelemetryRequestData()
                 .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
                 .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
+                .setMetrics("test-data".getBytes(StandardCharsets.UTF_8))
                 .setTerminating(true), true).build();
 
         response = clientMetricsManager.processPushTelemetryRequest(
@@ -643,6 +713,10 @@ public class ClientMetricsManagerTest {
         assertNotNull(instance);
         assertTrue(instance.terminating());
         assertEquals(Errors.NONE, instance.lastKnownError());
+        // Should have 2 successful export metrics.
+        assertEquals((double) 2, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "Count").metricValue());
+        assertNotEquals(Double.NaN, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "Max").metricValue());
     }
 
     @Test
@@ -684,7 +758,7 @@ public class ClientMetricsManagerTest {
     }
 
     @Test
-    public void testPushTelemetrySubscriptionIdInvalid() throws UnknownHostException {
+    public void testPushTelemetrySubscriptionIdInvalid() throws Exception {
         GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
             new GetTelemetrySubscriptionsRequestData(), true).build();
 
@@ -697,6 +771,7 @@ public class ClientMetricsManagerTest {
         PushTelemetryRequest request = new PushTelemetryRequest.Builder(
             new PushTelemetryRequestData()
                 .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
+                .setMetrics("test-data".getBytes(StandardCharsets.UTF_8))
                 .setSubscriptionId(1234), true).build();
 
         PushTelemetryResponse response = clientMetricsManager.processPushTelemetryRequest(
@@ -705,6 +780,12 @@ public class ClientMetricsManagerTest {
         assertEquals(Errors.UNKNOWN_SUBSCRIPTION_ID, response.error());
         assertFalse(instance.terminating());
         assertEquals(Errors.UNKNOWN_SUBSCRIPTION_ID, instance.lastKnownError());
+        // Should have 1 unknown subscription request metric and no successful export.
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "Count").metricValue());
+        assertEquals(Double.NaN, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "Max").metricValue());
+
     }
 
     @Test
@@ -733,7 +814,7 @@ public class ClientMetricsManagerTest {
     }
 
     @Test
-    public void testPushTelemetryNullMetricsData() throws UnknownHostException {
+    public void testPushTelemetryNullMetricsData() throws Exception {
         GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
             new GetTelemetrySubscriptionsRequestData(), true).build();
 
@@ -756,11 +837,17 @@ public class ClientMetricsManagerTest {
         assertEquals(Errors.NONE, response.error());
         assertFalse(instance.terminating());
         assertEquals(Errors.NONE, instance.lastKnownError());
+        // Metrics should not report any export.
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "Count").metricValue());
+        assertEquals(Double.NaN, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "Max").metricValue());
     }
 
     @Test
     public void testPushTelemetryMetricsTooLarge() throws UnknownHostException {
-        clientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 1, time);
+        kafkaMetrics = new Metrics();
+        clientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 1, time, kafkaMetrics);
 
         GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
             new GetTelemetrySubscriptionsRequestData(), true).build();
@@ -791,7 +878,7 @@ public class ClientMetricsManagerTest {
     }
 
     @Test
-    public void testPushTelemetryConcurrentRequestNewClientInstance() throws UnknownHostException, InterruptedException {
+    public void testPushTelemetryConcurrentRequestNewClientInstance() throws Exception {
         GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
             new GetTelemetrySubscriptionsRequestData(), true).build();
 
@@ -811,7 +898,8 @@ public class ClientMetricsManagerTest {
         CountDownLatch lock = new CountDownLatch(2);
         List<PushTelemetryResponse> responses = Collections.synchronizedList(new ArrayList<>());
 
-        ClientMetricsManager newClientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time);
+        kafkaMetrics = new Metrics();
+        ClientMetricsManager newClientMetricsManager = new ClientMetricsManager(clientMetricsReceiverPlugin, 100, time, kafkaMetrics);
 
         Thread thread = new Thread(() -> {
             try {
@@ -848,16 +936,20 @@ public class ClientMetricsManagerTest {
             if (response.error() == Errors.THROTTLING_QUOTA_EXCEEDED) {
                 throttlingErrorCount++;
             } else {
-                // As subscription is updates hence 1 request shall fail with unknown subscription id.
                 assertEquals(Errors.NONE, response.error());
             }
         }
         // 1 request should fail with throttling error.
         assertEquals(1, throttlingErrorCount);
+        // Metrics should report 1 export and 1 throttle error.
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.THROTTLE + "Count").metricValue());
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "Count").metricValue());
+        assertNotEquals(Double.NaN, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "Max").metricValue());
     }
 
     @Test
-    public void testPushTelemetryConcurrentRequestAfterSubscriptionUpdate() throws UnknownHostException, InterruptedException {
+    public void testPushTelemetryConcurrentRequestAfterSubscriptionUpdate() throws Exception {
         GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
             new GetTelemetrySubscriptionsRequestData(), true).build();
 
@@ -921,10 +1013,58 @@ public class ClientMetricsManagerTest {
         }
         // 1 request should fail with throttling error.
         assertEquals(1, throttlingErrorCount);
+        // Metrics should report 1 subscription, 1 throttle error and no successful export.
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST + "Count").metricValue());
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.THROTTLE + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "Count").metricValue());
+        assertEquals(Double.NaN, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "Max").metricValue());
     }
 
     @Test
-    public void testCacheEviction() throws UnknownHostException, InterruptedException {
+    public void testPushTelemetryPluginException() throws Exception {
+        ClientMetricsReceiverPlugin receiverPlugin = Mockito.mock(ClientMetricsReceiverPlugin.class);
+        Mockito.doThrow(new RuntimeException("test exception")).when(receiverPlugin).exportMetrics(Mockito.any(), Mockito.any());
+
+        kafkaMetrics = new Metrics();
+        clientMetricsManager = new ClientMetricsManager(receiverPlugin, 100, time, 100, kafkaMetrics);
+
+        clientMetricsManager.updateSubscription("sub-1", ClientMetricsTestUtils.defaultProperties());
+        assertEquals(1, clientMetricsManager.subscriptions().size());
+
+        GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
+            new GetTelemetrySubscriptionsRequestData(), true).build();
+
+        GetTelemetrySubscriptionsResponse subscriptionsResponse = clientMetricsManager.processGetTelemetrySubscriptionRequest(
+            subscriptionsRequest, ClientMetricsTestUtils.requestContext());
+
+        ClientMetricsInstance instance = clientMetricsManager.clientInstance(subscriptionsResponse.data().clientInstanceId());
+        assertNotNull(instance);
+
+        PushTelemetryRequest request = new Builder(
+            new PushTelemetryRequestData()
+                .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
+                .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
+                .setCompressionType(CompressionType.NONE.id)
+                .setMetrics("test-data".getBytes(StandardCharsets.UTF_8)), true).build();
+
+        PushTelemetryResponse response = clientMetricsManager.processPushTelemetryRequest(
+            request, ClientMetricsTestUtils.requestContext());
+
+        assertEquals(Errors.INVALID_RECORD, response.error());
+        assertFalse(instance.terminating());
+        assertEquals(Errors.INVALID_RECORD, instance.lastKnownError());
+        // Metrics should report 1 plugin export error and 0 successful export.
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.UNKNOWN_SUBSCRIPTION_REQUEST + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.THROTTLE + "Count").metricValue());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "Count").metricValue());
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "Count").metricValue());
+        // Should have default NaN value, must not register export time.
+        assertEquals(Double.NaN, getMetric(ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "Max").metricValue());
+    }
+
+    @Test
+    public void testCacheEviction() throws Exception {
         Properties properties = new Properties();
         properties.put("metrics", ClientMetricsConfigs.ALL_SUBSCRIBED_METRICS_CONFIG);
         properties.put(ClientMetricsConfigs.PUSH_INTERVAL_MS, "100");
@@ -936,6 +1076,10 @@ public class ClientMetricsManagerTest {
         GetTelemetrySubscriptionsResponse response = clientMetricsManager.processGetTelemetrySubscriptionRequest(
             request, ClientMetricsTestUtils.requestContext());
         assertEquals(Errors.NONE, response.error());
+
+        // Metrics for instance should exist.
+        assertEquals(12, kafkaMetrics.metrics().size());
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
 
         assertNotNull(clientMetricsManager.clientInstance(response.data().clientInstanceId()));
         assertEquals(1, clientMetricsManager.expirationTimer().size());
@@ -950,10 +1094,13 @@ public class ClientMetricsManagerTest {
                 Thread.sleep(50);
             }
         });
+        // Metrics for instance should be removed.
+        assertEquals(2, kafkaMetrics.metrics().size());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
     }
 
     @Test
-    public void testCacheEvictionWithMultipleClients() throws UnknownHostException, InterruptedException {
+    public void testCacheEvictionWithMultipleClients() throws Exception {
         Properties properties = new Properties();
         properties.put("metrics", ClientMetricsConfigs.ALL_SUBSCRIBED_METRICS_CONFIG);
         properties.put(ClientMetricsConfigs.PUSH_INTERVAL_MS, "100");
@@ -970,6 +1117,10 @@ public class ClientMetricsManagerTest {
             request, ClientMetricsTestUtils.requestContext());
         assertEquals(Errors.NONE, response2.error());
 
+        // Metrics for both instances should exist.
+        assertEquals(22, kafkaMetrics.metrics().size());
+        assertEquals((double) 2, getMetric(ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
+
         assertNotNull(clientMetricsManager.clientInstance(response1.data().clientInstanceId()));
         assertNotNull(clientMetricsManager.clientInstance(response2.data().clientInstanceId()));
         assertEquals(2, clientMetricsManager.expirationTimer().size());
@@ -985,10 +1136,13 @@ public class ClientMetricsManagerTest {
                 Thread.sleep(50);
             }
         });
+        // Metrics for both instances should be removed.
+        assertEquals(2, kafkaMetrics.metrics().size());
+        assertEquals((double) 0, getMetric(ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
     }
 
     @Test
-    public void testCacheExpirationTaskCancelledOnInstanceUpdate() throws UnknownHostException {
+    public void testCacheExpirationTaskCancelledOnInstanceUpdate() throws Exception {
         GetTelemetrySubscriptionsRequest request = new GetTelemetrySubscriptionsRequest.Builder(
             new GetTelemetrySubscriptionsRequestData(), true).build();
 
@@ -1023,5 +1177,18 @@ public class ClientMetricsManagerTest {
         assertNotNull(instance);
         assertNotNull(instance.expirationTimerTask());
         assertEquals(1, clientMetricsManager.expirationTimer().size());
+        // Metrics size should remain same on instance update.
+        assertEquals(12, kafkaMetrics.metrics().size());
+        assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
+    }
+
+    private KafkaMetric getMetric(String name) throws Exception {
+        Optional<Entry<MetricName, KafkaMetric>> metric = kafkaMetrics.metrics().entrySet().stream()
+            .filter(entry -> entry.getKey().name().equals(name))
+            .findFirst();
+        if (!metric.isPresent())
+            throw new Exception(String.format("Could not find metric called %s", name));
+
+        return metric.get().getValue();
     }
 }

--- a/server/src/test/java/org/apache/kafka/server/ClientMetricsManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/ClientMetricsManagerTest.java
@@ -205,7 +205,7 @@ public class ClientMetricsManagerTest {
         ClientMetricsInstance instance = clientMetricsManager.clientInstance(response.data().clientInstanceId());
         assertNotNull(instance);
         assertEquals(Errors.NONE, instance.lastKnownError());
-        // Validate metrics should have instance count metric, kafka metrics count and 5 sensors with 10 metrics
+        // Validate metrics should have instance count metric, kafka metrics count and 4 sensors with 10 metrics
         // registered i.e. 12 metrics.
         assertEquals(12, kafkaMetrics.metrics().size());
         // Metrics should only have one instance.
@@ -542,7 +542,7 @@ public class ClientMetricsManagerTest {
         assertEquals(Errors.NONE, response.error());
         assertFalse(instance.terminating());
         assertEquals(Errors.NONE, instance.lastKnownError());
-        // Validate metrics should have instance count metric, kafka metrics count and 5 sensors with 10 metrics
+        // Validate metrics should have instance count metric, kafka metrics count and 4 sensors with 10 metrics
         // registered i.e. 12 metrics.
         assertEquals(12, kafkaMetrics.metrics().size());
         assertEquals((double) 1, getMetric(ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());
@@ -579,7 +579,7 @@ public class ClientMetricsManagerTest {
             request, ClientMetricsTestUtils.requestContext());
 
         assertEquals(Errors.NONE, response.error());
-        // Validate metrics should have instance count metric, kafka metrics count and 5 sensors with 10 metrics
+        // Validate metrics should have instance count metric, kafka metrics count and 4 sensors with 10 metrics
         // registered i.e. 12 metrics.
         assertEquals(12, kafkaMetrics.metrics().size());
         assertEquals((double) 1, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.INSTANCE_COUNT).metricValue());


### PR DESCRIPTION
The KIP-714 defines broker metrics [here](https://cwiki.apache.org/confluence/display/KAFKA/KIP-714%3A+Client+metrics+and+observability#KIP714:Clientmetricsandobservability-Metrics) which should help determining the client instances metrics managed by the broker. However, there is certain change as per the metrics defined in KIP and the implementation which have been highlighted below. We can discuss and either amend the KIP or the implementation, though I prefer the former.

There are 2 ways 2 emit metrics in broker i.e. using Kafka Metrics or Yammer Metrics. I have used Kafka Metrics as want to have minimal dependency on Yammer (though open for suggestions).

**Changes/Query** | Metric Name | Type | Group | Tags
-- | -- | -- | -- | --
What should be the name of the tag for broker's version and how can we fetch that as I do not see any placeholder in RequestContext?  | ClientMetricsInstanceCount | Gauge | ClientMetrics | version: broker's software version
The metric is defined as Meter which according to KafkaMetrics requires another metric called Rate hence 2 metrics are emitted for same as `ClientMetricsPluginErrorCount` and `ClientMetricsPluginErrorRate` | ClientMetricsPluginErrorCount | Meter | ClientMetrics | client_instance_idreason (reason for the failure)
The metric is defined as Meter which according to KafkaMetrics requires another metric called Rate hence 2 metrics are emitted for same as `ClientMetricsPluginExportCount` and `ClientMetricsPluginExportRate` | ClientMetricsPluginExportCount | Meter | ClientMetrics | client_instance_id
The metric is defined as Meter which according to KafkaMetrics requires another metric called Rate hence 2 metrics are emitted for same as `ClientMetricsThrottleCount` and `ClientMetricsThrottleRate` | ClientMetricsThrottleCount | Meter | ClientMetrics | client_instance_id
The metric is defined as Meter which according to KafkaMetrics requires another metric called Rate hence 2 metrics are emitted for same as `ClientMetricsUnknownSubscriptionRequestCount` and `ClientMetricsUnknownSubscriptionRequestRate`. Also removed the client version tag. | ClientMetricsUnknownSubscriptionRequestCount | Meter | ClientMetrics | client version: client's software version
The metric is defined as Histogram but generally we use `Avg` and `Max` as metrics to capture `latency` related metrics (which requires Histogram) hence I have 2 metrics for same as `ClientMetricsPluginExportTimeAvg` and `ClientMetricsPluginExportTimeMax` | ClientMetricsPluginExportTime | Histogram | ClientMetrics | client_instance_id


<img width="890" alt="Screenshot 2024-01-29 at 10 06 18 PM" src="https://github.com/apache/kafka/assets/2861565/65770ce4-b514-4b5e-b718-9c393c501be7">



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
