### PR TITLE
MINOR: Mark ConsumerGroupDescribe API as stable

### DIFF
--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json
@@ -19,10 +19,6 @@
   "listeners": ["zkBroker", "broker"],
   "name": "ConsumerGroupDescribeRequest",
   "validVersions": "0",
-  // The ConsumerGroupDescribe API is added as part of KIP-848 and is still
-  // under development. Hence, the API is not exposed by default by brokers
-  // unless explicitly enabled.
-  "latestVersionUnstable": true,
   "flexibleVersions": "0+",
   "fields": [
     { "name": "GroupIds", "type": "[]string", "versions": "0+", "entityType": "groupId",

--- a/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json
@@ -87,13 +87,7 @@
     ]},
     { "name": "Assignment", "versions": "0+", "fields": [
       { "name": "TopicPartitions", "type": "[]TopicPartitions", "versions": "0+",
-        "about": "The assigned topic-partitions to the member." },
-      { "name": "Error", "type": "int8", "versions": "0+",
-        "about": "The assigned error." },
-      { "name": "MetadataVersion", "type": "int32", "versions": "0+",
-        "about": "The assignor metadata version." },
-      { "name": "MetadataBytes", "type": "bytes", "versions": "0+",
-        "about": "The assignor metadata bytes." }
+        "about": "The assigned topic-partitions to the member." }
     ]}
   ]
 }


### PR DESCRIPTION
This patch marks the ConsumerGroupDescribe API as stable. This is required in order to use the admin tools with the new protocol. The patch also removes the fields related to the client side assignor as this is not implemented yet.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
