### PR TITLE
MINOR: Store separate output per test case instead of suite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -438,6 +438,12 @@ subprojects {
     }
     logTestStdout.rehydrate(delegate, owner, this)()
 
+    reports {
+      junitXml {
+        outputPerTestCase = true
+      }
+    }
+
     exclude testsToExclude
 
     if (shouldUseJUnit5)
@@ -465,6 +471,12 @@ subprojects {
       displayGranularity = 0
     }
     logTestStdout.rehydrate(delegate, owner, this)()
+
+    reports {
+      junitXml {
+        outputPerTestCase = true
+      }
+    }
 
     exclude testsToExclude
 
@@ -508,6 +520,12 @@ subprojects {
       displayGranularity = 0
     }
     logTestStdout.rehydrate(delegate, owner, this)()
+
+    reports {
+      junitXml {
+        outputPerTestCase = true
+      }
+    }
 
     exclude testsToExclude
 


### PR DESCRIPTION
Currently, output captured during tests is combined for every test in the suite and stored in a single location. This makes it difficult to diagnose CI failures since that combined test output is truncated if it exceeds a certain length, which often means that output for entire test cases at a time gets completely wiped.

The change here causes output to be stored per test case (i.e., method) instead of suite (i.e., class), which should make more information available and reduce the impact of truncation. If/when it becomes possible to store complete test output for failing tests only (this is currently not feasible with the Jenkins JUnit plugin), it will also allow us to retain less test output since we'll be able to store the output of individual failed cases instead of entire suites that may only contain one or two failures.

I'm unsure if this approach works for JUnit 5 or not, so I'm opening this PR as a draft for now. If/when I've been able to validate compatibility, I'll mark it ready for review.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
