### PR TITLE
KAFKA-16157: fix topic recreation handling with offline disks

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -133,6 +133,9 @@ class LogManager(logDirs: Seq[File],
 
   private val preferredLogDirs = new ConcurrentHashMap[TopicPartition, String]()
 
+  def hasOfflineLogDirs(): Boolean = offlineLogDirs.nonEmpty
+  def onlineLogDirId(uuid: Uuid): Boolean = directoryIds.exists(_._2 == uuid)
+
   private def offlineLogDirs: Iterable[File] = {
     val logDirsSet = mutable.Set[File]() ++= logDirs
     _liveLogDirs.forEach(dir => logDirsSet -= dir)

--- a/core/src/main/scala/kafka/server/DelayedDeleteRecords.scala
+++ b/core/src/main/scala/kafka/server/DelayedDeleteRecords.scala
@@ -84,7 +84,7 @@ class DelayedDeleteRecords(delayMs: Long,
                 (false, Errors.NOT_LEADER_OR_FOLLOWER, DeleteRecordsResponse.INVALID_LOW_WATERMARK)
             }
 
-          case HostedPartition.Offline =>
+          case HostedPartition.Offline(_) =>
             (false, Errors.KAFKA_STORAGE_ERROR, DeleteRecordsResponse.INVALID_LOW_WATERMARK)
 
           case HostedPartition.None =>

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -4804,7 +4804,10 @@ class ReplicaManagerTest {
 
       replicaManager.becomeLeaderOrFollower(0, request, (_, _) => ())
 
-      assertEquals(HostedPartition.Offline, replicaManager.getPartition(topicPartition))
+      assertEquals(
+        HostedPartition.Offline(Some(request.topicIds().get(topicPartition.topic()))),
+        replicaManager.getPartition(topicPartition)
+      )
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }
@@ -5563,7 +5566,7 @@ class ReplicaManagerTest {
       replicaManager.applyDelta(topicsDelta, leaderMetadataImage)
       verifyRLMOnLeadershipChange(Collections.emptySet(), Collections.emptySet())
 
-      assertEquals(HostedPartition.Offline, replicaManager.getPartition(topicPartition))
+      assertEquals(HostedPartition.Offline(Some(FOO_UUID)), replicaManager.getPartition(topicPartition))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }


### PR DESCRIPTION
In Kraft mode, the broker fails to handle topic recreation correctly with broken disks. This is because `ReplicaManager` tracks HostedPartitions which are on an offline disk but it doesn't associate TopicId information with them.

This change updates `HostedPartition.Offline` to associate topic id information. We also update the log creation logic in `Partition::createLogInAssignedDirectoryId` to not just rely on `targetLogDirectoryId == DirectoryId.UNASSIGNED` to determine if the log to be created is "new".

Please refer to the comments in https://issues.apache.org/jira/browse/KAFKA-16157 for more information.