### PR TITLE
KAFKA-14412: Add statestore.uncommitted.max.bytes

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1028,6 +1028,7 @@ public class KafkaStreams implements AutoCloseable {
         totalCacheSize = getTotalCacheSize(applicationConfigs);
         final int numStreamThreads = topologyMetadata.getNumStreamThreads(applicationConfigs);
         final long cacheSizePerThread = getCacheSizePerThread(numStreamThreads);
+        final long maxUncommittedBytesPerThread = getMaxUncommittedBytesPerThread(numStreamThreads);
 
         GlobalStreamThread.State globalThreadState = null;
         if (hasGlobalTopology) {
@@ -1058,14 +1059,16 @@ public class KafkaStreams implements AutoCloseable {
 
         queryableStoreProvider = new QueryableStoreProvider(globalStateStoreProvider);
         for (int i = 1; i <= numStreamThreads; i++) {
-            createAndAddStreamThread(cacheSizePerThread, i);
+            createAndAddStreamThread(cacheSizePerThread, maxUncommittedBytesPerThread, i);
         }
 
         stateDirCleaner = setupStateDirCleaner();
         rocksDBMetricsRecordingService = maybeCreateRocksDBMetricsRecordingService(clientId, applicationConfigs);
     }
 
-    private StreamThread createAndAddStreamThread(final long cacheSizePerThread, final int threadIdx) {
+    private StreamThread createAndAddStreamThread(final long cacheSizePerThread,
+                                                  final long maxUncommitteBytesPerThread,
+                                                  final int threadIdx) {
         final StreamThread streamThread = StreamThread.create(
             topologyMetadata,
             applicationConfigs,
@@ -1082,7 +1085,8 @@ public class KafkaStreams implements AutoCloseable {
             delegatingStandbyUpdateListener,
             threadIdx,
             KafkaStreams.this::closeToError,
-            streamsUncaughtExceptionHandler
+            streamsUncaughtExceptionHandler,
+            maxUncommitteBytesPerThread
         );
         streamThread.setStateListener(streamStateListener);
         threads.add(streamThread);
@@ -1123,12 +1127,13 @@ public class KafkaStreams implements AutoCloseable {
                 final int threadIdx = getNextThreadIndex();
                 final int numLiveThreads = getNumLiveStreamThreads();
                 final long cacheSizePerThread = getCacheSizePerThread(numLiveThreads + 1);
+                final long maxUncommittedBytesPerThread = getMaxUncommittedBytesPerThread(numLiveThreads + 1);
                 log.info("Adding StreamThread-{}, there will now be {} live threads and the new cache size per thread is {}",
                          threadIdx, numLiveThreads + 1, cacheSizePerThread);
                 resizeThreadCache(cacheSizePerThread);
                 // Creating thread should hold the lock in order to avoid duplicate thread index.
                 // If the duplicate index happen, the metadata of thread may be duplicate too.
-                streamThread = createAndAddStreamThread(cacheSizePerThread, threadIdx);
+                streamThread = createAndAddStreamThread(cacheSizePerThread, maxUncommittedBytesPerThread, threadIdx);
             }
 
             synchronized (stateLock) {
@@ -1341,6 +1346,17 @@ public class KafkaStreams implements AutoCloseable {
             return totalCacheSize;
         }
         return totalCacheSize / (numStreamThreads + (topologyMetadata.hasGlobalTopology() ? 1 : 0));
+    }
+
+    private long getMaxUncommittedBytesPerThread(final int numStreamThreads) {
+        final long maxUncommittedBytes = applicationConfigs.getLong(StreamsConfig.STATESTORE_UNCOMMITTED_MAX_BYTES_CONFIG);
+        if (maxUncommittedBytes == -1) {
+            return -1;
+        }
+        if (numStreamThreads == 0) {
+            return maxUncommittedBytes;
+        }
+        return maxUncommittedBytes / (numStreamThreads + (topologyMetadata.hasGlobalTopology() ? 1 : 0));
     }
 
     private void resizeThreadCache(final long cacheSizePerThread) {

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -504,6 +504,7 @@ public class StreamsConfig extends AbstractConfig {
     public static final String STATESTORE_CACHE_MAX_BYTES_CONFIG = "statestore.cache.max.bytes";
     public static final String STATESTORE_CACHE_MAX_BYTES_DOC = "Maximum number of memory bytes to be used for statestore cache across all threads";
 
+    public static final long UNBOUNDED_STATESTORE_UNCOMMITTED_BYTES = -1L;
     public static final String STATESTORE_UNCOMMITTED_MAX_BYTES_CONFIG = "statestore.uncommitted.max.bytes";
     public static final String STATESTORE_UNCOMMITTED_MAX_BYTES_DOC = "Maximum number of memory bytes to be used to buffer uncommitted state-store records. " +
             "If this limit is exceeded, a task commit will be requested. No limit: -1. ";

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -506,8 +506,7 @@ public class StreamsConfig extends AbstractConfig {
 
     public static final String STATESTORE_UNCOMMITTED_MAX_BYTES_CONFIG = "statestore.uncommitted.max.bytes";
     public static final String STATESTORE_UNCOMMITTED_MAX_BYTES_DOC = "Maximum number of memory bytes to be used to buffer uncommitted state-store records. " +
-            "If this limit is exceeded, a task commit will be requested. No limit: -1. " +
-            "Note: if this is too high or unbounded, it's possible for RocksDB to trigger out-of-memory errors.";
+            "If this limit is exceeded, a task commit will be requested. No limit: -1. ";
 
     /** {@code client.id} */
     @SuppressWarnings("WeakerAccess")

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -504,6 +504,11 @@ public class StreamsConfig extends AbstractConfig {
     public static final String STATESTORE_CACHE_MAX_BYTES_CONFIG = "statestore.cache.max.bytes";
     public static final String STATESTORE_CACHE_MAX_BYTES_DOC = "Maximum number of memory bytes to be used for statestore cache across all threads";
 
+    public static final String STATESTORE_UNCOMMITTED_MAX_BYTES_CONFIG = "statestore.uncommitted.max.bytes";
+    public static final String STATESTORE_UNCOMMITTED_MAX_BYTES_DOC = "Maximum number of memory bytes to be used to buffer uncommitted state-store records. " +
+            "If this limit is exceeded, a task commit will be requested. No limit: -1. " +
+            "Note: if this is too high or unbounded, it's possible for RocksDB to trigger out-of-memory errors.";
+
     /** {@code client.id} */
     @SuppressWarnings("WeakerAccess")
     public static final String CLIENT_ID_CONFIG = CommonClientConfigs.CLIENT_ID_CONFIG;
@@ -874,6 +879,12 @@ public class StreamsConfig extends AbstractConfig {
                     atLeast(0),
                     Importance.MEDIUM,
                     STATESTORE_CACHE_MAX_BYTES_DOC)
+            .define(STATESTORE_UNCOMMITTED_MAX_BYTES_CONFIG,
+                    Type.LONG,
+                    64 * 1024 * 1024L,
+                    atLeast(-1),
+                    Importance.MEDIUM,
+                    STATESTORE_UNCOMMITTED_MAX_BYTES_DOC)
             .define(CLIENT_ID_CONFIG,
                     Type.STRING,
                     "",

--- a/streams/src/main/java/org/apache/kafka/streams/processor/StateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/StateStore.java
@@ -165,4 +165,22 @@ public interface StateStore {
             "getPosition is not implemented by this StateStore (" + getClass() + ")"
         );
     }
+
+    /**
+     * Return an approximate count of memory used by records not yet committed to this StateStore.
+     * <p>
+     * This method will return an approximation of the memory that would be freed by the next call to {@link
+     * #flush()}.
+     * <p>
+     * If no records have been written to this store since {@link #init(StateStoreContext, StateStore) opening}, or
+     * since the last {@link #flush()}; or if this store does not support atomic transactions, it will return {@code
+     * 0}, as no records are currently being buffered.
+     *
+     * @return The approximate size of all records awaiting {@link #flush()}; or {@code 0} if this store does not
+     *         support transactions, or has not been written to since {@link #init(StateStoreContext, StateStore)} or
+     *         last {@link #flush()}.
+     */
+    default long approximateNumUncommittedBytes() {
+        return 0;
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -438,4 +438,11 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
     public final String changelogFor(final String storeName) {
         return storeToChangelogTopic.get(storeName);
     }
+
+    @Override
+    public long approximateNumUncommittedBytes() {
+        return globalStores.values().stream()
+            .map(optional -> optional.map(StateStore::approximateNumUncommittedBytes).orElse(0L))
+            .reduce(0L, Long::sum);
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -754,4 +754,11 @@ public class ProcessorStateManager implements StateManager {
             checkpointFile.delete();
         }
     }
+
+    @Override
+    public long approximateNumUncommittedBytes() {
+        return stores.values().stream()
+                .map(metadata -> metadata.store().approximateNumUncommittedBytes())
+                .reduce(0L, Long::sum);
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManager.java
@@ -57,4 +57,10 @@ public interface StateManager {
 
     // TODO: we can remove this when consolidating global state manager into processor state manager
     StateStore getGlobalStore(final String name);
+
+    /**
+     * @return The approximate total size of all records not yet committed to {@link StateStore state stores} managed
+     *         by this StateManager.
+     */
+    long approximateNumUncommittedBytes();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -366,7 +366,8 @@ public class StreamThread extends Thread implements ProcessingThread {
                                       final StandbyUpdateListener userStandbyUpdateListener,
                                       final int threadIdx,
                                       final Runnable shutdownErrorHook,
-                                      final BiConsumer<Throwable, Boolean> streamsUncaughtExceptionHandler) {
+                                      final BiConsumer<Throwable, Boolean> streamsUncaughtExceptionHandler,
+                                      final long maxUncommittedBytes) {
         final String threadId = clientId + "-StreamThread-" + threadIdx;
 
         final String logPrefix = String.format("stream-thread [%s] ", threadId);
@@ -453,7 +454,8 @@ public class StreamThread extends Thread implements ProcessingThread {
             adminClient,
             stateDirectory,
             stateUpdater,
-            schedulingTaskManager
+            schedulingTaskManager,
+            maxUncommittedBytes
         );
         referenceContainer.taskManager = taskManager;
 
@@ -1374,7 +1376,7 @@ public class StreamThread extends Thread implements ProcessingThread {
      */
     int maybeCommit() {
         final int committed;
-        if (now - lastCommitMs > commitTimeMs) {
+        if (taskManager.needsCommit() || now - lastCommitMs > commitTimeMs) {
             if (log.isDebugEnabled()) {
                 log.debug("Committing all active tasks {} and standby tasks {} since {}ms has elapsed (commit interval is {}ms)",
                           taskManager.activeRunningTaskIds(), taskManager.standbyTaskIds(), now - lastCommitMs, commitTimeMs);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1376,7 +1376,7 @@ public class StreamThread extends Thread implements ProcessingThread {
      */
     int maybeCommit() {
         final int committed;
-        if (taskManager.needsCommit() || now - lastCommitMs > commitTimeMs) {
+        if (taskManager.needsCommit(true) || now - lastCommitMs > commitTimeMs) {
             if (log.isDebugEnabled()) {
                 log.debug("Committing all active tasks {} and standby tasks {} since {}ms has elapsed (commit interval is {}ms)",
                           taskManager.activeRunningTaskIds(), taskManager.standbyTaskIds(), now - lastCommitMs, commitTimeMs);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1376,7 +1376,7 @@ public class StreamThread extends Thread implements ProcessingThread {
      */
     int maybeCommit() {
         final int committed;
-        if (taskManager.needsCommit(true) || now - lastCommitMs > commitTimeMs) {
+        if (taskManager.transactionBuffersExceedCapacity(true) || now - lastCommitMs > commitTimeMs) {
             if (log.isDebugEnabled()) {
                 log.debug("Committing all active tasks {} and standby tasks {} since {}ms has elapsed (commit interval is {}ms)",
                           taskManager.activeRunningTaskIds(), taskManager.standbyTaskIds(), now - lastCommitMs, commitTimeMs);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1376,7 +1376,7 @@ public class StreamThread extends Thread implements ProcessingThread {
      */
     int maybeCommit() {
         final int committed;
-        if (taskManager.transactionBuffersExceedCapacity(true) || now - lastCommitMs > commitTimeMs) {
+        if (taskManager.transactionBuffersWillExceedCapacity() || now - lastCommitMs > commitTimeMs) {
             if (log.isDebugEnabled()) {
                 log.debug("Committing all active tasks {} and standby tasks {} since {}ms has elapsed (commit interval is {}ms)",
                           taskManager.activeRunningTaskIds(), taskManager.standbyTaskIds(), now - lastCommitMs, commitTimeMs);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutor.java
@@ -141,7 +141,7 @@ public class TaskExecutor {
     int commitTasksAndMaybeUpdateCommittableOffsets(final Collection<Task> tasksToCommit,
                                                     final Map<Task, Map<TopicPartition, OffsetAndMetadata>> consumedOffsetsAndMetadata) {
         int committed = 0;
-        final boolean enfoceCheckpoint = taskManager.needsCommit(false);
+        final boolean enforceCheckpoint = taskManager.needsCommit(false);
         for (final Task task : tasksToCommit) {
             // we need to call commitNeeded first since we need to update committable offsets
             if (task.commitNeeded()) {
@@ -159,7 +159,7 @@ public class TaskExecutor {
                 task.clearTaskTimeout();
                 ++committed;
                 // under EOS, we need to enforce a checkpoint if our transaction buffers will exceeded their capacity
-                task.postCommit(enfoceCheckpoint);
+                task.postCommit(enforceCheckpoint);
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutor.java
@@ -141,7 +141,7 @@ public class TaskExecutor {
     int commitTasksAndMaybeUpdateCommittableOffsets(final Collection<Task> tasksToCommit,
                                                     final Map<Task, Map<TopicPartition, OffsetAndMetadata>> consumedOffsetsAndMetadata) {
         int committed = 0;
-        final boolean enforceCheckpoint = taskManager.transactionBuffersExceedCapacity(false);
+        final boolean enforceCheckpoint = taskManager.transactionBuffersExceedCapacity();
         for (final Task task : tasksToCommit) {
             // we need to call commitNeeded first since we need to update committable offsets
             if (task.commitNeeded()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskExecutor.java
@@ -141,7 +141,7 @@ public class TaskExecutor {
     int commitTasksAndMaybeUpdateCommittableOffsets(final Collection<Task> tasksToCommit,
                                                     final Map<Task, Map<TopicPartition, OffsetAndMetadata>> consumedOffsetsAndMetadata) {
         int committed = 0;
-        final boolean enforceCheckpoint = taskManager.needsCommit(false);
+        final boolean enforceCheckpoint = taskManager.transactionBuffersExceedCapacity(false);
         for (final Task task : tasksToCommit) {
             // we need to call commitNeeded first since we need to update committable offsets
             if (task.commitNeeded()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1843,8 +1843,8 @@ public class TaskManager {
     }
 
     boolean needsCommit(final boolean updateDelta) {
-        if (maxUncommittedStateBytes < 0) {
-            // if our transaction buffers are unbounded, we never need to force an early commit
+        final boolean transactionBuffersAreUnbounded = maxUncommittedStateBytes < 0;
+        if (transactionBuffersAreUnbounded) {
             return false;
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1103,10 +1103,10 @@ public class TaskManager {
             for (final Task task : commitNeededActiveTasks) {
                 if (!dirtyTasks.contains(task)) {
                     try {
-                        // we only enforce a checkpoint if the transaction buffers are full
-                        // to avoid unnecessary flushing of stores under EOS
-                        final boolean enforceCheckpoint = maxUncommittedStateBytes > -1 && tasks.approximateUncommittedStateBytes() >= maxUncommittedStateBytes;
-                        task.postCommit(enforceCheckpoint);
+                        // for non-revoking active tasks, we should not enforce checkpoint
+                        // since if it is EOS enabled, no checkpoint should be written while
+                        // the task is in RUNNING tate
+                        task.postCommit(false);
                     } catch (final RuntimeException e) {
                         log.error("Exception caught while post-committing task " + task.id(), e);
                         maybeSetFirstException(false, maybeWrapTaskException(e, task.id()), firstException);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1842,7 +1842,13 @@ public class TaskManager {
         }
     }
 
-    boolean transactionBuffersExceedCapacity(final boolean predictNextCycle) {
+    private boolean transactionBuffersExceedCapacity = false;
+
+    boolean transactionBuffersExceedCapacity() {
+        return transactionBuffersExceedCapacity;
+    }
+
+    boolean transactionBuffersWillExceedCapacity() {
         final boolean transactionBuffersAreUnbounded = maxUncommittedStateBytes < 0;
         if (transactionBuffersAreUnbounded) {
             return false;
@@ -1860,9 +1866,9 @@ public class TaskManager {
                 maxUncommittedStateBytes, lastUncommittedBytes, uncommittedBytes, deltaBytes
             );
         }
-        if (predictNextCycle) {
-            lastUncommittedBytes = uncommittedBytes;
-        }
+
+        transactionBuffersExceedCapacity = needsCommit;
+        lastUncommittedBytes = uncommittedBytes;
         return needsCommit;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -102,6 +102,7 @@ public class TaskManager {
     private final DefaultTaskManager schedulingTaskManager;
     private final long maxUncommittedStateBytes;
     private long lastUncommittedBytes = 0L;
+    private boolean transactionBuffersExceedCapacity = false;
 
     TaskManager(final Time time,
                 final ChangelogReader changelogReader,
@@ -1841,8 +1842,6 @@ public class TaskManager {
             maybeThrowTaskExceptions(schedulingTaskManager.drainUncaughtExceptions());
         }
     }
-
-    private boolean transactionBuffersExceedCapacity = false;
 
     boolean transactionBuffersExceedCapacity() {
         return transactionBuffersExceedCapacity;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
@@ -1848,7 +1849,7 @@ public class TaskManager {
     }
 
     boolean transactionBuffersWillExceedCapacity() {
-        final boolean transactionBuffersAreUnbounded = maxUncommittedStateBytes < 0;
+        final boolean transactionBuffersAreUnbounded = maxUncommittedStateBytes == StreamsConfig.UNBOUNDED_STATESTORE_UNCOMMITTED_BYTES;
         if (transactionBuffersAreUnbounded) {
             return false;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -100,6 +100,8 @@ public class TaskManager {
     private final StandbyTaskCreator standbyTaskCreator;
     private final StateUpdater stateUpdater;
     private final DefaultTaskManager schedulingTaskManager;
+    private final long maxUncommittedStateBytes;
+
     TaskManager(final Time time,
                 final ChangelogReader changelogReader,
                 final UUID processId,
@@ -111,7 +113,8 @@ public class TaskManager {
                 final Admin adminClient,
                 final StateDirectory stateDirectory,
                 final StateUpdater stateUpdater,
-                final DefaultTaskManager schedulingTaskManager
+                final DefaultTaskManager schedulingTaskManager,
+                final long maxUncommittedStateBytes
                 ) {
         this.time = time;
         this.processId = processId;
@@ -134,8 +137,11 @@ public class TaskManager {
             this.tasks,
             this,
             topologyMetadata.taskExecutionMetadata(),
-            logContext
+            logContext,
+            maxUncommittedStateBytes
         );
+
+        this.maxUncommittedStateBytes = maxUncommittedStateBytes;
     }
 
     void setMainConsumer(final Consumer<byte[], byte[]> mainConsumer) {
@@ -1097,10 +1103,10 @@ public class TaskManager {
             for (final Task task : commitNeededActiveTasks) {
                 if (!dirtyTasks.contains(task)) {
                     try {
-                        // for non-revoking active tasks, we should not enforce checkpoint
-                        // since if it is EOS enabled, no checkpoint should be written while
-                        // the task is in RUNNING tate
-                        task.postCommit(false);
+                        // we only enforce a checkpoint if the transaction buffers are full
+                        // to avoid unnecessary flushing of stores under EOS
+                        final boolean enforceCheckpoint = maxUncommittedStateBytes > -1 && tasks.approximateUncommittedStateBytes() >= maxUncommittedStateBytes;
+                        task.postCommit(enforceCheckpoint);
                     } catch (final RuntimeException e) {
                         log.error("Exception caught while post-committing task " + task.id(), e);
                         maybeSetFirstException(false, maybeWrapTaskException(e, task.id()), firstException);
@@ -1836,6 +1842,25 @@ public class TaskManager {
         }
     }
 
+    private long lastUncommittedBytes = 0L;
+
+    boolean needsCommit() {
+        // force an early commit if the uncommitted bytes exceeds or is *likely to exceed* the configured threshold
+        final long uncommittedBytes = tasks.approximateUncommittedStateBytes();
+
+        final long deltaBytes = Math.min(uncommittedBytes, Math.max(uncommittedBytes, uncommittedBytes - lastUncommittedBytes));
+
+        final boolean needsCommit =  maxUncommittedStateBytes > -1 && uncommittedBytes + deltaBytes > maxUncommittedStateBytes;
+        if (needsCommit) {
+            log.debug(
+                    "Needs commit because we will exceed max uncommitted bytes before next commit. max: {}, last: {}, current: {}, delta: {}",
+                    maxUncommittedStateBytes, lastUncommittedBytes, uncommittedBytes, deltaBytes
+            );
+        }
+        lastUncommittedBytes = uncommittedBytes;
+        return needsCommit;
+    }
+
     /**
      * @throws TaskMigratedException if committing offsets failed (non-EOS)
      *                               or if the task producer got fenced (EOS)
@@ -1889,7 +1914,9 @@ public class TaskManager {
         if (rebalanceInProgress) {
             return -1;
         } else {
-            return taskExecutor.commitTasksAndMaybeUpdateCommittableOffsets(tasksToCommit, consumedOffsetsAndMetadata);
+            final int committedOffsets = taskExecutor.commitTasksAndMaybeUpdateCommittableOffsets(tasksToCommit, consumedOffsetsAndMetadata);
+            lastUncommittedBytes = 0L;
+            return committedOffsets;
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1856,8 +1856,8 @@ public class TaskManager {
         final boolean needsCommit = uncommittedBytes + deltaBytes > maxUncommittedStateBytes;
         if (needsCommit) {
             log.debug(
-                    "Needs commit because we will exceed max uncommitted bytes before next commit. max: {}, last: {}, current: {}, delta: {}",
-                    maxUncommittedStateBytes, lastUncommittedBytes, uncommittedBytes, deltaBytes
+                "Needs commit because we will exceed max uncommitted bytes before next commit. max: {}, last: {}, current: {}, delta: {}",
+                maxUncommittedStateBytes, lastUncommittedBytes, uncommittedBytes, deltaBytes
             );
         }
         if (updateDelta) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -101,6 +101,7 @@ public class TaskManager {
     private final StateUpdater stateUpdater;
     private final DefaultTaskManager schedulingTaskManager;
     private final long maxUncommittedStateBytes;
+    private long lastUncommittedBytes = 0L;
 
     TaskManager(final Time time,
                 final ChangelogReader changelogReader,
@@ -1841,9 +1842,6 @@ public class TaskManager {
         }
     }
 
-    // track the size of the transaction buffer on each iteration to predict when it will be exceeded in advance
-    private long lastUncommittedBytes = 0L;
-
     boolean needsCommit(final boolean updateDelta) {
         if (maxUncommittedStateBytes < 0) {
             // if our transaction buffers are unbounded, we never need to force an early commit
@@ -1855,7 +1853,7 @@ public class TaskManager {
 
         final long deltaBytes = Math.max(0, uncommittedBytes - lastUncommittedBytes);
 
-        final boolean needsCommit =  maxUncommittedStateBytes > -1 && uncommittedBytes + deltaBytes > maxUncommittedStateBytes;
+        final boolean needsCommit =  uncommittedBytes + deltaBytes > maxUncommittedStateBytes;
         if (needsCommit) {
             log.debug(
                     "Needs commit because we will exceed max uncommitted bytes before next commit. max: {}, last: {}, current: {}, delta: {}",

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1853,7 +1853,7 @@ public class TaskManager {
 
         final long deltaBytes = Math.max(0, uncommittedBytes - lastUncommittedBytes);
 
-        final boolean needsCommit =  uncommittedBytes + deltaBytes > maxUncommittedStateBytes;
+        final boolean needsCommit = uncommittedBytes + deltaBytes > maxUncommittedStateBytes;
         if (needsCommit) {
             log.debug(
                     "Needs commit because we will exceed max uncommitted bytes before next commit. max: {}, last: {}, current: {}, delta: {}",

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1842,7 +1842,7 @@ public class TaskManager {
         }
     }
 
-    boolean needsCommit(final boolean updateDelta) {
+    boolean transactionBuffersExceedCapacity(final boolean predictNextCycle) {
         final boolean transactionBuffersAreUnbounded = maxUncommittedStateBytes < 0;
         if (transactionBuffersAreUnbounded) {
             return false;
@@ -1860,7 +1860,7 @@ public class TaskManager {
                 maxUncommittedStateBytes, lastUncommittedBytes, uncommittedBytes, deltaBytes
             );
         }
-        if (updateDelta) {
+        if (predictNextCycle) {
             lastUncommittedBytes = uncommittedBytes;
         }
         return needsCommit;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1925,8 +1925,7 @@ public class TaskManager {
         if (rebalanceInProgress) {
             return -1;
         } else {
-            final int committedOffsets = taskExecutor.commitTasksAndMaybeUpdateCommittableOffsets(tasksToCommit, consumedOffsetsAndMetadata);
-            return committedOffsets;
+            return taskExecutor.commitTasksAndMaybeUpdateCommittableOffsets(tasksToCommit, consumedOffsetsAndMetadata);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
@@ -404,4 +404,11 @@ class Tasks implements TasksRegistry {
     public boolean contains(final TaskId taskId) {
         return getTask(taskId) != null;
     }
+
+    @Override
+    public long approximateUncommittedStateBytes() {
+        return activeTasksPerId.values().stream()
+                .map(task -> task.stateManager().approximateNumUncommittedBytes())
+                .reduce(0L, Long::sum);
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TasksRegistry.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TasksRegistry.java
@@ -100,4 +100,10 @@ public interface TasksRegistry {
     Set<TaskId> allTaskIds();
 
     boolean contains(final TaskId taskId);
+
+    /**
+     * @return The approximate total size of all records not yet committed to state stores managed
+     *         by this StateManager.
+     */
+    long approximateUncommittedStateBytes();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
@@ -286,6 +286,11 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
     }
 
     @Override
+    public long approximateNumUncommittedBytes() {
+        return segments.approximateNumUncommittedBytes();
+    }
+
+    @Override
     public void flush() {
         segments.flush();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -338,6 +338,11 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
     }
 
     @Override
+    public long approximateNumUncommittedBytes() {
+        return segments.approximateNumUncommittedBytes();
+    }
+
+    @Override
     public void flush() {
         segments.flush();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractSegments.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.state.internals;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.processor.StateStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -156,6 +157,13 @@ abstract class AbstractSegments<S extends Segment> implements Segments<S> {
             }
         }
         return result;
+    }
+
+    @Override
+    public long approximateNumUncommittedBytes() {
+        return segments.values().stream()
+            .map(StateStore::approximateNumUncommittedBytes)
+            .reduce(0L, Long::sum);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueStoreWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueStoreWrapper.java
@@ -133,6 +133,11 @@ public class KeyValueStoreWrapper<K, V> implements StateStore {
     }
 
     @Override
+    public long approximateNumUncommittedBytes() {
+        return store.approximateNumUncommittedBytes();
+    }
+
+    @Override
     public void flush() {
         store.flush();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueToTimestampedKeyValueByteStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueToTimestampedKeyValueByteStoreAdapter.java
@@ -206,6 +206,11 @@ public class KeyValueToTimestampedKeyValueByteStoreAdapter implements KeyValueSt
         return store.approximateNumEntries();
     }
 
+    @Override
+    public long approximateNumUncommittedBytes() {
+        return store.approximateNumUncommittedBytes();
+    }
+
     private static class KeyValueToTimestampedKeyValueAdapterIterator implements ManagedKeyValueIterator<Bytes, byte[]> {
 
         private final RocksDbIterator rocksDbIterator;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegments.java
@@ -113,6 +113,11 @@ public class LogicalKeyValueSegments extends AbstractSegments<LogicalKeyValueSeg
     }
 
     @Override
+    public long approximateNumUncommittedBytes() {
+        return physicalStore.approximateNumUncommittedBytes();
+    }
+
+    @Override
     public void flush() {
         physicalStore.flush();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -740,6 +740,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         void deleteRange(final ColumnFamilyHandle columnFamily, final byte[] from, final byte[] to) throws RocksDBException;
         long approximateNumEntries(final ColumnFamilyHandle columnFamily) throws RocksDBException;
         void flush(final ColumnFamilyHandle... columnFamilies) throws RocksDBException;
+        long approximateNumUncommittedBytes();
         void reset();
         void close();
     }
@@ -789,6 +790,10 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         @Override
         public long approximateNumEntries(final ColumnFamilyHandle columnFamily) throws RocksDBException {
             return db.getLongProperty(columnFamily, "rocksdb.estimate-num-keys");
+        }
+
+        public long approximateNumUncommittedBytes() {
+            return 0;
         }
 
         @Override
@@ -1012,6 +1017,11 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
     @Override
     public Position getPosition() {
         return position;
+    }
+
+    @Override
+    public long approximateNumUncommittedBytes() {
+        return dbAccessor.approximateNumUncommittedBytes();
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
@@ -191,6 +191,11 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V> implements TimeOrderedKeyVal
     }
 
     @Override
+    public long approximateNumUncommittedBytes() {
+        return store.approximateNumUncommittedBytes();
+    }
+
+    @Override
     public void flush() {
         store.flush();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStore.java
@@ -304,6 +304,11 @@ public class RocksDBVersionedStore implements VersionedKeyValueStore<Bytes, byte
     }
 
     @Override
+    public long approximateNumUncommittedBytes() {
+        return segmentStores.approximateNumUncommittedBytes();
+    }
+
+    @Override
     public void flush() {
         segmentStores.flush();
         // flushing segments store includes flushing latest value store, since they share the

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Segments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Segments.java
@@ -38,6 +38,8 @@ interface Segments<S extends Segment> {
 
     List<S> allSegments(final boolean forward);
 
+    long approximateNumUncommittedBytes();
+
     void flush();
 
     void close();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/VersionedKeyValueToBytesStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/VersionedKeyValueToBytesStoreAdapter.java
@@ -99,6 +99,11 @@ public class VersionedKeyValueToBytesStoreAdapter implements VersionedBytesStore
     }
 
     @Override
+    public long approximateNumUncommittedBytes() {
+        return inner.approximateNumUncommittedBytes();
+    }
+
+    @Override
     public void flush() {
         inner.flush();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowToTimestampedWindowByteStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowToTimestampedWindowByteStoreAdapter.java
@@ -169,6 +169,11 @@ class WindowToTimestampedWindowByteStoreAdapter implements WindowStore<Bytes, by
     }
 
     @Override
+    public long approximateNumUncommittedBytes() {
+        return store.approximateNumUncommittedBytes();
+    }
+
+    @Override
     public void flush() {
         store.flush();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
@@ -151,4 +151,9 @@ public abstract class WrappedStateStore<S extends StateStore, K, V> implements S
     public S wrapped() {
         return wrapped;
     }
+
+    @Override
+    public long approximateNumUncommittedBytes() {
+        return wrapped.approximateNumUncommittedBytes();
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -268,7 +268,8 @@ public class KafkaStreamsTest {
                 any(StandbyUpdateListener.class),
                 anyInt(),
                 any(Runnable.class),
-                any()
+                any(),
+                anyLong()
         )).thenReturn(streamThreadOne).thenReturn(streamThreadTwo);
 
         streamsConfigUtils = mockStatic(StreamsConfigUtils.class);

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -1328,9 +1328,23 @@ public class StreamsConfigTest {
     }
 
     @Test
+    public void testStateStoreMaxUncommittedBytesShouldAllowPositive() {
+        props.put(StreamsConfig.STATESTORE_UNCOMMITTED_MAX_BYTES_CONFIG, 2);
+        final StreamsConfig config = new StreamsConfig(props);
+        assertEquals(Long.valueOf(2), config.getLong(StreamsConfig.STATESTORE_UNCOMMITTED_MAX_BYTES_CONFIG));
+    }
+
+    @Test
     public void shouldUseDefaultStateStoreMaxUncommittedBytesConfigWhenNoConfigIsSet() {
         final StreamsConfig config = new StreamsConfig(props);
         assertEquals(Long.valueOf(64 * 1024 * 1024), config.getLong(StreamsConfig.STATESTORE_UNCOMMITTED_MAX_BYTES_CONFIG));
+    }
+
+    @Test
+    public void shouldNotAllowNegativeStateStoreMaxUncommittedBytesConfig() {
+        props.put(StreamsConfig.STATESTORE_UNCOMMITTED_MAX_BYTES_CONFIG, -2);
+        final ConfigException ce = assertThrows(ConfigException.class, () -> new StreamsConfig(props));
+        assertTrue(ce.getMessage().contains(StreamsConfig.STATESTORE_UNCOMMITTED_MAX_BYTES_CONFIG));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -1321,6 +1321,19 @@ public class StreamsConfigTest {
     }
 
     @Test
+    public void testStateStoreMaxUncommittedBytesShouldAllowUnbounded() {
+        props.put(StreamsConfig.STATESTORE_UNCOMMITTED_MAX_BYTES_CONFIG, -1);
+        final StreamsConfig config = new StreamsConfig(props);
+        assertEquals(Long.valueOf(-1), config.getLong(StreamsConfig.STATESTORE_UNCOMMITTED_MAX_BYTES_CONFIG));
+    }
+
+    @Test
+    public void shouldUseDefaultStateStoreMaxUncommittedBytesConfigWhenNoConfigIsSet() {
+        final StreamsConfig config = new StreamsConfig(props);
+        assertEquals(Long.valueOf(64 * 1024 * 1024), config.getLong(StreamsConfig.STATESTORE_UNCOMMITTED_MAX_BYTES_CONFIG));
+    }
+
+    @Test
     public void testCaseInsensitiveSecurityProtocol() {
         final String saslSslLowerCase = SecurityProtocol.SASL_SSL.name.toLowerCase(Locale.ROOT);
         props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, saslSslLowerCase);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -1092,6 +1092,34 @@ public class GlobalStateManagerImplTest {
         assertThat(time.milliseconds() - startTime, equalTo(331_100L));
     }
 
+    @Test
+    public void shouldHaveZeroUncommittedBytesWhenThereAreNoStores() {
+        assertEquals(0L, stateManager.approximateNumUncommittedBytes());
+    }
+
+    @Test
+    public void shouldHaveZeroUncommittedBytesWhenStoresHaveNone() {
+        initializeConsumer(0, 0, t1, t2, t3, t4);
+        processorContext.setStateManger(stateManager);
+        stateManager.initialize();
+        assertEquals(store1, stateManager.getGlobalStore(storeName1));
+        assertEquals(store2, stateManager.getGlobalStore(storeName2));
+        assertEquals(store3, stateManager.getGlobalStore(storeName3));
+        assertEquals(store4, stateManager.getGlobalStore(storeName4));
+        assertEquals(0L, stateManager.approximateNumUncommittedBytes());
+    }
+
+    @Test
+    public void shouldSumUncommittedBytesOfStores() {
+        initializeConsumer(0, 0, t1, t2, t3, t4);
+        processorContext.setStateManger(stateManager);
+        stateManager.initialize();
+        store1.uncommittedBytes = 100;
+        store2.uncommittedBytes = 250;
+        store3.uncommittedBytes = 10;
+        assertEquals(360L, stateManager.approximateNumUncommittedBytes());
+    }
+
     private void writeCorruptCheckpoint() throws IOException {
         final File checkpointFile = new File(stateManager.baseDir(), StateManagerUtil.CHECKPOINT_FILE_NAME);
         try (final OutputStream stream = Files.newOutputStream(checkpointFile.toPath())) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerStub.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerStub.java
@@ -74,4 +74,9 @@ public class StateManagerStub implements StateManager {
     public String changelogFor(final String storeName) {
         return null;
     }
+
+    @Override
+    public long approximateNumUncommittedBytes() {
+        return 0;
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -163,7 +163,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atMostOnce;
@@ -1092,21 +1091,21 @@ public class StreamThreadTest {
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
         final Task runningTask = mock(Task.class);
         final TaskManager taskManager = mockTaskManagerCommit(runningTask, 2);
-        when(taskManager.transactionBuffersExceedCapacity(anyBoolean())).thenReturn(false);
+        when(taskManager.transactionBuffersWillExceedCapacity()).thenReturn(false);
 
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
         thread = buildStreamThread(consumer, taskManager, config, topologyMetadata);
 
         // initial commit because no commit since start of application
-        when(taskManager.transactionBuffersExceedCapacity(anyBoolean())).thenReturn(false);
+        when(taskManager.transactionBuffersWillExceedCapacity()).thenReturn(false);
         thread.setNow(mockTime.milliseconds());
         thread.maybeCommit();
         verify(taskManager).commit(mkSet(runningTask));
 
         // early commit requested, despite interval not having passed
         clearInvocations(taskManager);
-        when(taskManager.transactionBuffersExceedCapacity(anyBoolean())).thenReturn(true);
+        when(taskManager.transactionBuffersWillExceedCapacity()).thenReturn(true);
         mockTime.sleep(commitInterval - 20L);
         thread.setNow(mockTime.milliseconds());
         thread.maybeCommit();
@@ -1114,7 +1113,7 @@ public class StreamThreadTest {
 
         // no commit because interval has not passed and no early commit requested
         clearInvocations(taskManager);
-        when(taskManager.transactionBuffersExceedCapacity(anyBoolean())).thenReturn(false);
+        when(taskManager.transactionBuffersWillExceedCapacity()).thenReturn(false);
         mockTime.sleep(10L);
         thread.setNow(mockTime.milliseconds());
         thread.maybeCommit();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -338,7 +338,8 @@ public class StreamThreadTest {
             new MockStandbyUpdateListener(),
             threadIdx,
             null,
-            HANDLER
+            HANDLER,
+            -1L
         );
     }
 
@@ -743,7 +744,8 @@ public class StreamThreadTest {
             new MockStandbyUpdateListener(),
             threadIdx,
             null,
-            mockExceptionHandler
+            mockExceptionHandler,
+            -1L
         );
 
         mockClientSupplier.nextRebalanceMs().set(mockTime.milliseconds() - 1L);
@@ -805,7 +807,8 @@ public class StreamThreadTest {
             new MockStandbyUpdateListener(),
             threadIdx,
             null,
-            null
+            null,
+            -1L
         );
 
         mockClientSupplier.nextRebalanceMs().set(mockTime.milliseconds() - 1L);
@@ -1041,7 +1044,8 @@ public class StreamThreadTest {
             null,
             null,
             null,
-            null
+            null,
+            -1L
         ) {
             @Override
             int commit(final Collection<Task> tasksToCommit) {
@@ -1146,7 +1150,8 @@ public class StreamThreadTest {
             null,
             null,
             stateUpdater,
-            schedulingTaskManager
+            schedulingTaskManager,
+            -1L
         ) {
             @Override
             int commit(final Collection<Task> tasksToCommit) {
@@ -1953,7 +1958,8 @@ public class StreamThreadTest {
             new MockStandbyUpdateListener(),
             threadIdx,
             null,
-            HANDLER
+            HANDLER,
+            -1L
         );
 
         thread.setState(StreamThread.State.STARTING);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1092,21 +1092,21 @@ public class StreamThreadTest {
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
         final Task runningTask = mock(Task.class);
         final TaskManager taskManager = mockTaskManagerCommit(runningTask, 2);
-        when(taskManager.needsCommit(anyBoolean())).thenReturn(false);
+        when(taskManager.transactionBuffersExceedCapacity(anyBoolean())).thenReturn(false);
 
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
         thread = buildStreamThread(consumer, taskManager, config, topologyMetadata);
 
         // initial commit because no commit since start of application
-        when(taskManager.needsCommit(anyBoolean())).thenReturn(false);
+        when(taskManager.transactionBuffersExceedCapacity(anyBoolean())).thenReturn(false);
         thread.setNow(mockTime.milliseconds());
         thread.maybeCommit();
         verify(taskManager).commit(mkSet(runningTask));
 
         // early commit requested, despite interval not having passed
         clearInvocations(taskManager);
-        when(taskManager.needsCommit(anyBoolean())).thenReturn(true);
+        when(taskManager.transactionBuffersExceedCapacity(anyBoolean())).thenReturn(true);
         mockTime.sleep(commitInterval - 20L);
         thread.setNow(mockTime.milliseconds());
         thread.maybeCommit();
@@ -1114,7 +1114,7 @@ public class StreamThreadTest {
 
         // no commit because interval has not passed and no early commit requested
         clearInvocations(taskManager);
-        when(taskManager.needsCommit(anyBoolean())).thenReturn(false);
+        when(taskManager.transactionBuffersExceedCapacity(anyBoolean())).thenReturn(false);
         mockTime.sleep(10L);
         thread.setNow(mockTime.milliseconds());
         thread.maybeCommit();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutorTest.java
@@ -38,7 +38,7 @@ public class TaskExecutorTest {
         final TaskManager taskManager = mock(TaskManager.class);
         final TaskExecutionMetadata metadata = mock(TaskExecutionMetadata.class);
 
-        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext());
+        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext(), -1L);
 
         taskExecutor.punctuate();
         verify(tasks).activeTasks();
@@ -57,7 +57,7 @@ public class TaskExecutorTest {
         when(taskManager.threadProducer()).thenReturn(producer);
         when(producer.transactionInFlight()).thenReturn(true);
 
-        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext());
+        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext(), -1L);
         taskExecutor.commitOffsetsOrTransaction(Collections.emptyMap());
 
         verify(producer).commitTransaction(Collections.emptyMap(), groupMetadata);
@@ -81,7 +81,7 @@ public class TaskExecutorTest {
         when(taskManager.streamsProducerForTask(taskId)).thenReturn(producer);
         when(producer.transactionInFlight()).thenReturn(true);
 
-        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext());
+        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext(), -1L);
         taskExecutor.commitOffsetsOrTransaction(Collections.emptyMap());
 
         verify(producer).commitTransaction(Collections.emptyMap(), groupMetadata);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskExecutorTest.java
@@ -38,7 +38,7 @@ public class TaskExecutorTest {
         final TaskManager taskManager = mock(TaskManager.class);
         final TaskExecutionMetadata metadata = mock(TaskExecutionMetadata.class);
 
-        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext(), -1L);
+        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext());
 
         taskExecutor.punctuate();
         verify(tasks).activeTasks();
@@ -57,7 +57,7 @@ public class TaskExecutorTest {
         when(taskManager.threadProducer()).thenReturn(producer);
         when(producer.transactionInFlight()).thenReturn(true);
 
-        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext(), -1L);
+        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext());
         taskExecutor.commitOffsetsOrTransaction(Collections.emptyMap());
 
         verify(producer).commitTransaction(Collections.emptyMap(), groupMetadata);
@@ -81,7 +81,7 @@ public class TaskExecutorTest {
         when(taskManager.streamsProducerForTask(taskId)).thenReturn(producer);
         when(producer.transactionInFlight()).thenReturn(true);
 
-        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext(), -1L);
+        final TaskExecutor taskExecutor = new TaskExecutor(tasks, taskManager, metadata, new LogContext());
         taskExecutor.commitOffsetsOrTransaction(Collections.emptyMap());
 
         verify(producer).commitTransaction(Collections.emptyMap(), groupMetadata);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -234,10 +234,19 @@ public class TaskManagerTest {
         return setUpTaskManager(processingMode, tasks, stateUpdaterEnabled, false);
     }
 
+
     private TaskManager setUpTaskManager(final ProcessingMode processingMode,
                                          final TasksRegistry tasks,
                                          final boolean stateUpdaterEnabled,
                                          final boolean processingThreadsEnabled) {
+        return setUpTaskManager(processingMode, tasks, stateUpdaterEnabled, processingThreadsEnabled, -1L);
+    }
+
+    private TaskManager setUpTaskManager(final ProcessingMode processingMode,
+                                         final TasksRegistry tasks,
+                                         final boolean stateUpdaterEnabled,
+                                         final boolean processingThreadsEnabled,
+                                         final long maxUncommittedStateBytes) {
         topologyMetadata = new TopologyMetadata(topologyBuilder, new DummyStreamsConfig(processingMode));
         final TaskManager taskManager = new TaskManager(
             time,
@@ -252,7 +261,7 @@ public class TaskManagerTest {
             stateDirectory,
             stateUpdaterEnabled ? stateUpdater : null,
             processingThreadsEnabled ? schedulingTaskManager : null,
-            -1L
+            maxUncommittedStateBytes
         );
         taskManager.setMainConsumer(consumer);
         return taskManager;
@@ -5134,6 +5143,116 @@ public class TaskManagerTest {
         topologyMetadata.pauseTopology(UNNAMED_TOPOLOGY);
 
         assertEquals(taskManager.notPausedTasks().size(), 0);
+    }
+
+    @Test
+    public void shouldNeverFlagTransactionBuffersAsExceededWhenCapacityIsInfinite() {
+        final Tasks tasks = mock(Tasks.class);
+        taskManager = setUpTaskManager(
+                StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+                tasks,
+                false,
+                false,
+                -1L
+        );
+
+        assertFalse(taskManager.transactionBuffersWillExceedCapacity());
+        assertFalse(taskManager.transactionBuffersExceedCapacity());
+    }
+
+    @Test
+    public void shouldAlwaysFlagTransactionBuffersAsExceededWhenCapacityIsZero() {
+        final Tasks tasks = mock(Tasks.class);
+        taskManager = setUpTaskManager(
+                StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+                tasks,
+                false,
+                false,
+                0L
+        );
+
+        when(tasks.approximateUncommittedStateBytes()).thenReturn(100L);
+
+        assertTrue(taskManager.transactionBuffersWillExceedCapacity());
+        assertTrue(taskManager.transactionBuffersExceedCapacity());
+    }
+
+    @Test
+    public void shouldFlagTransactionBuffersAsExceededWhenCapacityIsExceeded() {
+        final Tasks tasks = mock(Tasks.class);
+        taskManager = setUpTaskManager(
+                StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+                tasks,
+                false,
+                false,
+                100L
+        );
+
+        when(tasks.approximateUncommittedStateBytes()).thenReturn(200L);
+
+        assertTrue(taskManager.transactionBuffersWillExceedCapacity());
+        assertTrue(taskManager.transactionBuffersExceedCapacity());
+    }
+
+    @Test
+    public void shouldNotFlagTransactionBuffersAsExceededWhenCapacityIsNotExceeded() {
+        final Tasks tasks = mock(Tasks.class);
+        taskManager = setUpTaskManager(
+                StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+                tasks,
+                false,
+                false,
+                100L
+        );
+
+        when(tasks.approximateUncommittedStateBytes()).thenReturn(50L);
+
+        assertFalse(taskManager.transactionBuffersWillExceedCapacity());
+        assertFalse(taskManager.transactionBuffersExceedCapacity());
+    }
+
+    @Test
+    public void shouldFlagTransactionBuffersAsExceededWhenCapacityWillBeExceededNextIteration() {
+        final Tasks tasks = mock(Tasks.class);
+        taskManager = setUpTaskManager(
+                StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+                tasks,
+                false,
+                false,
+                100L
+        );
+
+        when(tasks.approximateUncommittedStateBytes()).thenReturn(50L);
+
+        assertFalse(taskManager.transactionBuffersWillExceedCapacity());
+        assertFalse(taskManager.transactionBuffersExceedCapacity());
+
+        when(tasks.approximateUncommittedStateBytes()).thenReturn(80L);
+
+        assertTrue(taskManager.transactionBuffersWillExceedCapacity());
+        assertTrue(taskManager.transactionBuffersExceedCapacity());
+    }
+
+    @Test
+    public void shouldResetTransactionBufferEstimationOnEachIteration() {
+        final Tasks tasks = mock(Tasks.class);
+        taskManager = setUpTaskManager(
+                StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE,
+                tasks,
+                false,
+                false,
+                100L
+        );
+
+        when(tasks.approximateUncommittedStateBytes()).thenReturn(75L);
+
+        assertTrue(taskManager.transactionBuffersWillExceedCapacity());
+        assertTrue(taskManager.transactionBuffersExceedCapacity());
+
+        when(tasks.approximateUncommittedStateBytes()).thenReturn(10L);
+
+        assertFalse(taskManager.transactionBuffersWillExceedCapacity());
+        assertFalse(taskManager.transactionBuffersExceedCapacity());
     }
 
     private static void expectRestoreToBeCompleted(final Consumer<byte[], byte[]> consumer) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -251,7 +251,8 @@ public class TaskManagerTest {
             adminClient,
             stateDirectory,
             stateUpdaterEnabled ? stateUpdater : null,
-            processingThreadsEnabled ? schedulingTaskManager : null
+            processingThreadsEnabled ? schedulingTaskManager : null,
+            -1L
         );
         taskManager.setMainConsumer(consumer);
         return taskManager;

--- a/streams/src/test/java/org/apache/kafka/test/GlobalStateManagerStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/GlobalStateManagerStub.java
@@ -103,4 +103,9 @@ public class GlobalStateManagerStub implements GlobalStateManager {
     public String changelogFor(final String storeName) {
         return null;
     }
+
+    @Override
+    public long approximateNumUncommittedBytes() {
+        return 0;
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/test/MockKeyValueStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockKeyValueStore.java
@@ -44,6 +44,7 @@ public class MockKeyValueStore implements KeyValueStore<Object, Object> {
     public boolean closed = true;
     public final ArrayList<Integer> keys = new ArrayList<>();
     public final ArrayList<byte[]> values = new ArrayList<>();
+    public long uncommittedBytes = 0;
 
     public MockKeyValueStore(final String name,
                              final boolean persistent) {
@@ -145,5 +146,10 @@ public class MockKeyValueStore implements KeyValueStore<Object, Object> {
     @Override
     public long approximateNumEntries() {
         return 0;
+    }
+
+    @Override
+    public long approximateNumUncommittedBytes() {
+        return uncommittedBytes;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/test/NoOpReadOnlyStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/NoOpReadOnlyStore.java
@@ -31,6 +31,7 @@ public class NoOpReadOnlyStore<K, V> implements ReadOnlyKeyValueStore<K, V>, Sta
     private boolean open = true;
     public boolean initialized;
     public boolean flushed;
+    public long uncommittedBytes = 0;
 
     public NoOpReadOnlyStore() {
         this("", false);
@@ -114,4 +115,8 @@ public class NoOpReadOnlyStore<K, V> implements ReadOnlyKeyValueStore<K, V>, Sta
         throw new UnsupportedOperationException("Position handling not implemented");
     }
 
+    @Override
+    public long approximateNumUncommittedBytes() {
+        return uncommittedBytes;
+    }
 }


### PR DESCRIPTION
This configuration controls the maximum amount of local state store data to buffer in transaction buffers.

When the total uncommitted data, across all stores and all threads, exceeds this value, a Task commit will be triggered, even if `commit.interval.ms` has not yet elapsed. This prevents application from hitting OutOfMemory errors when the `commit.interval.ms` is set to a high value, and transactional state stores are in-use.

StateStores that support transactions can implement `approximateNumUncommittedBytes` to track the size of the data not yet committed to the store.

By default, `approximateUncommitted` returns `0`, which means that all data is immediately committed to the state store.