### PR TITLE
KAFKA-16196: Handle invalid whole value casts in the Cast transform gracefully

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -405,7 +405,12 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
                 throw new ConfigException(ReplaceField.ConfigName.RENAME, mappings, "Invalid rename mapping: " + mapping);
             }
             if (parts.length == 1) {
-                Schema.Type targetType = Schema.Type.valueOf(parts[0].trim().toUpperCase(Locale.ROOT));
+                Schema.Type targetType;
+                try {
+                    targetType = Schema.Type.valueOf(parts[0].trim().toUpperCase(Locale.ROOT));
+                } catch (IllegalArgumentException e) {
+                    throw new ConfigException("Invalid type found in casting spec: " + parts[0].trim(), e);
+                }
                 m.put(WHOLE_VALUE_CAST, validCastType(targetType, FieldType.OUTPUT));
                 isWholeValueCast = true;
             } else {
@@ -420,7 +425,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         }
         if (isWholeValueCast && mappings.size() > 1) {
             throw new ConfigException("Cast transformations that specify a type to cast the entire value to "
-                    + "may ony specify a single cast in their spec");
+                    + "may only specify a single cast in their spec");
         }
         return m;
     }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -17,11 +17,6 @@
 
 package org.apache.kafka.connect.transforms;
 
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.data.Decimal;
@@ -38,10 +33,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -73,6 +72,7 @@ public class CastTest {
     @Test
     public void testConfigInvalidTargetType() {
         assertThrows(ConfigException.class, () -> xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:array")));
+        assertThrows(ConfigException.class, () -> xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "array")));
     }
 
     @Test


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/KAFKA-16196
- The Cast transform currently doesn't handle invalid whole value casts gracefully. A whole value cast is configured like `{"spec": "int8"}` as opposed to a field level cast like `{"spec": "field1:int8"}`.
- If an invalid field level cast is specified (for instance - `{"spec": "field1:invalid"}`), this results in a `ConfigException` being thrown here - https://github.com/apache/kafka/blob/5f410ceb04878ca44d2d007655155b5303a47907/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java#L416 which is handled gracefully as a validation error here - https://github.com/apache/kafka/blob/5f410ceb04878ca44d2d007655155b5303a47907/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java#L605-L609
- However, invalid whole value casts (for instance - `{"spec": "invalid"}`) aren't handled appropriately and result in an 
`IllegalArgumentException` being thrown, which surfaces as an uncaught exception and a `500 Internal Server Error` response from the connector create / update / config validation REST API endpoint.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
