### PR TITLE
KAFKA-16162: resend broker registration on metadata update to IBP 3.7-IV2

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -244,6 +244,19 @@ class BrokerLifecycleManager(
     eventQueue.append(new OfflineDirEvent(directory))
   }
 
+  def handleKraftJBODMetadataVersionUpdate(): Unit = {
+    eventQueue.append(new KraftJBODMetadataVersionUpdateEvent())
+  }
+
+  private class KraftJBODMetadataVersionUpdateEvent extends EventQueue.Event {
+    override def run(): Unit = {
+      if (!isZkBroker) {
+        registered = false
+        scheduleNextCommunicationImmediately()
+      }
+    }
+  }
+
   def brokerEpoch: Long = _brokerEpoch
 
   def state: BrokerState = _state

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -452,7 +452,9 @@ class BrokerServer(
           authorizer
         ),
         sharedServer.initialBrokerMetadataLoadFaultHandler,
-        sharedServer.metadataPublishingFaultHandler)
+        sharedServer.metadataPublishingFaultHandler,
+        lifecycleManager
+      )
       metadataPublishers.add(brokerMetadataPublisher)
 
       // Register parts of the broker that can be reconfigured via dynamic configs.  This needs to

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -23,13 +23,14 @@ import java.util.Collections.{singleton, singletonList, singletonMap}
 import java.util.Properties
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import kafka.log.{LogManager, UnifiedLog}
-import kafka.server.{BrokerServer, KafkaConfig, ReplicaManager}
+import kafka.server.{BrokerLifecycleManager, BrokerServer, KafkaConfig, ReplicaManager}
 import kafka.testkit.{KafkaClusterTestKit, TestKitNodes}
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET
 import org.apache.kafka.clients.admin.{Admin, AlterConfigOp, ConfigEntry, NewTopic}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.config.ConfigResource.Type.BROKER
+import org.apache.kafka.common.metadata.FeatureLevelRecord
 import org.apache.kafka.common.utils.Exit
 import org.apache.kafka.common.{DirectoryId, TopicPartition, Uuid}
 import org.apache.kafka.coordinator.group.GroupCoordinator
@@ -38,12 +39,13 @@ import org.apache.kafka.image.loader.LogDeltaManifest
 import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.metadata.PartitionRegistration
 import org.apache.kafka.raft.LeaderAndEpoch
+import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.fault.FaultHandler
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
-import org.mockito.Mockito.{doThrow, mock, verify}
+import org.mockito.Mockito.{clearInvocations, doThrow, mock, times, verify, verifyNoInteractions}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 
@@ -293,7 +295,8 @@ class BrokerMetadataPublisherTest {
       mock(classOf[DelegationTokenPublisher]),
       mock(classOf[AclPublisher]),
       faultHandler,
-      faultHandler
+      faultHandler,
+      mock(classOf[BrokerLifecycleManager]),
     )
 
     val image = MetadataImage.EMPTY
@@ -311,5 +314,91 @@ class BrokerMetadataPublisherTest {
         .build());
 
     verify(groupCoordinator).onNewMetadataImage(image, delta)
+  }
+
+  @Test
+  def testMetadataVersionUpdateToIBP_3_7_IV2OrAboveTriggersBrokerReRegistration(): Unit = {
+    // When
+    val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(0, ""))
+    val metadataCache = new KRaftMetadataCache(0)
+    val logManager = mock(classOf[LogManager])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val groupCoordinator = mock(classOf[GroupCoordinator])
+    val faultHandler = mock(classOf[FaultHandler])
+    val brokerLifecycleManager = mock(classOf[BrokerLifecycleManager])
+
+    val metadataPublisher = new BrokerMetadataPublisher(
+      config,
+      metadataCache,
+      logManager,
+      replicaManager,
+      groupCoordinator,
+      mock(classOf[TransactionCoordinator]),
+      mock(classOf[DynamicConfigPublisher]),
+      mock(classOf[DynamicClientQuotaPublisher]),
+      mock(classOf[ScramPublisher]),
+      mock(classOf[DelegationTokenPublisher]),
+      mock(classOf[AclPublisher]),
+      faultHandler,
+      faultHandler,
+      brokerLifecycleManager,
+    )
+
+    val image = MetadataImage.EMPTY
+    val delta = new MetadataDelta.Builder()
+      .setImage(image)
+      .build()
+
+    // We first upgrade metadata version to 3_6_IV2
+    delta.replay(new FeatureLevelRecord().
+      setName(MetadataVersion.FEATURE_NAME).
+      setFeatureLevel(MetadataVersion.IBP_3_6_IV2.featureLevel()))
+
+    metadataPublisher.onMetadataUpdate(delta, image,
+      LogDeltaManifest.newBuilder()
+        .provenance(MetadataProvenance.EMPTY)
+        .leaderAndEpoch(LeaderAndEpoch.UNKNOWN)
+        .numBatches(1)
+        .elapsedNs(100)
+        .numBytes(42)
+        .build());
+
+    // This should NOT trigger broker reregistration
+    verifyNoInteractions(brokerLifecycleManager)
+
+    // We then upgrade to IBP_3_7_IV2
+    delta.replay(new FeatureLevelRecord().
+      setName(MetadataVersion.FEATURE_NAME).
+      setFeatureLevel(MetadataVersion.IBP_3_7_IV2.featureLevel()))
+
+    metadataPublisher.onMetadataUpdate(delta, image,
+      LogDeltaManifest.newBuilder()
+        .provenance(MetadataProvenance.EMPTY)
+        .leaderAndEpoch(LeaderAndEpoch.UNKNOWN)
+        .numBatches(1)
+        .elapsedNs(100)
+        .numBytes(42)
+        .build());
+
+    // This SHOULD trigger a broker registration
+    verify(brokerLifecycleManager, times(1)).handleKraftJBODMetadataVersionUpdate()
+    clearInvocations(brokerLifecycleManager)
+
+    // Finally upgrade to IBP_3_8_IV0
+    delta.replay(new FeatureLevelRecord().
+      setName(MetadataVersion.FEATURE_NAME).
+      setFeatureLevel(MetadataVersion.IBP_3_8_IV0.featureLevel()))
+
+    metadataPublisher.onMetadataUpdate(delta, image,
+      LogDeltaManifest.newBuilder()
+        .provenance(MetadataProvenance.EMPTY)
+        .leaderAndEpoch(LeaderAndEpoch.UNKNOWN)
+        .numBatches(1)
+        .elapsedNs(100)
+        .numBytes(42)
+        .build());
+
+    // This should NOT trigger broker reregistration
+    verify(brokerLifecycleManager, times(0))
   }
 }

--- a/server-common/src/main/java/org/apache/kafka/common/DirectoryId.java
+++ b/server-common/src/main/java/org/apache/kafka/common/DirectoryId.java
@@ -153,6 +153,16 @@ public class DirectoryId {
         if (LOST.equals(dir)) {
             return false;
         }
+
+        // The only time we should have a size be 0 is if we were at a MV prior to 3.7-IV2
+        // and the system was upgraded. In this case the original list of directories was purged
+        // during broker registration so we don't know if the directory is online. We assume
+        // that a broker will halt if all its log directories are down. Eventually the broker
+        // will send another registration request with information about all log directories.
+        // Refer KAFKA-16162 for more information
+        if (sortedOnlineDirs.isEmpty()) {
+            return true;
+        }
         return Collections.binarySearch(sortedOnlineDirs, dir) >= 0;
     }
 }

--- a/server-common/src/test/java/org/apache/kafka/common/DirectoryIdTest.java
+++ b/server-common/src/test/java/org/apache/kafka/common/DirectoryIdTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -67,12 +68,16 @@ public class DirectoryIdTest {
 
     @Test
     void testIsOnline() {
+        // Given
         List<Uuid> sortedDirs = Arrays.asList(
                 Uuid.fromString("imQKg2cXTVe8OUFNa3R9bg"),
                 Uuid.fromString("Mwy5wxTDQxmsZwGzjsaX7w"),
                 Uuid.fromString("s8rHMluuSDCnxt3FmKwiyw")
         );
         sortedDirs.sort(Uuid::compareTo);
+        List<Uuid> emptySortedDirs = Collections.emptyList();
+
+        // When/Then
         assertTrue(DirectoryId.isOnline(Uuid.fromString("imQKg2cXTVe8OUFNa3R9bg"), sortedDirs));
         assertTrue(DirectoryId.isOnline(Uuid.fromString("Mwy5wxTDQxmsZwGzjsaX7w"), sortedDirs));
         assertTrue(DirectoryId.isOnline(Uuid.fromString("s8rHMluuSDCnxt3FmKwiyw"), sortedDirs));
@@ -80,5 +85,6 @@ public class DirectoryIdTest {
         assertTrue(DirectoryId.isOnline(DirectoryId.UNASSIGNED, sortedDirs));
         assertFalse(DirectoryId.isOnline(DirectoryId.LOST, sortedDirs));
         assertFalse(DirectoryId.isOnline(Uuid.fromString("AMYchbMtS6yhtsXbca7DQg"), sortedDirs));
+        assertTrue(DirectoryId.isOnline(Uuid.randomUuid(), emptySortedDirs));
     }
 }


### PR DESCRIPTION
We update metadata update handler to resend broker registration when metadata has been updated to >= `3.7-IV2` so that the controller becomes aware of the log directories in the broker.

We also update `DirectoryId::isOnline` to return true on an empty list of log directories while the controller awaits broker registration.

- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
