### PR TITLE
MINOR: Move SplitSegmentResult to storage module

### DIFF
--- a/core/src/main/scala/kafka/log/LogLoader.scala
+++ b/core/src/main/scala/kafka/log/LogLoader.scala
@@ -283,7 +283,7 @@ class LogLoader(
             scheduler,
             logDirFailureChannel,
             logIdent)
-          deleteProducerSnapshotsAsync(result.deletedSegments)
+          deleteProducerSnapshotsAsync(result.getDeletedSegments.asScala)
       }
     }
     throw new IllegalStateException()

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -41,7 +41,7 @@ import org.apache.kafka.server.record.BrokerCompressionType
 import org.apache.kafka.server.util.Scheduler
 import org.apache.kafka.storage.internals.checkpoint.{LeaderEpochCheckpointFile, PartitionMetadataFile}
 import org.apache.kafka.storage.internals.epoch.LeaderEpochFileCache
-import org.apache.kafka.storage.internals.log.{AbortedTxn, AppendOrigin, BatchMetadata, CompletedTxn, EpochEntry, FetchDataInfo, FetchIsolation, LastRecord, LeaderHwChange, LogAppendInfo, LogConfig, LogDirFailureChannel, LogFileUtils, LogOffsetMetadata, LogOffsetSnapshot, LogOffsetsListener, LogSegment, LogSegments, LogStartOffsetIncrementReason, LogValidator, ProducerAppendInfo, ProducerStateManager, ProducerStateManagerConfig, RollParams, VerificationGuard}
+import org.apache.kafka.storage.internals.log.{AbortedTxn, AppendOrigin, BatchMetadata, CompletedTxn, EpochEntry, FetchDataInfo, FetchIsolation, LastRecord, LeaderHwChange, LogAppendInfo, LogConfig, LogDirFailureChannel, LogFileUtils, LogOffsetMetadata, LogOffsetSnapshot, LogOffsetsListener, LogSegment, LogSegments, LogStartOffsetIncrementReason, LogValidator, ProducerAppendInfo, ProducerStateManager, ProducerStateManagerConfig, RollParams, SplitSegmentResult, VerificationGuard}
 
 import java.io.{File, IOException}
 import java.nio.file.{Files, Path}
@@ -1913,8 +1913,8 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 
   private[log] def splitOverflowedSegment(segment: LogSegment): List[LogSegment] = lock synchronized {
     val result = UnifiedLog.splitOverflowedSegment(segment, localLog.segments, dir, topicPartition, config, scheduler, logDirFailureChannel, logIdent)
-    deleteProducerSnapshots(result.deletedSegments, asyncDelete = true)
-    result.newSegments.toList
+    deleteProducerSnapshots(result.getDeletedSegments.asScala, asyncDelete = true)
+    result.getNewSegments.asScala.toList
   }
 
   private[log] def deleteProducerSnapshots(segments: Iterable[LogSegment], asyncDelete: Boolean): Unit = {

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/SplitSegmentResult.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/SplitSegmentResult.java
@@ -1,0 +1,28 @@
+package org.apache.kafka.storage.internals.log;
+
+/**
+ * Holds the result of splitting a segment into one or more segments, see LocalLog.splitOverflowedSegment().
+ */
+public class SplitSegmentResult {
+    private Iterable<LogSegment> deletedSegments;
+    private Iterable<LogSegment> newSegments;
+
+    /**
+     * Create a SplitSegmentResult with the provided parameters.
+     *
+     * @param deletedSegments segments deleted when splitting a segment
+     * @param newSegments new segments created when splitting a segment
+     */
+    public SplitSegmentResult(Iterable<LogSegment> deletedSegments, Iterable<LogSegment> newSegments) {
+        this.deletedSegments = deletedSegments;
+        this.newSegments = newSegments;
+    }
+
+    public Iterable<LogSegment> getDeletedSegments() {
+        return deletedSegments;
+    }
+
+    public Iterable<LogSegment> getNewSegments() {
+        return newSegments;
+    }
+}


### PR DESCRIPTION
Move SplitSegmentResult to storage module

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
