### PR TITLE
KAFKA-16214: add client info in authentication error log

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServer.java
@@ -42,6 +42,8 @@ import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.kafka.common.utils.Utils.USERNAME_MAX_LEN;
+
 /**
  * {@code SaslServer} implementation for SASL/OAUTHBEARER in Kafka. An instance
  * of {@link OAuthBearerToken} is available upon successful authentication via
@@ -162,7 +164,7 @@ public class OAuthBearerSaslServer implements SaslServer {
             String returnedMessage = jsonErrorResponse(callback.errorStatus(), callback.errorScope(),
                     callback.errorOpenIDConfiguration());
             if (!authorizationId.isEmpty()) {
-                errorMessage = String.format("The authorizationId {%s}: %s", authorizationId, returnedMessage);
+                errorMessage = String.format("The authorizationId {%s}: %s", Utils.sanitizeString(authorizationId, USERNAME_MAX_LEN), returnedMessage);
             } else {
                 errorMessage = returnedMessage;
             }
@@ -176,7 +178,7 @@ public class OAuthBearerSaslServer implements SaslServer {
         if (!authorizationId.isEmpty() && !authorizationId.equals(token.principalName()))
             throw new SaslAuthenticationException(String.format(
                     "Authentication failed: Client requested an authorization id (%s) that is different from the token's principal name (%s)",
-                    authorizationId, token.principalName()));
+                    Utils.sanitizeString(authorizationId, USERNAME_MAX_LEN), Utils.sanitizeString(token.principalName(), USERNAME_MAX_LEN)));
 
         Map<String, String> validExtensions = processExtensions(token, extensions);
 

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServer.java
@@ -159,10 +159,15 @@ public class OAuthBearerSaslServer implements SaslServer {
         }
         OAuthBearerToken token = callback.token();
         if (token == null) {
-            errorMessage = jsonErrorResponse(callback.errorStatus(), callback.errorScope(),
+            String returnedMessage = jsonErrorResponse(callback.errorStatus(), callback.errorScope(),
                     callback.errorOpenIDConfiguration());
+            if (!authorizationId.isEmpty()) {
+                errorMessage = String.format("The authorizationId {%s}: %s", authorizationId, returnedMessage);
+            } else {
+                errorMessage = returnedMessage;
+            }
             log.debug(errorMessage);
-            return errorMessage.getBytes(StandardCharsets.UTF_8);
+            return returnedMessage.getBytes(StandardCharsets.UTF_8);
         }
         /*
          * We support the client specifying an authorization ID as per the SASL

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServer.java
@@ -93,7 +93,7 @@ public class PlainSaslServer implements SaslServer {
             throw new SaslAuthenticationException("Authentication failed: username not specified");
         }
         if (password.isEmpty()) {
-            throw new SaslAuthenticationException("Authentication failed: password not specified");
+            throw new SaslAuthenticationException(String.format("Authentication failed: password not specified for user {%s}", username));
         }
 
         NameCallback nameCallback = new NameCallback("username", username);
@@ -101,12 +101,12 @@ public class PlainSaslServer implements SaslServer {
         try {
             callbackHandler.handle(new Callback[]{nameCallback, authenticateCallback});
         } catch (Throwable e) {
-            throw new SaslAuthenticationException("Authentication failed: credentials for user could not be verified", e);
+            throw new SaslAuthenticationException(String.format("Authentication failed: credentials for user could not be verified for user {%s}", username), e);
         }
         if (!authenticateCallback.authenticated())
-            throw new SaslAuthenticationException("Authentication failed: Invalid username or password");
+            throw new SaslAuthenticationException(String.format("Authentication failed: Invalid username or password for user {%s}", username));
         if (!authorizationIdFromClient.isEmpty() && !authorizationIdFromClient.equals(username))
-            throw new SaslAuthenticationException("Authentication failed: Client requested an authorization id that is different from username");
+            throw new SaslAuthenticationException(String.format("Authentication failed: Client requested an authorization id {%s} that is different from username {%s}", authorizationIdFromClient, username));
 
         this.authorizationId = username;
 

--- a/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/internals/ScramSaslServer.java
@@ -47,6 +47,8 @@ import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.kafka.common.utils.Utils.USERNAME_MAX_LEN;
+
 /**
  * SaslServer implementation for SASL/SCRAM. This server is configured with a callback
  * handler for integration with a credential manager. Kafka brokers provide callbacks
@@ -116,7 +118,7 @@ public class ScramSaslServer implements SaslServer {
                             credentialCallback = tokenCallback;
                             callbackHandler.handle(new Callback[]{nameCallback, tokenCallback});
                             if (tokenCallback.tokenOwner() == null)
-                                throw new SaslException("Token Authentication failed: Invalid tokenId : " + username);
+                                throw new SaslException("Token Authentication failed: Invalid tokenId : " + Utils.sanitizeString(username, USERNAME_MAX_LEN));
                             this.authorizationId = tokenCallback.tokenOwner();
                             this.tokenExpiryTimestamp = tokenCallback.tokenExpiryTimestamp();
                         } else {
@@ -127,10 +129,11 @@ public class ScramSaslServer implements SaslServer {
                         }
                         this.scramCredential = credentialCallback.scramCredential();
                         if (scramCredential == null)
-                            throw new SaslException(String.format("Authentication failed: Invalid user {%s} credentials", username));
+                            throw new SaslException(String.format("Authentication failed: Invalid user {%s} credentials", Utils.sanitizeString(username, USERNAME_MAX_LEN)));
                         String authorizationIdFromClient = clientFirstMessage.authorizationId();
                         if (!authorizationIdFromClient.isEmpty() && !authorizationIdFromClient.equals(username))
-                            throw new SaslAuthenticationException(String.format("Authentication failed: Client requested an authorization id {%s} that is different from username {%s}", authorizationIdFromClient, username));
+                            throw new SaslAuthenticationException(String.format("Authentication failed: Client requested an authorization id {%s} that is different from username {%s}",
+                                    Utils.sanitizeString(authorizationIdFromClient, USERNAME_MAX_LEN), Utils.sanitizeString(username, USERNAME_MAX_LEN)));
 
                         if (scramCredential.iterations() < mechanism.minIterations())
                             throw new SaslException("Iterations " + scramCredential.iterations() +  " is less than the minimum " + mechanism.minIterations() + " for " + mechanism);
@@ -143,7 +146,7 @@ public class ScramSaslServer implements SaslServer {
                     } catch (SaslException | AuthenticationException e) {
                         throw e;
                     } catch (Throwable e) {
-                        throw new SaslException("Authentication failed: Credentials could not be obtained" + (username == null ? "" : " for user " + username), e);
+                        throw new SaslException("Authentication failed: Credentials could not be obtained" + (username == null ? "" : " for user " + Utils.sanitizeString(username, USERNAME_MAX_LEN)), e);
                     }
 
                 case RECEIVE_CLIENT_FINAL_MESSAGE:
@@ -157,7 +160,7 @@ public class ScramSaslServer implements SaslServer {
                         setState(State.COMPLETE);
                         return serverFinalMessage.toBytes();
                     } catch (InvalidKeyException e) {
-                        throw new SaslException("Authentication failed: Invalid client final message" + (username == null ? "" : " for user " + username), e);
+                        throw new SaslException("Authentication failed: Invalid client final message" + (username == null ? "" : " for user " + Utils.sanitizeString(username, USERNAME_MAX_LEN)), e);
                     }
 
                 default:
@@ -228,9 +231,9 @@ public class ScramSaslServer implements SaslServer {
             byte[] clientSignature = formatter.clientSignature(expectedStoredKey, clientFirstMessage, serverFirstMessage, clientFinalMessage);
             byte[] computedStoredKey = formatter.storedKey(clientSignature, clientFinalMessage.proof());
             if (!MessageDigest.isEqual(computedStoredKey, expectedStoredKey))
-                throw new SaslException("Invalid client credentials" + (username == null ? "" : " for user " + username));
+                throw new SaslException("Invalid client credentials" + (username == null ? "" : " for user " + Utils.sanitizeString(username, USERNAME_MAX_LEN)));
         } catch (InvalidKeyException e) {
-            throw new SaslException("Sasl client verification failed" + (username == null ? "" : " for user " + username), e);
+            throw new SaslException("Sasl client verification failed" + (username == null ? "" : " for user " + Utils.sanitizeString(username, USERNAME_MAX_LEN)), e);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -92,6 +92,8 @@ public final class Utils {
 
     private Utils() {}
 
+    public static final int USERNAME_MAX_LEN = 20;
+
     // This matches URIs of formats: host:port and protocol:\\host:port
     // IPv6 is supported with [ip] pattern
     private static final Pattern HOST_PORT_PATTERN = Pattern.compile(".*?\\[?([0-9a-zA-Z\\-%._:]*)\\]?:([0-9]+)");
@@ -1673,6 +1675,20 @@ public final class Utils {
             }
         }
         return result;
+    }
+
+    /**
+     * Sanitize the string by limiting the max length and trim the spaces (i.e. \s\r\n\t)
+     * @param str the original string
+     * @param len the max length of the string
+     * @return sanitized string
+     */
+    public static String sanitizeString(String str, int len) {
+        String ret = str;
+        if (str.length() > len) {
+            ret = str.substring(0, len) + "...";
+        }
+        return ret.replaceAll("[\\s\\r\\n\\t]", "");
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServerTest.java
@@ -189,8 +189,9 @@ public class OAuthBearerSaslServerTest {
 
     @Test
     public void authorizationIdNotEqualsAuthenticationId() {
-        assertThrows(SaslAuthenticationException.class,
-            () -> saslServer.evaluateResponse(clientInitialResponse(USER + "x")));
+        Throwable t = assertThrows(SaslAuthenticationException.class,
+            () -> saslServer.evaluateResponse(clientInitialResponse(USER + "xxxxxxxxxxxxxxxxxx")));
+        assertEquals("Authentication failed: Client requested an authorization id (userxxxxxxxxxxxxxxxx...) that is different from the token's principal name (user)", t.getMessage());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
@@ -36,6 +36,7 @@ public class PlainSaslServerTest {
     private static final String USER_A = "userA";
     private static final String PASSWORD_A = "passwordA";
     private static final String USER_B = "userB";
+    private static final String LONG_USER_C = "userCcccccccccccccccccccccc";
     private static final String PASSWORD_B = "passwordB";
 
     private PlainSaslServer saslServer;
@@ -67,7 +68,8 @@ public class PlainSaslServerTest {
 
     @Test
     public void authorizationIdNotEqualsAuthenticationId() {
-        assertThrows(SaslAuthenticationException.class, () -> saslServer.evaluateResponse(saslMessage(USER_B, USER_A, PASSWORD_A)));
+        Throwable t = assertThrows(SaslAuthenticationException.class, () -> saslServer.evaluateResponse(saslMessage(LONG_USER_C, USER_A, PASSWORD_A)));
+        assertEquals("Authentication failed: Client requested an authorization id {userCccccccccccccccc...} that is different from username {userA}", t.getMessage());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramSaslServerTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.security.token.delegation.internals.DelegationTok
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -35,6 +36,7 @@ public class ScramSaslServerTest {
 
     private static final String USER_A = "userA";
     private static final String USER_B = "userB";
+    private static final String LONG_USER_C = "userCcccccccccccccccccccccc";
 
     private ScramMechanism mechanism;
     private ScramFormatter formatter;
@@ -65,7 +67,8 @@ public class ScramSaslServerTest {
 
     @Test
     public void authorizationIdNotEqualsAuthenticationId() {
-        assertThrows(SaslAuthenticationException.class, () -> saslServer.evaluateResponse(clientFirstMessage(USER_A, USER_B)));
+        Throwable t = assertThrows(SaslAuthenticationException.class, () -> saslServer.evaluateResponse(clientFirstMessage(USER_A, LONG_USER_C)));
+        assertEquals("Authentication failed: Client requested an authorization id {userCccccccccccccccc...} that is different from username {userA}", t.getMessage());
     }
 
     private byte[] clientFirstMessage(String userName, String authorizationId) {

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -995,6 +995,19 @@ public class UtilsTest {
         assertEquals(expected, recorded);
     }
 
+    @Test
+    public void testSanitizeString() {
+        String a = "a\tb\nc\rd\r\n";
+        assertEquals("abcd", Utils.sanitizeString(a, 10));
+
+        a = "aaaaaaaaaa";
+        assertEquals("aaaaa...", Utils.sanitizeString(a, 5));
+
+        // The space and \t will be counted as length 5 and then get trimmed
+        a = "a a\taaaaaaaa\r\n";
+        assertEquals("aaa...", Utils.sanitizeString(a, 5));
+    }
+
     private Callable<Void> recordingCallable(Map<String, Object> recordingMap, String success, TestException failure) {
         return () -> {
             if (success == null)


### PR DESCRIPTION
When client authenticate failed, the server will log with the client IP address only. The the IP address sometimes cannot represent a specific user, especially if there is proxy between client and server. Ex:

```
INFO [SocketServer listenerType=ZK_BROKER, nodeId=0] Failed authentication with /127.0.0.1 (channelId=127.0.0.1:9093-127.0.0.1:53223-5) (Authentication failed: Invalid username or password) (org.apache.kafka.common.network.Selector)
```

If there are many failed authentication log appeared in the server, it'd be better to identify who is triggering it soon. Adding the client info to the log is a good start. This PR adds the user info in the log if any. After this PR, the log will be like this:
```
INFO [SocketServer listenerType=ZK_BROKER, nodeId=0] Failed authentication with /127.0.0.1 (channelId=127.0.0.1:9093-127.0.0.1:54700-0) (Authentication failed: Invalid username or password for user {abc}) (org.apache.kafka.common.network.Selector)
```
I tried to add the info in the caller side (i.e. [Selector](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/network/Selector.java#L611)), but we only have KafkaChannel info there, we cannot get client info (i.e. principle) if authentication is not successful. So add the user info in the authenticator side.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
