### PR TITLE
Fix to include runtime dependencies in clients

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -303,6 +303,20 @@ subprojects {
           } else {
             apply plugin: 'com.github.johnrengelman.shadow'
             artifact shadowJar
+            // work around issue with 'shadow' to resolve runtime dependencies correctly. This requires
+            // any project relying on 'shadow' dependencies.
+            afterEvaluate {
+              pom.withXml { xml ->
+                def dependenciesNode = xml.asNode().appendNode('dependencies')
+                project.configurations.shadow.allDependencies.each {
+                  def dependencyNode = dependenciesNode.appendNode('dependency')
+                  dependencyNode.appendNode('groupId', it.group)
+                  dependencyNode.appendNode('artifactId', it.name)
+                  dependencyNode.appendNode('version', it.version)
+                  dependencyNode.appendNode('scope', 'runtime')
+                }
+              }
+            }
           }
 
           afterEvaluate {


### PR DESCRIPTION
Fix in the following https://github.com/apache/kafka/pull/15127 introduced a regression for `kafka-clients` pom where runtime dependencies were not included in the `kafka-clients` pom. The PR has a workaround to add the dependencies defined as `shadow/runtime` dependencies for `shadowJar` in clients `pom`.

Though `project.shadow.component(mavenJava)` earlier used to add the runtime dependencies itself but as that creates an issue with `signing` of the jar which was removed in PR https://github.com/apache/kafka/pull/15127 hence this workaround is needed to add the `runtime` dependencies in pom.

#### Difference in pom from 3.6.2 release:

![Screenshot 2024-01-29 at 2 32 25 PM](https://github.com/apache/kafka/assets/2861565/b0f1d551-f997-4a00-93ed-80f738e3a23f)

cc: @stanislavkozlovski @ijuma @xvrl 


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
