### PR TITLE
KAFKA-16203: Fix bug on auto-commit empty offsets blocking inflight

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/CommitRequestManager.java
@@ -240,10 +240,10 @@ public class CommitRequestManager implements RequestManager, MemberStateListener
             return CompletableFuture.completedFuture(null);
         }
 
-        CompletableFuture<Void> result = addOffsetCommitRequest(offsets, expirationTimeMs, retryOnStaleEpoch)
-            .whenComplete(autoCommitCallback(offsets));
         autocommit.resetTimer();
         autocommit.setInflightCommitStatus(true);
+        CompletableFuture<Void> result = addOffsetCommitRequest(offsets, expirationTimeMs, retryOnStaleEpoch)
+            .whenComplete(autoCommitCallback(offsets));
         return result;
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CommitRequestManagerTest.java
@@ -426,6 +426,41 @@ public class CommitRequestManagerTest {
     }
 
     @Test
+    public void testAutoCommitEmptyOffsetsDoesNotGenerateRequest() {
+        CommitRequestManager commitRequestManger = create(true, 100);
+        time.sleep(100);
+        commitRequestManger.updateAutoCommitTimer(time.milliseconds());
+        CompletableFuture<Void> result = commitRequestManger.maybeAutoCommitAllConsumedAsync();
+
+        assertTrue(commitRequestManger.pendingRequests.unsentOffsetCommits.isEmpty());
+        assertTrue(result.isDone());
+        assertFalse(result.isCompletedExceptionally());
+    }
+
+    @Test
+    public void testAutoCommitEmptyDoesNotLeaveInflightRequestFlagOn() {
+        TopicPartition t1p = new TopicPartition("topic1", 0);
+        subscriptionState.assignFromUser(singleton(t1p));
+        CommitRequestManager commitRequestManger = create(true, 100);
+
+        // Auto-commit of empty offsets
+        time.sleep(100);
+        commitRequestManger.updateAutoCommitTimer(time.milliseconds());
+        CompletableFuture<Void> result = commitRequestManger.maybeAutoCommitAllConsumedAsync();
+        assertTrue(result.isDone());
+        assertFalse(result.isCompletedExceptionally());
+
+        // Next auto-commit consumed offsets (not empty). Should generate a request, ensuring
+        // that the previous auto-commit of empty did not leave the inflight request flag on
+        subscriptionState.seek(t1p, 100);
+        time.sleep(100);
+        commitRequestManger.updateAutoCommitTimer(time.milliseconds());
+        result = commitRequestManger.maybeAutoCommitAllConsumedAsync();
+        assertFalse(commitRequestManger.pendingRequests.unsentOffsetCommits.isEmpty());
+        assertFalse(result.isDone());
+    }
+
+    @Test
     public void testOffsetFetchRequestEnsureDuplicatedRequestSucceed() {
         CommitRequestManager commitRequestManger = create(true, 100);
         when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(mockedNode));


### PR DESCRIPTION
Fixes a bug with the auto-commit logic. When auto-committing empty offsets, the operation completes without generating a request, but mistakenly leaves the inflight request flag on. This makes that following auto-commits won't generate requests, even if offsets have been consumed. 