### PR TITLE
KAFKA-16205 Allow MetadataLoader to coalesce small batches

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/image/loader/MetadataLoaderTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/loader/MetadataLoaderTest.java
@@ -312,6 +312,7 @@ public class MetadataLoaderTest {
                         setFeatureLevel(IBP_3_3_IV2.featureLevel()), (short) 0))));
             assertFalse(snapshotReader.closed);
             loader.handleLoadSnapshot(snapshotReader);
+            loader.time().sleep(100);
             loader.waitForAllEventsToBeHandled();
             assertTrue(snapshotReader.closed);
             publishers.get(0).firstPublish.get(1, TimeUnit.MINUTES);
@@ -378,6 +379,7 @@ public class MetadataLoaderTest {
             snapshotReader.setTime((MockTime) loader.time());
         }
         loader.handleLoadSnapshot(snapshotReader);
+        loader.time().sleep(100);
         loader.waitForAllEventsToBeHandled();
     }
 
@@ -474,6 +476,7 @@ public class MetadataLoaderTest {
                 )
             ).setTime(time);
             loader.handleCommit(batchReader);
+            time.sleep(100);
             loader.waitForAllEventsToBeHandled();
             assertTrue(batchReader.closed);
             assertEquals(300L, loader.lastAppliedOffset());


### PR DESCRIPTION
Rather than immediately publishing a MetadataDelta for each commit handled from the Raft layer, this patch uses a short deferral window for accumulating changes from multiple Raft commits. A deferred event is enqueued after handling a commit from Raft which will flush the metadata buffered in MetadataBatchLoader. Only a single deferred event is enqueued at any given time.

When handling snapshots, the deferred event is cancelled and MetadataBatchLoader is immediately flushed. This is to ensure proper serialization of the metadata publishings.