### PR TITLE
KAFKA-16210: Update jose4j to 0.9.4

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -238,7 +238,7 @@ jetty-servlet-9.4.53.v20231009
 jetty-servlets-9.4.53.v20231009
 jetty-util-9.4.53.v20231009
 jetty-util-ajax-9.4.53.v20231009
-jose4j-0.9.3
+jose4j-0.9.4
 lz4-java-1.8.0
 maven-artifact-3.8.8
 metrics-core-4.1.12.1

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -117,7 +117,7 @@ versions += [
   jaxrs: "2.1.1",
   jfreechart: "1.0.0",
   jopt: "5.0.4",
-  jose4j: "0.9.3",
+  jose4j: "0.9.4",
   junit: "5.10.0",
   jqwik: "1.7.4",
   kafka_0100: "0.10.0.1",


### PR DESCRIPTION
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

`org.bitbucket.b_c:jose4j` 0.9.3 is susceptible to Denial of Service per [CVE-2023-51775](https://www.cve.org/CVERecord?id=CVE-2023-51775).

This PR updates `kafka` to use 0.9.4.

Thank you