### PR TITLE
KAFKA-16101: Additional fixes on KRaft migration documentation

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -4054,7 +4054,7 @@ listeners=CONTROLLER://:9093
           </ul>
         </td>
         <td>
-          It is important to perform the <code>zookeeper-shell.sh</code> step quickly together with rolling at least one broker, to minimize the amount of
+          It is important to perform the <code>zookeeper-shell.sh</code> step quickly together with rolling at least one broker (into pure ZooKeeper mode), to minimize the amount of
           time that the cluster lacks a controller.
         </td>
       </tr>
@@ -4063,7 +4063,8 @@ listeners=CONTROLLER://:9093
         <td>
           <ul>
             <li>
-              On each broker, remove the <code>process.roles</code> configuration, and
+              On each broker, remove the <code>process.roles</code> configuration,
+              replace the <code>node.id</code> with <code>broker.id</code> and
               restore the <code>zookeeper.connect</code> configuration to its previous value.
               If your cluster requires other ZooKeeper configurations for brokers, such as
               <code>zookeeper.ssl.protocol</code>, re-add those configurations as well.
@@ -4079,7 +4080,7 @@ listeners=CONTROLLER://:9093
             <li>
               On each broker, remove the <code>zookeeper.metadata.migration.enable</code>,
               <code>controller.listener.names</code>, and <code>controller.quorum.voters</code>
-              configurations. Replace <code>node.id</code> with <code>broker.id</code>.
+              configurations.
               Then perform a second rolling restart of all brokers.
             </li>
             <li>
@@ -4090,7 +4091,7 @@ listeners=CONTROLLER://:9093
         <td>
           <ul>
             <li>
-              It is important to perform the <code>zookeeper-shell.sh</code> step <b>quickly</b> together with rolling at least one broker, to minimize the amount of
+              It is important to perform the <code>zookeeper-shell.sh</code> step <b>quickly</b> together with rolling at least one broker (into pure ZooKeeper mode), to minimize the amount of
               time that the cluster lacks a controller.
             </li>
             <li>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -4045,7 +4045,7 @@ listeners=CONTROLLER://:9093
             <li>
               On each broker, remove the <code>zookeeper.metadata.migration.enable</code>,
               <code>controller.listener.names</code>, and <code>controller.quorum.voters</code>
-              configurations, and replace <code>node.id</code> with <code>broker.id</code>.
+              configurations.
               Then perform a rolling restart of all brokers.
             </li>
             <li>
@@ -4054,7 +4054,7 @@ listeners=CONTROLLER://:9093
           </ul>
         </td>
         <td>
-          It is important to perform the <code>zookeeper-shell.sh</code> step quickly, to minimize the amount of
+          It is important to perform the <code>zookeeper-shell.sh</code> step quickly together with rolling at least one broker, to minimize the amount of
           time that the cluster lacks a controller.
         </td>
       </tr>
@@ -4090,7 +4090,7 @@ listeners=CONTROLLER://:9093
         <td>
           <ul>
             <li>
-              It is important to perform the <code>zookeeper-shell.sh</code> step <b>quickly</b>, to minimize the amount of
+              It is important to perform the <code>zookeeper-shell.sh</code> step <b>quickly</b> together with rolling at least one broker, to minimize the amount of
               time that the cluster lacks a controller.
             </li>
             <li>


### PR DESCRIPTION
This PR fixes a couple of things related to the #15193 PR.

When you complete "Enter Migration Mode on the brokers", we are actually in "Enabling the migration on the brokers" referring to the migration guide and the broker doesn't really have `node.id` yet but still `broker.id`, so the PR removes a statement saying to replace the one with the other.

Also, during rollback it's not enough just deleting the `/controller` znode quickly after shutting down controllers because the controller election doesn't start yet until at least one broker is rolled back with the right configuration. Until the rolling and when controllers are down, the brokers just log something like this even if you deleted the znode "quickly":

```shell
[2024-01-30 09:27:52,394] DEBUG [zk-broker-0-to-controller-quorum-channel-manager]: Controller isn't cached, looking for local metadata changes (kafka.server.BrokerToControllerRequestThread)
[2024-01-30 09:27:52,394] INFO [zk-broker-0-to-controller-quorum-channel-manager]: Recorded new controller, from now on will use node localhost:9093 (id: 1 rack: null) (kafka.server.BrokerToControllerRequestThread)
```

You have to reduce the amount of time between deleting the znode and rolling at least one broker, so that an election can start.