### PR TITLE
KAFKA-16204: Create partition dir for mockLog

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -4381,6 +4381,9 @@ class ReplicaManagerTest {
 
   private def setupMockLog(path: String): UnifiedLog = {
     val mockLog = mock(classOf[UnifiedLog])
+    val partitionDir = new File(path, s"$topic-0")
+    partitionDir.mkdir()
+    when(mockLog.dir).thenReturn(partitionDir)
     when(mockLog.parentDir).thenReturn(path)
     when(mockLog.topicId).thenReturn(Some(topicId))
     when(mockLog.topicPartition).thenReturn(new TopicPartition(topic, 0))


### PR DESCRIPTION
`00000000000000000001.snapshot` is created by
`ProducerStateManager::takeSnapshot`. Its field `logDir` is the return value of `UnifiedLog::dir` which was not mocked before. This resulted in the producer snapshot beeing created in the subproject root.

The fix is to create the partition directory and setting the mock appropriately.