### PR TITLE
MINOR: Cleanup log.dirs in ReplicaManagerTest on JVM exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@ Vagrantfile.local
 
 config/server-*
 config/zookeeper-*
-core/data/*
-core/data2/*
 gradle/wrapper/*.jar
 gradlew.bat
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Vagrantfile.local
 config/server-*
 config/zookeeper-*
 core/data/*
+core/data2/*
 gradle/wrapper/*.jar
 gradlew.bat
 

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -196,6 +196,22 @@ public class TestUtils {
     }
 
     /**
+     * Create a temporary directory under the given root directory.
+     * The root directory is removed on JVM exit if it doesn't already exist
+     * when this function is invoked.
+     *
+     * @param root path to create temporary directory under
+     * @return the temporary directory created within {@code root}
+     */
+    public static File tempRelativeDir(String root) {
+        File rootFile = new File(root);
+        if (rootFile.mkdir()) {
+            rootFile.deleteOnExit();
+        }
+        return tempDirectory(rootFile.toPath(), null);
+    }
+
+    /**
      * Create a temporary relative directory in the specified parent directory with the given prefix.
      *
      * @param parent The parent folder path name, if null using the default temporary-file directory

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -138,16 +138,7 @@ object TestUtils extends Logging {
     parentFile.mkdirs()
 
     val result = JTestUtils.tempDirectory(parentFile.toPath, null)
-
     parentFile.deleteOnExit()
-    Exit.addShutdownHook("delete-temp-log-dir-on-exit", {
-      try {
-        Utils.delete(parentFile)
-      } catch {
-        case e: IOException => error(s"Error deleting ${parentFile.getAbsolutePath}", e)
-      }
-    })
-
     result
   }
 

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -133,14 +133,7 @@ object TestUtils extends Logging {
   /**
    * Create a temporary relative directory
    */
-  def tempRelativeDir(parent: String): File = {
-    val parentFile = new File(parent)
-    parentFile.mkdirs()
-
-    val result = JTestUtils.tempDirectory(parentFile.toPath, null)
-    parentFile.deleteOnExit()
-    result
-  }
+  def tempRelativeDir(root: String): File = JTestUtils.tempRelativeDir(root)
 
   /**
    * Create a random log directory in the format <string>-<int> used for Kafka partition logs.

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -137,7 +137,18 @@ object TestUtils extends Logging {
     val parentFile = new File(parent)
     parentFile.mkdirs()
 
-    JTestUtils.tempDirectory(parentFile.toPath, null)
+    val result = JTestUtils.tempDirectory(parentFile.toPath, null)
+
+    parentFile.deleteOnExit()
+    Exit.addShutdownHook("delete-temp-log-dir-on-exit", {
+      try {
+        Utils.delete(parentFile)
+      } catch {
+        case e: IOException => error(s"Error deleting ${parentFile.getAbsolutePath}", e)
+      }
+    })
+
+    result
   }
 
   /**


### PR DESCRIPTION
`ReplicaManagerTest::setupReplicaManagerWithMockedPurgatories` creates two log dirs, `core/data` and `core/data2` and test `testActiveProducerState` creates a partition in `core/data2`.

This PR adds `core/data2` and all files/directories within it to `.gitignore`.