### PR TITLE
MINOR: Fixes broken build

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -487,7 +487,7 @@ class DeleteTopicTest extends QuorumTestHarness {
     if (isKRaftTest()) {
       // Restart KRaft quorum with the updated config
       val overridingProps = new Properties()
-      overridingProps.put(KafkaConfig.DeleteTopicEnableProp, false)
+      overridingProps.put(KafkaConfig.DeleteTopicEnableProp, false.toString)
       implementation = newKRaftQuorum(overridingProps)
     }
 


### PR DESCRIPTION
Because of lack of implicit conversions, boolean properties need to be passed as Strings
This is done in other parts of the code already

Fixes broken build introduced in https://github.com/apache/kafka/pull/14846

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
