### PR TITLE
Revert "MINOR: Fix "No suitable checks publisher found" message during CI build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ def doTest(env, target = "test") {
   sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
       --profile --continue -PkeepAliveMode="session" -PtestLoggingEvents=started,passed,skipped,failed \
       -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=10"""
-  junit skipPublishingChecks: true, testResults: '**/build/test-results/**/TEST-*.xml'
+  junit '**/build/test-results/**/TEST-*.xml'
 }
 
 def doStreamsArchetype() {


### PR DESCRIPTION
This appears to have had unanticipated consequences for Gradle Enterprise; the last build reported for trunk was the one triggered after this commit was merged.

We should revert, verify that Gradle Enterprise behavior is restored, and then possibly investigate the "No suitable checks publisher found" message as a follow-up (with the goal of not disrupting our CI environment the same way we did with the initial attempt).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
