### PR TITLE
KAFKA-15917: Wait for zombie sink tasks' consumers to commit offsets before trying to modify their offsets in integration tests

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorOffset.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorOffset.java
@@ -76,4 +76,12 @@ public class ConnectorOffset {
     public int hashCode() {
         return Objects.hash(partition, offset);
     }
+
+    @Override
+    public String toString() {
+        return "{" +
+                "partition=" + partition +
+                ", offset=" + offset +
+                '}';
+    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorOffsets.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorOffsets.java
@@ -88,4 +88,9 @@ public class ConnectorOffsets {
     public int hashCode() {
         return Objects.hashCode(offsets);
     }
+
+    @Override
+    public String toString() {
+        return Objects.toString(offsets);
+    }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
@@ -988,7 +988,7 @@ public class OffsetsApiIntegrationTest {
      *
      * @param connectorName the name of the sink connector whose offsets are to be verified
      * @param expectedTopic the name of the Kafka topic that the sink connector is consuming from
-     * @param expectedPartitions the number of partitions that exist for the Kafka<<< topic
+     * @param expectedPartitions the number of partitions that exist for the Kafka topic
      * @param expectedOffset the expected consumer group offset for each partition
      * @param conditionDetails the condition that we're waiting to achieve (for example: Sink connector should process
      *                         10 records)

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
@@ -812,9 +812,6 @@ public class OffsetsApiIntegrationTest {
         verifyExpectedSinkConnectorOffsets(connectorName, topic, 1, NUM_RECORDS_PER_PARTITION,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");
 
-        verifyExpectedSinkConnectorOffsets(connectorName, topic, 1, NUM_RECORDS_PER_PARTITION,
-                "Sink connector consumer group offsets should catch up to the topic end offsets");
-
         connect.stopConnector(connectorName);
 
         // Try to reset the offsets

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -77,6 +79,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Tag("integration")
 public class OffsetsApiIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(OffsetsApiIntegrationTest.class);
+
     private static final long OFFSET_COMMIT_INTERVAL_MS = TimeUnit.SECONDS.toMillis(1);
     private static final long OFFSET_READ_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
     private static final int NUM_WORKERS = 3;
@@ -983,7 +988,7 @@ public class OffsetsApiIntegrationTest {
      *
      * @param connectorName the name of the sink connector whose offsets are to be verified
      * @param expectedTopic the name of the Kafka topic that the sink connector is consuming from
-     * @param expectedPartitions the number of partitions that exist for the Kafka topic
+     * @param expectedPartitions the number of partitions that exist for the Kafka<<< topic
      * @param expectedOffset the expected consumer group offset for each partition
      * @param conditionDetails the condition that we're waiting to achieve (for example: Sink connector should process
      *                         10 records)
@@ -991,19 +996,45 @@ public class OffsetsApiIntegrationTest {
      */
     private void verifyExpectedSinkConnectorOffsets(String connectorName, String expectedTopic, int expectedPartitions,
                                                     int expectedOffset, String conditionDetails) throws InterruptedException {
-        waitForCondition(() -> {
-            ConnectorOffsets offsets = connect.connectorOffsets(connectorName);
-            if (offsets.offsets().size() != expectedPartitions) {
-                return false;
-            }
-            for (ConnectorOffset offset: offsets.offsets()) {
-                assertEquals(expectedTopic, offset.partition().get(SinkUtils.KAFKA_TOPIC_KEY));
-                if ((Integer) offset.offset().get(SinkUtils.KAFKA_OFFSET_KEY) != expectedOffset) {
-                    return false;
+        AtomicReference<ConnectorOffsets> latestOffsets = new AtomicReference<>();
+        waitForCondition(
+                () -> {
+                    ConnectorOffsets offsets;
+                    try {
+                        offsets = connect.connectorOffsets(connectorName);
+                    } catch (Throwable t) {
+                        log.warn("Failed to list offsets for sink connector {}", connectorName, t);
+                        return false;
+                    }
+
+                    latestOffsets.set(offsets);
+
+                    if (offsets.offsets().size() != expectedPartitions) {
+                        return false;
+                    }
+                    for (ConnectorOffset offset: offsets.offsets()) {
+                        assertEquals(expectedTopic, offset.partition().get(SinkUtils.KAFKA_TOPIC_KEY));
+                        if ((Integer) offset.offset().get(SinkUtils.KAFKA_OFFSET_KEY) != expectedOffset) {
+                            return false;
+                        }
+                    }
+                    return true;
+                },
+                OFFSET_READ_TIMEOUT_MS,
+                () -> {
+                    String result = conditionDetails + ". ";
+                    ConnectorOffsets offsets = latestOffsets.get();
+                    if (offsets == null) {
+                        result += "No attempt to list the offsets for the connector ever succeeded.";
+                    } else {
+                        result += "Expected every committed offset to be for topic " + expectedTopic
+                                + " and for " + expectedPartitions + " partition(s) of that topic to have "
+                                + "a committed offset of " + expectedOffset + ". ";
+                        result += "The most-recently-available offsets for the connector are: " + offsets;
+                    }
+                    return result;
                 }
-            }
-            return true;
-        }, OFFSET_READ_TIMEOUT_MS, conditionDetails);
+        );
     }
 
     /**

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
@@ -457,6 +457,11 @@ public class OffsetsApiIntegrationTest {
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(connectorName, 1,
                 "Connector tasks did not start in time.");
 
+        // Make sure the tasks' consumers have had a chance to actually form a group
+        // (otherwise, the reset request will succeed because there won't be any active consumers)
+        verifyExpectedSinkConnectorOffsets(connectorName, topic, 1, NUM_RECORDS_PER_PARTITION,
+                "Sink connector consumer group offsets should catch up to the topic end offsets");
+
         connect.stopConnector(connectorName);
 
         // Try to delete the offsets for the single topic partition
@@ -801,6 +806,11 @@ public class OffsetsApiIntegrationTest {
         connect.configureConnector(connectorName, connectorConfigs);
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(connectorName, 1,
                 "Connector tasks did not start in time.");
+
+        // Make sure the tasks' consumers have had a chance to actually form a group
+        // (otherwise, the reset request will succeed because there won't be any active consumers)
+        verifyExpectedSinkConnectorOffsets(connectorName, topic, 1, NUM_RECORDS_PER_PARTITION,
+                "Sink connector consumer group offsets should catch up to the topic end offsets");
 
         verifyExpectedSinkConnectorOffsets(connectorName, topic, 1, NUM_RECORDS_PER_PARTITION,
                 "Sink connector consumer group offsets should catch up to the topic end offsets");


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-15917)

In some rare cases, our integration tests observe that tasks are up and running for our sink connectors, and issue a subsequent request to stop the connector, before the consumers of these tasks have had a chance to form/join a group. When this happens, requests to alter/reset the offsets for the connector actually succeed, since the group either doesn't exist, or is completely empty.

As a quick fix, we can wait for offsets to be committed for the connector before stopping it and attempting to modify its offsets. This goes a bit further than necessary (we should only have to wait for at least one task's consumer to have formed/joined a group), but off the top of my head it was the cleanest and briefest way to guarantee that a group had been formed. It also makes a little more sense in the context of the test, since there's not much use in modifying connector offsets when none exist yet.

In addition, the assertion error messages generated when sink connectors do not catch up to the expected committed offsets in time are augmented with useful information about the expected and actual offsets.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
