### PR TITLE
KAFKA-16197: Print Connect worker specific logs on poll timeout expiry

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1215,7 +1215,7 @@ public abstract class AbstractCoordinator implements Closeable {
     }
 
     // visible for testing
-    synchronized RequestFuture<Void> sendHeartbeatRequest() {
+    public synchronized RequestFuture<Void> sendHeartbeatRequest() {
         log.debug("Sending Heartbeat request with generation {} and member id {} to coordinator {}",
             generation.generationId, generation.memberId, coordinator);
         HeartbeatRequest.Builder requestBuilder =

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1143,6 +1143,16 @@ public abstract class AbstractCoordinator implements Closeable {
         }
     }
 
+    protected void handlePollTimeoutExpiry() {
+        log.warn("consumer poll timeout has expired. This means the time between subsequent calls to poll() " +
+            "was longer than the configured max.poll.interval.ms, which typically implies that " +
+            "the poll loop is spending too much time processing messages. You can address this " +
+            "either by increasing max.poll.interval.ms or by reducing the maximum size of batches " +
+            "returned in poll() with max.poll.records.");
+
+        maybeLeaveGroup("consumer poll timeout has expired.");
+    }
+
     /**
      * Sends LeaveGroupRequest and logs the {@code leaveReason}, unless this member is using static membership or is already
      * not part of the group (ie does not have a valid member id, is in the UNJOINED state, or the coordinator is unknown).
@@ -1508,13 +1518,7 @@ public abstract class AbstractCoordinator implements Closeable {
                         } else if (heartbeat.pollTimeoutExpired(now)) {
                             // the poll timeout has expired, which means that the foreground thread has stalled
                             // in between calls to poll().
-                            log.warn("consumer poll timeout has expired. This means the time between subsequent calls to poll() " +
-                                "was longer than the configured max.poll.interval.ms, which typically implies that " +
-                                "the poll loop is spending too much time processing messages. You can address this " +
-                                "either by increasing max.poll.interval.ms or by reducing the maximum size of batches " +
-                                "returned in poll() with max.poll.records.");
-
-                            maybeLeaveGroup("consumer poll timeout has expired.");
+                            handlePollTimeoutExpiry();
                         } else if (!heartbeat.shouldHeartbeat(now)) {
                             // poll again after waiting for the retry backoff in case the heartbeat failed or the
                             // coordinator disconnected. Note that the heartbeat timing takes account of

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1215,7 +1215,7 @@ public abstract class AbstractCoordinator implements Closeable {
     }
 
     // visible for testing
-    public synchronized RequestFuture<Void> sendHeartbeatRequest() {
+    synchronized RequestFuture<Void> sendHeartbeatRequest() {
         log.debug("Sending Heartbeat request with generation {} and member id {} to coordinator {}",
             generation.generationId, generation.memberId, coordinator);
         HeartbeatRequest.Builder requestBuilder =

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -2705,8 +2705,12 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         }
 
         @Override
-        public Stage onPollTimeoutExpiry() {
-            return tickThreadStage;
+        public void onPollTimeoutExpiry() {
+            log.warn("worker poll timeout has expired. The last known action being performed by the worker is : {} and may contribute to the timeout. " +
+                "Please review the last action (if known) for any corrective actions. " +
+                "One of the ways of addressing this can be increasing the rebalance.timeout.ms configuration value. Please note that " +
+                "rebalance.timeout.ms also controls the maximum allowed time for each worker to join the group once a " +
+                "rebalance has begun so the set value should not be very high", tickThreadStage == null ? "not known" : tickThreadStage.description());
         }
 
         private void resetActiveTopics(Collection<String> connectors, Collection<ConnectorTaskId> tasks) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -2704,6 +2704,11 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             }
         }
 
+        @Override
+        public Stage onPollTimeoutExpiry() {
+            return tickThreadStage;
+        }
+
         private void resetActiveTopics(Collection<String> connectors, Collection<ConnectorTaskId> tasks) {
             String stageDescription = "resetting the list of active topics for " + connectors.size() + " and " + tasks.size() + " tasks";
             try (TickThreadStage stage = new TickThreadStage(stageDescription)) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -267,6 +267,18 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
         return JoinGroupRequest.UNKNOWN_MEMBER_ID;
     }
 
+    @Override
+    protected void handlePollTimeoutExpiry() {
+        log.warn("worker poll timeout has expired. This means the time between subsequent calls to poll() " +
+            "in DistributedHerder tick() method was longer than the configured rebalance.timeout.ms. " +
+            "If you see this happening consistently, then it can be addressed by either adding more workers " +
+            "to the connect cluster or by increasing the rebalance.timeout.ms configuration value. Please note that " +
+            "rebalance.timeout.ms also controls the maximum allowed time for each worker to join the group once a " +
+            "rebalance has begun so the set value should not be very high");
+
+        maybeLeaveGroup("worker poll timeout has expired.");
+    }
+
     /**
      * Return the current generation. The generation refers to this worker's knowledge with
      * respect to which generation is the latest one and, therefore, this information is local.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -28,7 +28,6 @@ import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.connect.storage.ClusterConfigState;
 import org.apache.kafka.connect.storage.ConfigBackingStore;
 import org.apache.kafka.connect.util.ConnectorTaskId;
-import org.apache.kafka.connect.util.Stage;
 import org.slf4j.Logger;
 
 import java.io.Closeable;
@@ -270,15 +269,7 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
 
     @Override
     protected void handlePollTimeoutExpiry() {
-        Stage currentStage = listener.onPollTimeoutExpiry();
-        log.warn("worker poll timeout has expired. This means the time between subsequent calls to poll() " +
-            "in DistributedHerder tick() method was longer than the configured rebalance.timeout.ms. " +
-            "The last known stage executing on the tick thread is : {}. " +
-            "Please review the last known stage for tick thread (if known) for any corrective actions. " +
-            "One of the ways of addressing this can be increasing the rebalance.timeout.ms configuration value. Please note that " +
-            "rebalance.timeout.ms also controls the maximum allowed time for each worker to join the group once a " +
-            "rebalance has begun so the set value should not be very high", currentStage == null ? "not known" : currentStage.description());
-
+        listener.onPollTimeoutExpiry();
         maybeLeaveGroup("worker poll timeout has expired.");
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.connect.storage.ClusterConfigState;
 import org.apache.kafka.connect.storage.ConfigBackingStore;
 import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.apache.kafka.connect.util.Stage;
 import org.slf4j.Logger;
 
 import java.io.Closeable;
@@ -269,12 +270,14 @@ public class WorkerCoordinator extends AbstractCoordinator implements Closeable 
 
     @Override
     protected void handlePollTimeoutExpiry() {
+        Stage currentStage = listener.onPollTimeoutExpiry();
         log.warn("worker poll timeout has expired. This means the time between subsequent calls to poll() " +
             "in DistributedHerder tick() method was longer than the configured rebalance.timeout.ms. " +
-            "If you see this happening consistently, then it can be addressed by either adding more workers " +
-            "to the connect cluster or by increasing the rebalance.timeout.ms configuration value. Please note that " +
+            "The last known stage executing on the tick thread is : {}. " +
+            "Please review the last known stage for tick thread (if known) for any corrective actions. " +
+            "One of the ways of addressing this can be increasing the rebalance.timeout.ms configuration value. Please note that " +
             "rebalance.timeout.ms also controls the maximum allowed time for each worker to join the group once a " +
-            "rebalance has begun so the set value should not be very high");
+            "rebalance has begun so the set value should not be very high", currentStage == null ? "not known" : currentStage.description());
 
         maybeLeaveGroup("worker poll timeout has expired.");
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerRebalanceListener.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerRebalanceListener.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.runtime.distributed;
 
 import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.apache.kafka.connect.util.Stage;
 
 import java.util.Collection;
 
@@ -36,4 +37,15 @@ public interface WorkerRebalanceListener {
      * or tasks might refer to all or some of the connectors and tasks running on the worker.
      */
     void onRevoked(String leader, Collection<String> connectors, Collection<ConnectorTaskId> tasks);
+
+
+    /**
+     * Invoked when a worker experiences a poll timeout expiry. Invoking this method allows getting
+     * the stage which was currently being executed when the poll timeout happened. The default implementation
+     * returns null
+     * @return The current stage being executed. Could be null
+     */
+    default Stage onPollTimeoutExpiry() {
+        return null;
+    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerRebalanceListener.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerRebalanceListener.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.connect.runtime.distributed;
 
 import org.apache.kafka.connect.util.ConnectorTaskId;
-import org.apache.kafka.connect.util.Stage;
 
 import java.util.Collection;
 
@@ -40,12 +39,7 @@ public interface WorkerRebalanceListener {
 
 
     /**
-     * Invoked when a worker experiences a poll timeout expiry. Invoking this method allows getting
-     * the stage which was currently being executed when the poll timeout happened. The default implementation
-     * returns null
-     * @return The current stage being executed. Could be null
+     * Invoked when a worker experiences a poll timeout expiry.
      */
-    default Stage onPollTimeoutExpiry() {
-        return null;
-    }
+    void onPollTimeoutExpiry();
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -102,7 +102,7 @@ public class BlockingConnectorTest {
     private static final String CONNECTOR_CONFIG = "Connector::config";
     private static final String CONNECTOR_VERSION = "Connector::version";
     private static final String TASK_START = "Task::start";
-    private static final String TASK_STOP = "Task::stop";
+    static final String TASK_STOP = "Task::stop";
     private static final String TASK_VERSION = "Task::version";
     private static final String SINK_TASK_INITIALIZE = "SinkTask::initialize";
     private static final String SINK_TASK_PUT = "SinkTask::put";

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -850,6 +850,22 @@ public class ConnectWorkerIntegrationTest {
         );
     }
 
+    @Test
+    public void testPollTimeoutExpiry() throws Exception {
+        final String configTopic = "test-poll-timeout-expiry-config";
+        workerProps.put(CONFIG_TOPIC_CONFIG, configTopic);
+
+        workerProps.put(SCHEDULED_REBALANCE_MAX_DELAY_MS_CONFIG, "0");
+        connect = connectBuilder
+            .numBrokers(1)
+            .numWorkers(2)
+            .build();
+        connect.start();
+        connect.assertions().assertAtLeastNumWorkersAreUp(2,
+            "Worker did not start in time");
+
+    }
+
     private void assertTimeoutException(Runnable operation, String expectedStageDescription) throws InterruptedException {
         connect.requestTimeout(1_000);
         AtomicReference<Throwable> latestError = new AtomicReference<>();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -3239,26 +3239,6 @@ public class DistributedHerderTest {
     }
 
     @Test
-    public void testPollTimeoutExpiry() {
-        connectProtocolVersion = CONNECT_PROTOCOL_V1;
-        when(member.memberId()).thenReturn("member");
-        when(member.currentProtocolVersion()).thenReturn(connectProtocolVersion);
-
-        herder.tick();
-
-        // Assign a connector to this worker, and have it start it.
-        // Let's assume it takes a long time to start the connector which makes the poll timeout to expire
-        expectRebalance(Collections.emptyList(), Collections.emptyList(), ConnectProtocol.Assignment.NO_ERROR, 1, singletonList(CONN1), Collections.emptyList(), 0);
-        expectConfigRefreshAndSnapshot(SNAPSHOT);
-        ArgumentCaptor<Callback<TargetState>> onFirstStart = ArgumentCaptor.forClass(Callback.class);
-        doAnswer(invocation -> {
-            time.sleep(61000);
-            onFirstStart.getValue().onCompletion(null, TargetState.STARTED);
-            return true;
-        }).when(worker).startConnector(eq(CONN1), eq(CONN1_CONFIG), any(), eq(herder), eq(TargetState.STARTED), onFirstStart.capture());
-    }
-
-    @Test
     public void shouldThrowWhenStartAndStopExecutorThrowsRejectedExecutionExceptionAndHerderNotStopping() {
         when(member.memberId()).thenReturn("leader");
         when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorIncrementalTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorIncrementalTest.java
@@ -559,6 +559,9 @@ public class WorkerCoordinatorIncrementalTest {
             this.revokedTasks = tasks;
             revokedCount++;
         }
+
+        @Override
+        public void onPollTimeoutExpiry() {}
     }
 
     private static ExtendedAssignment deserializeAssignment(Map<String, ByteBuffer> assignment,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/ConnectAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/ConnectAssertions.java
@@ -76,7 +76,7 @@ public class ConnectAssertions {
     }
 
     /**
-     * Assert that at least the requested number of workers are up and running.
+     * Assert that the exact number of workers are up and running.
      *
      * @param numWorkers the number of online workers
      */


### PR DESCRIPTION
Please refer to the description in [KAFKA-16197](https://issues.apache.org/jira/browse/KAFKA-16197). 

Note that there are 2 more instances [here](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java#L1131) and [here](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java#L1079) which print consumer specific changes but that had changes leaking into ConsumerCoordinator and other tests for it because of which I didn't include it as part of this PR. 