### PR TITLE
MINOR: Add MetadataType metric from KIP-866 #15299

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -304,6 +304,7 @@ class ControllerServer(
           .setQuorumFeatures(quorumFeatures)
           .setConfigSchema(configSchema)
           .setControllerMetrics(quorumControllerMetrics)
+          .setMinMigrationBatchSize(config.migrationMetadataMinBatchSize)
           .setTime(time)
           .build()
         migrationDriver.start()

--- a/core/src/main/scala/kafka/server/KafkaBroker.scala
+++ b/core/src/main/scala/kafka/server/KafkaBroker.scala
@@ -34,7 +34,7 @@ import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.metadata.BrokerState
 import org.apache.kafka.server.NodeToControllerChannelManager
 import org.apache.kafka.server.authorizer.Authorizer
-import org.apache.kafka.server.metrics.{KafkaMetricsGroup, KafkaYammerMetrics}
+import org.apache.kafka.server.metrics.{KafkaMetricsGroup, KafkaYammerMetrics, MetadataTypeMetric}
 import org.apache.kafka.server.util.Scheduler
 
 import java.util
@@ -116,4 +116,11 @@ trait KafkaBroker extends Logging {
     metricsGroup.newGauge("linux-disk-read-bytes", () => linuxIoMetricsCollector.readBytes())
     metricsGroup.newGauge("linux-disk-write-bytes", () => linuxIoMetricsCollector.writeBytes())
   }
+  metricsGroup.newGauge(MetadataTypeMetric.METRIC_NAME, () => {
+    this match {
+      case _: BrokerServer => MetadataTypeMetric.KRAFT
+      case _: KafkaServer => MetadataTypeMetric.ZOOKEEPER
+      case _ => throw new IllegalStateException("Expected either BrokerServer or KafkaServer")
+    }
+  })
 }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -166,6 +166,7 @@ object KafkaConfig {
 
   /** ZK to KRaft Migration configs */
   val MigrationEnabledProp = "zookeeper.metadata.migration.enable"
+  val MigrationMetadataMinBatchSizeProp = "zookeeper.metadata.migration.min.batch.size"
 
   /** Enable eligible leader replicas configs */
   val ElrEnabledProp = "eligible.leader.replicas.enable"
@@ -1029,6 +1030,8 @@ object KafkaConfig {
       .defineInternal(ServerMaxStartupTimeMsProp, LONG, Defaults.SERVER_MAX_STARTUP_TIME_MS, atLeast(0), MEDIUM, ServerMaxStartupTimeMsDoc)
       .define(MigrationEnabledProp, BOOLEAN, false, HIGH, "Enable ZK to KRaft migration")
       .define(ElrEnabledProp, BOOLEAN, false, HIGH, "Enable the Eligible leader replicas")
+      .defineInternal(MigrationMetadataMinBatchSizeProp, INT, Defaults.MIGRATION_METADATA_MIN_BATCH_SIZE, atLeast(1),
+        MEDIUM, "Soft minimum batch size to use when migrating metadata from ZooKeeper to KRaft")
 
       /************* Authorizer Configuration ***********/
       .define(AuthorizerClassNameProp, STRING, Defaults.AUTHORIZER_CLASS_NAME, new ConfigDef.NonNullValidator(), LOW, AuthorizerClassNameDoc)
@@ -1538,6 +1541,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   def usesSelfManagedQuorum: Boolean = processRoles.nonEmpty
 
   val migrationEnabled: Boolean = getBoolean(KafkaConfig.MigrationEnabledProp)
+  val migrationMetadataMinBatchSize: Int = getInt(KafkaConfig.MigrationMetadataMinBatchSizeProp)
 
   val elrEnabled: Boolean = getBoolean(KafkaConfig.ElrEnabledProp)
 

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsTest.java
@@ -47,7 +47,8 @@ public class ControllerMetadataMetricsTest {
                         "kafka.controller:type=KafkaController,name=MetadataErrorCount",
                         "kafka.controller:type=KafkaController,name=OfflinePartitionsCount",
                         "kafka.controller:type=KafkaController,name=PreferredReplicaImbalanceCount",
-                        "kafka.controller:type=KafkaController,name=ZkMigrationState"
+                        "kafka.controller:type=KafkaController,name=ZkMigrationState",
+                        "kafka.controller:type=KafkaController,name=MetadataType"
                     )));
             }
             ControllerMetricsTestUtils.assertMetricsForTypeEqual(registry, "KafkaController",

--- a/server-common/src/main/java/org/apache/kafka/server/metrics/MetadataTypeMetric.java
+++ b/server-common/src/main/java/org/apache/kafka/server/metrics/MetadataTypeMetric.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.metrics;
+
+/**
+ * This metric is reported by broker and controllers in both KRaft and ZK modes. For brokers,
+ * it is included under the KafkaServer mbean. For controllers, it is under the KafkaController
+ * mbean. This metric was defined in KIP-866
+ */
+public final class MetadataTypeMetric {
+    public static final String METRIC_NAME = "MetadataType";
+
+    public static final int ZOOKEEPER = 1;
+    public static final int KRAFT = 2;
+    public static final int DUAL_WRITE = 3;
+}

--- a/server/src/main/java/org/apache/kafka/server/config/Defaults.java
+++ b/server/src/main/java/org/apache/kafka/server/config/Defaults.java
@@ -74,6 +74,7 @@ public class Defaults {
     /** ********* KRaft mode configs *********/
     public static final int EMPTY_NODE_ID = -1;
     public static final long SERVER_MAX_STARTUP_TIME_MS = Long.MAX_VALUE;
+    public static final int MIGRATION_METADATA_MIN_BATCH_SIZE = 200;
 
     /** ********* Authorizer Configuration *********/
     public static final String AUTHORIZER_CLASS_NAME = "";


### PR DESCRIPTION
This patch addresses a few minor observability and operational concerns for ZK to KRaft migrations.

The "MetadataType" metric is added to both the brokers and controllers, as defined in KIP-866. The values are: 1 (ZooKeeper), 2 (KRaft), 3 (Dual-Write). The brokers will only ever report ZooKeeper or KRaft, while  the controller can also report Dual-Write depending on the state of the ZK migration.

The "MigratingZkBrokerCount" metric is added to the ZK controller, where the value will always be zero. This aligns this metric with the KRaft controller, which makes monitoring a bit simpler.

During the ZK to KRaft migration, both of these metrics can be useful. Observing a non-zero MigratingZkBrokerCount means that the cluster is in a hybrid state with some ZK brokers and a KRaft controller. Also,     including a definitive metric for "is this KRaft or ZK?" is useful when observing brokers come up as KRaft during the migration process.