### PR TITLE
KAFKA-16220: Increase timeout in KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
@@ -212,7 +212,7 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
         }
 
         // the streams applications should have shut down into `ERROR` due to the IllegalStateException
-        waitForApplicationState(Arrays.asList(streams, streamsTwo, streamsThree), KafkaStreams.State.ERROR, ofSeconds(60));
+        waitForApplicationState(Arrays.asList(streams, streamsTwo, streamsThree), KafkaStreams.State.ERROR, ofSeconds(240));
     }
 
     private void verifyKTableKTableJoin(final Set<KeyValue<String, String>> expectedResult) throws Exception {


### PR DESCRIPTION
The test is flaky, since sometimes one of the threads haven't processed a single record that cause the ERROR state in test run (due to unlucky rebalancing).

See https://ge.apache.org/scans/tests?search.names=Git%20branch&search.relativeStartTime=P90D&search.rootProjectNames=kafka&search.timeZoneId=Europe%2FBerlin&search.values=trunk&tests.container=org.apache.kafka.streams.integration.KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest&tests.sortField=FLAKY&tests.test=shouldThrowIllegalArgumentExceptionWhenCustomPartitionerReturnsMultiplePartitions() for flaky failures.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
