### PR TITLE
Version downgrade for shadow jar plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,9 @@ plugins {
   // be dropped from gradle/resources/dependencycheck-suppressions.xml
   id "com.github.spotbugs" version '5.1.3' apply false
   id 'org.scoverage' version '7.0.1' apply false
-  id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
+  // Updating the shadow plugin version to 8.1.1 causes issue with signing and publishing the shadowed
+  // artifacts - see https://github.com/johnrengelman/shadow/issues/901
+  id 'com.github.johnrengelman.shadow' version '8.1.0' apply false
   id 'com.diffplug.spotless' version '6.14.0' apply false // 6.14.1 and newer require Java 11 at compile time, so we can't upgrade until AK 4.0
 }
 
@@ -302,7 +304,7 @@ subprojects {
             from components.java
           } else {
             apply plugin: 'com.github.johnrengelman.shadow'
-            artifact shadowJar
+            project.shadow.component(mavenJava)
           }
 
           afterEvaluate {


### PR DESCRIPTION
Shadow jar plugin version `8.1.1` causes issue when shadowed artifacts are `signed` and `published`. The issue occurs because `archiveBaseName` and `archiveClassifier` are not honoured correctly by publication and tries to find the shadow jar which doesn't exist - see https://github.com/johnrengelman/shadow/issues/901

This PR reverts the shadow plugin version upgrade added in the PR: https://github.com/apache/kafka/pull/13625 and also reverts the workaround to publish signed shadowed jar in the PR: https://github.com/apache/kafka/pull/15127

- I have verified the resultant `pom` for `kafka-clients` which does include the runtime dependencies.
- Verified the `kafka-clients.jar` has correct shaded classes
- Verified the release pipeline i.e. signing and publishing works correctly to remote maven repository.

@ijuma The query asked in the PR: https://github.com/apache/kafka/pull/15127 still stands as [Gradle Module Metadata](https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html) is never generated with `shadow jar plugin`.

cc: @stanislavkozlovski @AndrewJSchofield @xvrl 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
