### PR TITLE
MINOR: Upgrade maven artifact version to 3.9.6

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -240,7 +240,7 @@ jetty-util-9.4.53.v20231009
 jetty-util-ajax-9.4.53.v20231009
 jose4j-0.9.4
 lz4-java-1.8.0
-maven-artifact-3.9.4
+maven-artifact-3.9.6
 metrics-core-4.1.12.1
 metrics-core-2.2.0
 netty-buffer-4.1.100.Final

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -240,7 +240,7 @@ jetty-util-9.4.53.v20231009
 jetty-util-ajax-9.4.53.v20231009
 jose4j-0.9.4
 lz4-java-1.8.0
-maven-artifact-3.8.8
+maven-artifact-3.9.4
 metrics-core-4.1.12.1
 metrics-core-2.2.0
 netty-buffer-4.1.100.Final
@@ -253,7 +253,7 @@ netty-transport-classes-epoll-4.1.100.Final
 netty-transport-native-epoll-4.1.100.Final
 netty-transport-native-unix-common-4.1.100.Final
 opentelemetry-proto-1.0.0-alpha
-plexus-utils-3.3.1
+plexus-utils-3.5.1
 reflections-0.10.2
 reload4j-1.2.25
 rocksdbjni-7.9.2

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -560,7 +560,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 
 Maven Artifact
-Copyright 2001-2023 The Apache Software Foundation
+Copyright 2001-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -560,7 +560,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 
 Maven Artifact
-Copyright 2001-2019 The Apache Software Foundation
+Copyright 2001-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -143,7 +143,7 @@ versions += [
   kafka_35: "3.5.2",
   kafka_36: "3.6.1",
   lz4: "1.8.0",
-  mavenArtifact: "3.8.8",
+  mavenArtifact: "3.9.4",
   metrics: "2.2.0",
   netty: "4.1.100.Final",
   opentelemetryProto: "1.0.0-alpha",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -143,7 +143,7 @@ versions += [
   kafka_35: "3.5.2",
   kafka_36: "3.6.1",
   lz4: "1.8.0",
-  mavenArtifact: "3.9.4",
+  mavenArtifact: "3.9.6",
   metrics: "2.2.0",
   netty: "4.1.100.Final",
   opentelemetryProto: "1.0.0-alpha",


### PR DESCRIPTION
The main motivation behind this change is to keep dependencies updated to the latest stable version of tools
used to build and publish kafka, and one of the most of important tools is maven artifact

Here is the release notes of maven artifact 3.9.6 https://maven.apache.org/docs/3.9.6/release-notes.html

One of of the big changes for this version is that java 8 is the minimum version required to use this version of maven

The build on local machine is working as perfectly, but we need to check the build on Jenkins


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
