### PR TITLE
KAFKA-16215; KAFKA-16178: Fix member not rejoining after error

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -342,7 +342,7 @@ public class HeartbeatRequestManager implements RequestManager {
         String message;
 
         this.heartbeatState.reset();
-        boolean skipBackoff = false;
+        this.heartbeatRequestState.onFailedAttempt(currentTimeMs);
 
         switch (error) {
             case NOT_COORDINATOR:
@@ -353,7 +353,7 @@ public class HeartbeatRequestManager implements RequestManager {
                 logInfo(message, response, currentTimeMs);
                 coordinatorRequestManager.markCoordinatorUnknown(errorMessage, currentTimeMs);
                 // Skip backoff so that the next HB is sent as soon as the new coordinator is discovered
-                skipBackoff = true;
+                heartbeatRequestState.resetBackoff();
                 break;
 
             case COORDINATOR_NOT_AVAILABLE:
@@ -363,7 +363,7 @@ public class HeartbeatRequestManager implements RequestManager {
                 logInfo(message, response, currentTimeMs);
                 coordinatorRequestManager.markCoordinatorUnknown(errorMessage, currentTimeMs);
                 // Skip backoff so that the next HB is sent as soon as the new coordinator is discovered
-                skipBackoff = true;
+                heartbeatRequestState.resetBackoff();
                 break;
 
             case COORDINATOR_LOAD_IN_PROGRESS:
@@ -401,7 +401,7 @@ public class HeartbeatRequestManager implements RequestManager {
                 logInfo(message, response, currentTimeMs);
                 membershipManager.transitionToFenced();
                 // Skip backoff so that a next HB to rejoin is sent as soon as the fenced member releases it assignment
-                skipBackoff = true;
+                heartbeatRequestState.resetBackoff();
                 break;
 
             case UNKNOWN_MEMBER_ID:
@@ -410,7 +410,7 @@ public class HeartbeatRequestManager implements RequestManager {
                 logInfo(message, response, currentTimeMs);
                 membershipManager.transitionToFenced();
                 // Skip backoff so that a next HB to rejoin is sent as soon as the fenced member releases it assignment
-                skipBackoff = true;
+                heartbeatRequestState.resetBackoff();
                 break;
 
             default:
@@ -419,8 +419,6 @@ public class HeartbeatRequestManager implements RequestManager {
                 handleFatalFailure(error.exception(errorMessage));
                 break;
         }
-
-        this.heartbeatRequestState.onFailedAttempt(currentTimeMs, skipBackoff);
     }
 
     private void logInfo(final String message,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -353,7 +353,7 @@ public class HeartbeatRequestManager implements RequestManager {
                 logInfo(message, response, currentTimeMs);
                 coordinatorRequestManager.markCoordinatorUnknown(errorMessage, currentTimeMs);
                 // Skip backoff so that the next HB is sent as soon as the new coordinator is discovered
-                heartbeatRequestState.resetBackoff();
+                heartbeatRequestState.reset();
                 break;
 
             case COORDINATOR_NOT_AVAILABLE:
@@ -363,7 +363,7 @@ public class HeartbeatRequestManager implements RequestManager {
                 logInfo(message, response, currentTimeMs);
                 coordinatorRequestManager.markCoordinatorUnknown(errorMessage, currentTimeMs);
                 // Skip backoff so that the next HB is sent as soon as the new coordinator is discovered
-                heartbeatRequestState.resetBackoff();
+                heartbeatRequestState.reset();
                 break;
 
             case COORDINATOR_LOAD_IN_PROGRESS:
@@ -401,7 +401,7 @@ public class HeartbeatRequestManager implements RequestManager {
                 logInfo(message, response, currentTimeMs);
                 membershipManager.transitionToFenced();
                 // Skip backoff so that a next HB to rejoin is sent as soon as the fenced member releases it assignment
-                heartbeatRequestState.resetBackoff();
+                heartbeatRequestState.reset();
                 break;
 
             case UNKNOWN_MEMBER_ID:
@@ -410,7 +410,7 @@ public class HeartbeatRequestManager implements RequestManager {
                 logInfo(message, response, currentTimeMs);
                 membershipManager.transitionToFenced();
                 // Skip backoff so that a next HB to rejoin is sent as soon as the fenced member releases it assignment
-                heartbeatRequestState.resetBackoff();
+                heartbeatRequestState.reset();
                 break;
 
             default:

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -400,7 +400,7 @@ public class HeartbeatRequestManager implements RequestManager {
                         membershipManager.memberId(), membershipManager.memberEpoch());
                 logInfo(message, response, currentTimeMs);
                 membershipManager.transitionToFenced();
-                // Skip backoff so that a next HB to rejoin is sent as soon as the fenced member releases it assignment
+                // Skip backoff so that a next HB to rejoin is sent as soon as the fenced member releases its assignment
                 heartbeatRequestState.reset();
                 break;
 
@@ -409,7 +409,7 @@ public class HeartbeatRequestManager implements RequestManager {
                         membershipManager.memberId());
                 logInfo(message, response, currentTimeMs);
                 membershipManager.transitionToFenced();
-                // Skip backoff so that a next HB to rejoin is sent as soon as the fenced member releases it assignment
+                // Skip backoff so that a next HB to rejoin is sent as soon as the fenced member releases its assignment
                 heartbeatRequestState.reset();
                 break;
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -267,11 +267,13 @@ public class HeartbeatRequestManager implements RequestManager {
             return logResponse(request);
         else
             return request.whenComplete((response, exception) -> {
+                long completionTimeMs = request.handler().completionTimeMs();
+                heartbeatRequestState.updateLastReceivedTime(completionTimeMs);
                 if (response != null) {
                     metricsManager.recordRequestLatency(response.requestLatencyMs());
-                    onResponse((ConsumerGroupHeartbeatResponse) response.responseBody(), request.handler().completionTimeMs());
+                    onResponse((ConsumerGroupHeartbeatResponse) response.responseBody(), completionTimeMs);
                 } else {
-                    onFailure(exception, request.handler().completionTimeMs());
+                    onFailure(exception, completionTimeMs);
                 }
             });
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestState.java
@@ -107,6 +107,13 @@ class RequestState {
     }
 
     /**
+     * Update the lastReceivedTime in milliseconds, indicating that a response has been received.
+     */
+    public void updateLastReceivedTime(final long lastReceivedMs) {
+        this.lastReceivedMs = lastReceivedMs;
+    }
+
+    /**
      * Callback invoked after a successful send. This resets the number of attempts
      * to 0, but the minimal backoff will still be enforced prior to allowing a new
      * send. To send immediately, use {@link #reset()}.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestState.java
@@ -132,16 +132,6 @@ class RequestState {
         this.numAttempts++;
     }
 
-    /**
-     * Set backoff and number of attempts to 0. This will ensure that the request is sent out
-     * again right away. Expected to be used when receiving errors responses that lead to a new
-     * request that can be sent without backing off (ex. member rejoining after fencing)
-     */
-    public void resetBackoff() {
-        this.backoffMs = 0;
-        this.numAttempts = 0;
-    }
-
     long remainingBackoffMs(final long currentTimeMs) {
         long timeSinceLastReceiveMs = currentTimeMs - this.lastReceivedMs;
         return Math.max(0, backoffMs - timeSinceLastReceiveMs);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestState.java
@@ -127,17 +127,19 @@ class RequestState {
      * @param currentTimeMs Current time in milliseconds
      */
     public void onFailedAttempt(final long currentTimeMs) {
-        onFailedAttempt(currentTimeMs, false);
+        this.lastReceivedMs = currentTimeMs;
+        this.backoffMs = exponentialBackoff.backoff(numAttempts);
+        this.numAttempts++;
     }
 
-    public void onFailedAttempt(final long currentTimeMs, final boolean skipBackoff) {
-        this.lastReceivedMs = currentTimeMs;
-        if (skipBackoff) {
-            this.backoffMs = 0;
-        } else {
-            this.backoffMs = exponentialBackoff.backoff(numAttempts);
-        }
-        this.numAttempts++;
+    /**
+     * Set backoff and number of attempts to 0. This will ensure that the request is sent out
+     * again right away. Expected to be used when receiving errors responses that lead to a new
+     * request that can be sent without backing off (ex. member rejoining after fencing)
+     */
+    public void resetBackoff() {
+        this.backoffMs = 0;
+        this.numAttempts = 0;
     }
 
     long remainingBackoffMs(final long currentTimeMs) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestState.java
@@ -107,13 +107,6 @@ class RequestState {
     }
 
     /**
-     * Update the lastReceivedTime in milliseconds, indicating that a response has been received.
-     */
-    public void updateLastReceivedTime(final long lastReceivedMs) {
-        this.lastReceivedMs = lastReceivedMs;
-    }
-
-    /**
      * Callback invoked after a successful send. This resets the number of attempts
      * to 0, but the minimal backoff will still be enforced prior to allowing a new
      * send. To send immediately, use {@link #reset()}.
@@ -134,8 +127,16 @@ class RequestState {
      * @param currentTimeMs Current time in milliseconds
      */
     public void onFailedAttempt(final long currentTimeMs) {
+        onFailedAttempt(currentTimeMs, false);
+    }
+
+    public void onFailedAttempt(final long currentTimeMs, final boolean skipBackoff) {
         this.lastReceivedMs = currentTimeMs;
-        this.backoffMs = exponentialBackoff.backoff(numAttempts);
+        if (skipBackoff) {
+            this.backoffMs = 0;
+        } else {
+            this.backoffMs = exponentialBackoff.backoff(numAttempts);
+        }
         this.numAttempts++;
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
@@ -465,6 +465,13 @@ public class HeartbeatRequestManagerTest {
                 }
                 break;
         }
+
+        if (!isFatal) {
+            // Make sure a next heartbeat is sent for all non-fatal errors (to retry or rejoin)
+            time.sleep(DEFAULT_HEARTBEAT_INTERVAL_MS);
+            result = heartbeatRequestManager.poll(time.milliseconds());
+            assertEquals(1, result.unsentRequests.size());
+        }
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
@@ -445,16 +445,26 @@ public class HeartbeatRequestManagerTest {
 
             case COORDINATOR_LOAD_IN_PROGRESS:
                 verify(backgroundEventHandler, never()).add(any());
-                assertEquals(DEFAULT_RETRY_BACKOFF_MS, heartbeatRequestState.nextHeartbeatMs(time.milliseconds()));
+                assertEquals(DEFAULT_RETRY_BACKOFF_MS,
+                    heartbeatRequestState.nextHeartbeatMs(time.milliseconds()), "Request should " +
+                        "backoff after receiving a coordinator load in progress error. ");
                 break;
 
             case COORDINATOR_NOT_AVAILABLE:
             case NOT_COORDINATOR:
                 verify(backgroundEventHandler, never()).add(any());
                 verify(coordinatorRequestManager).markCoordinatorUnknown(any(), anyLong());
-                assertEquals(0, heartbeatRequestState.nextHeartbeatMs(time.milliseconds()));
+                assertEquals(0, heartbeatRequestState.nextHeartbeatMs(time.milliseconds()),
+                    "Request should not apply backoff so that the next heartbeat is sent " +
+                        "as soon as the new coordinator is discovered.");
                 break;
-
+            case UNKNOWN_MEMBER_ID:
+            case FENCED_MEMBER_EPOCH:
+                verify(backgroundEventHandler, never()).add(any());
+                assertEquals(0, heartbeatRequestState.nextHeartbeatMs(time.milliseconds()),
+                    "Request should not apply backoff so that the next heartbeat to rejoin is " +
+                        "sent as soon as the fenced member releases its assignment.");
+                break;
             default:
                 if (isFatal) {
                     // The memberStateManager should have stopped heartbeat at this point


### PR DESCRIPTION
This fixes a bug that was causing that members wouldn't rejoin the group after receiving an error in the heartbeat response (ex. fenced, not coordinator, as reported in KAFKA-16215 and KAFKA-16178). The issue was that when receiving a response with error, the response receive time was not being updated, so following heartbeat would be skipped, considering that there was already a previous one inflight.

Tests updated to cover this.  