### PR TITLE
KAFKA-16102: fix the dynamic modification of listeners' IP or port no…

### DIFF
--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -436,16 +436,27 @@ class DynamicBrokerConfigTest {
   @Test
   def testDynamicListenerConfig(): Unit = {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 9092)
-    val oldConfig =  KafkaConfig.fromProps(props)
+    val oldConfig = KafkaConfig.fromProps(props)
     val kafkaServer: KafkaServer = mock(classOf[kafka.server.KafkaServer])
     when(kafkaServer.config).thenReturn(oldConfig)
 
     props.put(KafkaConfig.ListenersProp, "PLAINTEXT://hostname:9092,SASL_PLAINTEXT://hostname:9093")
-    new DynamicListenerConfig(kafkaServer).validateReconfiguration(KafkaConfig(props))
+    val dynamicListenerConfig = new DynamicListenerConfig(kafkaServer)
+    dynamicListenerConfig.validateReconfiguration(KafkaConfig(props))
+
+    val server = mock(classOf[SocketServer])
+    when(kafkaServer.socketServer).thenReturn(server)
+    doNothing().when(server).removeListeners(any())
+    doNothing().when(server).addListeners(any())
+    val kafkaController = mock(classOf[KafkaController])
+    when(kafkaServer.kafkaController).thenReturn(kafkaController)
+    doNothing().when(kafkaController).updateBrokerInfo(any())
+    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://hostname:9093")
+    val newConfig = KafkaConfig.fromProps(props)
+    dynamicListenerConfig.reconfigure(oldConfig, newConfig)
 
     // it is illegal to update non-reconfiguable configs of existent listeners
     props.put("listener.name.plaintext.you.should.not.pass", "failure")
-    val dynamicListenerConfig = new DynamicListenerConfig(kafkaServer)
     assertThrows(classOf[ConfigException], () => dynamicListenerConfig.validateReconfiguration(KafkaConfig(props)))
   }
 

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -42,9 +42,9 @@ import org.apache.kafka.storage.internals.log.{LogConfig, ProducerStateManagerCo
 import org.apache.kafka.test.MockMetricsReporter
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.{ArgumentCaptor, ArgumentMatchers, Mockito}
-import org.mockito.Mockito.{mock, when}
+import org.mockito.Mockito.{doNothing, mock, when}
 
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._


### PR DESCRIPTION
When using the kafka-config.sh script to modify the IP and host in the listeners parameter, the configuration changes will not take effect dynamically. A broker restart is required for the changes to become effective.

Previously, changes would only take effect when increasing or decreasing the number of listeners, or modifying the names of the listeners.

When the IP or host changes, we also make modifications to the listener. Additionally, we address the exception "Security protocol cannot be updated for existing listener."
And there is a improvement as the error "Security protocol cannot be updated for existing listener" will be eliminated.

