### PR TITLE
KAFKA-16037: Update VerifiableConsumer to support KIP-848’s group protocol config

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -34,6 +34,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.GroupProtocol;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
@@ -528,6 +529,15 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .metavar("TOPIC")
                 .help("Consumes messages from this topic.");
 
+        parser.addArgument("--group-protocol")
+                .action(store())
+                .required(false)
+                .type(String.class)
+                .setDefault(GroupProtocol.CLASSIC.name)
+                .metavar("GROUP_PROTOCOL")
+                .dest("groupProtocol")
+                .help(String.format("Group protocol (must be one of %s)", Utils.join(GroupProtocol.values(), ", ")));
+
         parser.addArgument("--group-id")
                 .action(store())
                 .required(true)
@@ -617,6 +627,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
             }
         }
 
+        consumerProps.put(ConsumerConfig.GROUP_PROTOCOL_CONFIG, res.getString("groupProtocol"));
         consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, res.getString("groupId"));
 
         String groupInstanceId = res.getString("groupInstanceId");


### PR DESCRIPTION
Add the optional `--group-protocol` command line option that can be set in the system tests

There are no existing unit tests for `VerifiableConsumer`. It was tested by running the system tests locally without regression. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
