### PR TITLE
MINOR: Added ACLs authorizer change during migration

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3933,7 +3933,7 @@ controller.listener.names=CONTROLLER</pre>
   </p>
 
   <p>
-    If you broker has authorization configured via the <code>authorizer.class.name</code> property
+    If your broker has authorization configured via the <code>authorizer.class.name</code> property
     using <code>kafka.security.authorizer.AclAuthorizer</code>, this is also the time to change it
     to use <code>org.apache.kafka.metadata.authorizer.StandardAuthorizer</code> instead.
   </p>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3932,6 +3932,12 @@ controller.listener.names=CONTROLLER</pre>
     The zookeeper configurations should be removed at this point.
   </p>
 
+  <p>
+    If you broker has authorization configured via the <code>authorizer.class.name</code> property
+    using <code>kafka.security.authorizer.AclAuthorizer</code>, this is also the time to change it
+    to use <code>org.apache.kafka.metadata.authorizer.StandardAuthorizer</code> instead.
+  </p>
+
   <pre>
 # Sample KRaft broker server.properties listening on 9092
 process.roles=broker


### PR DESCRIPTION
This trivial PR makes clear when it's the right time to switch from `AclAuthorizer` to `StandardAuthorizer` during the migration process.
