### PR TITLE
KAFKA-16116: Rebalance Metrics for AsyncKafkaConsumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -327,7 +327,7 @@ public class HeartbeatRequestManager implements RequestManager {
             heartbeatRequestState.updateHeartbeatIntervalMs(response.data().heartbeatIntervalMs());
             heartbeatRequestState.onSuccessfulAttempt(currentTimeMs);
             heartbeatRequestState.resetTimer();
-            membershipManager.onHeartbeatResponseReceived(response.data());
+            membershipManager.onHeartbeatSuccess(response.data());
             maybeSendGroupMetadataUpdateEvent();
             return;
         }
@@ -357,7 +357,7 @@ public class HeartbeatRequestManager implements RequestManager {
 
         this.heartbeatState.reset();
         this.heartbeatRequestState.onFailedAttempt(currentTimeMs);
-        membershipManager.onHeartbeatError();
+        membershipManager.onHeartbeatFailure();
 
         switch (error) {
             case NOT_COORDINATOR:

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -357,6 +357,7 @@ public class HeartbeatRequestManager implements RequestManager {
 
         this.heartbeatState.reset();
         this.heartbeatRequestState.onFailedAttempt(currentTimeMs);
+        membershipManager.onHeartbeatError();
 
         switch (error) {
             case NOT_COORDINATOR:

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
@@ -68,12 +68,12 @@ public interface MembershipManager extends RequestManager {
      *
      * @param response Heartbeat response to extract member info and errors from.
      */
-    void onHeartbeatResponseReceived(ConsumerGroupHeartbeatResponseData response);
+    void onHeartbeatSuccess(ConsumerGroupHeartbeatResponseData response);
 
     /**
      * Notify the member that an error heartbeat response was received.
      */
-    void onHeartbeatError();
+    void onHeartbeatFailure();
 
     /**
      * Update state when a heartbeat is sent out. This will transition out of the states that end

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
@@ -71,6 +71,11 @@ public interface MembershipManager extends RequestManager {
     void onHeartbeatResponseReceived(ConsumerGroupHeartbeatResponseData response);
 
     /**
+     * Notify the member that an error heartbeat response was received.
+     */
+    void onHeartbeatError();
+
+    /**
      * Update state when a heartbeat is sent out. This will transition out of the states that end
      * when a heartbeat request is sent, without waiting for a response (ex.
      * {@link MemberState#ACKNOWLEDGING} and {@link MemberState#LEAVING}).

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -443,7 +443,6 @@ public class MembershipManagerImpl implements MembershipManager {
     @Override
     public void onHeartbeatError() {
         metricsManager.maybeRecordRebalanceFailed();
-        return;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -265,8 +265,10 @@ public class MembershipManagerImpl implements MembershipManager {
      * when the timer is reset, only when it completes releasing its assignment.
      */
     private CompletableFuture<Void> staleMemberAssignmentRelease;
+    
     /*
      * Holding onto rebalance metric sensors. This module records success and failure of rebalance events.
+     * Measures successful rebalance latency and number of failed rebalances.
      */
     private final RebalanceMetricsManager metricsManager;
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -267,7 +267,6 @@ public class MembershipManagerImpl implements MembershipManager {
     private CompletableFuture<Void> staleMemberAssignmentRelease;
     
     /*
-     * Holding onto rebalance metric sensors. This module records success and failure of rebalance events.
      * Measures successful rebalance latency and number of failed rebalances.
      */
     private final RebalanceMetricsManager metricsManager;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.GroupRebalanceConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
+import org.apache.kafka.clients.consumer.internals.metrics.RebalanceMetricsManager;
 import org.apache.kafka.common.internals.IdempotentCloser;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.telemetry.internals.ClientTelemetryReporter;
@@ -189,7 +190,8 @@ public class RequestManagers implements Closeable {
                             logContext,
                             clientTelemetryReporter,
                             backgroundEventHandler,
-                            time);
+                            time,
+                            new RebalanceMetricsManager(metrics));
                     membershipManager.registerStateListener(commit);
                     heartbeatRequestManager = new HeartbeatRequestManager(
                             logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -20,7 +20,6 @@ import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.GroupRebalanceConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
-import org.apache.kafka.clients.consumer.internals.metrics.RebalanceMetricsManager;
 import org.apache.kafka.common.internals.IdempotentCloser;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.telemetry.internals.ClientTelemetryReporter;
@@ -191,7 +190,7 @@ public class RequestManagers implements Closeable {
                             clientTelemetryReporter,
                             backgroundEventHandler,
                             time,
-                            new RebalanceMetricsManager(metrics));
+                            metrics);
                     membershipManager.registerStateListener(commit);
                     heartbeatRequestManager = new HeartbeatRequestManager(
                             logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/RebalanceMetricsManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/RebalanceMetricsManager.java
@@ -103,7 +103,7 @@ public class RebalanceMetricsManager {
     }
 
     public void maybeRecordRebalanceFailed() {
-        if (lastRebalanceStartMs < lastRebalanceEndMs)
+        if (lastRebalanceStartMs <= lastRebalanceEndMs)
             return;
         failedRebalanceSensor.record();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/RebalanceMetricsManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/RebalanceMetricsManager.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals.metrics;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.CumulativeCount;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.metrics.stats.WindowedCount;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_METRIC_GROUP_PREFIX;
+import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.COORDINATOR_METRICS_SUFFIX;
+
+public class RebalanceMetricsManager {
+    private final Sensor successfulRebalanceSensor;
+    private final Sensor failedRebalanceSensor;
+    private final String metricGroupName;
+
+    public final MetricName rebalanceLatencyAvg;
+    public final MetricName rebalanceLatencyMax;
+    public final MetricName rebalanceLatencyTotal;
+    public final MetricName rebalanceTotal;
+    public final MetricName rebalanceRatePerHour;
+    public final MetricName lastRebalanceSecondsAgo;
+    public final MetricName failedRebalanceTotal;
+    public final MetricName failedRebalanceRate;
+    private long lastRebalanceEndMs = -1L;
+    private long lastRebalanceStartMs = -1L;
+
+    public RebalanceMetricsManager(Metrics metrics) {
+        StackTraceElement[] st = Thread.currentThread().getStackTrace();
+        System.out.println("first:");
+        System.out.println(Arrays.toString(st));
+        metricGroupName = CONSUMER_METRIC_GROUP_PREFIX + COORDINATOR_METRICS_SUFFIX;
+
+        rebalanceLatencyAvg = createMetric(metrics, "rebalance-latency-avg",
+            "The average time taken for a group to complete a rebalance");
+        rebalanceLatencyMax = createMetric(metrics, "rebalance-latency-max",
+            "The max time taken for a group to complete a rebalance");
+        rebalanceLatencyTotal = createMetric(metrics, "rebalance-latency-total",
+            "The total number of milliseconds spent in rebalances");
+        rebalanceTotal = createMetric(metrics, "rebalance-total",
+            "The total number of rebalance events");
+        rebalanceRatePerHour = createMetric(metrics, "rebalance-rate-per-hour",
+            "The number of rebalance events per hour");
+        failedRebalanceTotal = createMetric(metrics, "failed-rebalance-total",
+            "The total number of failed rebalance events");
+        failedRebalanceRate = createMetric(metrics, "failed-rebalance-rate-per-hour",
+            "The number of failed rebalance events per hour");
+
+        successfulRebalanceSensor = metrics.sensor("rebalance-latency");
+        successfulRebalanceSensor.add(rebalanceLatencyAvg, new Avg());
+        successfulRebalanceSensor.add(rebalanceLatencyMax, new Max());
+        successfulRebalanceSensor.add(rebalanceLatencyTotal, new CumulativeSum());
+        successfulRebalanceSensor.add(rebalanceTotal, new CumulativeCount());
+        successfulRebalanceSensor.add(rebalanceRatePerHour, new Rate(TimeUnit.HOURS, new WindowedCount()));
+
+        failedRebalanceSensor = metrics.sensor("failed-rebalance");
+        failedRebalanceSensor.add(failedRebalanceTotal, new CumulativeSum());
+        failedRebalanceSensor.add(failedRebalanceRate, new Rate(TimeUnit.HOURS, new WindowedCount()));
+
+        Measurable lastRebalance = (config, now) -> {
+            if (lastRebalanceEndMs == -1L)
+                return -1d;
+            else
+                return TimeUnit.SECONDS.convert(now - lastRebalanceEndMs, TimeUnit.MILLISECONDS);
+        };
+        lastRebalanceSecondsAgo = createMetric(metrics,
+            "last-rebalance-seconds-ago",
+            "The number of seconds since the last rebalance event");
+        metrics.addMetric(lastRebalanceSecondsAgo, lastRebalance);
+
+        st = Thread.currentThread().getStackTrace();
+        System.out.println("starting:");
+        System.out.println(Arrays.toString(st));
+    }
+
+    private MetricName createMetric(Metrics metrics, String name, String description) {
+        return metrics.metricName(name, metricGroupName, description);
+    }
+
+    public void recordRebalanceStarted(long nowMs) {
+        lastRebalanceStartMs = nowMs;
+    }
+
+    public void recordRebalanceEnded(long nowMs) {
+        lastRebalanceEndMs = nowMs;
+        System.out.println("nowMS:" + nowMs);
+        System.out.println("startMs:" + lastRebalanceStartMs);
+        successfulRebalanceSensor.record(nowMs - lastRebalanceStartMs);
+    }
+
+    public void maybeRecordRebalanceFailed() {
+        if (lastRebalanceStartMs < lastRebalanceEndMs)
+            return;
+        failedRebalanceSensor.record();
+    }
+
+    public boolean rebalanceStarted() {
+        return lastRebalanceStartMs > lastRebalanceEndMs;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/RebalanceMetricsManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/RebalanceMetricsManager.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
 
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_METRIC_GROUP_PREFIX;
@@ -50,9 +49,6 @@ public class RebalanceMetricsManager {
     private long lastRebalanceStartMs = -1L;
 
     public RebalanceMetricsManager(Metrics metrics) {
-        StackTraceElement[] st = Thread.currentThread().getStackTrace();
-        System.out.println("first:");
-        System.out.println(Arrays.toString(st));
         metricGroupName = CONSUMER_METRIC_GROUP_PREFIX + COORDINATOR_METRICS_SUFFIX;
 
         rebalanceLatencyAvg = createMetric(metrics, "rebalance-latency-avg",
@@ -91,10 +87,6 @@ public class RebalanceMetricsManager {
             "last-rebalance-seconds-ago",
             "The number of seconds since the last rebalance event");
         metrics.addMetric(lastRebalanceSecondsAgo, lastRebalance);
-
-        st = Thread.currentThread().getStackTrace();
-        System.out.println("starting:");
-        System.out.println(Arrays.toString(st));
     }
 
     private MetricName createMetric(Metrics metrics, String name, String description) {
@@ -107,8 +99,6 @@ public class RebalanceMetricsManager {
 
     public void recordRebalanceEnded(long nowMs) {
         lastRebalanceEndMs = nowMs;
-        System.out.println("nowMS:" + nowMs);
-        System.out.println("startMs:" + lastRebalanceStartMs);
         successfulRebalanceSensor.record(nowMs - lastRebalanceStartMs);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.consumer.internals.events.ApplicationEventProces
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
 import org.apache.kafka.clients.consumer.internals.metrics.RebalanceCallbackMetricsManager;
+import org.apache.kafka.clients.consumer.internals.metrics.RebalanceMetricsManager;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.requests.MetadataResponse;
@@ -195,7 +196,22 @@ public class ConsumerTestBuilder implements Closeable {
                     gi.groupId,
                     gi.groupInstanceId,
                     metrics));
-            MembershipManager mm = mock(MembershipManagerImpl.class);
+            MembershipManager mm = spy(
+                new MembershipManagerImpl(
+                    gi.groupId,
+                    gi.groupInstanceId,
+                    groupRebalanceConfig.rebalanceTimeoutMs,
+                    gi.serverAssignor,
+                    subscriptions,
+                    commit,
+                    metadata,
+                    logContext,
+                    Optional.empty(),
+                    backgroundEventHandler,
+                    time,
+                    mock(RebalanceMetricsManager.class)
+                )
+            );
             HeartbeatRequestManager.HeartbeatState heartbeatState = spy(new HeartbeatRequestManager.HeartbeatState(
                     subscriptions,
                     mm,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerTestBuilder.java
@@ -195,21 +195,7 @@ public class ConsumerTestBuilder implements Closeable {
                     gi.groupId,
                     gi.groupInstanceId,
                     metrics));
-            MembershipManager mm = spy(
-                    new MembershipManagerImpl(
-                        gi.groupId,
-                        gi.groupInstanceId,
-                        groupRebalanceConfig.rebalanceTimeoutMs,
-                        gi.serverAssignor,
-                        subscriptions,
-                        commit,
-                        metadata,
-                        logContext,
-                        Optional.empty(),
-                        backgroundEventHandler,
-                        time
-                )
-            );
+            MembershipManager mm = mock(MembershipManagerImpl.class);
             HeartbeatRequestManager.HeartbeatState heartbeatState = spy(new HeartbeatRequestManager.HeartbeatState(
                     subscriptions,
                     mm,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
@@ -306,7 +306,7 @@ public class HeartbeatRequestManagerTest {
             new ConsumerGroupHeartbeatResponse(new ConsumerGroupHeartbeatResponseData()
             .setMemberId(memberId)
             .setMemberEpoch(memberEpoch));
-        membershipManager.onHeartbeatResponseReceived(result.data());
+        membershipManager.onHeartbeatSuccess(result.data());
 
         // Create a ConsumerHeartbeatRequest and verify the payload
         NetworkClientDelegate.PollResult pollResult = heartbeatRequestManager.poll(time.milliseconds());
@@ -441,7 +441,7 @@ public class HeartbeatRequestManagerTest {
         switch (error) {
             case NONE:
                 verify(backgroundEventHandler).add(any(GroupMetadataUpdateEvent.class));
-                verify(membershipManager, times(2)).onHeartbeatResponseReceived(mockResponse.data());
+                verify(membershipManager, times(2)).onHeartbeatSuccess(mockResponse.data());
                 assertEquals(DEFAULT_HEARTBEAT_INTERVAL_MS, heartbeatRequestState.nextHeartbeatMs(time.milliseconds()));
                 break;
 
@@ -547,7 +547,7 @@ public class HeartbeatRequestManagerTest {
                 .setMemberEpoch(1)
                 .setAssignment(assignmentTopic1));
         when(metadata.topicNames()).thenReturn(Collections.singletonMap(topicId, "topic1"));
-        membershipManager.onHeartbeatResponseReceived(rs1.data());
+        membershipManager.onHeartbeatSuccess(rs1.data());
 
         // We remain in RECONCILING state, as the assignment will be reconciled on the next poll
         assertEquals(MemberState.RECONCILING, membershipManager.state());
@@ -712,7 +712,7 @@ public class HeartbeatRequestManagerTest {
                 .setHeartbeatIntervalMs(DEFAULT_HEARTBEAT_INTERVAL_MS)
                 .setMemberId(memberId)
                 .setMemberEpoch(memberEpoch));
-        membershipManager.onHeartbeatResponseReceived(rs1.data());
+        membershipManager.onHeartbeatSuccess(rs1.data());
         assertEquals(MemberState.STABLE, membershipManager.state());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
@@ -2040,33 +2040,15 @@ public class MembershipManagerImplTest {
         MembershipManagerImpl membershipManager = createMembershipManagerJoiningGroup();
         ConsumerGroupHeartbeatResponse heartbeatResponse = createConsumerGroupHeartbeatResponse(null);
         membershipManager.onHeartbeatResponseReceived(heartbeatResponse.data());
-        ConsumerRebalanceListenerInvoker invoker = mock(ConsumerRebalanceListenerInvoker.class);
 
-        String topicName = "topic1";
         Uuid topicId = Uuid.randomUuid();
 
-        when(subscriptionState.assignedPartitions()).thenReturn(Collections.emptySet());
-        when(subscriptionState.hasAutoAssignedPartitions()).thenReturn(true);
-        when(subscriptionState.rebalanceListener()).thenReturn(Optional.of(mock(ConsumerRebalanceListener.class)));
-        doNothing().when(subscriptionState).markPendingRevocation(anySet());
-        when(metadata.topicNames()).thenReturn(Collections.singletonMap(topicId, topicName));
-
-        when(metadata.topicNames()).thenReturn(Collections.singletonMap(topicId, topicName));
         receiveAssignment(topicId, Arrays.asList(0, 1), membershipManager);
-
-        // assign partitions
-        performCallback(
-            membershipManager,
-            invoker,
-            ConsumerRebalanceListenerMethodName.ON_PARTITIONS_ASSIGNED,
-            topicPartitions(topicName, 0, 1),
-            false
-        );
 
         sleepRandomMs(time, 2000);
 
         assertTrue(rebalanceMetricsManager.rebalanceStarted());
-        membershipManager.transitionToFatal();
+        membershipManager.onHeartbeatError();
 
         assertEquals((double) 0, getMetricValue(metrics, rebalanceMetricsManager.rebalanceLatencyTotal));
         assertEquals(0d, getMetricValue(metrics, rebalanceMetricsManager.rebalanceTotal));


### PR DESCRIPTION
Adding the following rebalance metrics to the consumer:

rebalance-latency-avg
rebalance-latency-max
rebalance-latency-total
rebalance-rate-per-hour
rebalance-total
failed-rebalance-rate-per-hour
failed-rebalance-total

Due to the difference in protocol, we need to redefine when rebalance starts and ends.
**Start of Rebalance:**
Current: Right before sending out JoinGroup
ConsumerGroup: When the client receives assignments from the HB

**End of Rebalance - Successful Case:**
Current: Receiving SyncGroup request after transitioning to "COMPLETING_REBALANCE"
ConsumerGroup: After completing reconciliation and right before sending out "Ack" heartbeat

**End of Rebalance - Failed Case:**
Current: Any failure in the JoinGroup/SyncGroup response
ConsumerGroup: Failure in the heartbeat

Note: Afterall, we try to be consistent with the current protocol.  Rebalances start and end with sending and receiving network requests.  Failures in network requests signify the user failures in rebalance.  And it is entirely possible to have multiple failures before having a successful one.