### PR TITLE
MINOR: EventAccumulator should signal to one thread when key becomes available

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/EventAccumulator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/EventAccumulator.java
@@ -235,7 +235,7 @@ public class EventAccumulator<K, T extends EventAccumulator.Event<K>> implements
      */
     private void addAvailableKey(K key) {
         availableKeys.add(key);
-        condition.signalAll();
+        condition.signal();
     }
 
     /**


### PR DESCRIPTION
`signalAll` was mistakenly used instead of `signal` when a key become available in the `EventAccumulator`. The fix relies on existing tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
