### PR TITLE
MINOR:  ZKAcl Migration Client Test Problem failing in Scala version 2.12

### DIFF
--- a/core/src/test/scala/unit/kafka/zk/migration/ZkAclMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkAclMigrationClientTest.scala
@@ -231,7 +231,7 @@ class ZkAclMigrationClientTest extends ZkMigrationTestHarness {
 
     // Sync image to ZK
     val errorLogs = mutable.Buffer[String]()
-    val kraftMigrationZkWriter = new KRaftMigrationZkWriter(migrationClient, errorLogs.append)
+    val kraftMigrationZkWriter = new KRaftMigrationZkWriter(migrationClient, log => errorLogs.append(log))
     kraftMigrationZkWriter.handleSnapshot(image, (_, _, operation) => {
       migrationState = operation.apply(migrationState)
     })
@@ -276,7 +276,7 @@ class ZkAclMigrationClientTest extends ZkMigrationTestHarness {
   def testAclUpdateAndDelete(): Unit = {
     zkClient.createAclPaths()
     val errorLogs = mutable.Buffer[String]()
-    val kraftMigrationZkWriter = new KRaftMigrationZkWriter(migrationClient, errorLogs.append)
+    val kraftMigrationZkWriter = new KRaftMigrationZkWriter(migrationClient, log => errorLogs.append(log))
 
     val topicName = "topic-" + Uuid.randomUuid()
     val otherName = "other-" + Uuid.randomUuid()


### PR DESCRIPTION
```
[Error] /Users/hy/kafka/core/src/test/scala/unit/kafka/zk/migration/ZkAclMigrationClientTest.scala:234:88: type mismatch;
 found   : Seq[String] => Unit
 required: java.util.function.Consumer[String]
[Error] /Users/hy/kafka/core/src/test/scala/unit/kafka/zk/migration/ZkAclMigrationClientTest.scala:279:88: type mismatch;
 found   : Seq[String] => Unit
 required: java.util.function.Consumer[String]

```
Problem failing in Scala version 2.12

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
