### PR TITLE
KafkaDockerWrapper: correct KAFKA_HEAP_OPTS server property

### DIFF
--- a/core/src/main/scala/kafka/docker/KafkaDockerWrapper.scala
+++ b/core/src/main/scala/kafka/docker/KafkaDockerWrapper.scala
@@ -229,7 +229,7 @@ private object Constants {
   val KafkaToolsLog4jLoglevelEnv = "KAFKA_TOOLS_LOG4J_LOGLEVEL"
   val ExcludeServerPropsEnv: Set[String] = Set(
     "KAFKA_VERSION",
-    "KAFKA_HEAP_OPT",
+    "KAFKA_HEAP_OPTS",
     "KAFKA_LOG4J_OPTS",
     "KAFKA_OPTS",
     "KAFKA_JMX_OPTS",


### PR DESCRIPTION
#### Reproduction

Run Kafka in Docker with the `KAFKA_HEAP_OPTS` environment variable set

```bash
$ docker run -e KAFKA_HEAP_OPTS="-Xmx128m -Xms128m" apache/kafka:3.7.0-rc2
```

#### Expected
Kafka launches with the appropriate Xms and Xmx values.

#### Unexpected
Kafka crashes with the following log message:
```bash
....
===> Using provided cluster id 5L6g3nShT-eMCtK--X86sw ...
Exception in thread "main" org.apache.kafka.common.config.ConfigException: Missing required configuration `zookeeper.connect` which has no default value. at kafka.server.KafkaConfig.validateValues(KafkaConfig.scala:2294) at kafka.server.KafkaConfig.<init>(KafkaConfig.scala:2285) at kafka.server.KafkaConfig.<init>(KafkaConfig.scala:1634) at kafka.tools.StorageTool$.$anonfun$main$1(StorageTool.scala:52) at scala.Option.flatMap(Option.scala:283) at kafka.tools.StorageTool$.main(StorageTool.scala:52) at kafka.docker.KafkaDockerWrapper$.main(KafkaDockerWrapper.scala:47) at kafka.docker.KafkaDockerWrapper.main(KafkaDockerWrapper.scala)
```

### Proposed Change
I suspect (but have not rebuilt to confirm) that this is related to a typo in the `ExcludeServerPropsEnv` field in the `KafkaDockerWrapper`.