### PR TITLE
MINOR: Refactor GroupMetadataManagerTest

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -336,11 +336,11 @@
     <suppress checks="CyclomaticComplexity"
               files="(ConsumerGroupMember|GroupMetadataManager|GeneralUniformAssignmentBuilder).java"/>
     <suppress checks="(NPathComplexity|MethodLength)"
-              files="(GroupMetadataManager|ConsumerGroupTest|GroupMetadataManagerTest|GeneralUniformAssignmentBuilder).java"/>
+              files="(GroupMetadataManager|ConsumerGroupTest|GroupMetadataManagerTest|GroupMetadataManagerTestContext|GeneralUniformAssignmentBuilder).java"/>
     <suppress checks="NPathComplexity"
               files="CoordinatorRuntime.java"/>
     <suppress checks="ClassFanOutComplexity"
-              files="(GroupMetadataManager|GroupMetadataManagerTest|GroupCoordinatorService|GroupCoordinatorServiceTest).java"/>
+              files="(GroupMetadataManager|GroupMetadataManagerTest|GroupMetadataManagerTestContext|GroupCoordinatorService|GroupCoordinatorServiceTest).java"/>
     <suppress checks="ParameterNumber"
               files="(ConsumerGroupMember|GroupMetadataManager|GroupCoordinatorConfig).java"/>
     <suppress checks="ClassDataAbstractionCouplingCheck"

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
@@ -85,9 +85,9 @@ public class Assertions {
         if (assignment == null) return null;
 
         Map<Uuid, Set<Integer>> assignmentMap = new HashMap<>();
-        assignment.forEach(topicPartitions -> {
-            assignmentMap.put(topicPartitions.topicId(), new HashSet<>(topicPartitions.partitions()));
-        });
+        assignment.forEach(topicPartitions ->
+            assignmentMap.put(topicPartitions.topicId(), new HashSet<>(topicPartitions.partitions()))
+        );
         return assignmentMap;
     }
 
@@ -213,9 +213,9 @@ public class Assertions {
         List<ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions> assignment
     ) {
         Map<Uuid, Set<Integer>> assignmentMap = new HashMap<>();
-        assignment.forEach(topicPartitions -> {
-            assignmentMap.put(topicPartitions.topicId(), new HashSet<>(topicPartitions.partitions()));
-        });
+        assignment.forEach(topicPartitions ->
+            assignmentMap.put(topicPartitions.topicId(), new HashSet<>(topicPartitions.partitions()))
+        );
         return assignmentMap;
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
@@ -16,9 +16,20 @@
  */
 package org.apache.kafka.coordinator.group;
 
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.opentest4j.AssertionFailedError;
+
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Assertions {
@@ -27,5 +38,134 @@ public class Assertions {
         List<T> actual
     ) {
         assertEquals(new HashSet<>(expected), new HashSet<>(actual));
+    }
+
+    public static void assertResponseEquals(
+        ConsumerGroupHeartbeatResponseData expected,
+        ConsumerGroupHeartbeatResponseData actual
+    ) {
+        if (!responseEquals(expected, actual)) {
+            assertionFailure()
+                .expected(expected)
+                .actual(actual)
+                .buildAndThrow();
+        }
+    }
+
+    private static boolean responseEquals(
+        ConsumerGroupHeartbeatResponseData expected,
+        ConsumerGroupHeartbeatResponseData actual
+    ) {
+        if (expected.throttleTimeMs() != actual.throttleTimeMs()) return false;
+        if (expected.errorCode() != actual.errorCode()) return false;
+        if (!Objects.equals(expected.errorMessage(), actual.errorMessage())) return false;
+        if (!Objects.equals(expected.memberId(), actual.memberId())) return false;
+        if (expected.memberEpoch() != actual.memberEpoch()) return false;
+        if (expected.heartbeatIntervalMs() != actual.heartbeatIntervalMs()) return false;
+        // Unordered comparison of the assignments.
+        return responseAssignmentEquals(expected.assignment(), actual.assignment());
+    }
+
+    private static boolean responseAssignmentEquals(
+        ConsumerGroupHeartbeatResponseData.Assignment expected,
+        ConsumerGroupHeartbeatResponseData.Assignment actual
+    ) {
+        if (expected == actual) return true;
+        if (expected == null) return false;
+        if (actual == null) return false;
+
+        return Objects.equals(fromAssignment(expected.topicPartitions()), fromAssignment(actual.topicPartitions()));
+    }
+
+    private static Map<Uuid, Set<Integer>> fromAssignment(
+        List<ConsumerGroupHeartbeatResponseData.TopicPartitions> assignment
+    ) {
+        if (assignment == null) return null;
+
+        Map<Uuid, Set<Integer>> assignmentMap = new HashMap<>();
+        assignment.forEach(topicPartitions -> {
+            assignmentMap.put(topicPartitions.topicId(), new HashSet<>(topicPartitions.partitions()));
+        });
+        return assignmentMap;
+    }
+
+    public static void assertRecordsEquals(
+        List<Record> expectedRecords,
+        List<Record> actualRecords
+    ) {
+        try {
+            assertEquals(expectedRecords.size(), actualRecords.size());
+
+            for (int i = 0; i < expectedRecords.size(); i++) {
+                Record expectedRecord = expectedRecords.get(i);
+                Record actualRecord = actualRecords.get(i);
+                assertRecordEquals(expectedRecord, actualRecord);
+            }
+        } catch (AssertionFailedError e) {
+            assertionFailure()
+                .expected(expectedRecords)
+                .actual(actualRecords)
+                .buildAndThrow();
+        }
+    }
+
+    public static void assertRecordEquals(
+        Record expected,
+        Record actual
+    ) {
+        try {
+            assertApiMessageAndVersionEquals(expected.key(), actual.key());
+            assertApiMessageAndVersionEquals(expected.value(), actual.value());
+        } catch (AssertionFailedError e) {
+            assertionFailure()
+                .expected(expected)
+                .actual(actual)
+                .buildAndThrow();
+        }
+    }
+
+    private static void assertApiMessageAndVersionEquals(
+        ApiMessageAndVersion expected,
+        ApiMessageAndVersion actual
+    ) {
+        if (expected == actual) return;
+
+        assertEquals(expected.version(), actual.version());
+
+        if (actual.message() instanceof ConsumerGroupCurrentMemberAssignmentValue) {
+            // The order of the topics stored in ConsumerGroupCurrentMemberAssignmentValue is not
+            // always guaranteed. Therefore, we need a special comparator.
+            ConsumerGroupCurrentMemberAssignmentValue expectedValue =
+                (ConsumerGroupCurrentMemberAssignmentValue) expected.message();
+            ConsumerGroupCurrentMemberAssignmentValue actualValue =
+                (ConsumerGroupCurrentMemberAssignmentValue) actual.message();
+
+            assertEquals(expectedValue.memberEpoch(), actualValue.memberEpoch());
+            assertEquals(expectedValue.previousMemberEpoch(), actualValue.previousMemberEpoch());
+            assertEquals(expectedValue.targetMemberEpoch(), actualValue.targetMemberEpoch());
+            assertEquals(expectedValue.error(), actualValue.error());
+            assertEquals(expectedValue.metadataVersion(), actualValue.metadataVersion());
+            assertEquals(expectedValue.metadataBytes(), actualValue.metadataBytes());
+
+            // We transform those to Maps before comparing them.
+            assertEquals(fromTopicPartitions(expectedValue.assignedPartitions()),
+                fromTopicPartitions(actualValue.assignedPartitions()));
+            assertEquals(fromTopicPartitions(expectedValue.partitionsPendingRevocation()),
+                fromTopicPartitions(actualValue.partitionsPendingRevocation()));
+            assertEquals(fromTopicPartitions(expectedValue.partitionsPendingAssignment()),
+                fromTopicPartitions(actualValue.partitionsPendingAssignment()));
+        } else {
+            assertEquals(expected.message(), actual.message());
+        }
+    }
+
+    private static Map<Uuid, Set<Integer>> fromTopicPartitions(
+        List<ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions> assignment
+    ) {
+        Map<Uuid, Set<Integer>> assignmentMap = new HashMap<>();
+        assignment.forEach(topicPartitions -> {
+            assignmentMap.put(topicPartitions.topicId(), new HashSet<>(topicPartitions.partitions()));
+        });
+        return assignmentMap;
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Assertions {
+    public static <T> void assertUnorderedListEquals(
+        List<T> expected,
+        List<T> actual
+    ) {
+        assertEquals(new HashSet<>(expected), new HashSet<>(actual));
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/ConsumerGroupBuilder.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/ConsumerGroupBuilder.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-class ConsumerGroupBuilder {
+public class ConsumerGroupBuilder {
     private final String groupId;
     private final int groupEpoch;
     private int assignmentEpoch;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/ConsumerGroupBuilder.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/ConsumerGroupBuilder.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.coordinator.group.consumer.Assignment;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
+import org.apache.kafka.coordinator.group.consumer.TopicMetadata;
+import org.apache.kafka.image.TopicImage;
+import org.apache.kafka.image.TopicsImage;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class ConsumerGroupBuilder {
+    private final String groupId;
+    private final int groupEpoch;
+    private int assignmentEpoch;
+    private final Map<String, ConsumerGroupMember> members = new HashMap<>();
+    private final Map<String, Assignment> assignments = new HashMap<>();
+    private Map<String, TopicMetadata> subscriptionMetadata;
+
+    public ConsumerGroupBuilder(String groupId, int groupEpoch) {
+        this.groupId = groupId;
+        this.groupEpoch = groupEpoch;
+        this.assignmentEpoch = 0;
+    }
+
+    public ConsumerGroupBuilder withMember(ConsumerGroupMember member) {
+        this.members.put(member.memberId(), member);
+        return this;
+    }
+
+    public ConsumerGroupBuilder withSubscriptionMetadata(Map<String, TopicMetadata> subscriptionMetadata) {
+        this.subscriptionMetadata = subscriptionMetadata;
+        return this;
+    }
+
+    public ConsumerGroupBuilder withAssignment(String memberId, Map<Uuid, Set<Integer>> assignment) {
+        this.assignments.put(memberId, new Assignment(assignment));
+        return this;
+    }
+
+    public ConsumerGroupBuilder withAssignmentEpoch(int assignmentEpoch) {
+        this.assignmentEpoch = assignmentEpoch;
+        return this;
+    }
+
+    public List<Record> build(TopicsImage topicsImage) {
+        List<Record> records = new ArrayList<>();
+
+        // Add subscription records for members.
+        members.forEach((memberId, member) -> {
+            records.add(RecordHelpers.newMemberSubscriptionRecord(groupId, member));
+        });
+
+        // Add subscription metadata.
+        if (subscriptionMetadata == null) {
+            subscriptionMetadata = new HashMap<>();
+            members.forEach((memberId, member) -> {
+                member.subscribedTopicNames().forEach(topicName -> {
+                    TopicImage topicImage = topicsImage.getTopic(topicName);
+                    if (topicImage != null) {
+                        subscriptionMetadata.put(topicName, new TopicMetadata(
+                            topicImage.id(),
+                            topicImage.name(),
+                            topicImage.partitions().size(),
+                            Collections.emptyMap()
+                        ));
+                    }
+                });
+            });
+        }
+
+        if (!subscriptionMetadata.isEmpty()) {
+            records.add(RecordHelpers.newGroupSubscriptionMetadataRecord(groupId, subscriptionMetadata));
+        }
+
+        // Add group epoch record.
+        records.add(RecordHelpers.newGroupEpochRecord(groupId, groupEpoch));
+
+        // Add target assignment records.
+        assignments.forEach((memberId, assignment) -> {
+            records.add(RecordHelpers.newTargetAssignmentRecord(groupId, memberId, assignment.partitions()));
+        });
+
+        // Add target assignment epoch.
+        records.add(RecordHelpers.newTargetAssignmentEpochRecord(groupId, assignmentEpoch));
+
+        // Add current assignment records for members.
+        members.forEach((memberId, member) -> {
+            records.add(RecordHelpers.newCurrentAssignmentRecord(groupId, member));
+        });
+
+        return records;
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -62,6 +62,7 @@ import org.apache.kafka.coordinator.group.assignor.PartitionAssignor;
 import org.apache.kafka.coordinator.group.assignor.PartitionAssignorException;
 import org.apache.kafka.coordinator.group.consumer.Assignment;
 import org.apache.kafka.coordinator.group.consumer.ConsumerGroup;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroupBuilder;
 import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
 import org.apache.kafka.coordinator.group.consumer.TopicMetadata;
 import org.apache.kafka.coordinator.group.generated.GroupMetadataValue;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -4711,9 +4711,10 @@ public class GroupMetadataManagerTest {
         assertEquals(1, timeouts.size());
         timeouts.forEach(timeout -> {
             assertEquals(classicGroupHeartbeatKey("group-id", memberId), timeout.key);
-            assertEquals(Collections.singletonList(
-                GroupMetadataManagerTestContext.newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
-                timeout.result.records());
+            assertEquals(
+                Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
+                timeout.result.records()
+            );
         });
 
         assertTrue(joinResult.joinFuture.isDone());
@@ -5191,7 +5192,7 @@ public class GroupMetadataManagerTest {
         );
 
         assertEquals(
-            Collections.singletonList(GroupMetadataManagerTestContext.newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
             joinResult.records
         );
         assertFalse(joinResult.joinFuture.isDone());
@@ -5318,7 +5319,7 @@ public class GroupMetadataManagerTest {
         );
 
         assertEquals(
-            Collections.singletonList(GroupMetadataManagerTestContext.newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
             joinResult.records
         );
         assertFalse(joinResult.joinFuture.isDone());
@@ -5394,7 +5395,7 @@ public class GroupMetadataManagerTest {
             supportSkippingAssignment);
 
         assertEquals(
-            Collections.singletonList(GroupMetadataManagerTestContext.newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
             joinResult.records
         );
         assertFalse(joinResult.joinFuture.isDone());
@@ -5962,7 +5963,7 @@ public class GroupMetadataManagerTest {
         );
 
         assertEquals(
-            Collections.singletonList(GroupMetadataManagerTestContext.newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
             joinResult.records
         );
         // Simulate a successful write to the log.
@@ -6275,7 +6276,7 @@ public class GroupMetadataManagerTest {
         );
 
         assertEquals(
-            Collections.singletonList(GroupMetadataManagerTestContext.newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
             followerJoinResult.records
         );
         // Simulate a failed write to the log.
@@ -6332,7 +6333,7 @@ public class GroupMetadataManagerTest {
         leaderSyncResult.appendFuture.complete(null);
 
         assertEquals(
-            Collections.singletonList(GroupMetadataManagerTestContext.newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
             leaderSyncResult.records
         );
 
@@ -6382,7 +6383,7 @@ public class GroupMetadataManagerTest {
         );
 
         assertEquals(
-            Collections.singletonList(GroupMetadataManagerTestContext.newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
             followerJoinResult.records
         );
 
@@ -6594,7 +6595,7 @@ public class GroupMetadataManagerTest {
         );
 
         assertEquals(
-            Collections.singletonList(GroupMetadataManagerTestContext.newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
             followerJoinResult.records
         );
         // Simulate a successful write to log.
@@ -6801,7 +6802,7 @@ public class GroupMetadataManagerTest {
             );
 
             assertEquals(
-                Collections.singletonList(GroupMetadataManagerTestContext.newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+                Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
                 leaderJoinResult.records
             );
             // Simulate a successful write to log.
@@ -8243,7 +8244,7 @@ public class GroupMetadataManagerTest {
         ExpiredTimeout<Void, Record> timeout = timeouts.get(0);
         assertEquals(classicGroupSyncKey("group-id"), timeout.key);
         assertEquals(
-            Collections.singletonList(GroupMetadataManagerTestContext.newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
             timeout.result.records()
         );
 
@@ -8399,7 +8400,7 @@ public class GroupMetadataManagerTest {
 
             if (response.memberId().equals(leaderId)) {
                 assertEquals(
-                    Collections.singletonList(GroupMetadataManagerTestContext.newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+                    Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
                     syncResult.records
                 );
 
@@ -9059,7 +9060,7 @@ public class GroupMetadataManagerTest {
                 ))
         );
         assertEquals(
-            Collections.singletonList(GroupMetadataManagerTestContext.newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
             leaveResult.records()
         );
         // Simulate a successful write to the log.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -60,6 +60,7 @@ import org.apache.kafka.coordinator.group.assignor.GroupAssignment;
 import org.apache.kafka.coordinator.group.assignor.MemberAssignment;
 import org.apache.kafka.coordinator.group.assignor.PartitionAssignor;
 import org.apache.kafka.coordinator.group.assignor.PartitionAssignorException;
+import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
 import org.apache.kafka.coordinator.group.consumer.Assignment;
 import org.apache.kafka.coordinator.group.consumer.ConsumerGroup;
 import org.apache.kafka.coordinator.group.consumer.ConsumerGroupBuilder;
@@ -98,6 +99,10 @@ import static org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequ
 import static org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocolCollection;
 import static org.apache.kafka.common.requests.ConsumerGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH;
 import static org.apache.kafka.common.requests.JoinGroupRequest.UNKNOWN_MEMBER_ID;
+import static org.apache.kafka.coordinator.group.Assertions.assertRecordEquals;
+import static org.apache.kafka.coordinator.group.Assertions.assertRecordsEquals;
+import static org.apache.kafka.coordinator.group.Assertions.assertResponseEquals;
+import static org.apache.kafka.coordinator.group.Assertions.assertUnorderedListEquals;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
 import static org.apache.kafka.coordinator.group.GroupMetadataManager.appendGroupMetadataErrorToResponseError;
@@ -441,7 +446,7 @@ public class GroupMetadataManagerTest {
                 .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                 .setTopicPartitions(Collections.emptyList()));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId)
                 .setMemberEpoch(1)
@@ -487,7 +492,7 @@ public class GroupMetadataManagerTest {
             RecordHelpers.newCurrentAssignmentRecord(groupId, expectedMember)
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecords, result.records());
+        assertRecordsEquals(expectedRecords, result.records());
     }
 
     @Test
@@ -540,7 +545,7 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(10)
                 .setSubscribedTopicNames(Arrays.asList("foo", "bar")));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId)
                 .setMemberEpoch(11)
@@ -587,7 +592,7 @@ public class GroupMetadataManagerTest {
             RecordHelpers.newCurrentAssignmentRecord(groupId, expectedMember)
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecords, result.records());
+        assertRecordsEquals(expectedRecords, result.records());
     }
 
     @Test
@@ -677,7 +682,7 @@ public class GroupMetadataManagerTest {
                 .setServerAssignor("range")
                 .setTopicPartitions(Collections.emptyList()));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId3)
                 .setMemberEpoch(11)
@@ -725,9 +730,9 @@ public class GroupMetadataManagerTest {
             RecordHelpers.newCurrentAssignmentRecord(groupId, expectedMember3)
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecords.subList(0, 3), result.records().subList(0, 3));
-        Assertions.assertUnorderedListEquals(expectedRecords.subList(3, 6), result.records().subList(3, 6));
-        GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecords.subList(6, 8), result.records().subList(6, 8));
+        assertRecordsEquals(expectedRecords.subList(0, 3), result.records().subList(0, 3));
+        assertUnorderedListEquals(expectedRecords.subList(3, 6), result.records().subList(3, 6));
+        assertRecordsEquals(expectedRecords.subList(6, 8), result.records().subList(6, 8));
     }
 
     @Test
@@ -800,7 +805,7 @@ public class GroupMetadataManagerTest {
                 .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                 .setTopicPartitions(Collections.emptyList()));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId2)
                 .setMemberEpoch(LEAVE_GROUP_MEMBER_EPOCH),
@@ -821,7 +826,7 @@ public class GroupMetadataManagerTest {
             RecordHelpers.newGroupEpochRecord(groupId, 11)
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecords, result.records());
+        assertRecordsEquals(expectedRecords, result.records());
     }
 
     @Test
@@ -915,7 +920,7 @@ public class GroupMetadataManagerTest {
                 .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                 .setTopicPartitions(Collections.emptyList()));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId3)
                 .setMemberEpoch(11)
@@ -964,9 +969,9 @@ public class GroupMetadataManagerTest {
             RecordHelpers.newCurrentAssignmentRecord(groupId, expectedMember3)
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecords.subList(0, 3), result.records().subList(0, 3));
-        Assertions.assertUnorderedListEquals(expectedRecords.subList(3, 6), result.records().subList(3, 6));
-        GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecords.subList(6, 8), result.records().subList(6, 8));
+        assertRecordsEquals(expectedRecords.subList(0, 3), result.records().subList(0, 3));
+        assertUnorderedListEquals(expectedRecords.subList(3, 6), result.records().subList(3, 6));
+        assertRecordsEquals(expectedRecords.subList(6, 8), result.records().subList(6, 8));
     }
 
     @Test
@@ -1064,7 +1069,7 @@ public class GroupMetadataManagerTest {
                 .setTopicPartitions(Collections.emptyList()));
 
         // Member epoch of the response would be set to -2.
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId2)
                 .setMemberEpoch(-2),
@@ -1077,7 +1082,7 @@ public class GroupMetadataManagerTest {
             .build();
 
         assertEquals(1, result.records().size());
-        GroupMetadataManagerTestContext.assertRecordEquals(result.records().get(0), RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch));
+        assertRecordEquals(result.records().get(0), RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch));
 
         // Member 2 rejoins the group with the same instance id.
         CoordinatorResult<ConsumerGroupHeartbeatResponseData, Record> rejoinResult = context.consumerGroupHeartbeat(
@@ -1091,7 +1096,7 @@ public class GroupMetadataManagerTest {
                 .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                 .setTopicPartitions(Collections.emptyList()));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(member2RejoinId)
                 .setMemberEpoch(10)
@@ -1135,7 +1140,7 @@ public class GroupMetadataManagerTest {
             RecordHelpers.newCurrentAssignmentRecord(groupId, expectedRejoinedMember)
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecordsAfterRejoin, rejoinResult.records());
+        assertRecordsEquals(expectedRecordsAfterRejoin, rejoinResult.records());
         // Verify that there are no timers.
         context.assertNoSessionTimeout(groupId, memberId2);
         context.assertNoRevocationTimeout(groupId, memberId2);
@@ -1214,7 +1219,7 @@ public class GroupMetadataManagerTest {
                 .setTopicPartitions(Collections.emptyList()));
 
         // member epoch of the response would be set to -2
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId2)
                 .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH),
@@ -1227,7 +1232,7 @@ public class GroupMetadataManagerTest {
             .build();
 
         assertEquals(1, result.records().size());
-        GroupMetadataManagerTestContext.assertRecordEquals(result.records().get(0), RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch));
+        assertRecordEquals(result.records().get(0), RecordHelpers.newCurrentAssignmentRecord(groupId, member2UpdatedEpoch));
     }
 
     @Test
@@ -1303,7 +1308,7 @@ public class GroupMetadataManagerTest {
                 .setSubscribedTopicNames(Arrays.asList("foo", "bar"))
                 .setTopicPartitions(Collections.emptyList()));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId2)
                 .setMemberEpoch(LEAVE_GROUP_MEMBER_EPOCH),
@@ -1324,7 +1329,7 @@ public class GroupMetadataManagerTest {
             RecordHelpers.newGroupEpochRecord(groupId, 11)
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecords, result.records());
+        assertRecordsEquals(expectedRecords, result.records());
     }
 
     @Test
@@ -1749,7 +1754,7 @@ public class GroupMetadataManagerTest {
                 .setServerAssignor("range")
                 .setTopicPartitions(Collections.emptyList()));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId3)
                 .setMemberEpoch(11)
@@ -1760,7 +1765,7 @@ public class GroupMetadataManagerTest {
 
         // We only check the last record as the subscription/target assignment updates are
         // already covered by other tests.
-        GroupMetadataManagerTestContext.assertRecordEquals(
+        assertRecordEquals(
             RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId3)
                 .setMemberEpoch(11)
                 .setPreviousMemberEpoch(0)
@@ -1783,7 +1788,7 @@ public class GroupMetadataManagerTest {
             .setMemberId(memberId1)
             .setMemberEpoch(10));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId1)
                 .setMemberEpoch(10)
@@ -1800,7 +1805,7 @@ public class GroupMetadataManagerTest {
             result.response()
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(Collections.singletonList(
+        assertRecordsEquals(Collections.singletonList(
             RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId1)
                 .setMemberEpoch(10)
                 .setPreviousMemberEpoch(9)
@@ -1826,7 +1831,7 @@ public class GroupMetadataManagerTest {
             .setMemberId(memberId2)
             .setMemberEpoch(10));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId2)
                 .setMemberEpoch(10)
@@ -1843,7 +1848,7 @@ public class GroupMetadataManagerTest {
             result.response()
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(Collections.singletonList(
+        assertRecordsEquals(Collections.singletonList(
             RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId2)
                 .setMemberEpoch(10)
                 .setPreviousMemberEpoch(9)
@@ -1869,7 +1874,7 @@ public class GroupMetadataManagerTest {
             .setMemberId(memberId3)
             .setMemberEpoch(11));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId3)
                 .setMemberEpoch(11)
@@ -1897,7 +1902,7 @@ public class GroupMetadataManagerTest {
                     .setPartitions(Arrays.asList(0))
             )));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId1)
                 .setMemberEpoch(11)
@@ -1914,7 +1919,7 @@ public class GroupMetadataManagerTest {
             result.response()
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(Collections.singletonList(
+        assertRecordsEquals(Collections.singletonList(
             RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId1)
                 .setMemberEpoch(11)
                 .setPreviousMemberEpoch(10)
@@ -1935,7 +1940,7 @@ public class GroupMetadataManagerTest {
             .setMemberId(memberId2)
             .setMemberEpoch(10));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId2)
                 .setMemberEpoch(10)
@@ -1954,7 +1959,7 @@ public class GroupMetadataManagerTest {
             .setMemberId(memberId3)
             .setMemberEpoch(11));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId3)
                 .setMemberEpoch(11)
@@ -1967,7 +1972,7 @@ public class GroupMetadataManagerTest {
             result.response()
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(Collections.singletonList(
+        assertRecordsEquals(Collections.singletonList(
             RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId3)
                 .setMemberEpoch(11)
                 .setPreviousMemberEpoch(11)
@@ -1990,7 +1995,7 @@ public class GroupMetadataManagerTest {
             .setMemberId(memberId3)
             .setMemberEpoch(11));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId3)
                 .setMemberEpoch(11)
@@ -2018,7 +2023,7 @@ public class GroupMetadataManagerTest {
                     .setPartitions(Arrays.asList(2))
             )));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId2)
                 .setMemberEpoch(11)
@@ -2035,7 +2040,7 @@ public class GroupMetadataManagerTest {
             result.response()
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(Collections.singletonList(
+        assertRecordsEquals(Collections.singletonList(
             RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId2)
                 .setMemberEpoch(11)
                 .setPreviousMemberEpoch(10)
@@ -2056,7 +2061,7 @@ public class GroupMetadataManagerTest {
             .setMemberId(memberId3)
             .setMemberEpoch(11));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId3)
                 .setMemberEpoch(11)
@@ -2072,7 +2077,7 @@ public class GroupMetadataManagerTest {
             result.response()
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(Collections.singletonList(
+        assertRecordsEquals(Collections.singletonList(
             RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId3)
                 .setMemberEpoch(11)
                 .setPreviousMemberEpoch(11)
@@ -2152,7 +2157,7 @@ public class GroupMetadataManagerTest {
                 .setServerAssignor("range")
                 .setTopicPartitions(Collections.emptyList()));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId2)
                 .setMemberEpoch(11)
@@ -2161,7 +2166,7 @@ public class GroupMetadataManagerTest {
             result.response()
         );
 
-        GroupMetadataManagerTestContext.assertRecordEquals(
+        assertRecordEquals(
             RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId2)
                 .setMemberEpoch(11)
                 .setPreviousMemberEpoch(0)
@@ -2180,7 +2185,7 @@ public class GroupMetadataManagerTest {
             .setMemberId(memberId1)
             .setMemberEpoch(10));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId1)
                 .setMemberEpoch(10)
@@ -2193,7 +2198,7 @@ public class GroupMetadataManagerTest {
             result.response()
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(Collections.singletonList(
+        assertRecordsEquals(Collections.singletonList(
             RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId1)
                 .setMemberEpoch(10)
                 .setPreviousMemberEpoch(9)
@@ -2236,7 +2241,7 @@ public class GroupMetadataManagerTest {
                 .setServerAssignor("range")
                 .setTopicPartitions(Collections.emptyList()));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId3)
                 .setMemberEpoch(12)
@@ -2245,7 +2250,7 @@ public class GroupMetadataManagerTest {
             result.response()
         );
 
-        GroupMetadataManagerTestContext.assertRecordEquals(
+        assertRecordEquals(
             RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId3)
                 .setMemberEpoch(12)
                 .setPreviousMemberEpoch(0)
@@ -2264,7 +2269,7 @@ public class GroupMetadataManagerTest {
             .setMemberId(memberId1)
             .setMemberEpoch(10));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId1)
                 .setMemberEpoch(10)
@@ -2277,7 +2282,7 @@ public class GroupMetadataManagerTest {
             result.response()
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(Collections.singletonList(
+        assertRecordsEquals(Collections.singletonList(
                 RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId1)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(9)
@@ -2298,7 +2303,7 @@ public class GroupMetadataManagerTest {
             .setMemberId(memberId2)
             .setMemberEpoch(11));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId2)
                 .setMemberEpoch(12)
@@ -2307,7 +2312,7 @@ public class GroupMetadataManagerTest {
             result.response()
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(Collections.singletonList(
+        assertRecordsEquals(Collections.singletonList(
             RecordHelpers.newCurrentAssignmentRecord(groupId, new ConsumerGroupMember.Builder(memberId2)
                 .setMemberEpoch(12)
                 .setPreviousMemberEpoch(11)
@@ -2540,7 +2545,7 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(10));
 
         // The member gets partitions 3, 4 and 5 assigned.
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId)
                 .setMemberEpoch(11)
@@ -2580,7 +2585,7 @@ public class GroupMetadataManagerTest {
             RecordHelpers.newCurrentAssignmentRecord(groupId, expectedMember)
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecords, result.records());
+        assertRecordsEquals(expectedRecords, result.records());
 
         // Check next refresh time.
         assertFalse(consumerGroup.hasMetadataExpired(context.time.milliseconds()));
@@ -2669,7 +2674,7 @@ public class GroupMetadataManagerTest {
 
 
         // The member gets partitions 3, 4 and 5 assigned.
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId)
                 .setMemberEpoch(11)
@@ -2709,7 +2714,7 @@ public class GroupMetadataManagerTest {
             RecordHelpers.newCurrentAssignmentRecord(groupId, expectedMember)
         );
 
-        GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecords, result.records());
+        assertRecordsEquals(expectedRecords, result.records());
 
         // Check next refresh time.
         assertFalse(consumerGroup.hasMetadataExpired(context.time.milliseconds()));
@@ -3182,7 +3187,7 @@ public class GroupMetadataManagerTest {
                     .setSubscribedTopicNames(Collections.singletonList("foo"))
                     .setTopicPartitions(Collections.emptyList()));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId1)
                 .setMemberEpoch(1)
@@ -3224,7 +3229,7 @@ public class GroupMetadataManagerTest {
                 .setSubscribedTopicNames(Collections.singletonList("foo"))
                 .setTopicPartitions(Collections.emptyList()));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId2)
                 .setMemberEpoch(2)
@@ -3248,7 +3253,7 @@ public class GroupMetadataManagerTest {
                 .setRebalanceTimeoutMs(12000)
                 .setSubscribedTopicNames(Collections.singletonList("foo")));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId1)
                 .setMemberEpoch(1)
@@ -3296,7 +3301,7 @@ public class GroupMetadataManagerTest {
                 .setSubscribedTopicNames(Collections.singletonList("foo"))
                 .setTopicPartitions(Collections.emptyList()));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId3)
                 .setMemberEpoch(3)
@@ -3320,7 +3325,7 @@ public class GroupMetadataManagerTest {
                 .setRebalanceTimeoutMs(90000)
                 .setSubscribedTopicNames(Collections.singletonList("foo")));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId1)
                 .setMemberEpoch(1)
@@ -3353,7 +3358,7 @@ public class GroupMetadataManagerTest {
                     .setTopicId(fooTopicId)
                     .setPartitions(Collections.singletonList(0)))));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId1)
                 .setMemberEpoch(3)
@@ -3414,7 +3419,7 @@ public class GroupMetadataManagerTest {
                     .setSubscribedTopicNames(Collections.singletonList("foo"))
                     .setTopicPartitions(Collections.emptyList()));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId1)
                 .setMemberEpoch(1)
@@ -3456,7 +3461,7 @@ public class GroupMetadataManagerTest {
                 .setSubscribedTopicNames(Collections.singletonList("foo"))
                 .setTopicPartitions(Collections.emptyList()));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId2)
                 .setMemberEpoch(2)
@@ -3478,7 +3483,7 @@ public class GroupMetadataManagerTest {
                 .setMemberId(memberId1)
                 .setMemberEpoch(1));
 
-        GroupMetadataManagerTestContext.assertResponseEquals(
+        assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId1)
                 .setMemberEpoch(1)
@@ -3832,7 +3837,7 @@ public class GroupMetadataManagerTest {
             requiredKnownMemberId
         )).collect(Collectors.toList());
 
-        List<String> memberIds = GroupMetadataManagerTestContext.verifyClassicGroupJoinResponses(firstRoundJoinResults, 0, Errors.MEMBER_ID_REQUIRED);
+        List<String> memberIds = verifyClassicGroupJoinResponses(firstRoundJoinResults, 0, Errors.MEMBER_ID_REQUIRED);
         assertEquals(groupMaxSize + 1, memberIds.size());
         assertEquals(0, group.size());
         assertTrue(group.isInState(EMPTY));
@@ -3853,7 +3858,7 @@ public class GroupMetadataManagerTest {
         // the join group phase will complete.
         GroupMetadataManagerTestContext.assertNoOrEmptyResult(context.sleep(50));
 
-        GroupMetadataManagerTestContext.verifyClassicGroupJoinResponses(secondRoundJoinResults, groupMaxSize, Errors.GROUP_MAX_SIZE_REACHED);
+        verifyClassicGroupJoinResponses(secondRoundJoinResults, groupMaxSize, Errors.GROUP_MAX_SIZE_REACHED);
         assertEquals(groupMaxSize, group.size());
         assertEquals(0, group.numPendingJoinMembers());
         assertTrue(group.isInState(COMPLETING_REBALANCE));
@@ -3864,7 +3869,7 @@ public class GroupMetadataManagerTest {
             requiredKnownMemberId
         )).collect(Collectors.toList());
 
-        GroupMetadataManagerTestContext.verifyClassicGroupJoinResponses(thirdRoundJoinResults, groupMaxSize, Errors.GROUP_MAX_SIZE_REACHED);
+        verifyClassicGroupJoinResponses(thirdRoundJoinResults, groupMaxSize, Errors.GROUP_MAX_SIZE_REACHED);
     }
 
     @Test
@@ -3902,7 +3907,7 @@ public class GroupMetadataManagerTest {
         // we will complete the rebalance.
         GroupMetadataManagerTestContext.assertNoOrEmptyResult(context.sleep(50));
 
-        List<String> memberIds = GroupMetadataManagerTestContext.verifyClassicGroupJoinResponses(firstRoundJoinResults, groupMaxSize, Errors.GROUP_MAX_SIZE_REACHED);
+        List<String> memberIds = verifyClassicGroupJoinResponses(firstRoundJoinResults, groupMaxSize, Errors.GROUP_MAX_SIZE_REACHED);
 
         // Members that were accepted can rejoin while others are rejected in CompletingRebalance state.
         List<GroupMetadataManagerTestContext.JoinResult> secondRoundJoinResults = memberIds.stream().map(memberId -> context.sendClassicGroupJoin(
@@ -3910,7 +3915,7 @@ public class GroupMetadataManagerTest {
             requiredKnownMemberId
         )).collect(Collectors.toList());
 
-        GroupMetadataManagerTestContext.verifyClassicGroupJoinResponses(secondRoundJoinResults, 10, Errors.GROUP_MAX_SIZE_REACHED);
+        verifyClassicGroupJoinResponses(secondRoundJoinResults, 10, Errors.GROUP_MAX_SIZE_REACHED);
         assertEquals(groupMaxSize, group.size());
         assertEquals(0, group.numAwaitingJoinResponse());
         assertTrue(group.isInState(COMPLETING_REBALANCE));
@@ -3954,7 +3959,7 @@ public class GroupMetadataManagerTest {
         // we will complete the rebalance.
         GroupMetadataManagerTestContext.assertNoOrEmptyResult(context.sleep(50));
 
-        List<String> memberIds = GroupMetadataManagerTestContext.verifyClassicGroupJoinResponses(firstRoundJoinResults, groupMaxSize, Errors.GROUP_MAX_SIZE_REACHED);
+        List<String> memberIds = verifyClassicGroupJoinResponses(firstRoundJoinResults, groupMaxSize, Errors.GROUP_MAX_SIZE_REACHED);
 
         // Members which were accepted can rejoin, others are rejected, while
         // completing rebalance
@@ -3964,7 +3969,7 @@ public class GroupMetadataManagerTest {
                 .setGroupInstanceId(groupInstanceIds.get(i))
         )).collect(Collectors.toList());
 
-        GroupMetadataManagerTestContext.verifyClassicGroupJoinResponses(secondRoundJoinResults, groupMaxSize, Errors.GROUP_MAX_SIZE_REACHED);
+        verifyClassicGroupJoinResponses(secondRoundJoinResults, groupMaxSize, Errors.GROUP_MAX_SIZE_REACHED);
         assertEquals(groupMaxSize, group.size());
         assertEquals(0, group.numAwaitingJoinResponse());
         assertTrue(group.isInState(COMPLETING_REBALANCE));
@@ -3996,7 +4001,7 @@ public class GroupMetadataManagerTest {
         assertEquals(groupMaxSize + 1, group.numPendingJoinMembers());
         assertTrue(group.isInState(EMPTY));
 
-        List<String> memberIds = GroupMetadataManagerTestContext.verifyClassicGroupJoinResponses(firstRoundJoinResults, 0, Errors.MEMBER_ID_REQUIRED);
+        List<String> memberIds = verifyClassicGroupJoinResponses(firstRoundJoinResults, 0, Errors.MEMBER_ID_REQUIRED);
         assertEquals(groupMaxSize + 1, memberIds.size());
 
         // Second round of join requests with the generated member ids.
@@ -4027,7 +4032,7 @@ public class GroupMetadataManagerTest {
         // we will complete the rebalance.
         GroupMetadataManagerTestContext.assertNoOrEmptyResult(context.sleep(50));
 
-        GroupMetadataManagerTestContext.verifyClassicGroupJoinResponses(thirdRoundJoinResults, groupMaxSize, Errors.GROUP_MAX_SIZE_REACHED);
+        verifyClassicGroupJoinResponses(thirdRoundJoinResults, groupMaxSize, Errors.GROUP_MAX_SIZE_REACHED);
         assertEquals(groupMaxSize, group.size());
         assertEquals(0, group.numAwaitingJoinResponse());
         assertTrue(group.isInState(COMPLETING_REBALANCE));
@@ -4082,7 +4087,7 @@ public class GroupMetadataManagerTest {
         // Advance clock by rebalance timeout to complete join phase.
         GroupMetadataManagerTestContext.assertNoOrEmptyResult(context.sleep(10000));
 
-        GroupMetadataManagerTestContext.verifyClassicGroupJoinResponses(joinResults, groupMaxSize, Errors.GROUP_MAX_SIZE_REACHED);
+        verifyClassicGroupJoinResponses(joinResults, groupMaxSize, Errors.GROUP_MAX_SIZE_REACHED);
 
         assertEquals(groupMaxSize, group.size());
         assertTrue(group.isInState(COMPLETING_REBALANCE));
@@ -5399,7 +5404,7 @@ public class GroupMetadataManagerTest {
         assertTrue(joinResult.joinFuture.isDone());
 
         JoinGroupResponseData expectedResponse = new JoinGroupResponseData()
-            .setMembers(supportSkippingAssignment ? GroupMetadataManagerTestContext.toJoinResponseMembers(group) : Collections.emptyList())
+            .setMembers(supportSkippingAssignment ? toJoinResponseMembers(group) : Collections.emptyList())
             .setLeader(supportSkippingAssignment ? joinResult.joinFuture.get().memberId() : oldMemberId)
             .setMemberId(joinResult.joinFuture.get().memberId())
             .setGenerationId(1)
@@ -5648,7 +5653,7 @@ public class GroupMetadataManagerTest {
             .setMemberId(rebalanceResult.followerId)
             .setGenerationId(-1);
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedResponse,
             oldFollowerJoinResult.joinFuture.get(),
             group,
@@ -5702,9 +5707,9 @@ public class GroupMetadataManagerTest {
             .setLeader(rebalanceResult.leaderId)
             .setProtocolName("range")
             .setProtocolType("consumer")
-            .setMembers(GroupMetadataManagerTestContext.toJoinResponseMembers(group));
+            .setMembers(toJoinResponseMembers(group));
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedLeaderResponse,
             leaderJoinResult.joinFuture.get(),
             group,
@@ -5726,7 +5731,7 @@ public class GroupMetadataManagerTest {
             .setProtocolName("range")
             .setProtocolType("consumer");
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedFollowerResponse,
             oldFollowerJoinResult.joinFuture.get(),
             group,
@@ -5832,9 +5837,9 @@ public class GroupMetadataManagerTest {
             .setLeader(rebalanceResult.leaderId)
             .setProtocolName("range")
             .setProtocolType("consumer")
-            .setMembers(GroupMetadataManagerTestContext.toJoinResponseMembers(group));
+            .setMembers(toJoinResponseMembers(group));
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedLeaderResponse,
             leaderJoinResult.joinFuture.get(),
             group,
@@ -5853,7 +5858,7 @@ public class GroupMetadataManagerTest {
             .setProtocolType("consumer")
             .setMembers(Collections.emptyList());
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedDuplicateFollowerResponse,
             duplicateFollowerJoinResult.joinFuture.get(),
             group,
@@ -5872,7 +5877,7 @@ public class GroupMetadataManagerTest {
             .setProtocolType(null)
             .setMembers(Collections.emptyList());
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedOldFollowerResponse,
             oldFollowerJoinResult.joinFuture.get(),
             group,
@@ -5968,7 +5973,7 @@ public class GroupMetadataManagerTest {
             joinResult.joinFuture.get().memberId() : rebalanceResult.leaderId;
 
         List<JoinGroupResponseMember> members = supportSkippingAssignment ?
-            GroupMetadataManagerTestContext.toJoinResponseMembers(group) : Collections.emptyList();
+            toJoinResponseMembers(group) : Collections.emptyList();
 
         JoinGroupResponseData expectedJoinResponse = new JoinGroupResponseData()
             .setErrorCode(Errors.NONE.code())
@@ -5980,7 +5985,7 @@ public class GroupMetadataManagerTest {
             .setSkipAssignment(supportSkippingAssignment)
             .setMembers(members);
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedJoinResponse,
             joinResult.joinFuture.get(),
             group,
@@ -6054,9 +6059,9 @@ public class GroupMetadataManagerTest {
             .setLeader(rebalanceResult.leaderId)
             .setProtocolName("range")
             .setProtocolType("consumer")
-            .setMembers(GroupMetadataManagerTestContext.toJoinResponseMembers(group));
+            .setMembers(toJoinResponseMembers(group));
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedResponse,
             joinResponse,
             group,
@@ -6168,9 +6173,9 @@ public class GroupMetadataManagerTest {
             .setLeader(rebalanceResult.followerId)
             .setProtocolName("roundrobin")
             .setProtocolType("consumer")
-            .setMembers(GroupMetadataManagerTestContext.toJoinResponseMembers(group));
+            .setMembers(toJoinResponseMembers(group));
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedResponse,
             joinResult.joinFuture.get(),
             group,
@@ -6230,9 +6235,9 @@ public class GroupMetadataManagerTest {
             .setLeader(joinResult.joinFuture.get().memberId())
             .setProtocolName("roundrobin")
             .setProtocolType("consumer")
-            .setMembers(GroupMetadataManagerTestContext.toJoinResponseMembers(group));
+            .setMembers(toJoinResponseMembers(group));
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedResponse,
             joinResult.joinFuture.get(),
             group,
@@ -6287,7 +6292,7 @@ public class GroupMetadataManagerTest {
             .setSkipAssignment(false)
             .setMembers(Collections.emptyList());
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedResponse,
             followerJoinResult.joinFuture.get(),
             group,
@@ -6395,7 +6400,7 @@ public class GroupMetadataManagerTest {
             .setSkipAssignment(false)
             .setMembers(Collections.emptyList());
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedResponse,
             followerJoinResult.joinFuture.get(),
             group,
@@ -6491,9 +6496,9 @@ public class GroupMetadataManagerTest {
             .setProtocolName("range")
             .setProtocolType("consumer")
             .setSkipAssignment(false)
-            .setMembers(GroupMetadataManagerTestContext.toJoinResponseMembers(group));
+            .setMembers(toJoinResponseMembers(group));
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedLeaderResponse,
             leaderJoinResult.joinFuture.get(),
             group,
@@ -6511,7 +6516,7 @@ public class GroupMetadataManagerTest {
             .setSkipAssignment(false)
             .setMembers(Collections.emptyList());
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedFollowerResponse,
             followerJoinResult.joinFuture.get(),
             group,
@@ -6551,9 +6556,9 @@ public class GroupMetadataManagerTest {
             .setProtocolName("range")
             .setProtocolType("consumer")
             .setSkipAssignment(false)
-            .setMembers(GroupMetadataManagerTestContext.toJoinResponseMembers(group));
+            .setMembers(toJoinResponseMembers(group));
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedFollowerResponse,
             followerJoinResult.joinFuture.get(),
             group,
@@ -6610,7 +6615,7 @@ public class GroupMetadataManagerTest {
             .setSkipAssignment(false)
             .setMembers(Collections.emptyList());
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedFollowerResponse,
             followerJoinResult.joinFuture.get(),
             group,
@@ -6677,7 +6682,7 @@ public class GroupMetadataManagerTest {
             .setSkipAssignment(false)
             .setMembers(Collections.emptyList());
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedFollowerResponse,
             followerJoinResult.joinFuture.get(),
             group,
@@ -6933,9 +6938,9 @@ public class GroupMetadataManagerTest {
             .setProtocolName("range")
             .setProtocolType("consumer")
             .setSkipAssignment(false)
-            .setMembers(GroupMetadataManagerTestContext.toJoinResponseMembers(group));
+            .setMembers(toJoinResponseMembers(group));
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedLeaderResponse,
             leaderJoinResult.joinFuture.get(),
             group,
@@ -6953,7 +6958,7 @@ public class GroupMetadataManagerTest {
             .setSkipAssignment(false)
             .setMembers(Collections.emptyList());
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedNewMemberResponse,
             newMemberJoinResult.joinFuture.get(),
             group,
@@ -7029,9 +7034,9 @@ public class GroupMetadataManagerTest {
             .setProtocolName("range")
             .setProtocolType("consumer")
             .setSkipAssignment(false)
-            .setMembers(GroupMetadataManagerTestContext.toJoinResponseMembers(group));
+            .setMembers(toJoinResponseMembers(group));
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedLeaderResponse,
             newLeaderResponse,
             group,
@@ -7049,7 +7054,7 @@ public class GroupMetadataManagerTest {
             .setSkipAssignment(false)
             .setMembers(Collections.emptyList());
 
-        GroupMetadataManagerTestContext.checkJoinGroupResponse(
+        checkJoinGroupResponse(
             expectedNewMemberResponse,
             newFollowerResponse,
             group,
@@ -9604,5 +9609,66 @@ public class GroupMetadataManagerTest {
 
         verify(context.metrics, times(1)).onConsumerGroupStateTransition(null, ConsumerGroup.ConsumerGroupState.EMPTY);
         verify(context.metrics, times(1)).onConsumerGroupStateTransition(ConsumerGroup.ConsumerGroupState.EMPTY, null);
+    }
+
+    private static void checkJoinGroupResponse(
+        JoinGroupResponseData expectedResponse,
+        JoinGroupResponseData actualResponse,
+        ClassicGroup group,
+        ClassicGroupState expectedState,
+        Set<String> expectedGroupInstanceIds
+    ) {
+        assertEquals(expectedResponse, actualResponse);
+        assertTrue(group.isInState(expectedState));
+
+        Set<String> groupInstanceIds = actualResponse.members()
+                                                     .stream()
+                                                     .map(JoinGroupResponseMember::groupInstanceId)
+                                                     .collect(Collectors.toSet());
+
+        assertEquals(expectedGroupInstanceIds, groupInstanceIds);
+    }
+
+    private static List<JoinGroupResponseMember> toJoinResponseMembers(ClassicGroup group) {
+        List<JoinGroupResponseMember> members = new ArrayList<>();
+        String protocolName = group.protocolName().get();
+        group.allMembers().forEach(member -> {
+            members.add(
+                new JoinGroupResponseMember()
+                    .setMemberId(member.memberId())
+                    .setGroupInstanceId(member.groupInstanceId().orElse(""))
+                    .setMetadata(member.metadata(protocolName))
+            );
+        });
+
+        return members;
+    }
+
+    private static List<String> verifyClassicGroupJoinResponses(
+        List<GroupMetadataManagerTestContext.JoinResult> joinResults,
+        int expectedSuccessCount,
+        Errors expectedFailure
+    ) {
+        int successCount = 0;
+        List<String> memberIds = new ArrayList<>();
+        for (GroupMetadataManagerTestContext.JoinResult joinResult : joinResults) {
+            if (!joinResult.joinFuture.isDone()) {
+                fail("All responseFutures should be completed.");
+            }
+            try {
+                JoinGroupResponseData joinResponse = joinResult.joinFuture.get();
+                if (joinResponse.errorCode() == Errors.NONE.code()) {
+                    successCount++;
+                } else {
+                    assertEquals(expectedFailure.code(), joinResponse.errorCode());
+                }
+                memberIds.add(joinResponse.memberId());
+            } catch (Exception e) {
+                fail("Unexpected exception: " + e.getMessage());
+            }
+        }
+
+        assertEquals(expectedSuccessCount, successCount);
+        return memberIds;
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -1800,7 +1800,7 @@ public class GroupMetadataManagerTest {
                             .setPartitions(Arrays.asList(0, 1)),
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(barTopicId)
-                            .setPartitions(Arrays.asList(0))
+                            .setPartitions(Collections.singletonList(0))
                     ))),
             result.response()
         );
@@ -1840,10 +1840,10 @@ public class GroupMetadataManagerTest {
                     .setTopicPartitions(Arrays.asList(
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(fooTopicId)
-                            .setPartitions(Arrays.asList(3)),
+                            .setPartitions(Collections.singletonList(3)),
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(barTopicId)
-                            .setPartitions(Arrays.asList(2))
+                            .setPartitions(Collections.singletonList(2))
                     ))),
             result.response()
         );
@@ -1899,7 +1899,7 @@ public class GroupMetadataManagerTest {
                     .setPartitions(Arrays.asList(0, 1)),
                 new ConsumerGroupHeartbeatRequestData.TopicPartitions()
                     .setTopicId(barTopicId)
-                    .setPartitions(Arrays.asList(0))
+                    .setPartitions(Collections.singletonList(0))
             )));
 
         assertResponseEquals(
@@ -1914,7 +1914,7 @@ public class GroupMetadataManagerTest {
                             .setPartitions(Arrays.asList(0, 1)),
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(barTopicId)
-                            .setPartitions(Arrays.asList(0))
+                            .setPartitions(Collections.singletonList(0))
                     ))),
             result.response()
         );
@@ -1965,10 +1965,10 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(11)
                 .setHeartbeatIntervalMs(5000)
                 .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
-                    .setTopicPartitions(Arrays.asList(
+                    .setTopicPartitions(Collections.singletonList(
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(barTopicId)
-                            .setPartitions(Arrays.asList(1))))),
+                            .setPartitions(Collections.singletonList(1))))),
             result.response()
         );
 
@@ -2017,10 +2017,10 @@ public class GroupMetadataManagerTest {
             .setTopicPartitions(Arrays.asList(
                 new ConsumerGroupHeartbeatRequestData.TopicPartitions()
                     .setTopicId(fooTopicId)
-                    .setPartitions(Arrays.asList(3)),
+                    .setPartitions(Collections.singletonList(3)),
                 new ConsumerGroupHeartbeatRequestData.TopicPartitions()
                     .setTopicId(barTopicId)
-                    .setPartitions(Arrays.asList(2))
+                    .setPartitions(Collections.singletonList(2))
             )));
 
         assertResponseEquals(
@@ -2035,7 +2035,7 @@ public class GroupMetadataManagerTest {
                             .setPartitions(Arrays.asList(2, 3)),
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(barTopicId)
-                            .setPartitions(Arrays.asList(2))
+                            .setPartitions(Collections.singletonList(2))
                     ))),
             result.response()
         );
@@ -2073,7 +2073,7 @@ public class GroupMetadataManagerTest {
                             .setPartitions(Arrays.asList(4, 5)),
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(barTopicId)
-                            .setPartitions(Arrays.asList(1))))),
+                            .setPartitions(Collections.singletonList(1))))),
             result.response()
         );
 
@@ -2191,7 +2191,7 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(10)
                 .setHeartbeatIntervalMs(5000)
                 .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
-                    .setTopicPartitions(Arrays.asList(
+                    .setTopicPartitions(Collections.singletonList(
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(fooTopicId)
                             .setPartitions(Arrays.asList(0, 1))))),
@@ -2275,10 +2275,10 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(10)
                 .setHeartbeatIntervalMs(5000)
                 .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
-                    .setTopicPartitions(Arrays.asList(
+                    .setTopicPartitions(Collections.singletonList(
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(fooTopicId)
-                            .setPartitions(Arrays.asList(0))))),
+                            .setPartitions(Collections.singletonList(0))))),
             result.response()
         );
 
@@ -2551,7 +2551,7 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(11)
                 .setHeartbeatIntervalMs(5000)
                 .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
-                    .setTopicPartitions(Arrays.asList(
+                    .setTopicPartitions(Collections.singletonList(
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(fooTopicId)
                             .setPartitions(Arrays.asList(0, 1, 2, 3, 4, 5))
@@ -2680,7 +2680,7 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(11)
                 .setHeartbeatIntervalMs(5000)
                 .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
-                    .setTopicPartitions(Arrays.asList(
+                    .setTopicPartitions(Collections.singletonList(
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(fooTopicId)
                             .setPartitions(Arrays.asList(0, 1, 2, 3, 4, 5))
@@ -2797,7 +2797,7 @@ public class GroupMetadataManagerTest {
         // M2 in group 2 subscribes to foo.
         context.replay(RecordHelpers.newMemberSubscriptionRecord(groupId2,
             new ConsumerGroupMember.Builder("group2-m2")
-                .setSubscribedTopicNames(Arrays.asList("foo"))
+                .setSubscribedTopicNames(Collections.singletonList("foo"))
                 .build()));
 
         assertEquals(mkSet(groupId2), context.groupMetadataManager.groupsSubscribedToTopic("foo"));
@@ -2859,19 +2859,19 @@ public class GroupMetadataManagerTest {
         // M1 in group 3 subscribes to d.
         context.replay(RecordHelpers.newMemberSubscriptionRecord("group3",
             new ConsumerGroupMember.Builder("group3-m1")
-                .setSubscribedTopicNames(Arrays.asList("d"))
+                .setSubscribedTopicNames(Collections.singletonList("d"))
                 .build()));
 
         // M1 in group 4 subscribes to e.
         context.replay(RecordHelpers.newMemberSubscriptionRecord("group4",
             new ConsumerGroupMember.Builder("group4-m1")
-                .setSubscribedTopicNames(Arrays.asList("e"))
+                .setSubscribedTopicNames(Collections.singletonList("e"))
                 .build()));
 
         // M1 in group 5 subscribes to f.
         context.replay(RecordHelpers.newMemberSubscriptionRecord("group5",
             new ConsumerGroupMember.Builder("group5-m1")
-                .setSubscribedTopicNames(Arrays.asList("f"))
+                .setSubscribedTopicNames(Collections.singletonList("f"))
                 .build()));
 
         // Ensures that all refresh flags are set to the future.
@@ -2917,7 +2917,7 @@ public class GroupMetadataManagerTest {
             assertTrue(group.hasMetadataExpired(context.time.milliseconds()));
         });
 
-        Arrays.asList("group5").forEach(groupId -> {
+        Collections.singletonList("group5").forEach(groupId -> {
             ConsumerGroup group = context.groupMetadataManager.getOrMaybeCreateConsumerGroup(groupId, false);
             assertFalse(group.hasMetadataExpired(context.time.milliseconds()));
         });
@@ -3193,7 +3193,7 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(1)
                 .setHeartbeatIntervalMs(5000)
                 .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
-                    .setTopicPartitions(Arrays.asList(
+                    .setTopicPartitions(Collections.singletonList(
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(fooTopicId)
                             .setPartitions(Arrays.asList(0, 1, 2))))),
@@ -3259,7 +3259,7 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(1)
                 .setHeartbeatIntervalMs(5000)
                 .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
-                    .setTopicPartitions(Arrays.asList(
+                    .setTopicPartitions(Collections.singletonList(
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(fooTopicId)
                             .setPartitions(Arrays.asList(0, 1))))),
@@ -3331,10 +3331,10 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(1)
                 .setHeartbeatIntervalMs(5000)
                 .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
-                    .setTopicPartitions(Arrays.asList(
+                    .setTopicPartitions(Collections.singletonList(
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(fooTopicId)
-                            .setPartitions(Arrays.asList(0))))),
+                            .setPartitions(Collections.singletonList(0))))),
             result.response()
         );
 
@@ -3364,10 +3364,10 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(3)
                 .setHeartbeatIntervalMs(5000)
                 .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
-                    .setTopicPartitions(Arrays.asList(
+                    .setTopicPartitions(Collections.singletonList(
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(fooTopicId)
-                            .setPartitions(Arrays.asList(0))))),
+                            .setPartitions(Collections.singletonList(0))))),
             result.response()
         );
 
@@ -3425,7 +3425,7 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(1)
                 .setHeartbeatIntervalMs(5000)
                 .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
-                    .setTopicPartitions(Arrays.asList(
+                    .setTopicPartitions(Collections.singletonList(
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(fooTopicId)
                             .setPartitions(Arrays.asList(0, 1, 2))))),
@@ -3489,7 +3489,7 @@ public class GroupMetadataManagerTest {
                 .setMemberEpoch(1)
                 .setHeartbeatIntervalMs(5000)
                 .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
-                    .setTopicPartitions(Arrays.asList(
+                    .setTopicPartitions(Collections.singletonList(
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
                             .setTopicId(fooTopicId)
                             .setPartitions(Arrays.asList(0, 1))))),
@@ -3540,7 +3540,7 @@ public class GroupMetadataManagerTest {
                     .setTargetMemberEpoch(10)
                     .setClientId("client")
                     .setClientHost("localhost/127.0.0.1")
-                    .setSubscribedTopicNames(Arrays.asList("foo"))
+                    .setSubscribedTopicNames(Collections.singletonList("foo"))
                     .setServerAssignorName("range")
                     .setAssignedPartitions(mkAssignment(
                         mkTopicAssignment(fooTopicId, 0, 1, 2)))
@@ -3553,7 +3553,7 @@ public class GroupMetadataManagerTest {
                     .setTargetMemberEpoch(10)
                     .setClientId("client")
                     .setClientHost("localhost/127.0.0.1")
-                    .setSubscribedTopicNames(Arrays.asList("foo"))
+                    .setSubscribedTopicNames(Collections.singletonList("foo"))
                     .setServerAssignorName("range")
                     .setPartitionsPendingAssignment(mkAssignment(
                         mkTopicAssignment(fooTopicId, 3, 4, 5)))
@@ -3712,8 +3712,8 @@ public class GroupMetadataManagerTest {
             Collections.singletonList("foo"))).array();
         List<GroupMetadataValue.MemberMetadata> members = new ArrayList<>();
 
-        IntStream.range(0, 2).forEach(i -> {
-            members.add(new GroupMetadataValue.MemberMetadata()
+        IntStream.range(0, 2).forEach(i -> members.add(
+            new GroupMetadataValue.MemberMetadata()
                 .setMemberId("member-" + i)
                 .setGroupInstanceId("group-instance-id-" + i)
                 .setSubscription(subscription)
@@ -3722,8 +3722,7 @@ public class GroupMetadataManagerTest {
                 .setClientHost("host-" + i)
                 .setSessionTimeout(4000)
                 .setRebalanceTimeout(9000)
-            );
-        });
+        ));
 
         Record groupMetadataRecord = GroupMetadataManagerTestContext.newGroupMetadataRecord("group-id",
             new GroupMetadataValue()
@@ -3752,8 +3751,8 @@ public class GroupMetadataManagerTest {
             Collections.singletonList("foo"))).array();
         List<GroupMetadataValue.MemberMetadata> members = new ArrayList<>();
 
-        IntStream.range(0, 2).forEach(i -> {
-            members.add(new GroupMetadataValue.MemberMetadata()
+        IntStream.range(0, 2).forEach(i -> members.add(
+            new GroupMetadataValue.MemberMetadata()
                 .setMemberId("member-" + i)
                 .setGroupInstanceId("group-instance-id-" + i)
                 .setSubscription(subscription)
@@ -3762,8 +3761,8 @@ public class GroupMetadataManagerTest {
                 .setClientHost("host-" + i)
                 .setSessionTimeout(4000)
                 .setRebalanceTimeout(9000)
-            );
-        });
+            )
+        );
 
         Record groupMetadataRecord = GroupMetadataManagerTestContext.newGroupMetadataRecord("group-id",
             new GroupMetadataValue()
@@ -4054,20 +4053,18 @@ public class GroupMetadataManagerTest {
             .mapToObj(i -> group.generateMemberId("client-id", Optional.empty()))
             .collect(Collectors.toList());
 
-        memberIds.forEach(memberId -> {
-            group.add(
-                new ClassicGroupMember(
-                    memberId,
-                    Optional.empty(),
-                    "client-id",
-                    "client-host",
-                    10000,
-                    5000,
-                    "consumer",
-                    GroupMetadataManagerTestContext.toProtocols("range")
-                )
-            );
-        });
+        memberIds.forEach(memberId -> group.add(
+            new ClassicGroupMember(
+                memberId,
+                Optional.empty(),
+                "client-id",
+                "client-host",
+                10000,
+                5000,
+                "consumer",
+                GroupMetadataManagerTestContext.toProtocols("range")
+            )
+        ));
 
         context.groupMetadataManager.prepareRebalance(group, "test");
 
@@ -7859,14 +7856,12 @@ public class GroupMetadataManagerTest {
             .build();
         JoinGroupResponseData leaderJoinResponse = context.joinClassicGroupAsDynamicMemberAndCompleteRebalance("group-id");
 
-        assertThrows(IllegalGenerationException.class, () -> {
-            context.sendClassicGroupHeartbeat(
-                new HeartbeatRequestData()
-                    .setGroupId("group-id")
-                    .setMemberId(leaderJoinResponse.memberId())
-                    .setGenerationId(leaderJoinResponse.generationId() + 1)
-            );
-        });
+        assertThrows(IllegalGenerationException.class, () -> context.sendClassicGroupHeartbeat(
+            new HeartbeatRequestData()
+                .setGroupId("group-id")
+                .setMemberId(leaderJoinResponse.memberId())
+                .setGenerationId(leaderJoinResponse.generationId() + 1)
+        ));
     }
 
     @Test
@@ -8644,7 +8639,7 @@ public class GroupMetadataManagerTest {
             new ConsumerGroupDescribeResponseData.DescribedGroup()
                 .setGroupEpoch(epoch)
                 .setGroupId(consumerGroupIds.get(1))
-                .setMembers(Arrays.asList(
+                .setMembers(Collections.singletonList(
                     memberBuilder.build().asConsumerGroupDescribeMember(
                         new Assignment(Collections.emptyMap()),
                         new MetadataImageBuilder().build().topics()
@@ -9395,7 +9390,7 @@ public class GroupMetadataManagerTest {
     public void testClassicGroupDelete() {
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .build();
-        ClassicGroup group = context.createClassicGroup("group-id");
+        context.createClassicGroup("group-id");
 
         List<Record> expectedRecords = Collections.singletonList(RecordHelpers.newGroupMetadataTombstoneRecord("group-id"));
         List<Record> records = new ArrayList<>();
@@ -9428,7 +9423,7 @@ public class GroupMetadataManagerTest {
     public void testConsumerGroupDelete() {
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .build();
-        ConsumerGroup group = context.groupMetadataManager.getOrMaybeCreateConsumerGroup("group-id", true);
+        context.groupMetadataManager.getOrMaybeCreateConsumerGroup("group-id", true);
 
         List<Record> expectedRecords = Arrays.asList(
             RecordHelpers.newTargetAssignmentEpochTombstoneRecord("group-id"),
@@ -9554,12 +9549,12 @@ public class GroupMetadataManagerTest {
 
         // Even if there are more group metadata records loaded than tombstone records, the last replayed record
         // (tombstone in this test) is the latest state of the group. Hence, the overall metric count should be 0.
-        IntStream.range(0, 5).forEach(__ -> {
-            context.replay(RecordHelpers.newGroupMetadataRecord(group, Collections.emptyMap(), MetadataVersion.LATEST_PRODUCTION));
-        });
-        IntStream.range(0, 4).forEach(__ -> {
-            context.replay(RecordHelpers.newGroupMetadataTombstoneRecord("group-id"));
-        });
+        IntStream.range(0, 5).forEach(__ ->
+            context.replay(RecordHelpers.newGroupMetadataRecord(group, Collections.emptyMap(), MetadataVersion.LATEST_PRODUCTION))
+        );
+        IntStream.range(0, 4).forEach(__ ->
+            context.replay(RecordHelpers.newGroupMetadataTombstoneRecord("group-id"))
+        );
 
         verify(context.metrics, times(1)).onClassicGroupStateTransition(null, EMPTY);
         verify(context.metrics, times(1)).onClassicGroupStateTransition(EMPTY, null);
@@ -9598,9 +9593,9 @@ public class GroupMetadataManagerTest {
 
         // Even if there are more group epoch records loaded than tombstone records, the last replayed record
         // (tombstone in this test) is the latest state of the group. Hence, the overall metric count should be 0.
-        IntStream.range(0, 5).forEach(__ -> {
-            context.replay(RecordHelpers.newGroupEpochRecord("group-id", 0));
-        });
+        IntStream.range(0, 5).forEach(__ ->
+            context.replay(RecordHelpers.newGroupEpochRecord("group-id", 0))
+        );
         context.replay(RecordHelpers.newTargetAssignmentEpochTombstoneRecord("group-id"));
         context.replay(RecordHelpers.newGroupEpochTombstoneRecord("group-id"));
         IntStream.range(0, 3).forEach(__ -> {
@@ -9633,14 +9628,12 @@ public class GroupMetadataManagerTest {
     private static List<JoinGroupResponseMember> toJoinResponseMembers(ClassicGroup group) {
         List<JoinGroupResponseMember> members = new ArrayList<>();
         String protocolName = group.protocolName().get();
-        group.allMembers().forEach(member -> {
-            members.add(
-                new JoinGroupResponseMember()
-                    .setMemberId(member.memberId())
-                    .setGroupInstanceId(member.groupInstanceId().orElse(""))
-                    .setMetadata(member.metadata(protocolName))
-            );
-        });
+        group.allMembers().forEach(member -> members.add(
+            new JoinGroupResponseMember()
+                .setMemberId(member.memberId())
+                .setGroupInstanceId(member.groupInstanceId().orElse(""))
+                .setMetadata(member.metadata(protocolName))
+        ));
 
         return members;
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -726,7 +726,7 @@ public class GroupMetadataManagerTest {
         );
 
         GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecords.subList(0, 3), result.records().subList(0, 3));
-        GroupMetadataManagerTestContext.assertUnorderedListEquals(expectedRecords.subList(3, 6), result.records().subList(3, 6));
+        Assertions.assertUnorderedListEquals(expectedRecords.subList(3, 6), result.records().subList(3, 6));
         GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecords.subList(6, 8), result.records().subList(6, 8));
     }
 
@@ -965,7 +965,7 @@ public class GroupMetadataManagerTest {
         );
 
         GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecords.subList(0, 3), result.records().subList(0, 3));
-        GroupMetadataManagerTestContext.assertUnorderedListEquals(expectedRecords.subList(3, 6), result.records().subList(3, 6));
+        Assertions.assertUnorderedListEquals(expectedRecords.subList(3, 6), result.records().subList(3, 6));
         GroupMetadataManagerTestContext.assertRecordsEquals(expectedRecords.subList(6, 8), result.records().subList(6, 8));
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -139,13 +139,6 @@ public class GroupMetadataManagerTestContext {
         );
     }
 
-    public static Record newGroupMetadataRecordWithCurrentState(
-        ClassicGroup group,
-        MetadataVersion metadataVersion
-    ) {
-        return RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), metadataVersion);
-    }
-
     public static class RebalanceResult {
         int generationId;
         String leaderId;
@@ -671,7 +664,7 @@ public class GroupMetadataManagerTestContext {
             .build());
 
         assertEquals(
-            Collections.singletonList(newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
             syncResult.records
         );
         // Simulate a successful write to the log.
@@ -935,7 +928,7 @@ public class GroupMetadataManagerTestContext {
 
         // Now the group is stable, with the one member that joined above
         assertEquals(
-            Collections.singletonList(newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
             syncResult.records
         );
         // Simulate a successful write to log.
@@ -973,7 +966,7 @@ public class GroupMetadataManagerTestContext {
         syncResult = sendClassicGroupSync(syncRequest.setGenerationId(nextGenerationId));
 
         assertEquals(
-            Collections.singletonList(newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            Collections.singletonList(RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), MetadataVersion.latestTesting())),
             syncResult.records
         );
         // Simulate a successful write to log.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -109,12 +109,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 public class GroupMetadataManagerTestContext {
-    public static <T> void assertUnorderedListEquals(
-        List<T> expected,
-        List<T> actual
-    ) {
-        assertEquals(new HashSet<>(expected), new HashSet<>(actual));
-    }
 
     public static void assertResponseEquals(
         ConsumerGroupHeartbeatResponseData expected,
@@ -128,7 +122,7 @@ public class GroupMetadataManagerTestContext {
         }
     }
 
-    public static boolean responseEquals(
+    private static boolean responseEquals(
         ConsumerGroupHeartbeatResponseData expected,
         ConsumerGroupHeartbeatResponseData actual
     ) {
@@ -142,7 +136,7 @@ public class GroupMetadataManagerTestContext {
         return responseAssignmentEquals(expected.assignment(), actual.assignment());
     }
 
-    public static boolean responseAssignmentEquals(
+    private static boolean responseAssignmentEquals(
         ConsumerGroupHeartbeatResponseData.Assignment expected,
         ConsumerGroupHeartbeatResponseData.Assignment actual
     ) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -1,0 +1,1490 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
+import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.UnknownMemberIdException;
+import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
+import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
+import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
+import org.apache.kafka.common.message.DescribeGroupsResponseData;
+import org.apache.kafka.common.message.HeartbeatRequestData;
+import org.apache.kafka.common.message.HeartbeatResponseData;
+import org.apache.kafka.common.message.JoinGroupRequestData;
+import org.apache.kafka.common.message.JoinGroupResponseData;
+import org.apache.kafka.common.message.LeaveGroupRequestData;
+import org.apache.kafka.common.message.LeaveGroupResponseData;
+import org.apache.kafka.common.message.ListGroupsResponseData;
+import org.apache.kafka.common.message.SyncGroupRequestData;
+import org.apache.kafka.common.message.SyncGroupResponseData;
+import org.apache.kafka.common.network.ClientInformation;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.coordinator.group.assignor.PartitionAssignor;
+import org.apache.kafka.coordinator.group.classic.ClassicGroup;
+import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroup;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataKey;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMetadataValue;
+import org.apache.kafka.coordinator.group.generated.GroupMetadataKey;
+import org.apache.kafka.coordinator.group.generated.GroupMetadataValue;
+import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
+import org.apache.kafka.coordinator.group.runtime.CoordinatorResult;
+import org.apache.kafka.image.MetadataImage;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.MetadataVersion;
+import org.apache.kafka.timeline.SnapshotRegistry;
+import org.opentest4j.AssertionFailedError;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.kafka.common.requests.JoinGroupRequest.UNKNOWN_MEMBER_ID;
+import static org.apache.kafka.coordinator.group.GroupMetadataManager.EMPTY_RESULT;
+import static org.apache.kafka.coordinator.group.GroupMetadataManager.classicGroupHeartbeatKey;
+import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupRevocationTimeoutKey;
+import static org.apache.kafka.coordinator.group.GroupMetadataManager.consumerGroupSessionTimeoutKey;
+import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.COMPLETING_REBALANCE;
+import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.DEAD;
+import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.EMPTY;
+import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.PREPARING_REBALANCE;
+import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.STABLE;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+
+class GroupMetadataManagerTestContext {
+    public static <T> void assertUnorderedListEquals(
+        List<T> expected,
+        List<T> actual
+    ) {
+        assertEquals(new HashSet<>(expected), new HashSet<>(actual));
+    }
+
+    public static void assertResponseEquals(
+        ConsumerGroupHeartbeatResponseData expected,
+        ConsumerGroupHeartbeatResponseData actual
+    ) {
+        if (!responseEquals(expected, actual)) {
+            assertionFailure()
+                .expected(expected)
+                .actual(actual)
+                .buildAndThrow();
+        }
+    }
+
+    public static boolean responseEquals(
+        ConsumerGroupHeartbeatResponseData expected,
+        ConsumerGroupHeartbeatResponseData actual
+    ) {
+        if (expected.throttleTimeMs() != actual.throttleTimeMs()) return false;
+        if (expected.errorCode() != actual.errorCode()) return false;
+        if (!Objects.equals(expected.errorMessage(), actual.errorMessage())) return false;
+        if (!Objects.equals(expected.memberId(), actual.memberId())) return false;
+        if (expected.memberEpoch() != actual.memberEpoch()) return false;
+        if (expected.heartbeatIntervalMs() != actual.heartbeatIntervalMs()) return false;
+        // Unordered comparison of the assignments.
+        return responseAssignmentEquals(expected.assignment(), actual.assignment());
+    }
+
+    public static boolean responseAssignmentEquals(
+        ConsumerGroupHeartbeatResponseData.Assignment expected,
+        ConsumerGroupHeartbeatResponseData.Assignment actual
+    ) {
+        if (expected == actual) return true;
+        if (expected == null) return false;
+        if (actual == null) return false;
+
+        return Objects.equals(fromAssignment(expected.topicPartitions()), fromAssignment(actual.topicPartitions()));
+    }
+
+    public static Map<Uuid, Set<Integer>> fromAssignment(
+        List<ConsumerGroupHeartbeatResponseData.TopicPartitions> assignment
+    ) {
+        if (assignment == null) return null;
+
+        Map<Uuid, Set<Integer>> assignmentMap = new HashMap<>();
+        assignment.forEach(topicPartitions -> {
+            assignmentMap.put(topicPartitions.topicId(), new HashSet<>(topicPartitions.partitions()));
+        });
+        return assignmentMap;
+    }
+
+    public static void assertRecordsEquals(
+        List<Record> expectedRecords,
+        List<Record> actualRecords
+    ) {
+        try {
+            assertEquals(expectedRecords.size(), actualRecords.size());
+
+            for (int i = 0; i < expectedRecords.size(); i++) {
+                Record expectedRecord = expectedRecords.get(i);
+                Record actualRecord = actualRecords.get(i);
+                assertRecordEquals(expectedRecord, actualRecord);
+            }
+        } catch (AssertionFailedError e) {
+            assertionFailure()
+                .expected(expectedRecords)
+                .actual(actualRecords)
+                .buildAndThrow();
+        }
+    }
+
+    public static void assertRecordEquals(
+        Record expected,
+        Record actual
+    ) {
+        try {
+            assertApiMessageAndVersionEquals(expected.key(), actual.key());
+            assertApiMessageAndVersionEquals(expected.value(), actual.value());
+        } catch (AssertionFailedError e) {
+            assertionFailure()
+                .expected(expected)
+                .actual(actual)
+                .buildAndThrow();
+        }
+    }
+
+    public static void assertApiMessageAndVersionEquals(
+        ApiMessageAndVersion expected,
+        ApiMessageAndVersion actual
+    ) {
+        if (expected == actual) return;
+
+        assertEquals(expected.version(), actual.version());
+
+        if (actual.message() instanceof ConsumerGroupCurrentMemberAssignmentValue) {
+            // The order of the topics stored in ConsumerGroupCurrentMemberAssignmentValue is not
+            // always guaranteed. Therefore, we need a special comparator.
+            ConsumerGroupCurrentMemberAssignmentValue expectedValue =
+                (ConsumerGroupCurrentMemberAssignmentValue) expected.message();
+            ConsumerGroupCurrentMemberAssignmentValue actualValue =
+                (ConsumerGroupCurrentMemberAssignmentValue) actual.message();
+
+            assertEquals(expectedValue.memberEpoch(), actualValue.memberEpoch());
+            assertEquals(expectedValue.previousMemberEpoch(), actualValue.previousMemberEpoch());
+            assertEquals(expectedValue.targetMemberEpoch(), actualValue.targetMemberEpoch());
+            assertEquals(expectedValue.error(), actualValue.error());
+            assertEquals(expectedValue.metadataVersion(), actualValue.metadataVersion());
+            assertEquals(expectedValue.metadataBytes(), actualValue.metadataBytes());
+
+            // We transform those to Maps before comparing them.
+            assertEquals(fromTopicPartitions(expectedValue.assignedPartitions()),
+                fromTopicPartitions(actualValue.assignedPartitions()));
+            assertEquals(fromTopicPartitions(expectedValue.partitionsPendingRevocation()),
+                fromTopicPartitions(actualValue.partitionsPendingRevocation()));
+            assertEquals(fromTopicPartitions(expectedValue.partitionsPendingAssignment()),
+                fromTopicPartitions(actualValue.partitionsPendingAssignment()));
+        } else {
+            assertEquals(expected.message(), actual.message());
+        }
+    }
+
+    public static Map<Uuid, Set<Integer>> fromTopicPartitions(
+        List<ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions> assignment
+    ) {
+        Map<Uuid, Set<Integer>> assignmentMap = new HashMap<>();
+        assignment.forEach(topicPartitions -> {
+            assignmentMap.put(topicPartitions.topicId(), new HashSet<>(topicPartitions.partitions()));
+        });
+        return assignmentMap;
+    }
+
+    public static List<JoinGroupResponseData.JoinGroupResponseMember> toJoinResponseMembers(ClassicGroup group) {
+        List<JoinGroupResponseData.JoinGroupResponseMember> members = new ArrayList<>();
+        String protocolName = group.protocolName().get();
+        group.allMembers().forEach(member -> {
+            members.add(
+                new JoinGroupResponseData.JoinGroupResponseMember()
+                    .setMemberId(member.memberId())
+                    .setGroupInstanceId(member.groupInstanceId().orElse(""))
+                    .setMetadata(member.metadata(protocolName))
+            );
+        });
+
+        return members;
+    }
+
+    public static void checkJoinGroupResponse(
+        JoinGroupResponseData expectedResponse,
+        JoinGroupResponseData actualResponse,
+        ClassicGroup group,
+        ClassicGroupState expectedState,
+        Set<String> expectedGroupInstanceIds
+    ) {
+        assertEquals(expectedResponse, actualResponse);
+        assertTrue(group.isInState(expectedState));
+
+        Set<String> groupInstanceIds = actualResponse.members()
+            .stream()
+            .map(JoinGroupResponseData.JoinGroupResponseMember::groupInstanceId)
+            .collect(Collectors.toSet());
+
+        assertEquals(expectedGroupInstanceIds, groupInstanceIds);
+    }
+
+    public static void assertNoOrEmptyResult(List<MockCoordinatorTimer.ExpiredTimeout<Void, Record>> timeouts) {
+        assertTrue(timeouts.size() <= 1);
+        timeouts.forEach(timeout -> assertEquals(EMPTY_RESULT, timeout.result));
+    }
+
+    public static List<String> verifyClassicGroupJoinResponses(
+        List<JoinResult> joinResults,
+        int expectedSuccessCount,
+        Errors expectedFailure
+    ) {
+        int successCount = 0;
+        List<String> memberIds = new ArrayList<>();
+        for (JoinResult joinResult : joinResults) {
+            if (!joinResult.joinFuture.isDone()) {
+                fail("All responseFutures should be completed.");
+            }
+            try {
+                JoinGroupResponseData joinResponse = joinResult.joinFuture.get();
+                if (joinResponse.errorCode() == Errors.NONE.code()) {
+                    successCount++;
+                } else {
+                    assertEquals(expectedFailure.code(), joinResponse.errorCode());
+                }
+                memberIds.add(joinResponse.memberId());
+            } catch (Exception e) {
+                fail("Unexpected exception: " + e.getMessage());
+            }
+        }
+
+        assertEquals(expectedSuccessCount, successCount);
+        return memberIds;
+    }
+
+    public static JoinGroupRequestData.JoinGroupRequestProtocolCollection toProtocols(String... protocolNames) {
+        JoinGroupRequestData.JoinGroupRequestProtocolCollection protocols = new JoinGroupRequestData.JoinGroupRequestProtocolCollection(0);
+        List<String> topicNames = Arrays.asList("foo", "bar", "baz");
+        for (int i = 0; i < protocolNames.length; i++) {
+            protocols.add(new JoinGroupRequestData.JoinGroupRequestProtocol()
+                .setName(protocolNames[i])
+                .setMetadata(ConsumerProtocol.serializeSubscription(new ConsumerPartitionAssignor.Subscription(
+                    Collections.singletonList(topicNames.get(i % topicNames.size())))).array())
+            );
+        }
+        return protocols;
+    }
+
+    public static Record newGroupMetadataRecord(
+        String groupId,
+        GroupMetadataValue value,
+        MetadataVersion metadataVersion
+    ) {
+        return new Record(
+            new ApiMessageAndVersion(
+                new GroupMetadataKey()
+                    .setGroup(groupId),
+                (short) 2
+            ),
+            new ApiMessageAndVersion(
+                value,
+                metadataVersion.groupMetadataValueVersion()
+            )
+        );
+    }
+
+    public static Record newGroupMetadataRecordWithCurrentState(
+        ClassicGroup group,
+        MetadataVersion metadataVersion
+    ) {
+        return RecordHelpers.newGroupMetadataRecord(group, group.groupAssignment(), metadataVersion);
+    }
+
+    public static class RebalanceResult {
+        int generationId;
+        String leaderId;
+        byte[] leaderAssignment;
+        String followerId;
+        byte[] followerAssignment;
+
+        RebalanceResult(
+            int generationId,
+            String leaderId,
+            byte[] leaderAssignment,
+            String followerId,
+            byte[] followerAssignment
+        ) {
+            this.generationId = generationId;
+            this.leaderId = leaderId;
+            this.leaderAssignment = leaderAssignment;
+            this.followerId = followerId;
+            this.followerAssignment = followerAssignment;
+        }
+    }
+
+    public static class PendingMemberGroupResult {
+        String leaderId;
+        String followerId;
+        JoinGroupResponseData pendingMemberResponse;
+
+        public PendingMemberGroupResult(
+            String leaderId,
+            String followerId,
+            JoinGroupResponseData pendingMemberResponse
+        ) {
+            this.leaderId = leaderId;
+            this.followerId = followerId;
+            this.pendingMemberResponse = pendingMemberResponse;
+        }
+    }
+
+    public static class JoinResult {
+        CompletableFuture<JoinGroupResponseData> joinFuture;
+        List<Record> records;
+        CompletableFuture<Void> appendFuture;
+
+        public JoinResult(
+            CompletableFuture<JoinGroupResponseData> joinFuture,
+            CoordinatorResult<Void, Record> coordinatorResult
+        ) {
+            this.joinFuture = joinFuture;
+            this.records = coordinatorResult.records();
+            this.appendFuture = coordinatorResult.appendFuture();
+        }
+    }
+
+    public static class SyncResult {
+        CompletableFuture<SyncGroupResponseData> syncFuture;
+        List<Record> records;
+        CompletableFuture<Void> appendFuture;
+
+        public SyncResult(
+            CompletableFuture<SyncGroupResponseData> syncFuture,
+            CoordinatorResult<Void, Record> coordinatorResult
+        ) {
+            this.syncFuture = syncFuture;
+            this.records = coordinatorResult.records();
+            this.appendFuture = coordinatorResult.appendFuture();
+        }
+    }
+
+    public static class JoinGroupRequestBuilder {
+        String groupId = null;
+        String groupInstanceId = null;
+        String memberId = null;
+        String protocolType = "consumer";
+        JoinGroupRequestData.JoinGroupRequestProtocolCollection protocols = new JoinGroupRequestData.JoinGroupRequestProtocolCollection(0);
+        int sessionTimeoutMs = 500;
+        int rebalanceTimeoutMs = 500;
+        String reason = null;
+
+        JoinGroupRequestBuilder withGroupId(String groupId) {
+            this.groupId = groupId;
+            return this;
+        }
+
+        JoinGroupRequestBuilder withGroupInstanceId(String groupInstanceId) {
+            this.groupInstanceId = groupInstanceId;
+            return this;
+        }
+
+        JoinGroupRequestBuilder withMemberId(String memberId) {
+            this.memberId = memberId;
+            return this;
+        }
+
+        JoinGroupRequestBuilder withDefaultProtocolTypeAndProtocols() {
+            this.protocols = toProtocols("range");
+            return this;
+        }
+
+        JoinGroupRequestBuilder withProtocolSuperset() {
+            this.protocols = toProtocols("range", "roundrobin");
+            return this;
+        }
+
+        JoinGroupRequestBuilder withProtocolType(String protocolType) {
+            this.protocolType = protocolType;
+            return this;
+        }
+
+        JoinGroupRequestBuilder withProtocols(JoinGroupRequestData.JoinGroupRequestProtocolCollection protocols) {
+            this.protocols = protocols;
+            return this;
+        }
+
+        JoinGroupRequestBuilder withRebalanceTimeoutMs(int rebalanceTimeoutMs) {
+            this.rebalanceTimeoutMs = rebalanceTimeoutMs;
+            return this;
+        }
+
+        JoinGroupRequestBuilder withSessionTimeoutMs(int sessionTimeoutMs) {
+            this.sessionTimeoutMs = sessionTimeoutMs;
+            return this;
+        }
+
+        JoinGroupRequestBuilder withReason(String reason) {
+            this.reason = reason;
+            return this;
+        }
+
+        JoinGroupRequestData build() {
+            return new JoinGroupRequestData()
+                .setGroupId(groupId)
+                .setGroupInstanceId(groupInstanceId)
+                .setMemberId(memberId)
+                .setProtocolType(protocolType)
+                .setProtocols(protocols)
+                .setRebalanceTimeoutMs(rebalanceTimeoutMs)
+                .setSessionTimeoutMs(sessionTimeoutMs)
+                .setReason(reason);
+        }
+    }
+
+    public static class SyncGroupRequestBuilder {
+        String groupId = null;
+        String groupInstanceId = null;
+        String memberId = null;
+        String protocolType = "consumer";
+        String protocolName = "range";
+        int generationId = 0;
+        List<SyncGroupRequestData.SyncGroupRequestAssignment> assignment = Collections.emptyList();
+
+        SyncGroupRequestBuilder withGroupId(String groupId) {
+            this.groupId = groupId;
+            return this;
+        }
+
+        SyncGroupRequestBuilder withGroupInstanceId(String groupInstanceId) {
+            this.groupInstanceId = groupInstanceId;
+            return this;
+        }
+
+        SyncGroupRequestBuilder withMemberId(String memberId) {
+            this.memberId = memberId;
+            return this;
+        }
+
+        SyncGroupRequestBuilder withGenerationId(int generationId) {
+            this.generationId = generationId;
+            return this;
+        }
+
+        SyncGroupRequestBuilder withProtocolType(String protocolType) {
+            this.protocolType = protocolType;
+            return this;
+        }
+
+        SyncGroupRequestBuilder withProtocolName(String protocolName) {
+            this.protocolName = protocolName;
+            return this;
+        }
+
+        SyncGroupRequestBuilder withAssignment(List<SyncGroupRequestData.SyncGroupRequestAssignment> assignment) {
+            this.assignment = assignment;
+            return this;
+        }
+
+
+        SyncGroupRequestData build() {
+            return new SyncGroupRequestData()
+                .setGroupId(groupId)
+                .setGroupInstanceId(groupInstanceId)
+                .setMemberId(memberId)
+                .setGenerationId(generationId)
+                .setProtocolType(protocolType)
+                .setProtocolName(protocolName)
+                .setAssignments(assignment);
+        }
+    }
+
+    public static class Builder {
+        final private MockTime time = new MockTime();
+        final private MockCoordinatorTimer<Void, Record> timer = new MockCoordinatorTimer<>(time);
+        final private LogContext logContext = new LogContext();
+        final private SnapshotRegistry snapshotRegistry = new SnapshotRegistry(logContext);
+        final private TopicPartition groupMetadataTopicPartition = new TopicPartition("topic", 0);
+        private MetadataImage metadataImage;
+        private List<PartitionAssignor> consumerGroupAssignors = Collections.singletonList(new MockPartitionAssignor("range"));
+        private List<ConsumerGroupBuilder> consumerGroupBuilders = new ArrayList<>();
+        private int consumerGroupMaxSize = Integer.MAX_VALUE;
+        private int consumerGroupMetadataRefreshIntervalMs = Integer.MAX_VALUE;
+        private int classicGroupMaxSize = Integer.MAX_VALUE;
+        private int classicGroupInitialRebalanceDelayMs = 3000;
+        final private int classicGroupNewMemberJoinTimeoutMs = 5 * 60 * 1000;
+        private int classicGroupMinSessionTimeoutMs = 10;
+        private int classicGroupMaxSessionTimeoutMs = 10 * 60 * 1000;
+        private GroupCoordinatorMetricsShard metrics = mock(GroupCoordinatorMetricsShard.class);
+
+        public Builder withMetadataImage(MetadataImage metadataImage) {
+            this.metadataImage = metadataImage;
+            return this;
+        }
+
+        public Builder withAssignors(List<PartitionAssignor> assignors) {
+            this.consumerGroupAssignors = assignors;
+            return this;
+        }
+
+        public Builder withConsumerGroup(ConsumerGroupBuilder builder) {
+            this.consumerGroupBuilders.add(builder);
+            return this;
+        }
+
+        public Builder withConsumerGroupMaxSize(int consumerGroupMaxSize) {
+            this.consumerGroupMaxSize = consumerGroupMaxSize;
+            return this;
+        }
+
+        public Builder withConsumerGroupMetadataRefreshIntervalMs(int consumerGroupMetadataRefreshIntervalMs) {
+            this.consumerGroupMetadataRefreshIntervalMs = consumerGroupMetadataRefreshIntervalMs;
+            return this;
+        }
+
+        public Builder withClassicGroupMaxSize(int classicGroupMaxSize) {
+            this.classicGroupMaxSize = classicGroupMaxSize;
+            return this;
+        }
+
+        public Builder withClassicGroupInitialRebalanceDelayMs(int classicGroupInitialRebalanceDelayMs) {
+            this.classicGroupInitialRebalanceDelayMs = classicGroupInitialRebalanceDelayMs;
+            return this;
+        }
+
+        public Builder withClassicGroupMinSessionTimeoutMs(int classicGroupMinSessionTimeoutMs) {
+            this.classicGroupMinSessionTimeoutMs = classicGroupMinSessionTimeoutMs;
+            return this;
+        }
+
+        public Builder withClassicGroupMaxSessionTimeoutMs(int classicGroupMaxSessionTimeoutMs) {
+            this.classicGroupMaxSessionTimeoutMs = classicGroupMaxSessionTimeoutMs;
+            return this;
+        }
+
+        public GroupMetadataManagerTestContext build() {
+            if (metadataImage == null) metadataImage = MetadataImage.EMPTY;
+            if (consumerGroupAssignors == null) consumerGroupAssignors = Collections.emptyList();
+
+            GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext(
+                time,
+                timer,
+                snapshotRegistry,
+                metrics,
+                new GroupMetadataManager.Builder()
+                    .withSnapshotRegistry(snapshotRegistry)
+                    .withLogContext(logContext)
+                    .withTime(time)
+                    .withTimer(timer)
+                    .withMetadataImage(metadataImage)
+                    .withConsumerGroupHeartbeatInterval(5000)
+                    .withConsumerGroupSessionTimeout(45000)
+                    .withConsumerGroupMaxSize(consumerGroupMaxSize)
+                    .withConsumerGroupAssignors(consumerGroupAssignors)
+                    .withConsumerGroupMetadataRefreshIntervalMs(consumerGroupMetadataRefreshIntervalMs)
+                    .withClassicGroupMaxSize(classicGroupMaxSize)
+                    .withClassicGroupMinSessionTimeoutMs(classicGroupMinSessionTimeoutMs)
+                    .withClassicGroupMaxSessionTimeoutMs(classicGroupMaxSessionTimeoutMs)
+                    .withClassicGroupInitialRebalanceDelayMs(classicGroupInitialRebalanceDelayMs)
+                    .withClassicGroupNewMemberJoinTimeoutMs(classicGroupNewMemberJoinTimeoutMs)
+                    .withGroupCoordinatorMetricsShard(metrics)
+                    .build(),
+                classicGroupInitialRebalanceDelayMs,
+                classicGroupNewMemberJoinTimeoutMs
+            );
+
+            consumerGroupBuilders.forEach(builder -> {
+                builder.build(metadataImage.topics()).forEach(context::replay);
+            });
+
+            context.commit();
+
+            return context;
+        }
+    }
+
+    final MockTime time;
+    final MockCoordinatorTimer<Void, Record> timer;
+    final SnapshotRegistry snapshotRegistry;
+    final GroupCoordinatorMetricsShard metrics;
+    final GroupMetadataManager groupMetadataManager;
+    final int classicGroupInitialRebalanceDelayMs;
+    final int classicGroupNewMemberJoinTimeoutMs;
+
+    long lastCommittedOffset = 0L;
+    long lastWrittenOffset = 0L;
+
+    public GroupMetadataManagerTestContext(
+        MockTime time,
+        MockCoordinatorTimer<Void, Record> timer,
+        SnapshotRegistry snapshotRegistry,
+        GroupCoordinatorMetricsShard metrics,
+        GroupMetadataManager groupMetadataManager,
+        int classicGroupInitialRebalanceDelayMs,
+        int classicGroupNewMemberJoinTimeoutMs
+    ) {
+        this.time = time;
+        this.timer = timer;
+        this.snapshotRegistry = snapshotRegistry;
+        this.metrics = metrics;
+        this.groupMetadataManager = groupMetadataManager;
+        this.classicGroupInitialRebalanceDelayMs = classicGroupInitialRebalanceDelayMs;
+        this.classicGroupNewMemberJoinTimeoutMs = classicGroupNewMemberJoinTimeoutMs;
+        snapshotRegistry.getOrCreateSnapshot(lastWrittenOffset);
+    }
+
+    public void commit() {
+        long lastCommittedOffset = this.lastCommittedOffset;
+        this.lastCommittedOffset = lastWrittenOffset;
+        snapshotRegistry.deleteSnapshotsUpTo(lastCommittedOffset);
+    }
+
+    public void rollback() {
+        lastWrittenOffset = lastCommittedOffset;
+        snapshotRegistry.revertToSnapshot(lastCommittedOffset);
+    }
+
+    public ConsumerGroup.ConsumerGroupState consumerGroupState(
+        String groupId
+    ) {
+        return groupMetadataManager
+            .getOrMaybeCreateConsumerGroup(groupId, false)
+            .state();
+    }
+
+    public ConsumerGroupMember.MemberState consumerGroupMemberState(
+        String groupId,
+        String memberId
+    ) {
+        return groupMetadataManager
+            .getOrMaybeCreateConsumerGroup(groupId, false)
+            .getOrMaybeCreateMember(memberId, false)
+            .state();
+    }
+
+    public CoordinatorResult<ConsumerGroupHeartbeatResponseData, Record> consumerGroupHeartbeat(
+        ConsumerGroupHeartbeatRequestData request
+    ) {
+        RequestContext context = new RequestContext(
+            new RequestHeader(
+                ApiKeys.CONSUMER_GROUP_HEARTBEAT,
+                ApiKeys.CONSUMER_GROUP_HEARTBEAT.latestVersion(),
+                "client",
+                0
+            ),
+            "1",
+            InetAddress.getLoopbackAddress(),
+            KafkaPrincipal.ANONYMOUS,
+            ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT,
+            ClientInformation.EMPTY,
+            false
+        );
+
+        CoordinatorResult<ConsumerGroupHeartbeatResponseData, Record> result = groupMetadataManager.consumerGroupHeartbeat(
+            context,
+            request
+        );
+
+        result.records().forEach(this::replay);
+        return result;
+    }
+
+    public List<MockCoordinatorTimer.ExpiredTimeout<Void, Record>> sleep(long ms) {
+        time.sleep(ms);
+        List<MockCoordinatorTimer.ExpiredTimeout<Void, Record>> timeouts = timer.poll();
+        timeouts.forEach(timeout -> {
+            if (timeout.result.replayRecords()) {
+                timeout.result.records().forEach(this::replay);
+            }
+        });
+        return timeouts;
+    }
+
+    public MockCoordinatorTimer.ScheduledTimeout<Void, Record> assertSessionTimeout(
+        String groupId,
+        String memberId,
+        long delayMs
+    ) {
+        MockCoordinatorTimer.ScheduledTimeout<Void, Record> timeout =
+            timer.timeout(consumerGroupSessionTimeoutKey(groupId, memberId));
+        assertNotNull(timeout);
+        assertEquals(time.milliseconds() + delayMs, timeout.deadlineMs);
+        return timeout;
+    }
+
+    public void assertNoSessionTimeout(
+        String groupId,
+        String memberId
+    ) {
+        MockCoordinatorTimer.ScheduledTimeout<Void, Record> timeout =
+            timer.timeout(consumerGroupSessionTimeoutKey(groupId, memberId));
+        assertNull(timeout);
+    }
+
+    public MockCoordinatorTimer.ScheduledTimeout<Void, Record> assertRevocationTimeout(
+        String groupId,
+        String memberId,
+        long delayMs
+    ) {
+        MockCoordinatorTimer.ScheduledTimeout<Void, Record> timeout =
+            timer.timeout(consumerGroupRevocationTimeoutKey(groupId, memberId));
+        assertNotNull(timeout);
+        assertEquals(time.milliseconds() + delayMs, timeout.deadlineMs);
+        return timeout;
+    }
+
+    public void assertNoRevocationTimeout(
+        String groupId,
+        String memberId
+    ) {
+        MockCoordinatorTimer.ScheduledTimeout<Void, Record> timeout =
+            timer.timeout(consumerGroupRevocationTimeoutKey(groupId, memberId));
+        assertNull(timeout);
+    }
+
+    ClassicGroup createClassicGroup(String groupId) {
+        return groupMetadataManager.getOrMaybeCreateClassicGroup(groupId, true);
+    }
+
+    public JoinResult sendClassicGroupJoin(
+        JoinGroupRequestData request
+    ) {
+        return sendClassicGroupJoin(request, false);
+    }
+
+    public JoinResult sendClassicGroupJoin(
+        JoinGroupRequestData request,
+        boolean requireKnownMemberId
+    ) {
+        return sendClassicGroupJoin(request, requireKnownMemberId, false);
+    }
+
+    public JoinResult sendClassicGroupJoin(
+        JoinGroupRequestData request,
+        boolean requireKnownMemberId,
+        boolean supportSkippingAssignment
+    ) {
+        // requireKnownMemberId is true: version >= 4 (See JoinGroupRequest#requiresKnownMemberId())
+        // supportSkippingAssignment is true: version >= 9 (See JoinGroupRequest#supportsSkippingAssignment())
+        short joinGroupVersion = 3;
+
+        if (requireKnownMemberId) {
+            joinGroupVersion = 4;
+            if (supportSkippingAssignment) {
+                joinGroupVersion = ApiKeys.JOIN_GROUP.latestVersion();
+            }
+        }
+
+        RequestContext context = new RequestContext(
+            new RequestHeader(
+                ApiKeys.JOIN_GROUP,
+                joinGroupVersion,
+                "client",
+                0
+            ),
+            "1",
+            InetAddress.getLoopbackAddress(),
+            KafkaPrincipal.ANONYMOUS,
+            ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT,
+            ClientInformation.EMPTY,
+            false
+        );
+
+        CompletableFuture<JoinGroupResponseData> responseFuture = new CompletableFuture<>();
+        CoordinatorResult<Void, Record> coordinatorResult = groupMetadataManager.classicGroupJoin(
+            context,
+            request,
+            responseFuture
+        );
+
+        return new JoinResult(responseFuture, coordinatorResult);
+    }
+
+    public JoinGroupResponseData joinClassicGroupAsDynamicMemberAndCompleteRebalance(
+        String groupId
+    ) throws Exception {
+        ClassicGroup group = createClassicGroup(groupId);
+
+        JoinGroupResponseData leaderJoinResponse =
+            joinClassicGroupAsDynamicMemberAndCompleteJoin(new JoinGroupRequestBuilder()
+                .withGroupId("group-id")
+                .withMemberId(UNKNOWN_MEMBER_ID)
+                .withDefaultProtocolTypeAndProtocols()
+                .withRebalanceTimeoutMs(10000)
+                .withSessionTimeoutMs(5000)
+                .build());
+
+        assertEquals(1, leaderJoinResponse.generationId());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+
+        SyncResult syncResult = sendClassicGroupSync(new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(leaderJoinResponse.memberId())
+            .withGenerationId(leaderJoinResponse.generationId())
+            .build());
+
+        assertEquals(
+            Collections.singletonList(newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            syncResult.records
+        );
+        // Simulate a successful write to the log.
+        syncResult.appendFuture.complete(null);
+
+        assertTrue(syncResult.syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncResult.syncFuture.get().errorCode());
+        assertTrue(group.isInState(STABLE));
+
+        return leaderJoinResponse;
+    }
+
+    public JoinGroupResponseData joinClassicGroupAsDynamicMemberAndCompleteJoin(
+        JoinGroupRequestData request
+    ) throws ExecutionException, InterruptedException {
+        boolean requireKnownMemberId = true;
+        String newMemberId = request.memberId();
+
+        if (request.memberId().equals(UNKNOWN_MEMBER_ID)) {
+            // Since member id is required, we need another round to get the successful join group result.
+            JoinResult firstJoinResult = sendClassicGroupJoin(
+                request,
+                requireKnownMemberId
+            );
+            assertTrue(firstJoinResult.records.isEmpty());
+            assertTrue(firstJoinResult.joinFuture.isDone());
+            assertEquals(Errors.MEMBER_ID_REQUIRED.code(), firstJoinResult.joinFuture.get().errorCode());
+            newMemberId = firstJoinResult.joinFuture.get().memberId();
+        }
+
+        // Second round
+        JoinGroupRequestData secondRequest = new JoinGroupRequestData()
+            .setGroupId(request.groupId())
+            .setMemberId(newMemberId)
+            .setProtocolType(request.protocolType())
+            .setProtocols(request.protocols())
+            .setSessionTimeoutMs(request.sessionTimeoutMs())
+            .setRebalanceTimeoutMs(request.rebalanceTimeoutMs())
+            .setReason(request.reason());
+
+        JoinResult secondJoinResult = sendClassicGroupJoin(
+            secondRequest,
+            requireKnownMemberId
+        );
+
+        assertTrue(secondJoinResult.records.isEmpty());
+        List<MockCoordinatorTimer.ExpiredTimeout<Void, Record>> timeouts = sleep(classicGroupInitialRebalanceDelayMs);
+        assertEquals(1, timeouts.size());
+        assertTrue(secondJoinResult.joinFuture.isDone());
+        assertEquals(Errors.NONE.code(), secondJoinResult.joinFuture.get().errorCode());
+
+        return secondJoinResult.joinFuture.get();
+    }
+
+    public JoinGroupResponseData joinClassicGroupAndCompleteJoin(
+        JoinGroupRequestData request,
+        boolean requireKnownMemberId,
+        boolean supportSkippingAssignment
+    ) throws ExecutionException, InterruptedException {
+        return joinClassicGroupAndCompleteJoin(
+            request,
+            requireKnownMemberId,
+            supportSkippingAssignment,
+            classicGroupInitialRebalanceDelayMs
+        );
+    }
+
+    public JoinGroupResponseData joinClassicGroupAndCompleteJoin(
+        JoinGroupRequestData request,
+        boolean requireKnownMemberId,
+        boolean supportSkippingAssignment,
+        int advanceClockMs
+    ) throws ExecutionException, InterruptedException {
+        if (requireKnownMemberId && request.groupInstanceId().isEmpty()) {
+            return joinClassicGroupAsDynamicMemberAndCompleteJoin(request);
+        }
+
+        try {
+            JoinResult joinResult = sendClassicGroupJoin(
+                request,
+                requireKnownMemberId,
+                supportSkippingAssignment
+            );
+
+            sleep(advanceClockMs);
+            assertTrue(joinResult.joinFuture.isDone());
+            assertEquals(Errors.NONE.code(), joinResult.joinFuture.get().errorCode());
+            return joinResult.joinFuture.get();
+        } catch (Exception e) {
+            fail("Failed to due: " + e.getMessage());
+        }
+        return null;
+    }
+
+    public SyncResult sendClassicGroupSync(SyncGroupRequestData request) {
+        RequestContext context = new RequestContext(
+            new RequestHeader(
+                ApiKeys.SYNC_GROUP,
+                ApiKeys.SYNC_GROUP.latestVersion(),
+                "client",
+                0
+            ),
+            "1",
+            InetAddress.getLoopbackAddress(),
+            KafkaPrincipal.ANONYMOUS,
+            ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT,
+            ClientInformation.EMPTY,
+            false
+        );
+
+        CompletableFuture<SyncGroupResponseData> responseFuture = new CompletableFuture<>();
+
+        CoordinatorResult<Void, Record> coordinatorResult = groupMetadataManager.classicGroupSync(
+            context,
+            request,
+            responseFuture
+        );
+
+        return new SyncResult(responseFuture, coordinatorResult);
+    }
+
+    public RebalanceResult staticMembersJoinAndRebalance(
+        String groupId,
+        String leaderInstanceId,
+        String followerInstanceId
+    ) throws Exception {
+        return staticMembersJoinAndRebalance(
+            groupId,
+            leaderInstanceId,
+            followerInstanceId,
+            10000,
+            5000
+        );
+    }
+
+    public RebalanceResult staticMembersJoinAndRebalance(
+        String groupId,
+        String leaderInstanceId,
+        String followerInstanceId,
+        int rebalanceTimeoutMs,
+        int sessionTimeoutMs
+    ) throws Exception {
+        ClassicGroup group = createClassicGroup("group-id");
+
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId(groupId)
+            .withGroupInstanceId(leaderInstanceId)
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withProtocolType("consumer")
+            .withProtocolSuperset()
+            .withRebalanceTimeoutMs(rebalanceTimeoutMs)
+            .withSessionTimeoutMs(sessionTimeoutMs)
+            .build();
+
+        JoinResult leaderJoinResult = sendClassicGroupJoin(joinRequest);
+        JoinResult followerJoinResult = sendClassicGroupJoin(joinRequest.setGroupInstanceId(followerInstanceId));
+
+        assertTrue(leaderJoinResult.records.isEmpty());
+        assertTrue(followerJoinResult.records.isEmpty());
+        assertFalse(leaderJoinResult.joinFuture.isDone());
+        assertFalse(followerJoinResult.joinFuture.isDone());
+
+        // The goal for two timer advance is to let first group initial join complete and set newMemberAdded flag to false. Next advance is
+        // to trigger the rebalance as needed for follower delayed join. One large time advance won't help because we could only populate one
+        // delayed join from purgatory and the new delayed op is created at that time and never be triggered.
+        assertNoOrEmptyResult(sleep(classicGroupInitialRebalanceDelayMs));
+        assertNoOrEmptyResult(sleep(classicGroupInitialRebalanceDelayMs));
+
+        assertTrue(leaderJoinResult.joinFuture.isDone());
+        assertTrue(followerJoinResult.joinFuture.isDone());
+        assertEquals(Errors.NONE.code(), leaderJoinResult.joinFuture.get().errorCode());
+        assertEquals(Errors.NONE.code(), followerJoinResult.joinFuture.get().errorCode());
+        assertEquals(1, leaderJoinResult.joinFuture.get().generationId());
+        assertEquals(1, followerJoinResult.joinFuture.get().generationId());
+        assertEquals(2, group.size());
+        assertEquals(1, group.generationId());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+
+        String leaderId = leaderJoinResult.joinFuture.get().memberId();
+        String followerId = followerJoinResult.joinFuture.get().memberId();
+        List<SyncGroupRequestData.SyncGroupRequestAssignment> assignment = new ArrayList<>();
+        assignment.add(new SyncGroupRequestData.SyncGroupRequestAssignment().setMemberId(leaderId)
+                                                                            .setAssignment(new byte[]{1}));
+        assignment.add(new SyncGroupRequestData.SyncGroupRequestAssignment().setMemberId(followerId)
+                                                                            .setAssignment(new byte[]{2}));
+
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId(groupId)
+            .withGroupInstanceId(leaderInstanceId)
+            .withMemberId(leaderId)
+            .withGenerationId(1)
+            .withAssignment(assignment)
+            .build();
+
+        SyncResult leaderSyncResult = sendClassicGroupSync(syncRequest);
+
+        // The generated record should contain the new assignment.
+        Map<String, byte[]> groupAssignment = assignment.stream().collect(Collectors.toMap(
+            SyncGroupRequestData.SyncGroupRequestAssignment::memberId, SyncGroupRequestData.SyncGroupRequestAssignment::assignment
+        ));
+        assertEquals(
+            Collections.singletonList(
+                RecordHelpers.newGroupMetadataRecord(group, groupAssignment, MetadataVersion.latestTesting())),
+            leaderSyncResult.records
+        );
+
+        // Simulate a successful write to the log.
+        leaderSyncResult.appendFuture.complete(null);
+
+        assertTrue(leaderSyncResult.syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), leaderSyncResult.syncFuture.get().errorCode());
+        assertTrue(group.isInState(STABLE));
+
+        SyncResult followerSyncResult = sendClassicGroupSync(
+            syncRequest.setGroupInstanceId(followerInstanceId)
+                       .setMemberId(followerId)
+                       .setAssignments(Collections.emptyList())
+        );
+
+        assertTrue(followerSyncResult.records.isEmpty());
+        assertTrue(followerSyncResult.syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), followerSyncResult.syncFuture.get().errorCode());
+        assertTrue(group.isInState(STABLE));
+
+        assertEquals(2, group.size());
+        assertEquals(1, group.generationId());
+
+        return new RebalanceResult(
+            1,
+            leaderId,
+            leaderSyncResult.syncFuture.get().assignment(),
+            followerId,
+            followerSyncResult.syncFuture.get().assignment()
+        );
+    }
+
+    public PendingMemberGroupResult setupGroupWithPendingMember(ClassicGroup group) throws Exception {
+        // Add the first member
+        JoinGroupRequestData joinRequest = new JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .withRebalanceTimeoutMs(10000)
+            .withSessionTimeoutMs(5000)
+            .build();
+
+        JoinGroupResponseData leaderJoinResponse =
+            joinClassicGroupAsDynamicMemberAndCompleteJoin(joinRequest);
+
+        List<SyncGroupRequestData.SyncGroupRequestAssignment> assignment = new ArrayList<>();
+        assignment.add(new SyncGroupRequestData.SyncGroupRequestAssignment().setMemberId(leaderJoinResponse.memberId()));
+        SyncGroupRequestData syncRequest = new SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(leaderJoinResponse.memberId())
+            .withGenerationId(leaderJoinResponse.generationId())
+            .withAssignment(assignment)
+            .build();
+
+        SyncResult syncResult = sendClassicGroupSync(syncRequest);
+
+        // Now the group is stable, with the one member that joined above
+        assertEquals(
+            Collections.singletonList(newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            syncResult.records
+        );
+        // Simulate a successful write to log.
+        syncResult.appendFuture.complete(null);
+
+        assertTrue(syncResult.syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncResult.syncFuture.get().errorCode());
+
+        // Start the join for the second member
+        JoinResult followerJoinResult = sendClassicGroupJoin(
+            joinRequest.setMemberId(UNKNOWN_MEMBER_ID)
+        );
+
+        assertTrue(followerJoinResult.records.isEmpty());
+        assertFalse(followerJoinResult.joinFuture.isDone());
+
+        JoinResult leaderJoinResult = sendClassicGroupJoin(
+            joinRequest.setMemberId(leaderJoinResponse.memberId())
+        );
+
+        assertTrue(leaderJoinResult.records.isEmpty());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+        assertTrue(leaderJoinResult.joinFuture.isDone());
+        assertTrue(followerJoinResult.joinFuture.isDone());
+        assertEquals(Errors.NONE.code(), leaderJoinResult.joinFuture.get().errorCode());
+        assertEquals(Errors.NONE.code(), followerJoinResult.joinFuture.get().errorCode());
+        assertEquals(leaderJoinResult.joinFuture.get().generationId(), followerJoinResult.joinFuture.get().generationId());
+        assertEquals(leaderJoinResponse.memberId(), leaderJoinResult.joinFuture.get().leader());
+        assertEquals(leaderJoinResponse.memberId(), followerJoinResult.joinFuture.get().leader());
+
+        int nextGenerationId = leaderJoinResult.joinFuture.get().generationId();
+        String followerId = followerJoinResult.joinFuture.get().memberId();
+
+        // Stabilize the group
+        syncResult = sendClassicGroupSync(syncRequest.setGenerationId(nextGenerationId));
+
+        assertEquals(
+            Collections.singletonList(newGroupMetadataRecordWithCurrentState(group, MetadataVersion.latestTesting())),
+            syncResult.records
+        );
+        // Simulate a successful write to log.
+        syncResult.appendFuture.complete(null);
+
+        assertTrue(syncResult.syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), syncResult.syncFuture.get().errorCode());
+        assertTrue(group.isInState(STABLE));
+
+        // Re-join an existing member, to transition the group to PreparingRebalance state.
+        leaderJoinResult = sendClassicGroupJoin(
+            joinRequest.setMemberId(leaderJoinResponse.memberId()));
+
+        assertTrue(leaderJoinResult.records.isEmpty());
+        assertFalse(leaderJoinResult.joinFuture.isDone());
+        assertTrue(group.isInState(PREPARING_REBALANCE));
+
+        // Create a pending member in the group
+        JoinResult pendingMemberJoinResult = sendClassicGroupJoin(
+            joinRequest
+                .setMemberId(UNKNOWN_MEMBER_ID)
+                .setSessionTimeoutMs(2500),
+            true
+        );
+
+        assertTrue(pendingMemberJoinResult.records.isEmpty());
+        assertTrue(pendingMemberJoinResult.joinFuture.isDone());
+        assertEquals(Errors.MEMBER_ID_REQUIRED.code(), pendingMemberJoinResult.joinFuture.get().errorCode());
+        assertEquals(1, group.numPendingJoinMembers());
+
+        // Re-join the second existing member
+        followerJoinResult = sendClassicGroupJoin(
+            joinRequest.setMemberId(followerId).setSessionTimeoutMs(5000)
+        );
+
+        assertTrue(followerJoinResult.records.isEmpty());
+        assertFalse(followerJoinResult.joinFuture.isDone());
+        assertTrue(group.isInState(PREPARING_REBALANCE));
+        assertEquals(2, group.size());
+        assertEquals(1, group.numPendingJoinMembers());
+
+        return new PendingMemberGroupResult(
+            leaderJoinResponse.memberId(),
+            followerId,
+            pendingMemberJoinResult.joinFuture.get()
+        );
+    }
+
+    public void verifySessionExpiration(ClassicGroup group, int timeoutMs) {
+        Set<String> expectedHeartbeatKeys = group.allMembers().stream()
+                                                 .map(member -> classicGroupHeartbeatKey(group.groupId(), member.memberId())).collect(Collectors.toSet());
+
+        // Member should be removed as session expires.
+        List<MockCoordinatorTimer.ExpiredTimeout<Void, Record>> timeouts = sleep(timeoutMs);
+        List<Record> expectedRecords = Collections.singletonList(newGroupMetadataRecord(
+            group.groupId(),
+            new GroupMetadataValue()
+                .setMembers(Collections.emptyList())
+                .setGeneration(group.generationId())
+                .setLeader(null)
+                .setProtocolType("consumer")
+                .setProtocol(null)
+                .setCurrentStateTimestamp(time.milliseconds()),
+            MetadataVersion.latestTesting()
+        ));
+
+
+        Set<String> heartbeatKeys = timeouts.stream().map(timeout -> timeout.key).collect(Collectors.toSet());
+        assertEquals(expectedHeartbeatKeys, heartbeatKeys);
+
+        // Only the last member leaving the group should result in the empty group metadata record.
+        int timeoutsSize = timeouts.size();
+        assertEquals(expectedRecords, timeouts.get(timeoutsSize - 1).result.records());
+        assertNoOrEmptyResult(timeouts.subList(0, timeoutsSize - 1));
+        assertTrue(group.isInState(EMPTY));
+        assertEquals(0, group.size());
+    }
+
+    public HeartbeatResponseData sendClassicGroupHeartbeat(
+        HeartbeatRequestData request
+    ) {
+        RequestContext context = new RequestContext(
+            new RequestHeader(
+                ApiKeys.HEARTBEAT,
+                ApiKeys.HEARTBEAT.latestVersion(),
+                "client",
+                0
+            ),
+            "1",
+            InetAddress.getLoopbackAddress(),
+            KafkaPrincipal.ANONYMOUS,
+            ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT,
+            ClientInformation.EMPTY,
+            false
+        );
+
+        return groupMetadataManager.classicGroupHeartbeat(
+            context,
+            request
+        );
+    }
+
+    public List<ListGroupsResponseData.ListedGroup> sendListGroups(List<String> statesFilter, List<String> typesFilter) {
+        Set<String> statesFilterSet = statesFilter.stream().collect(Collectors.toSet());
+        Set<String> typesFilterSet = typesFilter.stream().collect(Collectors.toSet());
+        return groupMetadataManager.listGroups(statesFilterSet, typesFilterSet, lastCommittedOffset);
+    }
+
+    public List<ConsumerGroupDescribeResponseData.DescribedGroup> sendConsumerGroupDescribe(List<String> groupIds) {
+        return groupMetadataManager.consumerGroupDescribe(groupIds, lastCommittedOffset);
+    }
+
+    public List<DescribeGroupsResponseData.DescribedGroup> describeGroups(List<String> groupIds) {
+        return groupMetadataManager.describeGroups(groupIds, lastCommittedOffset);
+    }
+
+    public void verifyHeartbeat(
+        String groupId,
+        JoinGroupResponseData joinResponse,
+        Errors expectedError
+    ) {
+        HeartbeatRequestData request = new HeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(joinResponse.memberId())
+            .setGenerationId(joinResponse.generationId());
+
+        if (expectedError == Errors.UNKNOWN_MEMBER_ID) {
+            assertThrows(UnknownMemberIdException.class, () -> sendClassicGroupHeartbeat(request));
+        } else {
+            HeartbeatResponseData response = sendClassicGroupHeartbeat(request);
+            assertEquals(expectedError.code(), response.errorCode());
+        }
+    }
+
+    public List<JoinGroupResponseData> joinWithNMembers(
+        String groupId,
+        int numMembers,
+        int rebalanceTimeoutMs,
+        int sessionTimeoutMs
+    ) {
+        ClassicGroup group = createClassicGroup(groupId);
+        boolean requireKnownMemberId = true;
+
+        // First join requests
+        JoinGroupRequestData request = new JoinGroupRequestBuilder()
+            .withGroupId(groupId)
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .withRebalanceTimeoutMs(rebalanceTimeoutMs)
+            .withSessionTimeoutMs(sessionTimeoutMs)
+            .build();
+
+        List<String> memberIds = IntStream.range(0, numMembers).mapToObj(i -> {
+            JoinResult joinResult = sendClassicGroupJoin(request, requireKnownMemberId);
+
+            assertTrue(joinResult.records.isEmpty());
+            assertTrue(joinResult.joinFuture.isDone());
+
+            try {
+                return joinResult.joinFuture.get().memberId();
+            } catch (Exception e) {
+                fail("Unexpected exception: " + e.getMessage());
+            }
+            return null;
+        }).collect(Collectors.toList());
+
+        // Second join requests
+        List<CompletableFuture<JoinGroupResponseData>> secondJoinFutures = IntStream.range(0, numMembers).mapToObj(i -> {
+            JoinResult joinResult = sendClassicGroupJoin(request.setMemberId(memberIds.get(i)), requireKnownMemberId);
+
+            assertTrue(joinResult.records.isEmpty());
+            assertFalse(joinResult.joinFuture.isDone());
+
+            return joinResult.joinFuture;
+        }).collect(Collectors.toList());
+
+        // Advance clock by initial rebalance delay.
+        assertNoOrEmptyResult(sleep(classicGroupInitialRebalanceDelayMs));
+        secondJoinFutures.forEach(future -> assertFalse(future.isDone()));
+        // Advance clock by rebalance timeout to complete join phase.
+        assertNoOrEmptyResult(sleep(rebalanceTimeoutMs));
+
+        List<JoinGroupResponseData> joinResponses = secondJoinFutures.stream().map(future -> {
+            assertTrue(future.isDone());
+            try {
+                assertEquals(Errors.NONE.code(), future.get().errorCode());
+                return future.get();
+            } catch (Exception e) {
+                fail("Unexpected exception: " + e.getMessage());
+            }
+            return null;
+        }).collect(Collectors.toList());
+
+        assertEquals(numMembers, group.size());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+
+        return joinResponses;
+    }
+
+    public CoordinatorResult<LeaveGroupResponseData, Record> sendClassicGroupLeave(
+        LeaveGroupRequestData request
+    ) {
+        RequestContext context = new RequestContext(
+            new RequestHeader(
+                ApiKeys.LEAVE_GROUP,
+                ApiKeys.LEAVE_GROUP.latestVersion(),
+                "client",
+                0
+            ),
+            "1",
+            InetAddress.getLoopbackAddress(),
+            KafkaPrincipal.ANONYMOUS,
+            ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT,
+            ClientInformation.EMPTY,
+            false
+        );
+
+        return groupMetadataManager.classicGroupLeave(context, request);
+    }
+
+    public void verifyDescribeGroupsReturnsDeadGroup(String groupId) {
+        List<DescribeGroupsResponseData.DescribedGroup> describedGroups =
+            describeGroups(Collections.singletonList(groupId));
+
+        assertEquals(
+            Collections.singletonList(new DescribeGroupsResponseData.DescribedGroup()
+                .setGroupId("group-id")
+                .setGroupState(DEAD.toString())
+            ),
+            describedGroups
+        );
+    }
+
+    private ApiMessage messageOrNull(ApiMessageAndVersion apiMessageAndVersion) {
+        if (apiMessageAndVersion == null) {
+            return null;
+        } else {
+            return apiMessageAndVersion.message();
+        }
+    }
+
+    public void replay(
+        Record record
+    ) {
+        ApiMessageAndVersion key = record.key();
+        ApiMessageAndVersion value = record.value();
+
+        if (key == null) {
+            throw new IllegalStateException("Received a null key in " + record);
+        }
+
+        switch (key.version()) {
+            case GroupMetadataKey.HIGHEST_SUPPORTED_VERSION:
+                groupMetadataManager.replay(
+                    (GroupMetadataKey) key.message(),
+                    (GroupMetadataValue) messageOrNull(value)
+                );
+                break;
+
+            case ConsumerGroupMemberMetadataKey.HIGHEST_SUPPORTED_VERSION:
+                groupMetadataManager.replay(
+                    (ConsumerGroupMemberMetadataKey) key.message(),
+                    (ConsumerGroupMemberMetadataValue) messageOrNull(value)
+                );
+                break;
+
+            case ConsumerGroupMetadataKey.HIGHEST_SUPPORTED_VERSION:
+                groupMetadataManager.replay(
+                    (ConsumerGroupMetadataKey) key.message(),
+                    (ConsumerGroupMetadataValue) messageOrNull(value)
+                );
+                break;
+
+            case ConsumerGroupPartitionMetadataKey.HIGHEST_SUPPORTED_VERSION:
+                groupMetadataManager.replay(
+                    (ConsumerGroupPartitionMetadataKey) key.message(),
+                    (ConsumerGroupPartitionMetadataValue) messageOrNull(value)
+                );
+                break;
+
+            case ConsumerGroupTargetAssignmentMemberKey.HIGHEST_SUPPORTED_VERSION:
+                groupMetadataManager.replay(
+                    (ConsumerGroupTargetAssignmentMemberKey) key.message(),
+                    (ConsumerGroupTargetAssignmentMemberValue) messageOrNull(value)
+                );
+                break;
+
+            case ConsumerGroupTargetAssignmentMetadataKey.HIGHEST_SUPPORTED_VERSION:
+                groupMetadataManager.replay(
+                    (ConsumerGroupTargetAssignmentMetadataKey) key.message(),
+                    (ConsumerGroupTargetAssignmentMetadataValue) messageOrNull(value)
+                );
+                break;
+
+            case ConsumerGroupCurrentMemberAssignmentKey.HIGHEST_SUPPORTED_VERSION:
+                groupMetadataManager.replay(
+                    (ConsumerGroupCurrentMemberAssignmentKey) key.message(),
+                    (ConsumerGroupCurrentMemberAssignmentValue) messageOrNull(value)
+                );
+                break;
+
+            default:
+                throw new IllegalStateException("Received an unknown record type " + key.version()
+                    + " in " + record);
+        }
+
+        lastWrittenOffset++;
+        snapshotRegistry.getOrCreateSnapshot(lastWrittenOffset);
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -49,6 +49,7 @@ import org.apache.kafka.coordinator.group.assignor.PartitionAssignor;
 import org.apache.kafka.coordinator.group.classic.ClassicGroup;
 import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
 import org.apache.kafka.coordinator.group.consumer.ConsumerGroup;
+import org.apache.kafka.coordinator.group.consumer.ConsumerGroupBuilder;
 import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentKey;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -107,7 +107,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
-class GroupMetadataManagerTestContext {
+public class GroupMetadataManagerTestContext {
     public static <T> void assertUnorderedListEquals(
         List<T> expected,
         List<T> actual
@@ -152,7 +152,7 @@ class GroupMetadataManagerTestContext {
         return Objects.equals(fromAssignment(expected.topicPartitions()), fromAssignment(actual.topicPartitions()));
     }
 
-    public static Map<Uuid, Set<Integer>> fromAssignment(
+    private static Map<Uuid, Set<Integer>> fromAssignment(
         List<ConsumerGroupHeartbeatResponseData.TopicPartitions> assignment
     ) {
         if (assignment == null) return null;
@@ -199,7 +199,7 @@ class GroupMetadataManagerTestContext {
         }
     }
 
-    public static void assertApiMessageAndVersionEquals(
+    private static void assertApiMessageAndVersionEquals(
         ApiMessageAndVersion expected,
         ApiMessageAndVersion actual
     ) {
@@ -234,7 +234,7 @@ class GroupMetadataManagerTestContext {
         }
     }
 
-    public static Map<Uuid, Set<Integer>> fromTopicPartitions(
+    private static Map<Uuid, Set<Integer>> fromTopicPartitions(
         List<ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions> assignment
     ) {
         Map<Uuid, Set<Integer>> assignmentMap = new HashMap<>();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/MetadataImageBuilder.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/MetadataImageBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metadata.PartitionRecord;
+import org.apache.kafka.common.metadata.RegisterBrokerRecord;
+import org.apache.kafka.common.metadata.TopicRecord;
+import org.apache.kafka.image.MetadataDelta;
+import org.apache.kafka.image.MetadataImage;
+import org.apache.kafka.image.MetadataProvenance;
+
+import java.util.Arrays;
+
+public class MetadataImageBuilder {
+    private MetadataDelta delta = new MetadataDelta(MetadataImage.EMPTY);
+
+    public MetadataImageBuilder addTopic(
+        Uuid topicId,
+        String topicName,
+        int numPartitions
+    ) {
+        // For testing purposes, the following criteria are used:
+        // - Number of replicas for each partition: 2
+        // - Number of brokers available in the cluster: 4
+        delta.replay(new TopicRecord().setTopicId(topicId).setName(topicName));
+        for (int i = 0; i < numPartitions; i++) {
+            delta.replay(new PartitionRecord()
+                .setTopicId(topicId)
+                .setPartitionId(i)
+                .setReplicas(Arrays.asList(i % 4, (i + 1) % 4)));
+        }
+        return this;
+    }
+
+    /**
+     * Add rack Ids for 4 broker Ids.
+     * <p>
+     * For testing purposes, each broker is mapped
+     * to a rack Id with the same broker Id as a suffix.
+     */
+    public MetadataImageBuilder addRacks() {
+        for (int i = 0; i < 4; i++) {
+            delta.replay(new RegisterBrokerRecord().setBrokerId(i).setRack("rack" + i));
+        }
+        return this;
+    }
+
+    public MetadataImage build() {
+        return delta.apply(MetadataProvenance.EMPTY);
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/MockPartitionAssignor.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/MockPartitionAssignor.java
@@ -22,7 +22,7 @@ import org.apache.kafka.coordinator.group.assignor.PartitionAssignor;
 import org.apache.kafka.coordinator.group.assignor.PartitionAssignorException;
 import org.apache.kafka.coordinator.group.assignor.SubscribedTopicDescriber;
 
-class MockPartitionAssignor implements PartitionAssignor {
+public class MockPartitionAssignor implements PartitionAssignor {
     private final String name;
     private GroupAssignment prepareGroupAssignment = null;
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/MockPartitionAssignor.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/MockPartitionAssignor.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+import org.apache.kafka.coordinator.group.assignor.AssignmentSpec;
+import org.apache.kafka.coordinator.group.assignor.GroupAssignment;
+import org.apache.kafka.coordinator.group.assignor.PartitionAssignor;
+import org.apache.kafka.coordinator.group.assignor.PartitionAssignorException;
+import org.apache.kafka.coordinator.group.assignor.SubscribedTopicDescriber;
+
+class MockPartitionAssignor implements PartitionAssignor {
+    private final String name;
+    private GroupAssignment prepareGroupAssignment = null;
+
+    MockPartitionAssignor(String name) {
+        this.name = name;
+    }
+
+    public void prepareGroupAssignment(GroupAssignment prepareGroupAssignment) {
+        this.prepareGroupAssignment = prepareGroupAssignment;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public GroupAssignment assign(AssignmentSpec assignmentSpec, SubscribedTopicDescriber subscribedTopicDescriber) throws PartitionAssignorException {
+        return prepareGroupAssignment;
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
@@ -2362,7 +2362,7 @@ public class OffsetMetadataManagerTest {
             "foo",
             true
         );
-        MetadataImage image = new GroupMetadataManagerTest.MetadataImageBuilder()
+        MetadataImage image = new MetadataImageBuilder()
             .addTopic(Uuid.randomUuid(), "foo", 1)
             .addRacks()
             .build();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
@@ -53,7 +53,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.opentest4j.AssertionFailedError;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -72,10 +71,10 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static org.apache.kafka.coordinator.group.Assertions.assertRecordEquals;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkSortedAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkSortedTopicAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
-import static org.apache.kafka.coordinator.group.Assertions.assertUnorderedListEquals;
 import static org.apache.kafka.coordinator.group.RecordHelpers.newCurrentAssignmentRecord;
 import static org.apache.kafka.coordinator.group.RecordHelpers.newCurrentAssignmentTombstoneRecord;
 import static org.apache.kafka.coordinator.group.RecordHelpers.newGroupEpochRecord;
@@ -88,10 +87,8 @@ import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignme
 import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentEpochTombstoneRecord;
 import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentRecord;
 import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentTombstoneRecord;
-import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 public class RecordHelpersTest {
@@ -865,144 +862,5 @@ public class RecordHelpersTest {
             partitionRacks.put(i, new HashSet<>(Arrays.asList("rack" + i % 4, "rack" + (i + 1) % 4)));
         }
         return partitionRacks;
-    }
-
-    /**
-     * Asserts whether the two provided lists of records are equal.
-     *
-     * @param expectedRecords   The expected list of records.
-     * @param actualRecords     The actual list of records.
-     */
-    public static void assertRecordsEquals(
-        List<Record> expectedRecords,
-        List<Record> actualRecords
-    ) {
-        try {
-            assertEquals(expectedRecords.size(), actualRecords.size());
-
-            for (int i = 0; i < expectedRecords.size(); i++) {
-                Record expectedRecord = expectedRecords.get(i);
-                Record actualRecord = actualRecords.get(i);
-                assertRecordEquals(expectedRecord, actualRecord);
-            }
-        } catch (AssertionFailedError e) {
-            assertionFailure()
-                .expected(expectedRecords)
-                .actual(actualRecords)
-                .buildAndThrow();
-        }
-    }
-
-    /**
-     * Asserts if the two provided records are equal.
-     *
-     * @param expectedRecord   The expected record.
-     * @param actualRecord     The actual record.
-     */
-    public static void assertRecordEquals(
-        Record expectedRecord,
-        Record actualRecord
-    ) {
-        try {
-            assertApiMessageAndVersionEquals(expectedRecord.key(), actualRecord.key());
-            assertApiMessageAndVersionEquals(expectedRecord.value(), actualRecord.value());
-        } catch (AssertionFailedError e) {
-            assertionFailure()
-                .expected(expectedRecord)
-                .actual(actualRecord)
-                .buildAndThrow();
-        }
-    }
-
-    private static void assertApiMessageAndVersionEquals(
-        ApiMessageAndVersion expected,
-        ApiMessageAndVersion actual
-    ) {
-        if (expected == actual) return;
-
-        assertEquals(expected.version(), actual.version());
-
-        if (actual.message() instanceof ConsumerGroupCurrentMemberAssignmentValue) {
-            // The order of the topics stored in ConsumerGroupCurrentMemberAssignmentValue is not
-            // always guaranteed. Therefore, we need a special comparator.
-            ConsumerGroupCurrentMemberAssignmentValue expectedValue =
-                (ConsumerGroupCurrentMemberAssignmentValue) expected.message();
-            ConsumerGroupCurrentMemberAssignmentValue actualValue =
-                (ConsumerGroupCurrentMemberAssignmentValue) actual.message();
-
-            assertEquals(expectedValue.memberEpoch(), actualValue.memberEpoch());
-            assertEquals(expectedValue.previousMemberEpoch(), actualValue.previousMemberEpoch());
-            assertEquals(expectedValue.targetMemberEpoch(), actualValue.targetMemberEpoch());
-            assertEquals(expectedValue.error(), actualValue.error());
-            assertEquals(expectedValue.metadataVersion(), actualValue.metadataVersion());
-            assertEquals(expectedValue.metadataBytes(), actualValue.metadataBytes());
-
-            // We transform those to Maps before comparing them.
-            assertEquals(fromTopicPartitions(expectedValue.assignedPartitions()),
-                fromTopicPartitions(actualValue.assignedPartitions()));
-            assertEquals(fromTopicPartitions(expectedValue.partitionsPendingRevocation()),
-                fromTopicPartitions(actualValue.partitionsPendingRevocation()));
-            assertEquals(fromTopicPartitions(expectedValue.partitionsPendingAssignment()),
-                fromTopicPartitions(actualValue.partitionsPendingAssignment()));
-        } else if (actual.message() instanceof ConsumerGroupPartitionMetadataValue) {
-            // The order of the racks stored in the PartitionMetadata of the ConsumerGroupPartitionMetadataValue
-            // is not always guaranteed. Therefore, we need a special comparator.
-            ConsumerGroupPartitionMetadataValue expectedValue =
-                (ConsumerGroupPartitionMetadataValue) expected.message();
-            ConsumerGroupPartitionMetadataValue actualValue =
-                (ConsumerGroupPartitionMetadataValue) actual.message();
-
-            List<ConsumerGroupPartitionMetadataValue.TopicMetadata> expectedTopicMetadataList =
-                expectedValue.topics();
-            List<ConsumerGroupPartitionMetadataValue.TopicMetadata> actualTopicMetadataList =
-                actualValue.topics();
-
-            if (expectedTopicMetadataList.size() != actualTopicMetadataList.size()) {
-                fail("Topic metadata lists have different sizes");
-            }
-
-            for (int i = 0; i < expectedTopicMetadataList.size(); i++) {
-                ConsumerGroupPartitionMetadataValue.TopicMetadata expectedTopicMetadata =
-                    expectedTopicMetadataList.get(i);
-                ConsumerGroupPartitionMetadataValue.TopicMetadata actualTopicMetadata =
-                    actualTopicMetadataList.get(i);
-
-                assertEquals(expectedTopicMetadata.topicId(), actualTopicMetadata.topicId());
-                assertEquals(expectedTopicMetadata.topicName(), actualTopicMetadata.topicName());
-                assertEquals(expectedTopicMetadata.numPartitions(), actualTopicMetadata.numPartitions());
-
-                List<ConsumerGroupPartitionMetadataValue.PartitionMetadata> expectedPartitionMetadataList =
-                    expectedTopicMetadata.partitionMetadata();
-                List<ConsumerGroupPartitionMetadataValue.PartitionMetadata> actualPartitionMetadataList =
-                    actualTopicMetadata.partitionMetadata();
-
-                // If the list is empty, rack information wasn't available for any replica of
-                // the partition and hence, the entry wasn't added to the record.
-                if (expectedPartitionMetadataList.size() != actualPartitionMetadataList.size()) {
-                    fail("Partition metadata lists have different sizes");
-                } else if (!expectedPartitionMetadataList.isEmpty() && !actualPartitionMetadataList.isEmpty()) {
-                    for (int j = 0; j < expectedTopicMetadataList.size(); j++) {
-                        ConsumerGroupPartitionMetadataValue.PartitionMetadata expectedPartitionMetadata =
-                            expectedPartitionMetadataList.get(j);
-                        ConsumerGroupPartitionMetadataValue.PartitionMetadata actualPartitionMetadata =
-                            actualPartitionMetadataList.get(j);
-
-                        assertEquals(expectedPartitionMetadata.partition(), actualPartitionMetadata.partition());
-                        assertUnorderedListEquals(expectedPartitionMetadata.racks(), actualPartitionMetadata.racks());
-                    }
-                }
-            }
-        } else {
-            assertEquals(expected.message(), actual.message());
-        }
-    }
-
-    private static Map<Uuid, Set<Integer>> fromTopicPartitions(
-        List<ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions> assignment
-    ) {
-        Map<Uuid, Set<Integer>> assignmentMap = new HashMap<>();
-        assignment.forEach(topicPartitions ->
-            assignmentMap.put(topicPartitions.topicId(), new HashSet<>(topicPartitions.partitions())));
-        return assignmentMap;
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
@@ -75,7 +75,7 @@ import java.util.stream.Stream;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkSortedAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkSortedTopicAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
-import static org.apache.kafka.coordinator.group.GroupMetadataManagerTest.assertUnorderedListEquals;
+import static org.apache.kafka.coordinator.group.GroupMetadataManagerTestContext.assertUnorderedListEquals;
 import static org.apache.kafka.coordinator.group.RecordHelpers.newCurrentAssignmentRecord;
 import static org.apache.kafka.coordinator.group.RecordHelpers.newCurrentAssignmentTombstoneRecord;
 import static org.apache.kafka.coordinator.group.RecordHelpers.newGroupEpochRecord;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/RecordHelpersTest.java
@@ -75,7 +75,7 @@ import java.util.stream.Stream;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkSortedAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkSortedTopicAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
-import static org.apache.kafka.coordinator.group.GroupMetadataManagerTestContext.assertUnorderedListEquals;
+import static org.apache.kafka.coordinator.group.Assertions.assertUnorderedListEquals;
 import static org.apache.kafka.coordinator.group.RecordHelpers.newCurrentAssignmentRecord;
 import static org.apache.kafka.coordinator.group.RecordHelpers.newCurrentAssignmentTombstoneRecord;
 import static org.apache.kafka.coordinator.group.RecordHelpers.newGroupEpochRecord;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupBuilder.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupBuilder.java
@@ -67,14 +67,14 @@ public class ConsumerGroupBuilder {
         List<Record> records = new ArrayList<>();
 
         // Add subscription records for members.
-        members.forEach((memberId, member) -> {
-            records.add(RecordHelpers.newMemberSubscriptionRecord(groupId, member));
-        });
+        members.forEach((memberId, member) ->
+            records.add(RecordHelpers.newMemberSubscriptionRecord(groupId, member))
+        );
 
         // Add subscription metadata.
         if (subscriptionMetadata == null) {
             subscriptionMetadata = new HashMap<>();
-            members.forEach((memberId, member) -> {
+            members.forEach((memberId, member) ->
                 member.subscribedTopicNames().forEach(topicName -> {
                     TopicImage topicImage = topicsImage.getTopic(topicName);
                     if (topicImage != null) {
@@ -85,8 +85,8 @@ public class ConsumerGroupBuilder {
                             Collections.emptyMap()
                         ));
                     }
-                });
-            });
+                })
+            );
         }
 
         if (!subscriptionMetadata.isEmpty()) {
@@ -97,17 +97,17 @@ public class ConsumerGroupBuilder {
         records.add(RecordHelpers.newGroupEpochRecord(groupId, groupEpoch));
 
         // Add target assignment records.
-        assignments.forEach((memberId, assignment) -> {
-            records.add(RecordHelpers.newTargetAssignmentRecord(groupId, memberId, assignment.partitions()));
-        });
+        assignments.forEach((memberId, assignment) ->
+            records.add(RecordHelpers.newTargetAssignmentRecord(groupId, memberId, assignment.partitions()))
+        );
 
         // Add target assignment epoch.
         records.add(RecordHelpers.newTargetAssignmentEpochRecord(groupId, assignmentEpoch));
 
         // Add current assignment records for members.
-        members.forEach((memberId, member) -> {
-            records.add(RecordHelpers.newCurrentAssignmentRecord(groupId, member));
-        });
+        members.forEach((memberId, member) ->
+            records.add(RecordHelpers.newCurrentAssignmentRecord(groupId, member))
+        );
 
         return records;
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupBuilder.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupBuilder.java
@@ -14,12 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.coordinator.group;
+package org.apache.kafka.coordinator.group.consumer;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.coordinator.group.consumer.Assignment;
-import org.apache.kafka.coordinator.group.consumer.ConsumerGroupMember;
-import org.apache.kafka.coordinator.group.consumer.TopicMetadata;
+import org.apache.kafka.coordinator.group.Record;
+import org.apache.kafka.coordinator.group.RecordHelpers;
 import org.apache.kafka.image.TopicImage;
 import org.apache.kafka.image.TopicsImage;
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupMemberTest.java
@@ -18,7 +18,7 @@ package org.apache.kafka.coordinator.group.consumer;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
-import org.apache.kafka.coordinator.group.GroupMetadataManagerTest;
+import org.apache.kafka.coordinator.group.MetadataImageBuilder;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
 import org.apache.kafka.image.MetadataImage;
@@ -320,7 +320,7 @@ public class ConsumerGroupMemberTest {
         Uuid topicId2 = Uuid.randomUuid();
         Uuid topicId3 = Uuid.randomUuid();
         Uuid topicId4 = Uuid.randomUuid();
-        MetadataImage metadataImage = new GroupMetadataManagerTest.MetadataImageBuilder()
+        MetadataImage metadataImage = new MetadataImageBuilder()
             .addTopic(topicId1, "topic1", 3)
             .addTopic(topicId2, "topic2", 3)
             .addTopic(topicId3, "topic3", 3)
@@ -398,7 +398,7 @@ public class ConsumerGroupMemberTest {
             .build();
 
         ConsumerGroupDescribeResponseData.Member consumerGroupDescribeMember = member.asConsumerGroupDescribeMember(
-            null, new GroupMetadataManagerTest.MetadataImageBuilder().build().topics());
+            null, new MetadataImageBuilder().build().topics());
 
         assertEquals(new ConsumerGroupDescribeResponseData.Assignment(), consumerGroupDescribeMember.targetAssignment());
     }
@@ -418,7 +418,7 @@ public class ConsumerGroupMemberTest {
             .setMemberId(memberId.toString())
             .setSubscribedTopicRegex("");
         ConsumerGroupDescribeResponseData.Member actual = member.asConsumerGroupDescribeMember(null,
-            new GroupMetadataManagerTest.MetadataImageBuilder()
+            new MetadataImageBuilder()
                 .addTopic(Uuid.randomUuid(), "foo", 3)
                 .build().topics()
         );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroupTest.java
@@ -25,7 +25,7 @@ import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.coordinator.group.Group;
-import org.apache.kafka.coordinator.group.GroupMetadataManagerTest;
+import org.apache.kafka.coordinator.group.MetadataImageBuilder;
 import org.apache.kafka.coordinator.group.OffsetAndMetadata;
 import org.apache.kafka.coordinator.group.OffsetExpirationCondition;
 import org.apache.kafka.coordinator.group.OffsetExpirationConditionImpl;
@@ -583,7 +583,7 @@ public class ConsumerGroupTest {
         Uuid barTopicId = Uuid.randomUuid();
         Uuid zarTopicId = Uuid.randomUuid();
 
-        MetadataImage image = new GroupMetadataManagerTest.MetadataImageBuilder()
+        MetadataImage image = new MetadataImageBuilder()
             .addTopic(fooTopicId, "foo", 1)
             .addTopic(barTopicId, "bar", 2)
             .addTopic(zarTopicId, "zar", 3)
@@ -921,7 +921,7 @@ public class ConsumerGroupTest {
         Uuid fooTopicId = Uuid.randomUuid();
         Uuid barTopicId = Uuid.randomUuid();
 
-        MetadataImage image = new GroupMetadataManagerTest.MetadataImageBuilder()
+        MetadataImage image = new MetadataImageBuilder()
             .addTopic(fooTopicId, "foo", 1)
             .addTopic(barTopicId, "bar", 2)
             .addRacks()
@@ -992,7 +992,7 @@ public class ConsumerGroupTest {
                     .setSubscribedTopicRegex("")
             ));
         ConsumerGroupDescribeResponseData.DescribedGroup actual = group.asDescribedGroup(1, "",
-            new GroupMetadataManagerTest.MetadataImageBuilder().build().topics());
+            new MetadataImageBuilder().build().topics());
 
         assertEquals(expected, actual);
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.apache.kafka.coordinator.group.Assertions.assertUnorderedListEquals;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
 import static org.apache.kafka.coordinator.group.RecordHelpers.newTargetAssignmentEpochRecord;
@@ -382,7 +383,7 @@ public class TargetAssignmentBuilderTest {
 
         assertEquals(3, result.records().size());
 
-        assertUnorderedList(Arrays.asList(
+        assertUnorderedListEquals(Arrays.asList(
             newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
                 mkTopicAssignment(fooTopicId, 4, 5, 6),
                 mkTopicAssignment(barTopicId, 4, 5, 6)
@@ -452,7 +453,7 @@ public class TargetAssignmentBuilderTest {
 
         assertEquals(4, result.records().size());
 
-        assertUnorderedList(Arrays.asList(
+        assertUnorderedListEquals(Arrays.asList(
             newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
                 mkTopicAssignment(fooTopicId, 1, 2),
                 mkTopicAssignment(barTopicId, 1, 2)
@@ -539,7 +540,7 @@ public class TargetAssignmentBuilderTest {
 
         assertEquals(4, result.records().size());
 
-        assertUnorderedList(Arrays.asList(
+        assertUnorderedListEquals(Arrays.asList(
             newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
                 mkTopicAssignment(fooTopicId, 1, 2),
                 mkTopicAssignment(barTopicId, 1, 2)
@@ -621,7 +622,7 @@ public class TargetAssignmentBuilderTest {
         assertEquals(3, result.records().size());
 
         // Member 1 has no record because its assignment did not change.
-        assertUnorderedList(Arrays.asList(
+        assertUnorderedListEquals(Arrays.asList(
             newTargetAssignmentRecord("my-group", "member-2", mkAssignment(
                 mkTopicAssignment(fooTopicId, 3, 4, 5),
                 mkTopicAssignment(barTopicId, 3, 4, 5)
@@ -695,7 +696,7 @@ public class TargetAssignmentBuilderTest {
 
         assertEquals(3, result.records().size());
 
-        assertUnorderedList(Arrays.asList(
+        assertUnorderedListEquals(Arrays.asList(
             newTargetAssignmentRecord("my-group", "member-1", mkAssignment(
                 mkTopicAssignment(fooTopicId, 1, 2, 3),
                 mkTopicAssignment(barTopicId, 1, 2, 3)
@@ -774,7 +775,7 @@ public class TargetAssignmentBuilderTest {
 
         assertEquals(2, result.records().size());
 
-        assertUnorderedList(Collections.singletonList(
+        assertUnorderedListEquals(Collections.singletonList(
             newTargetAssignmentRecord("my-group", "member-3-a", mkAssignment(
                 mkTopicAssignment(fooTopicId, 5, 6),
                 mkTopicAssignment(barTopicId, 5, 6)
@@ -802,12 +803,5 @@ public class TargetAssignmentBuilderTest {
         )));
 
         assertEquals(expectedAssignment, result.targetAssignment());
-    }
-    private static <T> void assertUnorderedList(
-        List<T> expected,
-        List<T> actual
-    ) {
-        assertEquals(expected.size(), actual.size());
-        assertEquals(new HashSet<>(expected), new HashSet<>(actual));
     }
 }


### PR DESCRIPTION
`GroupMetadataManagerTest` class got a little under control. We have too many things defined in it. As a first steps, this patch extracts all the inner classes. It also extracts all the helper methods. However, the logic is not changed at all.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
