### PR TITLE
KAFKA-14041: Avoid the keyword var for a variable declaration

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigTransformer.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigTransformer.java
@@ -81,11 +81,11 @@ public class ConfigTransformer {
         // Collect the variables from the given configs that need transformation
         for (Map.Entry<String, String> config : configs.entrySet()) {
             if (config.getValue() != null) {
-                List<ConfigVariable> vars = getVars(config.getValue(), DEFAULT_PATTERN);
-                for (ConfigVariable var : vars) {
-                    Map<String, Set<String>> keysByPath = keysByProvider.computeIfAbsent(var.providerName, k -> new HashMap<>());
-                    Set<String> keys = keysByPath.computeIfAbsent(var.path, k -> new HashSet<>());
-                    keys.add(var.variable);
+                List<ConfigVariable> configVars = getVars(config.getValue(), DEFAULT_PATTERN);
+                for (ConfigVariable configVar : configVars) {
+                    Map<String, Set<String>> keysByPath = keysByProvider.computeIfAbsent(configVar.providerName, k -> new HashMap<>());
+                    Set<String> keys = keysByPath.computeIfAbsent(configVar.path, k -> new HashSet<>());
+                    keys.add(configVar.variable);
                 }
             }
         }


### PR DESCRIPTION
This is simply a renaming refactor of some variables to avoid using the reserved word `var`. While it can be used as a variable name, it is unusual style to use a newly reserved word for a variable name.

There is no logical change as a result of this PR. There is no change to the tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
