### PR TITLE
KAFKA-16239: Clean up references to non-existent IntegrationTestHelper

### DIFF
--- a/checkstyle/import-control-core.xml
+++ b/checkstyle/import-control-core.xml
@@ -105,7 +105,6 @@
     <allow pkg="kafka.server"/>
     <allow pkg="kafka.zk" />
     <allow pkg="org.apache.kafka.clients.admin"/>
-    <allow pkg="integration.kafka.server" class="IntegrationTestHelper"/>
     <subpackage name="annotation">
       <allow pkg="kafka.test"/>
     </subpackage>

--- a/core/src/test/java/kafka/test/junit/README.md
+++ b/core/src/test/java/kafka/test/junit/README.md
@@ -107,7 +107,6 @@ previously garnered from the test hierarchy.
 
 * ClusterConfig: a mutable cluster configuration, includes cluster type, number of brokers, properties, etc
 * ClusterInstance: a shim to the underlying class that actually runs the cluster, provides access to things like SocketServers
-* IntegrationTestHelper: connection related functions taken from IntegrationTestHarness and BaseRequestTest
 
 In order to have one of these objects injected, simply add it as a parameter to your test class, `@BeforeEach` method, or test method.
 
@@ -115,23 +114,7 @@ In order to have one of these objects injected, simply add it as a parameter to 
 | --- | --- | --- | --- | --- |
 | ClusterConfig | yes | yes | yes* | Once in the test, changing config has no effect |
 | ClusterInstance | yes* | no | yes | Injectable at class level for convenience, can only be accessed inside test |
-| IntegrationTestHelper | yes | yes | yes | - |
 
-```scala
-@ExtendWith(value = Array(classOf[ClusterTestExtensions]))
-class SomeTestClass(helper: IntegrationTestHelper) {
- 
-  @BeforeEach
-  def setup(config: ClusterConfig): Unit = {
-    config.serverProperties().put("foo", "bar")
-  }
-
-  @ClusterTest
-  def testSomething(cluster: ClusterInstance): Unit = {
-    val topics = cluster.createAdminClient().listTopics()
-  }
-}
-```
 
 # Gotchas
 * Test methods annotated with JUnit's `@Test` will still be run, but no cluster will be started and no dependency 

--- a/core/src/test/java/kafka/test/junit/RaftClusterInvocationContext.java
+++ b/core/src/test/java/kafka/test/junit/RaftClusterInvocationContext.java
@@ -59,7 +59,6 @@ import java.util.stream.Stream;
  * <ul>
  *     <li>ClusterConfig (the same instance passed to the constructor)</li>
  *     <li>ClusterInstance (includes methods to expose underlying SocketServer-s)</li>
- *     <li>IntegrationTestHelper (helper methods)</li>
  * </ul>
  */
 public class RaftClusterInvocationContext implements TestTemplateInvocationContext {

--- a/core/src/test/java/kafka/test/junit/ZkClusterInvocationContext.java
+++ b/core/src/test/java/kafka/test/junit/ZkClusterInvocationContext.java
@@ -61,7 +61,6 @@ import java.util.stream.Stream;
  * <ul>
  *     <li>ClusterConfig (the same instance passed to the constructor)</li>
  *     <li>ClusterInstance (includes methods to expose underlying SocketServer-s)</li>
- *     <li>IntegrationTestHelper (helper methods)</li>
  * </ul>
  */
 public class ZkClusterInvocationContext implements TestTemplateInvocationContext {


### PR DESCRIPTION
Clean up references to non-existent IntegrationTestHelper