### PR TITLE
MINOR: log AssignReplicasToDirsRequest dispatch and handling

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -2147,9 +2147,7 @@ public class ReplicationControlManager {
         if (!leaderAndIsrUpdates.isEmpty()) {
             generateLeaderAndIsrUpdates("offline-dir-assignment", brokerId, NO_LEADER, records, leaderAndIsrUpdates.iterator());
         }
-        if (log.isInfoEnabled()) {
-            log.info("Handled AssignReplicasToDirRequest from broker {} with {} directories", brokerId, request.directories().size());
-        }
+        log.info("Handled AssignReplicasToDirRequest from broker {} with {} directories", brokerId, request.directories().size());
         return ControllerResult.of(records, response);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -2147,6 +2147,9 @@ public class ReplicationControlManager {
         if (!leaderAndIsrUpdates.isEmpty()) {
             generateLeaderAndIsrUpdates("offline-dir-assignment", brokerId, NO_LEADER, records, leaderAndIsrUpdates.iterator());
         }
+        if (log.isInfoEnabled()) {
+            log.info("Handled AssignReplicasToDirRequest from broker {} with {} directories", brokerId, request.directories().size());
+        }
         return ControllerResult.of(records, response);
     }
 

--- a/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
@@ -270,9 +270,7 @@ public class AssignmentsManager {
             }
             Map<TopicIdPartition, Uuid> assignment = inflight.entrySet().stream()
                     .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().dirId));
-            if (log.isInfoEnabled()) {
-                log.info("Dispatching {} assignments:  {}", assignment.size(), assignment);
-            }
+            log.info("Dispatching {} assignments: {}", assignment.size(), assignment);
             channelManager.sendRequest(new AssignReplicasToDirsRequest.Builder(
                     buildRequestData(brokerId, brokerEpochSupplier.get(), assignment)),
                     new AssignReplicasToDirsRequestCompletionHandler());

--- a/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
@@ -270,8 +270,8 @@ public class AssignmentsManager {
             }
             Map<TopicIdPartition, Uuid> assignment = inflight.entrySet().stream()
                     .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().dirId));
-            if (log.isDebugEnabled()) {
-                log.debug("Dispatching {} assignments:  {}", assignment.size(), assignment);
+            if (log.isInfoEnabled()) {
+                log.info("Dispatching {} assignments:  {}", assignment.size(), assignment);
             }
             channelManager.sendRequest(new AssignReplicasToDirsRequest.Builder(
                     buildRequestData(brokerId, brokerEpochSupplier.get(), assignment)),


### PR DESCRIPTION
It's hard to ascertain at the moment if AssignmentsManager dispatched an `AssignReplicasToDirsRequest` to the controller and if the controller handled it. This PR adds info logs for observability.