### PR TITLE
Fix: ignore heartbeat response if leaving

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -712,7 +712,7 @@ public class MembershipManagerImpl implements MembershipManager {
     @Override
     public void onHeartbeatRequestSkipped() {
         if (state == MemberState.LEAVING) {
-            log.warn("Heartbeat for leaving group could not be sent. Member {} with epoch {} will transition to {}.",
+            log.debug("Heartbeat for leaving group could not be sent. Member {} with epoch {} will transition to {}.",
                     memberId, memberEpoch, MemberState.UNSUBSCRIBED);
             transitionToUnsubscribed();
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -352,6 +352,11 @@ public class MembershipManagerImpl implements MembershipManager {
             );
             throw new IllegalArgumentException(errorMessage);
         }
+        if (state == MemberState.LEAVING) {
+            log.debug("Ignoring heartbeat response received from broker. Member {} with epoch {} is " +
+                    "already leaving the group.", memberId, memberEpoch);
+            return;
+        }
 
         // Update the group member id label in the client telemetry reporter if the member id has
         // changed. Initially the member id is empty, and it is updated when the member joins the
@@ -707,7 +712,7 @@ public class MembershipManagerImpl implements MembershipManager {
     @Override
     public void onHeartbeatRequestSkipped() {
         if (state == MemberState.LEAVING) {
-            log.debug("Heartbeat for leaving group could not be sent. Member {} with epoch {} will transition to {}.",
+            log.warn("Heartbeat for leaving group could not be sent. Member {} with epoch {} will transition to {}.",
                     memberId, memberEpoch, MemberState.UNSUBSCRIBED);
             transitionToUnsubscribed();
         }


### PR DESCRIPTION
When the consumer enters state LEAVING, it sets the epoch to the leave epoch, such as -1. When the timing is right, we may get a heartbeat response after entering the state LEAVING, which resets the epoch to the member epoch on the server. The result is that the consumer never leaves the group.

Seems like c6f4c604d8e50ad9e182eeb66f0d1650aa44f277 changed the timing inside the consumer to relatively frequently triggers this problem inside `DescribeConsumerGroupTest`.

We fix it by ignoring any heartbeat responses when we are in state LEAVING.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
