### PR TITLE
MINOR: Fix group metadata loading log

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -1634,9 +1634,9 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                                             ctx.transitionTo(CoordinatorState.ACTIVE);
                                             if (summary != null) {
                                                 runtimeMetrics.recordPartitionLoadSensor(summary.startTimeMs(), summary.endTimeMs());
-                                                log.info("Finished loading of metadata from {} in {}ms with epoch {} where {}ms " +
+                                                log.info("Finished loading of metadata from {} with epoch {} in {}ms where {}ms " +
                                                     "was spent in the scheduler. Loaded {} records which total to {} bytes.",
-                                                    summary.endTimeMs() - summary.startTimeMs(), tp, partitionEpoch,
+                                                    tp, partitionEpoch, summary.endTimeMs() - summary.startTimeMs(),
                                                     summary.schedulerQueueTimeMs(), summary.numRecords(), summary.numBytes()
                                                 );
                                             }


### PR DESCRIPTION
Spotted the following log: 
```
[2024-02-14 09:59:30,103] INFO [GroupCoordinator id=1] Finished loading of metadata from 39 in __consumer_offsets-4ms with epoch 2 where 39ms was spent in the scheduler. Loaded 0 records which total to 0 bytes. (org.apache.kafka.coordinator.group.runtime.CoordinatorRuntime)
```
The partition and the time are incorrect. This patch fixes it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
