### PR TITLE
MINOR: Fix KafkaAdminClientTest.testClientInstanceId

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -7258,7 +7258,7 @@ public class KafkaAdminClientTest {
                 request -> request instanceof GetTelemetrySubscriptionsRequest,
                 new GetTelemetrySubscriptionsResponse(responseData));
 
-            Uuid result = env.adminClient().clientInstanceId(Duration.ofMillis(10));
+            Uuid result = env.adminClient().clientInstanceId(Duration.ofSeconds(1));
             assertEquals(expected, result);
         }
     }


### PR DESCRIPTION
This patch tries to address the [flakiness](https://ge.apache.org/scans/tests?search.rootProjectNames=kafka&search.timeZoneId=Europe%2FZurich&tests.container=org.apache.kafka.clients.admin.KafkaAdminClientTest&tests.sortField=FLAKY&tests.test=testClientInstanceId()) of `KafkaAdminClientTest.testClientInstanceId`. The test fails with `org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment.`. I believe that it is because 10ms is not enough when our CI is busy. Let's try with 1s.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
