### PR TITLE
[KAFKA-16069]  Source Tasks re-transform records after Retriable exceptions

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTaskTest.java
@@ -691,7 +691,7 @@ public class AbstractWorkerSourceTaskTest {
         // aren't re-processed when we retry the call to sendRecords()
         verify(transformationChain, times(1)).apply(any(), eq(record1));
         verify(transformationChain, times(1)).apply(any(), eq(record2));
-        verify(transformationChain, times(2)).apply(any(), eq(record3));
+        verify(transformationChain, times(1)).apply(any(), eq(record3));
     }
 
     private void expectSendRecord(Headers headers) {


### PR DESCRIPTION
If producer.send() throws a retriableException, exactly one single record would've been transformed (but not delivered). 
Simply storing SourceRecord and ProducerRecord (obtained after transformations and conversion) of this iteration should be enough. 

In next "sendRecords()", this stored information is used to potentially skip re-transformation and re-conversion of this record. 

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
