### PR TITLE
KAFKA-16165: Fix invalid transition on poll timer expiration

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -188,18 +188,18 @@ public class HeartbeatRequestManager implements RequestManager {
     @Override
     public NetworkClientDelegate.PollResult poll(long currentTimeMs) {
         if (!coordinatorRequestManager.coordinator().isPresent() ||
-            membershipManager.shouldSkipHeartbeat() ||
-            pollTimer.isExpired()) {
+            membershipManager.shouldSkipHeartbeat()) {
             membershipManager.onHeartbeatRequestSkipped();
             return NetworkClientDelegate.PollResult.EMPTY;
         }
         pollTimer.update(currentTimeMs);
-        if (pollTimer.isExpired()) {
-            logger.warn("consumer poll timeout has expired. This means the time between subsequent calls to poll() " +
-                "was longer than the configured max.poll.interval.ms, which typically implies that " +
-                "the poll loop is spending too much time processing messages. You can address this " +
-                "either by increasing max.poll.interval.ms or by reducing the maximum size of batches " +
-                "returned in poll() with max.poll.records.");
+        if (pollTimer.isExpired() && !membershipManager.isLeavingGroup()) {
+            logger.warn("Consumer poll timeout has expired. This means the time between " +
+                "subsequent calls to poll() was longer than the configured max.poll.interval.ms, " +
+                "which typically implies that the poll loop is spending too much time processing " +
+                "messages. You can address this either by increasing max.poll.interval.ms or by " +
+                "reducing the maximum size of batches returned in poll() with max.poll.records.");
+
             // This should trigger a heartbeat with leave group epoch
             membershipManager.transitionToStale();
             NetworkClientDelegate.UnsentRequest request = makeHeartbeatRequest(currentTimeMs, true);
@@ -242,12 +242,16 @@ public class HeartbeatRequestManager implements RequestManager {
     }
 
     /**
-     * When consumer polls, we need to reset the pollTimer.  If the poll timer has expired, we rejoin when the user
-     * repoll the consumer.
+     * Reset the poll timer, indicating that the user has called consumer.poll(). If the member
+     * is in {@link MemberState#STALE} state due to expired poll timer, this will transition the
+     * member to {@link MemberState#JOINING}, so that it rejoins the group.
      */
     public void resetPollTimer(final long pollMs) {
         pollTimer.update(pollMs);
         pollTimer.reset(maxPollIntervalMs);
+        if (membershipManager.state() == MemberState.STALE) {
+            membershipManager.transitionToJoining();
+        }
     }
 
     private NetworkClientDelegate.UnsentRequest makeHeartbeatRequest(final long currentTimeMs,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MemberState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MemberState.java
@@ -107,7 +107,7 @@ public enum MemberState {
      * hasn't been a call to consumer.poll within the <code>max.poll.interval.ms</code>. While in
      * this state, the member will send a heartbeat to leave the group, invoke the
      * onPartitionsLost callback, and clear its assignments. The member will only transition
-     * out of this state when the user polls the consumer again. The member will then transition
+     * out of this state on the next application poll event. The member will then transition
      * to JOINING, to rejoin the group.
      */
     STALE;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MemberState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MemberState.java
@@ -103,9 +103,12 @@ public enum MemberState {
     FATAL,
 
     /**
-     * An intermediate state indicating the consumer is staled because the user has not polled the consumer
-     * within the <code>max.poll.interval.ms</code> time bound; therefore causing the member to leave the
-     * group. The member rejoins on the next poll.
+     * The member transitions to this state when the poll timer expires, indicating that there
+     * hasn't been a call to consumer.poll within the <code>max.poll.interval.ms</code>. While in
+     * this state, the member will send a heartbeat to leave the group, invoke the
+     * onPartitionsLost callback, and clear its assignments. The member will only transition
+     * out of this state when the user polls the consumer again. The member will then transition
+     * to JOINING, to rejoin the group.
      */
     STALE;
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
@@ -64,13 +64,6 @@ public interface MembershipManager extends RequestManager {
     MemberState state();
 
     /**
-     * @return True if the poll timer expired, indicating that there hasn't been a call to
-     * consumer poll within the max poll interval. In this case, the member will proactively
-     * leave the group, and rejoin on the next call to poll.
-     */
-    boolean isStale();
-
-    /**
      * Update member info and transition member state based on a successful heartbeat response.
      *
      * @param response Heartbeat response to extract member info and errors from.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
@@ -64,9 +64,11 @@ public interface MembershipManager extends RequestManager {
     MemberState state();
 
     /**
-     * @return True if the member is staled due to expired poll timer.
+     * @return True if the poll timer expired, indicating that there hasn't been a call to
+     * consumer poll within the max poll interval. In this case, the member will proactively
+     * leave the group, and rejoin on the next call to poll.
      */
-    boolean isStaled();
+    boolean isStale();
 
     /**
      * Update member info and transition member state based on a successful heartbeat response.
@@ -174,4 +176,10 @@ public interface MembershipManager extends RequestManager {
      * transitions of new data received from the server, as defined in {@link MemberStateListener}.
      */
     void registerStateListener(MemberStateListener listener);
+
+    /**
+     * @return True if the member is preparing to leave the group (waiting for callbacks), or
+     * leaving (sending last heartbeat).
+     */
+    boolean isLeavingGroup();
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -336,16 +336,6 @@ public class MembershipManagerImpl implements MembershipManager {
     }
 
     /**
-     * @return True if there hasn't been a call to consumer.poll() withing the max.poll.interval.
-     * In that case, it is expected that the member will leave the group and rejoin on the next
-     * call to consumer.poll().
-     */
-    @Override
-    public boolean isStale() {
-        return state == MemberState.STALE;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -746,7 +746,7 @@ public class MembershipManagerImpl implements MembershipManager {
 
     /**
      * Sets the epoch to the leave group epoch and clears the assignments. The member will rejoin with
-     * the existing subscriptions on the next time user polls.
+     * the existing subscriptions after the next application poll event.
      */
     @Override
     public void transitionToStale() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
@@ -1611,6 +1611,61 @@ public class MembershipManagerImplTest {
         testOnPartitionsLost(Optional.of(new KafkaException("Intentional error for test")));
     }
 
+    @Test
+    public void testTransitionToStaleWhileReconciling() {
+        MembershipManagerImpl membershipManager = memberJoinWithAssignment();
+        clearInvocations(subscriptionState);
+        assertEquals(MemberState.RECONCILING, membershipManager.state());
+
+        membershipManager.transitionToStale();
+        assertStaleMemberClearsAssignmentsAndLeaves(membershipManager);
+    }
+
+    @Test
+    public void testTransitionToStaleWhileJoining() {
+        MembershipManagerImpl membershipManager = createMembershipManagerJoiningGroup();
+        doNothing().when(subscriptionState).assignFromSubscribed(any());
+        assertEquals(MemberState.JOINING, membershipManager.state());
+
+        membershipManager.transitionToStale();
+        assertStaleMemberClearsAssignmentsAndLeaves(membershipManager);
+    }
+
+    @Test
+    public void testTransitionToStaleWhileStable() {
+        MembershipManagerImpl membershipManager = createMembershipManagerJoiningGroup();
+        ConsumerGroupHeartbeatResponse heartbeatResponse = createConsumerGroupHeartbeatResponse(null);
+        membershipManager.onHeartbeatResponseReceived(heartbeatResponse.data());
+        doNothing().when(subscriptionState).assignFromSubscribed(any());
+        assertEquals(MemberState.STABLE, membershipManager.state());
+
+        membershipManager.transitionToStale();
+        assertStaleMemberClearsAssignmentsAndLeaves(membershipManager);
+    }
+
+    @Test
+    public void testTransitionToStaleWhileAcknowledging() {
+        MembershipManagerImpl membershipManager = mockJoinAndReceiveAssignment(true);
+        doNothing().when(subscriptionState).assignFromSubscribed(any());
+        clearInvocations(subscriptionState);
+        assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
+
+        membershipManager.transitionToStale();
+        assertStaleMemberClearsAssignmentsAndLeaves(membershipManager);
+    }
+
+    @Test
+    public void testStaleMemberDoesNotSendHeartbeatAndAllowsTransitionToJoiningToRecover() {
+        MembershipManagerImpl membershipManager = createMemberInStableState();
+        doNothing().when(subscriptionState).assignFromSubscribed(any());
+        membershipManager.transitionToStale();
+        assertTrue(membershipManager.shouldSkipHeartbeat(), "Stale member should not send " +
+            "heartbeats");
+        // Check that a transition to joining is allowed, which is what is expected to happen
+        // when the poll timer is reset.
+        membershipManager.transitionToJoining();
+    }
+
     private void mockPartitionOwnedAndNewPartitionAdded(String topicName,
                                                         int partitionOwned,
                                                         int partitionAdded,
@@ -1756,21 +1811,26 @@ public class MembershipManagerImplTest {
         verify(subscriptionState, never()).rebalanceListener();
     }
 
-    @Test
-    public void testTransitionToStaled() {
-        MembershipManager membershipManager = memberJoinWithAssignment("topic", Uuid.randomUuid());
-        membershipManager.transitionToStale();
+    private void assertStaleMemberClearsAssignmentsAndLeaves(MembershipManagerImpl membershipManager) {
+        assertEquals(MemberState.STALE, membershipManager.state());
+
+        // Should clear subscriptions, current assignments, and reset epoch to leave the group
+        verify(subscriptionState).assignFromSubscribed(Collections.emptySet());
+        assertTrue(membershipManager.currentAssignment().isEmpty());
+        assertTrue(membershipManager.topicsAwaitingReconciliation().isEmpty());
         assertEquals(LEAVE_GROUP_MEMBER_EPOCH, membershipManager.memberEpoch());
     }
 
     @Test
-    public void testHeartbeatSentOnStaledMember() {
+    public void testHeartbeatSentOnStaleMember() {
         MembershipManagerImpl membershipManager = createMemberInStableState();
         subscriptionState.subscribe(Collections.singleton("topic"), Optional.empty());
         subscriptionState.assignFromSubscribed(Collections.singleton(new TopicPartition("topic", 0)));
         membershipManager.transitionToStale();
         membershipManager.onHeartbeatRequestSent();
-        assertEquals(MemberState.JOINING, membershipManager.state());
+        // Member should remain in STALE state. Only when the poll timer is reset the member will
+        // transition to JOINING.
+        assertEquals(MemberState.STALE, membershipManager.state());
         assertTrue(membershipManager.currentAssignment().isEmpty());
         assertTrue(subscriptionState.assignedPartitions().isEmpty());
     }
@@ -2157,10 +2217,11 @@ public class MembershipManagerImplTest {
                 ));
     }
 
-    private MembershipManager memberJoinWithAssignment(String topicName, Uuid topicId) {
+    private MembershipManagerImpl memberJoinWithAssignment() {
+        Uuid topicId = Uuid.randomUuid();
         MembershipManagerImpl membershipManager = mockJoinAndReceiveAssignment(true);
         membershipManager.onHeartbeatRequestSent();
-        when(metadata.topicNames()).thenReturn(Collections.singletonMap(topicId, topicName));
+        when(metadata.topicNames()).thenReturn(Collections.singletonMap(topicId, "topic"));
         receiveAssignment(topicId, Collections.singletonList(0), membershipManager);
         membershipManager.onHeartbeatRequestSent();
         assertFalse(membershipManager.currentAssignment().isEmpty());


### PR DESCRIPTION
This fixes an invalid transition (leaving->stale) that was discovered in the system tests. The underlying issue was that the poll timer expiration logic was blindly forcing a transition to stale and sending a leave group, without considering that the member could be already leaving. 
The fix included in this PR ensures that the poll timer expiration logic, whose purpose is to leave the group, is only applied if the member is not already leaving. Note that it also fixes the transition out of the STALE state, that should only happen when the poll timer is reset. 

As a result of this changes:
- If the poll timer expires while the member is not leaving, the poll timer expiration logic is applied: it will transition to stale, send a leave group, and remain in STALE state until the timer is reset. At that point the member will transition to JOINING to rejoin the group. 
- If the poll timer expires while the member is already leaving, the poll timer expiration logic does not apply, and just lets the HB continue. Not that this would be the case of member in PREPARE_LEAVING waiting for callbacks to complete (needs to continue sending HB), or LEAVING (needs to send the last HB to leave).