### PR TITLE
KAFKA-16259 Immutable MetadataCache to improve client performance

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -75,7 +75,7 @@ public class Metadata implements Closeable {
     private KafkaException fatalException;
     private Set<String> invalidTopics;
     private Set<String> unauthorizedTopics;
-    private MetadataCache cache = MetadataCache.empty();
+    private volatile MetadataCache cache = MetadataCache.empty();
     private boolean needFullUpdate;
     private boolean needPartialUpdate;
     private long equivalentResponseCount;
@@ -123,7 +123,7 @@ public class Metadata implements Closeable {
     /**
      * Get the current cluster info without blocking
      */
-    public synchronized Cluster fetch() {
+    public Cluster fetch() {
         return cache.cluster();
     }
 
@@ -278,7 +278,7 @@ public class Metadata implements Closeable {
     /**
      * @return a mapping from topic names to topic IDs for all topics with valid IDs in the cache
      */
-    public synchronized Map<String, Uuid> topicIds() {
+    public Map<String, Uuid> topicIds() {
         return cache.topicIds();
     }
 


### PR DESCRIPTION
*More detailed description of your change,
current MetadataCache is partially (but not fully) immutable, thus read/write requires synchronization and led to high produce latency with large number of topics in a kafka cluster
This change improves performance of metadata cache read operation of native kafka producer with copy-on-write strategy

What is copy-on-write strategy
It’s a solution to reduce synchronized lock contention by making the object immutable, and always create a new instance when updating, but since the object is immutable, read operation will be free from waiting, thus produce latency reduced significantly

Besides performance, it can also make the metadata cache immutable from unexpected modification, reduce occurrence of code bugs due to incorrect synchronization 

*Summary of testing strategy (including rationale)
Add unit test to cover concurrent read/write
Run in production, with large scale for over 3months 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
