### PR TITLE
KAFKA-14226: [connect:transform] Introduce support for nested structures

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -640,6 +640,7 @@
       <allow class="org.apache.kafka.connect.source.SourceRecord" />
       <allow class="org.apache.kafka.connect.sink.SinkRecord" />
       <allow pkg="org.apache.kafka.connect.transforms.util" />
+      <allow pkg="org.apache.kafka.connect.transforms.field" />
     </subpackage>
   </subpackage>
 

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/FieldSyntaxVersion.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/FieldSyntaxVersion.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.Utils;
+
+import java.util.Locale;
+
+/**
+ * Defines semantics of field paths by versioning.
+ *
+ * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-821%3A+Connect+Transforms+support+for+nested+structures">KIP-821</a>
+ * @see SingleFieldPath
+ * @see MultiFieldPaths
+ */
+public enum FieldSyntaxVersion {
+    /**
+     * No support to access nested fields, only attributes at the root of data structure.
+     * Backward compatible (i.e. before KIP-821).
+     */
+    V1,
+    /**
+     * Support to access nested fields using dotted notation
+     * (with backtick pairs to wrap field names that include dots).
+     */
+    V2;
+
+    public static final String FIELD_SYNTAX_VERSION_CONFIG = "field.syntax.version";
+    public static final String FIELD_SYNTAX_VERSION_DOC =
+            "Defines the version of the syntax to access fields. "
+                    + "If set to `V1`, then the field paths are limited to access the elements at the root level of the struct or map. "
+                    + "If set to `V2`, the syntax will support accessing nested elements. "
+                    + "To access nested elements, dotted notation is used. "
+                    + "If dots are already included in the field name, "
+                    + "then backtick pairs can be used to wrap field names containing dots. "
+                    + "E.g. to access the subfield `baz` from a field named \"foo.bar\" in a struct/map "
+                    + "the following format can be used to access its elements: \"`foo.bar`.baz\".";
+
+    public static final String FIELD_SYNTAX_VERSION_DEFAULT_VALUE = V1.name();
+
+    public static ConfigDef appendConfig(ConfigDef configDef) {
+        return configDef
+                .define(
+                        FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG,
+                        ConfigDef.Type.STRING,
+                        FieldSyntaxVersion.FIELD_SYNTAX_VERSION_DEFAULT_VALUE,
+                        ConfigDef.CaseInsensitiveValidString.in(Utils.enumOptions(FieldSyntaxVersion.class)),
+                        ConfigDef.Importance.HIGH,
+                        FieldSyntaxVersion.FIELD_SYNTAX_VERSION_DOC);
+    }
+
+    public static FieldSyntaxVersion fromConfig(AbstractConfig config) {
+        final String fieldSyntaxVersion = config.getString(FIELD_SYNTAX_VERSION_CONFIG);
+        try {
+            return FieldSyntaxVersion.valueOf(fieldSyntaxVersion.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new ConfigException(FIELD_SYNTAX_VERSION_CONFIG, fieldSyntaxVersion, "Unrecognized field syntax version");
+        }
+    }
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/MapValueUpdater.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/MapValueUpdater.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import java.util.Map;
+
+/**
+ * Function to update a schemaless Map based on Field Paths.
+ */
+@FunctionalInterface
+public interface MapValueUpdater {
+
+    /**
+     * @param originalParent original data object
+     * @param updatedParent data object being updated
+     * @param fieldPath if match happened, null if applies to other fields
+     * @param fieldName field name
+     */
+    void apply(
+            Map<String, Object> originalParent,
+            Map<String, Object> updatedParent,
+            SingleFieldPath fieldPath,
+            String fieldName
+    );
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/MultiFieldPaths.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/MultiFieldPaths.java
@@ -1,0 +1,581 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Multiple field paths to access data objects ({@code Struct} or {@code Map}) efficiently,
+ * instead of multiple individual {@link SingleFieldPath single-field paths}.
+ *
+ * <p>If the SMT requires accessing a single field on the same data object,
+ * use {@link SingleFieldPath} instead.
+ *
+ * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-821%3A+Connect+Transforms+support+for+nested+structures">KIP-821</a>
+ * @see SingleFieldPath
+ * @see FieldSyntaxVersion
+ */
+public class MultiFieldPaths {
+    final Trie trie = new Trie();
+
+    MultiFieldPaths(Set<SingleFieldPath> paths) {
+        paths.forEach(trie::insert);
+    }
+
+    public static MultiFieldPaths of(List<String> fields, FieldSyntaxVersion syntaxVersion) {
+        return new MultiFieldPaths(fields.stream()
+            .map(f -> new SingleFieldPath(f, syntaxVersion))
+            .collect(Collectors.toSet()));
+    }
+
+    /**
+     * Find values at the field paths
+     *
+     * @param struct data value
+     * @return map of field paths and field/values
+     */
+    public Map<SingleFieldPath, Map.Entry<Field, Object>> fieldAndValuesFrom(Struct struct) {
+        if (trie.isEmpty()) return Collections.emptyMap();
+        return findFieldAndValues(struct, trie.root, new HashMap<>());
+    }
+
+    private Map<SingleFieldPath, Map.Entry<Field, Object>> findFieldAndValues(
+        Struct originalValue,
+        TrieNode trieAt,
+        Map<SingleFieldPath, Map.Entry<Field, Object>> fieldAndValueMap
+    ) {
+        for (Map.Entry<String, TrieNode> step : trieAt.steps().entrySet()) {
+            Field field = originalValue.schema().field(step.getKey());
+            if (step.getValue().isLeaf()) {
+                Map.Entry<Field, Object> fieldAndValue =
+                    field != null
+                        ? new AbstractMap.SimpleImmutableEntry<>(field, originalValue.get(field))
+                        : null;
+                fieldAndValueMap.put(step.getValue().path, fieldAndValue);
+            } else {
+                if (field.schema().type() == Type.STRUCT) {
+                    findFieldAndValues(
+                        originalValue.getStruct(field.name()),
+                        step.getValue(),
+                        fieldAndValueMap
+                    );
+                }
+            }
+        }
+        return fieldAndValueMap;
+    }
+
+    /**
+     * Find values at the field paths
+     *
+     * @param value data value
+     * @return map of field paths and field/values
+     */
+    public Map<SingleFieldPath, Map.Entry<String, Object>> fieldAndValuesFrom(Map<String, Object> value) {
+        if (trie.isEmpty()) return Collections.emptyMap();
+        return findFieldAndValues(value, trie.root, new HashMap<>());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<SingleFieldPath, Map.Entry<String, Object>> findFieldAndValues(
+        Map<String, Object> value,
+        TrieNode trieAt,
+        Map<SingleFieldPath, Map.Entry<String, Object>> fieldAndValueMap
+    ) {
+        for (Map.Entry<String, TrieNode> step : trieAt.steps().entrySet()) {
+            Object fieldValue = value.get(step.getKey());
+            if (step.getValue().isLeaf()) {
+                fieldAndValueMap.put(
+                    step.getValue().path,
+                    new AbstractMap.SimpleImmutableEntry<>(step.getKey(), fieldValue)
+                );
+            } else {
+                if (fieldValue instanceof Map) {
+                    findFieldAndValues(
+                        (Map<String, Object>) fieldValue,
+                        step.getValue(),
+                        fieldAndValueMap
+                    );
+                }
+            }
+        }
+        return fieldAndValueMap;
+    }
+
+    /**
+     * Access {@code Map} fields and apply functions to update field values.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields keep values from original struct.
+     *
+     * @param originalValue schema-based data value
+     * @param whenFound     function to apply when current path(s) is/are found
+     * @return updated data value
+     */
+    public Map<String, Object> updateValuesFrom(
+        Map<String, Object> originalValue,
+        MapValueUpdater whenFound
+    ) {
+        if (trie.isEmpty()) return originalValue;
+        return updateValues(originalValue, trie.root, whenFound,
+            (originalParent, updatedParent, fieldPath, fieldName) -> {
+                // filter out
+            },
+            (originalParent, updatedParent, fieldPath, fieldName) ->
+                updatedParent.put(fieldName, originalParent.get(fieldName)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> updateValues(
+        Map<String, Object> originalValue,
+        TrieNode trieAt,
+        MapValueUpdater matching,
+        MapValueUpdater notFound,
+        MapValueUpdater others
+    ) {
+        if (originalValue == null) return null;
+        Map<String, Object> updatedValue = new HashMap<>(originalValue.size());
+        Map<String, TrieNode> notFoundFields = new HashMap<>(trieAt.steps);
+        for (Map.Entry<String, Object> entry : originalValue.entrySet()) {
+            String fieldName = entry.getKey();
+            Object fieldValue = entry.getValue();
+            if (!trieAt.isEmpty()) {
+                if (trieAt.contains(fieldName)) {
+                    notFoundFields.remove(fieldName);
+                    TrieNode trieValue = trieAt.get(fieldName);
+                    if (trieValue.isLeaf()) {
+                        matching.apply(originalValue, updatedValue, trieValue.path, fieldName);
+                    } else {
+                        if (fieldValue instanceof Map) {
+                            Map<String, Object> updatedField = updateValues(
+                                (Map<String, Object>) fieldValue,
+                                trieValue,
+                                matching, notFound, others);
+                            updatedValue.put(fieldName, updatedField);
+                        } else {
+                            // add back to not found and apply others, as only leaf values are updated
+                            notFoundFields.put(fieldName, trieValue);
+                            others.apply(originalValue, updatedValue, null, fieldName);
+                        }
+                    }
+                } else {
+                    others.apply(originalValue, updatedValue, null, fieldName);
+                }
+            } else {
+                others.apply(originalValue, updatedValue, null, fieldName);
+            }
+        }
+
+        for (Map.Entry<String, TrieNode> entry : notFoundFields.entrySet()) {
+            String fieldName = entry.getKey();
+            TrieNode trieValue = entry.getValue();
+            if (trieValue.isLeaf()) {
+                notFound.apply(originalValue, updatedValue, trieValue.path, fieldName);
+            } else {
+                Map<String, Object> updatedField = updateValues(
+                    new HashMap<>(),
+                    trieValue,
+                    matching, notFound, others);
+                updatedValue.put(fieldName, updatedField);
+            }
+        }
+
+        return updatedValue;
+    }
+
+    /**
+     * Access {@code Struct} fields and apply functions to update field values.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields keep values from original struct.
+     *
+     * @param originalSchema original struct schema
+     * @param originalValue  schema-based data value
+     * @param updatedSchema  updated struct schema
+     * @param whenFound      function to apply when current path(s) is/are found
+     * @return updated data value
+     */
+    public Struct updateValuesFrom(
+        Schema originalSchema,
+        Struct originalValue,
+        Schema updatedSchema,
+        StructValueUpdater whenFound
+    ) {
+        if (trie.isEmpty()) return originalValue;
+        return updateValues(originalSchema, originalValue, updatedSchema, trie.root, whenFound,
+            (originalParent, originalField, updatedParent, updatedField, fieldPath) -> {
+                // filter out
+            },
+            (originalParent, originalField, updatedParent, nullUpdatedField, nullFieldPath) ->
+                updatedParent.put(originalField.name(), originalParent.get(originalField)));
+    }
+
+    private Struct updateValues(
+        Schema originalSchema,
+        Struct originalValue,
+        Schema updateSchema,
+        TrieNode trieAt,
+        StructValueUpdater matching,
+        StructValueUpdater notFound,
+        StructValueUpdater others
+    ) {
+        Struct updatedValue = new Struct(updateSchema);
+        Map<String, TrieNode> notFoundFields = trieAt.steps();
+        for (Field field : originalSchema.fields()) {
+            if (!trieAt.isEmpty()) {
+                if (trieAt.contains(field.name())) {
+                    notFoundFields.remove(field.name());
+                    final TrieNode trieValue = trieAt.get(field.name());
+                    if (trieValue.isLeaf()) {
+                        matching.apply(
+                            originalValue,
+                            originalSchema.field(field.name()),
+                            updatedValue,
+                            updateSchema.field(field.name()),
+                            trieValue.path
+                        );
+                    } else {
+                        if (field.schema().type() == Type.STRUCT) {
+                            Struct fieldValue = updateValues(
+                                field.schema(),
+                                originalValue.getStruct(field.name()),
+                                updateSchema.field(field.name()).schema(),
+                                trieValue,
+                                matching, notFound, others
+                            );
+                            updatedValue.put(updateSchema.field(field.name()), fieldValue);
+                        } else {
+                            // add back to not found and apply others, as only leaf values are updated
+                            notFoundFields.put(field.name(), trieValue);
+                            others.apply(originalValue, field, updatedValue, null, null);
+                        }
+                    }
+                } else {
+                    others.apply(originalValue, field, updatedValue, null, null);
+                }
+            } else {
+                others.apply(originalValue, field, updatedValue, null, null);
+            }
+        }
+        for (Map.Entry<String, TrieNode> entry : notFoundFields.entrySet()) {
+            String fieldName = entry.getKey();
+            TrieNode trieValue = entry.getValue();
+            if (trieValue.isLeaf()) {
+                notFound.apply(
+                    originalValue,
+                    null,
+                    updatedValue,
+                    updateSchema.field(fieldName),
+                    trieValue.path
+                );
+            } else {
+                Struct fieldValue = updateValues(
+                    SchemaBuilder.struct().build(),
+                    null,
+                    updateSchema.field(fieldName).schema(),
+                    trieValue,
+                    matching, notFound, others
+                );
+                updatedValue.put(updateSchema.field(fieldName), fieldValue);
+            }
+        }
+        return updatedValue;
+    }
+
+    /**
+     * Prepares a new schema based on an original one, and applies an update function
+     * when the current path(s) is found.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields are copied from original schema.
+     *
+     * <p>A copy of the {@code Schema} is used as a base for the updated schema.
+     *
+     * @param originalSchema baseline schema
+     * @param whenFound      function to apply when current path(s) is/are found
+     * @return an updated schema. Resulting schemas are usually cached for further access
+     */
+    public Schema updateSchemaFrom(
+        Schema originalSchema,
+        StructSchemaUpdater whenFound
+    ) {
+        if (trie.isEmpty()) return originalSchema;
+        SchemaBuilder updated = SchemaUtil.copySchemaBasics(originalSchema, SchemaBuilder.struct());
+        return updateSchema(originalSchema, updated, trie.root, whenFound,
+            (schemaBuilder, field, fieldPath) -> { /* ignore */ },
+            (schemaBuilder, field, fieldPath) -> schemaBuilder.field(field.name(), field.schema()));
+    }
+
+
+    /**
+     * Prepares a new schema based on an original one, and applies an update function
+     * when the current path(s) is found.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields are copied from original schema.
+     *
+     * @param originalSchema        baseline schema
+     * @param baselineSchemaBuilder baseline schema build, if changes to the baseline
+     *                              are required before copying original
+     * @param whenFound             function to apply when current path(s) is/are found.
+     * @return an updated schema. Resulting schemas are usually cached for further access.
+     */
+    public Schema updateSchemaFrom(
+        Schema originalSchema,
+        SchemaBuilder baselineSchemaBuilder,
+        StructSchemaUpdater whenFound
+    ) {
+        if (trie.isEmpty()) return originalSchema;
+        return updateSchema(originalSchema, baselineSchemaBuilder, trie.root, whenFound,
+            (schemaBuilder, field, fieldPath) -> { /* ignore */ },
+            (schemaBuilder, field, fieldPath) -> schemaBuilder.field(field.name(), field.schema()));
+    }
+
+    private Schema updateSchema(
+        Schema originalSchema,
+        SchemaBuilder baseSchemaBuilder,
+        TrieNode trieAt,
+        StructSchemaUpdater whenFound,
+        StructSchemaUpdater whenNotFound,
+        StructSchemaUpdater toOtherFields
+    ) {
+        if (originalSchema.isOptional()) {
+            baseSchemaBuilder.optional();
+        }
+        Map<String, TrieNode> notFoundFields = trieAt.steps();
+        for (Field field : originalSchema.fields()) {
+            if (!trieAt.isEmpty()) {
+                if (!trieAt.contains(field.name())) {
+                    toOtherFields.apply(baseSchemaBuilder, field, null);
+                } else {
+                    notFoundFields.remove(field.name());
+                    TrieNode trieNode = trieAt.get(field.name());
+                    if (trieNode.isLeaf()) {
+                        whenFound.apply(baseSchemaBuilder, field, trieNode.path);
+                    } else {
+                        if (field.schema().type() == Type.STRUCT) {
+                            Schema fieldSchema = updateSchema(
+                                field.schema(),
+                                SchemaBuilder.struct(),
+                                trieNode,
+                                whenFound, whenNotFound, toOtherFields);
+                            baseSchemaBuilder.field(field.name(), fieldSchema);
+                        } else {
+                            toOtherFields.apply(baseSchemaBuilder, field, null);
+                        }
+                    }
+                }
+            } else {
+                toOtherFields.apply(baseSchemaBuilder, field, null);
+            }
+        }
+        for (Map.Entry<String, TrieNode> entry : notFoundFields.entrySet()) {
+            String fieldName = entry.getKey();
+            TrieNode trieValue = entry.getValue();
+            if (trieValue.isLeaf()) {
+                whenNotFound.apply(baseSchemaBuilder, null, trieValue.path);
+            } else {
+                Schema fieldSchema = updateSchema(
+                    SchemaBuilder.struct().build(),
+                    SchemaBuilder.struct(),
+                    trieValue,
+                    whenFound, whenNotFound, toOtherFields);
+                baseSchemaBuilder.field(fieldName, fieldSchema);
+            }
+        }
+        return baseSchemaBuilder.build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MultiFieldPaths that = (MultiFieldPaths) o;
+        return Objects.equals(trie, that.trie);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(trie);
+    }
+
+    @Override
+    public String toString() {
+        return "FieldPaths(trie = " + trie + ")";
+    }
+
+    // Invariants:
+    // - Trie values contain either a nested trie or a field path when it is a leaf.
+    // - A trie flattens overlapping paths (e.g. `foo` and `foo.bar` in V2, only `foo.bar` would be kept)
+    static class Trie {
+        TrieNode root;
+
+        Trie() {
+            root = new TrieNode();
+        }
+
+
+        public void insert(SingleFieldPath path) {
+            TrieNode current = root;
+
+            for (String step : path.stepsWithoutLast()) {
+                if (!current.contains(step)) {
+                    current.addStep(step);
+                }
+
+                current = current.get(step);
+            }
+
+            final String step = path.lastStep();
+            if (!current.contains(step)) {
+                current.addLeaf(step, path);
+            }
+        }
+
+        public boolean isEmpty() {
+            return root.isEmpty();
+        }
+
+        public Optional<TrieNode> find(String step) {
+            return root.find(step);
+        }
+
+        public int size() {
+            if (root.isEmpty()) return 0;
+            return root.size();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Trie trie = (Trie) o;
+            return Objects.equals(root, trie.root);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(root);
+        }
+
+        @Override
+        public String toString() {
+            return "Trie(" +
+                "root = " + root +
+                ')';
+        }
+    }
+
+    static class TrieNode {
+        Map<String, TrieNode> steps = new HashMap<>();
+        SingleFieldPath path;
+
+        TrieNode() {
+        }
+
+        private TrieNode(SingleFieldPath path) {
+            this.path = path;
+        }
+
+        public boolean contains(String step) {
+            return steps.containsKey(step);
+        }
+
+        public void addStep(String step) {
+            if (path != null) path = null;
+            steps.put(step, new TrieNode());
+        }
+
+        public void addLeaf(String step, SingleFieldPath path) {
+            if (this.path != null) this.path = null;
+            steps.put(step, new TrieNode(path));
+        }
+
+        public TrieNode get(String step) {
+            return steps.get(step);
+        }
+
+        public Optional<TrieNode> find(String step) {
+            return Optional.ofNullable(steps.get(step));
+        }
+
+        public boolean isEmpty() {
+            return steps.isEmpty() && path == null;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TrieNode trieNode = (TrieNode) o;
+            return Objects.equals(steps, trieNode.steps) && Objects.equals(path, trieNode.path);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(steps, path);
+        }
+
+        @Override
+        public String toString() {
+            return "TrieNode(" +
+                "steps = " + steps +
+                (path != null ? (", path = " + path) : "") +
+                ')';
+        }
+
+        public boolean isLeaf() {
+            return path != null;
+        }
+
+        public Map<String, TrieNode> steps() {
+            return new HashMap<>(steps);
+        }
+
+        public int size() {
+            if (isLeaf()) return 1;
+            int size = 0;
+            for (TrieNode child : steps.values()) {
+                size = size + child.size();
+            }
+            return size;
+        }
+    }
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -1,0 +1,507 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A SingleFieldPath is composed of one or more field names, known as path steps,
+ * to access values within a data object (either {@code Struct} or {@code Map<String, Object>}).
+ *
+ * <p>If the SMT requires accessing multiple fields on the same data object, use {@link MultiFieldPaths} instead.
+ *
+ * <p>The field path semantics are defined by the {@link FieldSyntaxVersion syntax version}.
+ *
+ * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-821%3A+Connect+Transforms+support+for+nested+structures">KIP-821</a>
+ * @see FieldSyntaxVersion
+ * @see MultiFieldPaths
+ */
+public class SingleFieldPath {
+    // Invariants:
+    // - A field path can contain one or more steps
+    private static final char BACKTICK = '`';
+    private static final char DOT = '.';
+    private static final char BACKSLASH = '\\';
+
+    private final List<String> steps;
+
+    public SingleFieldPath(String pathText, FieldSyntaxVersion version) {
+        Objects.requireNonNull(pathText, "Field path cannot be null");
+        switch (version) {
+            case V1: // backward compatibility
+                this.steps = Collections.singletonList(pathText);
+                break;
+            case V2:
+                this.steps = buildFieldPathV2(pathText);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown syntax version: " + version);
+        }
+    }
+
+    private static List<String> buildFieldPathV2(String path) {
+        final List<String> steps = new ArrayList<>();
+        // path character index to track backticks and dots and break path into steps
+        int idx = 0;
+        while (idx < path.length() && idx >= 0) {
+            if (path.charAt(idx) != BACKTICK) {
+                final int start = idx;
+                idx = path.indexOf(String.valueOf(DOT), idx);
+                if (idx >= 0) { // get path step and move forward
+                    String field = path.substring(start, idx);
+                    steps.add(field);
+                    idx++;
+                } else { // add all
+                    String field = path.substring(start);
+                    steps.add(field);
+                }
+            } else { // has backtick
+                int backtickAt = idx;
+                idx++;
+                StringBuilder field = new StringBuilder();
+                int start = idx;
+                while (true) {
+                    // find closing backtick
+                    idx = path.indexOf(String.valueOf(BACKTICK), idx);
+                    if (idx == -1) { // if not found, then fail
+                        failWhenIncompleteBacktickPair(path, backtickAt);
+                    }
+
+                    // backtick escaped if right after backslash
+                    boolean escaped = path.charAt(idx - 1) == BACKSLASH;
+
+                    if (idx >= path.length() - 1) { // at the end of path
+                        if (escaped) { // but escaped, then fail
+                            failWhenIncompleteBacktickPair(path, backtickAt);
+                        }
+                        field.append(path, start, idx);
+                        // we've reached the end of the path, and the last character is the backtick
+                        steps.add(field.toString());
+                        idx++;
+                        break;
+                    }
+
+                    if (path.charAt(idx + 1) != DOT) { // not followed by a dot
+                        // this backtick isn't followed by a dot; include it in the field name, but continue
+                        // looking for a matching backtick that is followed by a dot
+                        idx++;
+                        continue;
+                    }
+
+                    if (escaped) {
+                        // this backtick was escaped; include it in the field name, but continue
+                        // looking for an unescaped matching backtick
+                        field.append(path, start, idx - 1)
+                            .append(BACKTICK);
+
+                        idx++;
+                        start = idx;
+                        continue;
+                    }
+
+                    // we've found our matching backtick
+                    field.append(path, start, idx);
+                    steps.add(field.toString());
+                    idx += 2; // increment by two to include the backtick and the dot after it
+                    break;
+                }
+            }
+        }
+        // add last step if last char is a dot
+        if (!path.isEmpty() && path.charAt(path.length() - 1) == DOT)
+            steps.add("");
+        return Collections.unmodifiableList(steps);
+    }
+
+    private static void failWhenIncompleteBacktickPair(String path, int backtickAt) {
+        throw new ConfigException("Incomplete backtick pair in path: [" + path + "],"
+                + " consider adding a backslash before backtick at position " + backtickAt
+                + " to escape it");
+    }
+
+
+    /**
+     * Access a {@code Field} at the current path within a schema {@code Schema}
+     * If field is not found, then {@code null} is returned.
+     */
+    public Field fieldFrom(Schema schema) {
+        if (schema == null) return null;
+
+        Schema current = schema;
+        for (String pathSegment : stepsWithoutLast()) {
+            final Field field = current.field(pathSegment);
+            if (field != null) {
+                current = field.schema();
+            } else {
+                return null;
+            }
+        }
+        return current.field(lastStep());
+    }
+
+    /**
+     * Access a value at the current path within a schema-based {@code Struct}
+     * If object is not found, then {@code null} is returned.
+     */
+    public Object valueFrom(Struct struct) {
+        if (struct == null) return null;
+
+        Struct current = struct;
+        for (String pathSegment : stepsWithoutLast()) {
+            // Check to see if the field actually exists
+            if (current.schema().field(pathSegment) == null) {
+                return null;
+            }
+            current = current.getStruct(pathSegment);
+        }
+
+        if (current.schema().field(lastStep()) != null) {
+            return current.get(lastStep());
+        } else {
+            return null;
+        }
+    }
+
+    List<String> stepsWithoutLast() {
+        return steps.subList(0, lastStepIndex());
+    }
+
+    /**
+     * Access a value at the current path within a schemaless {@code Map<String, Object>}.
+     * If object is not found, then {@code null} is returned.
+     */
+    @SuppressWarnings("unchecked")
+    public Object valueFrom(Map<String, Object> map) {
+        if (map == null) return null;
+
+        if (steps.size() == 1) {
+            return map.get(steps.get(0));
+        } else {
+            Map<String, Object> current = map;
+            for (int i = 0; i < steps.size(); i++) {
+                if (current == null) {
+                    return null;
+                }
+                if (i == lastStepIndex()) {
+                    return current.get(steps.get(i));
+                } else {
+                    current = (Map<String, Object>) current.get(steps.get(i));
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Access {@code Map} fields and apply functions to update field values.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields keep values from original struct.
+     *
+     * @param originalValue schema-based data value
+     * @param whenFound     function to apply when current path(s) is/are found
+     * @return updated data value
+     */
+    public Map<String, Object> updateValueFrom(
+        Map<String, Object> originalValue,
+        MapValueUpdater whenFound
+    ) {
+        return updateValue(originalValue, 0, whenFound,
+            (originalParent, updatedParent, fieldPath, fieldName) -> {
+                // filter out
+            },
+            (originalParent, updatedParent, fieldPath, fieldName) ->
+                updatedParent.put(fieldName, originalParent.get(fieldName)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> updateValue(
+        Map<String, Object> originalValue,
+        int step,
+        MapValueUpdater update,
+        MapValueUpdater notFound,
+        MapValueUpdater others
+    ) {
+        if (originalValue == null) return null;
+        Map<String, Object> updatedParent = new HashMap<>(originalValue.size());
+        boolean found = false;
+        for (Map.Entry<String, Object> entry : originalValue.entrySet()) {
+            String fieldName = entry.getKey();
+            Object fieldValue = entry.getValue();
+            if (steps.get(step).equals(fieldName)) {
+                found = true;
+                if (step < lastStepIndex()) {
+                    if (fieldValue instanceof Map) {
+                        Map<String, Object> updatedField = updateValue(
+                            (Map<String, Object>) fieldValue,
+                            step + 1,
+                            update,
+                            notFound,
+                            others);
+                        updatedParent.put(fieldName, updatedField);
+                    } else {
+                        // add back to not found and apply others, as only leaf values are updated
+                        found = false;
+                        others.apply(originalValue, updatedParent, null, fieldName);
+                    }
+                } else {
+                    update.apply(originalValue, updatedParent, this, fieldName);
+                }
+            } else {
+                others.apply(originalValue, updatedParent, null, fieldName);
+            }
+        }
+
+        if (!found) {
+            notFound.apply(originalValue, updatedParent, this, stepAt(step));
+        }
+
+        return updatedParent;
+    }
+
+    /**
+     * Access {@code Struct} fields and apply functions to update field values.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields keep values from original struct.
+     *
+     * @param originalSchema original struct schema
+     * @param originalValue  schema-based data value
+     * @param updatedSchema  updated struct schema
+     * @param whenFound      function to apply when current path(s) is/are found
+     * @return updated data value
+     */
+    public Struct updateValueFrom(
+        Schema originalSchema,
+        Struct originalValue,
+        Schema updatedSchema,
+        StructValueUpdater whenFound
+    ) {
+        return updateValue(originalSchema, originalValue, updatedSchema, 0, whenFound,
+            (originalParent, originalField, updatedParent, updatedField, fieldPath) -> {
+                // filter out
+            },
+            (originalParent, originalField, updatedParent, nullUpdatedField, nullFieldPath) ->
+                updatedParent.put(originalField.name(), originalParent.get(originalField)));
+    }
+
+    private Struct updateValue(
+        Schema originalSchema,
+        Struct originalValue,
+        Schema updateSchema,
+        int step,
+        StructValueUpdater update,
+        StructValueUpdater notFound,
+        StructValueUpdater others
+    ) {
+        Struct updated = new Struct(updateSchema);
+        boolean found = false;
+        for (Field field : originalSchema.fields()) {
+            if (step < steps.size()) {
+                if (steps.get(step).equals(field.name())) {
+                    found = true;
+                    if (step == lastStepIndex()) {
+                        update.apply(
+                            originalValue,
+                            field,
+                            updated,
+                            updateSchema.field(field.name()),
+                            this
+                        );
+                    } else {
+                        if (field.schema().type() == Type.STRUCT) {
+                            Struct fieldValue = updateValue(
+                                field.schema(),
+                                originalValue.getStruct(field.name()),
+                                updateSchema.field(field.name()).schema(),
+                                step + 1,
+                                update,
+                                notFound,
+                                others
+                            );
+                            updated.put(field.name(), fieldValue);
+                        } else {
+                            // add back to not found and apply others, as only leaf values are updated
+                            found = false;
+                            others.apply(originalValue, field, updated, null, this);
+                        }
+                    }
+                } else {
+                    others.apply(originalValue, field, updated, null, this);
+                }
+            }
+        }
+        if (!found) {
+            notFound.apply(
+                originalValue,
+                null,
+                updated,
+                updateSchema.field(stepAt(step)),
+                this);
+        }
+        return updated;
+    }
+
+    /**
+     * Prepares a new schema based on an original one, and applies an update function
+     * when the current path(s) is found.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields are copied from original schema.
+     *
+     * <p>A copy of the {@code Schema} is used as a base for the updated schema.
+     *
+     * @param originalSchema baseline schema
+     * @param whenFound      function to apply when current path(s) is/are found
+     * @return an updated schema. Resulting schemas are usually cached for further access
+     */
+    public Schema updateSchemaFrom(Schema originalSchema, StructSchemaUpdater whenFound) {
+        SchemaBuilder updated = SchemaUtil.copySchemaBasics(originalSchema, SchemaBuilder.struct());
+        return updateSchema(originalSchema, updated, 0, whenFound,
+            (schemaBuilder, field, fieldPath) -> { /* ignore */ },
+            (schemaBuilder, field, fieldPath) -> schemaBuilder.field(field.name(), field.schema()));
+    }
+
+    /**
+     * Prepares a new schema based on an original one, and applies an update function
+     * when the current path(s) is found.
+     *
+     * <p>If path is not found, no function is applied, and the path is ignored.
+     *
+     * <p>Other fields are copied from original schema.
+     *
+     * @param originalSchema        baseline schema
+     * @param baselineSchemaBuilder baseline schema build, if changes to the baseline
+     *                              are required before copying original
+     * @param whenFound             function to apply when current path(s) is/are found.
+     * @return an updated schema. Resulting schemas are usually cached for further access.
+     */
+    public Schema updateSchemaFrom(
+        Schema originalSchema,
+        SchemaBuilder baselineSchemaBuilder,
+        StructSchemaUpdater whenFound
+    ) {
+        return updateSchema(originalSchema, baselineSchemaBuilder, 0, whenFound,
+            (schemaBuilder, field, fieldPath) -> { /* ignore */ },
+            (schemaBuilder, field, fieldPath) -> schemaBuilder.field(field.name(), field.schema()));
+    }
+
+    // Recursive implementation to update schema at different steps.
+    // Consider that resulting schemas are usually cached.
+    private Schema updateSchema(
+        Schema operatingSchema,
+        SchemaBuilder builder,
+        int step,
+        StructSchemaUpdater matching,
+        StructSchemaUpdater notFound,
+        StructSchemaUpdater others
+    ) {
+        if (operatingSchema.isOptional()) {
+            builder.optional();
+        }
+        if (operatingSchema.defaultValue() != null) {
+            builder.defaultValue(operatingSchema.defaultValue());
+        }
+        boolean matched = false;
+        for (Field field : operatingSchema.fields()) {
+            if (step < steps.size()) {
+                if (steps.get(step).equals(field.name())) {
+                    matched = true;
+                    if (step == lastStepIndex()) {
+                        matching.apply(builder, field, this);
+                    } else {
+                        Schema fieldSchema = updateSchema(
+                            field.schema(),
+                            SchemaBuilder.struct(),
+                            step + 1,
+                            matching,
+                            notFound,
+                            others);
+                        builder.field(field.name(), fieldSchema);
+                    }
+                } else {
+                    others.apply(builder, field, null);
+                }
+            } else {
+                others.apply(builder, field, null);
+            }
+        }
+        if (!matched) {
+            notFound.apply(builder, null, this);
+        }
+        return builder.build();
+    }
+
+    public String last() {
+        return lastStep();
+    }
+
+    public boolean isEmpty() {
+        return steps.isEmpty();
+    }
+
+    public String stepAt(int i) {
+        return i < steps.size() ? steps.get(i) : "";
+    }
+
+    // For testing
+    String[] path() {
+        return steps.toArray(new String[0]);
+    }
+
+    String lastStep() {
+        return steps.get(lastStepIndex());
+    }
+
+    private int lastStepIndex() {
+        return steps.size() - 1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SingleFieldPath that = (SingleFieldPath) o;
+        return Objects.equals(steps, that.steps);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(steps);
+    }
+
+    @Override
+    public String toString() {
+        return "FieldPath(path = " + String.join(".", steps) + ")";
+    }
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/StructSchemaUpdater.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/StructSchemaUpdater.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+/**
+ * Function to update Struct schemas based on Field Paths.
+ *
+ * @see org.apache.kafka.connect.data.Schema
+ */
+@FunctionalInterface
+public interface StructSchemaUpdater {
+
+    /**
+     * Apply schema update function.
+     *
+     * @param schemaBuilder builder to be updated. Required, not nullable.
+     * @param field nullable when updating fields that do not exist. e.g. paths not found.
+     * @param fieldPath nullable when updating a field that is not related to a path.
+     */
+    void apply(SchemaBuilder schemaBuilder, Field field, SingleFieldPath fieldPath);
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/StructValueUpdater.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/StructValueUpdater.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Struct;
+
+/**
+ * Function to update a Struct based on Field Paths.
+ *
+ * @see org.apache.kafka.connect.data.Struct
+ */
+@FunctionalInterface
+public interface StructValueUpdater {
+
+    void apply(Struct originalParent, Field originalField, Struct updatedParent, Field updatedField, SingleFieldPath fieldPath);
+}

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/FieldPathNotationTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/FieldPathNotationTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FieldPathNotationTest {
+    final static String[] EMPTY_PATH = new String[] {};
+
+    @Test
+    void shouldBuildV1WithDotsAndBacktickPair() {
+        // Given v1
+        // When path contains dots, then single step path
+        assertArrayEquals(
+                new String[] {"foo.bar.baz"},
+                new SingleFieldPath("foo.bar.baz", FieldSyntaxVersion.V1).path());
+        // When path contains backticks, then single step path
+        assertArrayEquals(
+                new String[] {"foo`bar`"},
+                new SingleFieldPath("foo`bar`", FieldSyntaxVersion.V1).path());
+        // When path contains dots and backticks, then single step path
+        assertArrayEquals(
+                new String[] {"foo.`bar.baz`"},
+                new SingleFieldPath("foo.`bar.baz`", FieldSyntaxVersion.V1).path());
+    }
+
+    @Test
+    void shouldBuildV2WithEmptyPath() {
+        // Given v2
+        // When path is empty
+        // Then build a path with no steps
+        assertArrayEquals(EMPTY_PATH, new SingleFieldPath("", FieldSyntaxVersion.V2).path());
+    }
+
+    @Test
+    void shouldBuildV2WithoutDots() {
+        // Given v2
+        // When path without dots
+        // Then build a single step path
+        assertArrayEquals(new String[] {"foobarbaz"}, new SingleFieldPath("foobarbaz", FieldSyntaxVersion.V2).path());
+    }
+
+    @Test
+    void shouldBuildV2WhenIncludesDots() {
+        // Given v2 and fields without dots
+        // When path includes dots
+        // Then build a path with steps separated by dots
+        assertArrayEquals(new String[] {"foo", "bar", "baz"}, new SingleFieldPath("foo.bar.baz", FieldSyntaxVersion.V2).path());
+    }
+
+    @Test
+    void shouldBuildV2WithoutWrappingBackticks() {
+        // Given v2 and fields without dots
+        // When backticks are not wrapping a field name
+        // Then build a single step path including backticks
+        assertArrayEquals(new String[] {"foo`bar`baz"}, new SingleFieldPath("foo`bar`baz", FieldSyntaxVersion.V2).path());
+    }
+
+    @Test
+    void shouldBuildV2WhenIncludesDotsAndBacktickPair() {
+        // Given v2 and fields including dots
+        // When backticks are wrapping a field name (i.e. withing edges or between dots)
+        // Then build a path with steps separated by dots and not including backticks
+        assertArrayEquals(new String[] {"foo.bar.baz"}, new SingleFieldPath("`foo.bar.baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "bar.baz"}, new SingleFieldPath("foo.`bar.baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo.bar", "baz"}, new SingleFieldPath("`foo.bar`.baz", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "bar", "baz"}, new SingleFieldPath("foo.`bar`.baz", FieldSyntaxVersion.V2).path());
+    }
+
+    @Test
+    void shouldBuildV2AndIgnoreBackticksThatAreNotWrapping() {
+        // Given v2 and fields including dots and backticks
+        // When backticks are wrapping a field name (i.e. withing edges or between dots)
+        // Then build a path with steps separated by dots and including non-wrapping backticks
+        assertArrayEquals(new String[] {"foo", "`bar.baz"}, new SingleFieldPath("foo.``bar.baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "bar.baz`"}, new SingleFieldPath("foo.`bar.baz``", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "ba`r.baz"}, new SingleFieldPath("foo.`ba`r.baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "ba`r", "baz"}, new SingleFieldPath("foo.ba`r.baz", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "`bar`", "baz"}, new SingleFieldPath("foo.``bar``.baz", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"`foo.bar.baz`"}, new SingleFieldPath("``foo.bar.baz``", FieldSyntaxVersion.V2).path());
+    }
+
+    @Test
+    void shouldBuildV2AndEscapeBackticks() {
+        // Given v2 and fields including dots and backticks
+        // When backticks are wrapping a field name (i.e. withing edges or between dots)
+        // and wrapping backticks that are part of the field name are escaped with backslashes
+        // Then build a path with steps separated by dots and including escaped and non-wrapping backticks
+        assertArrayEquals(new String[] {"foo", "bar`.baz"}, new SingleFieldPath("foo.`bar\\`.baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "bar.`baz"}, new SingleFieldPath("foo.`bar.`baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "bar`.`baz"}, new SingleFieldPath("foo.`bar\\`.`baz`", FieldSyntaxVersion.V2).path());
+        assertArrayEquals(new String[] {"foo", "bar\\`.\\`baz"}, new SingleFieldPath("foo.`bar\\\\`.\\`baz`", FieldSyntaxVersion.V2).path());
+    }
+
+    @Test
+    void shouldFailV2WhenIncompleteBackticks() {
+        // Given v2
+        // When backticks are not closed and not escaped
+        // Then it should fail
+        ConfigException e0 = assertThrows(ConfigException.class,
+                () -> new SingleFieldPath("`foo.bar.baz", FieldSyntaxVersion.V2));
+        assertEquals(
+                "Incomplete backtick pair in path: [`foo.bar.baz], consider adding a backslash before backtick at position 0 to escape it",
+                e0.getMessage()
+        );
+        ConfigException e1 = assertThrows(ConfigException.class,
+                () -> new SingleFieldPath("foo.`bar.baz", FieldSyntaxVersion.V2));
+        assertEquals(
+                "Incomplete backtick pair in path: [foo.`bar.baz], consider adding a backslash before backtick at position 4 to escape it",
+                e1.getMessage()
+        );
+        ConfigException e2 = assertThrows(ConfigException.class,
+                () -> new SingleFieldPath("foo.bar.`baz", FieldSyntaxVersion.V2));
+        assertEquals(
+                "Incomplete backtick pair in path: [foo.bar.`baz], consider adding a backslash before backtick at position 8 to escape it",
+                e2.getMessage()
+        );
+        ConfigException e3 = assertThrows(ConfigException.class,
+                () -> {
+                    SingleFieldPath p = new SingleFieldPath("foo.bar.`baz\\`", FieldSyntaxVersion.V2);
+                    System.out.println(Arrays.toString(p.path()));
+                });
+        assertEquals(
+                "Incomplete backtick pair in path: [foo.bar.`baz\\`], consider adding a backslash before backtick at position 8 to escape it",
+                e3.getMessage()
+        );
+    }
+}

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/FieldSyntaxVersionTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/FieldSyntaxVersionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class FieldSyntaxVersionTest {
+    @Test
+    void shouldAppendConfigToDef() {
+        ConfigDef def = FieldSyntaxVersion.appendConfig(new ConfigDef());
+        assertEquals(def.configKeys().size(), 1);
+        final ConfigDef.ConfigKey configKey = def.configKeys().get("field.syntax.version");
+        assertEquals(configKey.name, "field.syntax.version");
+        assertEquals(configKey.defaultValue, "V1");
+    }
+
+    @Test
+    void shouldFailWhenAppendConfigToDefAgain() {
+        ConfigDef def = FieldSyntaxVersion.appendConfig(new ConfigDef());
+        assertEquals(def.configKeys().size(), 1);
+        ConfigException e = assertThrows(ConfigException.class, () -> FieldSyntaxVersion.appendConfig(def));
+        assertEquals(e.getMessage(), "Configuration field.syntax.version is defined twice.");
+    }
+
+    @ParameterizedTest
+    @CsvSource({"v1,V1", "v2,V2", "V1,V1", "V2,V2"})
+    void shouldGetVersionFromConfig(String input, FieldSyntaxVersion version) {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("field.syntax.version", input);
+        AbstractConfig config = new AbstractConfig(FieldSyntaxVersion.appendConfig(new ConfigDef()), configs);
+        assertEquals(version, FieldSyntaxVersion.fromConfig(config));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"v3", "V 1", "v", "V 2", "2", "1"})
+    void shouldFailWhenWrongVersionIsPassed(String input) {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("field.syntax.version", input);
+        ConfigException e = assertThrows(ConfigException.class, () -> new AbstractConfig(FieldSyntaxVersion.appendConfig(new ConfigDef()), configs));
+        assertEquals(
+            "Invalid value " + input + " for configuration field.syntax.version: " +
+                "String must be one of (case insensitive): V1, V2",
+            e.getMessage());
+    }
+}

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/MultiFieldPathsTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/MultiFieldPathsTest.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MultiFieldPathsTest {
+
+    @Test void shouldBuildEmptyTrie() {
+        MultiFieldPaths.Trie trie = new MultiFieldPaths.Trie();
+        assertTrue(trie.isEmpty());
+    }
+
+    @Test void shouldBuildMultiPathWithSinglePathV1() {
+        SingleFieldPath path = new SingleFieldPath("foo.bar.baz", FieldSyntaxVersion.V1);
+        MultiFieldPaths paths = createMultiFieldPaths(path);
+        assertFalse(paths.trie.isEmpty());
+        assertEquals(1, paths.trie.size());
+
+        final Optional<MultiFieldPaths.TrieNode> maybeFoo = paths.trie.find("foo.bar.baz");
+        assertTrue(maybeFoo.isPresent());
+        assertEquals(path, maybeFoo.get().path);
+    }
+
+    @Test void shouldBuildMultiPathWithSinglePathV2() {
+        SingleFieldPath path = new SingleFieldPath("foo.bar.baz", FieldSyntaxVersion.V2);
+        MultiFieldPaths paths = createMultiFieldPaths(path);
+        assertFalse(paths.trie.isEmpty());
+        assertEquals(1, paths.trie.size());
+
+        final Optional<MultiFieldPaths.TrieNode> maybeV1 = paths.trie.find("foo.bar.baz");
+        assertFalse(maybeV1.isPresent());
+        final Optional<MultiFieldPaths.TrieNode> maybeFoo = paths.trie.find("foo");
+        assertTrue(maybeFoo.isPresent());
+        assertFalse(maybeFoo.get().isLeaf());
+        final Optional<MultiFieldPaths.TrieNode> maybeBar = maybeFoo.get().find("bar");
+        assertTrue(maybeBar.isPresent());
+        assertFalse(maybeBar.get().isLeaf());
+        final Optional<MultiFieldPaths.TrieNode> maybeBaz = maybeBar.get().find("baz");
+        assertTrue(maybeBaz.isPresent());
+        assertTrue(maybeBaz.get().isLeaf());
+        assertEquals(path, maybeBaz.get().path);
+    }
+
+
+    @Test void shouldBuildMultiPathWithMultipleSinglePathV2() {
+        MultiFieldPaths paths = createMultiFieldPaths(
+            new SingleFieldPath("foo.bar", FieldSyntaxVersion.V2),
+            new SingleFieldPath("foo.baz", FieldSyntaxVersion.V2),
+            new SingleFieldPath("test", FieldSyntaxVersion.V2));
+        assertFalse(paths.trie.isEmpty());
+        assertEquals(3, paths.trie.size());
+
+        final Optional<MultiFieldPaths.TrieNode> maybeFoo = paths.trie.find("foo");
+        assertTrue(maybeFoo.isPresent());
+        assertFalse(maybeFoo.get().isLeaf());
+        final Optional<MultiFieldPaths.TrieNode> maybeBar = maybeFoo.get().find("bar");
+        assertTrue(maybeBar.isPresent());
+        assertTrue(maybeBar.get().isLeaf());
+        final Optional<MultiFieldPaths.TrieNode> maybeBaz = maybeFoo.get().find("baz");
+        assertTrue(maybeBaz.isPresent());
+        assertTrue(maybeBaz.get().isLeaf());
+        final Optional<MultiFieldPaths.TrieNode> maybeTest = paths.trie.find("test");
+        assertTrue(maybeTest.isPresent());
+        assertTrue(maybeTest.get().isLeaf());
+    }
+
+    @Test void shouldFlatOverlappingPaths() {
+        final SingleFieldPath foo = new SingleFieldPath("foo", FieldSyntaxVersion.V2);
+        final SingleFieldPath fooBar = new SingleFieldPath("foo.bar", FieldSyntaxVersion.V2);
+
+        MultiFieldPaths.Trie trie1 = new MultiFieldPaths.Trie();
+        trie1.insert(foo);
+        trie1.insert(fooBar);
+        assertFalse(trie1.isEmpty());
+        assertEquals(1, trie1.size());
+
+        final Optional<MultiFieldPaths.TrieNode> maybeFoo1 = trie1.find("foo");
+        assertTrue(maybeFoo1.isPresent());
+        final MultiFieldPaths.TrieNode fooNode1 = maybeFoo1.get();
+        assertFalse(fooNode1.isLeaf());
+        final Optional<MultiFieldPaths.TrieNode> maybeBar1 = fooNode1.find("bar");
+        assertTrue(maybeBar1.isPresent());
+        final MultiFieldPaths.TrieNode barNode = maybeBar1.get();
+        assertTrue(barNode.isLeaf());
+        assertEquals(fooBar, barNode.path);
+
+        MultiFieldPaths.Trie trie2 = new MultiFieldPaths.Trie();
+        trie2.insert(fooBar);
+        trie2.insert(foo);
+        assertFalse(trie2.isEmpty());
+        assertEquals(1, trie2.size());
+
+        final Optional<MultiFieldPaths.TrieNode> maybeFoo2 = trie2.find("foo");
+        assertTrue(maybeFoo2.isPresent());
+        final MultiFieldPaths.TrieNode fooNode2 = maybeFoo2.get();
+        assertFalse(fooNode2.isLeaf());
+        final Optional<MultiFieldPaths.TrieNode> barNode2 = fooNode2.find("bar");
+        assertTrue(barNode2.isPresent());
+        assertTrue(barNode2.get().isLeaf());
+        assertEquals(fooBar, barNode2.get().path);
+
+        assertEquals(trie1, trie2);
+    }
+
+    @Test void shouldRenameSchemaV1Fields() {
+        Schema schema = SchemaBuilder.struct()
+                .field("foo", Schema.STRING_SCHEMA)
+                .field("bar", Schema.STRING_SCHEMA)
+                .field("baz", Schema.INT32_SCHEMA)
+                .build();
+
+        MultiFieldPaths fieldPath = MultiFieldPaths.of(Arrays.asList("foo", "bar"), FieldSyntaxVersion.V1);
+        SchemaBuilder updated = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+        Schema result = fieldPath.updateSchemaFrom(
+                schema,
+                updated,
+                (builder, field, path) -> builder.field(field.name() + "_other", field.schema())
+        );
+
+        assertEquals(3, result.fields().size());
+        assertEquals("foo_other", result.fields().get(0).name());
+        assertEquals("bar_other", result.fields().get(1).name());
+        assertEquals("baz", result.fields().get(2).name());
+    }
+
+    @Test void shouldRenameSchemaV2Fields() {
+        SchemaBuilder nested = SchemaBuilder.struct()
+                .field("bar", Schema.STRING_SCHEMA)
+                .field("baz", Schema.INT32_SCHEMA);
+        Schema schema = SchemaBuilder.struct()
+                .field("foo", nested)
+                .build();
+
+        MultiFieldPaths fieldPath = MultiFieldPaths.of(Arrays.asList("foo.baz", "foo.bar"), FieldSyntaxVersion.V2);
+        Schema result = fieldPath.updateSchemaFrom(
+                schema,
+                (builder, field, path) -> builder.field(field.name() + "_other", field.schema())
+        );
+
+        assertEquals(1, result.fields().size());
+        assertEquals(2, result.field("foo").schema().fields().size());
+        assertEquals("bar_other", result.field("foo").schema().fields().get(0).name());
+        assertEquals("baz_other", result.field("foo").schema().fields().get(1).name());
+    }
+
+    @Test void shouldUpdateValuesV1FromSchemaless() {
+        Map<String, Object> value = new HashMap<>();
+        value.put("foo", 42);
+        value.put("bar", 21);
+
+        SingleFieldPath fooPath = new SingleFieldPath("foo", FieldSyntaxVersion.V1);
+        SingleFieldPath barPath = new SingleFieldPath("bar", FieldSyntaxVersion.V1);
+        MultiFieldPaths fieldPaths = createMultiFieldPaths(fooPath, barPath);
+        Map<String, Object> updated = fieldPaths.updateValuesFrom(
+                value,
+                (orig, map, f, k) -> map.put(k, ((Integer) orig.get(k)) * 2)
+        );
+
+        Map<SingleFieldPath, Map.Entry<String, Object>> actual = fieldPaths.fieldAndValuesFrom(updated);
+        assertEquals(84, actual.get(fooPath).getValue());
+        assertEquals(42, actual.get(barPath).getValue());
+    }
+
+    @Test void shouldUpdateNestedValuesV2FromSchemaless() {
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("bar", 21);
+        nested.put("baz", 42);
+        Map<String, Object> value = Collections.singletonMap("foo", nested);
+
+        SingleFieldPath barPath = new SingleFieldPath("foo.bar", FieldSyntaxVersion.V2);
+        SingleFieldPath bazPath = new SingleFieldPath("foo.baz", FieldSyntaxVersion.V2);
+        MultiFieldPaths fieldPaths = createMultiFieldPaths(bazPath, barPath);
+        Map<String, Object> updated = fieldPaths.updateValuesFrom(
+                value,
+                (orig, map, f, k) -> map.put(k, ((Integer) orig.get(k)) * 2)
+        );
+
+        Map<SingleFieldPath, Map.Entry<String, Object>> actual = fieldPaths.fieldAndValuesFrom(updated);
+        assertEquals(84, actual.get(bazPath).getValue());
+        assertEquals(42, actual.get(barPath).getValue());
+    }
+
+    @Test void shouldUpdateValueV1WithSchema() {
+        Schema schema = SchemaBuilder.struct()
+                .field("foo.bar", Schema.INT32_SCHEMA)
+                .field("foo.baz", Schema.INT32_SCHEMA)
+                .build();
+        Struct value = new Struct(schema)
+                .put("foo.bar", 21)
+                .put("foo.baz", 42);
+
+        SingleFieldPath bazPath = new SingleFieldPath("foo.baz", FieldSyntaxVersion.V1);
+        SingleFieldPath barPath = new SingleFieldPath("foo.bar", FieldSyntaxVersion.V1);
+        MultiFieldPaths fieldPaths = createMultiFieldPaths(bazPath, barPath);
+        Struct updated = fieldPaths.updateValuesFrom(schema, value, schema,
+                (orig, oldField, s, updatedField, f) -> s.put(updatedField, ((Integer) orig.get(oldField)) * 2));
+
+        Map<SingleFieldPath, Map.Entry<Field, Object>> actual = fieldPaths.fieldAndValuesFrom(updated);
+        assertEquals(84, actual.get(bazPath).getValue());
+        assertEquals(42, actual.get(barPath).getValue());
+    }
+
+    @Test void shouldUpdateNestedValueV2WithSchema() {
+        SchemaBuilder nestedSchema = SchemaBuilder.struct()
+                .field("bar", Schema.INT32_SCHEMA)
+                .field("baz", Schema.INT32_SCHEMA);
+        Schema schema = SchemaBuilder.struct()
+                .field("foo", nestedSchema)
+                .build();
+        Struct nested = new Struct(nestedSchema)
+                .put("bar", 21)
+                .put("baz", 42);
+        Struct value = new Struct(schema).put("foo", nested);
+
+        SingleFieldPath bazPath = new SingleFieldPath("foo.baz", FieldSyntaxVersion.V2);
+        SingleFieldPath barPath = new SingleFieldPath("foo.bar", FieldSyntaxVersion.V2);
+        MultiFieldPaths fieldPaths = createMultiFieldPaths(bazPath, barPath);
+        Struct updated = fieldPaths.updateValuesFrom(schema, value, schema,
+                (orig, oldField, s, updatedField, f) -> s.put(updatedField, ((Integer) orig.get(oldField)) * 2));
+
+        Map<SingleFieldPath, Map.Entry<Field, Object>> actual = fieldPaths.fieldAndValuesFrom(updated);
+        assertEquals(84, actual.get(bazPath).getValue());
+        assertEquals(42, actual.get(barPath).getValue());
+    }
+
+    static MultiFieldPaths createMultiFieldPaths(SingleFieldPath... fields) {
+        return new MultiFieldPaths(new HashSet<>(Arrays.asList(fields)));
+    }
+}

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/SingleFieldPathTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/field/SingleFieldPathTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms.field;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+import org.junit.jupiter.api.Test;
+
+class SingleFieldPathTest {
+
+    @Test void shouldFilterSchemaV1Fields() {
+        Schema schema = SchemaBuilder.struct().field("foo", Schema.STRING_SCHEMA)
+            .field("bar", Schema.STRING_SCHEMA)
+            .field("baz", Schema.INT32_SCHEMA)
+            .build();
+
+        SchemaBuilder updated = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+        Schema result = new SingleFieldPath("foo", FieldSyntaxVersion.V1)
+            .updateSchemaFrom(schema, updated, (builder, field, path) -> {
+                // ignore field
+            });
+
+        assertEquals(2, result.fields().size());
+        assertEquals("bar", result.fields().get(0).name());
+        assertEquals("baz", result.fields().get(1).name());
+    }
+    @Test void shouldFilterSchemaV2Fields() {
+        Schema schema = SchemaBuilder.struct().field("foo",
+            SchemaBuilder.struct().field("bar", Schema.STRING_SCHEMA)
+                .field("baz", Schema.INT32_SCHEMA))
+            .build();
+
+        SchemaBuilder updated = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+        SingleFieldPath fieldPath = new SingleFieldPath("foo.baz", FieldSyntaxVersion.V2);
+        Schema result = fieldPath.updateSchemaFrom(
+                schema,
+                updated, (builder, field, path) -> {
+                        // ignore field
+                });
+
+        assertEquals(1, result.fields().size());
+        assertEquals(1, result.field("foo").schema().fields().size());
+        assertEquals("bar", result.field("foo").schema().fields().get(0).name());
+    }
+
+    @Test void shouldRenameSchemaV1Fields() {
+        Schema schema = SchemaBuilder.struct()
+                .field("foo", Schema.STRING_SCHEMA)
+                .field("bar", Schema.STRING_SCHEMA)
+                .field("baz", Schema.INT32_SCHEMA)
+                .build();
+
+        SingleFieldPath fieldPath = new SingleFieldPath("foo", FieldSyntaxVersion.V1);
+        Schema result = fieldPath.updateSchemaFrom(
+                schema,
+                (builder, field, path) -> builder.field("other", field.schema())
+        );
+
+        assertEquals(3, result.fields().size());
+        assertEquals("other", result.fields().get(0).name());
+        assertEquals("bar", result.fields().get(1).name());
+        assertEquals("baz", result.fields().get(2).name());
+    }
+
+    @Test void shouldRenameSchemaV2Fields() {
+        SchemaBuilder nested = SchemaBuilder.struct()
+                .field("bar", Schema.STRING_SCHEMA)
+                .field("baz", Schema.INT32_SCHEMA);
+        Schema schema = SchemaBuilder.struct()
+                .field("foo", nested)
+                .build();
+
+        SingleFieldPath fieldPath = new SingleFieldPath("foo.baz", FieldSyntaxVersion.V2);
+        Schema result = fieldPath.updateSchemaFrom(
+                schema,
+                (builder, field, path) -> builder.field("other", field.schema())
+        );
+
+        assertEquals(1, result.fields().size());
+        assertEquals(2, result.field("foo").schema().fields().size());
+        assertEquals("bar", result.field("foo").schema().fields().get(0).name());
+        assertEquals("other", result.field("foo").schema().fields().get(1).name());
+    }
+
+    @Test void shouldUpdateValueV1FromSchemaless() {
+        Map<String, Object> value = Collections.singletonMap("foo", 42);
+
+        SingleFieldPath fieldPath = new SingleFieldPath("foo", FieldSyntaxVersion.V1);
+        Map<String, Object> updated = fieldPath
+            .updateValueFrom(value, (orig, map, f, k) -> map.put(k, ((Integer) orig.get(k)) * 2));
+
+        assertEquals(84, fieldPath.valueFrom(updated));
+    }
+
+    @Test void shouldUpdateNestedValueV2FromSchemaless() {
+        Map<String, Object> value = Collections.singletonMap("foo", Collections.singletonMap("bar", 42));
+
+        SingleFieldPath fieldPath = new SingleFieldPath("foo.bar", FieldSyntaxVersion.V2);
+        Map<String, Object> updated = fieldPath.updateValueFrom(
+                value,
+                (original, map, f, k) -> map.put(k, ((Integer) original.get(k)) * 2)
+        );
+
+        assertEquals(84, fieldPath.valueFrom(updated));
+    }
+
+    @Test void shouldUpdateValueV1WithSchema() {
+        Schema schema = SchemaBuilder.struct().field("foo", Schema.INT32_SCHEMA).build();
+        Struct value = new Struct(schema).put("foo", 42);
+
+        SingleFieldPath fieldPath = new SingleFieldPath("foo", FieldSyntaxVersion.V1);
+        Struct updated = fieldPath.updateValueFrom(schema, value, schema,
+                (orig, oldField, s, updatedField, f) -> s.put(updatedField, ((Integer) orig.get(oldField)) * 2));
+
+        assertEquals(84, fieldPath.valueFrom(updated));
+    }
+
+    @Test void shouldUpdateNestedValueV2WithSchema() {
+        SchemaBuilder barSchema = SchemaBuilder.struct().field("bar", Schema.INT32_SCHEMA);
+        Schema schema = SchemaBuilder.struct().field("foo", barSchema).build();
+        Struct value = new Struct(schema).put("foo", new Struct(barSchema).put("bar", 42));
+
+        SingleFieldPath fieldPath = new SingleFieldPath("foo.bar", FieldSyntaxVersion.V2);
+        Struct updated = fieldPath.updateValueFrom(schema, value, schema,
+                (orig, oldField, s, updatedField, f) -> s.put(updatedField, ((Integer) orig.get(oldField)) * 2));
+
+        assertEquals(84, fieldPath.valueFrom(updated));
+    }
+
+    @Test
+    void shouldIncludeEmptyFieldNames() {
+        assertArrayEquals(
+            new String[] {"", "", ""},
+            new SingleFieldPath("..", FieldSyntaxVersion.V2).path()
+        );
+        assertArrayEquals(
+            new String[] {"foo", "", ""},
+            new SingleFieldPath("foo..", FieldSyntaxVersion.V2).path()
+        );
+        assertArrayEquals(
+            new String[] {"", "bar", ""},
+            new SingleFieldPath(".bar.", FieldSyntaxVersion.V2).path()
+        );
+        assertArrayEquals(
+            new String[] {"", "", "baz"},
+            new SingleFieldPath("..baz", FieldSyntaxVersion.V2).path()
+        );
+    }
+
+    @Test void shouldReturnNullFieldWhenFieldNotFound() {
+        SchemaBuilder barSchema = SchemaBuilder.struct().field("bar", Schema.INT32_SCHEMA);
+        Schema schema = SchemaBuilder.struct().field("foo", barSchema).build();
+
+        assertNull(new SingleFieldPath("un.known", FieldSyntaxVersion.V2).fieldFrom(schema));
+        assertNull(new SingleFieldPath("foo.unknown", FieldSyntaxVersion.V2).fieldFrom(schema));
+        assertNull(new SingleFieldPath("unknown", FieldSyntaxVersion.V2).fieldFrom(schema));
+    }
+
+    @Test void shouldReturnNullValueWhenFieldNotFound() {
+        SchemaBuilder barSchema = SchemaBuilder.struct().field("bar", Schema.INT32_SCHEMA);
+        Schema schema = SchemaBuilder.struct().field("foo", barSchema).build();
+        Struct struct = new Struct(schema).put("foo", new Struct(barSchema).put("bar", 42));
+
+        assertNull(new SingleFieldPath("un.known", FieldSyntaxVersion.V2).valueFrom(struct));
+        assertNull(new SingleFieldPath("foo.unknown", FieldSyntaxVersion.V2).valueFrom(struct));
+        assertNull(new SingleFieldPath("unknown", FieldSyntaxVersion.V2).valueFrom(struct));
+    }
+}


### PR DESCRIPTION
[KIP-821](https://cwiki.apache.org/confluence/display/KAFKA/KIP-821%3A+Connect+Transforms+support+for+nested+structures) implementation.

Includes the following changes:

Firts (main) commit includes:
- Introduces a new modules inside `o.a.k.connect.transforms`: `fields`
- FieldPath interface and 2 implementations: `SingleFieldPath` and `MultiFieldPaths`
- Utils to hold and update Map, Struct and Schema values.

Following commits add changes to initial set of SMTs to include how new module is used:
- Add support for nested fields to the following SMTs:
  - ExtractField
  - HeaderFrom
  - MaskField
  - TimestampConverter

Upcoming SMTs will be updated in following PRs to complete the scope of KIP-821.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
