### PR TITLE
KAFKA-15349: ducker-ak should fail fast when gradlew systemTestLibs fails

### DIFF
--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -477,7 +477,7 @@ ducker_test() {
     done
     
     must_pushd "${kafka_dir}"
-    (test -f ./gradlew || gradle) && ./gradlew systemTestLibs
+    (test -f ./gradlew || gradle) && ./gradlew systemTestLibs || die "ducker_test: Failed to build system test libraries, please check the error log."
     must_popd
     if [[ "${debug}" -eq 1 ]]; then
         local ducktape_cmd="python3 -m debugpy --listen 0.0.0.0:${debugpy_port} --wait-for-client /usr/local/bin/ducktape"

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -477,7 +477,7 @@ ducker_test() {
     done
     
     must_pushd "${kafka_dir}"
-    (test -f ./gradlew || gradle) && ./gradlew systemTestLibs || die "ducker_test: Failed to build system test libraries, please check the error log."
+    ( (test -f ./gradlew || gradle) && ./gradlew systemTestLibs ) || die "ducker_test: Failed to build system test libraries, please check the error log."
     must_popd
     if [[ "${debug}" -eq 1 ]]; then
         local ducktape_cmd="python3 -m debugpy --listen 0.0.0.0:${debugpy_port} --wait-for-client /usr/local/bin/ducktape"


### PR DESCRIPTION
In this modification, if ./gradlew systemTestLibs fails, the script will output an error message and terminate execution using the die function. This ensures that the script fails fast and prompts the user to address the error before continuing.


*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
