### PR TITLE
KAFKA-16284: Fix performance regression in RocksDB

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -252,7 +252,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         // with the measurements from Rocks DB
         setupStatistics(configs, dbOptions);
         openRocksDB(dbOptions, columnFamilyOptions);
-        dbAccessor = new DirectDBAccessor(db, fOptions);
+        dbAccessor = new DirectDBAccessor(db, fOptions, wOptions);
         open = true;
 
         addValueProvidersToMetricsRecorder();
@@ -744,10 +744,12 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
 
         private final RocksDB db;
         private final FlushOptions flushOptions;
+        private final WriteOptions wOptions;
 
-        DirectDBAccessor(final RocksDB db, final FlushOptions flushOptions) {
+        DirectDBAccessor(final RocksDB db, final FlushOptions flushOptions, final WriteOptions wOptions) {
             this.db = db;
             this.flushOptions = flushOptions;
+            this.wOptions = wOptions;
         }
 
         @Override
@@ -767,17 +769,17 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
 
         @Override
         public void put(final ColumnFamilyHandle columnFamily, final byte[] key, final byte[] value) throws RocksDBException {
-            db.put(columnFamily, key, value);
+            db.put(columnFamily, wOptions, key, value);
         }
 
         @Override
         public void delete(final ColumnFamilyHandle columnFamily, final byte[] key) throws RocksDBException {
-            db.delete(columnFamily, key);
+            db.delete(columnFamily, wOptions, key);
         }
 
         @Override
         public void deleteRange(final ColumnFamilyHandle columnFamily, final byte[] from, final byte[] to) throws RocksDBException {
-            db.deleteRange(columnFamily, from, to);
+            db.deleteRange(columnFamily, wOptions, from, to);
         }
 
         @Override


### PR DESCRIPTION
A performance regression introduced in commit 5bc3aa428067dff1f2b9075ff5d1351fb05d4b10 reduces the write performance in RocksDB by ~3x. The bug is that we fail to pass the `WriteOptions` that disable the write-ahead log into the DB accessor.

For testing, the time to write 10 times 1 Million records into one RocksDB each were measured:

 * Before 5bc3aa428067dff1f2b9075ff5d1351fb05d4b10: 7954ms, 12933ms
 * After 5bc3aa428067dff1f2b9075ff5d1351fb05d4b10: 30345ms, 31992ms
 * After 5bc3aa428067dff1f2b9075ff5d1351fb05d4b10 with this fix: 8040ms, 10563ms
 * On current trunk with this fix:  9508ms, 10441ms
 
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
