### PR TITLE
KAFKA-16283: notify users about RoundRobinPartitioner bug

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -297,7 +297,8 @@ public class ProducerConfig extends AbstractConfig {
             "<p> 1) If no partition is specified but a key is present, choose a partition based on a hash of the key." +
             "<p> 2) If no partition or key is present, choose the sticky partition that changes when at least " + BATCH_SIZE_CONFIG + " bytes are produced to the partition." +
             "</li>" +
-            "<li><code>org.apache.kafka.clients.producer.RoundRobinPartitioner</code>: A partitioning strategy where " +
+            "<li><code>org.apache.kafka.clients.producer.RoundRobinPartitioner</code>: <b>Please do not use this because of a serious bug found " +
+            "that the partitioner will only send to half of the partitions. See KAFKA-16283 for more detail</b>. A partitioning strategy where " +
             "each record in a series of consecutive records is sent to a different partition, regardless of whether the 'key' is provided or not, " +
             "until partitions run out and the process starts over again. Note: There's a known issue that will cause uneven distribution when a new batch is created. " +
             "See KAFKA-9965 for more detail." +

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -34,6 +34,8 @@
 	<li>Kafka Streams ships multiple KIPs for IQv2 support.
             See the <a href="/{{version}}/documentation/streams/upgrade-guide#streams_api_changes_370">Kafka Streams upgrade section</a> for more details.
         </li>
+        <li>A serious bug found in RoundRobinPartitioner that it will only send to half of the partitions.
+            Please replace it with the default partitioner or other partitioner. See <a href="https://issues.apache.org/jira/browse/KAFKA-16283">KAFKA-16283</a> for more detail</li>
     </ul>
 
 <h4><a id="upgrade_3_6_0" href="#upgrade_3_6_0">Upgrading to 3.6.0 from any version 0.8.x through 3.5.x</a></h4>


### PR DESCRIPTION
Add notes in "3.7.0 notable changes" and "config doc" to notify users about the bug KAFKA-16283 and not to use `RoundRobinPartitioner`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
