### PR TITLE
HOTFIX: Fix compilation error in TransactionManagerTest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -2550,8 +2550,7 @@ public class TransactionManagerTest {
         transactionManager.maybeAddPartition(tp0);
         accumulator.beginFlush();
 
-        drainedBatches = accumulator.drain(metadataMock, nodes, Integer.MAX_VALUE,
-            time.milliseconds());
+        drainedBatches = accumulator.drain(metadataCache, nodes, Integer.MAX_VALUE, time.milliseconds());
 
         // We still shouldn't drain batches because the partition call didn't complete yet.
         assertTrue(drainedBatches.containsKey(node1.id()));


### PR DESCRIPTION
Variable `metadataMock` was removed by https://github.com/apache/kafka/pull/15323 after the CI build of https://github.com/apache/kafka/pull/15320 was run and before https://github.com/apache/kafka/pull/15320 was merged.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
