### PR TITLE
KAFKA-16295: Align RocksDB and in-memory store init() sequences

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -170,9 +170,6 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
     @Override
     public void init(final StateStoreContext context,
                      final StateStore root) {
-        // open the DB dir
-        metricsRecorder.init(getMetricsImpl(context), context.taskId());
-        openDB(context.appConfigs(), context.stateDir());
 
         final File positionCheckpointFile = new File(context.stateDir(), name() + ".position");
         this.positionCheckpoint = new OffsetCheckpoint(positionCheckpointFile);
@@ -186,6 +183,11 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
             (RecordBatchingStateRestoreCallback) this::restoreBatch,
             () -> StoreQueryUtils.checkpointPosition(positionCheckpoint, position)
         );
+
+        // open the DB dir
+        metricsRecorder.init(getMetricsImpl(context), context.taskId());
+        openDB(context.appConfigs(), context.stateDir());
+
         consistencyEnabled = StreamsConfig.InternalConfig.getBoolean(
             context.appConfigs(),
             IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,


### PR DESCRIPTION
For RocksDB stores, we open the store first and then call #register. However the in-memory store actually registers itself first, before marking itself as open. This change aligns the RocksDB init sequence with that off the in-memory stores by moving the store opening to be after registration.
More context: https://lists.apache.org/thread/f4z1vmpb21xhyxl6966xtcb3958fyx5d

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
