### PR TITLE
KAFKA-15215: migrate StreamedJoinTest to Mockito

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2334,6 +2334,7 @@ project(':streams:streams-scala') {
     testImplementation libs.junitJupiter
     testImplementation libs.easymock
     testImplementation libs.mockitoCore
+    testImplementation libs.mockitoJunitJupiter // supports MockitoExtension
     testImplementation libs.hamcrest
     testRuntimeOnly libs.slf4jlog4j
   }

--- a/build.gradle
+++ b/build.gradle
@@ -2333,6 +2333,7 @@ project(':streams:streams-scala') {
 
     testImplementation libs.junitJupiter
     testImplementation libs.easymock
+    testImplementation libs.mockitoCore
     testImplementation libs.hamcrest
     testRuntimeOnly libs.slf4jlog4j
   }

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/StreamJoinedTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/StreamJoinedTest.scala
@@ -21,24 +21,21 @@ import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder
 import org.apache.kafka.streams.scala.serialization.Serdes
 import org.apache.kafka.streams.scala.serialization.Serdes._
 import org.apache.kafka.streams.state.Stores
-import org.easymock.EasyMock
-import org.easymock.EasyMock.{createMock, replay}
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.{BeforeEach, Test}
+import org.mockito.Mockito.{mock, when}
 
 import java.time.Duration
 
 class StreamJoinedTest {
 
-  val builder: InternalStreamsBuilder = createMock(classOf[InternalStreamsBuilder])
-  val topoBuilder: InternalTopologyBuilder = createMock(classOf[InternalTopologyBuilder])
+  val builder: InternalStreamsBuilder = mock(classOf[InternalStreamsBuilder])
+  val topoBuilder: InternalTopologyBuilder = mock(classOf[InternalTopologyBuilder])
 
   @BeforeEach
   def before(): Unit = {
-    EasyMock.expect(builder.internalTopologyBuilder()).andReturn(topoBuilder);
-    EasyMock.expect(topoBuilder.topologyConfigs()).andReturn(null)
-    replay(topoBuilder)
-    replay(builder)
+    when(builder.internalTopologyBuilder()).thenReturn(topoBuilder)
+    when(topoBuilder.topologyConfigs()).thenReturn(null)
   }
 
   @Test

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/StreamJoinedTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/StreamJoinedTest.scala
@@ -22,11 +22,16 @@ import org.apache.kafka.streams.scala.serialization.Serdes
 import org.apache.kafka.streams.scala.serialization.Serdes._
 import org.apache.kafka.streams.state.Stores
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.{BeforeEach, Test}
 import org.mockito.Mockito.{mock, when}
+import org.mockito.junit.jupiter.{MockitoExtension, MockitoSettings}
+import org.mockito.quality.Strictness
 
 import java.time.Duration
 
+@ExtendWith(Array(classOf[MockitoExtension]))
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 class StreamJoinedTest {
 
   val builder: InternalStreamsBuilder = mock(classOf[InternalStreamsBuilder])


### PR DESCRIPTION
See https://github.com/apache/kafka/pull/14648#discussion_r1499780993 -- turns out I didn't use it because it wasn't included as a build dependency 😆 

cc @ableegoldman @ijuma 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
