### PR TITLE
MINOR: Optimize EventAccumulator

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/EventAccumulator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/EventAccumulator.java
@@ -27,7 +27,6 @@ import java.util.Queue;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -137,31 +136,43 @@ public class EventAccumulator<K, T extends EventAccumulator.Event<K>> implements
     }
 
     /**
-     * Returns the next {{@link Event}} available. This method block indefinitely until
-     * one event is ready or the accumulator is closed.
+     * Returns the next {{@link Event}} available or null if no event is
+     * available.
      *
-     * @return The next event.
-     */
-    public T poll() {
-        return poll(Long.MAX_VALUE, TimeUnit.SECONDS);
-    }
-
-    /**
-     * Returns the next {{@link Event}} available. This method blocks for the provided
-     * time and returns null of not event is available.
-     *
-     * @param timeout   The timeout.
-     * @param unit      The timeout unit.
      * @return The next event available or null.
      */
-    public T poll(long timeout, TimeUnit unit) {
+    public T poll() {
         lock.lock();
         try {
             K key = randomKey();
-            long nanos = unit.toNanos(timeout);
-            while (key == null && !closed && nanos > 0) {
+            if (key == null) return null;
+
+            Queue<T> queue = queues.get(key);
+            T event = queue.poll();
+
+            if (queue.isEmpty()) queues.remove(key);
+            inflightKeys.add(key);
+            size--;
+
+            return event;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns the next {{@link Event}} available. This method blocks until an
+     * event is available or the thread is interrupted.
+     *
+     * @return The next event available or null.
+     */
+    public T take() {
+        lock.lock();
+        try {
+            K key = randomKey();
+            while (key == null && !closed) {
                 try {
-                    nanos = condition.awaitNanos(nanos);
+                    condition.await();
                 } catch (InterruptedException e) {
                     // Ignore.
                 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/EventAccumulator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/EventAccumulator.java
@@ -162,7 +162,7 @@ public class EventAccumulator<K, T extends EventAccumulator.Event<K>> implements
 
     /**
      * Returns the next {{@link Event}} available. This method blocks until an
-     * event is available or the thread is interrupted.
+     * event is available or accumulator is closed.
      *
      * @return The next event available or null.
      */

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -128,7 +127,7 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
         private void handleEvents() {
             while (!shuttingDown) {
                 recordPollStartTime(time.milliseconds());
-                CoordinatorEvent event = accumulator.poll();
+                CoordinatorEvent event = accumulator.take();
                 recordPollEndTime(time.milliseconds());
                 if (event != null) {
                     try {
@@ -148,8 +147,8 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
         }
 
         private void drainEvents() {
-            CoordinatorEvent event = accumulator.poll(0, TimeUnit.MILLISECONDS);
-            while (event != null) {
+            CoordinatorEvent event;
+            while ((event = accumulator.poll()) != null) {
                 try {
                     log.debug("Draining event: {}.", event);
                     metrics.recordEventQueueTime(time.milliseconds() - event.createdTimeMs());
@@ -159,8 +158,6 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
                 } finally {
                     accumulator.done(event);
                 }
-
-                event = accumulator.poll(0, TimeUnit.MILLISECONDS);
             }
         }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/EventAccumulatorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/EventAccumulatorTest.java
@@ -78,7 +78,7 @@ public class EventAccumulatorTest {
         EventAccumulator<Integer, MockEvent> accumulator = new EventAccumulator<>();
 
         assertEquals(0, accumulator.size());
-        assertNull(accumulator.poll(0, TimeUnit.MICROSECONDS));
+        assertNull(accumulator.poll());
 
         List<MockEvent> events = Arrays.asList(
             new MockEvent(1, 0),
@@ -97,14 +97,14 @@ public class EventAccumulatorTest {
 
         Set<MockEvent> polledEvents = new HashSet<>();
         for (int i = 0; i < events.size(); i++) {
-            MockEvent event = accumulator.poll(0, TimeUnit.MICROSECONDS);
+            MockEvent event = accumulator.poll();
             assertNotNull(event);
             polledEvents.add(event);
             assertEquals(events.size() - 1 - i, accumulator.size());
             accumulator.done(event);
         }
 
-        assertNull(accumulator.poll(0, TimeUnit.MICROSECONDS));
+        assertNull(accumulator.poll());
         assertEquals(new HashSet<>(events), polledEvents);
         assertEquals(0, accumulator.size());
 
@@ -126,27 +126,27 @@ public class EventAccumulatorTest {
         MockEvent event = null;
 
         // Poll event0.
-        event = accumulator.poll(0, TimeUnit.MICROSECONDS);
+        event = accumulator.poll();
         assertEquals(event0, event);
 
         // Poll returns null because key is inflight.
-        assertNull(accumulator.poll(0, TimeUnit.MICROSECONDS));
+        assertNull(accumulator.poll());
         accumulator.done(event);
 
         // Poll event1.
-        event = accumulator.poll(0, TimeUnit.MICROSECONDS);
+        event = accumulator.poll();
         assertEquals(event1, event);
 
         // Poll returns null because key is inflight.
-        assertNull(accumulator.poll(0, TimeUnit.MICROSECONDS));
+        assertNull(accumulator.poll());
         accumulator.done(event);
 
         // Poll event2.
-        event = accumulator.poll(0, TimeUnit.MICROSECONDS);
+        event = accumulator.poll();
         assertEquals(event2, event);
 
         // Poll returns null because key is inflight.
-        assertNull(accumulator.poll(0, TimeUnit.MICROSECONDS));
+        assertNull(accumulator.poll());
         accumulator.done(event);
 
         accumulator.close();
@@ -160,9 +160,9 @@ public class EventAccumulatorTest {
         MockEvent event1 = new MockEvent(1, 1);
         MockEvent event2 = new MockEvent(1, 2);
 
-        CompletableFuture<MockEvent> future0 = CompletableFuture.supplyAsync(accumulator::poll);
-        CompletableFuture<MockEvent> future1 = CompletableFuture.supplyAsync(accumulator::poll);
-        CompletableFuture<MockEvent> future2 = CompletableFuture.supplyAsync(accumulator::poll);
+        CompletableFuture<MockEvent> future0 = CompletableFuture.supplyAsync(accumulator::take);
+        CompletableFuture<MockEvent> future1 = CompletableFuture.supplyAsync(accumulator::take);
+        CompletableFuture<MockEvent> future2 = CompletableFuture.supplyAsync(accumulator::take);
         List<CompletableFuture<MockEvent>> futures = Arrays.asList(future0, future1, future2);
 
         assertFalse(future0.isDone());
@@ -215,9 +215,9 @@ public class EventAccumulatorTest {
     public void testCloseUnblockWaitingThreads() throws ExecutionException, InterruptedException, TimeoutException {
         EventAccumulator<Integer, MockEvent> accumulator = new EventAccumulator<>();
 
-        CompletableFuture<MockEvent> future0 = CompletableFuture.supplyAsync(accumulator::poll);
-        CompletableFuture<MockEvent> future1 = CompletableFuture.supplyAsync(accumulator::poll);
-        CompletableFuture<MockEvent> future2 = CompletableFuture.supplyAsync(accumulator::poll);
+        CompletableFuture<MockEvent> future0 = CompletableFuture.supplyAsync(accumulator::take);
+        CompletableFuture<MockEvent> future1 = CompletableFuture.supplyAsync(accumulator::take);
+        CompletableFuture<MockEvent> future2 = CompletableFuture.supplyAsync(accumulator::take);
 
         assertFalse(future0.isDone());
         assertFalse(future1.isDone());


### PR DESCRIPTION
`poll(long timeout, TimeUnit unit)` is either used with `Long.MAX_VALUE` or `0`. This patch replaces it with `poll` and `take`. It removes the `awaitNanos` usage.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
