### PR TITLE
MINOR: Remove the redundant space in the comments 

### DIFF
--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadata.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadata.java
@@ -32,7 +32,7 @@ public abstract class RemoteLogMetadata {
     private final int brokerId;
 
     /**
-     * Epoch time in milli seconds at which this event is generated.
+     * Epoch time in milliseconds at which this event is generated.
      */
     private final long eventTimestampMs;
 
@@ -42,7 +42,7 @@ public abstract class RemoteLogMetadata {
     }
 
     /**
-     * @return Epoch time in milli seconds at which this event is occurred.
+     * @return Epoch time in milliseconds at which this event is occurred.
      */
     public long eventTimestampMs() {
         return eventTimestampMs;


### PR DESCRIPTION
Hi, all
As I browsed the files I found the space between the words can be removed.
Thanks!

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
