### PR TITLE
MINOR: detect uninitalized MetadataResponse and retry in KafkaAdminCl…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1357,7 +1357,9 @@ public class KafkaAdminClient extends AdminClient {
                     }
                 } else {
                     try {
-                        call.handleResponse(response.responseBody());
+                        final AbstractResponse responseBody = response.responseBody();
+                        validateResponse(responseBody);
+                        call.handleResponse(responseBody);
                         if (log.isTraceEnabled())
                             log.trace("{} got response {}", call, response.responseBody());
                     } catch (Throwable t) {
@@ -1366,6 +1368,13 @@ public class KafkaAdminClient extends AdminClient {
                         call.fail(now, t);
                     }
                 }
+            }
+        }
+
+        private void validateResponse(final AbstractResponse abstractResponse) {
+            if (abstractResponse instanceof MetadataResponse) {
+                if (((MetadataResponse) abstractResponse).brokers().isEmpty())
+                    throw new StaleMetadataException("Metadata fetch failed due to missing broker list");
             }
         }
 
@@ -3367,8 +3376,6 @@ public class KafkaAdminClient extends AdminClient {
             void handleResponse(AbstractResponse abstractResponse) {
                 MetadataResponse metadataResponse = (MetadataResponse) abstractResponse;
                 Collection<Node> nodes = metadataResponse.brokers();
-                if (nodes.isEmpty())
-                    throw new StaleMetadataException("Metadata fetch failed due to missing broker list");
 
                 HashSet<Node> allNodes = new HashSet<>(nodes);
                 final ListConsumerGroupsResults results = new ListConsumerGroupsResults(allNodes, all);

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -6994,21 +6994,9 @@ public class KafkaAdminClientTest {
     @Test
     public void testListTransactions() throws Exception {
         try (AdminClientUnitTestEnv env = mockClientEnv()) {
-            MetadataResponseData.MetadataResponseBrokerCollection brokers =
-                new MetadataResponseData.MetadataResponseBrokerCollection();
-
-            env.cluster().nodes().forEach(node -> {
-                brokers.add(new MetadataResponseData.MetadataResponseBroker()
-                    .setHost(node.host())
-                    .setNodeId(node.id())
-                    .setPort(node.port())
-                    .setRack(node.rack())
-                );
-            });
-
             env.kafkaClient().prepareResponse(
                 request -> request instanceof MetadataRequest,
-                new MetadataResponse(new MetadataResponseData().setBrokers(brokers),
+                new MetadataResponse(new MetadataResponseData().setBrokers(brokers(env)),
                     MetadataResponseData.HIGHEST_SUPPORTED_VERSION)
             );
 
@@ -7127,7 +7115,8 @@ public class KafkaAdminClientTest {
                 MetadataRequest metadataRequest = (MetadataRequest) request;
                 return metadataRequest.topics().equals(singletonList(topicPartition.topic()));
             },
-            new MetadataResponse(new MetadataResponseData().setTopics(responseTopics),
+            new MetadataResponse(new MetadataResponseData().setTopics(responseTopics)
+                    .setBrokers(brokers(env)),
                 MetadataResponseData.HIGHEST_SUPPORTED_VERSION)
         );
     }
@@ -7373,6 +7362,44 @@ public class KafkaAdminClientTest {
             assertNotNull(result.all());
             TestUtils.assertFutureThrows(result.all(), Errors.UNSUPPORTED_VERSION.exception().getClass());
         }
+    }
+
+    @Test
+    public void describeTopicsWithEmptyMetadataRetries() throws Exception {
+        try (AdminClientUnitTestEnv env = mockClientEnv()) {
+            MetadataResponsePartition metadataResponsePartition = new MetadataResponsePartition()
+                    .setPartitionIndex(0);
+            MetadataResponseData.MetadataResponseTopicCollection topics =
+                    new MetadataResponseData.MetadataResponseTopicCollection();
+            topics.add(new MetadataResponseTopic().setName("test-topic").setPartitions(singletonList(metadataResponsePartition)));
+
+            env.kafkaClient().prepareResponse(
+                    request -> request instanceof MetadataRequest,
+                    new MetadataResponse(new MetadataResponseData(), MetadataResponseData.HIGHEST_SUPPORTED_VERSION));
+
+            env.kafkaClient().prepareResponse(
+                    request -> request instanceof MetadataRequest,
+                    new MetadataResponse(new MetadataResponseData().setBrokers(brokers(env))
+                            .setTopics(topics), MetadataResponseData.HIGHEST_SUPPORTED_VERSION));
+
+            DescribeTopicsResult describeTopicsResult = env.adminClient().describeTopics(singleton("test-topic"));
+            assertTrue(describeTopicsResult.allTopicNames().get().containsKey("test-topic"));
+        }
+    }
+
+    private static MetadataResponseData.MetadataResponseBrokerCollection brokers(AdminClientUnitTestEnv env) {
+        MetadataResponseData.MetadataResponseBrokerCollection brokers =
+                new MetadataResponseData.MetadataResponseBrokerCollection();
+
+        env.cluster().nodes().forEach(node ->
+                brokers.add(new MetadataResponseData.MetadataResponseBroker()
+                        .setHost(node.host())
+                        .setNodeId(node.id())
+                        .setPort(node.port())
+                        .setRack(node.rack())
+                ));
+
+        return brokers;
     }
 
     private static ListClientMetricsResourcesResponse prepareListClientMetricsResourcesResponse(Errors error) {


### PR DESCRIPTION
…ient

## Description

Brokers can respond to metadata requests with uninitialized metadata when they are starting up. The [NetworkClient](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java#L1187-L1191) detects this scenario and ignores the empty metadata so that it can be retried later. Unfortunately the KafkaAdminClient only detects empty metadata for [listConsumerGroups](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java#L3369-L3371). The impact of this is that other metadata requests fail with incorrect errors when handling an uninitialized metadata response. For example describeTopics will throw an UnknownTopicOrPartitionException for topics that do exist in the cluster.

This PR changes the KafkaAdminClient to detect any MetadataResponse that contains an empty broker set and throws a StaleMetadataException, that enables the call to be automatically retried. For example `describeTopics`, `listTopics`, `describeCluster` and the clients own metadata fetches will now be retried if the returned brokers set is empty. Additionally any calls that rely on metadata using the AllBrokerStrategy or the PartitionLeaderStrategy. `listConsumerGroups` was already retrying and will continue to do so.

## Discussion

I think the better long term solution here is to have the brokers respond with a specific error when their metadata is uninitialized. This would be a clearer signal to all clients instead of relying on the obscure empty brokers condition. That would be a larger change so I'd like some feedback on whether that's the direction we want to go.

I don't think the StaleMetadataException is the perfect exception for the uninitialized metadata scenario but there was precedent for it already in `listConsumerGroups` so I went with that. Open to creating a new exception type if people would like or just making the message within more clear.

## Testing

I wrote a unit test that proves `describeTopics` will now retry when it receives an empty metadata response. This same test fails with an UnknownTopicOrPartitionException without my change. I also patched one of the other test scenarios (describeProducers) to include brokers in its mock metadata response, because that test would fail otherwise now.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
