### PR TITLE
KAFKA-16167: Disable wakeups during autocommit on close

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/WakeupTrigger.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/WakeupTrigger.java
@@ -73,6 +73,8 @@ public class WakeupTrigger {
             } else if (task instanceof WakeupFuture) {
                 currentTask.completeExceptionally(new WakeupException());
                 return null;
+            } else if (task instanceof DisabledWakeups) {
+                return task;
             }
             // last active state is still active
             throw new KafkaException("Last active task is still active");
@@ -88,6 +90,8 @@ public class WakeupTrigger {
             } else if (task instanceof WakeupFuture) {
                 throwWakeupException.set(true);
                 return null;
+            } else if (task instanceof DisabledWakeups) {
+                return task;
             }
             // last active state is still active
             throw new IllegalStateException("Last active task is still active");
@@ -95,6 +99,10 @@ public class WakeupTrigger {
         if (throwWakeupException.get()) {
             throw new WakeupException();
         }
+    }
+
+    public void disableWakeups() {
+        pendingTask.set(new DisabledWakeups());
     }
 
     public void clearTask() {
@@ -130,6 +138,9 @@ public class WakeupTrigger {
     }
 
     interface Wakeupable { }
+
+    // Set to block wakeups from happening and pending actions to be registered.
+    static class DisabledWakeups implements Wakeupable { }
 
     static class ActiveFuture implements Wakeupable {
         private final CompletableFuture<?> future;


### PR DESCRIPTION
When the consumer is closed, we perform a sychronous autocommit. We don't want to be woken up here, because we are already executing a close operation under a deadline. This is in line with the behavior of the old consumer.

This fixes PlaintextConsumerTest.testAutoCommitOnCloseAfterWakeup which is flaky on trunk - because we return immediately from the synchronous commit with a WakeupException, which causes us to not wait for the commit to finish and thereby sometimes miss the committed offset when a new consumer is created.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
