### PR TITLE
KAFKA-16317: Add event process rate in GroupCoordinatorRuntimeMetrics

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/CoordinatorRuntimeMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/CoordinatorRuntimeMetrics.java
@@ -67,7 +67,7 @@ public interface CoordinatorRuntimeMetrics extends AutoCloseable {
     void registerEventQueueSizeGauge(Supplier<Integer> sizeSupplier);
 
     /**
-     * Update the event rate.
+     * Update the event process sensor.
      */
-    void recordEventProcess();
+    void recordEventProcessSensor();
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/CoordinatorRuntimeMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/CoordinatorRuntimeMetrics.java
@@ -65,4 +65,9 @@ public interface CoordinatorRuntimeMetrics extends AutoCloseable {
      * @param sizeSupplier The size supplier.
      */
     void registerEventQueueSizeGauge(Supplier<Integer> sizeSupplier);
+
+    /**
+     * Update the event rate.
+     */
+    void recordEventProcess();
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
@@ -228,7 +228,7 @@ public class GroupCoordinatorRuntimeMetrics implements CoordinatorRuntimeMetrics
     }
 
     @Override
-    public void recordEventProcess() {
+    public void recordEventProcessSensor() {
         eventProcessSensor.record();
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Meter;
 import org.apache.kafka.common.metrics.stats.Min;
 import org.apache.kafka.coordinator.group.runtime.CoordinatorRuntime.CoordinatorState;
 
@@ -79,6 +80,11 @@ public class GroupCoordinatorRuntimeMetrics implements CoordinatorRuntimeMetrics
      */
     private final Sensor threadIdleRatioSensor;
 
+    /**
+     * The event rate sensor.
+     */
+    private final Sensor eventProcessSensor;
+
     public GroupCoordinatorRuntimeMetrics(Metrics metrics) {
         this.metrics = Objects.requireNonNull(metrics);
 
@@ -133,6 +139,15 @@ public class GroupCoordinatorRuntimeMetrics implements CoordinatorRuntimeMetrics
                 METRICS_GROUP,
                 "The average thread idle ratio over the last 30 seconds."
             ), new Avg());
+
+        this.eventProcessSensor = metrics.sensor("EventProcess");
+        this.eventProcessSensor.add(new Meter(
+            metrics.metricName("event-process-rate",
+                METRICS_GROUP,
+                "The event processing rate"),
+            metrics.metricName("event-process-count",
+                METRICS_GROUP,
+                "The total number of events processed")));
     }
 
     /**
@@ -210,6 +225,11 @@ public class GroupCoordinatorRuntimeMetrics implements CoordinatorRuntimeMetrics
     @Override
     public void recordThreadIdleRatio(double ratio) {
         threadIdleRatioSensor.record(ratio);
+    }
+
+    @Override
+    public void recordEventProcess() {
+        eventProcessSensor.record();
     }
 
     @Override

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
@@ -136,7 +136,7 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
                         metrics.recordEventQueueTime(dequeuedTimeMs - event.createdTimeMs());
                         event.run();
                         metrics.recordEventQueueProcessingTime(time.milliseconds() - dequeuedTimeMs);
-                        metrics.recordEventProcess();
+                        metrics.recordEventProcessSensor();
                     } catch (Throwable t) {
                         log.error("Failed to run event {} due to: {}.", event, t.getMessage(), t);
                         event.complete(t);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
@@ -136,6 +136,7 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
                         metrics.recordEventQueueTime(dequeuedTimeMs - event.createdTimeMs());
                         event.run();
                         metrics.recordEventQueueProcessingTime(time.milliseconds() - dequeuedTimeMs);
+                        metrics.recordEventProcess();
                     } catch (Throwable t) {
                         log.error("Failed to run event {} due to: {}.", event, t.getMessage(), t);
                         event.complete(t);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetricsTest.java
@@ -134,6 +134,27 @@ public class GroupCoordinatorRuntimeMetricsTest {
         }
     }
 
+    @Test
+    public void testEventProcessSensor() {
+        Time time = new MockTime();
+        Metrics metrics = new Metrics(time);
+
+        try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(metrics)) {
+            IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordEventProcess());
+
+            org.apache.kafka.common.MetricName metricName = metrics.metricName(
+                "event-process-rate", METRICS_GROUP);
+
+            KafkaMetric metric = metrics.metrics().get(metricName);
+            assertEquals(3.0 / 30, metric.metricValue());
+
+            metricName = metrics.metricName(
+                "event-process-count", METRICS_GROUP);
+            metric = metrics.metrics().get(metricName);
+            assertEquals(3.0, metric.metricValue());
+        }
+    }
+
     private static void assertMetricGauge(Metrics metrics, org.apache.kafka.common.MetricName metricName, long count) {
         assertEquals(count, (long) metrics.metric(metricName).metricValue());
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetricsTest.java
@@ -140,7 +140,7 @@ public class GroupCoordinatorRuntimeMetricsTest {
         Metrics metrics = new Metrics(time);
 
         try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(metrics)) {
-            IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordEventProcess());
+            IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordEventProcessSensor());
 
             org.apache.kafka.common.MetricName metricName = metrics.metricName(
                 "event-process-rate", METRICS_GROUP);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
@@ -515,7 +515,7 @@ public class MultiThreadedEventProcessorTest {
     }
 
     @Test
-    public void testRecordEventProcess() throws Exception {
+    public void testRecordEventProcessSensor() throws Exception {
         GroupCoordinatorRuntimeMetrics mockRuntimeMetrics = mock(GroupCoordinatorRuntimeMetrics.class);
         Time mockTime = new MockTime();
         AtomicInteger numEventsExecuted = new AtomicInteger(0);
@@ -545,7 +545,7 @@ public class MultiThreadedEventProcessorTest {
             // Enqueue the other event.
             FutureEvent<Integer> otherEvent = new FutureEvent<>(
                 new TopicPartition("foo", 0), () -> {
-                verify(mockRuntimeMetrics, times(1)).recordEventProcess();
+                verify(mockRuntimeMetrics, times(1)).recordEventProcessSensor();
                 return numEventsExecuted.incrementAndGet();
             },
                 false,
@@ -556,7 +556,7 @@ public class MultiThreadedEventProcessorTest {
 
             // Events should not be completed.
             assertFalse(otherEvent.future.isDone());
-            verify(mockRuntimeMetrics, times(0)).recordEventProcess();
+            verify(mockRuntimeMetrics, times(0)).recordEventProcessSensor();
 
             // Release the blocking event to unblock the thread.
             blockingEvent.release();
@@ -571,7 +571,7 @@ public class MultiThreadedEventProcessorTest {
             assertTrue(otherEvent.future.isDone());
             assertFalse(otherEvent.future.isCompletedExceptionally());
             assertEquals(2, numEventsExecuted.get());
-            verify(mockRuntimeMetrics, times(2)).recordEventProcess();
+            verify(mockRuntimeMetrics, times(2)).recordEventProcessSensor();
         }
     }
 }


### PR DESCRIPTION
This metric will help identify how fast all coordinator threads process events. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
