### PR TITLE
MINOR: AddPartitionsToTxnManager performance optimizations

### DIFF
--- a/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
+++ b/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
@@ -32,7 +32,7 @@ import org.apache.kafka.server.util.{InterBrokerSendThread, RequestAndCompletion
 
 import java.util
 import java.util.concurrent.TimeUnit
-import scala.collection.{Set, Seq, mutable}
+import scala.collection.{Seq, mutable}
 import scala.jdk.CollectionConverters._
 
 object AddPartitionsToTxnManager {
@@ -66,6 +66,7 @@ class AddPartitionsToTxnManager(
 
   this.logIdent = logPrefix
 
+  private val interBrokerListenerName = config.interBrokerListenerName
   private val inflightNodes = mutable.HashSet[Node]()
   private val nodesToTransactions = mutable.Map[Node, TransactionDataAndCallbacks]()
 
@@ -80,10 +81,9 @@ class AddPartitionsToTxnManager(
     topicPartitions: Seq[TopicPartition],
     callback: AddPartitionsToTxnManager.AppendCallback
   ): Unit = {
-    val (error, node) = getTransactionCoordinator(partitionFor(transactionalId))
-
-    if (error != Errors.NONE) {
-      callback(topicPartitions.map(tp => tp -> error).toMap)
+    val coordinatorNode = getTransactionCoordinator(partitionFor(transactionalId))
+    if (coordinatorNode.isEmpty) {
+      callback(topicPartitions.map(tp => tp -> Errors.COORDINATOR_NOT_AVAILABLE).toMap)
     } else {
       val topicCollection = new AddPartitionsToTxnTopicCollection()
       topicPartitions.groupBy(_.topic).forKeyValue { (topic, tps) =>
@@ -99,7 +99,7 @@ class AddPartitionsToTxnManager(
         .setVerifyOnly(true)
         .setTopics(topicCollection)
 
-      addTxnData(node, transactionData, callback)
+      addTxnData(coordinatorNode.get, transactionData, callback)
     }
   }
 
@@ -146,31 +146,10 @@ class AddPartitionsToTxnManager(
     }
   }
 
-  private def getTransactionCoordinator(partition: Int): (Errors, Node) = {
-    val listenerName = config.interBrokerListenerName
-
-    val topicMetadata = metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), listenerName)
-
-    if (topicMetadata.headOption.isEmpty) {
-      // If topic is not created, then the transaction is definitely not started.
-      (Errors.COORDINATOR_NOT_AVAILABLE, Node.noNode)
-    } else {
-      if (topicMetadata.head.errorCode != Errors.NONE.code) {
-        (Errors.COORDINATOR_NOT_AVAILABLE, Node.noNode)
-      } else {
-        val coordinatorEndpoint = topicMetadata.head.partitions.asScala
-          .find(_.partitionIndex == partition)
-          .filter(_.leaderId != MetadataResponse.NO_LEADER_ID)
-          .flatMap(metadata => metadataCache.getAliveBrokerNode(metadata.leaderId, listenerName))
-
-        coordinatorEndpoint match {
-          case Some(endpoint) =>
-            (Errors.NONE, endpoint)
-          case _ =>
-            (Errors.COORDINATOR_NOT_AVAILABLE, Node.noNode)
-        }
-      }
-    }
+  private def getTransactionCoordinator(partition: Int): Option[Node] = {
+   metadataCache.getPartitionInfo(Topic.TRANSACTION_STATE_TOPIC_NAME, partition)
+      .filter(_.leader != MetadataResponse.NO_LEADER_ID)
+      .flatMap(metadata => metadataCache.getAliveBrokerNode(metadata.leader, interBrokerListenerName))
   }
 
   private def topicPartitionsToError(transactionData: AddPartitionsToTxnTransaction, error: Errors): Map[TopicPartition, Errors] = {

--- a/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnManagerTest.scala
@@ -24,8 +24,9 @@ import org.apache.kafka.clients.{ClientResponse, NetworkClient}
 import org.apache.kafka.common.errors.{AuthenticationException, SaslAuthenticationException, UnsupportedVersionException}
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.message.AddPartitionsToTxnRequestData.{AddPartitionsToTxnTopic, AddPartitionsToTxnTopicCollection, AddPartitionsToTxnTransaction, AddPartitionsToTxnTransactionCollection}
-import org.apache.kafka.common.message.{AddPartitionsToTxnResponseData, MetadataResponseData}
+import org.apache.kafka.common.message.{AddPartitionsToTxnResponseData}
 import org.apache.kafka.common.message.AddPartitionsToTxnResponseData.AddPartitionsToTxnResultCollection
+import org.apache.kafka.common.message.UpdateMetadataRequestData.UpdateMetadataPartitionState
 import org.apache.kafka.common.{Node, TopicPartition}
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractResponse, AddPartitionsToTxnRequest, AddPartitionsToTxnResponse}
@@ -98,19 +99,20 @@ class AddPartitionsToTxnManagerTest {
     when(partitionFor.apply(transactionalId1)).thenReturn(0)
     when(partitionFor.apply(transactionalId2)).thenReturn(1)
     when(partitionFor.apply(transactionalId3)).thenReturn(0)
-    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
-      .thenReturn(Seq(
-        new MetadataResponseData.MetadataResponseTopic()
-          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
-          .setPartitions(List(
-            new MetadataResponseData.MetadataResponsePartition()
-              .setPartitionIndex(0)
-              .setLeaderId(0),
-            new MetadataResponseData.MetadataResponsePartition()
-              .setPartitionIndex(1)
-              .setLeaderId(1)
-          ).asJava)
-      ))
+    when(metadataCache.getPartitionInfo(Topic.TRANSACTION_STATE_TOPIC_NAME, 0))
+      .thenReturn(Some(
+        new UpdateMetadataPartitionState()
+          .setTopicName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setPartitionIndex(0)
+          .setLeader(0)))
+
+    when(metadataCache.getPartitionInfo(Topic.TRANSACTION_STATE_TOPIC_NAME, 1))
+      .thenReturn(Some(
+        new UpdateMetadataPartitionState()
+          .setTopicName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setPartitionIndex(1)
+          .setLeader(1)))
+
     when(metadataCache.getAliveBrokerNode(0, config.interBrokerListenerName))
       .thenReturn(Some(node0))
     when(metadataCache.getAliveBrokerNode(1, config.interBrokerListenerName))
@@ -167,22 +169,24 @@ class AddPartitionsToTxnManagerTest {
     when(partitionFor.apply(transactionalId1)).thenReturn(0)
     when(partitionFor.apply(transactionalId2)).thenReturn(1)
     when(partitionFor.apply(transactionalId3)).thenReturn(2)
-    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
-      .thenReturn(Seq(
-        new MetadataResponseData.MetadataResponseTopic()
-          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
-          .setPartitions(List(
-            new MetadataResponseData.MetadataResponsePartition()
-              .setPartitionIndex(0)
-              .setLeaderId(0),
-            new MetadataResponseData.MetadataResponsePartition()
-              .setPartitionIndex(1)
-              .setLeaderId(1),
-            new MetadataResponseData.MetadataResponsePartition()
-              .setPartitionIndex(2)
-              .setLeaderId(2)
-          ).asJava)
-      ))
+    when(metadataCache.getPartitionInfo(Topic.TRANSACTION_STATE_TOPIC_NAME, 0))
+      .thenReturn(Some(
+        new UpdateMetadataPartitionState()
+          .setTopicName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setPartitionIndex(0)
+          .setLeader(0)))
+    when(metadataCache.getPartitionInfo(Topic.TRANSACTION_STATE_TOPIC_NAME, 1))
+      .thenReturn(Some(
+        new UpdateMetadataPartitionState()
+          .setTopicName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setPartitionIndex(1)
+          .setLeader(1)))
+    when(metadataCache.getPartitionInfo(Topic.TRANSACTION_STATE_TOPIC_NAME, 2))
+      .thenReturn(Some(
+        new UpdateMetadataPartitionState()
+          .setTopicName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setPartitionIndex(2)
+          .setLeader(2)))
     when(metadataCache.getAliveBrokerNode(0, config.interBrokerListenerName))
       .thenReturn(Some(node0))
     when(metadataCache.getAliveBrokerNode(1, config.interBrokerListenerName))
@@ -247,51 +251,26 @@ class AddPartitionsToTxnManagerTest {
     }
 
     // The transaction state topic does not exist.
-    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
-      .thenReturn(Seq())
-    checkError()
-
-    // The metadata of the transaction state topic returns an error.
-    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
-      .thenReturn(Seq(
-        new MetadataResponseData.MetadataResponseTopic()
-          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
-          .setErrorCode(Errors.BROKER_NOT_AVAILABLE.code)
-      ))
-    checkError()
-
-    // The partition does not exist.
-    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
-      .thenReturn(Seq(
-        new MetadataResponseData.MetadataResponseTopic()
-          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
-      ))
+    when(metadataCache.getPartitionInfo(Topic.TRANSACTION_STATE_TOPIC_NAME, 0))
+      .thenReturn(Option.empty)
     checkError()
 
     // The partition has no leader.
-    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
-      .thenReturn(Seq(
-        new MetadataResponseData.MetadataResponseTopic()
-          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
-          .setPartitions(List(
-            new MetadataResponseData.MetadataResponsePartition()
-              .setPartitionIndex(0)
-              .setLeaderId(-1)
-          ).asJava)
-      ))
+    when(metadataCache.getPartitionInfo(Topic.TRANSACTION_STATE_TOPIC_NAME, 0))
+      .thenReturn(Some(
+        new UpdateMetadataPartitionState()
+          .setTopicName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setPartitionIndex(0)
+          .setLeader(-1)))
     checkError()
 
     // The leader is not available.
-    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
-      .thenReturn(Seq(
-        new MetadataResponseData.MetadataResponseTopic()
-          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
-          .setPartitions(List(
-            new MetadataResponseData.MetadataResponsePartition()
-              .setPartitionIndex(0)
-              .setLeaderId(0)
-          ).asJava)
-      ))
+    when(metadataCache.getPartitionInfo(Topic.TRANSACTION_STATE_TOPIC_NAME, 0))
+      .thenReturn(Some(
+        new UpdateMetadataPartitionState()
+          .setTopicName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setPartitionIndex(0)
+          .setLeader(0)))
     checkError()
   }
 
@@ -299,16 +278,12 @@ class AddPartitionsToTxnManagerTest {
   def testAddPartitionsToTxnHandlerErrorHandling(): Unit = {
     when(partitionFor.apply(transactionalId1)).thenReturn(0)
     when(partitionFor.apply(transactionalId2)).thenReturn(0)
-    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
-      .thenReturn(Seq(
-        new MetadataResponseData.MetadataResponseTopic()
-          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
-          .setPartitions(List(
-            new MetadataResponseData.MetadataResponsePartition()
-              .setPartitionIndex(0)
-              .setLeaderId(0)
-          ).asJava)
-      ))
+    when(metadataCache.getPartitionInfo(Topic.TRANSACTION_STATE_TOPIC_NAME, 0))
+      .thenReturn(Some(
+        new UpdateMetadataPartitionState()
+          .setTopicName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setPartitionIndex(0)
+          .setLeader(0)))
     when(metadataCache.getAliveBrokerNode(0, config.interBrokerListenerName))
       .thenReturn(Some(node0))
 
@@ -380,19 +355,18 @@ class AddPartitionsToTxnManagerTest {
 
     when(partitionFor.apply(transactionalId1)).thenReturn(0)
     when(partitionFor.apply(transactionalId2)).thenReturn(1)
-    when(metadataCache.getTopicMetadata(Set(Topic.TRANSACTION_STATE_TOPIC_NAME), config.interBrokerListenerName))
-      .thenReturn(Seq(
-        new MetadataResponseData.MetadataResponseTopic()
-          .setName(Topic.TRANSACTION_STATE_TOPIC_NAME)
-          .setPartitions(List(
-            new MetadataResponseData.MetadataResponsePartition()
-              .setPartitionIndex(0)
-              .setLeaderId(0),
-            new MetadataResponseData.MetadataResponsePartition()
-              .setPartitionIndex(1)
-              .setLeaderId(1)
-          ).asJava)
-      ))
+    when(metadataCache.getPartitionInfo(Topic.TRANSACTION_STATE_TOPIC_NAME, 0))
+      .thenReturn(Some(
+        new UpdateMetadataPartitionState()
+          .setTopicName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setPartitionIndex(0)
+          .setLeader(0)))
+    when(metadataCache.getPartitionInfo(Topic.TRANSACTION_STATE_TOPIC_NAME, 1))
+      .thenReturn(Some(
+        new UpdateMetadataPartitionState()
+          .setTopicName(Topic.TRANSACTION_STATE_TOPIC_NAME)
+          .setPartitionIndex(1)
+          .setLeader(1)))
     when(metadataCache.getAliveBrokerNode(0, config.interBrokerListenerName))
       .thenReturn(Some(node0))
     when(metadataCache.getAliveBrokerNode(1, config.interBrokerListenerName))


### PR DESCRIPTION
A few minor optimizations:
1. Cache the interbroker listener name instead of computing it each time. The value of the interbroker listener name cannot change without a process restart, and the `KafkaConfig.interBrokerListenerName` call can be quite expensive.
2. we're currently grabbing all partitions for the transaction state topic in getTransactionCoordinator. Instead, just query the partition we care about. This also simplifies the code somewhat since `getPartitionInfo` does not include error codes. The partition is either available or not (we return NOT_COORDINATOR in all cases anyway).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
