### PR TITLE
kafka-connect configuration file uses UTF-8 character set.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
@@ -684,7 +685,7 @@ public final class Utils {
 
         if (filename != null) {
             try (InputStream propStream = Files.newInputStream(Paths.get(filename))) {
-                props.load(propStream);
+                props.load(new InputStreamReader(propStream, "UTF-8"));
             }
         } else {
             System.out.println("Did not load any properties since the property file is not specified");


### PR DESCRIPTION
Currently, when using ``kafka-connect`` configuration files (such as ``connect-standalone.properties``) in non-English regions, if they contain non-ASCII characters, the program will not recognize them.

### Motivation
Specifically, when we use ``debezium`` (https://debezium.io/), we need to specify the excluded database table through configuration. At this time, our database table name is Chinese, because the default read configuration does not use ``UTF-8`` Encoding, which causes the configuration to become garbled after being read and cannot be correctly excluded.

``debezium`` uses the ``kafka-clients`` package directly, so this cannot be solved in ``debezium``.

### Note
``UTF-8`` encoding doesn't break ``ASCII`` reading, so should this be backported to an earlier version?


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
