### PR TITLE
MINOR: fix link for ListTransactionsOptions#filterOnDuration

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1634,7 +1634,7 @@ public interface Admin extends AutoCloseable {
      * should typically attempt to reduce the size of the result set using
      * {@link ListTransactionsOptions#filterProducerIds(Collection)} or
      * {@link ListTransactionsOptions#filterStates(Collection)} or
-     * {@link ListTransactionsOptions#durationFilter(Long)}
+     * {@link ListTransactionsOptions#filterOnDuration(long)}.
      *
      * @param options Options to control the method behavior (including filters)
      * @return The result


### PR DESCRIPTION
There is no `ListTransactionsOptions#durationFilter(Long)` function.
Change the link to `ListTransactionsOptions#filterOnDuration(long)`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
