### PR TITLE
KAFKA-16322 upgrade jline from 3.22.0 to 3.25.1

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -333,7 +333,7 @@ zstd-jni-1.5.5-11 see: licenses/zstd-jni-BSD-2-clause
 ---------------------------------------
 BSD 3-Clause
 
-jline-3.22.0, see: licenses/jline-BSD-3-clause
+jline-3.25.1, see: licenses/jline-BSD-3-clause
 jsr305-3.0.2, see: licenses/jsr305-BSD-3-clause
 paranamer-2.8, see: licenses/paranamer-BSD-3-clause
 protobuf-java-3.23.4, see: licenses/protobuf-java-BSD-3-clause

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -108,7 +108,7 @@ versions += [
   javassist: "3.29.2-GA",
   jetty: "9.4.53.v20231009",
   jersey: "2.39.1",
-  jline: "3.22.0",
+  jline: "3.25.1",
   jmh: "1.37",
   hamcrest: "2.2",
   scalaLogging: "3.9.4",


### PR DESCRIPTION
## Context
An issue in the component "GroovyEngine.execute" of jline-groovy versions through 3.24.1 allows attackers to cause an OOM (OutofMemory) error. Please refer to [this link](https://devhub.checkmarx.com/cve-details/CVE-2023-50572/) for more details. 

## Solution
Upgrade the jline from from 3.22.0 to 3.25.1 to address this issue. 

## Test
Follow [KAFKA-12622](https://issues.apache.org/jira/browse/KAFKA-12622) to verify that we don't miss any dependencies license in the LICENSE-binary. 

1. check the license
```
./gradlewAll clean releaseTarGz
 tar xzf core/build/distributions/kafka_2.13-3.8.0-SNAPSHOT.tgz
cd kafka_2.13-3.8.0-SNAPSHOT
for f in $(ls libs | grep -v "^kafka\|connect\|trogdor"); do if ! grep -q ${f%.*} LICENSE; then echo "${f%.*} is missing in license file"; fi; done
```
there is no output.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
