### PR TITLE
MINOR: Resolve SslContextFactory method deprecations

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
@@ -61,7 +61,7 @@ public class RestClient {
     }
 
     // VisibleForTesting
-    HttpClient httpClient(SslContextFactory sslContextFactory) {
+    HttpClient httpClient(SslContextFactory.Client sslContextFactory) {
         return sslContextFactory != null ? new HttpClient(sslContextFactory) : new HttpClient();
     }
 
@@ -120,7 +120,7 @@ public class RestClient {
         Objects.requireNonNull(method, "method must be non-null");
         Objects.requireNonNull(responseFormat, "response format must be non-null");
         // Only try to load SSL configs if we have to (see KAFKA-14816)
-        SslContextFactory sslContextFactory = url.startsWith("https://")
+        SslContextFactory.Client sslContextFactory = url.startsWith("https://")
                 ? SSLUtils.createClientSideSslContextFactory(config)
                 : null;
         HttpClient client = httpClient(sslContextFactory);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -159,7 +159,7 @@ public abstract class RestServer {
         ServerConnector connector;
 
         if (PROTOCOL_HTTPS.equals(protocol)) {
-            SslContextFactory ssl;
+            SslContextFactory.Server ssl;
             if (isAdmin) {
                 ssl = SSLUtils.createServerSideSslContextFactory(config, RestServerConfig.ADMIN_LISTENERS_HTTPS_CONFIGS_PREFIX);
             } else {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/util/SSLUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/util/SSLUtils.java
@@ -40,7 +40,7 @@ public class SSLUtils {
     /**
      * Configures SSL/TLS for HTTPS Jetty Server using configs with the given prefix
      */
-    public static SslContextFactory createServerSideSslContextFactory(AbstractConfig config, String prefix) {
+    public static SslContextFactory.Server createServerSideSslContextFactory(AbstractConfig config, String prefix) {
         Map<String, Object> sslConfigValues = config.valuesWithPrefixAllOrNothing(prefix);
 
         final SslContextFactory.Server ssl = new SslContextFactory.Server();
@@ -56,14 +56,14 @@ public class SSLUtils {
     /**
      * Configures SSL/TLS for HTTPS Jetty Server
      */
-    public static SslContextFactory createServerSideSslContextFactory(AbstractConfig config) {
+    public static SslContextFactory.Server createServerSideSslContextFactory(AbstractConfig config) {
         return createServerSideSslContextFactory(config, "listeners.https.");
     }
 
     /**
      * Configures SSL/TLS for HTTPS Jetty Client
      */
-    public static SslContextFactory createClientSideSslContextFactory(AbstractConfig config) {
+    public static SslContextFactory.Client createClientSideSslContextFactory(AbstractConfig config) {
         Map<String, Object> sslConfigValues = config.valuesWithPrefixAllOrNothing("listeners.https.");
 
         final SslContextFactory.Client ssl = new SslContextFactory.Client();
@@ -147,7 +147,7 @@ public class SSLUtils {
     /**
      * Configures hostname verification related settings in SslContextFactory
      */
-    protected static void configureSslContextFactoryEndpointIdentification(SslContextFactory ssl, Map<String, Object> sslConfigValues) {
+    protected static void configureSslContextFactoryEndpointIdentification(SslContextFactory.Client ssl, Map<String, Object> sslConfigValues) {
         String sslEndpointIdentificationAlg = (String) sslConfigValues.get(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
         if (sslEndpointIdentificationAlg != null)
             ssl.setEndpointIdentificationAlgorithm(sslEndpointIdentificationAlg);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestForwardingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestForwardingIntegrationTest.java
@@ -89,7 +89,7 @@ public class RestForwardingIntegrationTest {
     @Mock
     private Herder leaderHerder;
 
-    private SslContextFactory factory;
+    private SslContextFactory.Client factory;
     private CloseableHttpClient httpClient;
     private Collection<CloseableHttpResponse> responses;
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/util/SSLUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/util/SSLUtilsTest.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-@SuppressWarnings("deprecation")
 public class SSLUtilsTest {
 
     @Test
@@ -63,7 +62,7 @@ public class SSLUtilsTest {
         configMap.put("ssl.trustmanager.algorithm", "PKIX");
 
         RestServerConfig config = RestServerConfig.forPublic(null, configMap);
-        SslContextFactory ssl = SSLUtils.createServerSideSslContextFactory(config);
+        SslContextFactory.Server ssl = SSLUtils.createServerSideSslContextFactory(config);
 
         Assert.assertEquals("file:///path/to/keystore", ssl.getKeyStorePath());
         Assert.assertEquals("file:///path/to/truststore", ssl.getTrustStorePath());
@@ -101,15 +100,13 @@ public class SSLUtilsTest {
         configMap.put("ssl.trustmanager.algorithm", "PKIX");
 
         RestServerConfig config = RestServerConfig.forPublic(null, configMap);
-        SslContextFactory ssl = SSLUtils.createClientSideSslContextFactory(config);
+        SslContextFactory.Client ssl = SSLUtils.createClientSideSslContextFactory(config);
 
         Assert.assertEquals("file:///path/to/keystore", ssl.getKeyStorePath());
         Assert.assertEquals("file:///path/to/truststore", ssl.getTrustStorePath());
         Assert.assertEquals("SunJSSE", ssl.getProvider());
         Assert.assertArrayEquals(new String[] {"SSL_RSA_WITH_RC4_128_SHA", "SSL_RSA_WITH_RC4_128_MD5"}, ssl.getIncludeCipherSuites());
         Assert.assertEquals("SHA1PRNG", ssl.getSecureRandomAlgorithm());
-        Assert.assertFalse(ssl.getNeedClientAuth());
-        Assert.assertFalse(ssl.getWantClientAuth());
         Assert.assertEquals("JKS", ssl.getKeyStoreType());
         Assert.assertEquals("JKS", ssl.getTrustStoreType());
         Assert.assertEquals("TLS", ssl.getProtocol());
@@ -131,7 +128,7 @@ public class SSLUtilsTest {
         configMap.put("ssl.secure.random.implementation", "SHA1PRNG");
 
         RestServerConfig config = RestServerConfig.forPublic(null, configMap);
-        SslContextFactory ssl = SSLUtils.createServerSideSslContextFactory(config);
+        SslContextFactory.Server ssl = SSLUtils.createServerSideSslContextFactory(config);
 
         Assert.assertEquals(SslConfigs.DEFAULT_SSL_KEYSTORE_TYPE, ssl.getKeyStoreType());
         Assert.assertEquals(SslConfigs.DEFAULT_SSL_TRUSTSTORE_TYPE, ssl.getTrustStoreType());
@@ -156,7 +153,7 @@ public class SSLUtilsTest {
         configMap.put("ssl.secure.random.implementation", "SHA1PRNG");
 
         RestServerConfig config = RestServerConfig.forPublic(null, configMap);
-        SslContextFactory ssl = SSLUtils.createClientSideSslContextFactory(config);
+        SslContextFactory.Client ssl = SSLUtils.createClientSideSslContextFactory(config);
 
         Assert.assertEquals(SslConfigs.DEFAULT_SSL_KEYSTORE_TYPE, ssl.getKeyStoreType());
         Assert.assertEquals(SslConfigs.DEFAULT_SSL_TRUSTSTORE_TYPE, ssl.getTrustStoreType());
@@ -164,7 +161,5 @@ public class SSLUtilsTest {
         Assert.assertArrayEquals(Arrays.asList(SslConfigs.DEFAULT_SSL_ENABLED_PROTOCOLS.split("\\s*,\\s*")).toArray(), ssl.getIncludeProtocols());
         Assert.assertEquals(SslConfigs.DEFAULT_SSL_KEYMANGER_ALGORITHM, ssl.getKeyManagerFactoryAlgorithm());
         Assert.assertEquals(SslConfigs.DEFAULT_SSL_TRUSTMANAGER_ALGORITHM, ssl.getTrustManagerFactoryAlgorithm());
-        Assert.assertFalse(ssl.getNeedClientAuth());
-        Assert.assertFalse(ssl.getWantClientAuth());
     }
 }


### PR DESCRIPTION
The SSLUtilsTest uses the deprecated methods SslContextFactory#getNeedClientAuth and #getWantClientAuth. These are only valid in the context of a server, so they were moved to the SslContextFactory.Server class. We can avoid the deprecation but keep the assertions in the test by using the SslContextFactory.Server type instead of the parent SslContextFactory type.

I did the same for the call-sites in main, and for the SslContextFactory.Client type. This is necessary for a future upgrade of Jetty which actually removes these methods, and expects the specialized forms to be passed-around instead. This should not have any functional changes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
