### PR TITLE
KAFKA-16252: Fix the documentation and adjust the format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3051,7 +3051,7 @@ project(':connect:runtime') {
   }
 
   task genConnectMetricsDocs(type: JavaExec) {
-    classpath = sourceSets.test.runtimeClasspath
+    classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.connect.runtime.ConnectMetrics'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "connect_metrics.html").newOutputStream()

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -277,40 +277,33 @@ public class Metrics implements Closeable {
                 }
             }
         }
-        
         StringBuilder b = new StringBuilder();
-        b.append("<table class=\"data-table\"><tbody>\n");
-    
+        b.append("<table class=\"data-table\">\n<tbody>\n");
+
         for (Entry<String, Map<String, String>> e : beansAndAttributes.entrySet()) {
             b.append("<tr>\n");
-            b.append("<td colspan=3 class=\"mbeanName\" style=\"background-color:#ccc; font-weight: bold;\">");
-            b.append(e.getKey());
-            b.append("</td>");
-            b.append("</tr>\n");
-            
-            b.append("<tr>\n");
-            b.append("<th style=\"width: 90px\"></th>\n");
-            b.append("<th>Attribute name</th>\n");
+            b.append("<th>Metric/Attribute name</th>\n");
             b.append("<th>Description</th>\n");
+            b.append("<th>Mbean name</th>\n");
             b.append("</tr>\n");
             
             for (Entry<String, String> e2 : e.getValue().entrySet()) {
                 b.append("<tr>\n");
-                b.append("<td></td>");
                 b.append("<td>");
                 b.append(e2.getKey());
-                b.append("</td>");
+                b.append("</td>\n");
                 b.append("<td>");
                 b.append(e2.getValue());
-                b.append("</td>");
+                b.append("</td>\n");
+                b.append("<td>");
+                b.append(e.getKey());
+                b.append("</td>\n");
                 b.append("</tr>\n");
             }
     
         }
         b.append("</tbody></table>");
-    
         return b.toString();
-    
     }
 
     public MetricConfig config() {

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -279,14 +279,12 @@ public class Metrics implements Closeable {
         }
         StringBuilder b = new StringBuilder();
         b.append("<table class=\"data-table\">\n<tbody>\n");
-
+        b.append("<tr>\n");
+        b.append("<th>Metric/Attribute name</th>\n");
+        b.append("<th>Description</th>\n");
+        b.append("<th>Mbean name</th>\n");
+        b.append("</tr>\n");
         for (Entry<String, Map<String, String>> e : beansAndAttributes.entrySet()) {
-            b.append("<tr>\n");
-            b.append("<th>Metric/Attribute name</th>\n");
-            b.append("<th>Description</th>\n");
-            b.append("<th>Mbean name</th>\n");
-            b.append("</tr>\n");
-            
             for (Entry<String, String> e2 : e.getValue().entrySet()) {
                 b.append("<tr>\n");
                 b.append("<td>");
@@ -300,7 +298,6 @@ public class Metrics implements Closeable {
                 b.append("</td>\n");
                 b.append("</tr>\n");
             }
-    
         }
         b.append("</tbody></table>");
         return b.toString();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -432,7 +432,6 @@ public class ConnectMetrics {
      * @param args the arguments
      */
     public static void main(String[] args) {
-        LogManager.shutdown();
         ConnectMetricsRegistry metrics = new ConnectMetricsRegistry();
         System.out.println(Metrics.toHtmlTable(JMX_PREFIX, metrics.getAllTemplates()));
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.metrics.internals.MetricsUtils;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
+import org.apache.log4j.LogManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -431,6 +432,7 @@ public class ConnectMetrics {
      * @param args the arguments
      */
     public static void main(String[] args) {
+        LogManager.shutdown();
         ConnectMetricsRegistry metrics = new ConnectMetricsRegistry();
         System.out.println(Metrics.toHtmlTable(JMX_PREFIX, metrics.getAllTemplates()));
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -30,7 +30,6 @@ import org.apache.kafka.common.metrics.internals.MetricsUtils;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
-import org.apache.log4j.LogManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Jira ticket: https://issues.apache.org/jira/browse/KAFKA-16252

### Background & Modification
Currently, there are few document files generated automatically like the task `genConnectMetricsDocs` 
However, the unwanted log information also added into it. 
And the format is not aligned with other which has Mbean located of the third column.

I modified the code logic so the format could follow other section in `ops.html`
Also close the log since we take everything from the std as a documentation

### Testing Strategy
Regen the docs and compare the format

#### origin generated file 
Top few lines from `connect_metrics.html` after executed the `./gradlew genConnectMetricsDocs`
```html
[2024-03-05 18:11:45,945] INFO Metrics scheduler closed (org.apache.kafka.common.metrics.Metrics:694)  
[2024-03-05 18:11:45,948] INFO Metrics reporters closed (org.apache.kafka.common.metrics.Metrics:704)  
<table class="data-table"><tbody>  
<tr>  
<td colspan=3 class="mbeanName" style="background-color:#ccc; font-weight: bold;">kafka.connect:type=connect-worker-metrics</td></tr>  
<tr>  
<th style="width: 90px"></th>  
<th>Attribute name</th>  
<th>Description</th>  
</tr>
<tr>  
<td></td><td>connector-count</td><td>The number of connectors run in this worker.</td></tr>  
<tr>  
<td></td><td>connector-startup-attempts-total</td><td>The total number of connector startups that this worker has attempted.</td></tr>  
<tr>  
<td></td><td>connector-startup-failure-percentage</td><td>The average percentage of this worker's connectors starts that failed.</td></tr>  
<tr>  
<td></td><td>connector-startup-failure-total</td><td>The total number of connector starts that failed.</td></tr>  
```
![image](https://github.com/apache/kafka/assets/38662781/2d0cac92-102e-45aa-81e3-7138aed509a9)

#### fixed generated file 
```html
<table class="data-table">
<tbody>
<tr>
<th>Metric/Attribute name</th>
<th>Description</th>
<th>Mbean name</th>
</tr>
<tr>
<td>connector-count</td>
<td>The number of connectors run in this worker.</td>
<td>kafka.connect:type=connect-worker-metrics</td>
</tr>
<tr>
<td>connector-startup-attempts-total</td>
<td>The total number of connector startups that this worker has attempted.</td>
<td>kafka.connect:type=connect-worker-metrics</td>
</tr>
```
![image](https://github.com/apache/kafka/assets/38662781/4e48d660-86e1-4706-a91d-a5d0c3bcdb37)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
