### PR TITLE
KAFKA-16335: Remove deprecated method of StreamPartitioner

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -1007,14 +1007,14 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         return doJoinOnForeignKey(other, foreignKeyExtractor, joiner, TableJoined.with(null, null), materialized, true);
     }
 
-    private final Function<Optional<Set<Integer>>, Integer> getPartition = maybeMulticastPartitions -> {
-        if (!maybeMulticastPartitions.isPresent()) {
-            return null;
+    private final Function<Optional<Set<Integer>>, Optional<Set<Integer>>> getPartition = maybeMulticastPartitions -> {
+        if (maybeMulticastPartitions == null || !maybeMulticastPartitions.isPresent()) {
+            return Optional.empty();
         }
         if (maybeMulticastPartitions.get().size() != 1) {
             throw new IllegalArgumentException("The partitions returned by StreamPartitioner#partitions method when used for FK join should be a singleton set");
         }
-        return maybeMulticastPartitions.get().iterator().next();
+        return maybeMulticastPartitions;
     };
 
 
@@ -1165,7 +1165,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
 
         final StreamPartitioner<K, SubscriptionResponseWrapper<VO>> foreignResponseSinkPartitioner =
                 tableJoinedInternal.partitioner() == null
-                        ? (topic, key, subscriptionResponseWrapper, numPartitions) -> subscriptionResponseWrapper.getPrimaryPartition()
+                        ? (topic, key, subscriptionResponseWrapper, numPartitions) -> Optional.of(Collections.singleton(subscriptionResponseWrapper.getPrimaryPartition()))
                         : (topic, key, val, numPartitions) -> getPartition.apply(tableJoinedInternal.partitioner().partitions(topic, key, null, numPartitions));
 
         final StreamSinkNode<K, SubscriptionResponseWrapper<VO>> foreignResponseSink =

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -1008,7 +1008,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
     }
 
     private final Function<Optional<Set<Integer>>, Optional<Set<Integer>>> getPartition = maybeMulticastPartitions -> {
-        if (maybeMulticastPartitions == null || !maybeMulticastPartitions.isPresent()) {
+        if (!maybeMulticastPartitions.isPresent()) {
             return Optional.empty();
         }
         if (maybeMulticastPartitions.get().size() != 1) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -1165,7 +1165,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
 
         final StreamPartitioner<K, SubscriptionResponseWrapper<VO>> defaultForeignResponseSinkPartitioner =
                 (topic, key, subscriptionResponseWrapper, numPartitions) -> {
-                    Integer partition = subscriptionResponseWrapper.getPrimaryPartition();
+                    final Integer partition = subscriptionResponseWrapper.getPrimaryPartition();
                     return partition == null ? Optional.empty() : Optional.of(Collections.singleton(partition));
                 };
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -1165,7 +1165,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
 
         final StreamPartitioner<K, SubscriptionResponseWrapper<VO>> foreignResponseSinkPartitioner =
                 tableJoinedInternal.partitioner() == null
-                        ? (topic, key, subscriptionResponseWrapper, numPartitions) -> Optional.of(Collections.singleton(subscriptionResponseWrapper.getPrimaryPartition()))
+                        ? (topic, key, val, numPartitions) -> val.getPrimaryPartition() == null ? Optional.empty() : Optional.of(Collections.singleton(val.getPrimaryPartition()))
                         : (topic, key, val, numPartitions) -> getPartition.apply(tableJoinedInternal.partitioner().partitions(topic, key, null, numPartitions));
 
         final StreamSinkNode<K, SubscriptionResponseWrapper<VO>> foreignResponseSink =

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitioner.java
@@ -20,6 +20,10 @@ import org.apache.kafka.clients.producer.internals.BuiltInPartitioner;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
 public class WindowedStreamPartitioner<K, V> implements StreamPartitioner<Windowed<K>, V> {
 
     private final WindowedSerializer<K> serializer;
@@ -40,13 +44,12 @@ public class WindowedStreamPartitioner<K, V> implements StreamPartitioner<Window
      * @return an integer between 0 and {@code numPartitions-1}, or {@code null} if the default partitioning logic should be used
      */
     @Override
-    @Deprecated
-    public Integer partition(final String topic, final Windowed<K> windowedKey, final V value, final int numPartitions) {
+    public Optional<Set<Integer>> partitions(final String topic, final Windowed<K> windowedKey, final V value, final int numPartitions) {
         // for windowed key, the key bytes should never be null
         final byte[] keyBytes = serializer.serializeBaseKey(topic, windowedKey);
 
         // stick with the same built-in partitioner util functions that producer used
         // to make sure its behavior is consistent with the producer
-        return BuiltInPartitioner.partitionForKey(keyBytes, numPartitions);
+        return Optional.of(Collections.singleton(BuiltInPartitioner.partitionForKey(keyBytes, numPartitions)));
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/StreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/StreamPartitioner.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.processor;
 
 import org.apache.kafka.streams.Topology;
 
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -54,18 +53,6 @@ import java.util.Set;
 public interface StreamPartitioner<K, V> {
 
     /**
-     * Determine the partition number for a record with the given key and value and the current number of partitions.
-     *
-     * @param topic the topic name this record is sent to
-     * @param key the key of the record
-     * @param value the value of the record
-     * @param numPartitions the total number of partitions
-     * @return an integer between 0 and {@code numPartitions-1}, or {@code null} if the default partitioning logic should be used
-     */
-    @Deprecated
-    Integer partition(String topic, K key, V value, int numPartitions);
-
-    /**
      * Determine the number(s) of the partition(s) to which a record with the given key and value should be sent, 
      * for the given topic and current partition count
      * @param topic the topic name this record is sent to
@@ -77,9 +64,5 @@ public interface StreamPartitioner<K, V> {
      * Optional of an empty set means the record won't be sent to any partitions i.e drop it.
      * Optional of Set of integers means the partitions to which the record should be sent to.
      * */
-    default Optional<Set<Integer>> partitions(String topic, K key, V value, int numPartitions) {
-        final Integer partition = partition(topic, key, value, numPartitions);
-        return partition == null ? Optional.empty() : Optional.of(Collections.singleton(partition));
-    }
-
+    Optional<Set<Integer>> partitions(String topic, K key, V value, int numPartitions);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamPartitioner.java
@@ -20,6 +20,10 @@ import org.apache.kafka.clients.producer.internals.BuiltInPartitioner;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
 public class DefaultStreamPartitioner<K, V> implements StreamPartitioner<K, V> {
 
     private final Serializer<K> keySerializer;
@@ -28,18 +32,16 @@ public class DefaultStreamPartitioner<K, V> implements StreamPartitioner<K, V> {
         this.keySerializer = keySerializer;
     }
 
-    @Override
-    @Deprecated
-    public Integer partition(final String topic, final K key, final V value, final int numPartitions) {
+    public Optional<Set<Integer>> partitions(final String topic, final K key, final V value, final int numPartitions) {
         final byte[] keyBytes = keySerializer.serialize(topic, key);
 
         // if the key bytes are not available, we just return null to let the producer to decide
         // which partition to send internally; otherwise stick with the same built-in partitioner
         // util functions that producer used to make sure its behavior is consistent with the producer
         if (keyBytes == null) {
-            return null;
+            return Optional.empty();
         } else {
-            return BuiltInPartitioner.partitionForKey(keyBytes, numPartitions);
+            return Optional.of(Collections.singleton(BuiltInPartitioner.partitionForKey(keyBytes, numPartitions)));
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamPartitioner.java
@@ -32,10 +32,11 @@ public class DefaultStreamPartitioner<K, V> implements StreamPartitioner<K, V> {
         this.keySerializer = keySerializer;
     }
 
+    @Override
     public Optional<Set<Integer>> partitions(final String topic, final K key, final V value, final int numPartitions) {
         final byte[] keyBytes = keySerializer.serialize(topic, key);
 
-        // if the key bytes are not available, we just return null to let the producer to decide
+        // if the key bytes are not available, we just return empty optional to let the producer decide
         // which partition to send internally; otherwise stick with the same built-in partitioner
         // util functions that producer used to make sure its behavior is consistent with the producer
         if (keyBytes == null) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -160,7 +160,7 @@ public class RecordCollectorImpl implements RecordCollector {
             }
             if (partitions.size() > 0) {
                 final Optional<Set<Integer>> maybeMulticastPartitions = partitioner.partitions(topic, key, value, partitions.size());
-                if (!maybeMulticastPartitions.isPresent()) {
+                if (maybeMulticastPartitions == null || !maybeMulticastPartitions.isPresent()) {
                     // A null//empty partition indicates we should use the default partitioner
                     send(topic, key, value, headers, null, timestamp, keySerializer, valueSerializer, processorNodeId, context);
                 } else {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -160,7 +160,7 @@ public class RecordCollectorImpl implements RecordCollector {
             }
             if (partitions.size() > 0) {
                 final Optional<Set<Integer>> maybeMulticastPartitions = partitioner.partitions(topic, key, value, partitions.size());
-                if (maybeMulticastPartitions == null || !maybeMulticastPartitions.isPresent()) {
+                if (!maybeMulticastPartitions.isPresent()) {
                     // A null//empty partition indicates we should use the default partitioner
                     send(topic, key, value, headers, null, timestamp, keySerializer, valueSerializer, processorNodeId, context);
                 } else {

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -1052,12 +1052,12 @@ public class KafkaStreamsTest {
         prepareThreadState(streamThreadOne, state1);
         prepareThreadState(streamThreadTwo, state2);
         try (final KafkaStreams streams = new KafkaStreams(getBuilderWithSource().build(), props, supplier, time)) {
-            assertThrows(StreamsNotStartedException.class, () -> streams.queryMetadataForKey("store", "key", (topic, key, value, numPartitions) -> 0));
+            assertThrows(StreamsNotStartedException.class, () -> streams.queryMetadataForKey("store", "key", (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(0))));
             streams.start();
             waitForApplicationState(Collections.singletonList(streams), KafkaStreams.State.RUNNING, DEFAULT_DURATION);
             streams.close();
             waitForApplicationState(Collections.singletonList(streams), KafkaStreams.State.NOT_RUNNING, DEFAULT_DURATION);
-            assertThrows(IllegalStateException.class, () -> streams.queryMetadataForKey("store", "key", (topic, key, value, numPartitions) -> 0));
+            assertThrows(IllegalStateException.class, () -> streams.queryMetadataForKey("store", "key", (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(0))));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
@@ -312,12 +312,6 @@ public class KStreamRepartitionIntegrationTest {
 
         class BroadcastingPartitioner implements StreamPartitioner<Integer, String> {
             @Override
-            @Deprecated
-            public Integer partition(final String topic, final Integer key, final String value, final int numPartitions) {
-                return null;
-            }
-
-            @Override
             public Optional<Set<Integer>> partitions(final String topic, final Integer key, final String value, final int numPartitions) {
                 partitionerInvocation.incrementAndGet();
                 return Optional.of(IntStream.range(0, numPartitions).boxed().collect(Collectors.toSet()));
@@ -382,7 +376,7 @@ public class KStreamRepartitionIntegrationTest {
             .<Integer, String>as(repartitionName)
             .withStreamPartitioner((topic, key, value, numPartitions) -> {
                 partitionerInvocation.incrementAndGet();
-                return partition;
+                return Optional.of(Collections.singleton(partition));
             });
 
         builder.stream(inputTopic, Consumed.with(Serdes.Integer(), Serdes.String()))

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
@@ -54,8 +54,8 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
@@ -54,6 +54,7 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -91,12 +92,6 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
     private static final Properties PRODUCER_CONFIG_2 = new Properties();
 
     static class MultiPartitioner implements StreamPartitioner<String, Void> {
-
-        @Override
-        @Deprecated
-        public Integer partition(final String topic, final String key, final Void value, final int numPartitions) {
-            return null;
-        }
 
         @Override
         public Optional<Set<Integer>> partitions(final String topic, final String key, final Void value, final int numPartitions) {
@@ -273,8 +268,8 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
         final ValueJoiner<String, String, String> joiner = (value1, value2) -> "value1=" + value1 + ",value2=" + value2;
 
         final TableJoined<String, String> tableJoined = TableJoined.with(
-            (topic, key, value, numPartitions) -> Math.abs(getKeyB(key).hashCode()) % numPartitions,
-            (topic, key, value, numPartitions) -> Math.abs(key.hashCode()) % numPartitions
+            (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(getKeyB(key).hashCode()) % numPartitions)),
+            (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(key.hashCode()) % numPartitions))
         );
 
         table1.join(table2, KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest::getKeyB, joiner, tableJoined, materialized)
@@ -316,7 +311,7 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
 
         final TableJoined<String, String> tableJoined = TableJoined.with(
                 new MultiPartitioner(),
-                (topic, key, value, numPartitions) -> Math.abs(key.hashCode()) % numPartitions
+                (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(key.hashCode()) % numPartitions))
         );
 
         table1.join(table2, KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest::getKeyB, joiner, tableJoined, materialized)
@@ -331,14 +326,14 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
     private static Repartitioned<String, String> repartitionA() {
         final Repartitioned<String, String> repartitioned = Repartitioned.as("a");
         return repartitioned.withKeySerde(Serdes.String()).withValueSerde(Serdes.String())
-            .withStreamPartitioner((topic, key, value, numPartitions) -> Math.abs(getKeyB(key).hashCode()) % numPartitions)
+            .withStreamPartitioner((topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(getKeyB(key).hashCode()) % numPartitions)))
             .withNumberOfPartitions(4);
     }
 
     private static Repartitioned<String, String> repartitionB() {
         final Repartitioned<String, String> repartitioned = Repartitioned.as("b");
         return repartitioned.withKeySerde(Serdes.String()).withValueSerde(Serdes.String())
-            .withStreamPartitioner((topic, key, value, numPartitions) -> Math.abs(key.hashCode()) % numPartitions)
+            .withStreamPartitioner((topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(key.hashCode()) % numPartitions)))
             .withNumberOfPartitions(4);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -53,7 +53,9 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -136,7 +138,8 @@ public class OptimizedKTableIntegrationTest {
                 final ReadOnlyKeyValueStore<Integer, Integer> store1 = IntegrationTestUtils.getStore(TABLE_NAME, kafkaStreams1, QueryableStoreTypes.keyValueStore());
                 final ReadOnlyKeyValueStore<Integer, Integer> store2 = IntegrationTestUtils.getStore(TABLE_NAME, kafkaStreams2, QueryableStoreTypes.keyValueStore());
 
-                final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> 0);
+                final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
+                        .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
 
                 try {
                     // Assert that the current value in store reflects all messages being processed

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -151,7 +151,8 @@ public class StoreQueryIntegrationTest {
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
         until(() -> {
 
-            final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> 0);
+            final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
+                    .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
 
             final QueryableStoreType<ReadOnlyKeyValueStore<Integer, Integer>> queryableStoreType = keyValueStore();
             final ReadOnlyKeyValueStore<Integer, Integer> store1 = getStore(TABLE_NAME, kafkaStreams1, queryableStoreType);
@@ -197,7 +198,8 @@ public class StoreQueryIntegrationTest {
         // Assert that all messages in the first batch were processed in a timely manner
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
         until(() -> {
-            final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> 0);
+            final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
+                    .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
 
             //key belongs to this partition
             final int keyPartition = keyQueryMetadata.partition();
@@ -313,7 +315,8 @@ public class StoreQueryIntegrationTest {
 
         // Assert that all messages in the first batch were processed in a timely manner
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
-        final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> 0);
+        final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
+                .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
 
         //key belongs to this partition
         final int keyPartition = keyQueryMetadata.partition();
@@ -555,12 +558,6 @@ public class StoreQueryIntegrationTest {
     public void shouldFailWithIllegalArgumentExceptionWhenIQPartitionerReturnsMultiplePartitions() throws Exception {
 
         class BroadcastingPartitioner implements StreamPartitioner<Integer, String> {
-            @Override
-            @Deprecated
-            public Integer partition(final String topic, final Integer key, final String value, final int numPartitions) {
-                return null;
-            }
-
             @Override
             public Optional<Set<Integer>> partitions(final String topic, final Integer key, final String value, final int numPartitions) {
                 return Optional.of(IntStream.range(0, numPartitions).boxed().collect(Collectors.toSet()));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
@@ -29,9 +29,12 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WindowedStreamPartitionerTest {
 
@@ -67,16 +70,16 @@ public class WindowedStreamPartitionerTest {
             final String value = key.toString();
             final byte[] valueBytes = stringSerializer.serialize(topicName, value);
 
-            final Integer expected = defaultPartitioner.partition("topic", key, keyBytes, value, valueBytes, cluster);
+            final Set<Integer> expected = Collections.singleton(defaultPartitioner.partition(topicName, key, keyBytes, value, valueBytes, cluster));
 
             for (int w = 1; w < 10; w++) {
                 final TimeWindow window = new TimeWindow(10 * w, 20 * w);
 
                 final Windowed<Integer> windowedKey = new Windowed<>(key, window);
-                @SuppressWarnings("deprecation")
-                final Integer actual = streamPartitioner.partition(topicName, windowedKey, value, infos.size());
+                final Optional<Set<Integer>> actual = streamPartitioner.partitions(topicName, windowedKey, value, infos.size());
 
-                assertEquals(expected, actual);
+                assertTrue(actual.isPresent());
+                assertEquals(expected, actual.get());
             }
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -1570,7 +1570,7 @@ public class ProcessorTopologyTest {
     }
 
     private StreamPartitioner<Object, Object> constantPartitioner(final Integer partition) {
-        return (topic, key, value, numPartitions) -> partition;
+        return (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(partition));
     }
 
     private Topology createSimpleTopology(final int partition) {
@@ -1598,13 +1598,6 @@ public class ProcessorTopologyTest {
     }
 
     static class DroppingPartitioner implements StreamPartitioner<String, String> {
-
-        @Override
-        @Deprecated
-        public Integer partition(final String topic, final String key, final String value, final int numPartitions) {
-            return null;
-        }
-
         @Override
         public Optional<Set<Integer>> partitions(final String topic, final String key, final String value, final int numPartitions) {
             final Set<Integer> partitions = new HashSet<>();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -1569,7 +1569,7 @@ public class ProcessorTopologyTest {
         assertEquals(headers, record.headers());
     }
 
-    private StreamPartitioner<Object, Object> constantPartitioner(final Integer partition) {
+    private StreamPartitioner<String, String> constantPartitioner(final Integer partition) {
         return (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(partition));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -569,7 +569,7 @@ public class RecordCollectorTest {
     }
 
     @Test
-    public void shouldUseDefaultPartitionerAsPartitionReturnsNull() {
+    public void shouldUseDefaultPartitionerAsPartitionReturnsEmptyOptional() {
 
         final StreamPartitioner<String, Object> streamPartitioner =
                 (topic, key, value, numPartitions) -> Optional.empty();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -572,7 +572,7 @@ public class RecordCollectorTest {
     public void shouldUseDefaultPartitionerAsPartitionReturnsNull() {
 
         final StreamPartitioner<String, Object> streamPartitioner =
-                (topic, key, value, numPartitions) -> null;
+                (topic, key, value, numPartitions) -> Optional.empty();
 
         final SinkNode<?, ?> sinkNode = new SinkNode<>(
                 sinkNodeName,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -143,7 +143,7 @@ public class RecordCollectorTest {
     private final UUID processId = UUID.randomUUID();
 
     private final StreamPartitioner<String, Object> streamPartitioner =
-        (topic, key, value, numPartitions) -> Integer.parseInt(key) % numPartitions;
+        (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Integer.parseInt(key) % numPartitions));
 
     private MockProducer<byte[], byte[]> mockProducer;
     private StreamsProducer streamsProducer;
@@ -313,13 +313,6 @@ public class RecordCollectorTest {
     @Test
     public void shouldSendOnlyToEvenPartitions() {
         class EvenPartitioner implements StreamPartitioner<String, Object> {
-
-            @Override
-            @Deprecated
-            public Integer partition(final String topic, final String key, final Object value, final int numPartitions) {
-                return null;
-            }
-
             @Override
             public Optional<Set<Integer>> partitions(final String topic, final String key, final Object value, final int numPartitions) {
                 final Set<Integer> partitions = new HashSet<>();
@@ -385,13 +378,6 @@ public class RecordCollectorTest {
     public void shouldBroadcastToAllPartitions() {
 
         class BroadcastingPartitioner implements StreamPartitioner<String, Object> {
-
-            @Override
-            @Deprecated
-            public Integer partition(final String topic, final String key, final Object value, final int numPartitions) {
-                return null;
-            }
-
             @Override
             public Optional<Set<Integer>> partitions(final String topic, final String key, final Object value, final int numPartitions) {
                 return Optional.of(IntStream.range(0, numPartitions).boxed().collect(Collectors.toSet()));
@@ -453,13 +439,6 @@ public class RecordCollectorTest {
     public void shouldDropAllRecords() {
 
         class DroppingPartitioner implements StreamPartitioner<String, Object> {
-
-            @Override
-            @Deprecated
-            public Integer partition(final String topic, final String key, final Object value, final int numPartitions) {
-                return null;
-            }
-
             @Override
             public Optional<Set<Integer>> partitions(final String topic, final String key, final Object value, final int numPartitions) {
                 return Optional.of(Collections.emptySet());
@@ -533,13 +512,6 @@ public class RecordCollectorTest {
     public void shouldUseDefaultPartitionerViaPartitions() {
 
         class DefaultPartitioner implements StreamPartitioner<String, Object> {
-
-            @Override
-            @Deprecated
-            public Integer partition(final String topic, final String key, final Object value, final int numPartitions) {
-                return null;
-            }
-
             @Override
             public Optional<Set<Integer>> partitions(final String topic, final String key, final Object value, final int numPartitions) {
                 return Optional.empty();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -112,7 +112,7 @@ public class StreamsMetadataStateTest {
         hostToActivePartitions = new HashMap<>();
         hostToActivePartitions.put(hostOne, mkSet(topic1P0, topic2P1, topic4P0));
         hostToActivePartitions.put(hostTwo, mkSet(topic2P0, topic1P1));
-        hostToActivePartitions.put(hostThree, Collections.singleton(topic3P0));™
+        hostToActivePartitions.put(hostThree, Collections.singleton(topic3P0));
         hostToStandbyPartitions = new HashMap<>();
         hostToStandbyPartitions.put(hostThree, mkSet(topic1P0, topic2P1, topic4P0));
         hostToStandbyPartitions.put(hostOne, mkSet(topic2P0, topic1P1));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -293,7 +293,7 @@ public class StreamsMetadataStateTest {
         final KeyQueryMetadata expected = new KeyQueryMetadata(hostTwo, mkSet(hostOne), 2);
 
 
-        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataForKey("merged-table",  "the-key",
+        final KeyQueryMetadata actual = metadataState.keyQueryMetadataForKey("merged-table",  "the-key",
             (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(2)));
 
         assertEquals(expected, actual);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -112,7 +112,7 @@ public class StreamsMetadataStateTest {
         hostToActivePartitions = new HashMap<>();
         hostToActivePartitions.put(hostOne, mkSet(topic1P0, topic2P1, topic4P0));
         hostToActivePartitions.put(hostTwo, mkSet(topic2P0, topic1P1));
-        hostToActivePartitions.put(hostThree, Collections.singleton(topic3P0));
+        hostToActivePartitions.put(hostThree, Collections.singleton(topic3P0));™
         hostToStandbyPartitions = new HashMap<>();
         hostToStandbyPartitions.put(hostThree, mkSet(topic1P0, topic2P1, topic4P0));
         hostToStandbyPartitions.put(hostOne, mkSet(topic2P0, topic1P1));
@@ -130,18 +130,11 @@ public class StreamsMetadataStateTest {
         topologyMetadata.buildAndRewriteTopology();
         metadataState = new StreamsMetadataState(topologyMetadata, hostOne, logContext);
         metadataState.onChange(hostToActivePartitions, hostToStandbyPartitions, partitionInfos);
-        partitioner = (topic, key, value, numPartitions) -> 1;
+        partitioner = (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(1));
         storeNames = mkSet("table-one", "table-two", "merged-table", globalTable);
     }
 
     static class MultiValuedPartitioner implements StreamPartitioner<String, Object> {
-
-        @Override
-        @Deprecated
-        public Integer partition(final String topic, final String key, final Object value, final int numPartitions) {
-            return null;
-        }
-
         @Override
         public Optional<Set<Integer>> partitions(final String topic, final String key, final Object value, final int numPartitions) {
             final Set<Integer> partitions = new HashSet<>();
@@ -299,8 +292,9 @@ public class StreamsMetadataStateTest {
 
         final KeyQueryMetadata expected = new KeyQueryMetadata(hostTwo, mkSet(hostOne), 2);
 
-        final KeyQueryMetadata actual = metadataState.keyQueryMetadataForKey("merged-table",  "the-key",
-            (topic, key, value, numPartitions) -> 2);
+
+        final KeyQueryMetadata actual = metadataState.getKeyQueryMetadataForKey("merged-table",  "the-key",
+            (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(2)));
 
         assertEquals(expected, actual);
     }

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/ProducedTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/ProducedTest.scala
@@ -23,7 +23,8 @@ import org.apache.kafka.streams.scala.serialization.Serdes._
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-import java.util.{Collections, Optional}
+import java.util
+import java.util.Optional
 
 class ProducedTest {
 
@@ -38,8 +39,12 @@ class ProducedTest {
 
   @Test
   def testCreateProducedWithSerdesAndStreamPartitioner(): Unit = {
-    val partitioner: StreamPartitioner[String, Long] = new StreamPartitioner[String, Long] {
-      override def partitions(topic: String, key: String, value: Long, numPartitions: Int): Optional[Set[Integer]] = Optional.of(Collections.singleton(0))
+    val partitioner = new StreamPartitioner[String, Long] {
+      override def partitions(topic: String, key: String, value: Long, numPartitions: Int): Optional[util.Set[Integer]] = {
+        val partitions = new util.HashSet[Integer]()
+        partitions.add(Int.box(0))
+        Optional.of(partitions)
+      }
     }
     val produced: Produced[String, Long] = Produced.`with`(partitioner)
 

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/ProducedTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/ProducedTest.scala
@@ -23,6 +23,8 @@ import org.apache.kafka.streams.scala.serialization.Serdes._
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
+import java.util.{Collections, Optional}
+
 class ProducedTest {
 
   @Test
@@ -36,8 +38,8 @@ class ProducedTest {
 
   @Test
   def testCreateProducedWithSerdesAndStreamPartitioner(): Unit = {
-    val partitioner = new StreamPartitioner[String, Long] {
-      override def partition(topic: String, key: String, value: Long, numPartitions: Int): Integer = 0
+    val partitioner: StreamPartitioner[String, Long] = new StreamPartitioner[String, Long] {
+      override def partitions(topic: String, key: String, value: Long, numPartitions: Int): Optional[Set[Integer]] = Optional.of(Collections.singleton(0))
     }
     val produced: Produced[String, Long] = Produced.`with`(partitioner)
 

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/ProducedTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/ProducedTest.scala
@@ -40,7 +40,12 @@ class ProducedTest {
   @Test
   def testCreateProducedWithSerdesAndStreamPartitioner(): Unit = {
     val partitioner = new StreamPartitioner[String, Long] {
-      override def partitions(topic: String, key: String, value: Long, numPartitions: Int): Optional[util.Set[Integer]] = {
+      override def partitions(
+        topic: String,
+        key: String,
+        value: Long,
+        numPartitions: Int
+      ): Optional[util.Set[Integer]] = {
         val partitions = new util.HashSet[Integer]()
         partitions.add(Int.box(0))
         Optional.of(partitions)

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/RepartitionedTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/RepartitionedTest.scala
@@ -61,7 +61,12 @@ class RepartitionedTest {
   @Test
   def testCreateRepartitionedWithSerdesAndTopicNameAndNumPartitionsAndStreamPartitioner(): Unit = {
     val partitioner = new StreamPartitioner[String, Long] {
-      override def partitions(topic: String, key: String, value: Long, numPartitions: Int): Optional[util.Set[Integer]] = {
+      override def partitions(
+        topic: String,
+        key: String,
+        value: Long,
+        numPartitions: Int
+      ): Optional[util.Set[Integer]] = {
         val partitions = new util.HashSet[Integer]()
         partitions.add(Int.box(0))
         Optional.of(partitions)
@@ -78,7 +83,12 @@ class RepartitionedTest {
   @Test
   def testCreateRepartitionedWithTopicNameAndNumPartitionsAndStreamPartitioner(): Unit = {
     val partitioner = new StreamPartitioner[String, Long] {
-      override def partitions(topic: String, key: String, value: Long, numPartitions: Int): Optional[util.Set[Integer]] = {
+      override def partitions(
+        topic: String,
+        key: String,
+        value: Long,
+        numPartitions: Int
+      ): Optional[util.Set[Integer]] = {
         val partitions = new util.HashSet[Integer]()
         partitions.add(Int.box(0))
         Optional.of(partitions)

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/RepartitionedTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/RepartitionedTest.scala
@@ -23,6 +23,9 @@ import org.apache.kafka.streams.scala.serialization.Serdes._
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
+import java.util
+import java.util.Optional
+
 class RepartitionedTest {
 
   @Test
@@ -58,7 +61,11 @@ class RepartitionedTest {
   @Test
   def testCreateRepartitionedWithSerdesAndTopicNameAndNumPartitionsAndStreamPartitioner(): Unit = {
     val partitioner = new StreamPartitioner[String, Long] {
-      override def partition(topic: String, key: String, value: Long, numPartitions: Int): Integer = 0
+      override def partitions(topic: String, key: String, value: Long, numPartitions: Int): Optional[util.Set[Integer]] = {
+        val partitions = new util.HashSet[Integer]()
+        partitions.add(Int.box(0))
+        Optional.of(partitions)
+      }
     }
     val repartitioned: Repartitioned[String, Long] = Repartitioned.`with`[String, Long](partitioner)
 
@@ -71,7 +78,11 @@ class RepartitionedTest {
   @Test
   def testCreateRepartitionedWithTopicNameAndNumPartitionsAndStreamPartitioner(): Unit = {
     val partitioner = new StreamPartitioner[String, Long] {
-      override def partition(topic: String, key: String, value: Long, numPartitions: Int): Integer = 0
+      override def partitions(topic: String, key: String, value: Long, numPartitions: Int): Optional[util.Set[Integer]] = {
+        val partitions = new util.HashSet[Integer]()
+        partitions.add(Int.box(0))
+        Optional.of(partitions)
+      }
     }
     val repartitioned: Repartitioned[String, Long] =
       Repartitioned


### PR DESCRIPTION
Remove deprecated method StreamPartitioner#partition.

All tests were updated if the new signature of `StreamPartitioner#partitions`.

