### PR TITLE
KAFKA-16318 : add javafoc for kafka metric

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -20,6 +20,27 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.utils.Time;
 
+/**
+ * A registry of sensors and metrics.
+ * <p>
+ * A metric is a named, numerical measurement. A sensor is a handle to record numerical measurements as they occur. Each
+ * Sensor has zero or more associated metrics.
+ * <p>
+ * Usage looks something like this:
+ *
+ * <pre>
+ * // set up metrics:
+ * Metrics metrics = new Metrics(); // this is the global repository of metrics and sensors
+ * Sensor sensor = metrics.sensor(&quot;message-sizes&quot;);
+ * MetricName metricName = new MetricName(&quot;message-size-avg&quot;, &quot;producer-metrics&quot;);
+ * sensor.add(metricName, new Avg());
+ * metricName = new MetricName(&quot;message-size-max&quot;, &quot;producer-metrics&quot;);
+ * sensor.add(metricName, new Max());
+ *
+ * // as messages are sent we record the sizes
+ * sensor.record(messageSize);
+ * </pre>
+ */
 public final class KafkaMetric implements Metric {
 
     private final MetricName metricName;

--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -49,7 +49,8 @@ public final class KafkaMetric implements Metric {
     }
 
     /**
-     * Get the configuration of this metric
+     * Get the configuration of this metric.
+     * This is supposed to be used by server only.
      * @return Return the config of this metric
      */
     public MetricConfig config() {

--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -21,25 +21,35 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.utils.Time;
 
 /**
- * A registry of sensors and metrics.
+ * An implementation of {@link Metric} interface.
  * <p>
- * A metric is a named, numerical measurement. A sensor is a handle to record numerical measurements as they occur. Each
- * Sensor has zero or more associated metrics.
+ * A KafkaMetric is a named metric for monitoring purpose. The metric value can be a {@link Measurable} or a {@link Gauge}.
+ * <pre>
+ * <b>metricName</b> The name of the metric
+ * <b>lock</b> A lock used for reading the metric value in case of race condition
+ * <b>time</b> The POSIX time in milliseconds the metric is being taken
+ * <b>metricValueProvider</b> The metric collecting implementation that implements {@link MetricValueProvider}
+ * <b>config</b> The metric configuration which is a {@link MetricConfig}
+ * </pre>
  * <p>
  * Usage looks something like this:
  *
- * <pre>
+ * <pre>{@code
  * // set up metrics:
- * Metrics metrics = new Metrics(); // this is the global repository of metrics and sensors
- * Sensor sensor = metrics.sensor(&quot;message-sizes&quot;);
- * MetricName metricName = new MetricName(&quot;message-size-avg&quot;, &quot;producer-metrics&quot;);
- * sensor.add(metricName, new Avg());
- * metricName = new MetricName(&quot;message-size-max&quot;, &quot;producer-metrics&quot;);
- * sensor.add(metricName, new Max());
  *
- * // as messages are sent we record the sizes
- * sensor.record(messageSize);
- * </pre>
+ * Map<String, String> tags = new HashMap<>();
+ * tags.put("key1", "value1");
+ *
+ * MetricConfig config = new MetricConfig().tags(metricTags);
+ * Time time = new SystemTime();
+ * metricName = new MetricName(&quot;message-size-max&quot;, &quot;producer-metrics&quot;);
+ *
+ * KafkaMetric m = new KafkaMetric(new Object(),
+ *                                 Objects.requireNonNull(metricName),
+ *                                 (Gauge<Integer>) (config, now) -> 1,
+ *                                 config,
+ *                                 time);
+ * }</pre>
  */
 public final class KafkaMetric implements Metric {
 

--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -20,37 +20,6 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.utils.Time;
 
-/**
- * An implementation of {@link Metric} interface.
- * <p>
- * A KafkaMetric is a named metric for monitoring purpose. The metric value can be a {@link Measurable} or a {@link Gauge}.
- * <pre>
- * <b>metricName</b> The name of the metric
- * <b>lock</b> A lock used for reading the metric value in case of race condition
- * <b>time</b> The POSIX time in milliseconds the metric is being taken
- * <b>metricValueProvider</b> The metric collecting implementation that implements {@link MetricValueProvider}
- * <b>config</b> The metric configuration which is a {@link MetricConfig}
- * </pre>
- * <p>
- * Usage looks something like this:
- *
- * <pre>{@code
- * // set up metrics:
- *
- * Map<String, String> tags = new HashMap<>();
- * tags.put("key1", "value1");
- *
- * MetricConfig config = new MetricConfig().tags(metricTags);
- * Time time = new SystemTime();
- * metricName = new MetricName(&quot;message-size-max&quot;, &quot;producer-metrics&quot;);
- *
- * KafkaMetric m = new KafkaMetric(new Object(),
- *                                 Objects.requireNonNull(metricName),
- *                                 (Gauge<Integer>) (config, now) -> 1,
- *                                 config,
- *                                 time);
- * }</pre>
- */
 public final class KafkaMetric implements Metric {
 
     private final MetricName metricName;
@@ -59,6 +28,7 @@ public final class KafkaMetric implements Metric {
     private final MetricValueProvider<?> metricValueProvider;
     private MetricConfig config;
 
+    // public for testing
     /**
      * Create a metric to monitor an object that implements MetricValueProvider.
      * @param lock The lock used to prevent race condition

--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -71,15 +71,28 @@ public final class KafkaMetric implements Metric {
         this.time = time;
     }
 
+    /**
+     * Get the configuration of this metric
+     * @return Return the config of this metric
+     */
     public MetricConfig config() {
         return this.config;
     }
 
+    /**
+     * Get the metric name
+     * @return Return the name of this metric
+     */
     @Override
     public MetricName metricName() {
         return this.metricName;
     }
 
+    /**
+     * Get the metric value, which could be a {@link Measurable} or a {@link Gauge}
+     * @return Return the metric value
+     * @throws IllegalStateException if the underlying metric is not a {@link Measurable} or a {@link Gauge}.
+     */
     @Override
     public Object metricValue() {
         long now = time.milliseconds();
@@ -93,6 +106,11 @@ public final class KafkaMetric implements Metric {
         }
     }
 
+    /**
+     * Get the underlying metric provider, which is a {@link Measurable}
+     * @return Return the metric provider
+     * @throws IllegalStateException if the underlying metric is not a {@link Measurable}.
+     */
     public Measurable measurable() {
         if (this.metricValueProvider instanceof Measurable)
             return (Measurable) metricValueProvider;
@@ -109,6 +127,10 @@ public final class KafkaMetric implements Metric {
         }
     }
 
+    /**
+     * Set the metric config. This is a thread-safe method
+     * @param config configuration for this metrics
+     */
     public void config(MetricConfig config) {
         synchronized (lock) {
             this.config = config;

--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -59,7 +59,14 @@ public final class KafkaMetric implements Metric {
     private final MetricValueProvider<?> metricValueProvider;
     private MetricConfig config;
 
-    // public for testing
+    /**
+     * Create a metric to monitor an object that implements MetricValueProvider.
+     * @param lock The lock used to prevent race condition
+     * @param metricName The name of the metric
+     * @param valueProvider The metric value provider associated with this metric
+     * @param config The configuration of the metric
+     * @param time The time instance to use with the metrics
+     */
     public KafkaMetric(Object lock, MetricName metricName, MetricValueProvider<?> valueProvider,
             MetricConfig config, Time time) {
         this.metricName = metricName;
@@ -89,7 +96,7 @@ public final class KafkaMetric implements Metric {
     }
 
     /**
-     * Get the metric value, which could be a {@link Measurable} or a {@link Gauge}
+     * Take the metric and return the value, which could be a {@link Measurable} or a {@link Gauge}
      * @return Return the metric value
      * @throws IllegalStateException if the underlying metric is not a {@link Measurable} or a {@link Gauge}.
      */
@@ -107,7 +114,7 @@ public final class KafkaMetric implements Metric {
     }
 
     /**
-     * Get the underlying metric provider, which is a {@link Measurable}
+     * Get the underlying metric provider, which should be a {@link Measurable}
      * @return Return the metric provider
      * @throws IllegalStateException if the underlying metric is not a {@link Measurable}.
      */
@@ -118,6 +125,11 @@ public final class KafkaMetric implements Metric {
             throw new IllegalStateException("Not a measurable: " + this.metricValueProvider.getClass());
     }
 
+    /**
+     * Take the metric and return the value, where the underlying metric provider should be a {@link Measurable}
+     * @param timeMs The time that this metric is taken
+     * @return Return the metric value if it's measurable, otherwise 0
+     */
     double measurableValue(long timeMs) {
         synchronized (this.lock) {
             if (this.metricValueProvider instanceof Measurable)
@@ -128,7 +140,7 @@ public final class KafkaMetric implements Metric {
     }
 
     /**
-     * Set the metric config. This is a thread-safe method
+     * Set the metric config.
      * @param config configuration for this metrics
      */
     public void config(MetricConfig config) {

--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -53,9 +53,7 @@ public final class KafkaMetric implements Metric {
      * @return Return the config of this metric
      */
     public MetricConfig config() {
-        synchronized (lock) {
-            return this.config;
-        }
+        return this.config;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -53,7 +53,9 @@ public final class KafkaMetric implements Metric {
      * @return Return the config of this metric
      */
     public MetricConfig config() {
-        return this.config;
+        synchronized (lock) {
+            return this.config;
+        }
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -111,6 +111,7 @@ public final class KafkaMetric implements Metric {
 
     /**
      * Set the metric config.
+     * This is supposed to be used by server only, DO NOT use this for your metrics.
      * @param config configuration for this metrics
      */
     public void config(MetricConfig config) {

--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -111,7 +111,7 @@ public final class KafkaMetric implements Metric {
 
     /**
      * Set the metric config.
-     * This is supposed to be used by server only, DO NOT use this for your metrics.
+     * This is supposed to be used by server only.
      * @param config configuration for this metrics
      */
     public void config(MetricConfig config) {


### PR DESCRIPTION
## Context
There was no javadoc for `KafkaMetric`
Jira ticket: https://issues.apache.org/jira/browse/KAFKA-16318

## Solution
Add the javadoc for this class

## Test
Run './gradlew javadoc' and `./gradlew releaseTarGz` both succeeded.

Screenshot in the IDE
<img width="930" alt="Screenshot 2024-03-07 at 12 20 04 AM" src="https://github.com/apache/kafka/assets/44309740/e1eaa6b4-8abe-44b4-84aa-c9f2043e02ec">


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
