### PR TITLE
KAFKA-15490: Fix dir path when marking offline

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -220,6 +220,7 @@ object BrokerMetadataCheckpoint extends Logging {
 class BrokerMetadataCheckpoint(val file: File) extends Logging {
   private val lock = new Object()
 
+  @throws(classOf[IOException])
   def write(properties: Properties): Unit = {
     lock synchronized {
       try {


### PR DESCRIPTION
## Bug
On startup, Kafka creates a checkpoint for broker metadata. If underlying storage throws an IOException for any reason (maybe disk is full), then Kafka should mark the directory as offline. However, in this case it doesn't do so.

## Root cause
When marking the partition offline, we incorrectly pass the path of checkpoint file whereas we should be providing the path of log dir

## Testing
Added a unit test that fails prior to this change and passes after it is successful. 

## Note
Note that this change is made on 3.6.x branch. 3.7.x/trunk may already be fixed as part of https://github.com/apache/kafka/commit/7060c08d6f9b0408e7f40a90499caf2e636fac61. I am working separately for a change in that branch.