### PR TITLE
KAFKA-16227: Avoid IllegalStateException during fetch initialization

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -540,6 +540,14 @@ public class SubscriptionState {
         return assignedState(tp).position;
     }
 
+    public synchronized FetchPosition positionOrNull(TopicPartition tp) {
+        final TopicPartitionState state = assignedStateOrNull(tp);
+        if (state == null) {
+            return null;
+        }
+        return assignedState(tp).position;
+    }
+
     public synchronized Long partitionLag(TopicPartition tp, IsolationLevel isolationLevel) {
         TopicPartitionState topicPartitionState = assignedState(tp);
         if (topicPartitionState.position == null) {
@@ -579,12 +587,35 @@ public class SubscriptionState {
         assignedState(tp).highWatermark(highWatermark);
     }
 
-    synchronized void updateLogStartOffset(TopicPartition tp, long logStartOffset) {
-        assignedState(tp).logStartOffset(logStartOffset);
+    synchronized boolean tryUpdatingHighWatermark(TopicPartition tp, long highWatermark) {
+        final TopicPartitionState state = assignedStateOrNull(tp);
+        if (state != null) {
+            assignedState(tp).highWatermark(highWatermark);
+            return true;
+        }
+        return false;
+    }
+
+    synchronized boolean tryUpdatingLogStartOffset(TopicPartition tp, long highWatermark) {
+        final TopicPartitionState state = assignedStateOrNull(tp);
+        if (state != null) {
+            assignedState(tp).logStartOffset(highWatermark);
+            return true;
+        }
+        return false;
     }
 
     synchronized void updateLastStableOffset(TopicPartition tp, long lastStableOffset) {
         assignedState(tp).lastStableOffset(lastStableOffset);
+    }
+
+    synchronized boolean tryUpdatingLastStableOffset(TopicPartition tp, long lastStableOffset) {
+        final TopicPartitionState state = assignedStateOrNull(tp);
+        if (state != null) {
+            assignedState(tp).lastStableOffset(lastStableOffset);
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -597,6 +628,28 @@ public class SubscriptionState {
      */
     public synchronized void updatePreferredReadReplica(TopicPartition tp, int preferredReadReplicaId, LongSupplier timeMs) {
         assignedState(tp).updatePreferredReadReplica(preferredReadReplicaId, timeMs);
+    }
+
+    /**
+     * Tries to set the preferred read replica with a lease timeout. After this time, the replica will no longer be valid and
+     * {@link #preferredReadReplica(TopicPartition, long)} will return an empty result. If the preferred replica of
+     * the partition could not be updated (e.g. because the partition is not assigned) this method will return
+     * {@code false}, otherwise it will return {@code true}.
+     *
+     * @param tp The topic partition
+     * @param preferredReadReplicaId The preferred read replica
+     * @param timeMs The time at which this preferred replica is no longer valid
+     * @return {@code true} if the preferred read replica was updated, {@code false} otherwise.
+     */
+    public synchronized boolean tryUpdatingPreferredReadReplica(TopicPartition tp,
+                                                             int preferredReadReplicaId,
+                                                             LongSupplier timeMs) {
+        final TopicPartitionState state = assignedStateOrNull(tp);
+        if (state != null) {
+            assignedState(tp).updatePreferredReadReplica(preferredReadReplicaId, timeMs);
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -654,6 +707,14 @@ public class SubscriptionState {
     public void requestOffsetReset(TopicPartition partition) {
         requestOffsetReset(partition, defaultResetStrategy);
     }
+
+    public synchronized void requestOffsetResetIfPartitionAssigned(TopicPartition partition) {
+        final TopicPartitionState state = assignedStateOrNull(partition);
+        if (state != null) {
+            state.reset(defaultResetStrategy);
+        }
+    }
+
 
     synchronized void setNextAllowedRetry(Set<TopicPartition> partitions, long nextAllowResetTimeMs) {
         for (TopicPartition partition : partitions) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchCollectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchCollectorTest.java
@@ -40,6 +40,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -61,11 +63,17 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * This tests the {@link FetchCollector} functionality in addition to what {@link FetcherTest} tests during the course
  * of its tests.
  */
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class FetchCollectorTest {
 
     private final static int DEFAULT_RECORD_COUNT = 10;
@@ -75,7 +83,7 @@ public class FetchCollectorTest {
     private final TopicPartition topicAPartition1 = new TopicPartition("topic-a", 1);
     private final TopicPartition topicAPartition2 = new TopicPartition("topic-a", 2);
     private final Set<TopicPartition> allPartitions = partitions(topicAPartition0, topicAPartition1, topicAPartition2);
-    private LogContext logContext;
+    private final LogContext logContext = new LogContext();
 
     private SubscriptionState subscriptions;
     private FetchConfig fetchConfig;
@@ -406,6 +414,228 @@ public class FetchCollectorTest {
         assertThrows(IllegalStateException.class, () -> fetchCollector.collectFetch(fetchBuffer));
     }
 
+    @Test
+    public void testCollectFetchInitializationWithNullPosition() {
+        final TopicPartition topicPartition0 = new TopicPartition("topic", 0);
+        final SubscriptionState subscriptions = mock(SubscriptionState.class);
+        when(subscriptions.hasValidPosition(topicPartition0)).thenReturn(true);
+        when(subscriptions.positionOrNull(topicPartition0)).thenReturn(null);
+        final FetchCollector<String, String> fetchCollector = createFetchCollector(subscriptions);
+        final Records records = createRecords();
+        FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData()
+            .setPartitionIndex(topicPartition0.partition())
+            .setHighWatermark(1000)
+            .setRecords(records);
+        final CompletedFetch completedFetch = new CompletedFetchBuilder()
+            .partitionData(partitionData)
+            .partition(topicPartition0).build();
+        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+        when(fetchBuffer.nextInLineFetch()).thenReturn(null);
+        when(fetchBuffer.peek()).thenReturn(completedFetch).thenReturn(null);
+
+        final Fetch<String, String> fetch = fetchCollector.collectFetch(fetchBuffer);
+
+        assertTrue(fetch.isEmpty());
+        verify(fetchBuffer).setNextInLineFetch(null);
+    }
+
+    @Test
+    public void testCollectFetchInitializationWithUpdateHighWatermarkOnNotAssignedPartition() {
+        final TopicPartition topicPartition0 = new TopicPartition("topic", 0);
+        final long fetchOffset = 42;
+        final long highWatermark = 1000;
+        final SubscriptionState subscriptions = mock(SubscriptionState.class);
+        when(subscriptions.hasValidPosition(topicPartition0)).thenReturn(true);
+        when(subscriptions.positionOrNull(topicPartition0)).thenReturn(new SubscriptionState.FetchPosition(fetchOffset));
+        when(subscriptions.tryUpdatingHighWatermark(topicPartition0, highWatermark)).thenReturn(false);
+        final FetchCollector<String, String> fetchCollector = createFetchCollector(subscriptions);
+        final Records records = createRecords();
+        FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData()
+            .setPartitionIndex(topicPartition0.partition())
+            .setHighWatermark(highWatermark)
+            .setRecords(records);
+        final CompletedFetch completedFetch = new CompletedFetchBuilder()
+            .partitionData(partitionData)
+            .partition(topicPartition0)
+            .fetchOffset(fetchOffset).build();
+        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+        when(fetchBuffer.nextInLineFetch()).thenReturn(null);
+        when(fetchBuffer.peek()).thenReturn(completedFetch).thenReturn(null);
+
+        final Fetch<String, String> fetch = fetchCollector.collectFetch(fetchBuffer);
+
+        assertTrue(fetch.isEmpty());
+        verify(fetchBuffer).setNextInLineFetch(null);
+    }
+
+    @Test
+    public void testCollectFetchInitializationWithUpdateLogStartOffsetOnNotAssignedPartition() {
+        final TopicPartition topicPartition0 = new TopicPartition("topic", 0);
+        final long fetchOffset = 42;
+        final long highWatermark = 1000;
+        final long logStartOffset = 10;
+        final SubscriptionState subscriptions = mock(SubscriptionState.class);
+        when(subscriptions.hasValidPosition(topicPartition0)).thenReturn(true);
+        when(subscriptions.positionOrNull(topicPartition0)).thenReturn(new SubscriptionState.FetchPosition(fetchOffset));
+        when(subscriptions.tryUpdatingHighWatermark(topicPartition0, highWatermark)).thenReturn(true);
+        when(subscriptions.tryUpdatingLogStartOffset(topicPartition0, logStartOffset)).thenReturn(false);
+        final FetchCollector<String, String> fetchCollector = createFetchCollector(subscriptions);
+        final Records records = createRecords();
+        FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData()
+            .setPartitionIndex(topicPartition0.partition())
+            .setHighWatermark(highWatermark)
+            .setRecords(records)
+            .setLogStartOffset(logStartOffset);
+        final CompletedFetch completedFetch = new CompletedFetchBuilder()
+            .partitionData(partitionData)
+            .partition(topicPartition0)
+            .fetchOffset(fetchOffset).build();
+        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+        when(fetchBuffer.nextInLineFetch()).thenReturn(null);
+        when(fetchBuffer.peek()).thenReturn(completedFetch).thenReturn(null);
+
+        final Fetch<String, String> fetch = fetchCollector.collectFetch(fetchBuffer);
+
+        assertTrue(fetch.isEmpty());
+        verify(fetchBuffer).setNextInLineFetch(null);
+    }
+
+    @Test
+    public void testCollectFetchInitializationWithUpdateLastStableOffsetOnNotAssignedPartition() {
+        final TopicPartition topicPartition0 = new TopicPartition("topic", 0);
+        final long fetchOffset = 42;
+        final long highWatermark = 1000;
+        final long logStartOffset = 10;
+        final long lastStableOffset = 900;
+        final SubscriptionState subscriptions = mock(SubscriptionState.class);
+        when(subscriptions.hasValidPosition(topicPartition0)).thenReturn(true);
+        when(subscriptions.positionOrNull(topicPartition0)).thenReturn(new SubscriptionState.FetchPosition(fetchOffset));
+        when(subscriptions.tryUpdatingHighWatermark(topicPartition0, highWatermark)).thenReturn(true);
+        when(subscriptions.tryUpdatingLogStartOffset(topicPartition0, logStartOffset)).thenReturn(true);
+        when(subscriptions.tryUpdatingLastStableOffset(topicPartition0, lastStableOffset)).thenReturn(false);
+        final FetchCollector<String, String> fetchCollector = createFetchCollector(subscriptions);
+        final Records records = createRecords();
+        FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData()
+            .setPartitionIndex(topicPartition0.partition())
+            .setHighWatermark(highWatermark)
+            .setRecords(records)
+            .setLogStartOffset(logStartOffset)
+            .setLastStableOffset(lastStableOffset);
+        final CompletedFetch completedFetch = new CompletedFetchBuilder()
+            .partitionData(partitionData)
+            .partition(topicPartition0)
+            .fetchOffset(fetchOffset).build();
+        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+        when(fetchBuffer.nextInLineFetch()).thenReturn(null);
+        when(fetchBuffer.peek()).thenReturn(completedFetch).thenReturn(null);
+
+        final Fetch<String, String> fetch = fetchCollector.collectFetch(fetchBuffer);
+
+        assertTrue(fetch.isEmpty());
+        verify(fetchBuffer).setNextInLineFetch(null);
+    }
+
+    @Test
+    public void testCollectFetchInitializationWithUpdatePreferredReplicaOnNotAssignedPartition() {
+        final TopicPartition topicPartition0 = new TopicPartition("topic", 0);
+        final long fetchOffset = 42;
+        final long highWatermark = 1000;
+        final long logStartOffset = 10;
+        final long lastStableOffset = 900;
+        final int preferredReadReplicaId = 21;
+        final SubscriptionState subscriptions = mock(SubscriptionState.class);
+        when(subscriptions.hasValidPosition(topicPartition0)).thenReturn(true);
+        when(subscriptions.positionOrNull(topicPartition0)).thenReturn(new SubscriptionState.FetchPosition(fetchOffset));
+        when(subscriptions.tryUpdatingHighWatermark(topicPartition0, highWatermark)).thenReturn(true);
+        when(subscriptions.tryUpdatingLogStartOffset(topicPartition0, logStartOffset)).thenReturn(true);
+        when(subscriptions.tryUpdatingLastStableOffset(topicPartition0, lastStableOffset)).thenReturn(true);
+        when(subscriptions.tryUpdatingPreferredReadReplica(eq(topicPartition0), eq(preferredReadReplicaId), any())).thenReturn(false);
+        final FetchCollector<String, String> fetchCollector = createFetchCollector(subscriptions);
+        final Records records = createRecords();
+        FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData()
+            .setPartitionIndex(topicPartition0.partition())
+            .setHighWatermark(highWatermark)
+            .setRecords(records)
+            .setLogStartOffset(logStartOffset)
+            .setLastStableOffset(lastStableOffset)
+            .setPreferredReadReplica(preferredReadReplicaId);
+        final CompletedFetch completedFetch = new CompletedFetchBuilder()
+            .partitionData(partitionData)
+            .partition(topicPartition0)
+            .fetchOffset(fetchOffset).build();
+        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+        when(fetchBuffer.nextInLineFetch()).thenReturn(null);
+        when(fetchBuffer.peek()).thenReturn(completedFetch).thenReturn(null);
+
+        final Fetch<String, String> fetch = fetchCollector.collectFetch(fetchBuffer);
+
+        assertTrue(fetch.isEmpty());
+        verify(fetchBuffer).setNextInLineFetch(null);
+    }
+
+    @Test
+    public void testCollectFetchInitializationOffsetOutOfRangeErrorWithNullPosition() {
+        final TopicPartition topicPartition0 = new TopicPartition("topic", 0);
+        final SubscriptionState subscriptions = mock(SubscriptionState.class);
+        when(subscriptions.hasValidPosition(topicPartition0)).thenReturn(true);
+        when(subscriptions.positionOrNull(topicPartition0)).thenReturn(null);
+        final FetchCollector<String, String> fetchCollector = createFetchCollector(subscriptions);
+        FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData()
+            .setPartitionIndex(topicPartition0.partition())
+            .setErrorCode(Errors.OFFSET_OUT_OF_RANGE.code());
+        final CompletedFetch completedFetch = new CompletedFetchBuilder()
+            .partitionData(partitionData)
+            .partition(topicPartition0).build();
+        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+        when(fetchBuffer.nextInLineFetch()).thenReturn(null);
+        when(fetchBuffer.peek()).thenReturn(completedFetch).thenReturn(null);
+
+        final Fetch<String, String> fetch = fetchCollector.collectFetch(fetchBuffer);
+
+        assertTrue(fetch.isEmpty());
+        verify(fetchBuffer).setNextInLineFetch(null);
+    }
+
+    @Test
+    public void testCollectFetchInitializationOffsetOutOfRangeErrorWithOffsetReset() {
+        final TopicPartition topicPartition0 = new TopicPartition("topic", 0);
+        final long fetchOffset = 42;
+        final SubscriptionState subscriptions = mock(SubscriptionState.class);
+        when(subscriptions.hasValidPosition(topicPartition0)).thenReturn(true);
+        when(subscriptions.positionOrNull(topicPartition0)).thenReturn(new SubscriptionState.FetchPosition(fetchOffset));
+        when(subscriptions.hasDefaultOffsetResetPolicy()).thenReturn(true);
+        final FetchCollector<String, String> fetchCollector = createFetchCollector(subscriptions);
+        FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData()
+            .setPartitionIndex(topicPartition0.partition())
+            .setErrorCode(Errors.OFFSET_OUT_OF_RANGE.code());
+        final CompletedFetch completedFetch = new CompletedFetchBuilder()
+            .partitionData(partitionData)
+            .partition(topicPartition0)
+            .fetchOffset(fetchOffset).build();
+        final FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+        when(fetchBuffer.nextInLineFetch()).thenReturn(null);
+        when(fetchBuffer.peek()).thenReturn(completedFetch).thenReturn(null);
+
+        final Fetch<String, String> fetch = fetchCollector.collectFetch(fetchBuffer);
+
+        assertTrue(fetch.isEmpty());
+        verify(subscriptions).requestOffsetResetIfPartitionAssigned(topicPartition0);
+        verify(fetchBuffer).setNextInLineFetch(null);
+    }
+
+    private FetchCollector<String, String> createFetchCollector(final SubscriptionState subscriptions) {
+        final Properties consumerProps = consumerProps();
+        return new FetchCollector<>(
+            logContext,
+            mock(ConsumerMetadata.class),
+            subscriptions,
+            new FetchConfig(new ConsumerConfig(consumerProps)),
+            new Deserializers<>(new StringDeserializer(), new StringDeserializer()),
+            mock(FetchMetricsManager.class),
+            new MockTime()
+        );
+    }
+
     /**
      * This is a handy utility method for returning a set from a varargs array.
      */
@@ -418,14 +648,7 @@ public class FetchCollectorTest {
     }
 
     private void buildDependencies(int maxPollRecords) {
-        logContext = new LogContext();
-
-        Properties p = new Properties();
-        p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-        p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        p.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, String.valueOf(maxPollRecords));
-
+        Properties p = consumerProperties(maxPollRecords);
         ConsumerConfig config = new ConsumerConfig(p);
 
         deserializers = new Deserializers<>(new StringDeserializer(), new StringDeserializer());
@@ -454,6 +677,20 @@ public class FetchCollectorTest {
                 time);
         fetchBuffer = new FetchBuffer(logContext);
         completedFetchBuilder = new CompletedFetchBuilder();
+    }
+
+    private Properties consumerProps() {
+        return consumerProperties(DEFAULT_MAX_POLL_RECORDS);
+    }
+
+    private Properties consumerProperties(final int maxPollRecords) {
+        Properties p = new Properties();
+        p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        p.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, String.valueOf(maxPollRecords));
+
+        return p;
     }
 
     private void assign(TopicPartition... partitions) {
@@ -527,6 +764,10 @@ public class FetchCollectorTest {
 
         private int recordCount = DEFAULT_RECORD_COUNT;
 
+        private TopicPartition topicPartition = topicAPartition0;
+
+        private FetchResponseData.PartitionData partitionData = null;
+
         private Errors error = null;
 
         private CompletedFetchBuilder fetchOffset(long fetchOffset) {
@@ -544,24 +785,29 @@ public class FetchCollectorTest {
             return this;
         }
 
+        private CompletedFetchBuilder partitionData(FetchResponseData.PartitionData partitionData) {
+            this.partitionData = partitionData;
+            return this;
+        }
+
+        private CompletedFetchBuilder partition(TopicPartition topicPartition) {
+            this.topicPartition = topicPartition;
+            return this;
+        }
+
         private CompletedFetch build() {
-            Records records;
-            ByteBuffer allocate = ByteBuffer.allocate(1024);
+            Records records = createRecords(recordCount);
 
-            try (MemoryRecordsBuilder builder = MemoryRecords.builder(allocate,
-                    CompressionType.NONE,
-                    TimestampType.CREATE_TIME,
-                    0)) {
-                for (int i = 0; i < recordCount; i++)
-                    builder.append(0L, "key".getBytes(), ("value-" + i).getBytes());
-
-                records = builder.build();
-            }
-
-            FetchResponseData.PartitionData partitionData = new FetchResponseData.PartitionData()
+            if (partitionData == null) {
+                partitionData = new FetchResponseData.PartitionData()
                     .setPartitionIndex(topicAPartition0.partition())
                     .setHighWatermark(1000)
                     .setRecords(records);
+            }
+
+            if (topicPartition != null) {
+                partitionData.setPartitionIndex(topicPartition.partition());
+            }
 
             if (error != null)
                 partitionData.setErrorCode(error.code());
@@ -571,11 +817,29 @@ public class FetchCollectorTest {
                     logContext,
                     subscriptions,
                     BufferSupplier.create(),
-                    topicAPartition0,
+                    topicPartition,
                     partitionData,
                     metricsAggregator,
                     fetchOffset,
                     ApiKeys.FETCH.latestVersion());
+        }
+    }
+
+    private Records createRecords() {
+        return createRecords(DEFAULT_RECORD_COUNT);
+    }
+
+    private Records createRecords(final int recordCount) {
+        ByteBuffer allocate = ByteBuffer.allocate(1024);
+
+        try (MemoryRecordsBuilder builder = MemoryRecords.builder(allocate,
+            CompressionType.NONE,
+            TimestampType.CREATE_TIME,
+            0)) {
+            for (int i = 0; i < recordCount; i++)
+                builder.append(0L, "key".getBytes(), ("value-" + i).getBytes());
+
+            return builder.build();
         }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.LongSupplier;
 import java.util.regex.Pattern;
 
 import static java.util.Collections.singleton;
@@ -895,4 +896,75 @@ public class SubscriptionStateTest {
         assertNull(state.partitionLag(tp0, IsolationLevel.READ_COMMITTED));
     }
 
+    @Test
+    public void testPositionOrNull() {
+        state.assignFromUser(Collections.singleton(tp0));
+        final TopicPartition unassignedPartition = new TopicPartition("unassigned", 0);
+        state.seek(tp0, 5);
+
+        assertEquals(5, state.positionOrNull(tp0).offset);
+        assertNull(state.positionOrNull(unassignedPartition));
+    }
+
+    @Test
+    public void testTryUpdatingHighWatermark() {
+        state.assignFromUser(Collections.singleton(tp0));
+        final TopicPartition unassignedPartition = new TopicPartition("unassigned", 0);
+
+        final long highWatermark = 10L;
+        assertTrue(state.tryUpdatingHighWatermark(tp0, highWatermark));
+        assertEquals(highWatermark, state.partitionEndOffset(tp0, IsolationLevel.READ_UNCOMMITTED));
+        assertFalse(state.tryUpdatingHighWatermark(unassignedPartition, highWatermark));
+    }
+
+    @Test
+    public void testTryUpdatingLogStartOffset() {
+        state.assignFromUser(Collections.singleton(tp0));
+        final TopicPartition unassignedPartition = new TopicPartition("unassigned", 0);
+        final long position = 25;
+        state.seek(tp0, position);
+
+        final long logStartOffset = 10L;
+        assertTrue(state.tryUpdatingLogStartOffset(tp0, logStartOffset));
+        assertEquals(position - logStartOffset, state.partitionLead(tp0));
+        assertFalse(state.tryUpdatingLogStartOffset(unassignedPartition, logStartOffset));
+    }
+
+    @Test
+    public void testTryUpdatingLastStableOffset() {
+        state.assignFromUser(Collections.singleton(tp0));
+        final TopicPartition unassignedPartition = new TopicPartition("unassigned", 0);
+
+        final long lastStableOffset = 10L;
+        assertTrue(state.tryUpdatingLastStableOffset(tp0, lastStableOffset));
+        assertEquals(lastStableOffset, state.partitionEndOffset(tp0, IsolationLevel.READ_COMMITTED));
+        assertFalse(state.tryUpdatingLastStableOffset(unassignedPartition, lastStableOffset));
+    }
+
+    @Test
+    public void testTryUpdatingPreferredReadReplica() {
+        state.assignFromUser(Collections.singleton(tp0));
+        final TopicPartition unassignedPartition = new TopicPartition("unassigned", 0);
+
+        final int preferredReadReplicaId = 10;
+        final LongSupplier expirationTimeMs = () -> System.currentTimeMillis() + 60000L;
+        assertTrue(state.tryUpdatingPreferredReadReplica(tp0, preferredReadReplicaId, expirationTimeMs));
+        assertEquals(Optional.of(preferredReadReplicaId), state.preferredReadReplica(tp0, System.currentTimeMillis()));
+        assertFalse(state.tryUpdatingPreferredReadReplica(unassignedPartition, preferredReadReplicaId, expirationTimeMs));
+        assertEquals(Optional.empty(), state.preferredReadReplica(unassignedPartition, System.currentTimeMillis()));
+    }
+
+    @Test
+    public void testRequestOffsetResetIfPartitionAssigned() {
+        state.assignFromUser(Collections.singleton(tp0));
+        final TopicPartition unassignedPartition = new TopicPartition("unassigned", 0);
+
+        state.requestOffsetResetIfPartitionAssigned(tp0);
+
+        assertTrue(state.isOffsetResetNeeded(tp0));
+
+        state.requestOffsetResetIfPartitionAssigned(unassignedPartition);
+
+        assertThrows(IllegalStateException.class, () -> state.isOffsetResetNeeded(unassignedPartition));
+    }
 }


### PR DESCRIPTION
The AsyncKafkaConsumer might throw an IllegalStateException during the initialization of a new fetch. The exception is caused by
 the partition being unassigned by the background thread before
the subscription state is accessed during initialisation.

This commit avoids the IllegalStateException by verifying that the partition was not unassigned each time the subscription state is accessed.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
