### PR TITLE
KAFKA-15302: Stale value returned when using store.all() with key deletion [docs]

### DIFF
--- a/docs/streams/developer-guide/memory-mgmt.html
+++ b/docs/streams/developer-guide/memory-mgmt.html
@@ -151,10 +151,8 @@ props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000);</code></pre>
     Serdes.Long())
   .withCachingEnabled();</code></pre>
       <p>Record caches are not supported for <a class="reference internal" href="processor-api.html#streams-developer-guide-state-store-versioned"><span class="std std-ref">versioned state stores</span></a>.</p>
-      <p><strong>Caution:</strong> When using <code class="docutils literal"><span class="pre">withCachingEnabled()</span></code>,
-        if you <code class="docutils literal"><span class="pre">delete()</span></code> a key from the Store while iterating(e.g., <code class="docutils literal"><span class="pre">KeyValueIterator</span></code>) through the keys,
-        the value of the key that hasn't been flushed from the cache may be returned as a stale value.
-        Therefore, when deleting, you must <code class="docutils literal"><span class="pre">flush()</span></code> the cache before the iterator.</p>
+      <p>To avoid reading stale data, you can <code class="docutils literal"><span class="pre">flush()</span></code> the store before creating the iterator.
+        Note, that flushing too often can lead to performance degration if RocksDB is used, so we advice to avoid flushing manually in general.</p>
     </div>
     <div class="section" id="rocksdb">
       <span id="streams-developer-guide-memory-management-rocksdb"></span><h2><a class="toc-backref" href="#id3">RocksDB</a><a class="headerlink" href="#rocksdb" title="Permalink to this headline"></a></h2>

--- a/docs/streams/developer-guide/memory-mgmt.html
+++ b/docs/streams/developer-guide/memory-mgmt.html
@@ -151,6 +151,10 @@ props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000);</code></pre>
     Serdes.Long())
   .withCachingEnabled();</code></pre>
       <p>Record caches are not supported for <a class="reference internal" href="processor-api.html#streams-developer-guide-state-store-versioned"><span class="std std-ref">versioned state stores</span></a>.</p>
+      <p><strong>Caution:</strong> When using <code class="docutils literal"><span class="pre">withCachingEnabled()</span></code>,
+        if you <code class="docutils literal"><span class="pre">delete()</span></code> a key from the Store while iterating(e.g., <code class="docutils literal"><span class="pre">KeyValueIterator</span></code>) through the keys,
+        the value of the key that hasn't been flushed from the cache may be returned as a stale value.
+        Therefore, when deleting, you must <code class="docutils literal"><span class="pre">flush()</span></code> the cache before the iterator.</p>
     </div>
     <div class="section" id="rocksdb">
       <span id="streams-developer-guide-memory-management-rocksdb"></span><h2><a class="toc-backref" href="#id3">RocksDB</a><a class="headerlink" href="#rocksdb" title="Permalink to this headline"></a></h2>


### PR DESCRIPTION
Related Issue
[KAFKA-15302](https://issues.apache.org/jira/browse/KAFKA-15302)

This PR adds documentation regarding the potential return of stale values when using 'withCachingEnabled' and deleting keys during store iteration.
Since there's a current solution involving flush(), modifications may not be made immediately. Hence, it's necessary to explicitly state in the documentation. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
