### PR TITLE
KAFKA-15853: Move KafkaConfig properties definition out of core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -850,6 +850,7 @@ project(':server') {
 
   dependencies {
     implementation project(':clients')
+    implementation project(':storage')
     implementation project(':server-common')
     implementation project(':group-coordinator')
     implementation project(':transaction-coordinator')
@@ -857,6 +858,18 @@ project(':server') {
     implementation libs.metrics
 
     implementation libs.slf4jApi
+
+    implementation(libs.zookeeper) {
+      // Dropwizard Metrics are required by ZooKeeper as of v3.6.0,
+      // but the library should *not* be used in Kafka code
+      implementation libs.dropwizardMetrics
+      exclude module: 'slf4j-log4j12'
+      exclude module: 'log4j'
+      // Both Kafka and Zookeeper use slf4j. ZooKeeper moved from log4j to logback in v3.8.0, but Kafka relies on reload4j.
+      // We are removing Zookeeper's dependency on logback so we have a singular logging backend.
+      exclude module: 'logback-classic'
+      exclude module: 'logback-core'
+    }
 
     compileOnly libs.log4j
 
@@ -1837,6 +1850,8 @@ project(':storage') {
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':core')
     testImplementation project(':core').sourceSets.test.output
+    testImplementation project(':server')
+    testImplementation project(':server').sourceSets.test.output
     testImplementation project(':server-common')
     testImplementation project(':server-common').sourceSets.test.output
     testImplementation libs.hamcrest
@@ -2174,6 +2189,7 @@ project(':streams') {
     testCompileOnly project(':streams:test-utils')
 
     testImplementation project(':clients').sourceSets.test.output
+    testImplementation project(':server')
     testImplementation project(':core')
     testImplementation project(':tools')
     testImplementation project(':core').sourceSets.test.output
@@ -2768,6 +2784,7 @@ project(':jmh-benchmarks') {
     implementation project(':storage')
     implementation project(':streams')
     implementation project(':core')
+    implementation project(':server')
     implementation project(':connect:api')
     implementation project(':connect:transforms')
     implementation project(':connect:json')
@@ -2986,6 +3003,7 @@ project(':connect:runtime') {
 
     testImplementation project(':clients').sourceSets.test.output
     testImplementation project(':core')
+    testImplementation project(':server')
     testImplementation project(':metadata')
     testImplementation project(':core').sourceSets.test.output
     testImplementation project(':server-common')
@@ -3201,6 +3219,8 @@ project(':connect:mirror') {
     testImplementation project(':connect:runtime').sourceSets.test.output
     testImplementation project(':core')
     testImplementation project(':core').sourceSets.test.output
+    testImplementation project(':server')
+    testImplementation project(':server').sourceSets.test.output
 
     testRuntimeOnly project(':connect:runtime')
     testRuntimeOnly libs.slf4jlog4j

--- a/checkstyle/import-control-core.xml
+++ b/checkstyle/import-control-core.xml
@@ -37,6 +37,7 @@
   <allow pkg="kafka.serializer" />
   <allow pkg="org.apache.kafka.common" />
   <allow pkg="org.mockito" class="AssignmentsManagerTest"/>
+  <allow pkg="org.apache.kafka.server"/>
 
   <!-- see KIP-544 for why KafkaYammerMetrics should be used instead of the global default yammer metrics registry
        https://cwiki.apache.org/confluence/display/KAFKA/KIP-544%3A+Make+metrics+exposed+via+JMX+configurable -->

--- a/checkstyle/import-control-server.xml
+++ b/checkstyle/import-control-server.xml
@@ -82,6 +82,11 @@
       <allow class="org.apache.kafka.server.authorizer.AuthorizableRequestContext" />
       <allow pkg="org.apache.kafka.server.telemetry" />
     </subpackage>
+    <subpackage name="config">
+      <allow pkg="org.apache.kafka.server" />
+      <allow pkg="org.apache.kafka.storage" />
+      <allow class="org.apache.zookeeper.client.ZKClientConfig" />
+    </subpackage>
   </subpackage>
 
   <subpackage name="security">

--- a/checkstyle/import-control-storage.xml
+++ b/checkstyle/import-control-storage.xml
@@ -111,6 +111,7 @@
         <allow pkg="org.apache.kafka.server.log" />
         <allow pkg="org.apache.kafka.server.log.remote" />
         <allow pkg="org.apache.kafka.server.log.remote.storage" />
+        <allow pkg="org.apache.kafka.server.config" />
 
         <allow pkg="org.apache.kafka.test" />
         <subpackage name="actions">
@@ -123,7 +124,6 @@
         </subpackage>
 
         <subpackage name="integration">
-            <allow class="org.apache.kafka.server.config.KafkaConfig" />
         </subpackage>
     </subpackage>
     <!-- END OF TIERED STORAGE INTEGRATION TEST IMPORT DEPENDENCIES -->

--- a/checkstyle/import-control-storage.xml
+++ b/checkstyle/import-control-storage.xml
@@ -123,6 +123,7 @@
         </subpackage>
 
         <subpackage name="integration">
+            <allow class="org.apache.kafka.server.config.KafkaConfig" />
         </subpackage>
     </subpackage>
     <!-- END OF TIERED STORAGE INTEGRATION TEST IMPORT DEPENDENCIES -->

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -533,6 +533,8 @@
       <!-- for tests -->
       <allow pkg="org.apache.kafka.connect.integration" />
       <allow pkg="org.apache.kafka.connect.mirror" />
+      <allow pkg="org.apache.kafka.server.config" />
+
       <allow pkg="kafka.server" />
       <subpackage name="rest">
         <allow pkg="javax.ws.rs" />
@@ -606,6 +608,8 @@
         <allow pkg="org.apache.kafka.metadata" />
         <allow pkg="org.eclipse.jetty.client"/>
         <allow class="org.apache.kafka.storage.internals.log.CleanerConfig" />
+        <!-- for test -->
+        <allow pkg="org.apache.kafka.server.config" />
       </subpackage>
     </subpackage>
 

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -304,6 +304,7 @@
     <allow pkg="kafka.server" />
     <allow pkg="org.apache.kafka.storage.internals" />
     <allow pkg="org.apache.kafka.server.common" />
+    <allow pkg="org.apache.kafka.server.config" />
     <allow pkg="org.apache.kafka.clients" />
     <allow pkg="org.apache.kafka.clients.admin" />
     <allow pkg="org.apache.kafka.clients.producer" />

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationSSLTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationSSLTest.java
@@ -20,14 +20,14 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.network.Mode;
 import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestUtils;
-
+import static org.apache.kafka.server.config.KafkaConfig.LISTENERS_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_LISTENER_NAME_PROP;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 
@@ -41,8 +41,8 @@ public class MirrorConnectorsIntegrationSSLTest extends MirrorConnectorsIntegrat
     public void startClusters() throws Exception {
         Map<String, Object> sslConfig = TestSslUtils.createSslConfig(false, true, Mode.SERVER, TestUtils.tempFile(), "testCert");
         // enable SSL on backup kafka broker
-        backupBrokerProps.put(KafkaConfig.ListenersProp(), "SSL://localhost:0");
-        backupBrokerProps.put(KafkaConfig.InterBrokerListenerNameProp(), "SSL");
+        backupBrokerProps.put(LISTENERS_PROP, "SSL://localhost:0");
+        backupBrokerProps.put(INTER_BROKER_LISTENER_NAME_PROP, "SSL");
         backupBrokerProps.putAll(sslConfig);
         
         Properties sslProps = new Properties();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -90,6 +90,16 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.server.config.KafkaConfig.LISTENERS_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.ZK_CONNECT_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.DELETE_TOPIC_ENABLE_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.AUTO_CREATE_TOPICS_ENABLE_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_LISTENER_NAME_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_SECURITY_PROTOCOL_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.BROKER_ID_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.LOG_DIR_PROP;
 
 /**
  * Setup an embedded Kafka cluster with specified number of brokers and specified broker properties. To be used for
@@ -130,7 +140,7 @@ public class EmbeddedKafkaCluster {
         // Since we support `stop` followed by `startOnlyKafkaOnSamePorts`, we track whether
         // a listener config is defined during initialization in order to know if it's
         // safe to override it
-        hasListenerConfig = brokerConfig.get(KafkaConfig.ListenersProp()) != null;
+        hasListenerConfig = brokerConfig.get(LISTENERS_PROP) != null;
 
         this.clientConfigs = clientConfigs;
     }
@@ -154,28 +164,28 @@ public class EmbeddedKafkaCluster {
     }
 
     private void doStart() {
-        brokerConfig.put(KafkaConfig.ZkConnectProp(), zKConnectString());
+        brokerConfig.put(ZK_CONNECT_PROP, zKConnectString());
 
-        putIfAbsent(brokerConfig, KafkaConfig.DeleteTopicEnableProp(), true);
-        putIfAbsent(brokerConfig, KafkaConfig.GroupInitialRebalanceDelayMsProp(), 0);
-        putIfAbsent(brokerConfig, KafkaConfig.OffsetsTopicReplicationFactorProp(), (short) brokers.length);
-        putIfAbsent(brokerConfig, KafkaConfig.AutoCreateTopicsEnableProp(), false);
+        putIfAbsent(brokerConfig, DELETE_TOPIC_ENABLE_PROP, true);
+        putIfAbsent(brokerConfig, GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, 0);
+        putIfAbsent(brokerConfig, OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, (short) brokers.length);
+        putIfAbsent(brokerConfig, AUTO_CREATE_TOPICS_ENABLE_PROP, false);
         // reduce the size of the log cleaner map to reduce test memory usage
         putIfAbsent(brokerConfig, CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE_PROP, 2 * 1024 * 1024L);
 
-        Object listenerConfig = brokerConfig.get(KafkaConfig.InterBrokerListenerNameProp());
+        Object listenerConfig = brokerConfig.get(INTER_BROKER_LISTENER_NAME_PROP);
         if (listenerConfig == null)
-            listenerConfig = brokerConfig.get(KafkaConfig.InterBrokerSecurityProtocolProp());
+            listenerConfig = brokerConfig.get(INTER_BROKER_SECURITY_PROTOCOL_PROP);
         if (listenerConfig == null)
             listenerConfig = "PLAINTEXT";
         listenerName = new ListenerName(listenerConfig.toString());
 
         for (int i = 0; i < brokers.length; i++) {
-            brokerConfig.put(KafkaConfig.BrokerIdProp(), i);
+            brokerConfig.put(BROKER_ID_PROP, i);
             currentBrokerLogDirs[i] = currentBrokerLogDirs[i] == null ? createLogDir() : currentBrokerLogDirs[i];
-            brokerConfig.put(KafkaConfig.LogDirProp(), currentBrokerLogDirs[i]);
+            brokerConfig.put(LOG_DIR_PROP, currentBrokerLogDirs[i]);
             if (!hasListenerConfig)
-                brokerConfig.put(KafkaConfig.ListenersProp(), listenerName.value() + "://localhost:" + currentBrokerPorts[i]);
+                brokerConfig.put(LISTENERS_PROP, listenerName.value() + "://localhost:" + currentBrokerPorts[i]);
             brokers[i] = TestUtils.createServer(new KafkaConfig(brokerConfig, true), time);
             currentBrokerPorts[i] = brokers[i].boundPort(listenerName);
         }
@@ -305,7 +315,7 @@ public class EmbeddedKafkaCluster {
     }
     
     public boolean sslEnabled() {
-        final String listeners = brokerConfig.getProperty(KafkaConfig.ListenersProp());
+        final String listeners = brokerConfig.getProperty(LISTENERS_PROP);
         return listeners != null && listeners.contains("SSL");
     }
 
@@ -463,7 +473,7 @@ public class EmbeddedKafkaCluster {
         Properties props = Utils.mkProperties(clientConfigs);
         props.putAll(adminClientConfig);
         props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
-        final Object listeners = brokerConfig.get(KafkaConfig.ListenersProp());
+        final Object listeners = brokerConfig.get(LISTENERS_PROP);
         if (listeners != null && listeners.toString().contains("SSL")) {
             props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, brokerConfig.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
             props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, ((Password) brokerConfig.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG)).value());

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -21,7 +21,6 @@ import kafka.cluster.EndPoint;
 import kafka.cluster.Partition;
 import kafka.log.UnifiedLog;
 import kafka.server.BrokerTopicStats;
-import kafka.server.KafkaConfig;
 import kafka.server.StopPartition;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicIdPartition;
@@ -120,6 +119,8 @@ import java.util.stream.Stream;
 
 import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_COMMON_CLIENT_PREFIX;
 import static org.apache.kafka.server.log.remote.storage.RemoteStorageMetrics.REMOTE_LOG_MANAGER_TASKS_AVG_IDLE_PERCENT_METRIC;
+import static org.apache.kafka.server.config.KafkaConfig.BROKER_ID_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.LOG_DIR_PROP;
 
 /**
  * This class is responsible for
@@ -248,7 +249,7 @@ public class RemoteLogManager implements Closeable {
 
     private void configureRSM() {
         final Map<String, Object> rsmProps = new HashMap<>(rlmConfig.remoteStorageManagerProps());
-        rsmProps.put(KafkaConfig.BrokerIdProp(), brokerId);
+        rsmProps.put(BROKER_ID_PROP, brokerId);
         remoteLogStorageManager.configure(rsmProps);
     }
 
@@ -281,8 +282,8 @@ public class RemoteLogManager implements Closeable {
         // update the remoteLogMetadataProps here to override endpoint config if any
         rlmmProps.putAll(rlmConfig.remoteLogMetadataManagerProps());
 
-        rlmmProps.put(KafkaConfig.BrokerIdProp(), brokerId);
-        rlmmProps.put(KafkaConfig.LogDirProp(), logDir);
+        rlmmProps.put(BROKER_ID_PROP, brokerId);
+        rlmmProps.put(LOG_DIR_PROP, logDir);
         rlmmProps.put("cluster.id", clusterId);
 
         remoteLogMetadataManager.configure(rlmmProps);

--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -211,7 +211,7 @@ object AclCommand extends Logging {
       val authorizerProperties =
         if (opts.options.has(opts.zkTlsConfigFile)) {
           // load in TLS configs both with and without the "authorizer." prefix
-          val validKeys = (KafkaConfig.ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().asScala.toList ++ KafkaConfig.ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().asScala.map("authorizer." + _).toList).asJava
+          val validKeys = (KafkaConfig.zkSslConfigToSystemPropertyMap.keySet().asScala.toList ++ KafkaConfig.zkSslConfigToSystemPropertyMap.keySet().asScala.map("authorizer." + _).toList).asJava
           authorizerPropertiesWithoutTls ++ Utils.loadProps(opts.options.valueOf(opts.zkTlsConfigFile), validKeys).asInstanceOf[java.util.Map[String, Any]].asScala
         }
         else
@@ -619,7 +619,7 @@ object AclCommand extends Logging {
       "DEPRECATED: Identifies the file where ZooKeeper client TLS connectivity properties are defined for" +
         " the default authorizer kafka.security.authorizer.AclAuthorizer." +
         " Any properties other than the following (with or without an \"authorizer.\" prefix) are ignored: " +
-        KafkaConfig.ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().asScala.toList.sorted.mkString(", ") +
+        KafkaConfig.zkSslConfigToSystemPropertyMap.keySet().asScala.toList.sorted.mkString(", ") +
         ". Note that if SASL is not configured and zookeeper.set.acl is supposed to be true due to mutual certificate authentication being used" +
         " then it is necessary to explicitly specify --authorizer-properties zookeeper.set.acl=true. " +
         AclCommand.AuthorizerDeprecationMessage)

--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -21,7 +21,7 @@ import java.util.Properties
 import joptsimple._
 import joptsimple.util.EnumConverter
 import kafka.security.authorizer.{AclAuthorizer, AclEntry}
-import kafka.server.KafkaConfig
+import org.apache.kafka.server.config.KafkaConfig
 import kafka.utils._
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
 import org.apache.kafka.common.acl._
@@ -200,7 +200,7 @@ object AclCommand extends Logging {
       // We will default the value of zookeeper.set.acl to true or false based on whether SASL is configured,
       // but if SASL is not configured and zookeeper.set.acl is supposed to be true due to mutual certificate authentication
       // then it will be up to the user to explicitly specify zookeeper.set.acl=true in the authorizer-properties.
-      val defaultProps = Map(KafkaConfig.ZkEnableSecureAclsProp -> JaasUtils.isZkSaslEnabled)
+      val defaultProps = Map(KafkaConfig.ZK_ENABLE_SECURE_ACLS_PROP -> JaasUtils.isZkSaslEnabled)
       val authorizerPropertiesWithoutTls =
         if (opts.options.has(opts.authorizerPropertiesOpt)) {
           val authorizerProperties = opts.options.valuesOf(opts.authorizerPropertiesOpt)
@@ -211,7 +211,7 @@ object AclCommand extends Logging {
       val authorizerProperties =
         if (opts.options.has(opts.zkTlsConfigFile)) {
           // load in TLS configs both with and without the "authorizer." prefix
-          val validKeys = (KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.toList ++ KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.map("authorizer." + _).toList).asJava
+          val validKeys = (KafkaConfig.ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().asScala.toList ++ KafkaConfig.ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().asScala.map("authorizer." + _).toList).asJava
           authorizerPropertiesWithoutTls ++ Utils.loadProps(opts.options.valueOf(opts.zkTlsConfigFile), validKeys).asInstanceOf[java.util.Map[String, Any]].asScala
         }
         else
@@ -619,7 +619,7 @@ object AclCommand extends Logging {
       "DEPRECATED: Identifies the file where ZooKeeper client TLS connectivity properties are defined for" +
         " the default authorizer kafka.security.authorizer.AclAuthorizer." +
         " Any properties other than the following (with or without an \"authorizer.\" prefix) are ignored: " +
-        KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.toList.sorted.mkString(", ") +
+        KafkaConfig.ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().asScala.toList.sorted.mkString(", ") +
         ". Note that if SASL is not configured and zookeeper.set.acl is supposed to be true due to mutual certificate authentication being used" +
         " then it is necessary to explicitly specify --authorizer-properties zookeeper.set.acl=true. " +
         AclCommand.AuthorizerDeprecationMessage)

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -864,7 +864,7 @@ object ConfigCommand extends Logging {
       .ofType(classOf[String])
     val zkTlsConfigFile: OptionSpec[String] = parser.accepts("zk-tls-config-file",
       "Identifies the file where ZooKeeper client TLS connectivity properties are defined.  Any properties other than " +
-        KafkaConfig.ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().asScala.toList.sorted.mkString(", ") + " are ignored.")
+        KafkaConfig.zkSslConfigToSystemPropertyMap.keySet().asScala.toList.sorted.mkString(", ") + " are ignored.")
       .withRequiredArg().describedAs("ZooKeeper TLS configuration").ofType(classOf[String])
     options = parser.parse(args : _*)
 

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 import java.util.{Collections, Properties}
 import joptsimple._
-import kafka.server.{DynamicBrokerConfig, DynamicConfig, KafkaConfig}
+import kafka.server.{DynamicBrokerConfig, DynamicConfig}
 import kafka.server.DynamicConfig.QuotaConfigs
 import kafka.utils.Implicits._
 import kafka.utils.{Exit, Logging}
@@ -35,7 +35,7 @@ import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity, 
 import org.apache.kafka.common.security.JaasUtils
 import org.apache.kafka.common.security.scram.internals.{ScramCredentialUtils, ScramFormatter, ScramMechanism}
 import org.apache.kafka.common.utils.{Sanitizer, Time, Utils}
-import org.apache.kafka.server.config.{ConfigEntityName, ConfigType}
+import org.apache.kafka.server.config.{ConfigEntityName, ConfigType, KafkaConfig}
 import org.apache.kafka.security.{PasswordEncoder, PasswordEncoderConfigs}
 import org.apache.kafka.server.util.{CommandDefaultOptions, CommandLineUtils}
 import org.apache.kafka.storage.internals.log.LogConfig
@@ -864,7 +864,7 @@ object ConfigCommand extends Logging {
       .ofType(classOf[String])
     val zkTlsConfigFile: OptionSpec[String] = parser.accepts("zk-tls-config-file",
       "Identifies the file where ZooKeeper client TLS connectivity properties are defined.  Any properties other than " +
-        KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.toList.sorted.mkString(", ") + " are ignored.")
+        KafkaConfig.ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().asScala.toList.sorted.mkString(", ") + " are ignored.")
       .withRequiredArg().describedAs("ZooKeeper TLS configuration").ofType(classOf[String])
     options = parser.parse(args : _*)
 

--- a/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
+++ b/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
@@ -18,7 +18,7 @@
 package kafka.admin
 
 import joptsimple.{OptionSet, OptionSpec, OptionSpecBuilder}
-import kafka.server.KafkaConfig
+import org.apache.kafka.server.config.KafkaConfig
 import kafka.utils.{Exit, Logging, ToolsUtils}
 import kafka.utils.Implicits._
 import kafka.zk.{ControllerZNode, KafkaZkClient, ZkData, ZkSecurityMigratorUtils}
@@ -81,7 +81,7 @@ object ZkSecurityMigrator extends Logging {
     if (jaasFile == null && !tlsClientAuthEnabled) {
       val errorMsg = s"No JAAS configuration file has been specified and no TLS client certificate has been specified. Please make sure that you set " +
         s"the system property ${JaasUtils.JAVA_LOGIN_CONFIG_PARAM} or provide a ZooKeeper client TLS configuration via --$tlsConfigFileOption <filename> " +
-        s"identifying at least ${KafkaConfig.ZkSslClientEnableProp}, ${KafkaConfig.ZkClientCnxnSocketProp}, and ${KafkaConfig.ZkSslKeyStoreLocationProp}"
+        s"identifying at least ${KafkaConfig.ZK_SSL_CLIENT_ENABLE_PROP}, ${KafkaConfig.ZK_CLIENT_CNXN_SOCKET_PROP}, and ${KafkaConfig.ZK_SSL_KEYSTORE_LOCATION_PROP}"
       System.err.println("ERROR: %s".format(errorMsg))
       throw new IllegalArgumentException("Incorrect configuration")
     }
@@ -124,7 +124,7 @@ object ZkSecurityMigrator extends Logging {
   }
 
   def createZkClientConfigFromFile(filename: String) : ZKClientConfig = {
-    val zkTlsConfigFileProps = Utils.loadProps(filename, KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.toList.asJava)
+    val zkTlsConfigFileProps = Utils.loadProps(filename, KafkaConfig.ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().asScala.toList.asJava)
     val zkClientConfig = new ZKClientConfig() // Initializes based on any system properties that have been set
     // Now override any set system properties with explicitly-provided values from the config file
     // Emit INFO logs due to camel-case property names encouraging mistakes -- help people see mistakes they make
@@ -156,7 +156,7 @@ object ZkSecurityMigrator extends Logging {
       "before migration. If not, exit the command.")
     val zkTlsConfigFile: OptionSpec[String] = parser.accepts(tlsConfigFileOption,
       "Identifies the file where ZooKeeper client TLS connectivity properties are defined.  Any properties other than " +
-        KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.mkString(", ") + " are ignored.")
+        KafkaConfig.ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().asScala.mkString(", ") + " are ignored.")
       .withRequiredArg().describedAs("ZooKeeper TLS configuration").ofType(classOf[String])
     options = parser.parse(args : _*)
   }

--- a/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
+++ b/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
@@ -124,7 +124,7 @@ object ZkSecurityMigrator extends Logging {
   }
 
   def createZkClientConfigFromFile(filename: String) : ZKClientConfig = {
-    val zkTlsConfigFileProps = Utils.loadProps(filename, KafkaConfig.ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().asScala.toList.asJava)
+    val zkTlsConfigFileProps = Utils.loadProps(filename, KafkaConfig.zkSslConfigToSystemPropertyMap.keySet().asScala.toList.asJava)
     val zkClientConfig = new ZKClientConfig() // Initializes based on any system properties that have been set
     // Now override any set system properties with explicitly-provided values from the config file
     // Emit INFO logs due to camel-case property names encouraging mistakes -- help people see mistakes they make
@@ -156,7 +156,7 @@ object ZkSecurityMigrator extends Logging {
       "before migration. If not, exit the command.")
     val zkTlsConfigFile: OptionSpec[String] = parser.accepts(tlsConfigFileOption,
       "Identifies the file where ZooKeeper client TLS connectivity properties are defined.  Any properties other than " +
-        KafkaConfig.ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().asScala.mkString(", ") + " are ignored.")
+        KafkaConfig.zkSslConfigToSystemPropertyMap.keySet().asScala.mkString(", ") + " are ignored.")
       .withRequiredArg().describedAs("ZooKeeper TLS configuration").ofType(classOf[String])
     options = parser.parse(args : _*)
   }

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -503,7 +503,7 @@ object LogCleaner {
     CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE_PROP,
     CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_LOAD_FACTOR_PROP,
     CleanerConfig.LOG_CLEANER_IO_BUFFER_SIZE_PROP,
-    KafkaConfig.MessageMaxBytesProp,
+    org.apache.kafka.server.config.KafkaConfig.MESSAGE_MAX_BYTES_PROP,
     CleanerConfig.LOG_CLEANER_IO_MAX_BYTES_PER_SECOND_PROP,
     CleanerConfig.LOG_CLEANER_BACKOFF_MS_PROP
   )

--- a/core/src/main/scala/kafka/metrics/KafkaMetricsConfig.scala
+++ b/core/src/main/scala/kafka/metrics/KafkaMetricsConfig.scala
@@ -20,7 +20,7 @@
 
 package kafka.metrics
 
-import kafka.server.KafkaConfig
+import org.apache.kafka.server.config.KafkaConfig
 import kafka.utils.{CoreUtils, VerifiableProperties}
 import org.apache.kafka.server.config.Defaults
 
@@ -32,12 +32,12 @@ class KafkaMetricsConfig(props: VerifiableProperties) {
    * Comma-separated list of reporter types. These classes should be on the
    * classpath and will be instantiated at run-time.
    */
-  val reporters: Seq[String] = CoreUtils.parseCsvList(props.getString(KafkaConfig.KafkaMetricsReporterClassesProp,
+  val reporters: Seq[String] = CoreUtils.parseCsvList(props.getString(KafkaConfig.KAFKA_METRICS_REPORTER_CLASSES_PROP,
     Defaults.KAFKA_METRIC_REPORTER_CLASSES))
 
   /**
    * The metrics polling interval (in seconds).
    */
-  val pollingIntervalSecs: Int = props.getInt(KafkaConfig.KafkaMetricsPollingIntervalSecondsProp,
+  val pollingIntervalSecs: Int = props.getInt(KafkaConfig.KAFKA_METRICS_POLLING_INTERVAL_SECONDS_PROP,
     Defaults.KAFKA_METRICS_POLLING_INTERVAL_SECONDS)
 }

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.scalalogging.Logger
 import com.yammer.metrics.core.{Histogram, Meter}
 import kafka.network
-import kafka.server.{KafkaConfig, RequestLocal}
+import kafka.server.RequestLocal
 import kafka.utils.{Logging, NotNothing, Pool}
 import kafka.utils.Implicits._
 import org.apache.kafka.common.config.ConfigResource
@@ -35,6 +35,7 @@ import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.network.Session
+import org.apache.kafka.server.config.KafkaConfig
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 
 import java.util

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -17,8 +17,8 @@
 package kafka.raft
 
 import kafka.log.UnifiedLog
-import kafka.server.KafkaConfig.{MetadataLogSegmentBytesProp, MetadataLogSegmentMinBytesProp}
-import kafka.server.{BrokerTopicStats, KafkaConfig, RequestLocal}
+import org.apache.kafka.server.config.KafkaConfig.{METADATA_LOG_SEGMENT_BYTES_PROP, METADATA_LOG_SEGMENT_MIN_BYTES_PROP, METADATA_LOG_SEGMENT_MILLIS_PROP, METADATA_MAX_RETENTION_BYTES_PROP, METADATA_MAX_RETENTION_MILLIS_PROP ,NODE_ID_PROP}
+import kafka.server.{BrokerTopicStats, RequestLocal}
 import kafka.utils.{CoreUtils, Logging}
 import org.apache.kafka.common.config.{AbstractConfig, TopicConfig}
 import org.apache.kafka.common.errors.InvalidConfigurationException
@@ -519,15 +519,15 @@ final class KafkaMetadataLog private (
 object MetadataLogConfig {
   def apply(config: AbstractConfig, maxBatchSizeInBytes: Int, maxFetchSizeInBytes: Int): MetadataLogConfig = {
     new MetadataLogConfig(
-      config.getInt(KafkaConfig.MetadataLogSegmentBytesProp),
-      config.getInt(KafkaConfig.MetadataLogSegmentMinBytesProp),
-      config.getLong(KafkaConfig.MetadataLogSegmentMillisProp),
-      config.getLong(KafkaConfig.MetadataMaxRetentionBytesProp),
-      config.getLong(KafkaConfig.MetadataMaxRetentionMillisProp),
+      config.getInt(METADATA_LOG_SEGMENT_BYTES_PROP),
+      config.getInt(METADATA_LOG_SEGMENT_MIN_BYTES_PROP),
+      config.getLong(METADATA_LOG_SEGMENT_MILLIS_PROP),
+      config.getLong(METADATA_MAX_RETENTION_BYTES_PROP),
+      config.getLong(METADATA_MAX_RETENTION_MILLIS_PROP),
       maxBatchSizeInBytes,
       maxFetchSizeInBytes,
       LogConfig.DEFAULT_FILE_DELETE_DELAY_MS,
-      config.getInt(KafkaConfig.NodeIdProp)
+      config.getInt(NODE_ID_PROP)
     )
   }
 }
@@ -565,7 +565,7 @@ object KafkaMetadataLog extends Logging {
 
     if (config.logSegmentBytes < config.logSegmentMinBytes) {
       throw new InvalidConfigurationException(
-        s"Cannot set $MetadataLogSegmentBytesProp below ${config.logSegmentMinBytes}: ${config.logSegmentBytes}"
+        s"Cannot set $METADATA_LOG_SEGMENT_BYTES_PROP below ${config.logSegmentMinBytes}: ${config.logSegmentBytes}"
       )
     } else if (defaultLogConfig.retentionMs >= 0) {
       throw new InvalidConfigurationException(
@@ -605,7 +605,7 @@ object KafkaMetadataLog extends Logging {
 
     // Print a warning if users have overridden the internal config
     if (config.logSegmentMinBytes != KafkaRaftClient.MAX_BATCH_SIZE_BYTES) {
-      metadataLog.error(s"Overriding $MetadataLogSegmentMinBytesProp is only supported for testing. Setting " +
+      metadataLog.error(s"Overriding $METADATA_LOG_SEGMENT_MIN_BYTES_PROP is only supported for testing. Setting " +
         s"this value too low may lead to an inability to write batches of metadata records.")
     }
 

--- a/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
@@ -36,7 +36,7 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.utils.{SecurityUtils, Time}
 import org.apache.kafka.server.authorizer.AclDeleteResult.AclBindingDeleteResult
 import org.apache.kafka.server.authorizer._
-import org.apache.kafka.server.config.KafkaConfig.{INTER_BROKER_PROTOCOL_VERSION_PROP, ZK_SSL_CLIENT_ENABLE_PROP, ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP, ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP}
+import org.apache.kafka.server.config.KafkaConfig.{INTER_BROKER_PROTOCOL_VERSION_PROP, ZK_SSL_CLIENT_ENABLE_PROP, zkSslConfigToSystemPropertyMap, ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP}
 import org.apache.kafka.server.common.MetadataVersion.IBP_2_0_IV1
 import org.apache.zookeeper.client.ZKClientConfig
 
@@ -106,7 +106,7 @@ object AclAuthorizer {
       // be sure to force creation since the zkSslClientEnable property in the kafkaConfig could be false
       val zkClientConfig = KafkaServer.zkClientConfigFromKafkaConfig(kafkaConfig, forceZkSslClientEnable = true)
       // add in any prefixed overlays
-      ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.asScala forKeyValue { (kafkaProp, sysProp) =>
+      zkSslConfigToSystemPropertyMap.asScala forKeyValue { (kafkaProp, sysProp) =>
         configMap.get(AclAuthorizer.configPrefix + kafkaProp).foreach { prefixedValue =>
           zkClientConfig.setProperty(sysProp,
             if (kafkaProp == ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP)

--- a/core/src/main/scala/kafka/server/ConfigAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ConfigAdminManager.scala
@@ -36,6 +36,7 @@ import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.{Alte
 import org.apache.kafka.common.protocol.Errors.{INVALID_REQUEST, UNKNOWN_SERVER_ERROR}
 import org.apache.kafka.common.requests.ApiError
 import org.apache.kafka.common.resource.{Resource, ResourceType}
+import org.apache.kafka.server.config.KafkaConfig.{configKeys, loggableValue}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.{Map, Seq}
@@ -179,7 +180,7 @@ class ConfigAdminManager(nodeId: Int,
         }
         new AlterConfigOp(new ConfigEntry(config.name(), config.value()), opType)
     }.toSeq
-    prepareIncrementalConfigs(alterConfigOps, configProps, KafkaConfig.configKeys)
+    prepareIncrementalConfigs(alterConfigOps, configProps, configKeys.asScala)
     try {
       validateBrokerConfigChange(configProps, configResource)
     } catch {
@@ -405,7 +406,7 @@ object ConfigAdminManager {
    */
   def toLoggableProps(resource: ConfigResource, configProps: Properties): Map[String, String] = {
     configProps.asScala.map {
-      case (key, value) => (key, KafkaConfig.loggableValue(resource.`type`, key, value))
+      case (key, value) => (key, loggableValue(resource.`type`, key, value))
     }
   }
 

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -19,7 +19,6 @@ package kafka.server
 
 import java.net.{InetAddress, UnknownHostException}
 import java.util.{Collections, Properties}
-import DynamicConfig.Broker._
 import kafka.controller.KafkaController
 import kafka.log.UnifiedLog
 import kafka.network.ConnectionQuotas
@@ -35,6 +34,8 @@ import org.apache.kafka.common.metrics.Quota._
 import org.apache.kafka.common.utils.Sanitizer
 import org.apache.kafka.server.ClientMetricsManager
 import org.apache.kafka.server.config.ConfigEntityName
+import org.apache.kafka.server.config.KafkaConfig.UNCLEAN_LEADER_ELECTION_ENABLE_PROP
+import org.apache.kafka.server.config.dynamic.BrokerDynamicConfigs._
 import org.apache.kafka.storage.internals.log.{LogConfig, ThrottledReplicaListValidator}
 import org.apache.kafka.storage.internals.log.LogConfig.MessageFormatVersion
 
@@ -108,7 +109,7 @@ class TopicConfigHandler(private val replicaManager: ReplicaManager,
     updateThrottledList(LogConfig.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, quotas.leader)
     updateThrottledList(LogConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, quotas.follower)
 
-    if (Try(topicConfig.getProperty(KafkaConfig.UncleanLeaderElectionEnableProp).toBoolean).getOrElse(false)) {
+    if (Try(topicConfig.getProperty(UNCLEAN_LEADER_ELECTION_ENABLE_PROP).toBoolean).getOrElse(false)) {
       kafkaController.foreach(_.enableTopicUncleanLeaderElection(topic))
     }
   }
@@ -244,15 +245,15 @@ class BrokerConfigHandler(private val brokerConfig: KafkaConfig,
       if (properties.containsKey(prop))
         properties.getProperty(prop).toLong
       else
-        DefaultReplicationThrottledRate
+        DEFAULT_REPLICATION_THROTTLED_RATE
     }
     if (brokerId == ConfigEntityName.DEFAULT)
       brokerConfig.dynamicConfig.updateDefaultConfig(properties)
     else if (brokerConfig.brokerId == brokerId.trim.toInt) {
       brokerConfig.dynamicConfig.updateBrokerConfig(brokerConfig.brokerId, properties)
-      quotaManagers.leader.updateQuota(upperBound(getOrDefault(LeaderReplicationThrottledRateProp).toDouble))
-      quotaManagers.follower.updateQuota(upperBound(getOrDefault(FollowerReplicationThrottledRateProp).toDouble))
-      quotaManagers.alterLogDirs.updateQuota(upperBound(getOrDefault(ReplicaAlterLogDirsIoMaxBytesPerSecondProp).toDouble))
+      quotaManagers.leader.updateQuota(upperBound(getOrDefault(LEADER_REPLICATION_THROTTLED_RATE_PROP).toDouble))
+      quotaManagers.follower.updateQuota(upperBound(getOrDefault(FOLLOWER_REPLICATION_THROTTLED_RATE_PROP).toDouble))
+      quotaManagers.alterLogDirs.updateQuota(upperBound(getOrDefault(REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_PROP).toDouble))
     }
   }
 }

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -22,7 +22,7 @@ import kafka.migration.MigrationPropagator
 import kafka.network.{DataPlaneAcceptor, SocketServer}
 import kafka.raft.KafkaRaftManager
 import kafka.security.CredentialProvider
-import kafka.server.KafkaConfig.{AlterConfigPolicyClassNameProp, CreateTopicPolicyClassNameProp}
+import org.apache.kafka.server.config.KafkaConfig.{ALTER_CONFIG_POLICY_CLASS_NAME_PROP, CREATE_TOPIC_POLICY_CLASS_NAME_PROP}
 import kafka.server.QuotaFactory.QuotaManagers
 
 import scala.collection.immutable
@@ -208,9 +208,9 @@ class ControllerServer(
       sharedServer.startForController()
 
       createTopicPolicy = Option(config.
-        getConfiguredInstance(CreateTopicPolicyClassNameProp, classOf[CreateTopicPolicy]))
+        getConfiguredInstance(CREATE_TOPIC_POLICY_CLASS_NAME_PROP, classOf[CreateTopicPolicy]))
       alterConfigPolicy = Option(config.
-        getConfiguredInstance(AlterConfigPolicyClassNameProp, classOf[AlterConfigPolicy]))
+        getConfiguredInstance(ALTER_CONFIG_POLICY_CLASS_NAME_PROP, classOf[AlterConfigPolicy]))
 
       val voterConnections = FutureUtils.waitWithLogging(logger.underlying, logIdent,
         "controller quorum voters future",

--- a/core/src/main/scala/kafka/server/DynamicConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicConfig.scala
@@ -20,11 +20,7 @@ package kafka.server
 import java.net.{InetAddress, UnknownHostException}
 import java.util.Properties
 import org.apache.kafka.common.config.ConfigDef
-import org.apache.kafka.common.config.ConfigDef.Importance._
-import org.apache.kafka.common.config.ConfigDef.Range._
-import org.apache.kafka.common.config.ConfigDef.Type._
-import org.apache.kafka.server.config.{ConfigEntityName, ReplicationQuotaManagerConfig}
-import org.apache.kafka.storage.internals.log.LogConfig
+import org.apache.kafka.server.config.ConfigEntityName
 
 import java.util
 import scala.jdk.CollectionConverters._
@@ -36,36 +32,15 @@ import scala.jdk.CollectionConverters._
 object DynamicConfig {
 
   object Broker {
-    // Properties
-    val LeaderReplicationThrottledRateProp = "leader.replication.throttled.rate"
-    val FollowerReplicationThrottledRateProp = "follower.replication.throttled.rate"
-    val ReplicaAlterLogDirsIoMaxBytesPerSecondProp = "replica.alter.log.dirs.io.max.bytes.per.second"
+    import org.apache.kafka.server.config.dynamic.BrokerDynamicConfigs._
+    import org.apache.kafka.server.config.KafkaConfig
 
-    // Defaults
-    val DefaultReplicationThrottledRate = ReplicationQuotaManagerConfig.DEFAULT_QUOTA_BYTES_PER_SECOND
+    DynamicBrokerConfig.addDynamicConfigs(BROKER_CONFIG_DEF)
+    val nonDynamicProps = KafkaConfig.configNames.asScala.toSet -- BROKER_CONFIG_DEF.names.asScala
 
-    // Documentation
-    val LeaderReplicationThrottledRateDoc = "A long representing the upper bound (bytes/sec) on replication traffic for leaders enumerated in the " +
-      s"property ${LogConfig.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG} (for each topic). This property can be only set dynamically. It is suggested that the " +
-      s"limit be kept above 1MB/s for accurate behaviour."
-    val FollowerReplicationThrottledRateDoc = "A long representing the upper bound (bytes/sec) on replication traffic for followers enumerated in the " +
-      s"property ${LogConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG} (for each topic). This property can be only set dynamically. It is suggested that the " +
-      s"limit be kept above 1MB/s for accurate behaviour."
-    val ReplicaAlterLogDirsIoMaxBytesPerSecondDoc = "A long representing the upper bound (bytes/sec) on disk IO used for moving replica between log directories on the same broker. " +
-      s"This property can be only set dynamically. It is suggested that the limit be kept above 1MB/s for accurate behaviour."
+    def names = BROKER_CONFIG_DEF.names
 
-    // Definitions
-    val brokerConfigDef = new ConfigDef()
-      // Round minimum value down, to make it easier for users.
-      .define(LeaderReplicationThrottledRateProp, LONG, DefaultReplicationThrottledRate, atLeast(0), MEDIUM, LeaderReplicationThrottledRateDoc)
-      .define(FollowerReplicationThrottledRateProp, LONG, DefaultReplicationThrottledRate, atLeast(0), MEDIUM, FollowerReplicationThrottledRateDoc)
-      .define(ReplicaAlterLogDirsIoMaxBytesPerSecondProp, LONG, DefaultReplicationThrottledRate, atLeast(0), MEDIUM, ReplicaAlterLogDirsIoMaxBytesPerSecondDoc)
-    DynamicBrokerConfig.addDynamicConfigs(brokerConfigDef)
-    val nonDynamicProps = KafkaConfig.configNames.toSet -- brokerConfigDef.names.asScala
-
-    def names = brokerConfigDef.names
-
-    def validate(props: Properties) = DynamicConfig.validate(brokerConfigDef, props, customPropsAllowed = true)
+    def validate(props: Properties) = DynamicConfig.validate(BROKER_CONFIG_DEF, props, customPropsAllowed = true)
   }
 
   object QuotaConfigs {

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -19,20 +19,16 @@ package kafka.server
 
 import java.{lang, util}
 import java.util.concurrent.TimeUnit
-import java.util.{Collections, Properties}
+import java.util.Properties
 import kafka.cluster.EndPoint
-import kafka.server.KafkaConfig.{ControllerListenerNamesProp, ListenerSecurityProtocolMapProp}
 import kafka.utils.CoreUtils.parseCsvList
 import kafka.utils.{CoreUtils, Logging}
 import kafka.utils.Implicits._
-import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.common.Reconfigurable
-import org.apache.kafka.common.config.{AbstractConfig, ConfigDef, ConfigException, ConfigResource, SaslConfigs, SecurityConfig, SslConfigs, TopicConfig}
-import org.apache.kafka.common.config.ConfigDef.{ConfigKey, ValidList}
-import org.apache.kafka.common.config.internals.BrokerSecurityConfigs
+import org.apache.kafka.common.config.{AbstractConfig, ConfigException, SaslConfigs, TopicConfig}
 import org.apache.kafka.common.config.types.Password
 import org.apache.kafka.common.network.ListenerName
-import org.apache.kafka.common.record.{CompressionType, LegacyRecord, Records, TimestampType}
+import org.apache.kafka.common.record.{CompressionType, TimestampType}
 import org.apache.kafka.common.security.auth.KafkaPrincipalSerde
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.Utils
@@ -40,16 +36,14 @@ import org.apache.kafka.coordinator.group.Group.GroupType
 import org.apache.kafka.coordinator.group.assignor.PartitionAssignor
 import org.apache.kafka.raft.RaftConfig
 import org.apache.kafka.security.authorizer.AuthorizerUtils
-import org.apache.kafka.security.PasswordEncoderConfigs
 import org.apache.kafka.server.ProcessRole
 import org.apache.kafka.server.authorizer.Authorizer
-import org.apache.kafka.server.common.{MetadataVersion, MetadataVersionValidator}
+import org.apache.kafka.server.config.KafkaConfig.populateSynonyms
+import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.common.MetadataVersion._
-import org.apache.kafka.server.config.{Defaults, ServerTopicConfigSynonyms}
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
-import org.apache.kafka.server.record.BrokerCompressionType
 import org.apache.kafka.server.util.Csv
-import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig, ProducerStateManagerConfig}
+import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig}
 import org.apache.kafka.storage.internals.log.LogConfig.MessageFormatVersion
 import org.apache.zookeeper.client.ZKClientConfig
 
@@ -59,1241 +53,12 @@ import scala.jdk.CollectionConverters._
 import scala.collection.{Map, Seq}
 
 object KafkaConfig {
-
-  private val LogConfigPrefix = "log."
+  import org.apache.kafka.server.config.KafkaConfig._
 
   def main(args: Array[String]): Unit = {
-    System.out.println(configDef.toHtml(4, (config: String) => "brokerconfigs_" + config,
+    System.out.println(CONFIG_DEF.toHtml(4, (config: String) => "brokerconfigs_" + config,
       DynamicBrokerConfig.dynamicConfigUpdateModes))
   }
-
-  /** ********* Zookeeper Configuration ***********/
-  val ZkConnectProp = "zookeeper.connect"
-  val ZkSessionTimeoutMsProp = "zookeeper.session.timeout.ms"
-  val ZkConnectionTimeoutMsProp = "zookeeper.connection.timeout.ms"
-  val ZkEnableSecureAclsProp = "zookeeper.set.acl"
-  val ZkMaxInFlightRequestsProp = "zookeeper.max.in.flight.requests"
-  val ZkSslClientEnableProp = "zookeeper.ssl.client.enable"
-  val ZkClientCnxnSocketProp = "zookeeper.clientCnxnSocket"
-  val ZkSslKeyStoreLocationProp = "zookeeper.ssl.keystore.location"
-  val ZkSslKeyStorePasswordProp = "zookeeper.ssl.keystore.password"
-  val ZkSslKeyStoreTypeProp = "zookeeper.ssl.keystore.type"
-  val ZkSslTrustStoreLocationProp = "zookeeper.ssl.truststore.location"
-  val ZkSslTrustStorePasswordProp = "zookeeper.ssl.truststore.password"
-  val ZkSslTrustStoreTypeProp = "zookeeper.ssl.truststore.type"
-  val ZkSslProtocolProp = "zookeeper.ssl.protocol"
-  val ZkSslEnabledProtocolsProp = "zookeeper.ssl.enabled.protocols"
-  val ZkSslCipherSuitesProp = "zookeeper.ssl.cipher.suites"
-  val ZkSslEndpointIdentificationAlgorithmProp = "zookeeper.ssl.endpoint.identification.algorithm"
-  val ZkSslCrlEnableProp = "zookeeper.ssl.crl.enable"
-  val ZkSslOcspEnableProp = "zookeeper.ssl.ocsp.enable"
-
-  // a map from the Kafka config to the corresponding ZooKeeper Java system property
-  private[kafka] val ZkSslConfigToSystemPropertyMap: Map[String, String] = Map(
-    ZkSslClientEnableProp -> ZKClientConfig.SECURE_CLIENT,
-    ZkClientCnxnSocketProp -> ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET,
-    ZkSslKeyStoreLocationProp -> "zookeeper.ssl.keyStore.location",
-    ZkSslKeyStorePasswordProp -> "zookeeper.ssl.keyStore.password",
-    ZkSslKeyStoreTypeProp -> "zookeeper.ssl.keyStore.type",
-    ZkSslTrustStoreLocationProp -> "zookeeper.ssl.trustStore.location",
-    ZkSslTrustStorePasswordProp -> "zookeeper.ssl.trustStore.password",
-    ZkSslTrustStoreTypeProp -> "zookeeper.ssl.trustStore.type",
-    ZkSslProtocolProp -> "zookeeper.ssl.protocol",
-    ZkSslEnabledProtocolsProp -> "zookeeper.ssl.enabledProtocols",
-    ZkSslCipherSuitesProp -> "zookeeper.ssl.ciphersuites",
-    ZkSslEndpointIdentificationAlgorithmProp -> "zookeeper.ssl.hostnameVerification",
-    ZkSslCrlEnableProp -> "zookeeper.ssl.crl",
-    ZkSslOcspEnableProp -> "zookeeper.ssl.ocsp")
-
-  private[kafka] def zooKeeperClientProperty(clientConfig: ZKClientConfig, kafkaPropName: String): Option[String] = {
-    Option(clientConfig.getProperty(ZkSslConfigToSystemPropertyMap(kafkaPropName)))
-  }
-
-  private[kafka] def setZooKeeperClientProperty(clientConfig: ZKClientConfig, kafkaPropName: String, kafkaPropValue: Any): Unit = {
-    clientConfig.setProperty(ZkSslConfigToSystemPropertyMap(kafkaPropName),
-      kafkaPropName match {
-        case ZkSslEndpointIdentificationAlgorithmProp => (kafkaPropValue.toString.toUpperCase == "HTTPS").toString
-        case ZkSslEnabledProtocolsProp | ZkSslCipherSuitesProp => kafkaPropValue match {
-          case list: java.util.List[_] => list.asScala.mkString(",")
-          case _ => kafkaPropValue.toString
-        }
-        case _ => kafkaPropValue.toString
-    })
-  }
-
-  // For ZooKeeper TLS client authentication to be enabled the client must (at a minimum) configure itself as using TLS
-  // with both a client connection socket and a key store location explicitly set.
-  private[kafka] def zkTlsClientAuthEnabled(zkClientConfig: ZKClientConfig): Boolean = {
-    zooKeeperClientProperty(zkClientConfig, ZkSslClientEnableProp).contains("true") &&
-      zooKeeperClientProperty(zkClientConfig, ZkClientCnxnSocketProp).isDefined &&
-      zooKeeperClientProperty(zkClientConfig, ZkSslKeyStoreLocationProp).isDefined
-  }
-
-  /** ********* General Configuration ***********/
-  val BrokerIdGenerationEnableProp = "broker.id.generation.enable"
-  val MaxReservedBrokerIdProp = "reserved.broker.max.id"
-  val BrokerIdProp = "broker.id"
-  val MessageMaxBytesProp = "message.max.bytes"
-  val NumNetworkThreadsProp = "num.network.threads"
-  val NumIoThreadsProp = "num.io.threads"
-  val BackgroundThreadsProp = "background.threads"
-  val NumReplicaAlterLogDirsThreadsProp = "num.replica.alter.log.dirs.threads"
-  val QueuedMaxRequestsProp = "queued.max.requests"
-  val QueuedMaxBytesProp = "queued.max.request.bytes"
-  val RequestTimeoutMsProp = CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG
-  val ConnectionSetupTimeoutMsProp = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG
-  val ConnectionSetupTimeoutMaxMsProp = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG
-
-  /** KRaft mode configs */
-  val ProcessRolesProp = "process.roles"
-  val InitialBrokerRegistrationTimeoutMsProp = "initial.broker.registration.timeout.ms"
-  val BrokerHeartbeatIntervalMsProp = "broker.heartbeat.interval.ms"
-  val BrokerSessionTimeoutMsProp = "broker.session.timeout.ms"
-  val NodeIdProp = "node.id"
-  val MetadataLogDirProp = "metadata.log.dir"
-  val MetadataSnapshotMaxNewRecordBytesProp = "metadata.log.max.record.bytes.between.snapshots"
-  val MetadataSnapshotMaxIntervalMsProp = "metadata.log.max.snapshot.interval.ms"
-  val ControllerListenerNamesProp = "controller.listener.names"
-  val SaslMechanismControllerProtocolProp = "sasl.mechanism.controller.protocol"
-  val MetadataLogSegmentMinBytesProp = "metadata.log.segment.min.bytes"
-  val MetadataLogSegmentBytesProp = "metadata.log.segment.bytes"
-  val MetadataLogSegmentMillisProp = "metadata.log.segment.ms"
-  val MetadataMaxRetentionBytesProp = "metadata.max.retention.bytes"
-  val MetadataMaxRetentionMillisProp = "metadata.max.retention.ms"
-  val QuorumVotersProp = RaftConfig.QUORUM_VOTERS_CONFIG
-  val MetadataMaxIdleIntervalMsProp = "metadata.max.idle.interval.ms"
-  val ServerMaxStartupTimeMsProp = "server.max.startup.time.ms"
-
-  /** ZK to KRaft Migration configs */
-  val MigrationEnabledProp = "zookeeper.metadata.migration.enable"
-  val MigrationMetadataMinBatchSizeProp = "zookeeper.metadata.migration.min.batch.size"
-
-  /** Enable eligible leader replicas configs */
-  val ElrEnabledProp = "eligible.leader.replicas.enable"
-
-  /************* Authorizer Configuration ***********/
-  val AuthorizerClassNameProp = "authorizer.class.name"
-  val EarlyStartListenersProp = "early.start.listeners"
-
-  /** ********* Socket Server Configuration ***********/
-  val ListenersProp = "listeners"
-  val AdvertisedListenersProp = "advertised.listeners"
-  val ListenerSecurityProtocolMapProp = "listener.security.protocol.map"
-  val ControlPlaneListenerNameProp = "control.plane.listener.name"
-  val SocketSendBufferBytesProp = "socket.send.buffer.bytes"
-  val SocketReceiveBufferBytesProp = "socket.receive.buffer.bytes"
-  val SocketRequestMaxBytesProp = "socket.request.max.bytes"
-  val SocketListenBacklogSizeProp = "socket.listen.backlog.size"
-  val MaxConnectionsPerIpProp = "max.connections.per.ip"
-  val MaxConnectionsPerIpOverridesProp = "max.connections.per.ip.overrides"
-  val MaxConnectionsProp = "max.connections"
-  val MaxConnectionCreationRateProp = "max.connection.creation.rate"
-  val ConnectionsMaxIdleMsProp = "connections.max.idle.ms"
-  val FailedAuthenticationDelayMsProp = "connection.failed.authentication.delay.ms"
-  /***************** rack configuration *************/
-  val RackProp = "broker.rack"
-  /** ********* Log Configuration ***********/
-  val NumPartitionsProp = "num.partitions"
-  val LogDirsProp = LogConfigPrefix + "dirs"
-  val LogDirProp = LogConfigPrefix + "dir"
-  val LogSegmentBytesProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.SEGMENT_BYTES_CONFIG)
-
-  val LogRollTimeMillisProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.SEGMENT_MS_CONFIG)
-  val LogRollTimeHoursProp = LogConfigPrefix + "roll.hours"
-
-  val LogRollTimeJitterMillisProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.SEGMENT_JITTER_MS_CONFIG)
-  val LogRollTimeJitterHoursProp = LogConfigPrefix + "roll.jitter.hours"
-
-  val LogRetentionTimeMillisProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.RETENTION_MS_CONFIG)
-  val LogRetentionTimeMinutesProp = LogConfigPrefix + "retention.minutes"
-  val LogRetentionTimeHoursProp = LogConfigPrefix + "retention.hours"
-
-  val LogRetentionBytesProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.RETENTION_BYTES_CONFIG)
-  val LogCleanupIntervalMsProp = LogConfigPrefix + "retention.check.interval.ms"
-  val LogCleanupPolicyProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.CLEANUP_POLICY_CONFIG)
-  val LogIndexSizeMaxBytesProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG)
-  val LogIndexIntervalBytesProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG)
-  val LogFlushIntervalMessagesProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG)
-  val LogDeleteDelayMsProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.FILE_DELETE_DELAY_MS_CONFIG)
-  val LogFlushSchedulerIntervalMsProp = LogConfigPrefix + "flush.scheduler.interval.ms"
-  val LogFlushIntervalMsProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.FLUSH_MS_CONFIG)
-  val LogFlushOffsetCheckpointIntervalMsProp = LogConfigPrefix + "flush.offset.checkpoint.interval.ms"
-  val LogFlushStartOffsetCheckpointIntervalMsProp = LogConfigPrefix + "flush.start.offset.checkpoint.interval.ms"
-  val LogPreAllocateProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.PREALLOCATE_CONFIG)
-
-  /* See `TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG` for details */
-  @deprecated("3.0")
-  val LogMessageFormatVersionProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG)
-
-  val LogMessageTimestampTypeProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG)
-
-  /* See `TopicConfig.MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_CONFIG` for details */
-  @deprecated("3.6")
-  val LogMessageTimestampDifferenceMaxMsProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_CONFIG)
-
-  val LogMessageTimestampBeforeMaxMsProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.MESSAGE_TIMESTAMP_BEFORE_MAX_MS_CONFIG)
-  val LogMessageTimestampAfterMaxMsProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.MESSAGE_TIMESTAMP_AFTER_MAX_MS_CONFIG)
-
-  val NumRecoveryThreadsPerDataDirProp = "num.recovery.threads.per.data.dir"
-  val AutoCreateTopicsEnableProp = "auto.create.topics.enable"
-  val MinInSyncReplicasProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG)
-  val CreateTopicPolicyClassNameProp = "create.topic.policy.class.name"
-  val AlterConfigPolicyClassNameProp = "alter.config.policy.class.name"
-  val LogMessageDownConversionEnableProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.MESSAGE_DOWNCONVERSION_ENABLE_CONFIG)
-  /** ********* Replication configuration ***********/
-  val ControllerSocketTimeoutMsProp = "controller.socket.timeout.ms"
-  val DefaultReplicationFactorProp = "default.replication.factor"
-  val ReplicaLagTimeMaxMsProp = "replica.lag.time.max.ms"
-  val ReplicaSocketTimeoutMsProp = "replica.socket.timeout.ms"
-  val ReplicaSocketReceiveBufferBytesProp = "replica.socket.receive.buffer.bytes"
-  val ReplicaFetchMaxBytesProp = "replica.fetch.max.bytes"
-  val ReplicaFetchWaitMaxMsProp = "replica.fetch.wait.max.ms"
-  val ReplicaFetchMinBytesProp = "replica.fetch.min.bytes"
-  val ReplicaFetchResponseMaxBytesProp = "replica.fetch.response.max.bytes"
-  val ReplicaFetchBackoffMsProp = "replica.fetch.backoff.ms"
-  val NumReplicaFetchersProp = "num.replica.fetchers"
-  val ReplicaHighWatermarkCheckpointIntervalMsProp = "replica.high.watermark.checkpoint.interval.ms"
-  val FetchPurgatoryPurgeIntervalRequestsProp = "fetch.purgatory.purge.interval.requests"
-  val ProducerPurgatoryPurgeIntervalRequestsProp = "producer.purgatory.purge.interval.requests"
-  val DeleteRecordsPurgatoryPurgeIntervalRequestsProp = "delete.records.purgatory.purge.interval.requests"
-  val AutoLeaderRebalanceEnableProp = "auto.leader.rebalance.enable"
-  val LeaderImbalancePerBrokerPercentageProp = "leader.imbalance.per.broker.percentage"
-  val LeaderImbalanceCheckIntervalSecondsProp = "leader.imbalance.check.interval.seconds"
-  val UncleanLeaderElectionEnableProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG)
-  val InterBrokerSecurityProtocolProp = "security.inter.broker.protocol"
-  val InterBrokerProtocolVersionProp = "inter.broker.protocol.version"
-  val InterBrokerListenerNameProp = "inter.broker.listener.name"
-  val ReplicaSelectorClassProp = "replica.selector.class"
-  /** ********* Controlled shutdown configuration ***********/
-  val ControlledShutdownMaxRetriesProp = "controlled.shutdown.max.retries"
-  val ControlledShutdownRetryBackoffMsProp = "controlled.shutdown.retry.backoff.ms"
-  val ControlledShutdownEnableProp = "controlled.shutdown.enable"
-
-  /** ********* Group coordinator configuration ***********/
-  val GroupMinSessionTimeoutMsProp = "group.min.session.timeout.ms"
-  val GroupMaxSessionTimeoutMsProp = "group.max.session.timeout.ms"
-  val GroupInitialRebalanceDelayMsProp = "group.initial.rebalance.delay.ms"
-  val GroupMaxSizeProp = "group.max.size"
-
-  /** New group coordinator configs */
-  val NewGroupCoordinatorEnableProp = "group.coordinator.new.enable"
-  val GroupCoordinatorRebalanceProtocolsProp = "group.coordinator.rebalance.protocols"
-  val GroupCoordinatorNumThreadsProp = "group.coordinator.threads"
-
-  /** Consumer group configs */
-  val ConsumerGroupSessionTimeoutMsProp = "group.consumer.session.timeout.ms"
-  val ConsumerGroupMinSessionTimeoutMsProp = "group.consumer.min.session.timeout.ms"
-  val ConsumerGroupMaxSessionTimeoutMsProp = "group.consumer.max.session.timeout.ms"
-  val ConsumerGroupHeartbeatIntervalMsProp = "group.consumer.heartbeat.interval.ms"
-  val ConsumerGroupMinHeartbeatIntervalMsProp = "group.consumer.min.heartbeat.interval.ms"
-  val ConsumerGroupMaxHeartbeatIntervalMsProp ="group.consumer.max.heartbeat.interval.ms"
-  val ConsumerGroupMaxSizeProp = "group.consumer.max.size"
-  val ConsumerGroupAssignorsProp = "group.consumer.assignors"
-
-  /** ********* Offset management configuration ***********/
-  val OffsetMetadataMaxSizeProp = "offset.metadata.max.bytes"
-  val OffsetsLoadBufferSizeProp = "offsets.load.buffer.size"
-  val OffsetsTopicReplicationFactorProp = "offsets.topic.replication.factor"
-  val OffsetsTopicPartitionsProp = "offsets.topic.num.partitions"
-  val OffsetsTopicSegmentBytesProp = "offsets.topic.segment.bytes"
-  val OffsetsTopicCompressionCodecProp = "offsets.topic.compression.codec"
-  val OffsetsRetentionMinutesProp = "offsets.retention.minutes"
-  val OffsetsRetentionCheckIntervalMsProp = "offsets.retention.check.interval.ms"
-  val OffsetCommitTimeoutMsProp = "offsets.commit.timeout.ms"
-  val OffsetCommitRequiredAcksProp = "offsets.commit.required.acks"
-
-  /** ********* Transaction management configuration ***********/
-  val TransactionalIdExpirationMsProp = "transactional.id.expiration.ms"
-  val TransactionsMaxTimeoutMsProp = "transaction.max.timeout.ms"
-  val TransactionsTopicMinISRProp = "transaction.state.log.min.isr"
-  val TransactionsLoadBufferSizeProp = "transaction.state.log.load.buffer.size"
-  val TransactionsTopicPartitionsProp = "transaction.state.log.num.partitions"
-  val TransactionsTopicSegmentBytesProp = "transaction.state.log.segment.bytes"
-  val TransactionsTopicReplicationFactorProp = "transaction.state.log.replication.factor"
-  val TransactionsAbortTimedOutTransactionCleanupIntervalMsProp = "transaction.abort.timed.out.transaction.cleanup.interval.ms"
-  val TransactionsRemoveExpiredTransactionalIdCleanupIntervalMsProp = "transaction.remove.expired.transaction.cleanup.interval.ms"
-
-  val TransactionPartitionVerificationEnableProp = "transaction.partition.verification.enable"
-
-  val ProducerIdExpirationMsProp = ProducerStateManagerConfig.PRODUCER_ID_EXPIRATION_MS
-  val ProducerIdExpirationCheckIntervalMsProp = "producer.id.expiration.check.interval.ms"
-
-  /** ********* Fetch Configuration **************/
-  val MaxIncrementalFetchSessionCacheSlots = "max.incremental.fetch.session.cache.slots"
-  val FetchMaxBytes = "fetch.max.bytes"
-
-  /** ********* Request Limit Configuration **************/
-  val MaxRequestPartitionSizeLimit = "max.request.partition.size.limit"
-
-  /** ********* Quota Configuration ***********/
-  val NumQuotaSamplesProp = "quota.window.num"
-  val NumReplicationQuotaSamplesProp = "replication.quota.window.num"
-  val NumAlterLogDirsReplicationQuotaSamplesProp = "alter.log.dirs.replication.quota.window.num"
-  val NumControllerQuotaSamplesProp = "controller.quota.window.num"
-  val QuotaWindowSizeSecondsProp = "quota.window.size.seconds"
-  val ReplicationQuotaWindowSizeSecondsProp = "replication.quota.window.size.seconds"
-  val AlterLogDirsReplicationQuotaWindowSizeSecondsProp = "alter.log.dirs.replication.quota.window.size.seconds"
-  val ControllerQuotaWindowSizeSecondsProp = "controller.quota.window.size.seconds"
-  val ClientQuotaCallbackClassProp = "client.quota.callback.class"
-
-  val DeleteTopicEnableProp = "delete.topic.enable"
-  val CompressionTypeProp = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.COMPRESSION_TYPE_CONFIG)
-
-  /** ********* Kafka Metrics Configuration ***********/
-  val MetricSampleWindowMsProp = CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG
-  val MetricNumSamplesProp: String = CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG
-  val MetricReporterClassesProp: String = CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG
-  val MetricRecordingLevelProp: String = CommonClientConfigs.METRICS_RECORDING_LEVEL_CONFIG
-  @deprecated
-  val AutoIncludeJmxReporterProp: String = CommonClientConfigs.AUTO_INCLUDE_JMX_REPORTER_CONFIG
-
-  /** ********* Kafka Yammer Metrics Reporters Configuration ***********/
-  val KafkaMetricsReporterClassesProp = "kafka.metrics.reporters"
-  val KafkaMetricsPollingIntervalSecondsProp = "kafka.metrics.polling.interval.secs"
-
-  /** ********* Kafka Client Telemetry Metrics Configuration ***********/
-  val ClientTelemetryMaxBytesProp = "telemetry.max.bytes"
-
-  /** ******** Common Security Configuration *************/
-  val PrincipalBuilderClassProp = BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG
-  val ConnectionsMaxReauthMsProp = BrokerSecurityConfigs.CONNECTIONS_MAX_REAUTH_MS
-  val SaslServerMaxReceiveSizeProp = BrokerSecurityConfigs.SASL_SERVER_MAX_RECEIVE_SIZE_CONFIG
-  val securityProviderClassProp = SecurityConfig.SECURITY_PROVIDERS_CONFIG
-
-  /** ********* SSL Configuration ****************/
-  val SslProtocolProp = SslConfigs.SSL_PROTOCOL_CONFIG
-  val SslProviderProp = SslConfigs.SSL_PROVIDER_CONFIG
-  val SslCipherSuitesProp = SslConfigs.SSL_CIPHER_SUITES_CONFIG
-  val SslEnabledProtocolsProp = SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG
-  val SslKeystoreTypeProp = SslConfigs.SSL_KEYSTORE_TYPE_CONFIG
-  val SslKeystoreLocationProp = SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG
-  val SslKeystorePasswordProp = SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG
-  val SslKeyPasswordProp = SslConfigs.SSL_KEY_PASSWORD_CONFIG
-  val SslKeystoreKeyProp = SslConfigs.SSL_KEYSTORE_KEY_CONFIG
-  val SslKeystoreCertificateChainProp = SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG
-  val SslTruststoreTypeProp = SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG
-  val SslTruststoreLocationProp = SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG
-  val SslTruststorePasswordProp = SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG
-  val SslTruststoreCertificatesProp = SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG
-  val SslKeyManagerAlgorithmProp = SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG
-  val SslTrustManagerAlgorithmProp = SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG
-  val SslEndpointIdentificationAlgorithmProp = SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG
-  val SslSecureRandomImplementationProp = SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG
-  val SslClientAuthProp = BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG
-  val SslPrincipalMappingRulesProp = BrokerSecurityConfigs.SSL_PRINCIPAL_MAPPING_RULES_CONFIG
-  var SslEngineFactoryClassProp = SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG
-  var SslAllowDnChangesProp = BrokerSecurityConfigs.SSL_ALLOW_DN_CHANGES_CONFIG
-  var SslAllowSanChangesProp = BrokerSecurityConfigs.SSL_ALLOW_SAN_CHANGES_CONFIG
-
-  /** ********* SASL Configuration ****************/
-  val SaslMechanismInterBrokerProtocolProp = "sasl.mechanism.inter.broker.protocol"
-  val SaslJaasConfigProp = SaslConfigs.SASL_JAAS_CONFIG
-  val SaslEnabledMechanismsProp = BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG
-  val SaslServerCallbackHandlerClassProp = BrokerSecurityConfigs.SASL_SERVER_CALLBACK_HANDLER_CLASS
-  val SaslClientCallbackHandlerClassProp = SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS
-  val SaslLoginClassProp = SaslConfigs.SASL_LOGIN_CLASS
-  val SaslLoginCallbackHandlerClassProp = SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS
-  val SaslKerberosServiceNameProp = SaslConfigs.SASL_KERBEROS_SERVICE_NAME
-  val SaslKerberosKinitCmdProp = SaslConfigs.SASL_KERBEROS_KINIT_CMD
-  val SaslKerberosTicketRenewWindowFactorProp = SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR
-  val SaslKerberosTicketRenewJitterProp = SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER
-  val SaslKerberosMinTimeBeforeReloginProp = SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN
-  val SaslKerberosPrincipalToLocalRulesProp = BrokerSecurityConfigs.SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES_CONFIG
-  val SaslLoginRefreshWindowFactorProp = SaslConfigs.SASL_LOGIN_REFRESH_WINDOW_FACTOR
-  val SaslLoginRefreshWindowJitterProp = SaslConfigs.SASL_LOGIN_REFRESH_WINDOW_JITTER
-  val SaslLoginRefreshMinPeriodSecondsProp = SaslConfigs.SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS
-  val SaslLoginRefreshBufferSecondsProp = SaslConfigs.SASL_LOGIN_REFRESH_BUFFER_SECONDS
-
-  val SaslLoginConnectTimeoutMsProp = SaslConfigs.SASL_LOGIN_CONNECT_TIMEOUT_MS
-  val SaslLoginReadTimeoutMsProp = SaslConfigs.SASL_LOGIN_READ_TIMEOUT_MS
-  val SaslLoginRetryBackoffMaxMsProp = SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MAX_MS
-  val SaslLoginRetryBackoffMsProp = SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MS
-  val SaslOAuthBearerScopeClaimNameProp = SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME
-  val SaslOAuthBearerSubClaimNameProp = SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME
-  val SaslOAuthBearerTokenEndpointUrlProp = SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL
-  val SaslOAuthBearerJwksEndpointUrlProp = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL
-  val SaslOAuthBearerJwksEndpointRefreshMsProp = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS
-  val SaslOAuthBearerJwksEndpointRetryBackoffMaxMsProp = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS
-  val SaslOAuthBearerJwksEndpointRetryBackoffMsProp = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS
-  val SaslOAuthBearerClockSkewSecondsProp = SaslConfigs.SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS
-  val SaslOAuthBearerExpectedAudienceProp = SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE
-  val SaslOAuthBearerExpectedIssuerProp = SaslConfigs.SASL_OAUTHBEARER_EXPECTED_ISSUER
-
-  /** ********* Delegation Token Configuration ****************/
-  val DelegationTokenSecretKeyAliasProp = "delegation.token.master.key"
-  val DelegationTokenSecretKeyProp = "delegation.token.secret.key"
-  val DelegationTokenMaxLifeTimeProp = "delegation.token.max.lifetime.ms"
-  val DelegationTokenExpiryTimeMsProp = "delegation.token.expiry.time.ms"
-  val DelegationTokenExpiryCheckIntervalMsProp = "delegation.token.expiry.check.interval.ms"
-
-  /** ********* Password encryption configuration for dynamic configs *********/
-  val PasswordEncoderSecretProp = PasswordEncoderConfigs.SECRET
-  val PasswordEncoderOldSecretProp = PasswordEncoderConfigs.OLD_SECRET
-  val PasswordEncoderKeyFactoryAlgorithmProp = PasswordEncoderConfigs.KEYFACTORY_ALGORITHM
-  val PasswordEncoderCipherAlgorithmProp = PasswordEncoderConfigs.CIPHER_ALGORITHM
-  val PasswordEncoderKeyLengthProp = PasswordEncoderConfigs.KEY_LENGTH
-  val PasswordEncoderIterationsProp = PasswordEncoderConfigs.ITERATIONS
-
-  /** Internal Configurations **/
-  val UnstableApiVersionsEnableProp = "unstable.api.versions.enable"
-  val UnstableMetadataVersionsEnableProp = "unstable.metadata.versions.enable"
-
-  /* Documentation */
-  /** ********* Zookeeper Configuration ***********/
-  val ZkConnectDoc = "Specifies the ZooKeeper connection string in the form <code>hostname:port</code> where host and port are the " +
-  "host and port of a ZooKeeper server. To allow connecting through other ZooKeeper nodes when that ZooKeeper machine is " +
-  "down you can also specify multiple hosts in the form <code>hostname1:port1,hostname2:port2,hostname3:port3</code>.\n" +
-  "The server can also have a ZooKeeper chroot path as part of its ZooKeeper connection string which puts its data under some path in the global ZooKeeper namespace. " +
-  "For example to give a chroot path of <code>/chroot/path</code> you would give the connection string as <code>hostname1:port1,hostname2:port2,hostname3:port3/chroot/path</code>."
-  val ZkSessionTimeoutMsDoc = "Zookeeper session timeout"
-  val ZkConnectionTimeoutMsDoc = "The max time that the client waits to establish a connection to ZooKeeper. If not set, the value in " + ZkSessionTimeoutMsProp + " is used"
-  val ZkEnableSecureAclsDoc = "Set client to use secure ACLs"
-  val ZkMaxInFlightRequestsDoc = "The maximum number of unacknowledged requests the client will send to ZooKeeper before blocking."
-  val ZkSslClientEnableDoc = "Set client to use TLS when connecting to ZooKeeper." +
-    " An explicit value overrides any value set via the <code>zookeeper.client.secure</code> system property (note the different name)." +
-    s" Defaults to false if neither is set; when true, <code>$ZkClientCnxnSocketProp</code> must be set (typically to <code>org.apache.zookeeper.ClientCnxnSocketNetty</code>); other values to set may include " +
-    ZkSslConfigToSystemPropertyMap.keys.toList.filter(x => x != ZkSslClientEnableProp && x != ZkClientCnxnSocketProp).sorted.mkString("<code>", "</code>, <code>", "</code>")
-  val ZkClientCnxnSocketDoc = "Typically set to <code>org.apache.zookeeper.ClientCnxnSocketNetty</code> when using TLS connectivity to ZooKeeper." +
-    s" Overrides any explicit value set via the same-named <code>${ZkSslConfigToSystemPropertyMap(ZkClientCnxnSocketProp)}</code> system property."
-  val ZkSslKeyStoreLocationDoc = "Keystore location when using a client-side certificate with TLS connectivity to ZooKeeper." +
-    s" Overrides any explicit value set via the <code>${ZkSslConfigToSystemPropertyMap(ZkSslKeyStoreLocationProp)}</code> system property (note the camelCase)."
-  val ZkSslKeyStorePasswordDoc = "Keystore password when using a client-side certificate with TLS connectivity to ZooKeeper." +
-    s" Overrides any explicit value set via the <code>${ZkSslConfigToSystemPropertyMap(ZkSslKeyStorePasswordProp)}</code> system property (note the camelCase)." +
-    " Note that ZooKeeper does not support a key password different from the keystore password, so be sure to set the key password in the keystore to be identical to the keystore password; otherwise the connection attempt to Zookeeper will fail."
-  val ZkSslKeyStoreTypeDoc = "Keystore type when using a client-side certificate with TLS connectivity to ZooKeeper." +
-    s" Overrides any explicit value set via the <code>${ZkSslConfigToSystemPropertyMap(ZkSslKeyStoreTypeProp)}</code> system property (note the camelCase)." +
-    " The default value of <code>null</code> means the type will be auto-detected based on the filename extension of the keystore."
-  val ZkSslTrustStoreLocationDoc = "Truststore location when using TLS connectivity to ZooKeeper." +
-    s" Overrides any explicit value set via the <code>${ZkSslConfigToSystemPropertyMap(ZkSslTrustStoreLocationProp)}</code> system property (note the camelCase)."
-  val ZkSslTrustStorePasswordDoc = "Truststore password when using TLS connectivity to ZooKeeper." +
-    s" Overrides any explicit value set via the <code>${ZkSslConfigToSystemPropertyMap(ZkSslTrustStorePasswordProp)}</code> system property (note the camelCase)."
-  val ZkSslTrustStoreTypeDoc = "Truststore type when using TLS connectivity to ZooKeeper." +
-    s" Overrides any explicit value set via the <code>${ZkSslConfigToSystemPropertyMap(ZkSslTrustStoreTypeProp)}</code> system property (note the camelCase)." +
-    " The default value of <code>null</code> means the type will be auto-detected based on the filename extension of the truststore."
-  val ZkSslProtocolDoc = "Specifies the protocol to be used in ZooKeeper TLS negotiation." +
-    s" An explicit value overrides any value set via the same-named <code>${ZkSslConfigToSystemPropertyMap(ZkSslProtocolProp)}</code> system property."
-  val ZkSslEnabledProtocolsDoc = "Specifies the enabled protocol(s) in ZooKeeper TLS negotiation (csv)." +
-    s" Overrides any explicit value set via the <code>${ZkSslConfigToSystemPropertyMap(ZkSslEnabledProtocolsProp)}</code> system property (note the camelCase)." +
-    s" The default value of <code>null</code> means the enabled protocol will be the value of the <code>${KafkaConfig.ZkSslProtocolProp}</code> configuration property."
-  val ZkSslCipherSuitesDoc = "Specifies the enabled cipher suites to be used in ZooKeeper TLS negotiation (csv)." +
-    s""" Overrides any explicit value set via the <code>${ZkSslConfigToSystemPropertyMap(ZkSslCipherSuitesProp)}</code> system property (note the single word \"ciphersuites\").""" +
-    " The default value of <code>null</code> means the list of enabled cipher suites is determined by the Java runtime being used."
-  val ZkSslEndpointIdentificationAlgorithmDoc = "Specifies whether to enable hostname verification in the ZooKeeper TLS negotiation process, with (case-insensitively) \"https\" meaning ZooKeeper hostname verification is enabled and an explicit blank value meaning it is disabled (disabling it is only recommended for testing purposes)." +
-    s""" An explicit value overrides any \"true\" or \"false\" value set via the <code>${ZkSslConfigToSystemPropertyMap(ZkSslEndpointIdentificationAlgorithmProp)}</code> system property (note the different name and values; true implies https and false implies blank)."""
-  val ZkSslCrlEnableDoc = "Specifies whether to enable Certificate Revocation List in the ZooKeeper TLS protocols." +
-    s" Overrides any explicit value set via the <code>${ZkSslConfigToSystemPropertyMap(ZkSslCrlEnableProp)}</code> system property (note the shorter name)."
-  val ZkSslOcspEnableDoc = "Specifies whether to enable Online Certificate Status Protocol in the ZooKeeper TLS protocols." +
-    s" Overrides any explicit value set via the <code>${ZkSslConfigToSystemPropertyMap(ZkSslOcspEnableProp)}</code> system property (note the shorter name)."
-  /** ********* General Configuration ***********/
-  val BrokerIdGenerationEnableDoc = s"Enable automatic broker id generation on the server. When enabled the value configured for $MaxReservedBrokerIdProp should be reviewed."
-  val MaxReservedBrokerIdDoc = "Max number that can be used for a broker.id"
-  val BrokerIdDoc = "The broker id for this server. If unset, a unique broker id will be generated." +
-  "To avoid conflicts between ZooKeeper generated broker id's and user configured broker id's, generated broker ids " +
-  "start from " + MaxReservedBrokerIdProp + " + 1."
-  val MessageMaxBytesDoc = TopicConfig.MAX_MESSAGE_BYTES_DOC +
-    s"This can be set per topic with the topic level <code>${TopicConfig.MAX_MESSAGE_BYTES_CONFIG}</code> config."
-  val NumNetworkThreadsDoc = s"The number of threads that the server uses for receiving requests from the network and sending responses to the network. Noted: each listener (except for controller listener) creates its own thread pool."
-  val NumIoThreadsDoc = "The number of threads that the server uses for processing requests, which may include disk I/O"
-  val NumReplicaAlterLogDirsThreadsDoc = "The number of threads that can move replicas between log directories, which may include disk I/O"
-  val BackgroundThreadsDoc = "The number of threads to use for various background processing tasks"
-  val QueuedMaxRequestsDoc = "The number of queued requests allowed for data-plane, before blocking the network threads"
-  val QueuedMaxRequestBytesDoc = "The number of queued bytes allowed before no more requests are read"
-  val RequestTimeoutMsDoc = CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC
-  val ConnectionSetupTimeoutMsDoc = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_DOC
-  val ConnectionSetupTimeoutMaxMsDoc = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC
-
-  /** KRaft mode configs */
-  val ProcessRolesDoc = "The roles that this process plays: 'broker', 'controller', or 'broker,controller' if it is both. " +
-    "This configuration is only applicable for clusters in KRaft (Kafka Raft) mode (instead of ZooKeeper). Leave this config undefined or empty for ZooKeeper clusters."
-  val InitialBrokerRegistrationTimeoutMsDoc = "When initially registering with the controller quorum, the number of milliseconds to wait before declaring failure and exiting the broker process."
-  val BrokerHeartbeatIntervalMsDoc = "The length of time in milliseconds between broker heartbeats. Used when running in KRaft mode."
-  val BrokerSessionTimeoutMsDoc = "The length of time in milliseconds that a broker lease lasts if no heartbeats are made. Used when running in KRaft mode."
-  val NodeIdDoc = "The node ID associated with the roles this process is playing when <code>process.roles</code> is non-empty. " +
-    "This is required configuration when running in KRaft mode."
-  val MetadataLogDirDoc = "This configuration determines where we put the metadata log for clusters in KRaft mode. " +
-    "If it is not set, the metadata log is placed in the first log directory from log.dirs."
-  val MetadataSnapshotMaxNewRecordBytesDoc = "This is the maximum number of bytes in the log between the latest " +
-    "snapshot and the high-watermark needed before generating a new snapshot. The default value is " +
-    s"${Defaults.METADATA_SNAPSHOT_MAX_NEW_RECORD_BYTES}. To generate snapshots based on the time elapsed, see " +
-    s"the <code>$MetadataSnapshotMaxIntervalMsProp</code> configuration. The Kafka node will generate a snapshot when " +
-    "either the maximum time interval is reached or the maximum bytes limit is reached."
-  val MetadataSnapshotMaxIntervalMsDoc = "This is the maximum number of milliseconds to wait to generate a snapshot " +
-    "if there are committed records in the log that are not included in the latest snapshot. A value of zero disables " +
-    s"time based snapshot generation. The default value is ${Defaults.METADATA_SNAPSHOT_MAX_INTERVAL_MS}. To generate " +
-    s"snapshots based on the number of metadata bytes, see the <code>$MetadataSnapshotMaxNewRecordBytesProp</code> " +
-    "configuration. The Kafka node will generate a snapshot when either the maximum time interval is reached or the " +
-    "maximum bytes limit is reached."
-  val MetadataMaxIdleIntervalMsDoc = "This configuration controls how often the active " +
-    "controller should write no-op records to the metadata partition. If the value is 0, no-op records " +
-    s"are not appended to the metadata partition. The default value is ${Defaults.METADATA_MAX_IDLE_INTERVAL_MS}"
-  val ControllerListenerNamesDoc = "A comma-separated list of the names of the listeners used by the controller. This is required " +
-    "if running in KRaft mode. When communicating with the controller quorum, the broker will always use the first listener in this list.\n " +
-    "Note: The ZooKeeper-based controller should not set this configuration."
-  val SaslMechanismControllerProtocolDoc = "SASL mechanism used for communication with controllers. Default is GSSAPI."
-  val MetadataLogSegmentBytesDoc = "The maximum size of a single metadata log file."
-  val MetadataLogSegmentMinBytesDoc = "Override the minimum size for a single metadata log file. This should be used for testing only."
-  val ServerMaxStartupTimeMsDoc = "The maximum number of milliseconds we will wait for the server to come up. " +
-  "By default there is no limit. This should be used for testing only."
-
-  val MetadataLogSegmentMillisDoc = "The maximum time before a new metadata log file is rolled out (in milliseconds)."
-  val MetadataMaxRetentionBytesDoc = "The maximum combined size of the metadata log and snapshots before deleting old " +
-    "snapshots and log files. Since at least one snapshot must exist before any logs can be deleted, this is a soft limit."
-  val MetadataMaxRetentionMillisDoc = "The number of milliseconds to keep a metadata log file or snapshot before " +
-    "deleting it. Since at least one snapshot must exist before any logs can be deleted, this is a soft limit."
-
-  /************* Authorizer Configuration ***********/
-  val AuthorizerClassNameDoc = s"The fully qualified name of a class that implements <code>${classOf[Authorizer].getName}</code>" +
-    " interface, which is used by the broker for authorization."
-  val EarlyStartListenersDoc = "A comma-separated list of listener names which may be started before the authorizer has finished " +
-   "initialization. This is useful when the authorizer is dependent on the cluster itself for bootstrapping, as is the case for " +
-   "the StandardAuthorizer (which stores ACLs in the metadata log.) By default, all listeners included in controller.listener.names " +
-   "will also be early start listeners. A listener should not appear in this list if it accepts external traffic."
-
-  /** ********* Socket Server Configuration ***********/
-  val ListenersDoc = "Listener List - Comma-separated list of URIs we will listen on and the listener names." +
-    s" If the listener name is not a security protocol, <code>$ListenerSecurityProtocolMapProp</code> must also be set.\n" +
-    " Listener names and port numbers must be unique unless \n" +
-    " one listener is an IPv4 address and the other listener is \n" +
-    " an IPv6 address (for the same port).\n" +
-    " Specify hostname as 0.0.0.0 to bind to all interfaces.\n" +
-    " Leave hostname empty to bind to default interface.\n" +
-    " Examples of legal listener lists:\n" +
-    " <code>PLAINTEXT://myhost:9092,SSL://:9091</code>\n" +
-    " <code>CLIENT://0.0.0.0:9092,REPLICATION://localhost:9093</code>\n" +
-    " <code>PLAINTEXT://127.0.0.1:9092,SSL://[::1]:9092</code>\n"
-  val AdvertisedListenersDoc = s"Listeners to publish to ZooKeeper for clients to use, if different than the <code>$ListenersProp</code> config property." +
-    " In IaaS environments, this may need to be different from the interface to which the broker binds." +
-    s" If this is not set, the value for <code>$ListenersProp</code> will be used." +
-    s" Unlike <code>$ListenersProp</code>, it is not valid to advertise the 0.0.0.0 meta-address.\n" +
-    s" Also unlike <code>$ListenersProp</code>, there can be duplicated ports in this property," +
-    " so that one listener can be configured to advertise another listener's address." +
-    " This can be useful in some cases where external load balancers are used."
-  val ListenerSecurityProtocolMapDoc = "Map between listener names and security protocols. This must be defined for " +
-    "the same security protocol to be usable in more than one port or IP. For example, internal and " +
-    "external traffic can be separated even if SSL is required for both. Concretely, the user could define listeners " +
-    "with names INTERNAL and EXTERNAL and this property as: <code>INTERNAL:SSL,EXTERNAL:SSL</code>. As shown, key and value are " +
-    "separated by a colon and map entries are separated by commas. Each listener name should only appear once in the map. " +
-    "Different security (SSL and SASL) settings can be configured for each listener by adding a normalised " +
-    "prefix (the listener name is lowercased) to the config name. For example, to set a different keystore for the " +
-    "INTERNAL listener, a config with name <code>listener.name.internal.ssl.keystore.location</code> would be set. " +
-    "If the config for the listener name is not set, the config will fallback to the generic config (i.e. <code>ssl.keystore.location</code>). " +
-    "Note that in KRaft a default mapping from the listener names defined by <code>controller.listener.names</code> to PLAINTEXT " +
-    "is assumed if no explicit mapping is provided and no other security protocol is in use."
-  val controlPlaneListenerNameDoc = "Name of listener used for communication between controller and brokers. " +
-    s"A broker will use the <code>$ControlPlaneListenerNameProp</code> to locate the endpoint in $ListenersProp list, to listen for connections from the controller. " +
-    "For example, if a broker's config is:\n" +
-    "<code>listeners = INTERNAL://192.1.1.8:9092, EXTERNAL://10.1.1.5:9093, CONTROLLER://192.1.1.8:9094" +
-    "listener.security.protocol.map = INTERNAL:PLAINTEXT, EXTERNAL:SSL, CONTROLLER:SSL" +
-    "control.plane.listener.name = CONTROLLER</code>\n" +
-    "On startup, the broker will start listening on \"192.1.1.8:9094\" with security protocol \"SSL\".\n" +
-    s"On the controller side, when it discovers a broker's published endpoints through ZooKeeper, it will use the <code>$ControlPlaneListenerNameProp</code> " +
-    "to find the endpoint, which it will use to establish connection to the broker.\n" +
-    "For example, if the broker's published endpoints on ZooKeeper are:\n" +
-    " <code>\"endpoints\" : [\"INTERNAL://broker1.example.com:9092\",\"EXTERNAL://broker1.example.com:9093\",\"CONTROLLER://broker1.example.com:9094\"]</code>\n" +
-    " and the controller's config is:\n" +
-    "<code>listener.security.protocol.map = INTERNAL:PLAINTEXT, EXTERNAL:SSL, CONTROLLER:SSL" +
-    "control.plane.listener.name = CONTROLLER</code>\n" +
-    "then the controller will use \"broker1.example.com:9094\" with security protocol \"SSL\" to connect to the broker.\n" +
-    "If not explicitly configured, the default value will be null and there will be no dedicated endpoints for controller connections.\n" +
-    s"If explicitly configured, the value cannot be the same as the value of <code>$InterBrokerListenerNameProp</code>."
-
-  val SocketSendBufferBytesDoc = "The SO_SNDBUF buffer of the socket server sockets. If the value is -1, the OS default will be used."
-  val SocketReceiveBufferBytesDoc = "The SO_RCVBUF buffer of the socket server sockets. If the value is -1, the OS default will be used."
-  val SocketRequestMaxBytesDoc = "The maximum number of bytes in a socket request"
-  val SocketListenBacklogSizeDoc = "The maximum number of pending connections on the socket. " +
-    "In Linux, you may also need to configure <code>somaxconn</code> and <code>tcp_max_syn_backlog</code> kernel parameters " +
-    "accordingly to make the configuration takes effect."
-  val MaxConnectionsPerIpDoc = "The maximum number of connections we allow from each ip address. This can be set to 0 if there are overrides " +
-    s"configured using $MaxConnectionsPerIpOverridesProp property. New connections from the ip address are dropped if the limit is reached."
-  val MaxConnectionsPerIpOverridesDoc = "A comma-separated list of per-ip or hostname overrides to the default maximum number of connections. " +
-    "An example value is \"hostName:100,127.0.0.1:200\""
-  val MaxConnectionsDoc = "The maximum number of connections we allow in the broker at any time. This limit is applied in addition " +
-    s"to any per-ip limits configured using $MaxConnectionsPerIpProp. Listener-level limits may also be configured by prefixing the " +
-    s"config name with the listener prefix, for example, <code>listener.name.internal.$MaxConnectionsProp</code>. Broker-wide limit " +
-    "should be configured based on broker capacity while listener limits should be configured based on application requirements. " +
-    "New connections are blocked if either the listener or broker limit is reached. Connections on the inter-broker listener are " +
-    "permitted even if broker-wide limit is reached. The least recently used connection on another listener will be closed in this case."
-  val MaxConnectionCreationRateDoc = "The maximum connection creation rate we allow in the broker at any time. Listener-level limits " +
-    s"may also be configured by prefixing the config name with the listener prefix, for example, <code>listener.name.internal.$MaxConnectionCreationRateProp</code>." +
-    "Broker-wide connection rate limit should be configured based on broker capacity while listener limits should be configured based on " +
-    "application requirements. New connections will be throttled if either the listener or the broker limit is reached, with the exception " +
-    "of inter-broker listener. Connections on the inter-broker listener will be throttled only when the listener-level rate limit is reached."
-  val ConnectionsMaxIdleMsDoc = "Idle connections timeout: the server socket processor threads close the connections that idle more than this"
-  val FailedAuthenticationDelayMsDoc = "Connection close delay on failed authentication: this is the time (in milliseconds) by which connection close will be delayed on authentication failure. " +
-    s"This must be configured to be less than $ConnectionsMaxIdleMsProp to prevent connection timeout."
-  /************* Rack Configuration **************/
-  val RackDoc = "Rack of the broker. This will be used in rack aware replication assignment for fault tolerance. Examples: <code>RACK1</code>, <code>us-east-1d</code>"
-  /** ********* Log Configuration ***********/
-  val NumPartitionsDoc = "The default number of log partitions per topic"
-  val LogDirDoc = "The directory in which the log data is kept (supplemental for " + LogDirsProp + " property)"
-  val LogDirsDoc = "A comma-separated list of the directories where the log data is stored. If not set, the value in " + LogDirProp + " is used."
-  val LogSegmentBytesDoc = "The maximum size of a single log file"
-  val LogRollTimeMillisDoc = "The maximum time before a new log segment is rolled out (in milliseconds). If not set, the value in " + LogRollTimeHoursProp + " is used"
-  val LogRollTimeHoursDoc = "The maximum time before a new log segment is rolled out (in hours), secondary to " + LogRollTimeMillisProp + " property"
-
-  val LogRollTimeJitterMillisDoc = "The maximum jitter to subtract from logRollTimeMillis (in milliseconds). If not set, the value in " + LogRollTimeJitterHoursProp + " is used"
-  val LogRollTimeJitterHoursDoc = "The maximum jitter to subtract from logRollTimeMillis (in hours), secondary to " + LogRollTimeJitterMillisProp + " property"
-
-  val LogRetentionTimeMillisDoc = "The number of milliseconds to keep a log file before deleting it (in milliseconds), If not set, the value in " + LogRetentionTimeMinutesProp + " is used. If set to -1, no time limit is applied."
-  val LogRetentionTimeMinsDoc = "The number of minutes to keep a log file before deleting it (in minutes), secondary to " + LogRetentionTimeMillisProp + " property. If not set, the value in " + LogRetentionTimeHoursProp + " is used"
-  val LogRetentionTimeHoursDoc = "The number of hours to keep a log file before deleting it (in hours), tertiary to " + LogRetentionTimeMillisProp + " property"
-
-  val LogRetentionBytesDoc = "The maximum size of the log before deleting it"
-  val LogCleanupIntervalMsDoc = "The frequency in milliseconds that the log cleaner checks whether any log is eligible for deletion"
-  val LogCleanupPolicyDoc = "The default cleanup policy for segments beyond the retention window. A comma separated list of valid policies. Valid policies are: \"delete\" and \"compact\""
-  val LogIndexSizeMaxBytesDoc = "The maximum size in bytes of the offset index"
-  val LogIndexIntervalBytesDoc = "The interval with which we add an entry to the offset index."
-  val LogFlushIntervalMessagesDoc = "The number of messages accumulated on a log partition before messages are flushed to disk."
-  val LogDeleteDelayMsDoc = "The amount of time to wait before deleting a file from the filesystem"
-  val LogFlushSchedulerIntervalMsDoc = "The frequency in ms that the log flusher checks whether any log needs to be flushed to disk"
-  val LogFlushIntervalMsDoc = "The maximum time in ms that a message in any topic is kept in memory before flushed to disk. If not set, the value in " + LogFlushSchedulerIntervalMsProp + " is used"
-  val LogFlushOffsetCheckpointIntervalMsDoc = "The frequency with which we update the persistent record of the last flush which acts as the log recovery point."
-  val LogFlushStartOffsetCheckpointIntervalMsDoc = "The frequency with which we update the persistent record of log start offset"
-  val LogPreAllocateEnableDoc = "Should pre allocate file when create new segment? If you are using Kafka on Windows, you probably need to set it to true."
-  val LogMessageFormatVersionDoc = "Specify the message format version the broker will use to append messages to the logs. The value should be a valid MetadataVersion. " +
-    "Some examples are: 0.8.2, 0.9.0.0, 0.10.0, check MetadataVersion for more details. By setting a particular message format version, the " +
-    "user is certifying that all the existing messages on disk are smaller or equal than the specified version. Setting this value incorrectly " +
-    "will cause consumers with older versions to break as they will receive messages with a format that they don't understand."
-
-  val LogMessageTimestampTypeDoc = "Define whether the timestamp in the message is message create time or log append time. The value should be either " +
-    "<code>CreateTime</code> or <code>LogAppendTime</code>."
-
-  val LogMessageTimestampDifferenceMaxMsDoc = "[DEPRECATED] The maximum difference allowed between the timestamp when a broker receives " +
-    "a message and the timestamp specified in the message. If log.message.timestamp.type=CreateTime, a message will be rejected " +
-    "if the difference in timestamp exceeds this threshold. This configuration is ignored if log.message.timestamp.type=LogAppendTime." +
-    "The maximum timestamp difference allowed should be no greater than log.retention.ms to avoid unnecessarily frequent log rolling."
-
-  val LogMessageTimestampBeforeMaxMsDoc = "This configuration sets the allowable timestamp difference between the " +
-    "broker's timestamp and the message timestamp. The message timestamp can be earlier than or equal to the broker's " +
-    "timestamp, with the maximum allowable difference determined by the value set in this configuration. " +
-    "If log.message.timestamp.type=CreateTime, the message will be rejected if the difference in timestamps exceeds " +
-    "this specified threshold. This configuration is ignored if log.message.timestamp.type=LogAppendTime."
-
-  val LogMessageTimestampAfterMaxMsDoc = "This configuration sets the allowable timestamp difference between the " +
-    "message timestamp and the broker's timestamp. The message timestamp can be later than or equal to the broker's " +
-    "timestamp, with the maximum allowable difference determined by the value set in this configuration. " +
-    "If log.message.timestamp.type=CreateTime, the message will be rejected if the difference in timestamps exceeds " +
-    "this specified threshold. This configuration is ignored if log.message.timestamp.type=LogAppendTime."
-
-  val NumRecoveryThreadsPerDataDirDoc = "The number of threads per data directory to be used for log recovery at startup and flushing at shutdown"
-  val AutoCreateTopicsEnableDoc = "Enable auto creation of topic on the server."
-  val MinInSyncReplicasDoc = "When a producer sets acks to \"all\" (or \"-1\"), " +
-    "<code>min.insync.replicas</code> specifies the minimum number of replicas that must acknowledge " +
-    "a write for the write to be considered successful. If this minimum cannot be met, " +
-    "then the producer will raise an exception (either <code>NotEnoughReplicas</code> or " +
-    "<code>NotEnoughReplicasAfterAppend</code>).<br>When used together, <code>min.insync.replicas</code> and acks " +
-    "allow you to enforce greater durability guarantees. A typical scenario would be to " +
-    "create a topic with a replication factor of 3, set <code>min.insync.replicas</code> to 2, and " +
-    "produce with acks of \"all\". This will ensure that the producer raises an exception " +
-    "if a majority of replicas do not receive a write."
-
-  val CreateTopicPolicyClassNameDoc = "The create topic policy class that should be used for validation. The class should " +
-    "implement the <code>org.apache.kafka.server.policy.CreateTopicPolicy</code> interface."
-  val AlterConfigPolicyClassNameDoc = "The alter configs policy class that should be used for validation. The class should " +
-    "implement the <code>org.apache.kafka.server.policy.AlterConfigPolicy</code> interface."
-  val LogMessageDownConversionEnableDoc = TopicConfig.MESSAGE_DOWNCONVERSION_ENABLE_DOC
-
-  /** ********* Replication configuration ***********/
-  val ControllerSocketTimeoutMsDoc = "The socket timeout for controller-to-broker channels."
-  val DefaultReplicationFactorDoc = "The default replication factors for automatically created topics."
-  val ReplicaLagTimeMaxMsDoc = "If a follower hasn't sent any fetch requests or hasn't consumed up to the leaders log end offset for at least this time," +
-  " the leader will remove the follower from isr"
-  val ReplicaSocketTimeoutMsDoc = "The socket timeout for network requests. Its value should be at least replica.fetch.wait.max.ms"
-  val ReplicaSocketReceiveBufferBytesDoc = "The socket receive buffer for network requests to the leader for replicating data"
-  val ReplicaFetchMaxBytesDoc = "The number of bytes of messages to attempt to fetch for each partition. This is not an absolute maximum, " +
-    "if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned " +
-    "to ensure that progress can be made. The maximum record batch size accepted by the broker is defined via " +
-    "<code>message.max.bytes</code> (broker config) or <code>max.message.bytes</code> (topic config)."
-  val ReplicaFetchWaitMaxMsDoc = "The maximum wait time for each fetcher request issued by follower replicas. This value should always be less than the " +
-  "replica.lag.time.max.ms at all times to prevent frequent shrinking of ISR for low throughput topics"
-  val ReplicaFetchMinBytesDoc = "Minimum bytes expected for each fetch response. If not enough bytes, wait up to <code>replica.fetch.wait.max.ms</code> (broker config)."
-  val ReplicaFetchResponseMaxBytesDoc = "Maximum bytes expected for the entire fetch response. Records are fetched in batches, " +
-    "and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch " +
-    "will still be returned to ensure that progress can be made. As such, this is not an absolute maximum. The maximum " +
-    "record batch size accepted by the broker is defined via <code>message.max.bytes</code> (broker config) or " +
-    "<code>max.message.bytes</code> (topic config)."
-  val NumReplicaFetchersDoc = "Number of fetcher threads used to replicate records from each source broker. The total number of fetchers " +
-  "on each broker is bound by <code>num.replica.fetchers</code> multiplied by the number of brokers in the cluster." +
-  "Increasing this value can increase the degree of I/O parallelism in the follower and leader broker at the cost " +
-  "of higher CPU and memory utilization."
-  val ReplicaFetchBackoffMsDoc = "The amount of time to sleep when fetch partition error occurs."
-  val ReplicaHighWatermarkCheckpointIntervalMsDoc = "The frequency with which the high watermark is saved out to disk"
-  val FetchPurgatoryPurgeIntervalRequestsDoc = "The purge interval (in number of requests) of the fetch request purgatory"
-  val ProducerPurgatoryPurgeIntervalRequestsDoc = "The purge interval (in number of requests) of the producer request purgatory"
-  val DeleteRecordsPurgatoryPurgeIntervalRequestsDoc = "The purge interval (in number of requests) of the delete records request purgatory"
-  val AutoLeaderRebalanceEnableDoc = s"Enables auto leader balancing. A background thread checks the distribution of partition leaders at regular intervals, configurable by $LeaderImbalanceCheckIntervalSecondsProp. If the leader imbalance exceeds $LeaderImbalancePerBrokerPercentageProp, leader rebalance to the preferred leader for partitions is triggered."
-  val LeaderImbalancePerBrokerPercentageDoc = "The ratio of leader imbalance allowed per broker. The controller would trigger a leader balance if it goes above this value per broker. The value is specified in percentage."
-  val LeaderImbalanceCheckIntervalSecondsDoc = "The frequency with which the partition rebalance check is triggered by the controller"
-  val UncleanLeaderElectionEnableDoc = "Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss"
-  val InterBrokerSecurityProtocolDoc = "Security protocol used to communicate between brokers. Valid values are: " +
-    s"${SecurityProtocol.names.asScala.mkString(", ")}. It is an error to set this and $InterBrokerListenerNameProp " +
-    "properties at the same time."
-  val InterBrokerProtocolVersionDoc = "Specify which version of the inter-broker protocol will be used.\n" +
-  " This is typically bumped after all brokers were upgraded to a new version.\n" +
-  " Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list."
-  val InterBrokerListenerNameDoc = s"Name of listener used for communication between brokers. If this is unset, the listener name is defined by $InterBrokerSecurityProtocolProp. " +
-    s"It is an error to set this and $InterBrokerSecurityProtocolProp properties at the same time."
-  val ReplicaSelectorClassDoc = "The fully qualified class name that implements ReplicaSelector. This is used by the broker to find the preferred read replica. By default, we use an implementation that returns the leader."
-  /** ********* Controlled shutdown configuration ***********/
-  val ControlledShutdownMaxRetriesDoc = "Controlled shutdown can fail for multiple reasons. This determines the number of retries when such failure happens"
-  val ControlledShutdownRetryBackoffMsDoc = "Before each retry, the system needs time to recover from the state that caused the previous failure (Controller fail over, replica lag etc). This config determines the amount of time to wait before retrying."
-  val ControlledShutdownEnableDoc = "Enable controlled shutdown of the server."
-
-  /** ********* Group coordinator configuration ***********/
-  val GroupMinSessionTimeoutMsDoc = "The minimum allowed session timeout for registered consumers. Shorter timeouts result in quicker failure detection at the cost of more frequent consumer heartbeating, which can overwhelm broker resources."
-  val GroupMaxSessionTimeoutMsDoc = "The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures."
-  val GroupInitialRebalanceDelayMsDoc = "The amount of time the group coordinator will wait for more consumers to join a new group before performing the first rebalance. A longer delay means potentially fewer rebalances, but increases the time until processing begins."
-  val GroupMaxSizeDoc = "The maximum number of consumers that a single consumer group can accommodate."
-
-  /** New group coordinator configs */
-  val NewGroupCoordinatorEnableDoc = "Enable the new group coordinator."
-  val GroupCoordinatorRebalanceProtocolsDoc = "The list of enabled rebalance protocols. Supported protocols: " + Utils.join(GroupType.values.toList.map(_.toString).asJava, ",") + ". " +
-    s"The ${GroupType.CONSUMER} rebalance protocol is in early access and therefore must not be used in production."
-  val GroupCoordinatorNumThreadsDoc = "The number of threads used by the group coordinator."
-
-  /** Consumer group configs */
-  val ConsumerGroupSessionTimeoutMsDoc = "The timeout to detect client failures when using the consumer group protocol."
-  val ConsumerGroupMinSessionTimeoutMsDoc = "The minimum allowed session timeout for registered consumers."
-  val ConsumerGroupMaxSessionTimeoutMsDoc = "The maximum allowed session timeout for registered consumers."
-  val ConsumerGroupHeartbeatIntervalMsDoc = "The heartbeat interval given to the members of a consumer group."
-  val ConsumerGroupMinHeartbeatIntervalMsDoc = "The minimum heartbeat interval for registered consumers."
-  val ConsumerGroupMaxHeartbeatIntervalMsDoc = "The maximum heartbeat interval for registered consumers."
-  val ConsumerGroupMaxSizeDoc = "The maximum number of consumers that a single consumer group can accommodate."
-  val ConsumerGroupAssignorsDoc = "The server side assignors as a list of full class names. The first one in the list is considered as the default assignor to be used in the case where the consumer does not specify an assignor."
-
-  /** ********* Offset management configuration ***********/
-  val OffsetMetadataMaxSizeDoc = "The maximum size for a metadata entry associated with an offset commit."
-  val OffsetsLoadBufferSizeDoc = "Batch size for reading from the offsets segments when loading offsets into the cache (soft-limit, overridden if records are too large)."
-  val OffsetsTopicReplicationFactorDoc = "The replication factor for the offsets topic (set higher to ensure availability). " +
-  "Internal topic creation will fail until the cluster size meets this replication factor requirement."
-  val OffsetsTopicPartitionsDoc = "The number of partitions for the offset commit topic (should not change after deployment)."
-  val OffsetsTopicSegmentBytesDoc = "The offsets topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads."
-  val OffsetsTopicCompressionCodecDoc = "Compression codec for the offsets topic - compression may be used to achieve \"atomic\" commits."
-  val OffsetsRetentionMinutesDoc = "For subscribed consumers, committed offset of a specific partition will be expired and discarded when 1) this retention period has elapsed after the consumer group loses all its consumers (i.e. becomes empty); " +
-    "2) this retention period has elapsed since the last time an offset is committed for the partition and the group is no longer subscribed to the corresponding topic. " +
-    "For standalone consumers (using manual assignment), offsets will be expired after this retention period has elapsed since the time of last commit. " +
-    "Note that when a group is deleted via the delete-group request, its committed offsets will also be deleted without extra retention period; " +
-    "also when a topic is deleted via the delete-topic request, upon propagated metadata update any group's committed offsets for that topic will also be deleted without extra retention period."
-  val OffsetsRetentionCheckIntervalMsDoc = "Frequency at which to check for stale offsets"
-  val OffsetCommitTimeoutMsDoc = "Offset commit will be delayed until all replicas for the offsets topic receive the commit " +
-  "or this timeout is reached. This is similar to the producer request timeout."
-  val OffsetCommitRequiredAcksDoc = "The required acks before the commit can be accepted. In general, the default (-1) should not be overridden."
-  /** ********* Transaction management configuration ***********/
-  val TransactionalIdExpirationMsDoc = "The time in ms that the transaction coordinator will wait without receiving any transaction status updates " +
-    "for the current transaction before expiring its transactional id. Transactional IDs will not expire while a the transaction is still ongoing."
-  val TransactionsMaxTimeoutMsDoc = "The maximum allowed timeout for transactions. " +
-    "If a client’s requested transaction time exceed this, then the broker will return an error in InitProducerIdRequest. This prevents a client from too large of a timeout, which can stall consumers reading from topics included in the transaction."
-  val TransactionsTopicMinISRDoc = "Overridden " + MinInSyncReplicasProp + " config for the transaction topic."
-  val TransactionsLoadBufferSizeDoc = "Batch size for reading from the transaction log segments when loading producer ids and transactions into the cache (soft-limit, overridden if records are too large)."
-  val TransactionsTopicReplicationFactorDoc = "The replication factor for the transaction topic (set higher to ensure availability). " +
-    "Internal topic creation will fail until the cluster size meets this replication factor requirement."
-  val TransactionsTopicPartitionsDoc = "The number of partitions for the transaction topic (should not change after deployment)."
-  val TransactionsTopicSegmentBytesDoc = "The transaction topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads"
-  val TransactionsAbortTimedOutTransactionsIntervalMsDoc = "The interval at which to rollback transactions that have timed out"
-  val TransactionsRemoveExpiredTransactionsIntervalMsDoc = "The interval at which to remove transactions that have expired due to <code>transactional.id.expiration.ms</code> passing"
-
-  val TransactionPartitionVerificationEnableDoc = "Enable verification that checks that the partition has been added to the transaction before writing transactional records to the partition"
-
-  val ProducerIdExpirationMsDoc = "The time in ms that a topic partition leader will wait before expiring producer IDs. Producer IDs will not expire while a transaction associated to them is still ongoing. " +
-    "Note that producer IDs may expire sooner if the last write from the producer ID is deleted due to the topic's retention settings. Setting this value the same or higher than " +
-    "<code>delivery.timeout.ms</code> can help prevent expiration during retries and protect against message duplication, but the default should be reasonable for most use cases."
-  val ProducerIdExpirationCheckIntervalMsDoc = "The interval at which to remove producer IDs that have expired due to <code>producer.id.expiration.ms</code> passing."
-
-  /** ********* Fetch Configuration **************/
-  val MaxIncrementalFetchSessionCacheSlotsDoc = "The maximum number of incremental fetch sessions that we will maintain."
-  val FetchMaxBytesDoc = "The maximum number of bytes we will return for a fetch request. Must be at least 1024."
-
-  /** ********* Request Limit Configuration **************/
-  val MaxRequestPartitionSizeLimitDoc = "The maximum number of partitions can be served in one request."
-
-  /** ********* Quota Configuration ***********/
-  val NumQuotaSamplesDoc = "The number of samples to retain in memory for client quotas"
-  val NumReplicationQuotaSamplesDoc = "The number of samples to retain in memory for replication quotas"
-  val NumAlterLogDirsReplicationQuotaSamplesDoc = "The number of samples to retain in memory for alter log dirs replication quotas"
-  val NumControllerQuotaSamplesDoc = "The number of samples to retain in memory for controller mutation quotas"
-  val QuotaWindowSizeSecondsDoc = "The time span of each sample for client quotas"
-  val ReplicationQuotaWindowSizeSecondsDoc = "The time span of each sample for replication quotas"
-  val AlterLogDirsReplicationQuotaWindowSizeSecondsDoc = "The time span of each sample for alter log dirs replication quotas"
-  val ControllerQuotaWindowSizeSecondsDoc = "The time span of each sample for controller mutations quotas"
-
-  val ClientQuotaCallbackClassDoc = "The fully qualified name of a class that implements the ClientQuotaCallback interface, " +
-    "which is used to determine quota limits applied to client requests. By default, the &lt;user&gt; and &lt;client-id&gt; " +
-    "quotas that are stored in ZooKeeper are applied. For any given request, the most specific quota that matches the user principal " +
-    "of the session and the client-id of the request is applied."
-
-  val DeleteTopicEnableDoc = "Enables delete topic. Delete topic through the admin tool will have no effect if this config is turned off"
-  val CompressionTypeDoc = "Specify the final compression type for a given topic. This configuration accepts the standard compression codecs " +
-  "('gzip', 'snappy', 'lz4', 'zstd'). It additionally accepts 'uncompressed' which is equivalent to no compression; and " +
-  "'producer' which means retain the original compression codec set by the producer."
-
-  /** ********* Kafka Metrics Configuration ***********/
-  val MetricSampleWindowMsDoc = CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_DOC
-  val MetricNumSamplesDoc = CommonClientConfigs.METRICS_NUM_SAMPLES_DOC
-  val MetricReporterClassesDoc = CommonClientConfigs.METRIC_REPORTER_CLASSES_DOC
-  val MetricRecordingLevelDoc = CommonClientConfigs.METRICS_RECORDING_LEVEL_DOC
-  val AutoIncludeJmxReporterDoc = CommonClientConfigs.AUTO_INCLUDE_JMX_REPORTER_DOC
-
-
-  /** ********* Kafka Yammer Metrics Reporter Configuration ***********/
-  val KafkaMetricsReporterClassesDoc = "A list of classes to use as Yammer metrics custom reporters." +
-    " The reporters should implement <code>kafka.metrics.KafkaMetricsReporter</code> trait. If a client wants" +
-    " to expose JMX operations on a custom reporter, the custom reporter needs to additionally implement an MBean" +
-    " trait that extends <code>kafka.metrics.KafkaMetricsReporterMBean</code> trait so that the registered MBean is compliant with" +
-    " the standard MBean convention."
-
-  val KafkaMetricsPollingIntervalSecondsDoc = s"The metrics polling interval (in seconds) which can be used" +
-    s" in $KafkaMetricsReporterClassesProp implementations."
-
-  /** ********* Kafka Client Telemetry Metrics Configuration ***********/
-  val ClientTelemetryMaxBytesDoc = "The maximum size (after compression if compression is used) of" +
-    " telemetry metrics pushed from a client to the broker. The default value is 1048576 (1 MB)."
-
-  /** ******** Common Security Configuration *************/
-  val PrincipalBuilderClassDoc = BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_DOC
-  val ConnectionsMaxReauthMsDoc = BrokerSecurityConfigs.CONNECTIONS_MAX_REAUTH_MS_DOC
-  val SaslServerMaxReceiveSizeDoc = BrokerSecurityConfigs.SASL_SERVER_MAX_RECEIVE_SIZE_DOC
-  val securityProviderClassDoc = SecurityConfig.SECURITY_PROVIDERS_DOC
-
-  /** ********* SSL Configuration ****************/
-  val SslProtocolDoc = SslConfigs.SSL_PROTOCOL_DOC
-  val SslProviderDoc = SslConfigs.SSL_PROVIDER_DOC
-  val SslCipherSuitesDoc = SslConfigs.SSL_CIPHER_SUITES_DOC
-  val SslEnabledProtocolsDoc = SslConfigs.SSL_ENABLED_PROTOCOLS_DOC
-  val SslKeystoreTypeDoc = SslConfigs.SSL_KEYSTORE_TYPE_DOC
-  val SslKeystoreLocationDoc = SslConfigs.SSL_KEYSTORE_LOCATION_DOC
-  val SslKeystorePasswordDoc = SslConfigs.SSL_KEYSTORE_PASSWORD_DOC
-  val SslKeyPasswordDoc = SslConfigs.SSL_KEY_PASSWORD_DOC
-  val SslKeystoreKeyDoc = SslConfigs.SSL_KEYSTORE_KEY_DOC
-  val SslKeystoreCertificateChainDoc = SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_DOC
-  val SslTruststoreTypeDoc = SslConfigs.SSL_TRUSTSTORE_TYPE_DOC
-  val SslTruststorePasswordDoc = SslConfigs.SSL_TRUSTSTORE_PASSWORD_DOC
-  val SslTruststoreLocationDoc = SslConfigs.SSL_TRUSTSTORE_LOCATION_DOC
-  val SslTruststoreCertificatesDoc = SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_DOC
-  val SslKeyManagerAlgorithmDoc = SslConfigs.SSL_KEYMANAGER_ALGORITHM_DOC
-  val SslTrustManagerAlgorithmDoc = SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_DOC
-  val SslEndpointIdentificationAlgorithmDoc = SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC
-  val SslSecureRandomImplementationDoc = SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_DOC
-  val SslClientAuthDoc = BrokerSecurityConfigs.SSL_CLIENT_AUTH_DOC
-  val SslPrincipalMappingRulesDoc = BrokerSecurityConfigs.SSL_PRINCIPAL_MAPPING_RULES_DOC
-  val SslEngineFactoryClassDoc = SslConfigs.SSL_ENGINE_FACTORY_CLASS_DOC
-  val SslAllowDnChangesDoc = BrokerSecurityConfigs.SSL_ALLOW_DN_CHANGES_DOC
-  val SslAllowSanChangesDoc = BrokerSecurityConfigs.SSL_ALLOW_SAN_CHANGES_DOC
-
-  /** ********* Sasl Configuration ****************/
-  val SaslMechanismInterBrokerProtocolDoc = "SASL mechanism used for inter-broker communication. Default is GSSAPI."
-  val SaslJaasConfigDoc = SaslConfigs.SASL_JAAS_CONFIG_DOC
-  val SaslEnabledMechanismsDoc = BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_DOC
-  val SaslServerCallbackHandlerClassDoc = BrokerSecurityConfigs.SASL_SERVER_CALLBACK_HANDLER_CLASS_DOC
-  val SaslClientCallbackHandlerClassDoc = SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS_DOC
-  val SaslLoginClassDoc = SaslConfigs.SASL_LOGIN_CLASS_DOC
-  val SaslLoginCallbackHandlerClassDoc = SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS_DOC
-  val SaslKerberosServiceNameDoc = SaslConfigs.SASL_KERBEROS_SERVICE_NAME_DOC
-  val SaslKerberosKinitCmdDoc = SaslConfigs.SASL_KERBEROS_KINIT_CMD_DOC
-  val SaslKerberosTicketRenewWindowFactorDoc = SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR_DOC
-  val SaslKerberosTicketRenewJitterDoc = SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER_DOC
-  val SaslKerberosMinTimeBeforeReloginDoc = SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN_DOC
-  val SaslKerberosPrincipalToLocalRulesDoc = BrokerSecurityConfigs.SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES_DOC
-  val SaslLoginRefreshWindowFactorDoc = SaslConfigs.SASL_LOGIN_REFRESH_WINDOW_FACTOR_DOC
-  val SaslLoginRefreshWindowJitterDoc = SaslConfigs.SASL_LOGIN_REFRESH_WINDOW_JITTER_DOC
-  val SaslLoginRefreshMinPeriodSecondsDoc = SaslConfigs.SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS_DOC
-  val SaslLoginRefreshBufferSecondsDoc = SaslConfigs.SASL_LOGIN_REFRESH_BUFFER_SECONDS_DOC
-
-  val SaslLoginConnectTimeoutMsDoc = SaslConfigs.SASL_LOGIN_CONNECT_TIMEOUT_MS_DOC
-  val SaslLoginReadTimeoutMsDoc = SaslConfigs.SASL_LOGIN_READ_TIMEOUT_MS_DOC
-  val SaslLoginRetryBackoffMaxMsDoc = SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MAX_MS_DOC
-  val SaslLoginRetryBackoffMsDoc = SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MS_DOC
-  val SaslOAuthBearerScopeClaimNameDoc = SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME_DOC
-  val SaslOAuthBearerSubClaimNameDoc = SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME_DOC
-  val SaslOAuthBearerTokenEndpointUrlDoc = SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL_DOC
-  val SaslOAuthBearerJwksEndpointUrlDoc = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL_DOC
-  val SaslOAuthBearerJwksEndpointRefreshMsDoc = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS_DOC
-  val SaslOAuthBearerJwksEndpointRetryBackoffMaxMsDoc = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS_DOC
-  val SaslOAuthBearerJwksEndpointRetryBackoffMsDoc = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS_DOC
-  val SaslOAuthBearerClockSkewSecondsDoc = SaslConfigs.SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS_DOC
-  val SaslOAuthBearerExpectedAudienceDoc = SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE_DOC
-  val SaslOAuthBearerExpectedIssuerDoc = SaslConfigs.SASL_OAUTHBEARER_EXPECTED_ISSUER_DOC
-
-  /** ********* Delegation Token Configuration ****************/
-  val DelegationTokenSecretKeyAliasDoc = s"DEPRECATED: An alias for $DelegationTokenSecretKeyProp, which should be used instead of this config."
-  val DelegationTokenSecretKeyDoc = "Secret key to generate and verify delegation tokens. The same key must be configured across all the brokers. " +
-    " If using Kafka with KRaft, the key must also be set across all controllers. " +
-    " If the key is not set or set to empty string, brokers will disable the delegation token support."
-  val DelegationTokenMaxLifeTimeDoc = "The token has a maximum lifetime beyond which it cannot be renewed anymore. Default value 7 days."
-  val DelegationTokenExpiryTimeMsDoc = "The token validity time in milliseconds before the token needs to be renewed. Default value 1 day."
-  val DelegationTokenExpiryCheckIntervalDoc = "Scan interval to remove expired delegation tokens."
-
-  /** ********* Password encryption configuration for dynamic configs *********/
-  val PasswordEncoderSecretDoc = "The secret used for encoding dynamically configured passwords for this broker."
-  val PasswordEncoderOldSecretDoc = "The old secret that was used for encoding dynamically configured passwords. " +
-    "This is required only when the secret is updated. If specified, all dynamically encoded passwords are " +
-    s"decoded using this old secret and re-encoded using $PasswordEncoderSecretProp when broker starts up."
-  val PasswordEncoderKeyFactoryAlgorithmDoc = "The SecretKeyFactory algorithm used for encoding dynamically configured passwords. " +
-    "Default is PBKDF2WithHmacSHA512 if available and PBKDF2WithHmacSHA1 otherwise."
-  val PasswordEncoderCipherAlgorithmDoc = "The Cipher algorithm used for encoding dynamically configured passwords."
-  val PasswordEncoderKeyLengthDoc =  "The key length used for encoding dynamically configured passwords."
-  val PasswordEncoderIterationsDoc =  "The iteration count used for encoding dynamically configured passwords."
-
-  @nowarn("cat=deprecation")
-  val configDef = {
-    import ConfigDef.Importance._
-    import ConfigDef.Range._
-    import ConfigDef.Type._
-    import ConfigDef.ValidString._
-
-    new ConfigDef()
-
-      /** ********* Zookeeper Configuration ***********/
-      .define(ZkConnectProp, STRING, null, HIGH, ZkConnectDoc)
-      .define(ZkSessionTimeoutMsProp, INT, Defaults.ZK_SESSION_TIMEOUT_MS, HIGH, ZkSessionTimeoutMsDoc)
-      .define(ZkConnectionTimeoutMsProp, INT, null, HIGH, ZkConnectionTimeoutMsDoc)
-      .define(ZkEnableSecureAclsProp, BOOLEAN, Defaults.ZK_ENABLE_SECURE_ACLS, HIGH, ZkEnableSecureAclsDoc)
-      .define(ZkMaxInFlightRequestsProp, INT, Defaults.ZK_MAX_IN_FLIGHT_REQUESTS, atLeast(1), HIGH, ZkMaxInFlightRequestsDoc)
-      .define(ZkSslClientEnableProp, BOOLEAN, Defaults.ZK_SSL_CLIENT_ENABLE, MEDIUM, ZkSslClientEnableDoc)
-      .define(ZkClientCnxnSocketProp, STRING, null, MEDIUM, ZkClientCnxnSocketDoc)
-      .define(ZkSslKeyStoreLocationProp, STRING, null, MEDIUM, ZkSslKeyStoreLocationDoc)
-      .define(ZkSslKeyStorePasswordProp, PASSWORD, null, MEDIUM, ZkSslKeyStorePasswordDoc)
-      .define(ZkSslKeyStoreTypeProp, STRING, null, MEDIUM, ZkSslKeyStoreTypeDoc)
-      .define(ZkSslTrustStoreLocationProp, STRING, null, MEDIUM, ZkSslTrustStoreLocationDoc)
-      .define(ZkSslTrustStorePasswordProp, PASSWORD, null, MEDIUM, ZkSslTrustStorePasswordDoc)
-      .define(ZkSslTrustStoreTypeProp, STRING, null, MEDIUM, ZkSslTrustStoreTypeDoc)
-      .define(ZkSslProtocolProp, STRING, Defaults.ZK_SSL_PROTOCOL, LOW, ZkSslProtocolDoc)
-      .define(ZkSslEnabledProtocolsProp, LIST, null, LOW, ZkSslEnabledProtocolsDoc)
-      .define(ZkSslCipherSuitesProp, LIST, null, LOW, ZkSslCipherSuitesDoc)
-      .define(ZkSslEndpointIdentificationAlgorithmProp, STRING, Defaults.ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, LOW, ZkSslEndpointIdentificationAlgorithmDoc)
-      .define(ZkSslCrlEnableProp, BOOLEAN, Defaults.ZK_SSL_CRL_ENABLE, LOW, ZkSslCrlEnableDoc)
-      .define(ZkSslOcspEnableProp, BOOLEAN, Defaults.ZK_SSL_OCSP_ENABLE, LOW, ZkSslOcspEnableDoc)
-
-      /** ********* General Configuration ***********/
-      .define(BrokerIdGenerationEnableProp, BOOLEAN, Defaults.BROKER_ID_GENERATION_ENABLE, MEDIUM, BrokerIdGenerationEnableDoc)
-      .define(MaxReservedBrokerIdProp, INT, Defaults.MAX_RESERVED_BROKER_ID, atLeast(0), MEDIUM, MaxReservedBrokerIdDoc)
-      .define(BrokerIdProp, INT, Defaults.BROKER_ID, HIGH, BrokerIdDoc)
-      .define(MessageMaxBytesProp, INT, LogConfig.DEFAULT_MAX_MESSAGE_BYTES, atLeast(0), HIGH, MessageMaxBytesDoc)
-      .define(NumNetworkThreadsProp, INT, Defaults.NUM_NETWORK_THREADS, atLeast(1), HIGH, NumNetworkThreadsDoc)
-      .define(NumIoThreadsProp, INT, Defaults.NUM_IO_THREADS, atLeast(1), HIGH, NumIoThreadsDoc)
-      .define(NumReplicaAlterLogDirsThreadsProp, INT, null, HIGH, NumReplicaAlterLogDirsThreadsDoc)
-      .define(BackgroundThreadsProp, INT, Defaults.BACKGROUND_THREADS, atLeast(1), HIGH, BackgroundThreadsDoc)
-      .define(QueuedMaxRequestsProp, INT, Defaults.QUEUED_MAX_REQUESTS, atLeast(1), HIGH, QueuedMaxRequestsDoc)
-      .define(QueuedMaxBytesProp, LONG, Defaults.QUEUED_MAX_REQUEST_BYTES, MEDIUM, QueuedMaxRequestBytesDoc)
-      .define(RequestTimeoutMsProp, INT, Defaults.REQUEST_TIMEOUT_MS, HIGH, RequestTimeoutMsDoc)
-      .define(ConnectionSetupTimeoutMsProp, LONG, Defaults.CONNECTION_SETUP_TIMEOUT_MS, MEDIUM, ConnectionSetupTimeoutMsDoc)
-      .define(ConnectionSetupTimeoutMaxMsProp, LONG, Defaults.CONNECTION_SETUP_TIMEOUT_MAX_MS, MEDIUM, ConnectionSetupTimeoutMaxMsDoc)
-
-      /*
-       * KRaft mode configs.
-       */
-      .define(MetadataSnapshotMaxNewRecordBytesProp, LONG, Defaults.METADATA_SNAPSHOT_MAX_NEW_RECORD_BYTES, atLeast(1), HIGH, MetadataSnapshotMaxNewRecordBytesDoc)
-      .define(MetadataSnapshotMaxIntervalMsProp, LONG, Defaults.METADATA_SNAPSHOT_MAX_INTERVAL_MS, atLeast(0), HIGH, MetadataSnapshotMaxIntervalMsDoc)
-      .define(ProcessRolesProp, LIST, Collections.emptyList(), ValidList.in("broker", "controller"), HIGH, ProcessRolesDoc)
-      .define(NodeIdProp, INT, Defaults.EMPTY_NODE_ID, null, HIGH, NodeIdDoc)
-      .define(InitialBrokerRegistrationTimeoutMsProp, INT, Defaults.INITIAL_BROKER_REGISTRATION_TIMEOUT_MS, null, MEDIUM, InitialBrokerRegistrationTimeoutMsDoc)
-      .define(BrokerHeartbeatIntervalMsProp, INT, Defaults.BROKER_HEARTBEAT_INTERVAL_MS, null, MEDIUM, BrokerHeartbeatIntervalMsDoc)
-      .define(BrokerSessionTimeoutMsProp, INT, Defaults.BROKER_SESSION_TIMEOUT_MS, null, MEDIUM, BrokerSessionTimeoutMsDoc)
-      .define(ControllerListenerNamesProp, STRING, null, null, HIGH, ControllerListenerNamesDoc)
-      .define(SaslMechanismControllerProtocolProp, STRING, SaslConfigs.DEFAULT_SASL_MECHANISM, null, HIGH, SaslMechanismControllerProtocolDoc)
-      .define(MetadataLogDirProp, STRING, null, null, HIGH, MetadataLogDirDoc)
-      .define(MetadataLogSegmentBytesProp, INT, LogConfig.DEFAULT_SEGMENT_BYTES, atLeast(Records.LOG_OVERHEAD), HIGH, MetadataLogSegmentBytesDoc)
-      .defineInternal(MetadataLogSegmentMinBytesProp, INT, 8 * 1024 * 1024, atLeast(Records.LOG_OVERHEAD), HIGH, MetadataLogSegmentMinBytesDoc)
-      .define(MetadataLogSegmentMillisProp, LONG, LogConfig.DEFAULT_SEGMENT_MS, null, HIGH, MetadataLogSegmentMillisDoc)
-      .define(MetadataMaxRetentionBytesProp, LONG, Defaults.METADATA_MAX_RETENTION_BYTES, null, HIGH, MetadataMaxRetentionBytesDoc)
-      .define(MetadataMaxRetentionMillisProp, LONG, LogConfig.DEFAULT_RETENTION_MS, null, HIGH, MetadataMaxRetentionMillisDoc)
-      .define(MetadataMaxIdleIntervalMsProp, INT, Defaults.METADATA_MAX_IDLE_INTERVAL_MS, atLeast(0), LOW, MetadataMaxIdleIntervalMsDoc)
-      .defineInternal(ServerMaxStartupTimeMsProp, LONG, Defaults.SERVER_MAX_STARTUP_TIME_MS, atLeast(0), MEDIUM, ServerMaxStartupTimeMsDoc)
-      .define(MigrationEnabledProp, BOOLEAN, false, HIGH, "Enable ZK to KRaft migration")
-      .define(ElrEnabledProp, BOOLEAN, false, HIGH, "Enable the Eligible leader replicas")
-      .defineInternal(MigrationMetadataMinBatchSizeProp, INT, Defaults.MIGRATION_METADATA_MIN_BATCH_SIZE, atLeast(1),
-        MEDIUM, "Soft minimum batch size to use when migrating metadata from ZooKeeper to KRaft")
-
-      /************* Authorizer Configuration ***********/
-      .define(AuthorizerClassNameProp, STRING, Defaults.AUTHORIZER_CLASS_NAME, new ConfigDef.NonNullValidator(), LOW, AuthorizerClassNameDoc)
-      .define(EarlyStartListenersProp, STRING, null,  HIGH, EarlyStartListenersDoc)
-
-      /** ********* Socket Server Configuration ***********/
-      .define(ListenersProp, STRING, Defaults.LISTENERS, HIGH, ListenersDoc)
-      .define(AdvertisedListenersProp, STRING, null, HIGH, AdvertisedListenersDoc)
-      .define(ListenerSecurityProtocolMapProp, STRING, Defaults.LISTENER_SECURITY_PROTOCOL_MAP, LOW, ListenerSecurityProtocolMapDoc)
-      .define(ControlPlaneListenerNameProp, STRING, null, HIGH, controlPlaneListenerNameDoc)
-      .define(SocketSendBufferBytesProp, INT, Defaults.SOCKET_SEND_BUFFER_BYTES, HIGH, SocketSendBufferBytesDoc)
-      .define(SocketReceiveBufferBytesProp, INT, Defaults.SOCKET_RECEIVE_BUFFER_BYTES, HIGH, SocketReceiveBufferBytesDoc)
-      .define(SocketRequestMaxBytesProp, INT, Defaults.SOCKET_REQUEST_MAX_BYTES, atLeast(1), HIGH, SocketRequestMaxBytesDoc)
-      .define(SocketListenBacklogSizeProp, INT, Defaults.SOCKET_LISTEN_BACKLOG_SIZE, atLeast(1), MEDIUM, SocketListenBacklogSizeDoc)
-      .define(MaxConnectionsPerIpProp, INT, Defaults.MAX_CONNECTIONS_PER_IP, atLeast(0), MEDIUM, MaxConnectionsPerIpDoc)
-      .define(MaxConnectionsPerIpOverridesProp, STRING, Defaults.MAX_CONNECTIONS_PER_IP_OVERRIDES, MEDIUM, MaxConnectionsPerIpOverridesDoc)
-      .define(MaxConnectionsProp, INT, Defaults.MAX_CONNECTIONS, atLeast(0), MEDIUM, MaxConnectionsDoc)
-      .define(MaxConnectionCreationRateProp, INT, Defaults.MAX_CONNECTION_CREATION_RATE, atLeast(0), MEDIUM, MaxConnectionCreationRateDoc)
-      .define(ConnectionsMaxIdleMsProp, LONG, Defaults.CONNECTIONS_MAX_IDLE_MS, MEDIUM, ConnectionsMaxIdleMsDoc)
-      .define(FailedAuthenticationDelayMsProp, INT, Defaults.FAILED_AUTHENTICATION_DELAY_MS, atLeast(0), LOW, FailedAuthenticationDelayMsDoc)
-
-      /************ Rack Configuration ******************/
-      .define(RackProp, STRING, null, MEDIUM, RackDoc)
-
-      /** ********* Log Configuration ***********/
-      .define(NumPartitionsProp, INT, Defaults.NUM_PARTITIONS, atLeast(1), MEDIUM, NumPartitionsDoc)
-      .define(LogDirProp, STRING, Defaults.LOG_DIR, HIGH, LogDirDoc)
-      .define(LogDirsProp, STRING, null, HIGH, LogDirsDoc)
-      .define(LogSegmentBytesProp, INT, LogConfig.DEFAULT_SEGMENT_BYTES, atLeast(LegacyRecord.RECORD_OVERHEAD_V0), HIGH, LogSegmentBytesDoc)
-
-      .define(LogRollTimeMillisProp, LONG, null, HIGH, LogRollTimeMillisDoc)
-      .define(LogRollTimeHoursProp, INT, TimeUnit.MILLISECONDS.toHours(LogConfig.DEFAULT_SEGMENT_MS).toInt, atLeast(1), HIGH, LogRollTimeHoursDoc)
-
-      .define(LogRollTimeJitterMillisProp, LONG, null, HIGH, LogRollTimeJitterMillisDoc)
-      .define(LogRollTimeJitterHoursProp, INT, TimeUnit.MILLISECONDS.toHours(LogConfig.DEFAULT_SEGMENT_JITTER_MS).toInt, atLeast(0), HIGH, LogRollTimeJitterHoursDoc)
-
-      .define(LogRetentionTimeMillisProp, LONG, null, HIGH, LogRetentionTimeMillisDoc)
-      .define(LogRetentionTimeMinutesProp, INT, null, HIGH, LogRetentionTimeMinsDoc)
-      .define(LogRetentionTimeHoursProp, INT, TimeUnit.MILLISECONDS.toHours(LogConfig.DEFAULT_RETENTION_MS).toInt, HIGH, LogRetentionTimeHoursDoc)
-
-      .define(LogRetentionBytesProp, LONG, LogConfig.DEFAULT_RETENTION_BYTES, HIGH, LogRetentionBytesDoc)
-      .define(LogCleanupIntervalMsProp, LONG, Defaults.LOG_CLEANUP_INTERVAL_MS, atLeast(1), MEDIUM, LogCleanupIntervalMsDoc)
-      .define(LogCleanupPolicyProp, LIST, LogConfig.DEFAULT_CLEANUP_POLICY, ValidList.in(TopicConfig.CLEANUP_POLICY_COMPACT, TopicConfig.CLEANUP_POLICY_DELETE), MEDIUM, LogCleanupPolicyDoc)
-      .define(CleanerConfig.LOG_CLEANER_THREADS_PROP, INT, CleanerConfig.LOG_CLEANER_THREADS, atLeast(0), MEDIUM, CleanerConfig.LOG_CLEANER_THREADS_DOC)
-      .define(CleanerConfig.LOG_CLEANER_IO_MAX_BYTES_PER_SECOND_PROP, DOUBLE, CleanerConfig.LOG_CLEANER_IO_MAX_BYTES_PER_SECOND, MEDIUM, CleanerConfig.LOG_CLEANER_IO_MAX_BYTES_PER_SECOND_DOC)
-      .define(CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE_PROP, LONG, CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE, MEDIUM, CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE_DOC)
-      .define(CleanerConfig.LOG_CLEANER_IO_BUFFER_SIZE_PROP, INT, CleanerConfig.LOG_CLEANER_IO_BUFFER_SIZE, atLeast(0), MEDIUM, CleanerConfig.LOG_CLEANER_IO_BUFFER_SIZE_DOC)
-      .define(CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_LOAD_FACTOR_PROP, DOUBLE, CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_LOAD_FACTOR, MEDIUM, CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_LOAD_FACTOR_DOC)
-      .define(CleanerConfig.LOG_CLEANER_BACKOFF_MS_PROP, LONG, CleanerConfig.LOG_CLEANER_BACKOFF_MS, atLeast(0), MEDIUM, CleanerConfig.LOG_CLEANER_BACKOFF_MS_DOC)
-      .define(CleanerConfig.LOG_CLEANER_MIN_CLEAN_RATIO_PROP, DOUBLE, LogConfig.DEFAULT_MIN_CLEANABLE_DIRTY_RATIO, between(0, 1), MEDIUM, CleanerConfig.LOG_CLEANER_MIN_CLEAN_RATIO_DOC)
-      .define(CleanerConfig.LOG_CLEANER_ENABLE_PROP, BOOLEAN, CleanerConfig.LOG_CLEANER_ENABLE, MEDIUM, CleanerConfig.LOG_CLEANER_ENABLE_DOC)
-      .define(CleanerConfig.LOG_CLEANER_DELETE_RETENTION_MS_PROP, LONG, LogConfig.DEFAULT_DELETE_RETENTION_MS, atLeast(0), MEDIUM, CleanerConfig.LOG_CLEANER_DELETE_RETENTION_MS_DOC)
-      .define(CleanerConfig.LOG_CLEANER_MIN_COMPACTION_LAG_MS_PROP, LONG, LogConfig.DEFAULT_MIN_COMPACTION_LAG_MS, atLeast(0), MEDIUM, CleanerConfig.LOG_CLEANER_MIN_COMPACTION_LAG_MS_DOC)
-      .define(CleanerConfig.LOG_CLEANER_MAX_COMPACTION_LAG_MS_PROP, LONG, LogConfig.DEFAULT_MAX_COMPACTION_LAG_MS, atLeast(1), MEDIUM, CleanerConfig.LOG_CLEANER_MAX_COMPACTION_LAG_MS_DOC)
-      .define(LogIndexSizeMaxBytesProp, INT, LogConfig.DEFAULT_SEGMENT_INDEX_BYTES, atLeast(4), MEDIUM, LogIndexSizeMaxBytesDoc)
-      .define(LogIndexIntervalBytesProp, INT, LogConfig.DEFAULT_INDEX_INTERVAL_BYTES, atLeast(0), MEDIUM, LogIndexIntervalBytesDoc)
-      .define(LogFlushIntervalMessagesProp, LONG, LogConfig.DEFAULT_FLUSH_MESSAGES_INTERVAL, atLeast(1), HIGH, LogFlushIntervalMessagesDoc)
-      .define(LogDeleteDelayMsProp, LONG, LogConfig.DEFAULT_FILE_DELETE_DELAY_MS, atLeast(0), HIGH, LogDeleteDelayMsDoc)
-      .define(LogFlushSchedulerIntervalMsProp, LONG, LogConfig.DEFAULT_FLUSH_MS, HIGH, LogFlushSchedulerIntervalMsDoc)
-      .define(LogFlushIntervalMsProp, LONG, null, HIGH, LogFlushIntervalMsDoc)
-      .define(LogFlushOffsetCheckpointIntervalMsProp, INT, Defaults.LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS, atLeast(0), HIGH, LogFlushOffsetCheckpointIntervalMsDoc)
-      .define(LogFlushStartOffsetCheckpointIntervalMsProp, INT, Defaults.LOG_FLUSH_START_OFFSET_CHECKPOINT_INTERVAL_MS, atLeast(0), HIGH, LogFlushStartOffsetCheckpointIntervalMsDoc)
-      .define(LogPreAllocateProp, BOOLEAN, LogConfig.DEFAULT_PREALLOCATE, MEDIUM, LogPreAllocateEnableDoc)
-      .define(NumRecoveryThreadsPerDataDirProp, INT, Defaults.NUM_RECOVERY_THREADS_PER_DATA_DIR, atLeast(1), HIGH, NumRecoveryThreadsPerDataDirDoc)
-      .define(AutoCreateTopicsEnableProp, BOOLEAN, Defaults.AUTO_CREATE_TOPICS_ENABLE, HIGH, AutoCreateTopicsEnableDoc)
-      .define(MinInSyncReplicasProp, INT, LogConfig.DEFAULT_MIN_IN_SYNC_REPLICAS, atLeast(1), HIGH, MinInSyncReplicasDoc)
-      .define(LogMessageFormatVersionProp, STRING, LogConfig.DEFAULT_MESSAGE_FORMAT_VERSION, new MetadataVersionValidator(), MEDIUM, LogMessageFormatVersionDoc)
-      .define(LogMessageTimestampTypeProp, STRING, LogConfig.DEFAULT_MESSAGE_TIMESTAMP_TYPE, in("CreateTime", "LogAppendTime"), MEDIUM, LogMessageTimestampTypeDoc)
-      .define(LogMessageTimestampDifferenceMaxMsProp, LONG, LogConfig.DEFAULT_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS, atLeast(0), MEDIUM, LogMessageTimestampDifferenceMaxMsDoc)
-      .define(LogMessageTimestampBeforeMaxMsProp, LONG, LogConfig.DEFAULT_MESSAGE_TIMESTAMP_BEFORE_MAX_MS, atLeast(0), MEDIUM, LogMessageTimestampBeforeMaxMsDoc)
-      .define(LogMessageTimestampAfterMaxMsProp, LONG, LogConfig.DEFAULT_MESSAGE_TIMESTAMP_AFTER_MAX_MS, atLeast(0), MEDIUM, LogMessageTimestampAfterMaxMsDoc)
-      .define(CreateTopicPolicyClassNameProp, CLASS, null, LOW, CreateTopicPolicyClassNameDoc)
-      .define(AlterConfigPolicyClassNameProp, CLASS, null, LOW, AlterConfigPolicyClassNameDoc)
-      .define(LogMessageDownConversionEnableProp, BOOLEAN, LogConfig.DEFAULT_MESSAGE_DOWNCONVERSION_ENABLE, LOW, LogMessageDownConversionEnableDoc)
-
-      /** ********* Replication configuration ***********/
-      .define(ControllerSocketTimeoutMsProp, INT, Defaults.CONTROLLER_SOCKET_TIMEOUT_MS, MEDIUM, ControllerSocketTimeoutMsDoc)
-      .define(DefaultReplicationFactorProp, INT, Defaults.REPLICATION_FACTOR, MEDIUM, DefaultReplicationFactorDoc)
-      .define(ReplicaLagTimeMaxMsProp, LONG, Defaults.REPLICA_LAG_TIME_MAX_MS, HIGH, ReplicaLagTimeMaxMsDoc)
-      .define(ReplicaSocketTimeoutMsProp, INT, Defaults.REPLICA_SOCKET_TIMEOUT_MS, HIGH, ReplicaSocketTimeoutMsDoc)
-      .define(ReplicaSocketReceiveBufferBytesProp, INT, Defaults.REPLICA_SOCKET_RECEIVE_BUFFER_BYTES, HIGH, ReplicaSocketReceiveBufferBytesDoc)
-      .define(ReplicaFetchMaxBytesProp, INT, Defaults.REPLICA_FETCH_MAX_BYTES, atLeast(0), MEDIUM, ReplicaFetchMaxBytesDoc)
-      .define(ReplicaFetchWaitMaxMsProp, INT, Defaults.REPLICA_FETCH_WAIT_MAX_MS, HIGH, ReplicaFetchWaitMaxMsDoc)
-      .define(ReplicaFetchBackoffMsProp, INT, Defaults.REPLICA_FETCH_BACKOFF_MS, atLeast(0), MEDIUM, ReplicaFetchBackoffMsDoc)
-      .define(ReplicaFetchMinBytesProp, INT, Defaults.REPLICA_FETCH_MIN_BYTES, HIGH, ReplicaFetchMinBytesDoc)
-      .define(ReplicaFetchResponseMaxBytesProp, INT, Defaults.REPLICA_FETCH_RESPONSE_MAX_BYTES, atLeast(0), MEDIUM, ReplicaFetchResponseMaxBytesDoc)
-      .define(NumReplicaFetchersProp, INT, Defaults.NUM_REPLICA_FETCHERS, HIGH, NumReplicaFetchersDoc)
-      .define(ReplicaHighWatermarkCheckpointIntervalMsProp, LONG, Defaults.REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS, HIGH, ReplicaHighWatermarkCheckpointIntervalMsDoc)
-      .define(FetchPurgatoryPurgeIntervalRequestsProp, INT, Defaults.FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS, MEDIUM, FetchPurgatoryPurgeIntervalRequestsDoc)
-      .define(ProducerPurgatoryPurgeIntervalRequestsProp, INT, Defaults.PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS, MEDIUM, ProducerPurgatoryPurgeIntervalRequestsDoc)
-      .define(DeleteRecordsPurgatoryPurgeIntervalRequestsProp, INT, Defaults.DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS, MEDIUM, DeleteRecordsPurgatoryPurgeIntervalRequestsDoc)
-      .define(AutoLeaderRebalanceEnableProp, BOOLEAN, Defaults.AUTO_LEADER_REBALANCE_ENABLE, HIGH, AutoLeaderRebalanceEnableDoc)
-      .define(LeaderImbalancePerBrokerPercentageProp, INT, Defaults.LEADER_IMBALANCE_PER_BROKER_PERCENTAGE, HIGH, LeaderImbalancePerBrokerPercentageDoc)
-      .define(LeaderImbalanceCheckIntervalSecondsProp, LONG, Defaults.LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS, atLeast(1), HIGH, LeaderImbalanceCheckIntervalSecondsDoc)
-      .define(UncleanLeaderElectionEnableProp, BOOLEAN, LogConfig.DEFAULT_UNCLEAN_LEADER_ELECTION_ENABLE, HIGH, UncleanLeaderElectionEnableDoc)
-      .define(InterBrokerSecurityProtocolProp, STRING, Defaults.INTER_BROKER_SECURITY_PROTOCOL, in(Utils.enumOptions(classOf[SecurityProtocol]):_*), MEDIUM, InterBrokerSecurityProtocolDoc)
-      .define(InterBrokerProtocolVersionProp, STRING, Defaults.INTER_BROKER_PROTOCOL_VERSION, new MetadataVersionValidator(), MEDIUM, InterBrokerProtocolVersionDoc)
-      .define(InterBrokerListenerNameProp, STRING, null, MEDIUM, InterBrokerListenerNameDoc)
-      .define(ReplicaSelectorClassProp, STRING, null, MEDIUM, ReplicaSelectorClassDoc)
-
-      /** ********* Controlled shutdown configuration ***********/
-      .define(ControlledShutdownMaxRetriesProp, INT, Defaults.CONTROLLED_SHUTDOWN_MAX_RETRIES, MEDIUM, ControlledShutdownMaxRetriesDoc)
-      .define(ControlledShutdownRetryBackoffMsProp, LONG, Defaults.CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS, MEDIUM, ControlledShutdownRetryBackoffMsDoc)
-      .define(ControlledShutdownEnableProp, BOOLEAN, Defaults.CONTROLLED_SHUTDOWN_ENABLE, MEDIUM, ControlledShutdownEnableDoc)
-
-      /** ********* Group coordinator configuration ***********/
-      .define(GroupMinSessionTimeoutMsProp, INT, Defaults.GROUP_MIN_SESSION_TIMEOUT_MS, MEDIUM, GroupMinSessionTimeoutMsDoc)
-      .define(GroupMaxSessionTimeoutMsProp, INT, Defaults.GROUP_MAX_SESSION_TIMEOUT_MS, MEDIUM, GroupMaxSessionTimeoutMsDoc)
-      .define(GroupInitialRebalanceDelayMsProp, INT, Defaults.GROUP_INITIAL_REBALANCE_DELAY_MS, MEDIUM, GroupInitialRebalanceDelayMsDoc)
-      .define(GroupMaxSizeProp, INT, Defaults.GROUP_MAX_SIZE, atLeast(1), MEDIUM, GroupMaxSizeDoc)
-
-      /** New group coordinator configs */
-      .define(GroupCoordinatorRebalanceProtocolsProp, LIST, Defaults.GROUP_COORDINATOR_REBALANCE_PROTOCOLS,
-        ConfigDef.ValidList.in(Utils.enumOptions(classOf[GroupType]):_*), MEDIUM, GroupCoordinatorRebalanceProtocolsDoc)
-      .define(GroupCoordinatorNumThreadsProp, INT, Defaults.GROUP_COORDINATOR_NUM_THREADS, atLeast(1), MEDIUM, GroupCoordinatorNumThreadsDoc)
-      // Internal configuration used by integration and system tests.
-      .defineInternal(NewGroupCoordinatorEnableProp, BOOLEAN, Defaults.NEW_GROUP_COORDINATOR_ENABLE, null, MEDIUM, NewGroupCoordinatorEnableDoc)
-
-      /** Consumer groups configs */
-      .define(ConsumerGroupSessionTimeoutMsProp, INT, Defaults.CONSUMER_GROUP_SESSION_TIMEOUT_MS, atLeast(1), MEDIUM, ConsumerGroupSessionTimeoutMsDoc)
-      .define(ConsumerGroupMinSessionTimeoutMsProp, INT, Defaults.CONSUMER_GROUP_MIN_SESSION_TIMEOUT_MS, atLeast(1), MEDIUM, ConsumerGroupMinSessionTimeoutMsDoc)
-      .define(ConsumerGroupMaxSessionTimeoutMsProp, INT, Defaults.CONSUMER_GROUP_MAX_SESSION_TIMEOUT_MS, atLeast(1), MEDIUM, ConsumerGroupMaxSessionTimeoutMsDoc)
-      .define(ConsumerGroupHeartbeatIntervalMsProp, INT, Defaults.CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS, atLeast(1), MEDIUM, ConsumerGroupHeartbeatIntervalMsDoc)
-      .define(ConsumerGroupMinHeartbeatIntervalMsProp, INT, Defaults.CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS, atLeast(1), MEDIUM, ConsumerGroupMinHeartbeatIntervalMsDoc)
-      .define(ConsumerGroupMaxHeartbeatIntervalMsProp, INT, Defaults.CONSUMER_GROUP_MAX_HEARTBEAT_INTERVAL_MS, atLeast(1), MEDIUM, ConsumerGroupMaxHeartbeatIntervalMsDoc)
-      .define(ConsumerGroupMaxSizeProp, INT, Defaults.CONSUMER_GROUP_MAX_SIZE, atLeast(1), MEDIUM, ConsumerGroupMaxSizeDoc)
-      .define(ConsumerGroupAssignorsProp, LIST, Defaults.CONSUMER_GROUP_ASSIGNORS, null, MEDIUM, ConsumerGroupAssignorsDoc)
-
-      /** ********* Offset management configuration ***********/
-      .define(OffsetMetadataMaxSizeProp, INT, Defaults.OFFSET_METADATA_MAX_SIZE, HIGH, OffsetMetadataMaxSizeDoc)
-      .define(OffsetsLoadBufferSizeProp, INT, Defaults.OFFSETS_LOAD_BUFFER_SIZE, atLeast(1), HIGH, OffsetsLoadBufferSizeDoc)
-      .define(OffsetsTopicReplicationFactorProp, SHORT, Defaults.OFFSETS_TOPIC_REPLICATION_FACTOR, atLeast(1), HIGH, OffsetsTopicReplicationFactorDoc)
-      .define(OffsetsTopicPartitionsProp, INT, Defaults.OFFSETS_TOPIC_PARTITIONS, atLeast(1), HIGH, OffsetsTopicPartitionsDoc)
-      .define(OffsetsTopicSegmentBytesProp, INT, Defaults.OFFSETS_TOPIC_SEGMENT_BYTES, atLeast(1), HIGH, OffsetsTopicSegmentBytesDoc)
-      .define(OffsetsTopicCompressionCodecProp, INT, Defaults.OFFSETS_TOPIC_COMPRESSION_CODEC, HIGH, OffsetsTopicCompressionCodecDoc)
-      .define(OffsetsRetentionMinutesProp, INT, Defaults.OFFSETS_RETENTION_MINUTES, atLeast(1), HIGH, OffsetsRetentionMinutesDoc)
-      .define(OffsetsRetentionCheckIntervalMsProp, LONG, Defaults.OFFSETS_RETENTION_CHECK_INTERVAL_MS, atLeast(1), HIGH, OffsetsRetentionCheckIntervalMsDoc)
-      .define(OffsetCommitTimeoutMsProp, INT, Defaults.OFFSET_COMMIT_TIMEOUT_MS, atLeast(1), HIGH, OffsetCommitTimeoutMsDoc)
-      .define(OffsetCommitRequiredAcksProp, SHORT, Defaults.OFFSET_COMMIT_REQUIRED_ACKS, HIGH, OffsetCommitRequiredAcksDoc)
-      .define(DeleteTopicEnableProp, BOOLEAN, Defaults.DELETE_TOPIC_ENABLE, HIGH, DeleteTopicEnableDoc)
-      .define(CompressionTypeProp, STRING, LogConfig.DEFAULT_COMPRESSION_TYPE, in(BrokerCompressionType.names.asScala.toSeq:_*), HIGH, CompressionTypeDoc)
-
-      /** ********* Transaction management configuration ***********/
-      .define(TransactionalIdExpirationMsProp, INT, Defaults.TRANSACTIONAL_ID_EXPIRATION_MS, atLeast(1), HIGH, TransactionalIdExpirationMsDoc)
-      .define(TransactionsMaxTimeoutMsProp, INT, Defaults.TRANSACTIONS_MAX_TIMEOUT_MS, atLeast(1), HIGH, TransactionsMaxTimeoutMsDoc)
-      .define(TransactionsTopicMinISRProp, INT, Defaults.TRANSACTIONS_TOPIC_MIN_ISR, atLeast(1), HIGH, TransactionsTopicMinISRDoc)
-      .define(TransactionsLoadBufferSizeProp, INT, Defaults.TRANSACTIONS_LOAD_BUFFER_SIZE, atLeast(1), HIGH, TransactionsLoadBufferSizeDoc)
-      .define(TransactionsTopicReplicationFactorProp, SHORT, Defaults.TRANSACTIONS_TOPIC_REPLICATION_FACTOR, atLeast(1), HIGH, TransactionsTopicReplicationFactorDoc)
-      .define(TransactionsTopicPartitionsProp, INT, Defaults.TRANSACTIONS_TOPIC_PARTITIONS, atLeast(1), HIGH, TransactionsTopicPartitionsDoc)
-      .define(TransactionsTopicSegmentBytesProp, INT, Defaults.TRANSACTIONS_TOPIC_SEGMENT_BYTES, atLeast(1), HIGH, TransactionsTopicSegmentBytesDoc)
-      .define(TransactionsAbortTimedOutTransactionCleanupIntervalMsProp, INT, Defaults.TRANSACTIONS_ABORT_TIMED_OUT_CLEANUP_INTERVAL_MS, atLeast(1), LOW, TransactionsAbortTimedOutTransactionsIntervalMsDoc)
-      .define(TransactionsRemoveExpiredTransactionalIdCleanupIntervalMsProp, INT, Defaults.TRANSACTIONS_REMOVE_EXPIRED_CLEANUP_INTERVAL_MS, atLeast(1), LOW, TransactionsRemoveExpiredTransactionsIntervalMsDoc)
-
-      .define(TransactionPartitionVerificationEnableProp, BOOLEAN, Defaults.TRANSACTION_PARTITION_VERIFICATION_ENABLE, LOW, TransactionPartitionVerificationEnableDoc)
-
-      .define(ProducerIdExpirationMsProp, INT, Defaults.PRODUCER_ID_EXPIRATION_MS, atLeast(1), LOW, ProducerIdExpirationMsDoc)
-      // Configuration for testing only as default value should be sufficient for typical usage
-      .defineInternal(ProducerIdExpirationCheckIntervalMsProp, INT, Defaults.PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS, atLeast(1), LOW, ProducerIdExpirationCheckIntervalMsDoc)
-
-      /** ********* Fetch Configuration **************/
-      .define(MaxIncrementalFetchSessionCacheSlots, INT, Defaults.MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS, atLeast(0), MEDIUM, MaxIncrementalFetchSessionCacheSlotsDoc)
-      .define(FetchMaxBytes, INT, Defaults.FETCH_MAX_BYTES, atLeast(1024), MEDIUM, FetchMaxBytesDoc)
-
-      /** ********* Request Limit Configuration ***********/
-      .define(MaxRequestPartitionSizeLimit, INT, Defaults.MAX_REQUEST_PARTITION_SIZE_LIMIT, atLeast(1), MEDIUM, MaxRequestPartitionSizeLimitDoc)
-
-      /** ********* Kafka Metrics Configuration ***********/
-      .define(MetricNumSamplesProp, INT, Defaults.METRIC_NUM_SAMPLES, atLeast(1), LOW, MetricNumSamplesDoc)
-      .define(MetricSampleWindowMsProp, LONG, Defaults.METRIC_SAMPLE_WINDOW_MS, atLeast(1), LOW, MetricSampleWindowMsDoc)
-      .define(MetricReporterClassesProp, LIST, Defaults.METRIC_REPORTER_CLASSES, LOW, MetricReporterClassesDoc)
-      .define(MetricRecordingLevelProp, STRING, Defaults.METRIC_RECORDING_LEVEL, LOW, MetricRecordingLevelDoc)
-      .define(AutoIncludeJmxReporterProp, BOOLEAN, Defaults.AUTO_INCLUDE_JMX_REPORTER, LOW, AutoIncludeJmxReporterDoc)
-
-      /** ********* Kafka Yammer Metrics Reporter Configuration for docs ***********/
-      .define(KafkaMetricsReporterClassesProp, LIST, Defaults.KAFKA_METRIC_REPORTER_CLASSES, LOW, KafkaMetricsReporterClassesDoc)
-      .define(KafkaMetricsPollingIntervalSecondsProp, INT, Defaults.KAFKA_METRICS_POLLING_INTERVAL_SECONDS, atLeast(1), LOW, KafkaMetricsPollingIntervalSecondsDoc)
-
-      /** ********* Kafka Client Telemetry Metrics Configuration ***********/
-      .define(ClientTelemetryMaxBytesProp, INT, Defaults.CLIENT_TELEMETRY_MAX_BYTES, atLeast(1), LOW, ClientTelemetryMaxBytesDoc)
-
-      /** ********* Quota configuration ***********/
-      .define(NumQuotaSamplesProp, INT, Defaults.NUM_QUOTA_SAMPLES, atLeast(1), LOW, NumQuotaSamplesDoc)
-      .define(NumReplicationQuotaSamplesProp, INT, Defaults.NUM_REPLICATION_QUOTA_SAMPLES, atLeast(1), LOW, NumReplicationQuotaSamplesDoc)
-      .define(NumAlterLogDirsReplicationQuotaSamplesProp, INT, Defaults.NUM_ALTER_LOG_DIRS_REPLICATION_QUOTA_SAMPLES, atLeast(1), LOW, NumAlterLogDirsReplicationQuotaSamplesDoc)
-      .define(NumControllerQuotaSamplesProp, INT, Defaults.NUM_CONTROLLER_QUOTA_SAMPLES, atLeast(1), LOW, NumControllerQuotaSamplesDoc)
-      .define(QuotaWindowSizeSecondsProp, INT, Defaults.QUOTA_WINDOW_SIZE_SECONDS, atLeast(1), LOW, QuotaWindowSizeSecondsDoc)
-      .define(ReplicationQuotaWindowSizeSecondsProp, INT, Defaults.REPLICATION_QUOTA_WINDOW_SIZE_SECONDS, atLeast(1), LOW, ReplicationQuotaWindowSizeSecondsDoc)
-      .define(AlterLogDirsReplicationQuotaWindowSizeSecondsProp, INT, Defaults.ALTER_LOG_DIRS_REPLICATION_QUOTA_WINDOW_SIZE_SECONDS, atLeast(1), LOW, AlterLogDirsReplicationQuotaWindowSizeSecondsDoc)
-      .define(ControllerQuotaWindowSizeSecondsProp, INT, Defaults.CONTROLLER_QUOTA_WINDOW_SIZE_SECONDS, atLeast(1), LOW, ControllerQuotaWindowSizeSecondsDoc)
-      .define(ClientQuotaCallbackClassProp, CLASS, null, LOW, ClientQuotaCallbackClassDoc)
-
-      /** ********* General Security Configuration ****************/
-      .define(ConnectionsMaxReauthMsProp, LONG, Defaults.CONNECTIONS_MAX_REAUTH_MS, MEDIUM, ConnectionsMaxReauthMsDoc)
-      .define(SaslServerMaxReceiveSizeProp, INT, Defaults.SERVER_MAX_RECEIVE_SIZE, MEDIUM, SaslServerMaxReceiveSizeDoc)
-      .define(securityProviderClassProp, STRING, null, LOW, securityProviderClassDoc)
-
-      /** ********* SSL Configuration ****************/
-      .define(PrincipalBuilderClassProp, CLASS, Defaults.PRINCIPAL_BUILDER, MEDIUM, PrincipalBuilderClassDoc)
-      .define(SslProtocolProp, STRING, Defaults.SSL_PROTOCOL, MEDIUM, SslProtocolDoc)
-      .define(SslProviderProp, STRING, null, MEDIUM, SslProviderDoc)
-      .define(SslEnabledProtocolsProp, LIST, Defaults.SSL_ENABLED_PROTOCOLS, MEDIUM, SslEnabledProtocolsDoc)
-      .define(SslKeystoreTypeProp, STRING, Defaults.SSL_KEYSTORE_TYPE, MEDIUM, SslKeystoreTypeDoc)
-      .define(SslKeystoreLocationProp, STRING, null, MEDIUM, SslKeystoreLocationDoc)
-      .define(SslKeystorePasswordProp, PASSWORD, null, MEDIUM, SslKeystorePasswordDoc)
-      .define(SslKeyPasswordProp, PASSWORD, null, MEDIUM, SslKeyPasswordDoc)
-      .define(SslKeystoreKeyProp, PASSWORD, null, MEDIUM, SslKeystoreKeyDoc)
-      .define(SslKeystoreCertificateChainProp, PASSWORD, null, MEDIUM, SslKeystoreCertificateChainDoc)
-      .define(SslTruststoreTypeProp, STRING, Defaults.SSL_TRUSTSTORE_TYPE, MEDIUM, SslTruststoreTypeDoc)
-      .define(SslTruststoreLocationProp, STRING, null, MEDIUM, SslTruststoreLocationDoc)
-      .define(SslTruststorePasswordProp, PASSWORD, null, MEDIUM, SslTruststorePasswordDoc)
-      .define(SslTruststoreCertificatesProp, PASSWORD, null, MEDIUM, SslTruststoreCertificatesDoc)
-      .define(SslKeyManagerAlgorithmProp, STRING, Defaults.SSL_KEY_MANAGER_ALGORITHM, MEDIUM, SslKeyManagerAlgorithmDoc)
-      .define(SslTrustManagerAlgorithmProp, STRING, Defaults.SSL_TRUST_MANAGER_ALGORITHM, MEDIUM, SslTrustManagerAlgorithmDoc)
-      .define(SslEndpointIdentificationAlgorithmProp, STRING, Defaults.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, LOW, SslEndpointIdentificationAlgorithmDoc)
-      .define(SslSecureRandomImplementationProp, STRING, null, LOW, SslSecureRandomImplementationDoc)
-      .define(SslClientAuthProp, STRING, Defaults.SSL_CLIENT_AUTHENTICATION, in(Defaults.SSL_CLIENT_AUTHENTICATION_VALID_VALUES:_*), MEDIUM, SslClientAuthDoc)
-      .define(SslCipherSuitesProp, LIST, Collections.emptyList(), MEDIUM, SslCipherSuitesDoc)
-      .define(SslPrincipalMappingRulesProp, STRING, Defaults.SSL_PRINCIPAL_MAPPING_RULES, LOW, SslPrincipalMappingRulesDoc)
-      .define(SslEngineFactoryClassProp, CLASS, null, LOW, SslEngineFactoryClassDoc)
-      .define(SslAllowDnChangesProp, BOOLEAN, BrokerSecurityConfigs.DEFAULT_SSL_ALLOW_DN_CHANGES_VALUE, LOW, SslAllowDnChangesDoc)
-      .define(SslAllowSanChangesProp, BOOLEAN, BrokerSecurityConfigs.DEFAULT_SSL_ALLOW_SAN_CHANGES_VALUE, LOW, SslAllowSanChangesDoc)
-
-      /** ********* Sasl Configuration ****************/
-      .define(SaslMechanismInterBrokerProtocolProp, STRING, Defaults.SASL_MECHANISM_INTER_BROKER_PROTOCOL, MEDIUM, SaslMechanismInterBrokerProtocolDoc)
-      .define(SaslJaasConfigProp, PASSWORD, null, MEDIUM, SaslJaasConfigDoc)
-      .define(SaslEnabledMechanismsProp, LIST, Defaults.SASL_ENABLED_MECHANISMS, MEDIUM, SaslEnabledMechanismsDoc)
-      .define(SaslServerCallbackHandlerClassProp, CLASS, null, MEDIUM, SaslServerCallbackHandlerClassDoc)
-      .define(SaslClientCallbackHandlerClassProp, CLASS, null, MEDIUM, SaslClientCallbackHandlerClassDoc)
-      .define(SaslLoginClassProp, CLASS, null, MEDIUM, SaslLoginClassDoc)
-      .define(SaslLoginCallbackHandlerClassProp, CLASS, null, MEDIUM, SaslLoginCallbackHandlerClassDoc)
-      .define(SaslKerberosServiceNameProp, STRING, null, MEDIUM, SaslKerberosServiceNameDoc)
-      .define(SaslKerberosKinitCmdProp, STRING, Defaults.SASL_KERBEROS_KINIT_CMD, MEDIUM, SaslKerberosKinitCmdDoc)
-      .define(SaslKerberosTicketRenewWindowFactorProp, DOUBLE, Defaults.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR, MEDIUM, SaslKerberosTicketRenewWindowFactorDoc)
-      .define(SaslKerberosTicketRenewJitterProp, DOUBLE, Defaults.SASL_KERBEROS_TICKET_RENEW_JITTER, MEDIUM, SaslKerberosTicketRenewJitterDoc)
-      .define(SaslKerberosMinTimeBeforeReloginProp, LONG, Defaults.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN, MEDIUM, SaslKerberosMinTimeBeforeReloginDoc)
-      .define(SaslKerberosPrincipalToLocalRulesProp, LIST, Defaults.SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES, MEDIUM, SaslKerberosPrincipalToLocalRulesDoc)
-      .define(SaslLoginRefreshWindowFactorProp, DOUBLE, Defaults.SASL_LOGIN_REFRESH_WINDOW_FACTOR, MEDIUM, SaslLoginRefreshWindowFactorDoc)
-      .define(SaslLoginRefreshWindowJitterProp, DOUBLE, Defaults.SASL_LOGIN_REFRESH_WINDOW_JITTER, MEDIUM, SaslLoginRefreshWindowJitterDoc)
-      .define(SaslLoginRefreshMinPeriodSecondsProp, SHORT, Defaults.SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS, MEDIUM, SaslLoginRefreshMinPeriodSecondsDoc)
-      .define(SaslLoginRefreshBufferSecondsProp, SHORT, Defaults.SASL_LOGIN_REFRESH_BUFFER_SECONDS, MEDIUM, SaslLoginRefreshBufferSecondsDoc)
-      .define(SaslLoginConnectTimeoutMsProp, INT, null, LOW, SaslLoginConnectTimeoutMsDoc)
-      .define(SaslLoginReadTimeoutMsProp, INT, null, LOW, SaslLoginReadTimeoutMsDoc)
-      .define(SaslLoginRetryBackoffMaxMsProp, LONG, Defaults.SASL_LOGIN_RETRY_BACKOFF_MAX_MS, LOW, SaslLoginRetryBackoffMaxMsDoc)
-      .define(SaslLoginRetryBackoffMsProp, LONG, Defaults.SASL_LOGIN_RETRY_BACKOFF_MS, LOW, SaslLoginRetryBackoffMsDoc)
-      .define(SaslOAuthBearerScopeClaimNameProp, STRING, Defaults.SASL_OAUTH_BEARER_SCOPE_CLAIM_NAME, LOW, SaslOAuthBearerScopeClaimNameDoc)
-      .define(SaslOAuthBearerSubClaimNameProp, STRING, Defaults.SASL_OAUTH_BEARER_SUB_CLAIM_NAME, LOW, SaslOAuthBearerSubClaimNameDoc)
-      .define(SaslOAuthBearerTokenEndpointUrlProp, STRING, null, MEDIUM, SaslOAuthBearerTokenEndpointUrlDoc)
-      .define(SaslOAuthBearerJwksEndpointUrlProp, STRING, null, MEDIUM, SaslOAuthBearerJwksEndpointUrlDoc)
-      .define(SaslOAuthBearerJwksEndpointRefreshMsProp, LONG, Defaults.SASL_OAUTH_BEARER_JWKS_ENDPOINT_REFRESH_MS, LOW, SaslOAuthBearerJwksEndpointRefreshMsDoc)
-      .define(SaslOAuthBearerJwksEndpointRetryBackoffMsProp, LONG, Defaults.SASL_OAUTH_BEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS, LOW, SaslOAuthBearerJwksEndpointRetryBackoffMsDoc)
-      .define(SaslOAuthBearerJwksEndpointRetryBackoffMaxMsProp, LONG, Defaults.SASL_OAUTH_BEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS, LOW, SaslOAuthBearerJwksEndpointRetryBackoffMaxMsDoc)
-      .define(SaslOAuthBearerClockSkewSecondsProp, INT, Defaults.SASL_OAUTH_BEARER_CLOCK_SKEW_SECONDS, LOW, SaslOAuthBearerClockSkewSecondsDoc)
-      .define(SaslOAuthBearerExpectedAudienceProp, LIST, null, LOW, SaslOAuthBearerExpectedAudienceDoc)
-      .define(SaslOAuthBearerExpectedIssuerProp, STRING, null, LOW, SaslOAuthBearerExpectedIssuerDoc)
-
-      /** ********* Delegation Token Configuration ****************/
-      .define(DelegationTokenSecretKeyAliasProp, PASSWORD, null, MEDIUM, DelegationTokenSecretKeyAliasDoc)
-      .define(DelegationTokenSecretKeyProp, PASSWORD, null, MEDIUM, DelegationTokenSecretKeyDoc)
-      .define(DelegationTokenMaxLifeTimeProp, LONG, Defaults.DELEGATION_TOKEN_MAX_LIFE_TIME_MS, atLeast(1), MEDIUM, DelegationTokenMaxLifeTimeDoc)
-      .define(DelegationTokenExpiryTimeMsProp, LONG, Defaults.DELEGATION_TOKEN_EXPIRY_TIME_MS, atLeast(1), MEDIUM, DelegationTokenExpiryTimeMsDoc)
-      .define(DelegationTokenExpiryCheckIntervalMsProp, LONG, Defaults.DELEGATION_TOKEN_EXPIRY_CHECK_INTERVAL_MS, atLeast(1), LOW, DelegationTokenExpiryCheckIntervalDoc)
-
-      /** ********* Password encryption configuration for dynamic configs *********/
-      .define(PasswordEncoderSecretProp, PASSWORD, null, MEDIUM, PasswordEncoderSecretDoc)
-      .define(PasswordEncoderOldSecretProp, PASSWORD, null, MEDIUM, PasswordEncoderOldSecretDoc)
-      .define(PasswordEncoderKeyFactoryAlgorithmProp, STRING, null, LOW, PasswordEncoderKeyFactoryAlgorithmDoc)
-      .define(PasswordEncoderCipherAlgorithmProp, STRING, Defaults.PASSWORD_ENCODER_CIPHER_ALGORITHM, LOW, PasswordEncoderCipherAlgorithmDoc)
-      .define(PasswordEncoderKeyLengthProp, INT, Defaults.PASSWORD_ENCODER_KEY_LENGTH, atLeast(8), LOW, PasswordEncoderKeyLengthDoc)
-      .define(PasswordEncoderIterationsProp, INT, Defaults.PASSWORD_ENCODER_ITERATIONS, atLeast(1024), LOW, PasswordEncoderIterationsDoc)
-
-      /** ********* Raft Quorum Configuration *********/
-      .define(RaftConfig.QUORUM_VOTERS_CONFIG, LIST, Defaults.QUORUM_VOTERS, new RaftConfig.ControllerQuorumVotersValidator(), HIGH, RaftConfig.QUORUM_VOTERS_DOC)
-      .define(RaftConfig.QUORUM_ELECTION_TIMEOUT_MS_CONFIG, INT, Defaults.QUORUM_ELECTION_TIMEOUT_MS, null, HIGH, RaftConfig.QUORUM_ELECTION_TIMEOUT_MS_DOC)
-      .define(RaftConfig.QUORUM_FETCH_TIMEOUT_MS_CONFIG, INT, Defaults.QUORUM_FETCH_TIMEOUT_MS, null, HIGH, RaftConfig.QUORUM_FETCH_TIMEOUT_MS_DOC)
-      .define(RaftConfig.QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG, INT, Defaults.QUORUM_ELECTION_BACKOFF_MS, null, HIGH, RaftConfig.QUORUM_ELECTION_BACKOFF_MAX_MS_DOC)
-      .define(RaftConfig.QUORUM_LINGER_MS_CONFIG, INT, Defaults.QUORUM_LINGER_MS, null, MEDIUM, RaftConfig.QUORUM_LINGER_MS_DOC)
-      .define(RaftConfig.QUORUM_REQUEST_TIMEOUT_MS_CONFIG, INT, Defaults.QUORUM_REQUEST_TIMEOUT_MS, null, MEDIUM, RaftConfig.QUORUM_REQUEST_TIMEOUT_MS_DOC)
-      .define(RaftConfig.QUORUM_RETRY_BACKOFF_MS_CONFIG, INT, Defaults.QUORUM_RETRY_BACKOFF_MS, null, LOW, RaftConfig.QUORUM_RETRY_BACKOFF_MS_DOC)
-
-      /** Internal Configurations **/
-      // This indicates whether unreleased APIs should be advertised by this node.
-      .defineInternal(UnstableApiVersionsEnableProp, BOOLEAN, false, HIGH)
-      // This indicates whether unreleased MetadataVersions should be enabled on this node.
-      .defineInternal(UnstableMetadataVersionsEnableProp, BOOLEAN, false, HIGH)
-  }
-
-  /** ********* Remote Log Management Configuration *********/
-  RemoteLogManagerConfig.CONFIG_DEF.configKeys().values().forEach(key => configDef.define(key))
-
-  def configNames: Seq[String] = configDef.names.asScala.toBuffer.sorted
-  private[server] def defaultValues: Map[String, _] = configDef.defaultValues.asScala
-  private[server] def configKeys: Map[String, ConfigKey] = configDef.configKeys.asScala
 
   def fromProps(props: Properties): KafkaConfig =
     fromProps(props, true)
@@ -1312,74 +77,16 @@ object KafkaConfig {
   }
 
   def apply(props: java.util.Map[_, _], doLog: Boolean = true): KafkaConfig = new KafkaConfig(props, doLog)
-
-  private def typeOf(name: String): Option[ConfigDef.Type] = Option(configDef.configKeys.get(name)).map(_.`type`)
-
-  def configType(configName: String): Option[ConfigDef.Type] = {
-    val configType = configTypeExact(configName)
-    if (configType.isDefined) {
-      return configType
-    }
-    typeOf(configName) match {
-      case Some(t) => Some(t)
-      case None =>
-        DynamicBrokerConfig.brokerConfigSynonyms(configName, matchListenerOverride = true).flatMap(typeOf).headOption
-    }
-  }
-
-  private def configTypeExact(exactName: String): Option[ConfigDef.Type] = {
-    val configType = typeOf(exactName).orNull
-    if (configType != null) {
-      Some(configType)
-    } else {
-      val configKey = DynamicConfig.Broker.brokerConfigDef.configKeys().get(exactName)
-      if (configKey != null) {
-        Some(configKey.`type`)
-      } else {
-        None
-      }
-    }
-  }
-
-  def maybeSensitive(configType: Option[ConfigDef.Type]): Boolean = {
-    // If we can't determine the config entry type, treat it as a sensitive config to be safe
-    configType.isEmpty || configType.contains(ConfigDef.Type.PASSWORD)
-  }
-
-  def loggableValue(resourceType: ConfigResource.Type, name: String, value: String): String = {
-    val maybeSensitive = resourceType match {
-      case ConfigResource.Type.BROKER => KafkaConfig.maybeSensitive(KafkaConfig.configType(name))
-      case ConfigResource.Type.TOPIC => KafkaConfig.maybeSensitive(LogConfig.configType(name).asScala)
-      case ConfigResource.Type.BROKER_LOGGER => false
-      case ConfigResource.Type.CLIENT_METRICS => false
-      case _ => true
-    }
-    if (maybeSensitive) Password.HIDDEN else value
-  }
-
-  /**
-   * Copy a configuration map, populating some keys that we want to treat as synonyms.
-   */
-  def populateSynonyms(input: util.Map[_, _]): util.Map[Any, Any] = {
-    val output = new util.HashMap[Any, Any](input)
-    val brokerId = output.get(KafkaConfig.BrokerIdProp)
-    val nodeId = output.get(KafkaConfig.NodeIdProp)
-    if (brokerId == null && nodeId != null) {
-      output.put(KafkaConfig.BrokerIdProp, nodeId)
-    } else if (brokerId != null && nodeId == null) {
-      output.put(KafkaConfig.NodeIdProp, brokerId)
-    }
-    output
-  }
 }
 
 class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynamicConfigOverride: Option[DynamicBrokerConfig])
-  extends AbstractConfig(KafkaConfig.configDef, props, doLog) with Logging {
+  extends AbstractConfig(org.apache.kafka.server.config.KafkaConfig.CONFIG_DEF, props, doLog) with Logging {
 
-  def this(props: java.util.Map[_, _]) = this(true, KafkaConfig.populateSynonyms(props), None)
-  def this(props: java.util.Map[_, _], doLog: Boolean) = this(doLog, KafkaConfig.populateSynonyms(props), None)
+  import org.apache.kafka.server.config.KafkaConfig._
+  def this(props: java.util.Map[_, _]) = this(true, populateSynonyms(props), None)
+  def this(props: java.util.Map[_, _], doLog: Boolean) = this(doLog, populateSynonyms(props), None)
   def this(props: java.util.Map[_, _], doLog: Boolean, dynamicConfigOverride: Option[DynamicBrokerConfig]) =
-    this(doLog, KafkaConfig.populateSynonyms(props), dynamicConfigOverride)
+    this(doLog, populateSynonyms(props), dynamicConfigOverride)
 
   // Cache the current config to avoid acquiring read lock to access from dynamicConfig
   @volatile private var currentConfig = this
@@ -1417,12 +124,12 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
     super.valuesWithPrefixOverride(prefix)
 
   /** ********* Zookeeper Configuration ***********/
-  val zkConnect: String = getString(KafkaConfig.ZkConnectProp)
-  val zkSessionTimeoutMs: Int = getInt(KafkaConfig.ZkSessionTimeoutMsProp)
+  val zkConnect: String = getString(ZK_CONNECT_PROP)
+  val zkSessionTimeoutMs: Int = getInt(ZK_SESSION_TIMEOUT_MS_PROP)
   val zkConnectionTimeoutMs: Int =
-    Option(getInt(KafkaConfig.ZkConnectionTimeoutMsProp)).map(_.toInt).getOrElse(getInt(KafkaConfig.ZkSessionTimeoutMsProp))
-  val zkEnableSecureAcls: Boolean = getBoolean(KafkaConfig.ZkEnableSecureAclsProp)
-  val zkMaxInFlightRequests: Int = getInt(KafkaConfig.ZkMaxInFlightRequestsProp)
+    Option(getInt(ZK_CONNECTION_TIMEOUT_MS_PROP)).map(_.toInt).getOrElse(getInt(ZK_SESSION_TIMEOUT_MS_PROP))
+  val zkEnableSecureAcls: Boolean = getBoolean(ZK_ENABLE_SECURE_ACLS_PROP)
+  val zkMaxInFlightRequests: Int = getInt(ZK_MAX_IN_FLIGHT_REQUESTS_PROP)
 
   private val _remoteLogManagerConfig = new RemoteLogManagerConfig(this)
   def remoteLogManagerConfig = _remoteLogManagerConfig
@@ -1432,7 +139,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
     // Need to translate any system property value from true/false (String) to true/false (Boolean)
     val actuallyProvided = originals.containsKey(propKey)
     if (actuallyProvided) getBoolean(propKey) else {
-      val sysPropValue = KafkaConfig.zooKeeperClientProperty(zkClientConfigViaSystemProperties, propKey)
+      val sysPropValue = zooKeeperClientProperty(zkClientConfigViaSystemProperties, propKey).asScala
       sysPropValue match {
         case Some("true") => true
         case Some(_) => false
@@ -1445,7 +152,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
     // Use the system property if it exists and the Kafka config value was defaulted rather than actually provided
     val actuallyProvided = originals.containsKey(propKey)
     if (actuallyProvided) getString(propKey) else {
-      KafkaConfig.zooKeeperClientProperty(zkClientConfigViaSystemProperties, propKey) match {
+      zooKeeperClientProperty(zkClientConfigViaSystemProperties, propKey).asScala match {
         case Some(v) => v
         case _ => getString(propKey) // not specified so use the default value
       }
@@ -1454,69 +161,69 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
 
   private def zkOptionalStringConfigOrSystemProperty(propKey: String): Option[String] = {
     Option(getString(propKey)).orElse {
-      KafkaConfig.zooKeeperClientProperty(zkClientConfigViaSystemProperties, propKey)
+      zooKeeperClientProperty(zkClientConfigViaSystemProperties, propKey).asScala
     }
   }
   private def zkPasswordConfigOrSystemProperty(propKey: String): Option[Password] = {
     Option(getPassword(propKey)).orElse {
-      KafkaConfig.zooKeeperClientProperty(zkClientConfigViaSystemProperties, propKey).map(new Password(_))
+      zooKeeperClientProperty(zkClientConfigViaSystemProperties, propKey).map(new Password(_)).asScala
     }
   }
   private def zkListConfigOrSystemProperty(propKey: String): Option[util.List[String]] = {
     Option(getList(propKey)).orElse {
-      KafkaConfig.zooKeeperClientProperty(zkClientConfigViaSystemProperties, propKey).map { sysProp =>
+      zooKeeperClientProperty(zkClientConfigViaSystemProperties, propKey).asScala.map { sysProp =>
         sysProp.split("\\s*,\\s*").toBuffer.asJava
       }
     }
   }
 
-  val zkSslClientEnable = zkBooleanConfigOrSystemPropertyWithDefaultValue(KafkaConfig.ZkSslClientEnableProp)
-  val zkClientCnxnSocketClassName = zkOptionalStringConfigOrSystemProperty(KafkaConfig.ZkClientCnxnSocketProp)
-  val zkSslKeyStoreLocation = zkOptionalStringConfigOrSystemProperty(KafkaConfig.ZkSslKeyStoreLocationProp)
-  val zkSslKeyStorePassword = zkPasswordConfigOrSystemProperty(KafkaConfig.ZkSslKeyStorePasswordProp)
-  val zkSslKeyStoreType = zkOptionalStringConfigOrSystemProperty(KafkaConfig.ZkSslKeyStoreTypeProp)
-  val zkSslTrustStoreLocation = zkOptionalStringConfigOrSystemProperty(KafkaConfig.ZkSslTrustStoreLocationProp)
-  val zkSslTrustStorePassword = zkPasswordConfigOrSystemProperty(KafkaConfig.ZkSslTrustStorePasswordProp)
-  val zkSslTrustStoreType = zkOptionalStringConfigOrSystemProperty(KafkaConfig.ZkSslTrustStoreTypeProp)
-  val ZkSslProtocol = zkStringConfigOrSystemPropertyWithDefaultValue(KafkaConfig.ZkSslProtocolProp)
-  val ZkSslEnabledProtocols = zkListConfigOrSystemProperty(KafkaConfig.ZkSslEnabledProtocolsProp)
-  val ZkSslCipherSuites = zkListConfigOrSystemProperty(KafkaConfig.ZkSslCipherSuitesProp)
+  val zkSslClientEnable = zkBooleanConfigOrSystemPropertyWithDefaultValue(ZK_SSL_CLIENT_ENABLE_PROP)
+  val zkClientCnxnSocketClassName = zkOptionalStringConfigOrSystemProperty(ZK_CLIENT_CNXN_SOCKET_PROP)
+  val zkSslKeyStoreLocation = zkOptionalStringConfigOrSystemProperty(ZK_SSL_KEYSTORE_LOCATION_PROP)
+  val zkSslKeyStorePassword = zkPasswordConfigOrSystemProperty(ZK_SSL_KEYSTORE_PASSWORD_PROP)
+  val zkSslKeyStoreType = zkOptionalStringConfigOrSystemProperty(ZK_SSL_KEYSTORE_TYPE_PROP)
+  val zkSslTrustStoreLocation = zkOptionalStringConfigOrSystemProperty(ZK_SSL_TRUSTSTORE_LOCATION_PROP)
+  val zkSslTrustStorePassword = zkPasswordConfigOrSystemProperty(ZK_SSL_TRUSTSTORE_PASSWORD_PROP)
+  val zkSslTrustStoreType = zkOptionalStringConfigOrSystemProperty(ZK_SSL_TRUSTSTORE_TYPE_PROP)
+  val ZkSslProtocol = zkStringConfigOrSystemPropertyWithDefaultValue(ZK_SSL_PROTOCOL_PROP)
+  val ZkSslEnabledProtocols = zkListConfigOrSystemProperty(ZK_SSL_ENABLED_PROTOCOLS_PROP)
+  val ZkSslCipherSuites = zkListConfigOrSystemProperty(ZK_SSL_CIPHER_SUITES_PROP)
   val ZkSslEndpointIdentificationAlgorithm = {
     // Use the system property if it exists and the Kafka config value was defaulted rather than actually provided
     // Need to translate any system property value from true/false to HTTPS/<blank>
-    val kafkaProp = KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp
+    val kafkaProp = ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP
     val actuallyProvided = originals.containsKey(kafkaProp)
     if (actuallyProvided)
       getString(kafkaProp)
     else {
-      KafkaConfig.zooKeeperClientProperty(zkClientConfigViaSystemProperties, kafkaProp) match {
+      zooKeeperClientProperty(zkClientConfigViaSystemProperties, kafkaProp).asScala match {
         case Some("true") => "HTTPS"
         case Some(_) => ""
         case None => getString(kafkaProp) // not specified so use the default value
       }
     }
   }
-  val ZkSslCrlEnable = zkBooleanConfigOrSystemPropertyWithDefaultValue(KafkaConfig.ZkSslCrlEnableProp)
-  val ZkSslOcspEnable = zkBooleanConfigOrSystemPropertyWithDefaultValue(KafkaConfig.ZkSslOcspEnableProp)
+  val ZkSslCrlEnable = zkBooleanConfigOrSystemPropertyWithDefaultValue(ZK_SSL_CRL_ENABLE_PROP)
+  val ZkSslOcspEnable = zkBooleanConfigOrSystemPropertyWithDefaultValue(ZK_SSL_OCSP_ENABLE_PROP)
   /** ********* General Configuration ***********/
-  val brokerIdGenerationEnable: Boolean = getBoolean(KafkaConfig.BrokerIdGenerationEnableProp)
-  val maxReservedBrokerId: Int = getInt(KafkaConfig.MaxReservedBrokerIdProp)
-  var brokerId: Int = getInt(KafkaConfig.BrokerIdProp)
-  val nodeId: Int = getInt(KafkaConfig.NodeIdProp)
-  val initialRegistrationTimeoutMs: Int = getInt(KafkaConfig.InitialBrokerRegistrationTimeoutMsProp)
-  val brokerHeartbeatIntervalMs: Int = getInt(KafkaConfig.BrokerHeartbeatIntervalMsProp)
-  val brokerSessionTimeoutMs: Int = getInt(KafkaConfig.BrokerSessionTimeoutMsProp)
+  val brokerIdGenerationEnable: Boolean = getBoolean(BROKER_ID_GENERATION_ENABLE_PROP)
+  val maxReservedBrokerId: Int = getInt(MAX_RESERVED_BROKER_ID_PROP)
+  var brokerId: Int = getInt(BROKER_ID_PROP)
+  val nodeId: Int = getInt(NODE_ID_PROP)
+  val initialRegistrationTimeoutMs: Int = getInt(INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_PROP)
+  val brokerHeartbeatIntervalMs: Int = getInt(BROKER_HEARTBEAT_INTERVAL_MS_PROP)
+  val brokerSessionTimeoutMs: Int = getInt(BROKER_SESSION_TIMEOUT_MS_PROP)
 
   def requiresZookeeper: Boolean = processRoles.isEmpty
   def usesSelfManagedQuorum: Boolean = processRoles.nonEmpty
 
-  val migrationEnabled: Boolean = getBoolean(KafkaConfig.MigrationEnabledProp)
-  val migrationMetadataMinBatchSize: Int = getInt(KafkaConfig.MigrationMetadataMinBatchSizeProp)
+  val migrationEnabled: Boolean = getBoolean(MIGRATION_ENABLED_PROP)
+  val migrationMetadataMinBatchSize: Int = getInt(MIGRATION_METADATA_MIN_BATCH_SIZE_PROP)
 
-  val elrEnabled: Boolean = getBoolean(KafkaConfig.ElrEnabledProp)
+  val elrEnabled: Boolean = getBoolean(ELR_ENABLED_PROP)
 
   private def parseProcessRoles(): Set[ProcessRole] = {
-    val roles = getList(KafkaConfig.ProcessRolesProp).asScala.map {
+    val roles = getList(PROCESS_ROLES_PROP).asScala.map {
       case "broker" => ProcessRole.BrokerRole
       case "controller" => ProcessRole.ControllerRole
       case role => throw new ConfigException(s"Unknown process role '$role'" +
@@ -1526,7 +233,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
     val distinctRoles: Set[ProcessRole] = roles.toSet
 
     if (distinctRoles.size != roles.size) {
-      throw new ConfigException(s"Duplicate role names found in `${KafkaConfig.ProcessRolesProp}`: $roles")
+      throw new ConfigException(s"Duplicate role names found in `${PROCESS_ROLES_PROP}`: $roles")
     }
 
     distinctRoles
@@ -1537,44 +244,44 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   }
 
   def metadataLogDir: String = {
-    Option(getString(KafkaConfig.MetadataLogDirProp)) match {
+    Option(getString(METADATA_LOG_DIR_PROP)) match {
       case Some(dir) => dir
       case None => logDirs.head
     }
   }
 
-  def metadataLogSegmentBytes = getInt(KafkaConfig.MetadataLogSegmentBytesProp)
-  def metadataLogSegmentMillis = getLong(KafkaConfig.MetadataLogSegmentMillisProp)
-  def metadataRetentionBytes = getLong(KafkaConfig.MetadataMaxRetentionBytesProp)
-  def metadataRetentionMillis = getLong(KafkaConfig.MetadataMaxRetentionMillisProp)
-  val serverMaxStartupTimeMs = getLong(KafkaConfig.ServerMaxStartupTimeMsProp)
+  def metadataLogSegmentBytes = getInt(METADATA_LOG_SEGMENT_BYTES_PROP)
+  def metadataLogSegmentMillis = getLong(METADATA_LOG_SEGMENT_MILLIS_PROP)
+  def metadataRetentionBytes = getLong(METADATA_MAX_RETENTION_BYTES_PROP)
+  def metadataRetentionMillis = getLong(METADATA_MAX_RETENTION_MILLIS_PROP)
+  val serverMaxStartupTimeMs = getLong(SERVER_MAX_STARTUP_TIME_MS_PROP)
 
-  def numNetworkThreads = getInt(KafkaConfig.NumNetworkThreadsProp)
-  def backgroundThreads = getInt(KafkaConfig.BackgroundThreadsProp)
-  val queuedMaxRequests = getInt(KafkaConfig.QueuedMaxRequestsProp)
-  val queuedMaxBytes = getLong(KafkaConfig.QueuedMaxBytesProp)
-  def numIoThreads = getInt(KafkaConfig.NumIoThreadsProp)
-  def messageMaxBytes = getInt(KafkaConfig.MessageMaxBytesProp)
-  val requestTimeoutMs = getInt(KafkaConfig.RequestTimeoutMsProp)
-  val connectionSetupTimeoutMs = getLong(KafkaConfig.ConnectionSetupTimeoutMsProp)
-  val connectionSetupTimeoutMaxMs = getLong(KafkaConfig.ConnectionSetupTimeoutMaxMsProp)
+  def numNetworkThreads = getInt(NUM_NETWORK_THREADS_PROP)
+  def backgroundThreads = getInt(BACKGROUND_THREADS_PROP)
+  val queuedMaxRequests = getInt(QUEUED_MAX_REQUESTS_PROP)
+  val queuedMaxBytes = getLong(QUEUED_MAX_BYTES_PROP)
+  def numIoThreads = getInt(NUM_IO_THREADS_PROP)
+  def messageMaxBytes = getInt(MESSAGE_MAX_BYTES_PROP)
+  val requestTimeoutMs = getInt(REQUEST_TIMEOUT_MS_PROP)
+  val connectionSetupTimeoutMs = getLong(CONNECTION_SETUP_TIMEOUT_MS_PROP)
+  val connectionSetupTimeoutMaxMs = getLong(CONNECTION_SETUP_TIMEOUT_MAX_MS_PROP)
 
   def getNumReplicaAlterLogDirsThreads: Int = {
-    val numThreads: Integer = Option(getInt(KafkaConfig.NumReplicaAlterLogDirsThreadsProp)).getOrElse(logDirs.size)
+    val numThreads: Integer = Option(getInt(NUM_REPLICA_ALTER_LOG_DIRS_THREADS_PROP)).getOrElse(logDirs.size)
     numThreads
   }
 
   /************* Metadata Configuration ***********/
-  val metadataSnapshotMaxNewRecordBytes = getLong(KafkaConfig.MetadataSnapshotMaxNewRecordBytesProp)
-  val metadataSnapshotMaxIntervalMs = getLong(KafkaConfig.MetadataSnapshotMaxIntervalMsProp)
+  val metadataSnapshotMaxNewRecordBytes = getLong(METADATA_SNAPSHOT_MAX_NEW_RECORD_BYTES_PROP)
+  val metadataSnapshotMaxIntervalMs = getLong(METADATA_SNAPSHOT_MAX_INTERVAL_MS_PROP)
   val metadataMaxIdleIntervalNs: Option[Long] = {
-    val value = TimeUnit.NANOSECONDS.convert(getInt(KafkaConfig.MetadataMaxIdleIntervalMsProp).toLong, TimeUnit.MILLISECONDS)
+    val value = TimeUnit.NANOSECONDS.convert(getInt(METADATA_MAX_IDLE_INTERVAL_MS_PROP).toLong, TimeUnit.MILLISECONDS)
     if (value > 0) Some(value) else None
   }
 
   /************* Authorizer Configuration ***********/
   def createNewAuthorizer(): Option[Authorizer] = {
-    val className = getString(KafkaConfig.AuthorizerClassNameProp)
+    val className = getString(AUTHORIZER_CLASS_NAME_PROP)
     if (className == null || className.isEmpty)
       None
     else {
@@ -1585,53 +292,53 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   val earlyStartListeners: Set[ListenerName] = {
     val listenersSet = listeners.map(_.listenerName).toSet
     val controllerListenersSet = controllerListeners.map(_.listenerName).toSet
-    Option(getString(KafkaConfig.EarlyStartListenersProp)) match {
+    Option(getString(EARLY_START_LISTENERS_PROP)) match {
       case None => controllerListenersSet
       case Some(str) =>
         str.split(",").map(_.trim()).filterNot(_.isEmpty).map { str =>
           val listenerName = new ListenerName(str)
           if (!listenersSet.contains(listenerName) && !controllerListenersSet.contains(listenerName))
-            throw new ConfigException(s"${KafkaConfig.EarlyStartListenersProp} contains " +
+            throw new ConfigException(s"${EARLY_START_LISTENERS_PROP} contains " +
               s"listener ${listenerName.value()}, but this is not contained in " +
-              s"${KafkaConfig.ListenersProp} or ${KafkaConfig.ControllerListenerNamesProp}")
+              s"${LISTENERS_PROP} or ${CONTROLLER_LISTENER_NAMES_PROP}")
           listenerName
         }.toSet
     }
   }
 
   /** ********* Socket Server Configuration ***********/
-  val socketSendBufferBytes = getInt(KafkaConfig.SocketSendBufferBytesProp)
-  val socketReceiveBufferBytes = getInt(KafkaConfig.SocketReceiveBufferBytesProp)
-  val socketRequestMaxBytes = getInt(KafkaConfig.SocketRequestMaxBytesProp)
-  val socketListenBacklogSize = getInt(KafkaConfig.SocketListenBacklogSizeProp)
-  val maxConnectionsPerIp = getInt(KafkaConfig.MaxConnectionsPerIpProp)
+  val socketSendBufferBytes = getInt(SOCKET_SEND_BUFFER_BYTES_PROP)
+  val socketReceiveBufferBytes = getInt(SOCKET_RECEIVE_BUFFER_BYTES_PROP)
+  val socketRequestMaxBytes = getInt(SOCKET_REQUEST_MAX_BYTES_PROP)
+  val socketListenBacklogSize = getInt(SOCKET_LISTEN_BACKLOG_SIZE_PROP)
+  val maxConnectionsPerIp = getInt(MAX_CONNECTIONS_PER_IP_PROP)
   val maxConnectionsPerIpOverrides: Map[String, Int] =
-    getMap(KafkaConfig.MaxConnectionsPerIpOverridesProp, getString(KafkaConfig.MaxConnectionsPerIpOverridesProp)).map { case (k, v) => (k, v.toInt)}
-  def maxConnections = getInt(KafkaConfig.MaxConnectionsProp)
-  def maxConnectionCreationRate = getInt(KafkaConfig.MaxConnectionCreationRateProp)
-  val connectionsMaxIdleMs = getLong(KafkaConfig.ConnectionsMaxIdleMsProp)
-  val failedAuthenticationDelayMs = getInt(KafkaConfig.FailedAuthenticationDelayMsProp)
+    getMap(MAX_CONNECTIONS_PER_IP_OVERRIDES_PROP, getString(MAX_CONNECTIONS_PER_IP_OVERRIDES_PROP)).map { case (k, v) => (k, v.toInt)}
+  def maxConnections = getInt(MAX_CONNECTIONS_PROP)
+  def maxConnectionCreationRate = getInt(MAX_CONNECTION_CREATION_RATE_PROP)
+  val connectionsMaxIdleMs = getLong(CONNECTIONS_MAX_IDLE_MS_PROP)
+  val failedAuthenticationDelayMs = getInt(FAILED_AUTHENTICATION_DELAY_MS_PROP)
 
   /***************** rack configuration **************/
-  val rack = Option(getString(KafkaConfig.RackProp))
-  val replicaSelectorClassName = Option(getString(KafkaConfig.ReplicaSelectorClassProp))
+  val rack = Option(getString(RACK_PROP))
+  val replicaSelectorClassName = Option(getString(REPLICA_SELECTOR_CLASS_PROP))
 
   /** ********* Log Configuration ***********/
-  val autoCreateTopicsEnable = getBoolean(KafkaConfig.AutoCreateTopicsEnableProp)
-  val numPartitions = getInt(KafkaConfig.NumPartitionsProp)
-  val logDirs = CoreUtils.parseCsvList(Option(getString(KafkaConfig.LogDirsProp)).getOrElse(getString(KafkaConfig.LogDirProp)))
-  def logSegmentBytes = getInt(KafkaConfig.LogSegmentBytesProp)
-  def logFlushIntervalMessages = getLong(KafkaConfig.LogFlushIntervalMessagesProp)
+  val autoCreateTopicsEnable = getBoolean(AUTO_CREATE_TOPICS_ENABLE_PROP)
+  val numPartitions = getInt(NUM_PARTITIONS_PROP)
+  val logDirs = CoreUtils.parseCsvList(Option(getString(LOG_DIRS_PROP)).getOrElse(getString(LOG_DIR_PROP)))
+  def logSegmentBytes = getInt(LOG_SEGMENT_BYTES_PROP)
+  def logFlushIntervalMessages = getLong(LOG_FLUSH_INTERVAL_MESSAGES_PROP)
   val logCleanerThreads = getInt(CleanerConfig.LOG_CLEANER_THREADS_PROP)
-  def numRecoveryThreadsPerDataDir = getInt(KafkaConfig.NumRecoveryThreadsPerDataDirProp)
-  val logFlushSchedulerIntervalMs = getLong(KafkaConfig.LogFlushSchedulerIntervalMsProp)
-  val logFlushOffsetCheckpointIntervalMs = getInt(KafkaConfig.LogFlushOffsetCheckpointIntervalMsProp).toLong
-  val logFlushStartOffsetCheckpointIntervalMs = getInt(KafkaConfig.LogFlushStartOffsetCheckpointIntervalMsProp).toLong
-  val logCleanupIntervalMs = getLong(KafkaConfig.LogCleanupIntervalMsProp)
-  def logCleanupPolicy = getList(KafkaConfig.LogCleanupPolicyProp)
-  val offsetsRetentionMinutes = getInt(KafkaConfig.OffsetsRetentionMinutesProp)
-  val offsetsRetentionCheckIntervalMs = getLong(KafkaConfig.OffsetsRetentionCheckIntervalMsProp)
-  def logRetentionBytes = getLong(KafkaConfig.LogRetentionBytesProp)
+  def numRecoveryThreadsPerDataDir = getInt(NUM_RECOVERY_THREADS_PER_DATA_DIR_PROP)
+  val logFlushSchedulerIntervalMs = getLong(LOG_FLUSH_SCHEDULER_INTERVAL_MS_PROP)
+  val logFlushOffsetCheckpointIntervalMs = getInt(LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS_PROP).toLong
+  val logFlushStartOffsetCheckpointIntervalMs = getInt(LOG_FLUSH_START_OFFSET_CHECKPOINT_INTERVAL_MS_PROP).toLong
+  val logCleanupIntervalMs = getLong(LOG_CLEANUP_INTERVAL_MS_PROP)
+  def logCleanupPolicy = getList(LOG_CLEANUP_POLICY_PROP)
+  val offsetsRetentionMinutes = getInt(OFFSETS_RETENTION_MINUTES_PROP)
+  val offsetsRetentionCheckIntervalMs = getLong(OFFSETS_RETENTION_CHECK_INTERVAL_MS_PROP)
+  def logRetentionBytes = getLong(LOG_RETENTION_BYTES_PROP)
   val logCleanerDedupeBufferSize = getLong(CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE_PROP)
   val logCleanerDedupeBufferLoadFactor = getDouble(CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_LOAD_FACTOR_PROP)
   val logCleanerIoBufferSize = getInt(CleanerConfig.LOG_CLEANER_IO_BUFFER_SIZE_PROP)
@@ -1642,19 +349,19 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   val logCleanerBackoffMs = getLong(CleanerConfig.LOG_CLEANER_BACKOFF_MS_PROP)
   def logCleanerMinCleanRatio = getDouble(CleanerConfig.LOG_CLEANER_MIN_CLEAN_RATIO_PROP)
   val logCleanerEnable = getBoolean(CleanerConfig.LOG_CLEANER_ENABLE_PROP)
-  def logIndexSizeMaxBytes = getInt(KafkaConfig.LogIndexSizeMaxBytesProp)
-  def logIndexIntervalBytes = getInt(KafkaConfig.LogIndexIntervalBytesProp)
-  def logDeleteDelayMs = getLong(KafkaConfig.LogDeleteDelayMsProp)
-  def logRollTimeMillis: java.lang.Long = Option(getLong(KafkaConfig.LogRollTimeMillisProp)).getOrElse(60 * 60 * 1000L * getInt(KafkaConfig.LogRollTimeHoursProp))
-  def logRollTimeJitterMillis: java.lang.Long = Option(getLong(KafkaConfig.LogRollTimeJitterMillisProp)).getOrElse(60 * 60 * 1000L * getInt(KafkaConfig.LogRollTimeJitterHoursProp))
-  def logFlushIntervalMs: java.lang.Long = Option(getLong(KafkaConfig.LogFlushIntervalMsProp)).getOrElse(getLong(KafkaConfig.LogFlushSchedulerIntervalMsProp))
-  def minInSyncReplicas = getInt(KafkaConfig.MinInSyncReplicasProp)
-  def logPreAllocateEnable: java.lang.Boolean = getBoolean(KafkaConfig.LogPreAllocateProp)
+  def logIndexSizeMaxBytes = getInt(LOG_INDEX_SIZE_MAX_BYTES_PROP)
+  def logIndexIntervalBytes = getInt(LOG_INDEX_INTERVAL_BYTES_PROP)
+  def logDeleteDelayMs = getLong(LOG_DELETE_DELAY_MS_PROP)
+  def logRollTimeMillis: java.lang.Long = Option(getLong(LOG_ROLL_TIME_MILLIS_PROP)).getOrElse(60 * 60 * 1000L * getInt(LOG_ROLL_TIME_HOURS_PROP))
+  def logRollTimeJitterMillis: java.lang.Long = Option(getLong(LOG_ROLL_TIME_JITTER_MILLIS_PROP)).getOrElse(60 * 60 * 1000L * getInt(LOG_ROLL_TIME_JITTER_HOURS_PROP))
+  def logFlushIntervalMs: java.lang.Long = Option(getLong(LOG_FLUSH_INTERVAL_MS_PROP)).getOrElse(getLong(LOG_FLUSH_SCHEDULER_INTERVAL_MS_PROP))
+  def minInSyncReplicas = getInt(MIN_IN_SYNC_REPLICAS_PROP)
+  def logPreAllocateEnable: java.lang.Boolean = getBoolean(LOG_PRE_ALLOCATE_PROP)
 
   // We keep the user-provided String as `MetadataVersion.fromVersionString` can choose a slightly different version (eg if `0.10.0`
   // is passed, `0.10.0-IV0` may be picked)
   @nowarn("cat=deprecation")
-  private val logMessageFormatVersionString = getString(KafkaConfig.LogMessageFormatVersionProp)
+  private val logMessageFormatVersionString = getString(LOG_MESSAGE_FORMAT_VERSION_PROP)
 
   /* See `TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG` for details */
   @deprecated("3.0")
@@ -1663,18 +370,18 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
       MetadataVersion.fromVersionString(LogConfig.DEFAULT_MESSAGE_FORMAT_VERSION)
     else MetadataVersion.fromVersionString(logMessageFormatVersionString)
 
-  def logMessageTimestampType = TimestampType.forName(getString(KafkaConfig.LogMessageTimestampTypeProp))
+  def logMessageTimestampType = TimestampType.forName(getString(LOG_MESSAGE_TIMESTAMP_TYPE_PROP))
 
   /* See `TopicConfig.MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_CONFIG` for details */
   @deprecated("3.6")
-  def logMessageTimestampDifferenceMaxMs: Long = getLong(KafkaConfig.LogMessageTimestampDifferenceMaxMsProp)
+  def logMessageTimestampDifferenceMaxMs: Long = getLong(LOG_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_PROP)
 
   // In the transition period before logMessageTimestampDifferenceMaxMs is removed, to maintain backward compatibility,
   // we are using its value if logMessageTimestampBeforeMaxMs default value hasn't changed.
   // See `TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG` for deprecation details
   @nowarn("cat=deprecation")
   def logMessageTimestampBeforeMaxMs: Long = {
-    val messageTimestampBeforeMaxMs: Long = getLong(KafkaConfig.LogMessageTimestampBeforeMaxMsProp)
+    val messageTimestampBeforeMaxMs: Long = getLong(LOG_MESSAGE_TIMESTAMP_BEFORE_MAX_MS_PROP)
     if (messageTimestampBeforeMaxMs != LogConfig.DEFAULT_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS) {
       messageTimestampBeforeMaxMs
     } else {
@@ -1687,7 +394,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   // See `TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG` for deprecation details
   @nowarn("cat=deprecation")
   def logMessageTimestampAfterMaxMs: Long = {
-    val messageTimestampAfterMaxMs: Long = getLong(KafkaConfig.LogMessageTimestampAfterMaxMsProp)
+    val messageTimestampAfterMaxMs: Long = getLong(LOG_MESSAGE_TIMESTAMP_AFTER_MAX_MS_PROP)
     if (messageTimestampAfterMaxMs != Long.MaxValue) {
       messageTimestampAfterMaxMs
     } else {
@@ -1695,43 +402,43 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
     }
   }
 
-  def logMessageDownConversionEnable: Boolean = getBoolean(KafkaConfig.LogMessageDownConversionEnableProp)
+  def logMessageDownConversionEnable: Boolean = getBoolean(LOG_MESSAGE_DOWN_CONVERSION_ENABLE_PROP)
 
   /** ********* Replication configuration ***********/
-  val controllerSocketTimeoutMs: Int = getInt(KafkaConfig.ControllerSocketTimeoutMsProp)
-  val defaultReplicationFactor: Int = getInt(KafkaConfig.DefaultReplicationFactorProp)
-  val replicaLagTimeMaxMs = getLong(KafkaConfig.ReplicaLagTimeMaxMsProp)
-  val replicaSocketTimeoutMs = getInt(KafkaConfig.ReplicaSocketTimeoutMsProp)
-  val replicaSocketReceiveBufferBytes = getInt(KafkaConfig.ReplicaSocketReceiveBufferBytesProp)
-  val replicaFetchMaxBytes = getInt(KafkaConfig.ReplicaFetchMaxBytesProp)
-  val replicaFetchWaitMaxMs = getInt(KafkaConfig.ReplicaFetchWaitMaxMsProp)
-  val replicaFetchMinBytes = getInt(KafkaConfig.ReplicaFetchMinBytesProp)
-  val replicaFetchResponseMaxBytes = getInt(KafkaConfig.ReplicaFetchResponseMaxBytesProp)
-  val replicaFetchBackoffMs = getInt(KafkaConfig.ReplicaFetchBackoffMsProp)
-  def numReplicaFetchers = getInt(KafkaConfig.NumReplicaFetchersProp)
-  val replicaHighWatermarkCheckpointIntervalMs = getLong(KafkaConfig.ReplicaHighWatermarkCheckpointIntervalMsProp)
-  val fetchPurgatoryPurgeIntervalRequests = getInt(KafkaConfig.FetchPurgatoryPurgeIntervalRequestsProp)
-  val producerPurgatoryPurgeIntervalRequests = getInt(KafkaConfig.ProducerPurgatoryPurgeIntervalRequestsProp)
-  val deleteRecordsPurgatoryPurgeIntervalRequests = getInt(KafkaConfig.DeleteRecordsPurgatoryPurgeIntervalRequestsProp)
-  val autoLeaderRebalanceEnable = getBoolean(KafkaConfig.AutoLeaderRebalanceEnableProp)
-  val leaderImbalancePerBrokerPercentage = getInt(KafkaConfig.LeaderImbalancePerBrokerPercentageProp)
-  val leaderImbalanceCheckIntervalSeconds: Long = getLong(KafkaConfig.LeaderImbalanceCheckIntervalSecondsProp)
-  def uncleanLeaderElectionEnable: java.lang.Boolean = getBoolean(KafkaConfig.UncleanLeaderElectionEnableProp)
+  val controllerSocketTimeoutMs: Int = getInt(CONTROLLER_SOCKET_TIMEOUT_MS_PROP)
+  val defaultReplicationFactor: Int = getInt(DEFAULT_REPLICATION_FACTOR_PROP)
+  val replicaLagTimeMaxMs = getLong(REPLICA_LAG_TIME_MAX_MS_PROP)
+  val replicaSocketTimeoutMs = getInt(REPLICA_SOCKET_TIMEOUT_MS_PROP)
+  val replicaSocketReceiveBufferBytes = getInt(REPLICA_SOCKET_RECEIVE_BUFFER_BYTES_PROP)
+  val replicaFetchMaxBytes = getInt(REPLICA_FETCH_MAX_BYTES_PROP)
+  val replicaFetchWaitMaxMs = getInt(REPLICA_FETCH_WAIT_MAX_MS_PROP)
+  val replicaFetchMinBytes = getInt(REPLICA_FETCH_MIN_BYTES_PROP)
+  val replicaFetchResponseMaxBytes = getInt(REPLICA_FETCH_RESPONSE_MAX_BYTES_PROP)
+  val replicaFetchBackoffMs = getInt(REPLICA_FETCH_BACKOFF_MS_PROP)
+  def numReplicaFetchers = getInt(NUM_REPLICA_FETCHERS_PROP)
+  val replicaHighWatermarkCheckpointIntervalMs = getLong(REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS_PROP)
+  val fetchPurgatoryPurgeIntervalRequests = getInt(FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS_PROP)
+  val producerPurgatoryPurgeIntervalRequests = getInt(PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS_PROP)
+  val deleteRecordsPurgatoryPurgeIntervalRequests = getInt(DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS_PROP)
+  val autoLeaderRebalanceEnable = getBoolean(AUTO_LEADER_REBALANCE_ENABLE_PROP)
+  val leaderImbalancePerBrokerPercentage = getInt(LEADER_IMBALANCE_PER_BROKER_PERCENTAGE_PROP)
+  val leaderImbalanceCheckIntervalSeconds: Long = getLong(LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS_PROP)
+  def uncleanLeaderElectionEnable: java.lang.Boolean = getBoolean(UNCLEAN_LEADER_ELECTION_ENABLE_PROP)
 
   // We keep the user-provided String as `MetadataVersion.fromVersionString` can choose a slightly different version (eg if `0.10.0`
   // is passed, `0.10.0-IV0` may be picked)
-  val interBrokerProtocolVersionString = getString(KafkaConfig.InterBrokerProtocolVersionProp)
+  val interBrokerProtocolVersionString = getString(INTER_BROKER_PROTOCOL_VERSION_PROP)
   val interBrokerProtocolVersion = if (processRoles.isEmpty) {
     MetadataVersion.fromVersionString(interBrokerProtocolVersionString)
   } else {
-    if (originals.containsKey(KafkaConfig.InterBrokerProtocolVersionProp)) {
+    if (originals.containsKey(INTER_BROKER_PROTOCOL_VERSION_PROP)) {
       // A user-supplied IBP was given
       val configuredVersion = MetadataVersion.fromVersionString(interBrokerProtocolVersionString)
       if (!configuredVersion.isKRaftSupported) {
-        throw new ConfigException(s"A non-KRaft version $interBrokerProtocolVersionString given for ${KafkaConfig.InterBrokerProtocolVersionProp}. " +
+        throw new ConfigException(s"A non-KRaft version $interBrokerProtocolVersionString given for ${INTER_BROKER_PROTOCOL_VERSION_PROP}. " +
           s"The minimum version is ${MetadataVersion.MINIMUM_KRAFT_VERSION}")
       } else {
-        warn(s"${KafkaConfig.InterBrokerProtocolVersionProp} is deprecated in KRaft mode as of 3.3 and will only " +
+        warn(s"${INTER_BROKER_PROTOCOL_VERSION_PROP} is deprecated in KRaft mode as of 3.3 and will only " +
           s"be read when first upgrading from a KRaft prior to 3.3. See kafka-storage.sh help for details on setting " +
           s"the metadata version for a new KRaft cluster.")
       }
@@ -1742,22 +449,22 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   }
 
   /** ********* Controlled shutdown configuration ***********/
-  val controlledShutdownMaxRetries = getInt(KafkaConfig.ControlledShutdownMaxRetriesProp)
-  val controlledShutdownRetryBackoffMs = getLong(KafkaConfig.ControlledShutdownRetryBackoffMsProp)
-  val controlledShutdownEnable = getBoolean(KafkaConfig.ControlledShutdownEnableProp)
+  val controlledShutdownMaxRetries = getInt(CONTROLLED_SHUTDOWN_MAX_RETRIES_PROP)
+  val controlledShutdownRetryBackoffMs = getLong(CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS_PROP)
+  val controlledShutdownEnable = getBoolean(CONTROLLED_SHUTDOWN_ENABLE_PROP)
 
   /** ********* Feature configuration ***********/
   def isFeatureVersioningSupported = interBrokerProtocolVersion.isFeatureVersioningSupported
 
   /** ********* Group coordinator configuration ***********/
-  val groupMinSessionTimeoutMs = getInt(KafkaConfig.GroupMinSessionTimeoutMsProp)
-  val groupMaxSessionTimeoutMs = getInt(KafkaConfig.GroupMaxSessionTimeoutMsProp)
-  val groupInitialRebalanceDelay = getInt(KafkaConfig.GroupInitialRebalanceDelayMsProp)
-  val groupMaxSize = getInt(KafkaConfig.GroupMaxSizeProp)
+  val groupMinSessionTimeoutMs = getInt(GROUP_MIN_SESSION_TIMEOUT_MS_PROP)
+  val groupMaxSessionTimeoutMs = getInt(GROUP_MAX_SESSION_TIMEOUT_MS_PROP)
+  val groupInitialRebalanceDelay = getInt(GROUP_INITIAL_REBALANCE_DELAY_MS_PROP)
+  val groupMaxSize = getInt(GROUP_MAX_SIZE_PROP)
 
   /** New group coordinator configs */
   val groupCoordinatorRebalanceProtocols = {
-    val protocols = getList(KafkaConfig.GroupCoordinatorRebalanceProtocolsProp)
+    val protocols = getList(GROUP_COORDINATOR_REBALANCE_PROTOCOLS_PROP)
       .asScala.map(_.toUpperCase).map(GroupType.valueOf).toSet
     if (!protocols.contains(GroupType.CLASSIC)) {
       throw new ConfigException(s"Disabling the '${GroupType.CLASSIC}' protocol is not supported.")
@@ -1770,60 +477,60 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   }
   // The new group coordinator is enabled in two cases: 1) The internal configuration to enable
   // it is explicitly set; or 2) the consumer rebalance protocol is enabled.
-  val isNewGroupCoordinatorEnabled = getBoolean(KafkaConfig.NewGroupCoordinatorEnableProp) ||
+  val isNewGroupCoordinatorEnabled = getBoolean(NEW_GROUP_COORDINATOR_ENABLE_PROP) ||
     groupCoordinatorRebalanceProtocols.contains(GroupType.CONSUMER)
-  val groupCoordinatorNumThreads = getInt(KafkaConfig.GroupCoordinatorNumThreadsProp)
+  val groupCoordinatorNumThreads = getInt(GROUP_COORDINATOR_NUM_THREADS_PROP)
 
   /** Consumer group configs */
-  val consumerGroupSessionTimeoutMs = getInt(KafkaConfig.ConsumerGroupSessionTimeoutMsProp)
-  val consumerGroupMinSessionTimeoutMs = getInt(KafkaConfig.ConsumerGroupMinSessionTimeoutMsProp)
-  val consumerGroupMaxSessionTimeoutMs = getInt(KafkaConfig.ConsumerGroupMaxSessionTimeoutMsProp)
-  val consumerGroupHeartbeatIntervalMs = getInt(KafkaConfig.ConsumerGroupHeartbeatIntervalMsProp)
-  val consumerGroupMinHeartbeatIntervalMs = getInt(KafkaConfig.ConsumerGroupMinHeartbeatIntervalMsProp)
-  val consumerGroupMaxHeartbeatIntervalMs = getInt(KafkaConfig.ConsumerGroupMaxHeartbeatIntervalMsProp)
-  val consumerGroupMaxSize = getInt(KafkaConfig.ConsumerGroupMaxSizeProp)
-  val consumerGroupAssignors = getConfiguredInstances(KafkaConfig.ConsumerGroupAssignorsProp, classOf[PartitionAssignor])
+  val consumerGroupSessionTimeoutMs = getInt(CONSUMER_GROUP_SESSION_TIMEOUT_MS_PROP)
+  val consumerGroupMinSessionTimeoutMs = getInt(CONSUMER_GROUP_MIN_SESSION_TIMEOUT_MS_PROP)
+  val consumerGroupMaxSessionTimeoutMs = getInt(CONSUMER_GROUP_MAX_SESSION_TIMEOUT_MS_PROP)
+  val consumerGroupHeartbeatIntervalMs = getInt(CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_PROP)
+  val consumerGroupMinHeartbeatIntervalMs = getInt(CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_PROP)
+  val consumerGroupMaxHeartbeatIntervalMs = getInt(CONSUMER_GROUP_MAX_HEARTBEAT_INTERVAL_MS_PROP)
+  val consumerGroupMaxSize = getInt(CONSUMER_GROUP_MAX_SIZE_PROP)
+  val consumerGroupAssignors = getConfiguredInstances(CONSUMER_GROUP_ASSIGNORS_PROP, classOf[PartitionAssignor])
 
   /** ********* Offset management configuration ***********/
-  val offsetMetadataMaxSize = getInt(KafkaConfig.OffsetMetadataMaxSizeProp)
-  val offsetsLoadBufferSize = getInt(KafkaConfig.OffsetsLoadBufferSizeProp)
-  val offsetsTopicReplicationFactor = getShort(KafkaConfig.OffsetsTopicReplicationFactorProp)
-  val offsetsTopicPartitions = getInt(KafkaConfig.OffsetsTopicPartitionsProp)
-  val offsetCommitTimeoutMs = getInt(KafkaConfig.OffsetCommitTimeoutMsProp)
-  val offsetCommitRequiredAcks = getShort(KafkaConfig.OffsetCommitRequiredAcksProp)
-  val offsetsTopicSegmentBytes = getInt(KafkaConfig.OffsetsTopicSegmentBytesProp)
-  val offsetsTopicCompressionType = Option(getInt(KafkaConfig.OffsetsTopicCompressionCodecProp)).map(value => CompressionType.forId(value)).orNull
+  val offsetMetadataMaxSize = getInt(OFFSET_METADATA_MAX_SIZE_PROP)
+  val offsetsLoadBufferSize = getInt(OFFSETS_LOAD_BUFFER_SIZE_PROP)
+  val offsetsTopicReplicationFactor = getShort(OFFSETS_TOPIC_REPLICATION_FACTOR_PROP)
+  val offsetsTopicPartitions = getInt(OFFSETS_TOPIC_PARTITIONS_PROP)
+  val offsetCommitTimeoutMs = getInt(OFFSET_COMMIT_TIMEOUT_MS_PROP)
+  val offsetCommitRequiredAcks = getShort(OFFSET_COMMIT_REQUIRED_ACKS_PROP)
+  val offsetsTopicSegmentBytes = getInt(OFFSETS_TOPIC_SEGMENT_BYTES_PROP)
+  val offsetsTopicCompressionType = Option(getInt(OFFSETS_TOPIC_COMPRESSION_CODEC_PROP)).map(value => CompressionType.forId(value)).orNull
 
   /** ********* Transaction management configuration ***********/
-  val transactionalIdExpirationMs = getInt(KafkaConfig.TransactionalIdExpirationMsProp)
-  val transactionMaxTimeoutMs = getInt(KafkaConfig.TransactionsMaxTimeoutMsProp)
-  val transactionTopicMinISR = getInt(KafkaConfig.TransactionsTopicMinISRProp)
-  val transactionsLoadBufferSize = getInt(KafkaConfig.TransactionsLoadBufferSizeProp)
-  val transactionTopicReplicationFactor = getShort(KafkaConfig.TransactionsTopicReplicationFactorProp)
-  val transactionTopicPartitions = getInt(KafkaConfig.TransactionsTopicPartitionsProp)
-  val transactionTopicSegmentBytes = getInt(KafkaConfig.TransactionsTopicSegmentBytesProp)
-  val transactionAbortTimedOutTransactionCleanupIntervalMs = getInt(KafkaConfig.TransactionsAbortTimedOutTransactionCleanupIntervalMsProp)
-  val transactionRemoveExpiredTransactionalIdCleanupIntervalMs = getInt(KafkaConfig.TransactionsRemoveExpiredTransactionalIdCleanupIntervalMsProp)
+  val transactionalIdExpirationMs = getInt(TRANSACTIONAL_ID_EXPIRATION_MS_PROP)
+  val transactionMaxTimeoutMs = getInt(TRANSACTIONS_MAX_TIMEOUT_MS_PROP)
+  val transactionTopicMinISR = getInt(TRANSACTIONS_TOPIC_MIN_ISR_PROP)
+  val transactionsLoadBufferSize = getInt(TRANSACTIONS_LOAD_BUFFER_SIZE_PROP)
+  val transactionTopicReplicationFactor = getShort(TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP)
+  val transactionTopicPartitions = getInt(TRANSACTIONS_TOPIC_PARTITIONS_PROP)
+  val transactionTopicSegmentBytes = getInt(TRANSACTIONS_TOPIC_SEGMENT_BYTES_PROP)
+  val transactionAbortTimedOutTransactionCleanupIntervalMs = getInt(TRANSACTIONS_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS_PROP)
+  val transactionRemoveExpiredTransactionalIdCleanupIntervalMs = getInt(TRANSACTIONS_REMOVE_EXPIRED_TRANSACTIONAL_ID_CLEANUP_INTERVAL_MS_PROP)
 
-  def transactionPartitionVerificationEnable = getBoolean(KafkaConfig.TransactionPartitionVerificationEnableProp)
+  def transactionPartitionVerificationEnable = getBoolean(TRANSACTION_PARTITION_VERIFICATION_ENABLE_PROP)
 
-  def producerIdExpirationMs = getInt(KafkaConfig.ProducerIdExpirationMsProp)
-  val producerIdExpirationCheckIntervalMs = getInt(KafkaConfig.ProducerIdExpirationCheckIntervalMsProp)
+  def producerIdExpirationMs = getInt(PRODUCER_ID_EXPIRATION_MS_PROP)
+  val producerIdExpirationCheckIntervalMs = getInt(PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS_PROP)
 
   /** ********* Metric Configuration **************/
-  val metricNumSamples = getInt(KafkaConfig.MetricNumSamplesProp)
-  val metricSampleWindowMs = getLong(KafkaConfig.MetricSampleWindowMsProp)
-  val metricRecordingLevel = getString(KafkaConfig.MetricRecordingLevelProp)
+  val metricNumSamples = getInt(METRIC_NUM_SAMPLES_PROP)
+  val metricSampleWindowMs = getLong(METRIC_SAMPLE_WINDOW_MS_PROP)
+  val metricRecordingLevel = getString(METRIC_RECORDING_LEVEL_PROP)
 
   /** ********* Kafka Client Telemetry Metrics Configuration ***********/
-  val clientTelemetryMaxBytes: Int = getInt(KafkaConfig.ClientTelemetryMaxBytesProp)
+  val clientTelemetryMaxBytes: Int = getInt(CLIENT_TELEMETRY_MAX_BYTES_PROP)
 
   /** ********* SSL/SASL Configuration **************/
   // Security configs may be overridden for listeners, so it is not safe to use the base values
   // Hence the base SSL/SASL configs are not fields of KafkaConfig, listener configs should be
   // retrieved using KafkaConfig#valuesWithPrefixOverride
   private def saslEnabledMechanisms(listenerName: ListenerName): Set[String] = {
-    val value = valuesWithPrefixOverride(listenerName.configPrefix).get(KafkaConfig.SaslEnabledMechanismsProp)
+    val value = valuesWithPrefixOverride(listenerName.configPrefix).get(SASL_ENABLED_MECHANISMS_PROP)
     if (value != null)
       value.asInstanceOf[util.List[String]].asScala.toSet
     else
@@ -1834,44 +541,44 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   def interBrokerSecurityProtocol = getInterBrokerListenerNameAndSecurityProtocol._2
   def controlPlaneListenerName = getControlPlaneListenerNameAndSecurityProtocol.map { case (listenerName, _) => listenerName }
   def controlPlaneSecurityProtocol = getControlPlaneListenerNameAndSecurityProtocol.map { case (_, securityProtocol) => securityProtocol }
-  def saslMechanismInterBrokerProtocol = getString(KafkaConfig.SaslMechanismInterBrokerProtocolProp)
+  def saslMechanismInterBrokerProtocol = getString(SASL_MECHANISM_INTER_BROKER_PROTOCOL_PROP)
   val saslInterBrokerHandshakeRequestEnable = interBrokerProtocolVersion.isSaslInterBrokerHandshakeRequestEnabled
 
   /** ********* DelegationToken Configuration **************/
-  val delegationTokenSecretKey = Option(getPassword(KafkaConfig.DelegationTokenSecretKeyProp))
-    .getOrElse(getPassword(KafkaConfig.DelegationTokenSecretKeyAliasProp))
+  val delegationTokenSecretKey = Option(getPassword(DELEGATION_TOKEN_SECRET_KEY_PROP))
+    .getOrElse(getPassword(DELEGATION_TOKEN_SECRET_KEY_ALIAS_PROP))
   val tokenAuthEnabled = delegationTokenSecretKey != null && delegationTokenSecretKey.value.nonEmpty
-  val delegationTokenMaxLifeMs = getLong(KafkaConfig.DelegationTokenMaxLifeTimeProp)
-  val delegationTokenExpiryTimeMs = getLong(KafkaConfig.DelegationTokenExpiryTimeMsProp)
-  val delegationTokenExpiryCheckIntervalMs = getLong(KafkaConfig.DelegationTokenExpiryCheckIntervalMsProp)
+  val delegationTokenMaxLifeMs = getLong(DELEGATION_TOKEN_MAX_LIFE_TIME_PROP)
+  val delegationTokenExpiryTimeMs = getLong(DELEGATION_TOKEN_EXPIRY_TIME_MS_PROP)
+  val delegationTokenExpiryCheckIntervalMs = getLong(DELEGATION_TOKEN_EXPIRY_CHECK_INTERVAL_MS_PROP)
 
   /** ********* Password encryption configuration for dynamic configs *********/
-  def passwordEncoderSecret = Option(getPassword(KafkaConfig.PasswordEncoderSecretProp))
-  def passwordEncoderOldSecret = Option(getPassword(KafkaConfig.PasswordEncoderOldSecretProp))
-  def passwordEncoderCipherAlgorithm = getString(KafkaConfig.PasswordEncoderCipherAlgorithmProp)
-  def passwordEncoderKeyFactoryAlgorithm = getString(KafkaConfig.PasswordEncoderKeyFactoryAlgorithmProp)
-  def passwordEncoderKeyLength = getInt(KafkaConfig.PasswordEncoderKeyLengthProp)
-  def passwordEncoderIterations = getInt(KafkaConfig.PasswordEncoderIterationsProp)
+  def passwordEncoderSecret = Option(getPassword(PASSWORD_ENCODER_SECRET_PROP))
+  def passwordEncoderOldSecret = Option(getPassword(PASSWORD_ENCODER_OLD_SECRET_PROP))
+  def passwordEncoderCipherAlgorithm = getString(PASSWORD_ENCODER_CIPHER_ALGORITHM_PROP)
+  def passwordEncoderKeyFactoryAlgorithm = getString(PASSWORD_ENCODER_KEY_FACTORY_ALGORITHM_PROP)
+  def passwordEncoderKeyLength = getInt(PASSWORD_ENCODER_KEY_LENGTH_PROP)
+  def passwordEncoderIterations = getInt(PASSWORD_ENCODER_ITERATIONS_PROP)
 
   /** ********* Quota Configuration **************/
-  val numQuotaSamples = getInt(KafkaConfig.NumQuotaSamplesProp)
-  val quotaWindowSizeSeconds = getInt(KafkaConfig.QuotaWindowSizeSecondsProp)
-  val numReplicationQuotaSamples = getInt(KafkaConfig.NumReplicationQuotaSamplesProp)
-  val replicationQuotaWindowSizeSeconds = getInt(KafkaConfig.ReplicationQuotaWindowSizeSecondsProp)
-  val numAlterLogDirsReplicationQuotaSamples = getInt(KafkaConfig.NumAlterLogDirsReplicationQuotaSamplesProp)
-  val alterLogDirsReplicationQuotaWindowSizeSeconds = getInt(KafkaConfig.AlterLogDirsReplicationQuotaWindowSizeSecondsProp)
-  val numControllerQuotaSamples = getInt(KafkaConfig.NumControllerQuotaSamplesProp)
-  val controllerQuotaWindowSizeSeconds = getInt(KafkaConfig.ControllerQuotaWindowSizeSecondsProp)
+  val numQuotaSamples = getInt(NUM_QUOTA_SAMPLES_PROP)
+  val quotaWindowSizeSeconds = getInt(QUOTA_WINDOW_SIZE_SECONDS_PROP)
+  val numReplicationQuotaSamples = getInt(NUM_REPLICATION_QUOTA_SAMPLES_PROP)
+  val replicationQuotaWindowSizeSeconds = getInt(REPLICATION_QUOTA_WINDOW_SIZE_SECONDS_PROP)
+  val numAlterLogDirsReplicationQuotaSamples = getInt(NUM_ALTER_LOG_DIRS_REPLICATION_QUOTA_SAMPLES_PROP)
+  val alterLogDirsReplicationQuotaWindowSizeSeconds = getInt(ALTER_LOG_DIRS_REPLICATION_QUOTA_WINDOW_SIZE_SECONDS_PROP)
+  val numControllerQuotaSamples = getInt(NUM_CONTROLLER_QUOTA_SAMPLES_PROP)
+  val controllerQuotaWindowSizeSeconds = getInt(CONTROLLER_QUOTA_WINDOW_SIZE_SECONDS_PROP)
 
   /** ********* Fetch Configuration **************/
-  val maxIncrementalFetchSessionCacheSlots = getInt(KafkaConfig.MaxIncrementalFetchSessionCacheSlots)
-  val fetchMaxBytes = getInt(KafkaConfig.FetchMaxBytes)
+  val maxIncrementalFetchSessionCacheSlots = getInt(MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS_PROP)
+  val fetchMaxBytes = getInt(FETCH_MAX_BYTES_PROP)
 
   /** ********* Request Limit Configuration ***********/
-  val maxRequestPartitionSizeLimit = getInt(KafkaConfig.MaxRequestPartitionSizeLimit)
+  val maxRequestPartitionSizeLimit = getInt(MAX_REQUEST_PARTITION_SIZE_LIMIT_PROP)
 
-  val deleteTopicEnable = getBoolean(KafkaConfig.DeleteTopicEnableProp)
-  def compressionType = getString(KafkaConfig.CompressionTypeProp)
+  val deleteTopicEnable = getBoolean(DELETE_TOPIC_ENABLE_PROP)
+  def compressionType = getString(COMPRESSION_TYPE_PROP)
 
   /** ********* Raft Quorum Configuration *********/
   val quorumVoters = getList(RaftConfig.QUORUM_VOTERS_CONFIG)
@@ -1883,8 +590,8 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   val quorumRetryBackoffMs = getInt(RaftConfig.QUORUM_RETRY_BACKOFF_MS_CONFIG)
 
   /** Internal Configurations **/
-  val unstableApiVersionsEnabled = getBoolean(KafkaConfig.UnstableApiVersionsEnableProp)
-  val unstableMetadataVersionsEnabled = getBoolean(KafkaConfig.UnstableMetadataVersionsEnableProp)
+  val unstableApiVersionsEnabled = getBoolean(UNSTABLE_API_VERSIONS_ENABLE_PROP)
+  val unstableMetadataVersionsEnabled = getBoolean(UNSTABLE_METADATA_VERSIONS_ENABLE_PROP)
 
   def addReconfigurable(reconfigurable: Reconfigurable): Unit = {
     dynamicConfig.addReconfigurable(reconfigurable)
@@ -1899,10 +606,10 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
     val millisInHour = 60L * millisInMinute
 
     val millis: java.lang.Long =
-      Option(getLong(KafkaConfig.LogRetentionTimeMillisProp)).getOrElse(
-        Option(getInt(KafkaConfig.LogRetentionTimeMinutesProp)) match {
+      Option(getLong(LOG_RETENTION_TIME_MILLIS_PROP)).getOrElse(
+        Option(getInt(LOG_RETENTION_TIME_MINUTES_PROP)) match {
           case Some(mins) => millisInMinute * mins
-          case None => getInt(KafkaConfig.LogRetentionTimeHoursProp) * millisInHour
+          case None => getInt(LOG_RETENTION_TIME_HOURS_PROP) * millisInHour
         })
 
     if (millis < 0) return -1
@@ -1918,10 +625,10 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   }
 
   def listeners: Seq[EndPoint] =
-    CoreUtils.listenerListToEndPoints(getString(KafkaConfig.ListenersProp), effectiveListenerSecurityProtocolMap)
+    CoreUtils.listenerListToEndPoints(getString(LISTENERS_PROP), effectiveListenerSecurityProtocolMap)
 
   def controllerListenerNames: Seq[String] = {
-    val value = Option(getString(KafkaConfig.ControllerListenerNamesProp)).getOrElse("")
+    val value = Option(getString(CONTROLLER_LISTENER_NAMES_PROP)).getOrElse("")
     if (value.isEmpty) {
       Seq.empty
     } else {
@@ -1932,7 +639,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   def controllerListeners: Seq[EndPoint] =
     listeners.filter(l => controllerListenerNames.contains(l.listenerName.value()))
 
-  def saslMechanismControllerProtocol: String = getString(KafkaConfig.SaslMechanismControllerProtocolProp)
+  def saslMechanismControllerProtocol: String = getString(SASL_MECHANISM_CONTROLLER_PROTOCOL_PROP)
 
   def controlPlaneListener: Option[EndPoint] = {
     controlPlaneListenerName.map { listenerName =>
@@ -1943,14 +650,14 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   def dataPlaneListeners: Seq[EndPoint] = {
     listeners.filterNot { listener =>
       val name = listener.listenerName.value()
-      name.equals(getString(KafkaConfig.ControlPlaneListenerNameProp)) ||
+      name.equals(getString(CONTROL_PLANE_LISTENER_NAME_PROP)) ||
         controllerListenerNames.contains(name)
     }
   }
 
   // Use advertised listeners if defined, fallback to listeners otherwise
   def effectiveAdvertisedListeners: Seq[EndPoint] = {
-    val advertisedListenersProp = getString(KafkaConfig.AdvertisedListenersProp)
+    val advertisedListenersProp = getString(ADVERTISED_LISTENERS_PROP)
     if (advertisedListenersProp != null)
       CoreUtils.listenerListToEndPoints(advertisedListenersProp, effectiveListenerSecurityProtocolMap, requireDistinctPorts=false)
     else
@@ -1958,30 +665,30 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   }
 
   private def getInterBrokerListenerNameAndSecurityProtocol: (ListenerName, SecurityProtocol) = {
-    Option(getString(KafkaConfig.InterBrokerListenerNameProp)) match {
-      case Some(_) if originals.containsKey(KafkaConfig.InterBrokerSecurityProtocolProp) =>
-        throw new ConfigException(s"Only one of ${KafkaConfig.InterBrokerListenerNameProp} and " +
-          s"${KafkaConfig.InterBrokerSecurityProtocolProp} should be set.")
+    Option(getString(INTER_BROKER_LISTENER_NAME_PROP)) match {
+      case Some(_) if originals.containsKey(INTER_BROKER_SECURITY_PROTOCOL_PROP) =>
+        throw new ConfigException(s"Only one of ${INTER_BROKER_LISTENER_NAME_PROP} and " +
+          s"${INTER_BROKER_SECURITY_PROTOCOL_PROP} should be set.")
       case Some(name) =>
         val listenerName = ListenerName.normalised(name)
         val securityProtocol = effectiveListenerSecurityProtocolMap.getOrElse(listenerName,
           throw new ConfigException(s"Listener with name ${listenerName.value} defined in " +
-            s"${KafkaConfig.InterBrokerListenerNameProp} not found in ${KafkaConfig.ListenerSecurityProtocolMapProp}."))
+            s"${INTER_BROKER_LISTENER_NAME_PROP} not found in ${LISTENER_SECURITY_PROTOCOL_MAP_PROP}."))
         (listenerName, securityProtocol)
       case None =>
-        val securityProtocol = getSecurityProtocol(getString(KafkaConfig.InterBrokerSecurityProtocolProp),
-          KafkaConfig.InterBrokerSecurityProtocolProp)
+        val securityProtocol = getSecurityProtocol(getString(INTER_BROKER_SECURITY_PROTOCOL_PROP),
+          INTER_BROKER_SECURITY_PROTOCOL_PROP)
         (ListenerName.forSecurityProtocol(securityProtocol), securityProtocol)
     }
   }
 
   private def getControlPlaneListenerNameAndSecurityProtocol: Option[(ListenerName, SecurityProtocol)] = {
-    Option(getString(KafkaConfig.ControlPlaneListenerNameProp)) match {
+    Option(getString(CONTROL_PLANE_LISTENER_NAME_PROP)) match {
       case Some(name) =>
         val listenerName = ListenerName.normalised(name)
         val securityProtocol = effectiveListenerSecurityProtocolMap.getOrElse(listenerName,
           throw new ConfigException(s"Listener with ${listenerName.value} defined in " +
-            s"${KafkaConfig.ControlPlaneListenerNameProp} not found in ${KafkaConfig.ListenerSecurityProtocolMapProp}."))
+            s"${CONTROL_PLANE_LISTENER_NAME_PROP} not found in ${LISTENER_SECURITY_PROTOCOL_MAP_PROP}."))
         Some(listenerName, securityProtocol)
 
       case None => None
@@ -1997,11 +704,11 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   }
 
   def effectiveListenerSecurityProtocolMap: Map[ListenerName, SecurityProtocol] = {
-    val mapValue = getMap(KafkaConfig.ListenerSecurityProtocolMapProp, getString(KafkaConfig.ListenerSecurityProtocolMapProp))
+    val mapValue = getMap(LISTENER_SECURITY_PROTOCOL_MAP_PROP, getString(LISTENER_SECURITY_PROTOCOL_MAP_PROP))
       .map { case (listenerName, protocolName) =>
-        ListenerName.normalised(listenerName) -> getSecurityProtocol(protocolName, KafkaConfig.ListenerSecurityProtocolMapProp)
+        ListenerName.normalised(listenerName) -> getSecurityProtocol(protocolName, LISTENER_SECURITY_PROTOCOL_MAP_PROP)
       }
-    if (usesSelfManagedQuorum && !originals.containsKey(ListenerSecurityProtocolMapProp)) {
+    if (usesSelfManagedQuorum && !originals.containsKey(LISTENER_SECURITY_PROTOCOL_MAP_PROP)) {
       // Nothing was specified explicitly for listener.security.protocol.map, so we are using the default value,
       // and we are using KRaft.
       // Add PLAINTEXT mappings for controller listeners as long as there is no SSL or SASL_{PLAINTEXT,SSL} in use
@@ -2009,7 +716,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
       // check controller listener names (they won't appear in listeners when process.roles=broker)
       // as well as listeners for occurrences of SSL or SASL_*
       if (controllerListenerNames.exists(isSslOrSasl) ||
-        parseCsvList(getString(KafkaConfig.ListenersProp)).exists(listenerValue => isSslOrSasl(EndPoint.parseListenerName(listenerValue)))) {
+        parseCsvList(getString(LISTENERS_PROP)).exists(listenerValue => isSslOrSasl(EndPoint.parseListenerName(listenerValue)))) {
         mapValue // don't add default mappings since we found something that is SSL or SASL_*
       } else {
         // add the PLAINTEXT mappings for all controller listener names that are not explicitly PLAINTEXT
@@ -2036,11 +743,11 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
   @nowarn("cat=deprecation")
   private def validateValues(): Unit = {
     if (nodeId != brokerId) {
-      throw new ConfigException(s"You must set `${KafkaConfig.NodeIdProp}` to the same value as `${KafkaConfig.BrokerIdProp}`.")
+      throw new ConfigException(s"You must set `${NODE_ID_PROP}` to the same value as `${BROKER_ID_PROP}`.")
     }
     if (requiresZookeeper) {
       if (zkConnect == null) {
-        throw new ConfigException(s"Missing required configuration `${KafkaConfig.ZkConnectProp}` which has no default value.")
+        throw new ConfigException(s"Missing required configuration `${ZK_CONNECT_PROP}` which has no default value.")
       }
       if (brokerIdGenerationEnable) {
         require(brokerId >= -1 && brokerId <= maxReservedBrokerId, "broker.id must be greater than or equal to -1 and not greater than reserved.broker.max.id")
@@ -2050,12 +757,12 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
     } else {
       // KRaft-based metadata quorum
       if (nodeId < 0) {
-        throw new ConfigException(s"Missing configuration `${KafkaConfig.NodeIdProp}` which is required " +
+        throw new ConfigException(s"Missing configuration `${NODE_ID_PROP}` which is required " +
           s"when `process.roles` is defined (i.e. when running in KRaft mode).")
       }
       if (migrationEnabled) {
         if (zkConnect == null) {
-          throw new ConfigException(s"If using `${KafkaConfig.MigrationEnabledProp}` in KRaft mode, `${KafkaConfig.ZkConnectProp}` must also be set.")
+          throw new ConfigException(s"If using `${MIGRATION_ENABLED_PROP}` in KRaft mode, `${ZK_CONNECT_PROP}` must also be set.")
         }
       }
     }
@@ -2079,39 +786,39 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
     val voterAddressSpecsByNodeId = RaftConfig.parseVoterConnections(quorumVoters)
     def validateNonEmptyQuorumVotersForKRaft(): Unit = {
       if (voterAddressSpecsByNodeId.isEmpty) {
-        throw new ConfigException(s"If using ${KafkaConfig.ProcessRolesProp}, ${KafkaConfig.QuorumVotersProp} must contain a parseable set of voters.")
+        throw new ConfigException(s"If using ${PROCESS_ROLES_PROP}, ${QUORUM_VOTERS_PROP} must contain a parseable set of voters.")
       }
     }
     def validateNonEmptyQuorumVotersForMigration(): Unit = {
       if (voterAddressSpecsByNodeId.isEmpty) {
-        throw new ConfigException(s"If using ${KafkaConfig.MigrationEnabledProp}, ${KafkaConfig.QuorumVotersProp} must contain a parseable set of voters.")
+        throw new ConfigException(s"If using ${MIGRATION_ENABLED_PROP}, ${QUORUM_VOTERS_PROP} must contain a parseable set of voters.")
       }
     }
     def validateControlPlaneListenerEmptyForKRaft(): Unit = {
       require(controlPlaneListenerName.isEmpty,
-        s"${KafkaConfig.ControlPlaneListenerNameProp} is not supported in KRaft mode.")
+        s"${CONTROL_PLANE_LISTENER_NAME_PROP} is not supported in KRaft mode.")
     }
     def validateAdvertisedListenersDoesNotContainControllerListenersForKRaftBroker(): Unit = {
       require(!advertisedListenerNames.exists(aln => controllerListenerNames.contains(aln.value())),
-        s"The advertised.listeners config must not contain KRaft controller listeners from ${KafkaConfig.ControllerListenerNamesProp} when ${KafkaConfig.ProcessRolesProp} contains the broker role because Kafka clients that send requests via advertised listeners do not send requests to KRaft controllers -- they only send requests to KRaft brokers.")
+        s"The advertised.listeners config must not contain KRaft controller listeners from ${CONTROLLER_LISTENER_NAMES_PROP} when ${PROCESS_ROLES_PROP} contains the broker role because Kafka clients that send requests via advertised listeners do not send requests to KRaft controllers -- they only send requests to KRaft brokers.")
     }
     def validateControllerQuorumVotersMustContainNodeIdForKRaftController(): Unit = {
       require(voterAddressSpecsByNodeId.containsKey(nodeId),
-        s"If ${KafkaConfig.ProcessRolesProp} contains the 'controller' role, the node id $nodeId must be included in the set of voters ${KafkaConfig.QuorumVotersProp}=${voterAddressSpecsByNodeId.asScala.keySet.toSet}")
+        s"If ${PROCESS_ROLES_PROP} contains the 'controller' role, the node id $nodeId must be included in the set of voters ${QUORUM_VOTERS_PROP}=${voterAddressSpecsByNodeId.asScala.keySet.toSet}")
     }
     def validateControllerListenerExistsForKRaftController(): Unit = {
       require(controllerListeners.nonEmpty,
-        s"${KafkaConfig.ControllerListenerNamesProp} must contain at least one value appearing in the '${KafkaConfig.ListenersProp}' configuration when running the KRaft controller role")
+        s"${CONTROLLER_LISTENER_NAMES_PROP} must contain at least one value appearing in the '${LISTENERS_PROP}' configuration when running the KRaft controller role")
     }
     def validateControllerListenerNamesMustAppearInListenersForKRaftController(): Unit = {
       val listenerNameValues = listeners.map(_.listenerName.value).toSet
       require(controllerListenerNames.forall(cln => listenerNameValues.contains(cln)),
-        s"${KafkaConfig.ControllerListenerNamesProp} must only contain values appearing in the '${KafkaConfig.ListenersProp}' configuration when running the KRaft controller role")
+        s"${CONTROLLER_LISTENER_NAMES_PROP} must only contain values appearing in the '${LISTENERS_PROP}' configuration when running the KRaft controller role")
     }
     def validateAdvertisedListenersNonEmptyForBroker(): Unit = {
       require(advertisedListenerNames.nonEmpty,
         "There must be at least one advertised listener." + (
-          if (processRoles.contains(ProcessRole.BrokerRole)) s" Perhaps all listeners appear in $ControllerListenerNamesProp?" else ""))
+          if (processRoles.contains(ProcessRole.BrokerRole)) s" Perhaps all listeners appear in $CONTROLLER_LISTENER_NAMES_PROP?" else ""))
     }
     if (processRoles == Set(ProcessRole.BrokerRole)) {
       // KRaft broker-only
@@ -2120,24 +827,24 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
       validateAdvertisedListenersDoesNotContainControllerListenersForKRaftBroker()
       // nodeId must not appear in controller.quorum.voters
       require(!voterAddressSpecsByNodeId.containsKey(nodeId),
-        s"If ${KafkaConfig.ProcessRolesProp} contains just the 'broker' role, the node id $nodeId must not be included in the set of voters ${KafkaConfig.QuorumVotersProp}=${voterAddressSpecsByNodeId.asScala.keySet.toSet}")
+        s"If ${PROCESS_ROLES_PROP} contains just the 'broker' role, the node id $nodeId must not be included in the set of voters ${QUORUM_VOTERS_PROP}=${voterAddressSpecsByNodeId.asScala.keySet.toSet}")
       // controller.listener.names must be non-empty...
       require(controllerListenerNames.nonEmpty,
-        s"${KafkaConfig.ControllerListenerNamesProp} must contain at least one value when running KRaft with just the broker role")
+        s"${CONTROLLER_LISTENER_NAMES_PROP} must contain at least one value when running KRaft with just the broker role")
       // controller.listener.names are forbidden in listeners...
       require(controllerListeners.isEmpty,
-        s"${KafkaConfig.ControllerListenerNamesProp} must not contain a value appearing in the '${KafkaConfig.ListenersProp}' configuration when running KRaft with just the broker role")
+        s"${CONTROLLER_LISTENER_NAMES_PROP} must not contain a value appearing in the '${LISTENERS_PROP}' configuration when running KRaft with just the broker role")
       // controller.listener.names must all appear in listener.security.protocol.map
       controllerListenerNames.foreach { name =>
         val listenerName = ListenerName.normalised(name)
         if (!effectiveListenerSecurityProtocolMap.contains(listenerName)) {
           throw new ConfigException(s"Controller listener with name ${listenerName.value} defined in " +
-            s"${KafkaConfig.ControllerListenerNamesProp} not found in ${KafkaConfig.ListenerSecurityProtocolMapProp}  (an explicit security mapping for each controller listener is required if ${KafkaConfig.ListenerSecurityProtocolMapProp} is non-empty, or if there are security protocols other than PLAINTEXT in use)")
+            s"${CONTROLLER_LISTENER_NAMES_PROP} not found in ${LISTENER_SECURITY_PROTOCOL_MAP_PROP}  (an explicit security mapping for each controller listener is required if ${LISTENER_SECURITY_PROTOCOL_MAP_PROP} is non-empty, or if there are security protocols other than PLAINTEXT in use)")
         }
       }
       // warn that only the first controller listener is used if there is more than one
       if (controllerListenerNames.size > 1) {
-        warn(s"${KafkaConfig.ControllerListenerNamesProp} has multiple entries; only the first will be used since ${KafkaConfig.ProcessRolesProp}=broker: ${controllerListenerNames.asJava}")
+        warn(s"${CONTROLLER_LISTENER_NAMES_PROP} has multiple entries; only the first will be used since ${PROCESS_ROLES_PROP}=broker: ${controllerListenerNames.asJava}")
       }
       validateAdvertisedListenersNonEmptyForBroker()
     } else if (processRoles == Set(ProcessRole.ControllerRole)) {
@@ -2146,13 +853,13 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
       validateControlPlaneListenerEmptyForKRaft()
       // advertised listeners must be empty when only the controller is configured
       require(
-        getString(KafkaConfig.AdvertisedListenersProp) == null,
-        s"The ${KafkaConfig.AdvertisedListenersProp} config must be empty when ${KafkaConfig.ProcessRolesProp}=controller"
+        getString(ADVERTISED_LISTENERS_PROP) == null,
+        s"The ${ADVERTISED_LISTENERS_PROP} config must be empty when ${PROCESS_ROLES_PROP}=controller"
       )
       // listeners should only contain listeners also enumerated in the controller listener
       require(
         effectiveAdvertisedListeners.isEmpty,
-        s"The ${KafkaConfig.ListenersProp} config must only contain KRaft controller listeners from ${KafkaConfig.ControllerListenerNamesProp} when ${KafkaConfig.ProcessRolesProp}=controller"
+        s"The ${LISTENERS_PROP} config must only contain KRaft controller listeners from ${CONTROLLER_LISTENER_NAMES_PROP} when ${PROCESS_ROLES_PROP}=controller"
       )
       validateControllerQuorumVotersMustContainNodeIdForKRaftController()
       validateControllerListenerExistsForKRaftController()
@@ -2171,18 +878,18 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
       if (migrationEnabled) {
         validateNonEmptyQuorumVotersForMigration()
         require(controllerListenerNames.nonEmpty,
-          s"${KafkaConfig.ControllerListenerNamesProp} must not be empty when running in ZooKeeper migration mode: ${controllerListenerNames.asJava}")
+          s"${CONTROLLER_LISTENER_NAMES_PROP} must not be empty when running in ZooKeeper migration mode: ${controllerListenerNames.asJava}")
         require(interBrokerProtocolVersion.isMigrationSupported, s"Cannot enable ZooKeeper migration without setting " +
-          s"'${KafkaConfig.InterBrokerProtocolVersionProp}' to 3.4 or higher")
+          s"'${INTER_BROKER_PROTOCOL_VERSION_PROP}' to 3.4 or higher")
         if (logDirs.size > 1) {
           require(interBrokerProtocolVersion.isDirectoryAssignmentSupported,
             s"Cannot enable ZooKeeper migration with multiple log directories (aka JBOD) without setting " +
-            s"'${KafkaConfig.InterBrokerProtocolVersionProp}' to ${MetadataVersion.IBP_3_7_IV2} or higher")
+            s"'${INTER_BROKER_PROTOCOL_VERSION_PROP}' to ${MetadataVersion.IBP_3_7_IV2} or higher")
         }
       } else {
         // controller listener names must be empty when not in KRaft mode
         require(controllerListenerNames.isEmpty,
-          s"${KafkaConfig.ControllerListenerNamesProp} must be empty when not running in KRaft mode: ${controllerListenerNames.asJava}")
+          s"${CONTROLLER_LISTENER_NAMES_PROP} must be empty when not running in KRaft mode: ${controllerListenerNames.asJava}")
       }
       validateAdvertisedListenersNonEmptyForBroker()
     }
@@ -2192,27 +899,27 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
       // validations for all broker setups (i.e. ZooKeeper and KRaft broker-only and KRaft co-located)
       validateAdvertisedListenersNonEmptyForBroker()
       require(advertisedListenerNames.contains(interBrokerListenerName),
-        s"${KafkaConfig.InterBrokerListenerNameProp} must be a listener name defined in ${KafkaConfig.AdvertisedListenersProp}. " +
+        s"${INTER_BROKER_LISTENER_NAME_PROP} must be a listener name defined in ${ADVERTISED_LISTENERS_PROP}. " +
           s"The valid options based on currently configured listeners are ${advertisedListenerNames.map(_.value).mkString(",")}")
       require(advertisedListenerNames.subsetOf(listenerNames),
-        s"${KafkaConfig.AdvertisedListenersProp} listener names must be equal to or a subset of the ones defined in ${KafkaConfig.ListenersProp}. " +
+        s"${ADVERTISED_LISTENERS_PROP} listener names must be equal to or a subset of the ones defined in ${LISTENERS_PROP}. " +
           s"Found ${advertisedListenerNames.map(_.value).mkString(",")}. The valid options based on the current configuration " +
           s"are ${listenerNames.map(_.value).mkString(",")}"
       )
     }
 
     require(!effectiveAdvertisedListeners.exists(endpoint => endpoint.host=="0.0.0.0"),
-      s"${KafkaConfig.AdvertisedListenersProp} cannot use the nonroutable meta-address 0.0.0.0. "+
+      s"${ADVERTISED_LISTENERS_PROP} cannot use the nonroutable meta-address 0.0.0.0. "+
       s"Use a routable IP address.")
 
     // validate control.plane.listener.name config
     if (controlPlaneListenerName.isDefined) {
       require(advertisedListenerNames.contains(controlPlaneListenerName.get),
-        s"${KafkaConfig.ControlPlaneListenerNameProp} must be a listener name defined in ${KafkaConfig.AdvertisedListenersProp}. " +
+        s"${CONTROL_PLANE_LISTENER_NAME_PROP} must be a listener name defined in ${ADVERTISED_LISTENERS_PROP}. " +
         s"The valid options based on currently configured listeners are ${advertisedListenerNames.map(_.value).mkString(",")}")
       // controlPlaneListenerName should be different from interBrokerListenerName
       require(!controlPlaneListenerName.get.value().equals(interBrokerListenerName.value()),
-        s"${KafkaConfig.ControlPlaneListenerNameProp}, when defined, should have a different value from the inter broker listener name. " +
+        s"${CONTROL_PLANE_LISTENER_NAME_PROP}, when defined, should have a different value from the inter broker listener name. " +
         s"Currently they both have the value ${controlPlaneListenerName.get}")
     }
 
@@ -2234,49 +941,49 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
     require(!interBrokerUsesSasl || saslInterBrokerHandshakeRequestEnable || saslMechanismInterBrokerProtocol == SaslConfigs.GSSAPI_MECHANISM,
       s"Only GSSAPI mechanism is supported for inter-broker communication with SASL when inter.broker.protocol.version is set to $interBrokerProtocolVersionString")
     require(!interBrokerUsesSasl || saslEnabledMechanisms(interBrokerListenerName).contains(saslMechanismInterBrokerProtocol),
-      s"${KafkaConfig.SaslMechanismInterBrokerProtocolProp} must be included in ${KafkaConfig.SaslEnabledMechanismsProp} when SASL is used for inter-broker communication")
+      s"${SASL_MECHANISM_INTER_BROKER_PROTOCOL_PROP} must be included in ${SASL_ENABLED_MECHANISMS_PROP} when SASL is used for inter-broker communication")
     require(queuedMaxBytes <= 0 || queuedMaxBytes >= socketRequestMaxBytes,
-      s"${KafkaConfig.QueuedMaxBytesProp} must be larger or equal to ${KafkaConfig.SocketRequestMaxBytesProp}")
+      s"${QUEUED_MAX_BYTES_PROP} must be larger or equal to ${SOCKET_REQUEST_MAX_BYTES_PROP}")
 
     if (maxConnectionsPerIp == 0)
-      require(maxConnectionsPerIpOverrides.nonEmpty, s"${KafkaConfig.MaxConnectionsPerIpProp} can be set to zero only if" +
-        s" ${KafkaConfig.MaxConnectionsPerIpOverridesProp} property is set.")
+      require(maxConnectionsPerIpOverrides.nonEmpty, s"${MAX_CONNECTIONS_PER_IP_PROP} can be set to zero only if" +
+        s" ${MAX_CONNECTIONS_PER_IP_OVERRIDES_PROP} property is set.")
 
     val invalidAddresses = maxConnectionsPerIpOverrides.keys.filterNot(address => Utils.validHostPattern(address))
     if (invalidAddresses.nonEmpty)
-      throw new IllegalArgumentException(s"${KafkaConfig.MaxConnectionsPerIpOverridesProp} contains invalid addresses : ${invalidAddresses.mkString(",")}")
+      throw new IllegalArgumentException(s"${MAX_CONNECTIONS_PER_IP_OVERRIDES_PROP} contains invalid addresses : ${invalidAddresses.mkString(",")}")
 
     if (connectionsMaxIdleMs >= 0)
       require(failedAuthenticationDelayMs < connectionsMaxIdleMs,
-        s"${KafkaConfig.FailedAuthenticationDelayMsProp}=$failedAuthenticationDelayMs should always be less than" +
-        s" ${KafkaConfig.ConnectionsMaxIdleMsProp}=$connectionsMaxIdleMs to prevent failed" +
+        s"${FAILED_AUTHENTICATION_DELAY_MS_PROP}=$failedAuthenticationDelayMs should always be less than" +
+        s" ${CONNECTIONS_MAX_IDLE_MS_PROP}=$connectionsMaxIdleMs to prevent failed" +
         s" authentication responses from timing out")
 
-    val principalBuilderClass = getClass(KafkaConfig.PrincipalBuilderClassProp)
-    require(principalBuilderClass != null, s"${KafkaConfig.PrincipalBuilderClassProp} must be non-null")
+    val principalBuilderClass = getClass(PRINCIPAL_BUILDER_CLASS_PROP)
+    require(principalBuilderClass != null, s"${PRINCIPAL_BUILDER_CLASS_PROP} must be non-null")
     require(classOf[KafkaPrincipalSerde].isAssignableFrom(principalBuilderClass),
-      s"${KafkaConfig.PrincipalBuilderClassProp} must implement KafkaPrincipalSerde")
+      s"${PRINCIPAL_BUILDER_CLASS_PROP} must implement KafkaPrincipalSerde")
 
     // New group coordinator configs validation.
     require(consumerGroupMaxHeartbeatIntervalMs >= consumerGroupMinHeartbeatIntervalMs,
-      s"${KafkaConfig.ConsumerGroupMaxHeartbeatIntervalMsProp} must be greater than or equals " +
-      s"to ${KafkaConfig.ConsumerGroupMinHeartbeatIntervalMsProp}")
+      s"${CONSUMER_GROUP_MAX_HEARTBEAT_INTERVAL_MS_PROP} must be greater than or equals " +
+      s"to ${CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_PROP}")
     require(consumerGroupHeartbeatIntervalMs >= consumerGroupMinHeartbeatIntervalMs,
-      s"${KafkaConfig.ConsumerGroupHeartbeatIntervalMsProp} must be greater than or equals " +
-      s"to ${KafkaConfig.ConsumerGroupMinHeartbeatIntervalMsProp}")
+      s"${CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_PROP} must be greater than or equals " +
+      s"to ${CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_PROP}")
     require(consumerGroupHeartbeatIntervalMs <= consumerGroupMaxHeartbeatIntervalMs,
-      s"${KafkaConfig.ConsumerGroupHeartbeatIntervalMsProp} must be less than or equals " +
-      s"to ${KafkaConfig.ConsumerGroupMaxHeartbeatIntervalMsProp}")
+      s"${CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_PROP} must be less than or equals " +
+      s"to ${CONSUMER_GROUP_MAX_HEARTBEAT_INTERVAL_MS_PROP}")
 
     require(consumerGroupMaxSessionTimeoutMs >= consumerGroupMinSessionTimeoutMs,
-      s"${KafkaConfig.ConsumerGroupMaxSessionTimeoutMsProp} must be greater than or equals " +
-      s"to ${KafkaConfig.ConsumerGroupMinSessionTimeoutMsProp}")
+      s"${CONSUMER_GROUP_MAX_SESSION_TIMEOUT_MS_PROP} must be greater than or equals " +
+      s"to ${CONSUMER_GROUP_MIN_SESSION_TIMEOUT_MS_PROP}")
     require(consumerGroupSessionTimeoutMs >= consumerGroupMinSessionTimeoutMs,
-      s"${KafkaConfig.ConsumerGroupSessionTimeoutMsProp} must be greater than or equals " +
-      s"to ${KafkaConfig.ConsumerGroupMinSessionTimeoutMsProp}")
+      s"${CONSUMER_GROUP_SESSION_TIMEOUT_MS_PROP} must be greater than or equals " +
+      s"to ${CONSUMER_GROUP_MIN_SESSION_TIMEOUT_MS_PROP}")
     require(consumerGroupSessionTimeoutMs <= consumerGroupMaxSessionTimeoutMs,
-      s"${KafkaConfig.ConsumerGroupSessionTimeoutMsProp} must be less than or equals " +
-      s"to ${KafkaConfig.ConsumerGroupMaxSessionTimeoutMsProp}")
+      s"${CONSUMER_GROUP_SESSION_TIMEOUT_MS_PROP} must be less than or equals " +
+      s"to ${CONSUMER_GROUP_MAX_SESSION_TIMEOUT_MS_PROP}")
   }
 
   /**
@@ -2319,7 +1026,7 @@ class KafkaConfig private(doLog: Boolean, val props: java.util.Map[_, _], dynami
 
   @nowarn("cat=deprecation")
   private def createBrokerWarningMessage: String = {
-    s"Broker configuration ${KafkaConfig.LogMessageFormatVersionProp} with value $logMessageFormatVersionString is ignored " +
+    s"Broker configuration ${LOG_MESSAGE_FORMAT_VERSION_PROP} with value $logMessageFormatVersionString is ignored " +
       s"because the inter-broker protocol version `$interBrokerProtocolVersionString` is greater or equal than 3.0. " +
       "This configuration is deprecated and it will be removed in Apache Kafka 4.0."
   }

--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -31,6 +31,7 @@ import org.apache.kafka.metadata.properties.MetaPropertiesEnsemble.VerificationF
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble}
 import org.apache.kafka.raft.RaftConfig
 import org.apache.kafka.server.ProcessRole
+import org.apache.kafka.server.config.KafkaConfig.CONFIG_DEF
 import org.apache.kafka.server.config.ServerTopicConfigSynonyms
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.storage.internals.log.LogConfig
@@ -192,7 +193,7 @@ object KafkaRaftServer {
   }
 
   val configSchema = new KafkaConfigSchema(Map(
-    ConfigResource.Type.BROKER -> new ConfigDef(KafkaConfig.configDef),
+    ConfigResource.Type.BROKER -> new ConfigDef(CONFIG_DEF),
     ConfigResource.Type.TOPIC -> LogConfig.configDefCopy,
   ).asJava, ServerTopicConfigSynonyms.ALL_TOPIC_CONFIG_SYNONYMS)
 }

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -58,6 +58,7 @@ import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.kafka.server.common.MetadataVersion._
 import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
 import org.apache.kafka.server.config.ConfigType
+import org.apache.kafka.server.config.KafkaConfig.{setZooKeeperClientProperty, ZK_SSL_CLIENT_ENABLE_PROP, ZK_CLIENT_CNXN_SOCKET_PROP, ZK_SSL_KEYSTORE_LOCATION_PROP, ZK_SSL_KEYSTORE_PASSWORD_PROP, ZK_SSL_KEYSTORE_TYPE_PROP, ZK_SSL_TRUSTSTORE_LOCATION_PROP, ZK_SSL_TRUSTSTORE_PASSWORD_PROP, ZK_SSL_TRUSTSTORE_TYPE_PROP, ZK_SSL_ENABLED_PROTOCOLS_PROP, ZK_SSL_CIPHER_SUITES_PROP, ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP, ZK_SSL_CRL_ENABLE_PROP, ZK_SSL_OCSP_ENABLE_PROP, ZK_SSL_PROTOCOL_PROP}
 import org.apache.kafka.server.fault.LoggingFaultHandler
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
@@ -80,20 +81,20 @@ object KafkaServer {
   def zkClientConfigFromKafkaConfig(config: KafkaConfig, forceZkSslClientEnable: Boolean = false): ZKClientConfig = {
     val clientConfig = new ZKClientConfig
     if (config.zkSslClientEnable || forceZkSslClientEnable) {
-      KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslClientEnableProp, "true")
-      config.zkClientCnxnSocketClassName.foreach(KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkClientCnxnSocketProp, _))
-      config.zkSslKeyStoreLocation.foreach(KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslKeyStoreLocationProp, _))
-      config.zkSslKeyStorePassword.foreach(x => KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslKeyStorePasswordProp, x.value))
-      config.zkSslKeyStoreType.foreach(KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslKeyStoreTypeProp, _))
-      config.zkSslTrustStoreLocation.foreach(KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslTrustStoreLocationProp, _))
-      config.zkSslTrustStorePassword.foreach(x => KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslTrustStorePasswordProp, x.value))
-      config.zkSslTrustStoreType.foreach(KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslTrustStoreTypeProp, _))
-      KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslProtocolProp, config.ZkSslProtocol)
-      config.ZkSslEnabledProtocols.foreach(KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslEnabledProtocolsProp, _))
-      config.ZkSslCipherSuites.foreach(KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslCipherSuitesProp, _))
-      KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp, config.ZkSslEndpointIdentificationAlgorithm)
-      KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslCrlEnableProp, config.ZkSslCrlEnable.toString)
-      KafkaConfig.setZooKeeperClientProperty(clientConfig, KafkaConfig.ZkSslOcspEnableProp, config.ZkSslOcspEnable.toString)
+      setZooKeeperClientProperty(clientConfig, ZK_SSL_CLIENT_ENABLE_PROP, "true")
+      config.zkClientCnxnSocketClassName.foreach(setZooKeeperClientProperty(clientConfig, ZK_CLIENT_CNXN_SOCKET_PROP, _))
+      config.zkSslKeyStoreLocation.foreach(setZooKeeperClientProperty(clientConfig, ZK_SSL_KEYSTORE_LOCATION_PROP, _))
+      config.zkSslKeyStorePassword.foreach(x => setZooKeeperClientProperty(clientConfig, ZK_SSL_KEYSTORE_PASSWORD_PROP, x.value))
+      config.zkSslKeyStoreType.foreach(setZooKeeperClientProperty(clientConfig, ZK_SSL_KEYSTORE_TYPE_PROP, _))
+      config.zkSslTrustStoreLocation.foreach(setZooKeeperClientProperty(clientConfig, ZK_SSL_TRUSTSTORE_LOCATION_PROP, _))
+      config.zkSslTrustStorePassword.foreach(x => setZooKeeperClientProperty(clientConfig, ZK_SSL_TRUSTSTORE_PASSWORD_PROP, x.value))
+      config.zkSslTrustStoreType.foreach(setZooKeeperClientProperty(clientConfig, ZK_SSL_TRUSTSTORE_TYPE_PROP, _))
+      setZooKeeperClientProperty(clientConfig, ZK_SSL_PROTOCOL_PROP, config.ZkSslProtocol)
+      config.ZkSslEnabledProtocols.foreach(setZooKeeperClientProperty(clientConfig, ZK_SSL_ENABLED_PROTOCOLS_PROP, _))
+      config.ZkSslCipherSuites.foreach(setZooKeeperClientProperty(clientConfig, ZK_SSL_CIPHER_SUITES_PROP, _))
+      setZooKeeperClientProperty(clientConfig, ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP, config.ZkSslEndpointIdentificationAlgorithm)
+      setZooKeeperClientProperty(clientConfig, ZK_SSL_CRL_ENABLE_PROP, config.ZkSslCrlEnable.toString)
+      setZooKeeperClientProperty(clientConfig, ZK_SSL_OCSP_ENABLE_PROP, config.ZkSslOcspEnable.toString)
     }
     // The zk sasl is enabled by default so it can produce false error when broker does not intend to use SASL.
     if (!JaasUtils.isZkSaslEnabled) clientConfig.setProperty(JaasUtils.ZK_SASL_CLIENT, "false")

--- a/core/src/main/scala/kafka/server/QuotaFactory.scala
+++ b/core/src/main/scala/kafka/server/QuotaFactory.scala
@@ -23,6 +23,7 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.server.quota.ClientQuotaCallback
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.server.config.{ClientQuotaManagerConfig, ReplicationQuotaManagerConfig}
+import org.apache.kafka.server.config.KafkaConfig.CLIENT_QUOTA_CALLBACK_CLASS_PROP
 import org.apache.kafka.server.quota.ClientQuotaType
 
 object QuotaType  {
@@ -74,7 +75,7 @@ object QuotaFactory extends Logging {
 
   def instantiate(cfg: KafkaConfig, metrics: Metrics, time: Time, threadNamePrefix: String): QuotaManagers = {
 
-    val clientQuotaCallback = Option(cfg.getConfiguredInstance(KafkaConfig.ClientQuotaCallbackClassProp,
+    val clientQuotaCallback = Option(cfg.getConfiguredInstance(CLIENT_QUOTA_CALLBACK_CLASS_PROP,
       classOf[ClientQuotaCallback]))
     QuotaManagers(
       new ClientQuotaManager(clientConfig(cfg), metrics, Fetch, time, threadNamePrefix, clientQuotaCallback),

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -48,6 +48,7 @@ import org.apache.kafka.common.requests.{AlterConfigsRequest, ApiError}
 import org.apache.kafka.common.security.scram.internals.{ScramCredentialUtils, ScramFormatter}
 import org.apache.kafka.common.utils.Sanitizer
 import org.apache.kafka.server.common.AdminOperationException
+import org.apache.kafka.server.config.KafkaConfig.{configKeys, CREATE_TOPIC_POLICY_CLASS_NAME_PROP, ALTER_CONFIG_POLICY_CLASS_NAME_PROP}
 import org.apache.kafka.server.config.{ConfigEntityName, ConfigType}
 import org.apache.kafka.storage.internals.log.LogConfig
 
@@ -79,10 +80,10 @@ class ZkAdminManager(val config: KafkaConfig,
   private val configHelper = new ConfigHelper(metadataCache, config, new ZkConfigRepository(adminZkClient))
 
   private val createTopicPolicy =
-    Option(config.getConfiguredInstance(KafkaConfig.CreateTopicPolicyClassNameProp, classOf[CreateTopicPolicy]))
+    Option(config.getConfiguredInstance(CREATE_TOPIC_POLICY_CLASS_NAME_PROP, classOf[CreateTopicPolicy]))
 
   private val alterConfigPolicy =
-    Option(config.getConfiguredInstance(KafkaConfig.AlterConfigPolicyClassNameProp, classOf[AlterConfigPolicy]))
+    Option(config.getConfiguredInstance(ALTER_CONFIG_POLICY_CLASS_NAME_PROP, classOf[AlterConfigPolicy]))
 
   def hasDelayedTopicOperations = topicPurgatory.numDelayed != 0
 
@@ -521,7 +522,7 @@ class ZkAdminManager(val config: KafkaConfig,
             else adminZkClient.fetchEntityConfig(ConfigType.BROKER, ConfigEntityName.DEFAULT)
 
             val configProps = this.config.dynamicConfig.fromPersistentProps(persistentProps, perBrokerConfig)
-            prepareIncrementalConfigs(alterConfigOps, configProps, KafkaConfig.configKeys)
+            prepareIncrementalConfigs(alterConfigOps, configProps, configKeys.asScala)
             alterBrokerConfigs(resource, validateOnly, configProps, configEntriesMap)
 
           case resourceType =>

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -28,6 +28,7 @@ import net.sourceforge.argparse4j.inf.Namespace
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.metadata.bootstrap.{BootstrapDirectory, BootstrapMetadata}
+import org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_PROTOCOL_VERSION_PROP
 import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
 import org.apache.kafka.common.metadata.FeatureLevelRecord
 import org.apache.kafka.common.metadata.UserScramCredentialRecord
@@ -60,7 +61,7 @@ object StorageTool extends Logging {
           val directories = configToLogDirectories(config.get)
           val clusterId = namespace.getString("cluster_id")
           val metadataVersion = getMetadataVersion(namespace,
-            Option(config.get.originals.get(KafkaConfig.InterBrokerProtocolVersionProp)).map(_.toString))
+            Option(config.get.originals.get(INTER_BROKER_PROTOCOL_VERSION_PROP)).map(_.toString))
           if (!metadataVersion.isKRaftSupported) {
             throw new TerseFailure(s"Must specify a valid KRaft metadata version of at least 3.0.")
           }

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -37,6 +37,7 @@ import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.common.{TopicPartition, Uuid, protocol}
 import org.apache.kafka.raft.errors.NotLeaderException
 import org.apache.kafka.raft.{Batch, BatchReader, LeaderAndEpoch, RaftClient, RaftConfig}
+import org.apache.kafka.server.config.KafkaConfig.PROCESS_ROLES_PROP
 import org.apache.kafka.server.common.{Features, MetadataVersion}
 import org.apache.kafka.server.common.serialization.RecordSerde
 import org.apache.kafka.server.fault.ProcessTerminatingFaultHandler
@@ -447,7 +448,7 @@ object TestRaftServer extends Logging {
 
       // KafkaConfig requires either `process.roles` or `zookeeper.connect`. Neither are
       // actually used by the test server, so we fill in `process.roles` with an arbitrary value.
-      serverProps.put(KafkaConfig.ProcessRolesProp, "controller")
+      serverProps.put(PROCESS_ROLES_PROP, "controller")
 
       val config = KafkaConfig.fromProps(serverProps, doLog = false)
       val throughput = opts.options.valueOf(opts.throughputOpt)

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -35,6 +35,7 @@ import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.common.{KafkaException, TopicPartition, Uuid}
 import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
 import org.apache.kafka.server.config.ConfigType
+import org.apache.kafka.server.config.KafkaConfig.{zkTlsClientAuthEnabled, ZK_ENABLE_SECURE_ACLS_PROP, ZK_SSL_CLIENT_ENABLE_PROP, ZK_CLIENT_CNXN_SOCKET_PROP, ZK_SSL_KEYSTORE_LOCATION_PROP}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.storage.internals.log.LogConfig
 import org.apache.zookeeper.KeeperException.{Code, NodeExistsException}
@@ -2345,13 +2346,13 @@ object KafkaZkClient {
 
   def createZkClient(name: String, time: Time, config: KafkaConfig, zkClientConfig: ZKClientConfig): KafkaZkClient = {
     val secureAclsEnabled = config.zkEnableSecureAcls
-    val isZkSecurityEnabled = JaasUtils.isZkSaslEnabled || KafkaConfig.zkTlsClientAuthEnabled(zkClientConfig)
+    val isZkSecurityEnabled = JaasUtils.isZkSaslEnabled || zkTlsClientAuthEnabled(zkClientConfig)
 
     if (secureAclsEnabled && !isZkSecurityEnabled)
       throw new java.lang.SecurityException(
-        s"${KafkaConfig.ZkEnableSecureAclsProp} is true, but ZooKeeper client TLS configuration identifying at least " +
-          s"${KafkaConfig.ZkSslClientEnableProp}, ${KafkaConfig.ZkClientCnxnSocketProp}, and " +
-          s"${KafkaConfig.ZkSslKeyStoreLocationProp} was not present and the verification of the JAAS login file failed " +
+        s"${ZK_ENABLE_SECURE_ACLS_PROP} is true, but ZooKeeper client TLS configuration identifying at least " +
+          s"${ZK_SSL_CLIENT_ENABLE_PROP}, ${ZK_CLIENT_CNXN_SOCKET_PROP}, and " +
+          s"${ZK_SSL_KEYSTORE_LOCATION_PROP} was not present and the verification of the JAAS login file failed " +
           s"${JaasUtils.zkSecuritySysConfigString}")
 
     KafkaZkClient(config.zkConnect, secureAclsEnabled, config.zkSessionTimeoutMs, config.zkConnectionTimeoutMs,

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -118,6 +118,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.server.config.KafkaConfig.BROKER_ID_PROP;
 import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_COMMON_CLIENT_PREFIX;
 import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_CONSUMER_PREFIX;
 import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_PRODUCER_PREFIX;
@@ -354,7 +355,7 @@ public class RemoteLogManagerTest {
         assertEquals(host + ":" + port, capture.getValue().get(REMOTE_LOG_METADATA_COMMON_CLIENT_PREFIX + "bootstrap.servers"));
         assertEquals(securityProtocol, capture.getValue().get(REMOTE_LOG_METADATA_COMMON_CLIENT_PREFIX + "security.protocol"));
         assertEquals(clusterId, capture.getValue().get("cluster.id"));
-        assertEquals(brokerId, capture.getValue().get(KafkaConfig.BrokerIdProp()));
+        assertEquals(brokerId, capture.getValue().get(BROKER_ID_PROP));
     }
 
     @Test
@@ -393,7 +394,7 @@ public class RemoteLogManagerTest {
             // should be overridden as SSL
             assertEquals("SSL", capture.getValue().get(REMOTE_LOG_METADATA_COMMON_CLIENT_PREFIX + "security.protocol"));
             assertEquals(clusterId, capture.getValue().get("cluster.id"));
-            assertEquals(brokerId, capture.getValue().get(KafkaConfig.BrokerIdProp()));
+            assertEquals(brokerId, capture.getValue().get(BROKER_ID_PROP));
         }
     }
 

--- a/core/src/test/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandlerTest.java
+++ b/core/src/test/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandlerTest.java
@@ -75,6 +75,10 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.server.config.KafkaConfig.NODE_ID_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.PROCESS_ROLES_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.QUORUM_VOTERS_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.CONTROLLER_LISTENER_NAMES_PROP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -534,11 +538,11 @@ class DescribeTopicPartitionsRequestHandlerTest {
             1,
             (short) 1,
             false);
-        properties.put(KafkaConfig.NodeIdProp(), Integer.toString(brokerId));
-        properties.put(KafkaConfig.ProcessRolesProp(), "broker");
+        properties.put(NODE_ID_PROP, Integer.toString(brokerId));
+        properties.put(PROCESS_ROLES_PROP, "broker");
         int voterId = brokerId + 1;
-        properties.put(KafkaConfig.QuorumVotersProp(), voterId + "@localhost:9093");
-        properties.put(KafkaConfig.ControllerListenerNamesProp(), "SSL");
+        properties.put(QUORUM_VOTERS_PROP, voterId + "@localhost:9093");
+        properties.put(CONTROLLER_LISTENER_NAMES_PROP, "SSL");
         TestUtils.setIbpAndMessageFormatVersions(properties, MetadataVersion.latestProduction());
         return new KafkaConfig(properties);
     }

--- a/core/src/test/java/kafka/test/junit/ZkClusterInvocationContext.java
+++ b/core/src/test/java/kafka/test/junit/ZkClusterInvocationContext.java
@@ -20,7 +20,6 @@ package kafka.test.junit;
 import kafka.api.IntegrationTestHarness;
 import kafka.network.SocketServer;
 import kafka.server.BrokerFeatures;
-import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
 import kafka.test.ClusterConfig;
 import kafka.test.ClusterInstance;
@@ -52,6 +51,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_PROTOCOL_VERSION_PROP;
 /**
  * Wraps a {@link IntegrationTestHarness} inside lifecycle methods for a test invocation. Each instance of this
  * class is provided with a configuration for the cluster.
@@ -111,7 +111,7 @@ public class ZkClusterInvocationContext implements TestTemplateInvocationContext
                     @Override
                     public Properties serverConfig() {
                         Properties props = clusterConfig.serverProperties();
-                        props.put(KafkaConfig.InterBrokerProtocolVersionProp(), clusterConfig.metadataVersion().version());
+                        props.put(INTER_BROKER_PROTOCOL_VERSION_PROP, clusterConfig.metadataVersion().version());
                         return props;
                     }
 

--- a/core/src/test/scala/integration/kafka/admin/BrokerApiVersionsCommandTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/BrokerApiVersionsCommandTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.NodeApiVersions
 import org.apache.kafka.common.message.ApiMessageType
 import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.requests.ApiVersionsResponse
+import org.apache.kafka.server.config.KafkaConfig.{UNSTABLE_API_VERSIONS_ENABLE_PROP, CONTROL_PLANE_LISTENER_NAME_PROP, LISTENER_SECURITY_PROTOCOL_MAP_PROP, ADVERTISED_LISTENERS_PROP}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull, assertTrue}
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.params.ParameterizedTest
@@ -42,18 +43,18 @@ class BrokerApiVersionsCommandTest extends KafkaServerTestHarness {
       TestUtils.createBrokerConfigs(1, null).map(props => {
         // Enable unstable api versions to be compatible with the new APIs under development,
         // maybe we can remove this after the new APIs is complete.
-        props.setProperty(KafkaConfig.UnstableApiVersionsEnableProp, "true")
+        props.setProperty(UNSTABLE_API_VERSIONS_ENABLE_PROP, "true")
         props
       }).map(KafkaConfig.fromProps)
     } else {
       TestUtils.createBrokerConfigs(1, zkConnect).map(props => {
         // Configure control plane listener to make sure we have separate listeners from client,
         // in order to avoid returning Envelope API version.
-        props.setProperty(KafkaConfig.ControlPlaneListenerNameProp, "CONTROLLER")
-        props.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT")
+        props.setProperty(CONTROL_PLANE_LISTENER_NAME_PROP, "CONTROLLER")
+        props.setProperty(LISTENER_SECURITY_PROTOCOL_MAP_PROP, "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT")
         props.setProperty("listeners", "PLAINTEXT://localhost:0,CONTROLLER://localhost:0")
-        props.setProperty(KafkaConfig.AdvertisedListenersProp, "PLAINTEXT://localhost:0,CONTROLLER://localhost:0")
-        props.setProperty(KafkaConfig.UnstableApiVersionsEnableProp, "true")
+        props.setProperty(ADVERTISED_LISTENERS_PROP, "PLAINTEXT://localhost:0,CONTROLLER://localhost:0")
+        props.setProperty(UNSTABLE_API_VERSIONS_ENABLE_PROP, "true")
         props
       }).map(KafkaConfig.fromProps)
     }

--- a/core/src/test/scala/integration/kafka/admin/ConfigCommandIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ConfigCommandIntegrationTest.scala
@@ -18,12 +18,13 @@ package kafka.admin
 
 import kafka.admin.ConfigCommand.ConfigCommandOptions
 import kafka.cluster.{Broker, EndPoint}
-import kafka.server.{KafkaConfig, QuorumTestHarness}
+import kafka.server.QuorumTestHarness
 import kafka.utils.{Exit, Logging, TestInfoUtils}
 import kafka.zk.{AdminZkClient, BrokerInfo}
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.apache.kafka.server.config.KafkaConfig.{PASSWORD_ENCODER_SECRET_PROP, PASSWORD_ENCODER_CIPHER_ALGORITHM_PROP, PASSWORD_ENCODER_ITERATIONS_PROP, PASSWORD_ENCODER_KEY_FACTORY_ALGORITHM_PROP, PASSWORD_ENCODER_KEY_LENGTH_PROP}
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.config.ConfigEntityName
 import org.junit.jupiter.api.Assertions._
@@ -134,10 +135,10 @@ class ConfigCommandIntegrationTest extends QuorumTestHarness with Logging {
 
     // Password config update with encoder secret should succeed and encoded password must be stored in ZK
     val configs = Map("listener.name.external.ssl.keystore.password" -> "secret", "log.cleaner.threads" -> "2")
-    val encoderConfigs = Map(KafkaConfig.PasswordEncoderSecretProp -> "encoder-secret")
+    val encoderConfigs = Map(PASSWORD_ENCODER_SECRET_PROP -> "encoder-secret")
     alterConfigWithZk(configs, Some(brokerId), encoderConfigs)
     val brokerConfigs = zkClient.getEntityConfigs("brokers", brokerId)
-    assertFalse(brokerConfigs.contains(KafkaConfig.PasswordEncoderSecretProp), "Encoder secret stored in ZooKeeper")
+    assertFalse(brokerConfigs.contains(PASSWORD_ENCODER_SECRET_PROP), "Encoder secret stored in ZooKeeper")
     assertEquals("2", brokerConfigs.getProperty("log.cleaner.threads")) // not encoded
     val encodedPassword = brokerConfigs.getProperty("listener.name.external.ssl.keystore.password")
     val passwordEncoder = ConfigCommand.createPasswordEncoder(encoderConfigs)
@@ -146,11 +147,11 @@ class ConfigCommandIntegrationTest extends QuorumTestHarness with Logging {
 
     // Password config update with overrides for encoder parameters
     val configs2 = Map("listener.name.internal.ssl.keystore.password" -> "secret2")
-    val encoderConfigs2 = Map(KafkaConfig.PasswordEncoderSecretProp -> "encoder-secret",
-      KafkaConfig.PasswordEncoderCipherAlgorithmProp -> "DES/CBC/PKCS5Padding",
-      KafkaConfig.PasswordEncoderIterationsProp -> "1024",
-      KafkaConfig.PasswordEncoderKeyFactoryAlgorithmProp -> "PBKDF2WithHmacSHA1",
-      KafkaConfig.PasswordEncoderKeyLengthProp -> "64")
+    val encoderConfigs2 = Map(PASSWORD_ENCODER_SECRET_PROP -> "encoder-secret",
+      PASSWORD_ENCODER_CIPHER_ALGORITHM_PROP -> "DES/CBC/PKCS5Padding",
+      PASSWORD_ENCODER_ITERATIONS_PROP -> "1024",
+      PASSWORD_ENCODER_KEY_FACTORY_ALGORITHM_PROP -> "PBKDF2WithHmacSHA1",
+      PASSWORD_ENCODER_KEY_LENGTH_PROP -> "64")
     alterConfigWithZk(configs2, Some(brokerId), encoderConfigs2)
     val brokerConfigs2 = zkClient.getEntityConfigs("brokers", brokerId)
     val encodedPassword2 = brokerConfigs2.getProperty("listener.name.internal.ssl.keystore.password")

--- a/core/src/test/scala/integration/kafka/admin/RemoteTopicCrudTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/RemoteTopicCrudTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.config.{ConfigException, ConfigResource, TopicConfig}
 import org.apache.kafka.common.errors.{InvalidConfigurationException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.utils.MockTime
+import org.apache.kafka.server.config.KafkaConfig.{LOG_RETENTION_BYTES_PROP, LOG_RETENTION_TIME_MILLIS_PROP}
 import org.apache.kafka.server.log.remote.storage.{NoOpRemoteLogMetadataManager, NoOpRemoteStorageManager, RemoteLogManagerConfig, RemoteLogSegmentId, RemoteLogSegmentMetadata, RemoteLogSegmentState}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.function.Executable
@@ -387,9 +388,9 @@ class RemoteTopicCrudTest extends IntegrationTestHarness {
     props.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, sysRemoteStorageEnabled.toString)
     props.put(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, storageManagerClassName)
     props.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP, metadataManagerClassName)
-    props.put(KafkaConfig.LogRetentionTimeMillisProp, "2000")
+    props.put(LOG_RETENTION_TIME_MILLIS_PROP, "2000")
     props.put(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP, "1000")
-    props.put(KafkaConfig.LogRetentionBytesProp, "2048")
+    props.put(LOG_RETENTION_BYTES_PROP, "2048")
     props.put(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP, "1024")
     props
   }

--- a/core/src/test/scala/integration/kafka/api/AbstractAuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractAuthorizerIntegrationTest.scala
@@ -14,7 +14,7 @@ package kafka.api
 
 import kafka.security.authorizer.AclAuthorizer
 import kafka.security.authorizer.AclEntry.WildcardHost
-import kafka.server.{BaseRequestTest, KafkaConfig}
+import kafka.server.BaseRequestTest
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.TopicPartition
@@ -28,6 +28,7 @@ import org.apache.kafka.common.resource.{Resource, ResourcePattern}
 import org.apache.kafka.common.resource.ResourceType.{CLUSTER, GROUP, TOPIC, TRANSACTIONAL_ID}
 import org.apache.kafka.common.security.auth.{AuthenticationContext, KafkaPrincipal}
 import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder
+import org.apache.kafka.server.config.KafkaConfig
 import org.apache.kafka.metadata.authorizer.StandardAuthorizer
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 
@@ -91,7 +92,7 @@ class AbstractAuthorizerIntegrationTest extends BaseRequestTest {
   consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, group)
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.put(KafkaConfig.BrokerIdProp, brokerId.toString)
+    properties.put(KafkaConfig.BROKER_ID_PROP, brokerId.toString)
     addNodeProperties(properties)
   }
 
@@ -103,18 +104,18 @@ class AbstractAuthorizerIntegrationTest extends BaseRequestTest {
 
   private def addNodeProperties(properties: Properties): Unit = {
     if (isKRaftTest()) {
-      properties.put(KafkaConfig.AuthorizerClassNameProp, classOf[StandardAuthorizer].getName)
+      properties.put(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[StandardAuthorizer].getName)
       properties.put(StandardAuthorizer.SUPER_USERS_CONFIG, BrokerPrincipal.toString)
     } else {
-      properties.put(KafkaConfig.AuthorizerClassNameProp, classOf[AclAuthorizer].getName)
+      properties.put(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[AclAuthorizer].getName)
     }
 
-    properties.put(KafkaConfig.OffsetsTopicPartitionsProp, "1")
-    properties.put(KafkaConfig.OffsetsTopicReplicationFactorProp, "1")
-    properties.put(KafkaConfig.TransactionsTopicPartitionsProp, "1")
-    properties.put(KafkaConfig.TransactionsTopicReplicationFactorProp, "1")
-    properties.put(KafkaConfig.TransactionsTopicMinISRProp, "1")
-    properties.put(KafkaConfig.UnstableApiVersionsEnableProp, "true")
+    properties.put(KafkaConfig.OFFSETS_TOPIC_PARTITIONS_PROP, "1")
+    properties.put(KafkaConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, "1")
+    properties.put(KafkaConfig.TRANSACTIONS_TOPIC_PARTITIONS_PROP, "1")
+    properties.put(KafkaConfig.TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, "1")
+    properties.put(KafkaConfig.TRANSACTIONS_TOPIC_MIN_ISR_PROP, "1")
+    properties.put(KafkaConfig.UNSTABLE_API_VERSIONS_ENABLE_PROP, "true")
     properties.put(BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, classOf[PrincipalBuilder].getName)
   }
 

--- a/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
@@ -24,8 +24,9 @@ import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.record.TimestampType
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.server.config.KafkaConfig
 import kafka.utils.TestUtils
-import kafka.server.{BaseRequestTest, KafkaConfig}
+import kafka.server.BaseRequestTest
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 
@@ -66,12 +67,12 @@ abstract class AbstractConsumerTest extends BaseRequestTest {
 
 
   override protected def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.setProperty(KafkaConfig.ControlledShutdownEnableProp, "false") // speed up shutdown
-    properties.setProperty(KafkaConfig.OffsetsTopicReplicationFactorProp, "3") // don't want to lose offset
-    properties.setProperty(KafkaConfig.OffsetsTopicPartitionsProp, "1")
-    properties.setProperty(KafkaConfig.GroupMinSessionTimeoutMsProp, "100") // set small enough session timeout
-    properties.setProperty(KafkaConfig.GroupMaxSessionTimeoutMsProp, groupMaxSessionTimeoutMs.toString)
-    properties.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "10")
+    properties.setProperty(KafkaConfig.CONTROLLED_SHUTDOWN_ENABLE_PROP, "false") // speed up shutdown
+    properties.setProperty(KafkaConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, "3") // don't want to lose offset
+    properties.setProperty(KafkaConfig.OFFSETS_TOPIC_PARTITIONS_PROP, "1")
+    properties.setProperty(KafkaConfig.GROUP_MIN_SESSION_TIMEOUT_MS_PROP, "100") // set small enough session timeout
+    properties.setProperty(KafkaConfig.GROUP_MAX_SESSION_TIMEOUT_MS_PROP, groupMaxSessionTimeoutMs.toString)
+    properties.setProperty(KafkaConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, "10")
   }
 
   @BeforeEach

--- a/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
@@ -20,7 +20,6 @@ import java.util
 import java.util.Properties
 import java.util.concurrent.ExecutionException
 import kafka.security.authorizer.AclEntry
-import kafka.server.KafkaConfig
 import kafka.utils.Logging
 import kafka.utils.TestUtils._
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, CreateTopicsOptions, CreateTopicsResult, DescribeClusterOptions, DescribeTopicsOptions, NewTopic, TopicDescription}
@@ -29,6 +28,7 @@ import org.apache.kafka.common.acl.AclOperation
 import org.apache.kafka.common.errors.{TopicExistsException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.resource.ResourceType
 import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo, Timeout}
 
@@ -196,20 +196,20 @@ abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logg
     // verify that they show up in the "configs" output of CreateTopics.
     if (testInfo.getTestMethod.toString.contains("testCreateTopicsReturnsConfigs")) {
       configs.foreach(config => {
-        config.setProperty(KafkaConfig.LogRollTimeHoursProp, "2")
-        config.setProperty(KafkaConfig.LogRetentionTimeMinutesProp, "240")
-        config.setProperty(KafkaConfig.LogRollTimeJitterMillisProp, "123")
+        config.setProperty(KafkaConfig.LOG_ROLL_TIME_HOURS_PROP, "2")
+        config.setProperty(KafkaConfig.LOG_RETENTION_TIME_MINUTES_PROP, "240")
+        config.setProperty(KafkaConfig.LOG_ROLL_TIME_JITTER_MILLIS_PROP, "123")
       })
     }
     configs.foreach { config =>
-      config.setProperty(KafkaConfig.DeleteTopicEnableProp, "true")
-      config.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
-      config.setProperty(KafkaConfig.AutoLeaderRebalanceEnableProp, "false")
-      config.setProperty(KafkaConfig.ControlledShutdownEnableProp, "false")
+      config.setProperty(KafkaConfig.DELETE_TOPIC_ENABLE_PROP, "true")
+      config.setProperty(KafkaConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, "0")
+      config.setProperty(KafkaConfig.AUTO_LEADER_REBALANCE_ENABLE_PROP, "false")
+      config.setProperty(KafkaConfig.CONTROLLED_SHUTDOWN_ENABLE_PROP, "false")
       // We set this in order to test that we don't expose sensitive data via describe configs. This will already be
       // set for subclasses with security enabled and we don't want to overwrite it.
-      if (!config.containsKey(KafkaConfig.SslTruststorePasswordProp))
-        config.setProperty(KafkaConfig.SslTruststorePasswordProp, "some.invalid.pass")
+      if (!config.containsKey(KafkaConfig.SSL_TRUSTSTORE_PASSWORD_PROP))
+        config.setProperty(KafkaConfig.SSL_TRUSTSTORE_PASSWORD_PROP, "some.invalid.pass")
     }
   }
 

--- a/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
@@ -33,6 +33,7 @@ import org.apache.kafka.common.network.{ListenerName, Mode}
 import org.apache.kafka.common.record.TimestampType
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.{KafkaException, TopicPartition}
+import org.apache.kafka.server.config.KafkaConfig.NUM_PARTITIONS_PROP
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -47,7 +48,7 @@ abstract class BaseProducerSendTest extends KafkaServerTestHarness {
   def generateConfigs: scala.collection.Seq[KafkaConfig] = {
     val overridingProps = new Properties()
     val numServers = 2
-    overridingProps.put(KafkaConfig.NumPartitionsProp, 4.toString)
+    overridingProps.put(NUM_PARTITIONS_PROP, 4.toString)
     TestUtils.createBrokerConfigs(
       numServers,
       zkConnectOrNull,

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit
 import java.util.{Collections, HashMap, Properties}
 import com.yammer.metrics.core.{Histogram, Meter}
 import kafka.api.QuotaTestClients._
-import kafka.server.{ClientQuotaManager, KafkaBroker, KafkaConfig, QuotaType}
+import kafka.server.{ClientQuotaManager, KafkaBroker, QuotaType}
 import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.admin.Admin
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig}
@@ -34,6 +34,7 @@ import org.apache.kafka.common.quota.ClientQuotaEntity
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.config.ClientQuotaManagerConfig
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -50,12 +51,12 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
   protected def consumerClientId = "QuotasTestConsumer-1"
   protected def createQuotaTestClients(topic: String, leaderNode: KafkaBroker): QuotaTestClients
 
-  this.serverConfig.setProperty(KafkaConfig.ControlledShutdownEnableProp, "false")
-  this.serverConfig.setProperty(KafkaConfig.OffsetsTopicReplicationFactorProp, "2")
-  this.serverConfig.setProperty(KafkaConfig.OffsetsTopicPartitionsProp, "1")
-  this.serverConfig.setProperty(KafkaConfig.GroupMinSessionTimeoutMsProp, "100")
-  this.serverConfig.setProperty(KafkaConfig.GroupMaxSessionTimeoutMsProp, "60000")
-  this.serverConfig.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
+  this.serverConfig.setProperty(KafkaConfig.CONTROLLED_SHUTDOWN_ENABLE_PROP, "false")
+  this.serverConfig.setProperty(KafkaConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, "2")
+  this.serverConfig.setProperty(KafkaConfig.OFFSETS_TOPIC_PARTITIONS_PROP, "1")
+  this.serverConfig.setProperty(KafkaConfig.GROUP_MIN_SESSION_TIMEOUT_MS_PROP, "100")
+  this.serverConfig.setProperty(KafkaConfig.GROUP_MAX_SESSION_TIMEOUT_MS_PROP, "60000")
+  this.serverConfig.setProperty(KafkaConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, "0")
   this.producerConfig.setProperty(ProducerConfig.ACKS_CONFIG, "-1")
   this.producerConfig.setProperty(ProducerConfig.BUFFER_MEMORY_CONFIG, "300000")
   this.producerConfig.setProperty(ProducerConfig.CLIENT_ID_CONFIG, producerClientId)

--- a/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
@@ -25,6 +25,7 @@ import org.apache.kafka.common.errors.GroupMaxSizeReachedException
 import org.apache.kafka.common.message.FindCoordinatorRequestData
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{FindCoordinatorRequest, FindCoordinatorResponse}
+import org.apache.kafka.server.config.KafkaConfig.{OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, OFFSETS_TOPIC_PARTITIONS_PROP, GROUP_MIN_SESSION_TIMEOUT_MS_PROP, GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, GROUP_MAX_SIZE_PROP, UNCLEAN_LEADER_ELECTION_ENABLE_PROP, AUTO_CREATE_TOPICS_ENABLE_PROP}
 import org.apache.kafka.server.util.ShutdownableThread
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, Disabled, Test}
@@ -53,13 +54,13 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
 
   private def generateKafkaConfigs(maxGroupSize: String = maxGroupSize.toString): Seq[KafkaConfig] = {
     val properties = new Properties
-    properties.put(KafkaConfig.OffsetsTopicReplicationFactorProp, "3") // don't want to lose offset
-    properties.put(KafkaConfig.OffsetsTopicPartitionsProp, "1")
-    properties.put(KafkaConfig.GroupMinSessionTimeoutMsProp, "10") // set small enough session timeout
-    properties.put(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
-    properties.put(KafkaConfig.GroupMaxSizeProp, maxGroupSize)
-    properties.put(KafkaConfig.UncleanLeaderElectionEnableProp, "true")
-    properties.put(KafkaConfig.AutoCreateTopicsEnableProp, "false")
+    properties.put(OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, "3") // don't want to lose offset
+    properties.put(OFFSETS_TOPIC_PARTITIONS_PROP, "1")
+    properties.put(GROUP_MIN_SESSION_TIMEOUT_MS_PROP, "10") // set small enough session timeout
+    properties.put(GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, "0")
+    properties.put(GROUP_MAX_SIZE_PROP, maxGroupSize)
+    properties.put(UNCLEAN_LEADER_ELECTION_ENABLE_PROP, "true")
+    properties.put(AUTO_CREATE_TOPICS_ENABLE_PROP, "false")
 
     FixedPortTestUtils.createBrokerConfigs(brokerCount, zkConnect, enableControlledShutdown = false)
       .map(KafkaConfig.fromProps(_, properties))

--- a/core/src/test/scala/integration/kafka/api/ConsumerTopicCreationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerTopicCreationTest.scala
@@ -22,11 +22,11 @@ import java.time.Duration
 import java.util
 import java.util.Collections
 
-import kafka.server.KafkaConfig
 import kafka.utils.{EmptyTestInfo, TestUtils}
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
@@ -55,8 +55,8 @@ object ConsumerTopicCreationTest {
     private val consumerClientId = "ConsumerTestConsumer"
 
     // configure server properties
-    this.serverConfig.setProperty(KafkaConfig.ControlledShutdownEnableProp, "false") // speed up shutdown
-    this.serverConfig.setProperty(KafkaConfig.AutoCreateTopicsEnableProp, brokerAutoTopicCreationEnable.toString)
+    this.serverConfig.setProperty(KafkaConfig.CONTROLLED_SHUTDOWN_ENABLE_PROP, "false") // speed up shutdown
+    this.serverConfig.setProperty(KafkaConfig.AUTO_CREATE_TOPICS_ENABLE_PROP, brokerAutoTopicCreationEnable.toString)
 
     // configure client properties
     this.producerConfig.setProperty(ProducerConfig.CLIENT_ID_CONFIG, producerClientId)

--- a/core/src/test/scala/integration/kafka/api/ConsumerWithLegacyMessageFormatIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerWithLegacyMessageFormatIntegrationTest.scala
@@ -16,11 +16,11 @@
  */
 package kafka.api
 
-import kafka.server.KafkaConfig
 import kafka.utils.TestInfoUtils
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
+import org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_PROTOCOL_VERSION_PROP
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNull, assertThrows}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -36,7 +36,7 @@ class ConsumerWithLegacyMessageFormatIntegrationTest extends AbstractConsumerTes
     // legacy message formats are only supported with IBP < 3.0
     // KRaft mode is not supported for inter.broker.protocol.version = 2.8, The minimum version required is 3.0-IV1"
     if (!isKRaftTest())
-      properties.put(KafkaConfig.InterBrokerProtocolVersionProp, "2.8")
+      properties.put(INTER_BROKER_PROTOCOL_VERSION_PROP, "2.8")
   }
 
   @nowarn("cat=deprecation")

--- a/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
+++ b/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
@@ -32,6 +32,8 @@ import org.apache.kafka.common.{Cluster, Reconfigurable}
 import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth._
+
+import org.apache.kafka.server.config.KafkaConfig
 import org.apache.kafka.server.quota._
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
@@ -62,10 +64,10 @@ class CustomQuotaCallbackTest extends IntegrationTestHarness with SaslSetup {
   @BeforeEach
   override def setUp(testInfo: TestInfo): Unit = {
     startSasl(jaasSections(kafkaServerSaslMechanisms, Some("SCRAM-SHA-256"), KafkaSasl, JaasTestUtils.KafkaServerContextName))
-    this.serverConfig.setProperty(KafkaConfig.ClientQuotaCallbackClassProp, classOf[GroupedUserQuotaCallback].getName)
-    this.serverConfig.setProperty(s"${listenerName.configPrefix}${KafkaConfig.PrincipalBuilderClassProp}",
+    this.serverConfig.setProperty(KafkaConfig.CLIENT_QUOTA_CALLBACK_CLASS_PROP, classOf[GroupedUserQuotaCallback].getName)
+    this.serverConfig.setProperty(s"${listenerName.configPrefix}${KafkaConfig.PRINCIPAL_BUILDER_CLASS_PROP}",
       classOf[GroupedUserPrincipalBuilder].getName)
-    this.serverConfig.setProperty(KafkaConfig.DeleteTopicEnableProp, "true")
+    this.serverConfig.setProperty(KafkaConfig.DELETE_TOPIC_ENABLE_PROP, "true")
     super.setUp(testInfo)
 
     producerConfig.put(SaslConfigs.SASL_JAAS_CONFIG,
@@ -367,7 +369,7 @@ class GroupedUserQuotaCallback extends ClientQuotaCallback with Reconfigurable w
   val partitionRatio = new ConcurrentHashMap[String, Double]()
 
   override def configure(configs: util.Map[String, _]): Unit = {
-    brokerId = configs.get(KafkaConfig.BrokerIdProp).toString.toInt
+    brokerId = configs.get(KafkaConfig.BROKER_ID_PROP).toString.toInt
     callbackInstances.incrementAndGet
   }
 

--- a/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationTest.scala
@@ -18,7 +18,6 @@ package kafka.api
 
 import java.util.Properties
 
-import kafka.server.KafkaConfig
 import kafka.utils._
 import kafka.tools.StorageTool
 import kafka.zk.ConfigEntityChangeNotificationZNode
@@ -27,6 +26,7 @@ import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.security.token.delegation.DelegationToken
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -54,8 +54,8 @@ class DelegationTokenEndToEndAuthorizationTest extends EndToEndAuthorizationTest
 
   protected val privilegedAdminClientConfig = new Properties()
 
-  this.serverConfig.setProperty(KafkaConfig.DelegationTokenSecretKeyProp, "testKey")
-  this.controllerConfig.setProperty(KafkaConfig.DelegationTokenSecretKeyProp, "testKey")
+  this.serverConfig.setProperty(KafkaConfig.DELEGATION_TOKEN_SECRET_KEY_PROP, "testKey")
+  this.controllerConfig.setProperty(KafkaConfig.DELEGATION_TOKEN_SECRET_KEY_PROP, "testKey")
 
   def createDelegationTokenOptions(): CreateDelegationTokenOptions = new CreateDelegationTokenOptions()
 

--- a/core/src/test/scala/integration/kafka/api/DescribeAuthorizedOperationsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DescribeAuthorizedOperationsTest.scala
@@ -16,7 +16,6 @@ import java.util
 import java.util.Properties
 
 import kafka.security.authorizer.{AclAuthorizer, AclEntry}
-import kafka.server.KafkaConfig
 import kafka.utils.{CoreUtils, JaasTestUtils, TestUtils}
 import org.apache.kafka.clients.admin._
 import org.apache.kafka.common.acl.AclOperation.{ALL, ALTER, CLUSTER_ACTION, DELETE, DESCRIBE}
@@ -26,6 +25,7 @@ import org.apache.kafka.common.resource.{PatternType, Resource, ResourcePattern,
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.server.authorizer.Authorizer
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNull}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
 
@@ -75,8 +75,8 @@ class DescribeAuthorizedOperationsTest extends IntegrationTestHarness with SaslS
   import DescribeAuthorizedOperationsTest._
 
   override val brokerCount = 1
-  this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "true")
-  this.serverConfig.setProperty(KafkaConfig.AuthorizerClassNameProp, classOf[AclAuthorizer].getName)
+  this.serverConfig.setProperty(KafkaConfig.ZK_ENABLE_SECURE_ACLS_PROP, "true")
+  this.serverConfig.setProperty(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[AclAuthorizer].getName)
 
   var client: Admin = _
 

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -24,7 +24,6 @@ import java.util.concurrent.ExecutionException
 import kafka.security.authorizer.AclAuthorizer
 import kafka.security.authorizer.AclEntry.WildcardHost
 import org.apache.kafka.metadata.authorizer.StandardAuthorizer
-import kafka.server._
 import kafka.utils._
 import org.apache.kafka.clients.admin.Admin
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig, ConsumerRecords}
@@ -38,6 +37,7 @@ import org.apache.kafka.common.resource._
 import org.apache.kafka.common.resource.ResourceType._
 import org.apache.kafka.common.resource.PatternType.{LITERAL, PREFIXED}
 import org.apache.kafka.common.security.auth._
+import org.apache.kafka.server.config.KafkaConfig
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo, Timeout}
@@ -132,11 +132,11 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     new AccessControlEntry(clientPrincipal.toString, "*", AclOperation.READ, AclPermissionType.ALLOW))
 
   // Some needed configuration for brokers, producers, and consumers
-  this.serverConfig.setProperty(KafkaConfig.OffsetsTopicPartitionsProp, "1")
-  this.serverConfig.setProperty(KafkaConfig.OffsetsTopicReplicationFactorProp, "3")
-  this.serverConfig.setProperty(KafkaConfig.MinInSyncReplicasProp, "3")
-  this.serverConfig.setProperty(KafkaConfig.DefaultReplicationFactorProp, "3")
-  this.serverConfig.setProperty(KafkaConfig.ConnectionsMaxReauthMsProp, "1500")
+  this.serverConfig.setProperty(KafkaConfig.OFFSETS_TOPIC_PARTITIONS_PROP, "1")
+  this.serverConfig.setProperty(KafkaConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, "3")
+  this.serverConfig.setProperty(KafkaConfig.MIN_IN_SYNC_REPLICAS_PROP, "3")
+  this.serverConfig.setProperty(KafkaConfig.DEFAULT_REPLICATION_FACTOR_PROP, "3")
+  this.serverConfig.setProperty(KafkaConfig.CONNECTIONS_MAX_REAUTH_MS_PROP, "1500")
   this.consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "group")
   this.consumerConfig.setProperty(ConsumerConfig.METADATA_MAX_AGE_CONFIG, "1500")
 
@@ -151,13 +151,13 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     if (TestInfoUtils.isKRaft(testInfo)) {
       this.serverConfig.setProperty(StandardAuthorizer.SUPER_USERS_CONFIG, kafkaPrincipal.toString)
       this.controllerConfig.setProperty(StandardAuthorizer.SUPER_USERS_CONFIG, kafkaPrincipal.toString + ";" + "User:ANONYMOUS")
-      this.serverConfig.setProperty(KafkaConfig.AuthorizerClassNameProp, classOf[StandardAuthorizer].getName)
-      this.controllerConfig.setProperty(KafkaConfig.AuthorizerClassNameProp, classOf[StandardAuthorizer].getName)
+      this.serverConfig.setProperty(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[StandardAuthorizer].getName)
+      this.controllerConfig.setProperty(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[StandardAuthorizer].getName)
     } else {
       // The next two configuration parameters enable ZooKeeper secure ACLs
       // and sets the Kafka authorizer, both necessary to enable security.
-      this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "true")
-      this.serverConfig.setProperty(KafkaConfig.AuthorizerClassNameProp, authorizerClass.getName)
+      this.serverConfig.setProperty(KafkaConfig.ZK_ENABLE_SECURE_ACLS_PROP, "true")
+      this.serverConfig.setProperty(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, authorizerClass.getName)
 
       // Set the specific principal that can update ACLs.
       this.serverConfig.setProperty(AclAuthorizer.SuperUsersProp, kafkaPrincipal.toString)

--- a/core/src/test/scala/integration/kafka/api/EndToEndClusterIdTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndClusterIdTest.scala
@@ -27,6 +27,7 @@ import kafka.utils.Implicits._
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.{ClusterResource, ClusterResourceListener, TopicPartition}
+import org.apache.kafka.server.config.KafkaConfig.METRIC_REPORTER_CLASSES_PROP
 import org.apache.kafka.test.{TestUtils => _, _}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
@@ -98,7 +99,7 @@ class EndToEndClusterIdTest extends KafkaServerTestHarness {
   val topic = "e2etopic"
   val part = 0
   val tp = new TopicPartition(topic, part)
-  this.serverConfig.setProperty(KafkaConfig.MetricReporterClassesProp, classOf[MockBrokerMetricsReporter].getName)
+  this.serverConfig.setProperty(METRIC_REPORTER_CLASSES_PROP, classOf[MockBrokerMetricsReporter].getName)
 
   override def generateConfigs = {
     val cfgs = TestUtils.createBrokerConfigs(serverCount, zkConnectOrNull, interBrokerSecurityProtocol = Some(securityProtocol),

--- a/core/src/test/scala/integration/kafka/api/GroupAuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/GroupAuthorizerIntegrationTest.scala
@@ -17,7 +17,7 @@ import java.util.concurrent.ExecutionException
 import kafka.api.GroupAuthorizerIntegrationTest._
 import kafka.security.authorizer.AclAuthorizer
 import kafka.security.authorizer.AclEntry.WildcardHost
-import kafka.server.{BaseRequestTest, KafkaConfig}
+import kafka.server.BaseRequestTest
 import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -30,6 +30,7 @@ import org.apache.kafka.common.resource.{PatternType, Resource, ResourcePattern,
 import org.apache.kafka.common.security.auth.{AuthenticationContext, KafkaPrincipal}
 import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder
 import org.apache.kafka.metadata.authorizer.StandardAuthorizer
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -74,23 +75,23 @@ class GroupAuthorizerIntegrationTest extends BaseRequestTest {
   }
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.put(KafkaConfig.BrokerIdProp, brokerId.toString)
+    properties.put(KafkaConfig.BROKER_ID_PROP, brokerId.toString)
     addNodeProperties(properties)
   }
 
   private def addNodeProperties(properties: Properties): Unit = {
     if (isKRaftTest()) {
-      properties.put(KafkaConfig.AuthorizerClassNameProp, classOf[StandardAuthorizer].getName)
+      properties.put(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[StandardAuthorizer].getName)
       properties.put(StandardAuthorizer.SUPER_USERS_CONFIG, BrokerPrincipal.toString)
     } else {
-      properties.put(KafkaConfig.AuthorizerClassNameProp, classOf[AclAuthorizer].getName)
+      properties.put(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[AclAuthorizer].getName)
     }
 
-    properties.put(KafkaConfig.OffsetsTopicPartitionsProp, "1")
-    properties.put(KafkaConfig.OffsetsTopicReplicationFactorProp, "1")
-    properties.put(KafkaConfig.TransactionsTopicPartitionsProp, "1")
-    properties.put(KafkaConfig.TransactionsTopicReplicationFactorProp, "1")
-    properties.put(KafkaConfig.TransactionsTopicMinISRProp, "1")
+    properties.put(KafkaConfig.OFFSETS_TOPIC_PARTITIONS_PROP, "1")
+    properties.put(KafkaConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, "1")
+    properties.put(KafkaConfig.TRANSACTIONS_TOPIC_PARTITIONS_PROP, "1")
+    properties.put(KafkaConfig.TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, "1")
+    properties.put(KafkaConfig.TRANSACTIONS_TOPIC_MIN_ISR_PROP, "1")
     properties.put(BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, classOf[GroupPrincipalBuilder].getName)
   }
 

--- a/core/src/test/scala/integration/kafka/api/GroupCoordinatorIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/GroupCoordinatorIntegrationTest.scala
@@ -18,6 +18,7 @@ import kafka.server.KafkaConfig
 import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.server.config.KafkaConfig.{OFFSETS_TOPIC_PARTITIONS_PROP, OFFSETS_TOPIC_COMPRESSION_CODEC_PROP}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -31,8 +32,8 @@ import org.apache.kafka.common.record.CompressionType
 class GroupCoordinatorIntegrationTest extends KafkaServerTestHarness {
   val offsetsTopicCompressionCodec = CompressionType.GZIP
   val overridingProps = new Properties()
-  overridingProps.put(KafkaConfig.OffsetsTopicPartitionsProp, "1")
-  overridingProps.put(KafkaConfig.OffsetsTopicCompressionCodecProp, offsetsTopicCompressionCodec.id.toString)
+  overridingProps.put(OFFSETS_TOPIC_PARTITIONS_PROP, "1")
+  overridingProps.put(OFFSETS_TOPIC_COMPRESSION_CODEC_PROP, offsetsTopicCompressionCodec.id.toString)
 
   override def generateConfigs = TestUtils.createBrokerConfigs(1, zkConnectOrNull, enableControlledShutdown = false).map {
     KafkaConfig.fromProps(_, overridingProps)

--- a/core/src/test/scala/integration/kafka/api/LogAppendTimeTest.scala
+++ b/core/src/test/scala/integration/kafka/api/LogAppendTimeTest.scala
@@ -18,10 +18,10 @@ package kafka.api
 
 import java.util.Collections
 import java.util.concurrent.TimeUnit
-import kafka.server.KafkaConfig
 import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.record.TimestampType
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals, assertTrue}
 import org.junit.jupiter.params.ParameterizedTest
@@ -37,8 +37,8 @@ class LogAppendTimeTest extends IntegrationTestHarness {
   val brokerCount: Int = 2
 
   // This will be used for the offsets topic as well
-  serverConfig.put(KafkaConfig.LogMessageTimestampTypeProp, TimestampType.LOG_APPEND_TIME.name)
-  serverConfig.put(KafkaConfig.OffsetsTopicReplicationFactorProp, "2")
+  serverConfig.put(KafkaConfig.LOG_MESSAGE_TIMESTAMP_TYPE_PROP, TimestampType.LOG_APPEND_TIME.name)
+  serverConfig.put(KafkaConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, "2")
 
   private val topic = "topic"
 

--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -13,7 +13,7 @@
 package kafka.api
 
 import java.util.{Locale, Properties}
-import kafka.server.{KafkaConfig, KafkaServer}
+import kafka.server.KafkaServer
 import kafka.utils.{JaasTestUtils, TestUtils}
 import com.yammer.metrics.core.{Gauge, Histogram, Meter}
 import org.apache.kafka.clients.consumer.Consumer
@@ -24,6 +24,7 @@ import org.apache.kafka.common.errors.{InvalidTopicException, UnknownTopicOrPart
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.security.authenticator.TestJaasConfig
+import org.apache.kafka.server.config.KafkaConfig
 import org.apache.kafka.server.log.remote.storage.{NoOpRemoteLogMetadataManager, NoOpRemoteStorageManager, RemoteLogManagerConfig, RemoteStorageMetrics}
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
@@ -43,9 +44,9 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
   private val kafkaServerSaslMechanisms = List(kafkaClientSaslMechanism)
   private val kafkaServerJaasEntryName =
     s"${listenerName.value.toLowerCase(Locale.ROOT)}.${JaasTestUtils.KafkaServerContextName}"
-  this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "false")
-  this.serverConfig.setProperty(KafkaConfig.AutoCreateTopicsEnableProp, "false")
-  this.serverConfig.setProperty(KafkaConfig.InterBrokerProtocolVersionProp, "2.8")
+  this.serverConfig.setProperty(KafkaConfig.ZK_ENABLE_SECURE_ACLS_PROP, "false")
+  this.serverConfig.setProperty(KafkaConfig.AUTO_CREATE_TOPICS_ENABLE_PROP, "false")
+  this.serverConfig.setProperty(KafkaConfig.INTER_BROKER_PROTOCOL_VERSION_PROP, "2.8")
   this.producerConfig.setProperty(ProducerConfig.LINGER_MS_CONFIG, "10")
   // intentionally slow message down conversion via gzip compression to ensure we can measure the time it takes
   this.producerConfig.setProperty(ProducerConfig.COMPRESSION_TYPE_CONFIG, "gzip")

--- a/core/src/test/scala/integration/kafka/api/ProducerFailureHandlingTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerFailureHandlingTest.scala
@@ -20,13 +20,14 @@ package kafka.api
 import java.util.concurrent.ExecutionException
 import java.util.Properties
 import kafka.integration.KafkaServerTestHarness
-import kafka.server.KafkaConfig
+import kafka.server.KafkaConfig.fromProps
 import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.producer._
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.record.{DefaultRecord, DefaultRecordBatch}
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -41,16 +42,16 @@ class ProducerFailureHandlingTest extends KafkaServerTestHarness {
   val numServers = 2
 
   val overridingProps = new Properties()
-  overridingProps.put(KafkaConfig.AutoCreateTopicsEnableProp, false.toString)
-  overridingProps.put(KafkaConfig.MessageMaxBytesProp, serverMessageMaxBytes.toString)
-  overridingProps.put(KafkaConfig.ReplicaFetchMaxBytesProp, replicaFetchMaxPartitionBytes.toString)
-  overridingProps.put(KafkaConfig.ReplicaFetchResponseMaxBytesDoc, replicaFetchMaxResponseBytes.toString)
+  overridingProps.put(KafkaConfig.AUTO_CREATE_TOPICS_ENABLE_PROP, false.toString)
+  overridingProps.put(KafkaConfig.MESSAGE_MAX_BYTES_PROP, serverMessageMaxBytes.toString)
+  overridingProps.put(KafkaConfig.REPLICA_FETCH_MAX_BYTES_PROP, replicaFetchMaxPartitionBytes.toString)
+  overridingProps.put(KafkaConfig.REPLICA_FETCH_RESPONSE_MAX_BYTES_DOC, replicaFetchMaxResponseBytes.toString)
   // Set a smaller value for the number of partitions for the offset commit topic (__consumer_offset topic)
   // so that the creation of that topic/partition(s) and subsequent leader assignment doesn't take relatively long
-  overridingProps.put(KafkaConfig.OffsetsTopicPartitionsProp, 1.toString)
+  overridingProps.put(KafkaConfig.OFFSETS_TOPIC_PARTITIONS_PROP, 1.toString)
 
   def generateConfigs =
-    TestUtils.createBrokerConfigs(numServers, zkConnectOrNull, false).map(KafkaConfig.fromProps(_, overridingProps))
+    TestUtils.createBrokerConfigs(numServers, zkConnectOrNull, false).map(fromProps(_, overridingProps))
 
   private var producer1: KafkaProducer[Array[Byte], Array[Byte]] = _
   private var producer2: KafkaProducer[Array[Byte], Array[Byte]] = _

--- a/core/src/test/scala/integration/kafka/api/ProducerIdExpirationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerIdExpirationTest.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors.{InvalidPidMappingException, TransactionalIdNotFoundException}
+import org.apache.kafka.server.config.KafkaConfig.{PRODUCER_ID_EXPIRATION_MS_PROP, AUTO_CREATE_TOPICS_ENABLE_PROP, OFFSETS_TOPIC_PARTITIONS_PROP, TRANSACTIONS_TOPIC_PARTITIONS_PROP, TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, TRANSACTIONS_TOPIC_MIN_ISR_PROP, CONTROLLED_SHUTDOWN_ENABLE_PROP, UNCLEAN_LEADER_ELECTION_ENABLE_PROP, AUTO_LEADER_REBALANCE_ENABLE_PROP, GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, TRANSACTIONS_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS_PROP, TRANSACTIONAL_ID_EXPIRATION_MS_PROP, TRANSACTIONS_REMOVE_EXPIRED_TRANSACTIONAL_ID_CLEANUP_INTERVAL_MS_PROP, PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS_PROP}
 import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
@@ -202,7 +203,7 @@ class ProducerIdExpirationTest extends KafkaServerTestHarness {
   }
 
   private def producerIdExpirationConfig(configValue: String): Map[ConfigResource, util.Collection[AlterConfigOp]] = {
-    val producerIdCfg = new ConfigEntry(KafkaConfig.ProducerIdExpirationMsProp, configValue)
+    val producerIdCfg = new ConfigEntry(PRODUCER_ID_EXPIRATION_MS_PROP, configValue)
     val configs = Collections.singletonList(new AlterConfigOp(producerIdCfg, AlterConfigOp.OpType.SET))
     Collections.singletonMap(configResource, configs)
   }
@@ -224,22 +225,22 @@ class ProducerIdExpirationTest extends KafkaServerTestHarness {
 
   private def serverProps(): Properties = {
     val serverProps = new Properties()
-    serverProps.put(KafkaConfig.AutoCreateTopicsEnableProp, false.toString)
+    serverProps.put(AUTO_CREATE_TOPICS_ENABLE_PROP, false.toString)
     // Set a smaller value for the number of partitions for the __consumer_offsets topic
     // so that the creation of that topic/partition(s) and subsequent leader assignment doesn't take relatively long.
-    serverProps.put(KafkaConfig.OffsetsTopicPartitionsProp, 1.toString)
-    serverProps.put(KafkaConfig.TransactionsTopicPartitionsProp, 3.toString)
-    serverProps.put(KafkaConfig.TransactionsTopicReplicationFactorProp, 2.toString)
-    serverProps.put(KafkaConfig.TransactionsTopicMinISRProp, 2.toString)
-    serverProps.put(KafkaConfig.ControlledShutdownEnableProp, true.toString)
-    serverProps.put(KafkaConfig.UncleanLeaderElectionEnableProp, false.toString)
-    serverProps.put(KafkaConfig.AutoLeaderRebalanceEnableProp, false.toString)
-    serverProps.put(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
-    serverProps.put(KafkaConfig.TransactionsAbortTimedOutTransactionCleanupIntervalMsProp, "200")
-    serverProps.put(KafkaConfig.TransactionalIdExpirationMsProp, "5000")
-    serverProps.put(KafkaConfig.TransactionsRemoveExpiredTransactionalIdCleanupIntervalMsProp, "500")
-    serverProps.put(KafkaConfig.ProducerIdExpirationMsProp, "10000")
-    serverProps.put(KafkaConfig.ProducerIdExpirationCheckIntervalMsProp, "500")
+    serverProps.put(OFFSETS_TOPIC_PARTITIONS_PROP, 1.toString)
+    serverProps.put(TRANSACTIONS_TOPIC_PARTITIONS_PROP, 3.toString)
+    serverProps.put(TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, 2.toString)
+    serverProps.put(TRANSACTIONS_TOPIC_MIN_ISR_PROP, 2.toString)
+    serverProps.put(CONTROLLED_SHUTDOWN_ENABLE_PROP, true.toString)
+    serverProps.put(UNCLEAN_LEADER_ELECTION_ENABLE_PROP, false.toString)
+    serverProps.put(AUTO_LEADER_REBALANCE_ENABLE_PROP, false.toString)
+    serverProps.put(GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, "0")
+    serverProps.put(TRANSACTIONS_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS_PROP, "200")
+    serverProps.put(TRANSACTIONAL_ID_EXPIRATION_MS_PROP, "5000")
+    serverProps.put(TRANSACTIONS_REMOVE_EXPIRED_TRANSACTIONAL_ID_CLEANUP_INTERVAL_MS_PROP, "500")
+    serverProps.put(PRODUCER_ID_EXPIRATION_MS_PROP, "10000")
+    serverProps.put(PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS_PROP, "500")
     serverProps
   }
 }

--- a/core/src/test/scala/integration/kafka/api/ProducerSendWhileDeletionTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerSendWhileDeletionTest.scala
@@ -16,11 +16,11 @@
  */
 package kafka.api
 
-import kafka.server.KafkaConfig
 import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.admin.NewPartitionReassignment
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -35,9 +35,9 @@ class ProducerSendWhileDeletionTest extends IntegrationTestHarness {
   val producerCount: Int = 1
   val brokerCount: Int = 2
 
-  serverConfig.put(KafkaConfig.NumPartitionsProp, 2.toString)
-  serverConfig.put(KafkaConfig.DefaultReplicationFactorProp, 2.toString)
-  serverConfig.put(KafkaConfig.AutoLeaderRebalanceEnableProp, false.toString)
+  serverConfig.put(KafkaConfig.NUM_PARTITIONS_PROP, 2.toString)
+  serverConfig.put(KafkaConfig.DEFAULT_REPLICATION_FACTOR_PROP, 2.toString)
+  serverConfig.put(KafkaConfig.AUTO_LEADER_REBALANCE_ENABLE_PROP, false.toString)
 
   producerConfig.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 5000L.toString)
   producerConfig.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 10000.toString)

--- a/core/src/test/scala/integration/kafka/api/RackAwareAutoTopicCreationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/RackAwareAutoTopicCreationTest.scala
@@ -23,6 +23,7 @@ import kafka.integration.KafkaServerTestHarness
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.server.config.KafkaConfig.{NUM_PARTITIONS_PROP, DEFAULT_REPLICATION_FACTOR_PROP}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 import scala.collection.Map
@@ -32,8 +33,8 @@ class RackAwareAutoTopicCreationTest extends KafkaServerTestHarness with RackAwa
   val numPartitions = 8
   val replicationFactor = 2
   val overridingProps = new Properties()
-  overridingProps.put(KafkaConfig.NumPartitionsProp, numPartitions.toString)
-  overridingProps.put(KafkaConfig.DefaultReplicationFactorProp, replicationFactor.toString)
+  overridingProps.put(NUM_PARTITIONS_PROP, numPartitions.toString)
+  overridingProps.put(DEFAULT_REPLICATION_FACTOR_PROP, replicationFactor.toString)
 
   def generateConfigs =
     (0 until numServers) map { node =>

--- a/core/src/test/scala/integration/kafka/api/SaslClientsWithInvalidCredentialsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslClientsWithInvalidCredentialsTest.scala
@@ -21,9 +21,9 @@ import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.common.errors.SaslAuthenticationException
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
 import org.junit.jupiter.api.Assertions._
-import kafka.server.KafkaConfig
 import kafka.utils.{JaasTestUtils, TestUtils}
 import kafka.zk.ConfigEntityChangeNotificationZNode
 import org.apache.kafka.common.security.auth.SecurityProtocol
@@ -40,9 +40,9 @@ class SaslClientsWithInvalidCredentialsTest extends AbstractSaslTest {
   val producerCount = 1
   val brokerCount = 1
 
-  this.serverConfig.setProperty(KafkaConfig.OffsetsTopicReplicationFactorProp, "1")
-  this.serverConfig.setProperty(KafkaConfig.TransactionsTopicReplicationFactorProp, "1")
-  this.serverConfig.setProperty(KafkaConfig.TransactionsTopicMinISRProp, "1")
+  this.serverConfig.setProperty(KafkaConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, "1")
+  this.serverConfig.setProperty(KafkaConfig.TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, "1")
+  this.serverConfig.setProperty(KafkaConfig.TRANSACTIONS_TOPIC_MIN_ISR_PROP, "1")
   this.consumerConfig.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
 
   val topic = "topic"

--- a/core/src/test/scala/integration/kafka/api/SaslGssapiSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslGssapiSslEndToEndAuthorizationTest.scala
@@ -17,10 +17,10 @@
 package kafka.api
 
 import kafka.security.authorizer.AclAuthorizer
-import kafka.server.KafkaConfig
 import kafka.utils.JaasTestUtils
 import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.security.auth._
+import org.apache.kafka.server.config.KafkaConfig
 
 import org.junit.jupiter.api.Assertions.assertNull
 
@@ -39,8 +39,8 @@ class SaslGssapiSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTe
   // Configure brokers to require SSL client authentication in order to verify that SASL_SSL works correctly even if the
   // client doesn't have a keystore. We want to cover the scenario where a broker requires either SSL client
   // authentication or SASL authentication with SSL as the transport layer (but not both).
-  serverConfig.put(KafkaConfig.SslClientAuthProp, "required")
-  controllerConfig.put(KafkaConfig.SslClientAuthProp, "required")
+  serverConfig.put(KafkaConfig.SSL_CLIENT_AUTH_PROP, "required")
+  controllerConfig.put(KafkaConfig.SSL_CLIENT_AUTH_PROP, "required")
   assertNull(producerConfig.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
   assertNull(consumerConfig.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
   assertNull(adminClientConfig.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))

--- a/core/src/test/scala/integration/kafka/api/SaslMultiMechanismConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslMultiMechanismConsumerTest.scala
@@ -12,7 +12,7 @@
   */
 package kafka.api
 
-import kafka.server.KafkaConfig
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo, Timeout}
 import kafka.utils.{JaasTestUtils, TestInfoUtils, TestUtils}
 import org.apache.kafka.common.security.auth.SecurityProtocol
@@ -25,7 +25,7 @@ import scala.jdk.CollectionConverters._
 class SaslMultiMechanismConsumerTest extends BaseConsumerTest with SaslSetup {
   private val kafkaClientSaslMechanism = "PLAIN"
   private val kafkaServerSaslMechanisms = List("GSSAPI", "PLAIN")
-  this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "true")
+  this.serverConfig.setProperty(KafkaConfig.ZK_ENABLE_SECURE_ACLS_PROP, "true")
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
   override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
   override protected val serverSaslProperties = Some(kafkaServerSaslProperties(kafkaServerSaslMechanisms, kafkaClientSaslMechanism))

--- a/core/src/test/scala/integration/kafka/api/SaslPlainPlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainPlaintextConsumerTest.scala
@@ -13,10 +13,10 @@
 package kafka.api
 
 import java.util.Locale
-import kafka.server.KafkaConfig
 import kafka.utils.{JaasTestUtils, TestUtils}
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo, Timeout}
 
 @Timeout(600)
@@ -26,7 +26,7 @@ class SaslPlainPlaintextConsumerTest extends BaseConsumerTest with SaslSetup {
   private val kafkaServerSaslMechanisms = List(kafkaClientSaslMechanism)
   private val kafkaServerJaasEntryName =
     s"${listenerName.value.toLowerCase(Locale.ROOT)}.${JaasTestUtils.KafkaServerContextName}"
-  this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "false")
+  this.serverConfig.setProperty(KafkaConfig.ZK_ENABLE_SECURE_ACLS_PROP, "false")
   // disable secure acls of zkClient in QuorumTestHarness
   override protected def zkAclsEnabled = Some(false)
   override protected def securityProtocol = SecurityProtocol.SASL_PLAINTEXT

--- a/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
@@ -24,7 +24,6 @@ import javax.security.auth.Subject
 import javax.security.auth.login.AppConfigurationEntry
 
 import scala.collection.Seq
-import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
 import kafka.utils.JaasTestUtils._
 import org.apache.kafka.common.config.SaslConfigs
@@ -33,6 +32,7 @@ import org.apache.kafka.common.network.Mode
 import org.apache.kafka.common.security.auth._
 import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder
 import org.apache.kafka.common.security.plain.PlainAuthenticateCallback
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -110,11 +110,11 @@ object SaslPlainSslEndToEndAuthorizationTest {
 class SaslPlainSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTest {
   import SaslPlainSslEndToEndAuthorizationTest._
 
-  this.serverConfig.setProperty(s"${listenerName.configPrefix}${KafkaConfig.SslClientAuthProp}", "required")
+  this.serverConfig.setProperty(s"${listenerName.configPrefix}${KafkaConfig.SSL_CLIENT_AUTH_PROP}", "required")
   this.serverConfig.setProperty(BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, classOf[TestPrincipalBuilder].getName)
-  this.serverConfig.put(KafkaConfig.SaslClientCallbackHandlerClassProp, classOf[TestClientCallbackHandler].getName)
+  this.serverConfig.put(KafkaConfig.SASL_CLIENT_CALLBACK_HANDLER_CLASS_PROP, classOf[TestClientCallbackHandler].getName)
   val mechanismPrefix = listenerName.saslMechanismConfigPrefix("PLAIN")
-  this.serverConfig.put(s"$mechanismPrefix${KafkaConfig.SaslServerCallbackHandlerClassProp}", classOf[TestServerCallbackHandler].getName)
+  this.serverConfig.put(s"$mechanismPrefix${KafkaConfig.SASL_SERVER_CALLBACK_HANDLER_CLASS_PROP}", classOf[TestServerCallbackHandler].getName)
   this.producerConfig.put(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS, classOf[TestClientCallbackHandler].getName)
   this.consumerConfig.put(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS, classOf[TestClientCallbackHandler].getName)
   this.adminClientConfig.put(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS, classOf[TestClientCallbackHandler].getName)

--- a/core/src/test/scala/integration/kafka/api/SaslSetup.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSetup.scala
@@ -23,7 +23,6 @@ import java.util.Properties
 import javax.security.auth.login.Configuration
 import scala.collection.Seq
 import kafka.security.minikdc.MiniKdc
-import kafka.server.KafkaConfig
 import kafka.utils.JaasTestUtils.{JaasSection, Krb5LoginModule, ZkDigestModule}
 import kafka.utils.{JaasTestUtils, TestUtils}
 import kafka.zk.{AdminZkClient, KafkaZkClient}
@@ -35,7 +34,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.security.authenticator.LoginManager
 import org.apache.kafka.common.security.scram.internals.{ScramCredentialUtils, ScramFormatter, ScramMechanism}
 import org.apache.kafka.common.utils.Time
-import org.apache.kafka.server.config.ConfigType
+import org.apache.kafka.server.config.{ConfigType, KafkaConfig}
 import org.apache.zookeeper.client.ZKClientConfig
 
 /*
@@ -131,7 +130,7 @@ trait SaslSetup {
 
   def kafkaServerSaslProperties(serverSaslMechanisms: Seq[String], interBrokerSaslMechanism: String): Properties = {
     val props = new Properties
-    props.put(KafkaConfig.SaslMechanismInterBrokerProtocolProp, interBrokerSaslMechanism)
+    props.put(KafkaConfig.SASL_MECHANISM_INTER_BROKER_PROTOCOL_PROP, interBrokerSaslMechanism)
     props.put(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG, serverSaslMechanisms.mkString(","))
     props
   }

--- a/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.common.resource.ResourceType.{GROUP, TOPIC}
 import org.apache.kafka.common.resource.{PatternType, Resource, ResourcePattern, ResourcePatternFilter, ResourceType}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.server.authorizer.Authorizer
+import org.apache.kafka.server.config.KafkaConfig.{ZK_ENABLE_SECURE_ACLS_PROP, AUTHORIZER_CLASS_NAME_PROP}
 import org.apache.kafka.storage.internals.log.LogConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
@@ -46,13 +47,13 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
 
   val authorizationAdmin = new AclAuthorizationAdmin(classOf[AclAuthorizer], classOf[AclAuthorizer])
 
-  this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "true")
+  this.serverConfig.setProperty(ZK_ENABLE_SECURE_ACLS_PROP, "true")
 
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
   override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
 
   override def generateConfigs: Seq[KafkaConfig] = {
-    this.serverConfig.setProperty(KafkaConfig.AuthorizerClassNameProp, authorizationAdmin.authorizerClassName)
+    this.serverConfig.setProperty(AUTHORIZER_CLASS_NAME_PROP, authorizationAdmin.authorizerClassName)
     super.generateConfigs
   }
 

--- a/core/src/test/scala/integration/kafka/api/SaslSslConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslConsumerTest.scala
@@ -12,14 +12,14 @@
   */
 package kafka.api
 
-import kafka.server.KafkaConfig
 import kafka.utils.{JaasTestUtils, TestUtils}
 import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo, Timeout}
 
 @Timeout(600)
 class SaslSslConsumerTest extends BaseConsumerTest with SaslSetup {
-  this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "true")
+  this.serverConfig.setProperty(KafkaConfig.ZK_ENABLE_SECURE_ACLS_PROP, "true")
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
   override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))
 

--- a/core/src/test/scala/integration/kafka/api/SslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SslAdminIntegrationTest.scala
@@ -17,7 +17,6 @@ import java.util.concurrent._
 
 import com.yammer.metrics.core.Gauge
 import kafka.security.authorizer.AclAuthorizer
-import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, CreateAclsResult}
 import org.apache.kafka.common.acl._
@@ -26,6 +25,7 @@ import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourceT
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.server.authorizer._
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull, assertTrue}
 import org.junit.jupiter.api.{AfterEach, Test}
 
@@ -80,7 +80,7 @@ object SslAdminIntegrationTest {
 class SslAdminIntegrationTest extends SaslSslAdminIntegrationTest {
   override val authorizationAdmin = new AclAuthorizationAdmin(classOf[SslAdminIntegrationTest.TestableAclAuthorizer], classOf[AclAuthorizer])
 
-  this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "true")
+  this.serverConfig.setProperty(KafkaConfig.ZK_ENABLE_SECURE_ACLS_PROP, "true")
 
   override protected def securityProtocol = SecurityProtocol.SSL
   override protected lazy val trustStoreFile = Some(TestUtils.tempFile("truststore", ".jks"))

--- a/core/src/test/scala/integration/kafka/api/TransactionsBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsBounceTest.scala
@@ -18,13 +18,14 @@
 package kafka.api
 
 import java.util.Properties
-import kafka.server.KafkaConfig
+import kafka.server.KafkaConfig.fromProps
 import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig}
 import org.apache.kafka.clients.producer.internals.ErrorLoggingCallback
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.server.util.ShutdownableThread
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -42,20 +43,20 @@ class TransactionsBounceTest extends IntegrationTestHarness {
   private val inputTopic = "input-topic"
 
   val overridingProps = new Properties()
-  overridingProps.put(KafkaConfig.AutoCreateTopicsEnableProp, false.toString)
-  overridingProps.put(KafkaConfig.MessageMaxBytesProp, serverMessageMaxBytes.toString)
+  overridingProps.put(KafkaConfig.AUTO_CREATE_TOPICS_ENABLE_PROP, false.toString)
+  overridingProps.put(KafkaConfig.MESSAGE_MAX_BYTES_PROP, serverMessageMaxBytes.toString)
   // Set a smaller value for the number of partitions for the offset commit topic (__consumer_offset topic)
   // so that the creation of that topic/partition(s) and subsequent leader assignment doesn't take relatively long
-  overridingProps.put(KafkaConfig.ControlledShutdownEnableProp, true.toString)
-  overridingProps.put(KafkaConfig.UncleanLeaderElectionEnableProp, false.toString)
-  overridingProps.put(KafkaConfig.AutoLeaderRebalanceEnableProp, false.toString)
-  overridingProps.put(KafkaConfig.OffsetsTopicPartitionsProp, 1.toString)
-  overridingProps.put(KafkaConfig.OffsetsTopicReplicationFactorProp, 3.toString)
-  overridingProps.put(KafkaConfig.MinInSyncReplicasProp, 2.toString)
-  overridingProps.put(KafkaConfig.TransactionsTopicPartitionsProp, 1.toString)
-  overridingProps.put(KafkaConfig.TransactionsTopicReplicationFactorProp, 3.toString)
-  overridingProps.put(KafkaConfig.GroupMinSessionTimeoutMsProp, "10") // set small enough session timeout
-  overridingProps.put(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
+  overridingProps.put(KafkaConfig.CONTROLLED_SHUTDOWN_ENABLE_PROP, true.toString)
+  overridingProps.put(KafkaConfig.UNCLEAN_LEADER_ELECTION_ENABLE_PROP, false.toString)
+  overridingProps.put(KafkaConfig.AUTO_LEADER_REBALANCE_ENABLE_PROP, false.toString)
+  overridingProps.put(KafkaConfig.OFFSETS_TOPIC_PARTITIONS_PROP, 1.toString)
+  overridingProps.put(KafkaConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, 3.toString)
+  overridingProps.put(KafkaConfig.MIN_IN_SYNC_REPLICAS_PROP, 2.toString)
+  overridingProps.put(KafkaConfig.TRANSACTIONS_TOPIC_PARTITIONS_PROP, 1.toString)
+  overridingProps.put(KafkaConfig.TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, 3.toString)
+  overridingProps.put(KafkaConfig.GROUP_MIN_SESSION_TIMEOUT_MS_PROP, "10") // set small enough session timeout
+  overridingProps.put(KafkaConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, "0")
 
   // This is the one of the few tests we currently allow to preallocate ports, despite the fact that this can result in transient
   // failures due to ports getting reused. We can't use random ports because of bad behavior that can result from bouncing
@@ -68,7 +69,7 @@ class TransactionsBounceTest extends IntegrationTestHarness {
   // a small risk of hitting errors due to port conflicts. Hopefully this is infrequent enough to not cause problems.
   override def generateConfigs = {
     FixedPortTestUtils.createBrokerConfigs(brokerCount, zkConnectOrNull, enableControlledShutdown = true)
-      .map(KafkaConfig.fromProps(_, overridingProps))
+      .map(fromProps(_, overridingProps))
   }
 
   override protected def brokerCount: Int = 4
@@ -184,7 +185,7 @@ class TransactionsBounceTest extends IntegrationTestHarness {
 
   private def createTopics() =  {
     val topicConfig = new Properties()
-    topicConfig.put(KafkaConfig.MinInSyncReplicasProp, 2.toString)
+    topicConfig.put(KafkaConfig.MIN_IN_SYNC_REPLICAS_PROP, 2.toString)
     createTopic(inputTopic, numPartitions, 3, topicConfig)
     createTopic(outputTopic, numPartitions, 3, topicConfig)
   }

--- a/core/src/test/scala/integration/kafka/api/TransactionsExpirationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsExpirationTest.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.admin.{Admin, ProducerState}
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.server.config.KafkaConfig.{AUTO_CREATE_TOPICS_ENABLE_PROP, OFFSETS_TOPIC_PARTITIONS_PROP, TRANSACTIONS_TOPIC_PARTITIONS_PROP, TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, TRANSACTIONS_TOPIC_MIN_ISR_PROP, CONTROLLED_SHUTDOWN_ENABLE_PROP, UNCLEAN_LEADER_ELECTION_ENABLE_PROP, AUTO_LEADER_REBALANCE_ENABLE_PROP, GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, TRANSACTIONS_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS_PROP, TRANSACTIONAL_ID_EXPIRATION_MS_PROP, TRANSACTIONS_REMOVE_EXPIRED_TRANSACTIONAL_ID_CLEANUP_INTERVAL_MS_PROP, PRODUCER_ID_EXPIRATION_MS_PROP, PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS_PROP}
 import org.apache.kafka.common.errors.{InvalidPidMappingException, TransactionalIdNotFoundException}
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
@@ -199,22 +200,22 @@ class TransactionsExpirationTest extends KafkaServerTestHarness {
 
   private def serverProps(): Properties = {
     val serverProps = new Properties()
-    serverProps.put(KafkaConfig.AutoCreateTopicsEnableProp, false.toString)
+    serverProps.put(AUTO_CREATE_TOPICS_ENABLE_PROP, false.toString)
     // Set a smaller value for the number of partitions for the __consumer_offsets topic
     // so that the creation of that topic/partition(s) and subsequent leader assignment doesn't take relatively long.
-    serverProps.put(KafkaConfig.OffsetsTopicPartitionsProp, 1.toString)
-    serverProps.put(KafkaConfig.TransactionsTopicPartitionsProp, 3.toString)
-    serverProps.put(KafkaConfig.TransactionsTopicReplicationFactorProp, 2.toString)
-    serverProps.put(KafkaConfig.TransactionsTopicMinISRProp, 2.toString)
-    serverProps.put(KafkaConfig.ControlledShutdownEnableProp, true.toString)
-    serverProps.put(KafkaConfig.UncleanLeaderElectionEnableProp, false.toString)
-    serverProps.put(KafkaConfig.AutoLeaderRebalanceEnableProp, false.toString)
-    serverProps.put(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
-    serverProps.put(KafkaConfig.TransactionsAbortTimedOutTransactionCleanupIntervalMsProp, "200")
-    serverProps.put(KafkaConfig.TransactionalIdExpirationMsProp, "10000")
-    serverProps.put(KafkaConfig.TransactionsRemoveExpiredTransactionalIdCleanupIntervalMsProp, "500")
-    serverProps.put(KafkaConfig.ProducerIdExpirationMsProp, "5000")
-    serverProps.put(KafkaConfig.ProducerIdExpirationCheckIntervalMsProp, "500")
+    serverProps.put(OFFSETS_TOPIC_PARTITIONS_PROP, 1.toString)
+    serverProps.put(TRANSACTIONS_TOPIC_PARTITIONS_PROP, 3.toString)
+    serverProps.put(TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, 2.toString)
+    serverProps.put(TRANSACTIONS_TOPIC_MIN_ISR_PROP, 2.toString)
+    serverProps.put(CONTROLLED_SHUTDOWN_ENABLE_PROP, true.toString)
+    serverProps.put(UNCLEAN_LEADER_ELECTION_ENABLE_PROP, false.toString)
+    serverProps.put(AUTO_LEADER_REBALANCE_ENABLE_PROP, false.toString)
+    serverProps.put(GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, "0")
+    serverProps.put(TRANSACTIONS_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS_PROP, "200")
+    serverProps.put(TRANSACTIONAL_ID_EXPIRATION_MS_PROP, "10000")
+    serverProps.put(TRANSACTIONS_REMOVE_EXPIRED_TRANSACTIONAL_ID_CLEANUP_INTERVAL_MS_PROP, "500")
+    serverProps.put(PRODUCER_ID_EXPIRATION_MS_PROP, "5000")
+    serverProps.put(PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS_PROP, "500")
     serverProps
   }
 }

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -22,13 +22,13 @@ import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 import java.util.{Optional, Properties}
-import kafka.server.KafkaConfig
 import kafka.utils.{TestInfoUtils, TestUtils}
 import kafka.utils.TestUtils.{consumeRecords, waitUntilTrue}
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig, ConsumerGroupMetadata, OffsetAndMetadata}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.errors.{InvalidProducerEpochException, ProducerFencedException, TimeoutException}
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -58,21 +58,21 @@ class TransactionsTest extends IntegrationTestHarness {
 
   def overridingProps(): Properties = {
     val props = new Properties()
-    props.put(KafkaConfig.AutoCreateTopicsEnableProp, false.toString)
+    props.put(KafkaConfig.AUTO_CREATE_TOPICS_ENABLE_PROP, false.toString)
      // Set a smaller value for the number of partitions for the __consumer_offsets topic + // so that the creation of that topic/partition(s) and subsequent leader assignment doesn't take relatively long
-    props.put(KafkaConfig.OffsetsTopicPartitionsProp, 1.toString)
-    props.put(KafkaConfig.TransactionsTopicPartitionsProp, 3.toString)
-    props.put(KafkaConfig.TransactionsTopicReplicationFactorProp, 2.toString)
-    props.put(KafkaConfig.TransactionsTopicMinISRProp, 2.toString)
-    props.put(KafkaConfig.ControlledShutdownEnableProp, true.toString)
-    props.put(KafkaConfig.UncleanLeaderElectionEnableProp, false.toString)
-    props.put(KafkaConfig.AutoLeaderRebalanceEnableProp, false.toString)
-    props.put(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
-    props.put(KafkaConfig.TransactionsAbortTimedOutTransactionCleanupIntervalMsProp, "200")
+    props.put(KafkaConfig.OFFSETS_TOPIC_PARTITIONS_PROP, 1.toString)
+    props.put(KafkaConfig.TRANSACTIONS_TOPIC_PARTITIONS_PROP, 3.toString)
+    props.put(KafkaConfig.TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, 2.toString)
+    props.put(KafkaConfig.TRANSACTIONS_TOPIC_MIN_ISR_PROP, 2.toString)
+    props.put(KafkaConfig.CONTROLLED_SHUTDOWN_ENABLE_PROP, true.toString)
+    props.put(KafkaConfig.UNCLEAN_LEADER_ELECTION_ENABLE_PROP, false.toString)
+    props.put(KafkaConfig.AUTO_LEADER_REBALANCE_ENABLE_PROP, false.toString)
+    props.put(KafkaConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, "0")
+    props.put(KafkaConfig.TRANSACTIONS_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS_PROP, "200")
 
     // The new group coordinator does not support verifying transactions yet.
     if (isNewGroupCoordinatorEnabled()) {
-      props.put(KafkaConfig.TransactionPartitionVerificationEnableProp, "false")
+      props.put(KafkaConfig.TRANSACTION_PARTITION_VERIFICATION_ENABLE_PROP, "false")
     }
 
     props
@@ -89,7 +89,7 @@ class TransactionsTest extends IntegrationTestHarness {
 
   def topicConfig(): Properties = {
     val topicConfig = new Properties()
-    topicConfig.put(KafkaConfig.MinInSyncReplicasProp, 2.toString)
+    topicConfig.put(KafkaConfig.MIN_IN_SYNC_REPLICAS_PROP, 2.toString)
     topicConfig
   }
 

--- a/core/src/test/scala/integration/kafka/api/TransactionsWithMaxInFlightOneTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsWithMaxInFlightOneTest.scala
@@ -24,6 +24,7 @@ import kafka.utils.{TestInfoUtils, TestUtils}
 import kafka.utils.TestUtils.consumeRecords
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.server.config.KafkaConfig.{MIN_IN_SYNC_REPLICAS_PROP, AUTO_CREATE_TOPICS_ENABLE_PROP, OFFSETS_TOPIC_PARTITIONS_PROP, OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, TRANSACTIONS_TOPIC_PARTITIONS_PROP, TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, TRANSACTIONS_TOPIC_MIN_ISR_PROP, CONTROLLED_SHUTDOWN_ENABLE_PROP, UNCLEAN_LEADER_ELECTION_ENABLE_PROP, AUTO_LEADER_REBALANCE_ENABLE_PROP, GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, TRANSACTIONS_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS_PROP}
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -55,7 +56,7 @@ class TransactionsWithMaxInFlightOneTest extends KafkaServerTestHarness {
   override def setUp(testInfo: TestInfo): Unit = {
     super.setUp(testInfo)
     val topicConfig = new Properties()
-    topicConfig.put(KafkaConfig.MinInSyncReplicasProp, 1.toString)
+    topicConfig.put(MIN_IN_SYNC_REPLICAS_PROP, 1.toString)
     createTopic(topic1, numPartitions, numBrokers, topicConfig)
     createTopic(topic2, numPartitions, numBrokers, topicConfig)
 
@@ -102,17 +103,17 @@ class TransactionsWithMaxInFlightOneTest extends KafkaServerTestHarness {
 
   private def serverProps() = {
     val serverProps = new Properties()
-    serverProps.put(KafkaConfig.AutoCreateTopicsEnableProp, false.toString)
-    serverProps.put(KafkaConfig.OffsetsTopicPartitionsProp, 1.toString)
-    serverProps.put(KafkaConfig.OffsetsTopicReplicationFactorProp, 1.toString)
-    serverProps.put(KafkaConfig.TransactionsTopicPartitionsProp, 1.toString)
-    serverProps.put(KafkaConfig.TransactionsTopicReplicationFactorProp, 1.toString)
-    serverProps.put(KafkaConfig.TransactionsTopicMinISRProp, 1.toString)
-    serverProps.put(KafkaConfig.ControlledShutdownEnableProp, true.toString)
-    serverProps.put(KafkaConfig.UncleanLeaderElectionEnableProp, false.toString)
-    serverProps.put(KafkaConfig.AutoLeaderRebalanceEnableProp, false.toString)
-    serverProps.put(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
-    serverProps.put(KafkaConfig.TransactionsAbortTimedOutTransactionCleanupIntervalMsProp, "200")
+    serverProps.put(AUTO_CREATE_TOPICS_ENABLE_PROP, false.toString)
+    serverProps.put(OFFSETS_TOPIC_PARTITIONS_PROP, 1.toString)
+    serverProps.put(OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, 1.toString)
+    serverProps.put(TRANSACTIONS_TOPIC_PARTITIONS_PROP, 1.toString)
+    serverProps.put(TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, 1.toString)
+    serverProps.put(TRANSACTIONS_TOPIC_MIN_ISR_PROP, 1.toString)
+    serverProps.put(CONTROLLED_SHUTDOWN_ENABLE_PROP, true.toString)
+    serverProps.put(UNCLEAN_LEADER_ELECTION_ENABLE_PROP, false.toString)
+    serverProps.put(AUTO_LEADER_REBALANCE_ENABLE_PROP, false.toString)
+    serverProps.put(GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, "0")
+    serverProps.put(TRANSACTIONS_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS_PROP, "200")
     serverProps
   }
 

--- a/core/src/test/scala/integration/kafka/api/UserClientIdQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/UserClientIdQuotaTest.scala
@@ -17,6 +17,7 @@ package kafka.api
 import kafka.server._
 import kafka.utils.TestUtils
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
+import org.apache.kafka.server.config.KafkaConfig.SSL_CLIENT_AUTH_PROP
 import org.apache.kafka.common.utils.Sanitizer
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 
@@ -30,7 +31,7 @@ class UserClientIdQuotaTest extends BaseQuotaTest {
 
   @BeforeEach
   override def setUp(testInfo: TestInfo): Unit = {
-    this.serverConfig.setProperty(KafkaConfig.SslClientAuthProp, "required")
+    this.serverConfig.setProperty(SSL_CLIENT_AUTH_PROP, "required")
     super.setUp(testInfo)
     quotaTestClients.alterClientQuotas(
       quotaTestClients.clientQuotaAlteration(

--- a/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
@@ -18,7 +18,7 @@
 package kafka.coordinator.transaction
 
 import kafka.network.SocketServer
-import kafka.server.{IntegrationTestUtils, KafkaConfig}
+import kafka.server.IntegrationTestUtils
 import kafka.test.annotation.{AutoStart, ClusterTest, ClusterTests, Type}
 import kafka.test.junit.ClusterTestExtensions
 import kafka.test.{ClusterConfig, ClusterInstance}
@@ -27,6 +27,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.requests.{InitProducerIdRequest, InitProducerIdResponse}
+import org.apache.kafka.server.config.KafkaConfig
 import org.apache.kafka.server.common.MetadataVersion
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Disabled, Timeout}
@@ -41,8 +42,8 @@ class ProducerIdsIntegrationTest {
 
   @BeforeEach
   def setup(clusterConfig: ClusterConfig): Unit = {
-    clusterConfig.serverProperties().put(KafkaConfig.TransactionsTopicPartitionsProp, "1")
-    clusterConfig.serverProperties().put(KafkaConfig.TransactionsTopicReplicationFactorProp, "3")
+    clusterConfig.serverProperties().put(KafkaConfig.TRANSACTIONS_TOPIC_PARTITIONS_PROP, "1")
+    clusterConfig.serverProperties().put(KafkaConfig.TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, "3")
   }
 
   @ClusterTests(Array(
@@ -56,8 +57,8 @@ class ProducerIdsIntegrationTest {
 
   @ClusterTest(clusterType = Type.ZK, brokers = 3, autoStart = AutoStart.NO)
   def testUniqueProducerIdsBumpIBP(clusterInstance: ClusterInstance): Unit = {
-    clusterInstance.config().serverProperties().put(KafkaConfig.InterBrokerProtocolVersionProp, "2.8")
-    clusterInstance.config().brokerServerProperties(0).put(KafkaConfig.InterBrokerProtocolVersionProp, "3.0-IV0")
+    clusterInstance.config().serverProperties().put(KafkaConfig.INTER_BROKER_PROTOCOL_VERSION_PROP, "2.8")
+    clusterInstance.config().brokerServerProperties(0).put(KafkaConfig.INTER_BROKER_PROTOCOL_VERSION_PROP, "3.0-IV0")
     clusterInstance.start()
     verifyUniqueIds(clusterInstance)
     clusterInstance.stop()
@@ -66,7 +67,7 @@ class ProducerIdsIntegrationTest {
   @ClusterTest(clusterType = Type.ZK, brokers = 1, autoStart = AutoStart.NO)
   @Timeout(20)
   def testHandleAllocateProducerIdsSingleRequestHandlerThread(clusterInstance: ClusterInstance): Unit = {
-    clusterInstance.config().serverProperties().put(KafkaConfig.NumIoThreadsProp, "1")
+    clusterInstance.config().serverProperties().put(KafkaConfig.NUM_IO_THREADS_PROP, "1")
     clusterInstance.start()
     verifyUniqueIds(clusterInstance)
     clusterInstance.stop()
@@ -75,7 +76,7 @@ class ProducerIdsIntegrationTest {
   @Disabled // TODO: Enable once producer id block size is configurable (KAFKA-15029)
   @ClusterTest(clusterType = Type.ZK, brokers = 1, autoStart = AutoStart.NO)
   def testMultipleAllocateProducerIdsRequest(clusterInstance: ClusterInstance): Unit = {
-    clusterInstance.config().serverProperties().put(KafkaConfig.NumIoThreadsProp, "2")
+    clusterInstance.config().serverProperties().put(KafkaConfig.NUM_IO_THREADS_PROP, "2")
     clusterInstance.start()
     verifyUniqueIds(clusterInstance)
     clusterInstance.stop()

--- a/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
@@ -22,7 +22,7 @@ import java.io.IOException
 import java.net.{InetAddress, Socket}
 import java.util.concurrent._
 import java.util.{Collections, Properties}
-import kafka.server.{BaseRequestTest, KafkaConfig}
+import kafka.server.BaseRequestTest
 import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.admin.Admin
 import org.apache.kafka.common.config.internals.QuotaConfigs
@@ -34,6 +34,7 @@ import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRec
 import org.apache.kafka.common.requests.{ProduceRequest, ProduceResponse}
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.{KafkaException, requests}
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -54,7 +55,7 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
   var admin: Admin = _
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.put(KafkaConfig.NumQuotaSamplesProp, "2")
+    properties.put(KafkaConfig.NUM_QUOTA_SAMPLES_PROP, "2")
     properties.put("listener.name.plaintext.max.connection.creation.rate", plaintextListenerDefaultQuota.toString)
   }
 
@@ -93,15 +94,15 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     }
 
     val props = new Properties
-    props.put(KafkaConfig.MaxConnectionsPerIpProp, maxConnectionsPerIP.toString)
-    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.MaxConnectionsPerIpProp, maxConnectionsPerIP.toString))
+    props.put(KafkaConfig.MAX_CONNECTIONS_PER_IP_PROP, maxConnectionsPerIP.toString)
+    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.MAX_CONNECTIONS_PER_IP_PROP, maxConnectionsPerIP.toString))
 
     verifyMaxConnections(maxConnectionsPerIP, connectAndVerify)
 
     // Increase MaxConnectionsPerIpOverrides for localhost to 7
     val maxConnectionsPerIPOverride = 7
-    props.put(KafkaConfig.MaxConnectionsPerIpOverridesProp, s"localhost:$maxConnectionsPerIPOverride")
-    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.MaxConnectionsPerIpOverridesProp, s"localhost:$maxConnectionsPerIPOverride"))
+    props.put(KafkaConfig.MAX_CONNECTIONS_PER_IP_OVERRIDES_PROP, s"localhost:$maxConnectionsPerIPOverride")
+    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.MAX_CONNECTIONS_PER_IP_OVERRIDES_PROP, s"localhost:$maxConnectionsPerIPOverride"))
 
     verifyMaxConnections(maxConnectionsPerIPOverride, connectAndVerify)
   }
@@ -123,18 +124,18 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
 
     // Reduce total broker MaxConnections to 5 at the cluster level
     val props = new Properties
-    props.put(KafkaConfig.MaxConnectionsProp, "5")
-    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.MaxConnectionsProp, "5"))
+    props.put(KafkaConfig.MAX_CONNECTIONS_PROP, "5")
+    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.MAX_CONNECTIONS_PROP, "5"))
     verifyMaxConnections(5, connectAndVerify)
 
     // Create another listener and verify listener connection limit of 5 for each listener
     val newListeners = "PLAINTEXT://localhost:0,INTERNAL://localhost:0"
-    props.put(KafkaConfig.ListenersProp, newListeners)
-    props.put(KafkaConfig.ListenerSecurityProtocolMapProp, "PLAINTEXT:PLAINTEXT,INTERNAL:PLAINTEXT, CONTROLLER: PLAINTEXT")
-    props.put(KafkaConfig.MaxConnectionsProp, "10")
+    props.put(KafkaConfig.LISTENERS_PROP, newListeners)
+    props.put(KafkaConfig.LISTENER_SECURITY_PROTOCOL_MAP_PROP, "PLAINTEXT:PLAINTEXT,INTERNAL:PLAINTEXT, CONTROLLER: PLAINTEXT")
+    props.put(KafkaConfig.MAX_CONNECTIONS_PROP, "10")
     props.put("listener.name.internal.max.connections", "5")
     props.put("listener.name.plaintext.max.connections", "5")
-    reconfigureServers(props, perBrokerConfig = true, (KafkaConfig.ListenersProp, newListeners))
+    reconfigureServers(props, perBrokerConfig = true, (KafkaConfig.LISTENERS_PROP, newListeners))
     waitForListener("INTERNAL")
 
     var conns = (connectionCount until 5).map(_ => connect("PLAINTEXT"))
@@ -145,7 +146,7 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
 
     // Increase MaxConnections for PLAINTEXT listener to 7 at the broker level
     val maxConnectionsPlaintext = 7
-    val listenerProp = s"${listener.configPrefix}${KafkaConfig.MaxConnectionsProp}"
+    val listenerProp = s"${listener.configPrefix}${KafkaConfig.MAX_CONNECTIONS_PROP}"
     props.put(listenerProp, maxConnectionsPlaintext.toString)
     reconfigureServers(props, perBrokerConfig = true, (listenerProp, maxConnectionsPlaintext.toString))
     verifyMaxConnections(maxConnectionsPlaintext, connectAndVerify)
@@ -187,9 +188,9 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     val newListenerNames = Seq("PLAINTEXT", "EXTERNAL")
     val newListeners = "PLAINTEXT://localhost:0,EXTERNAL://localhost:0"
     val props = new Properties
-    props.put(KafkaConfig.ListenersProp, newListeners)
-    props.put(KafkaConfig.ListenerSecurityProtocolMapProp, "PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT")
-    reconfigureServers(props, perBrokerConfig = true, (KafkaConfig.ListenersProp, newListeners))
+    props.put(KafkaConfig.LISTENERS_PROP, newListeners)
+    props.put(KafkaConfig.LISTENER_SECURITY_PROTOCOL_MAP_PROP, "PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT")
+    reconfigureServers(props, perBrokerConfig = true, (KafkaConfig.LISTENERS_PROP, newListeners))
     waitForListener("EXTERNAL")
 
     // The expected connection count after each test run
@@ -203,8 +204,8 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
 
     // Reduce total broker connection rate limit to 9 at the cluster level and verify the limit is enforced
     props.clear()  // so that we do not pass security protocol map which cannot be set at the cluster level
-    props.put(KafkaConfig.MaxConnectionCreationRateProp, connRateLimit.toString)
-    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.MaxConnectionCreationRateProp, connRateLimit.toString))
+    props.put(KafkaConfig.MAX_CONNECTION_CREATION_RATE_PROP, connRateLimit.toString)
+    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.MAX_CONNECTION_CREATION_RATE_PROP, connRateLimit.toString))
     // verify EXTERNAL listener is capped by broker-wide quota (PLAINTEXT is not capped by broker-wide limit, since it
     // has limited quota set and is a protected listener)
     verifyConnectionRate(8, connRateLimit, "EXTERNAL", ignoreIOExceptions = false)
@@ -212,8 +213,8 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
 
     // Set 4 conn/sec rate limit for each listener and verify it gets enforced
     val listenerConnRateLimit = 4
-    val plaintextListenerProp = s"${listener.configPrefix}${KafkaConfig.MaxConnectionCreationRateProp}"
-    props.put(s"listener.name.external.${KafkaConfig.MaxConnectionCreationRateProp}", listenerConnRateLimit.toString)
+    val plaintextListenerProp = s"${listener.configPrefix}${KafkaConfig.MAX_CONNECTION_CREATION_RATE_PROP}"
+    props.put(s"listener.name.external.${KafkaConfig.MAX_CONNECTION_CREATION_RATE_PROP}", listenerConnRateLimit.toString)
     props.put(plaintextListenerProp, listenerConnRateLimit.toString)
     reconfigureServers(props, perBrokerConfig = true, (plaintextListenerProp, listenerConnRateLimit.toString))
 

--- a/core/src/test/scala/integration/kafka/network/DynamicNumNetworkThreadsTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicNumNetworkThreadsTest.scala
@@ -17,12 +17,12 @@
  */
 package kafka.network
 
-import kafka.server.{BaseRequestTest, KafkaConfig}
+import kafka.server.BaseRequestTest
 import kafka.utils.{TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.apache.kafka.server.config.Defaults
+import org.apache.kafka.server.config.{Defaults, KafkaConfig}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -40,10 +40,10 @@ class DynamicNumNetworkThreadsTest extends BaseRequestTest {
   var admin: Admin = _
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.put(KafkaConfig.ListenersProp, s"$internal://localhost:0, $external://localhost:0")
-    properties.put(KafkaConfig.ListenerSecurityProtocolMapProp, s"$internal:PLAINTEXT, $external:PLAINTEXT")
-    properties.put(s"listener.name.${internal.toLowerCase}.${KafkaConfig.NumNetworkThreadsProp}", "2")
-    properties.put(KafkaConfig.NumNetworkThreadsProp, Defaults.NUM_NETWORK_THREADS.toString)
+    properties.put(KafkaConfig.LISTENERS_PROP, s"$internal://localhost:0, $external://localhost:0")
+    properties.put(KafkaConfig.LISTENER_SECURITY_PROTOCOL_MAP_PROP, s"$internal:PLAINTEXT, $external:PLAINTEXT")
+    properties.put(s"listener.name.${internal.toLowerCase}.${KafkaConfig.NUM_NETWORK_THREADS_PROP}", "2")
+    properties.put(KafkaConfig.NUM_NETWORK_THREADS_PROP, Defaults.NUM_NETWORK_THREADS.toString)
   }
 
   @BeforeEach
@@ -72,8 +72,8 @@ class DynamicNumNetworkThreadsTest extends BaseRequestTest {
     // Increase the base network thread count
     val newBaseNetworkThreadsCount = Defaults.NUM_NETWORK_THREADS + 1
     var props = new Properties
-    props.put(KafkaConfig.NumNetworkThreadsProp, newBaseNetworkThreadsCount.toString)
-    reconfigureServers(props, (KafkaConfig.NumNetworkThreadsProp, newBaseNetworkThreadsCount.toString))
+    props.put(KafkaConfig.NUM_NETWORK_THREADS_PROP, newBaseNetworkThreadsCount.toString)
+    reconfigureServers(props, (KafkaConfig.NUM_NETWORK_THREADS_PROP, newBaseNetworkThreadsCount.toString))
 
     // Only the external listener is changed
     assertEquals(2, getNumNetworkThreads(internal))
@@ -82,8 +82,8 @@ class DynamicNumNetworkThreadsTest extends BaseRequestTest {
     // Increase the network thread count for internal
     val newInternalNetworkThreadsCount = 3
     props = new Properties
-    props.put(s"listener.name.${internal.toLowerCase}.${KafkaConfig.NumNetworkThreadsProp}", newInternalNetworkThreadsCount.toString)
-    reconfigureServers(props, (s"listener.name.${internal.toLowerCase}.${KafkaConfig.NumNetworkThreadsProp}", newInternalNetworkThreadsCount.toString))
+    props.put(s"listener.name.${internal.toLowerCase}.${KafkaConfig.NUM_NETWORK_THREADS_PROP}", newInternalNetworkThreadsCount.toString)
+    reconfigureServers(props, (s"listener.name.${internal.toLowerCase}.${KafkaConfig.NUM_NETWORK_THREADS_PROP}", newInternalNetworkThreadsCount.toString))
 
     // The internal listener is changed
     assertEquals(newInternalNetworkThreadsCount, getNumNetworkThreads(internal))

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -61,6 +61,7 @@ import org.apache.kafka.common.security.scram.ScramCredential
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.apache.kafka.security.PasswordEncoder
 import org.apache.kafka.server.config.ConfigType
+import org.apache.kafka.server.config.KafkaConfig._
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.record.BrokerCompressionType
 import org.apache.kafka.server.util.ShutdownableThread
@@ -118,26 +119,26 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
       val props = if (isKRaftTest()) {
         val properties = TestUtils.createBrokerConfig(brokerId, null)
-        properties.put(KafkaConfig.AdvertisedListenersProp, s"$SecureInternal://localhost:0, $SecureExternal://localhost:0")
+        properties.put(ADVERTISED_LISTENERS_PROP, s"$SecureInternal://localhost:0, $SecureExternal://localhost:0")
         properties
       } else {
         val properties = TestUtils.createBrokerConfig(brokerId, zkConnect)
-        properties.put(KafkaConfig.ZkEnableSecureAclsProp, "true")
+        properties.put(ZK_ENABLE_SECURE_ACLS_PROP, "true")
         properties
       }
       props ++= securityProps(sslProperties1, TRUSTSTORE_PROPS)
       // Ensure that we can support multiple listeners per security protocol and multiple security protocols
-      props.put(KafkaConfig.ListenersProp, s"$SecureInternal://localhost:0, $SecureExternal://localhost:0")
-      props.put(KafkaConfig.ListenerSecurityProtocolMapProp, s"PLAINTEXT:PLAINTEXT, $SecureInternal:SSL, $SecureExternal:SASL_SSL, CONTROLLER:$controllerListenerSecurityProtocol")
-      props.put(KafkaConfig.InterBrokerListenerNameProp, SecureInternal)
-      props.put(KafkaConfig.SslClientAuthProp, "requested")
-      props.put(KafkaConfig.SaslMechanismInterBrokerProtocolProp, "PLAIN")
-      props.put(KafkaConfig.SaslEnabledMechanismsProp, kafkaServerSaslMechanisms.mkString(","))
-      props.put(KafkaConfig.LogSegmentBytesProp, "2000") // low value to test log rolling on config update
-      props.put(KafkaConfig.NumReplicaFetchersProp, "2") // greater than one to test reducing threads
-      props.put(KafkaConfig.PasswordEncoderSecretProp, "dynamic-config-secret")
-      props.put(KafkaConfig.LogRetentionTimeMillisProp, 1680000000.toString)
-      props.put(KafkaConfig.LogRetentionTimeHoursProp, 168.toString)
+      props.put(LISTENERS_PROP, s"$SecureInternal://localhost:0, $SecureExternal://localhost:0")
+      props.put(LISTENER_SECURITY_PROTOCOL_MAP_PROP, s"PLAINTEXT:PLAINTEXT, $SecureInternal:SSL, $SecureExternal:SASL_SSL, CONTROLLER:$controllerListenerSecurityProtocol")
+      props.put(INTER_BROKER_LISTENER_NAME_PROP, SecureInternal)
+      props.put(SSL_CLIENT_AUTH_PROP, "requested")
+      props.put(SASL_MECHANISM_INTER_BROKER_PROTOCOL_PROP, "PLAIN")
+      props.put(SASL_ENABLED_MECHANISMS_PROP, kafkaServerSaslMechanisms.mkString(","))
+      props.put(LOG_SEGMENT_BYTES_PROP, "2000") // low value to test log rolling on config update
+      props.put(NUM_REPLICA_FETCHERS_PROP, "2") // greater than one to test reducing threads
+      props.put(PASSWORD_ENCODER_SECRET_PROP, "dynamic-config-secret")
+      props.put(LOG_RETENTION_TIME_MILLIS_PROP, 1680000000.toString)
+      props.put(LOG_RETENTION_TIME_HOURS_PROP, 168.toString)
 
       props ++= sslProperties1
       props ++= securityProps(sslProperties1, KEYSTORE_PROPS, listenerPrefix(SecureInternal))
@@ -251,18 +252,18 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     // Verify a few log configs with and without synonyms
     val expectedProps = new Properties
-    expectedProps.setProperty(KafkaConfig.LogRetentionTimeMillisProp, "1680000000")
-    expectedProps.setProperty(KafkaConfig.LogRetentionTimeHoursProp, "168")
-    expectedProps.setProperty(KafkaConfig.LogRollTimeHoursProp, "168")
+    expectedProps.setProperty(LOG_RETENTION_TIME_MILLIS_PROP, "1680000000")
+    expectedProps.setProperty(LOG_RETENTION_TIME_HOURS_PROP, "168")
+    expectedProps.setProperty(LOG_ROLL_TIME_HOURS_PROP, "168")
     expectedProps.setProperty(CleanerConfig.LOG_CLEANER_THREADS_PROP, "1")
-    val logRetentionMs = configEntry(configDesc, KafkaConfig.LogRetentionTimeMillisProp)
-    verifyConfig(KafkaConfig.LogRetentionTimeMillisProp, logRetentionMs,
+    val logRetentionMs = configEntry(configDesc, LOG_RETENTION_TIME_MILLIS_PROP)
+    verifyConfig(LOG_RETENTION_TIME_MILLIS_PROP, logRetentionMs,
       isSensitive = false, isReadOnly = false, expectedProps)
-    val logRetentionHours = configEntry(configDesc, KafkaConfig.LogRetentionTimeHoursProp)
-    verifyConfig(KafkaConfig.LogRetentionTimeHoursProp, logRetentionHours,
+    val logRetentionHours = configEntry(configDesc, LOG_RETENTION_TIME_HOURS_PROP)
+    verifyConfig(LOG_RETENTION_TIME_HOURS_PROP, logRetentionHours,
       isSensitive = false, isReadOnly = true, expectedProps)
-    val logRollHours = configEntry(configDesc, KafkaConfig.LogRollTimeHoursProp)
-    verifyConfig(KafkaConfig.LogRollTimeHoursProp, logRollHours,
+    val logRollHours = configEntry(configDesc, LOG_ROLL_TIME_HOURS_PROP)
+    verifyConfig(LOG_ROLL_TIME_HOURS_PROP, logRollHours,
       isSensitive = false, isReadOnly = true, expectedProps)
     val logCleanerThreads = configEntry(configDesc, CleanerConfig.LOG_CLEANER_THREADS_PROP)
     verifyConfig(CleanerConfig.LOG_CLEANER_THREADS_PROP, logCleanerThreads,
@@ -270,14 +271,14 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     def synonymsList(configEntry: ConfigEntry): List[(String, ConfigSource)] =
       configEntry.synonyms.asScala.map(s => (s.name, s.source)).toList
-    assertEquals(List((KafkaConfig.LogRetentionTimeMillisProp, ConfigSource.STATIC_BROKER_CONFIG),
-      (KafkaConfig.LogRetentionTimeHoursProp, ConfigSource.STATIC_BROKER_CONFIG),
-      (KafkaConfig.LogRetentionTimeHoursProp, ConfigSource.DEFAULT_CONFIG)),
+    assertEquals(List((LOG_RETENTION_TIME_MILLIS_PROP, ConfigSource.STATIC_BROKER_CONFIG),
+      (LOG_RETENTION_TIME_HOURS_PROP, ConfigSource.STATIC_BROKER_CONFIG),
+      (LOG_RETENTION_TIME_HOURS_PROP, ConfigSource.DEFAULT_CONFIG)),
       synonymsList(logRetentionMs))
-    assertEquals(List((KafkaConfig.LogRetentionTimeHoursProp, ConfigSource.STATIC_BROKER_CONFIG),
-      (KafkaConfig.LogRetentionTimeHoursProp, ConfigSource.DEFAULT_CONFIG)),
+    assertEquals(List((LOG_RETENTION_TIME_HOURS_PROP, ConfigSource.STATIC_BROKER_CONFIG),
+      (LOG_RETENTION_TIME_HOURS_PROP, ConfigSource.DEFAULT_CONFIG)),
       synonymsList(logRetentionHours))
-    assertEquals(List((KafkaConfig.LogRollTimeHoursProp, ConfigSource.DEFAULT_CONFIG)), synonymsList(logRollHours))
+    assertEquals(List((LOG_ROLL_TIME_HOURS_PROP, ConfigSource.DEFAULT_CONFIG)), synonymsList(logRollHours))
     assertEquals(List((CleanerConfig.LOG_CLEANER_THREADS_PROP, ConfigSource.DEFAULT_CONFIG)), synonymsList(logCleanerThreads))
   }
 
@@ -293,8 +294,8 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     val brokerConfigs = describeConfig(adminClients.head, servers).entries.asScala
     // the following are values before updated
     assertFalse(brokerConfigs.exists(_.name == TestMetricsReporter.PollingIntervalProp), "Initial value of polling interval")
-    assertFalse(brokerConfigs.exists(_.name == configPrefix + KafkaConfig.SslTruststoreTypeProp), "Initial value of ssl truststore type")
-    assertNull(brokerConfigs.find(_.name == configPrefix+KafkaConfig.SslKeystorePasswordProp).get.value, "Initial value of ssl keystore password")
+    assertFalse(brokerConfigs.exists(_.name == configPrefix + SSL_TRUSTSTORE_TYPE_PROP), "Initial value of ssl truststore type")
+    assertNull(brokerConfigs.find(_.name == configPrefix+SSL_KEYSTORE_PASSWORD_PROP).get.value, "Initial value of ssl keystore password")
 
     // setup ssl properties
     val secProps = securityProps(sslProperties1, KEYSTORE_PROPS, configPrefix)
@@ -303,24 +304,24 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     val updatedProps = new Properties
     updatedProps.setProperty("config.providers", "file")
     updatedProps.setProperty("config.providers.file.class", "kafka.server.MockFileConfigProvider")
-    updatedProps.put(KafkaConfig.MetricReporterClassesProp, classOf[TestMetricsReporter].getName)
+    updatedProps.put(METRIC_REPORTER_CLASSES_PROP, classOf[TestMetricsReporter].getName)
 
     // 1. update Integer property using config provider
     updatedProps.put(TestMetricsReporter.PollingIntervalProp, PollingIntervalVal)
 
     // 2. update String property using config provider
-    updatedProps.put(configPrefix+KafkaConfig.SslTruststoreTypeProp, SslTruststoreTypeVal)
+    updatedProps.put(configPrefix+SSL_TRUSTSTORE_TYPE_PROP, SslTruststoreTypeVal)
 
     // merge two properties
     updatedProps ++= secProps
 
     // 3. update password property using config provider
-    updatedProps.put(configPrefix+KafkaConfig.SslKeystorePasswordProp, SslKeystorePasswordVal)
+    updatedProps.put(configPrefix+SSL_KEYSTORE_PASSWORD_PROP, SslKeystorePasswordVal)
 
     alterConfigsUsingConfigCommand(updatedProps)
     waitForConfig(TestMetricsReporter.PollingIntervalProp, "1000")
-    waitForConfig(configPrefix+KafkaConfig.SslTruststoreTypeProp, "JKS")
-    waitForConfig(configPrefix+KafkaConfig.SslKeystorePasswordProp, "ServerPassword")
+    waitForConfig(configPrefix+SSL_TRUSTSTORE_TYPE_PROP, "JKS")
+    waitForConfig(configPrefix+SSL_KEYSTORE_PASSWORD_PROP, "ServerPassword")
 
     // wait for MetricsReporter
     val reporters = TestMetricsReporter.waitForReporters(servers.size)
@@ -333,8 +334,8 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
       // fetch from ZK, values should be unresolved
       val props = fetchBrokerConfigsFromZooKeeper(servers.head)
       assertTrue(props.getProperty(TestMetricsReporter.PollingIntervalProp) == PollingIntervalVal, "polling interval is not updated in ZK")
-      assertTrue(props.getProperty(configPrefix + KafkaConfig.SslTruststoreTypeProp) == SslTruststoreTypeVal, "store type is not updated in ZK")
-      assertTrue(props.getProperty(configPrefix + KafkaConfig.SslKeystorePasswordProp) == SslKeystorePasswordVal, "keystore password is not updated in ZK")
+      assertTrue(props.getProperty(configPrefix + SSL_TRUSTSTORE_TYPE_PROP) == SslTruststoreTypeVal, "store type is not updated in ZK")
+      assertTrue(props.getProperty(configPrefix + SSL_KEYSTORE_PASSWORD_PROP) == SslKeystorePasswordVal, "keystore password is not updated in ZK")
     }
 
     // verify the update
@@ -540,7 +541,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     props.put(CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE_PROP, "20000000")
     props.put(CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_LOAD_FACTOR_PROP, "0.8")
     props.put(CleanerConfig.LOG_CLEANER_IO_BUFFER_SIZE_PROP, "300000")
-    props.put(KafkaConfig.MessageMaxBytesProp, "40000")
+    props.put(MESSAGE_MAX_BYTES_PROP, "40000")
     props.put(CleanerConfig.LOG_CLEANER_IO_MAX_BYTES_PER_SECOND_PROP, "50000000")
     props.put(CleanerConfig.LOG_CLEANER_BACKOFF_MS_PROP, "6000")
 
@@ -579,7 +580,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
   def testConsecutiveConfigChange(quorum: String): Unit = {
     val topic2 = "testtopic2"
     val topicProps = new Properties
-    topicProps.put(KafkaConfig.MinInSyncReplicasProp, "2")
+    topicProps.put(MIN_IN_SYNC_REPLICAS_PROP, "2")
     TestUtils.createTopicWithAdmin(adminClients.head, topic2, servers, controllerServers, numPartitions = 1, replicationFactor = numServers, topicConfig = topicProps)
 
     def getLogOrThrow(tp: TopicPartition): UnifiedLog = {
@@ -591,13 +592,13 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     }
 
     var log = getLogOrThrow(new TopicPartition(topic2, 0))
-    assertTrue(log.config.overriddenConfigs.contains(KafkaConfig.MinInSyncReplicasProp))
-    assertEquals("2", log.config.originals().get(KafkaConfig.MinInSyncReplicasProp).toString)
+    assertTrue(log.config.overriddenConfigs.contains(MIN_IN_SYNC_REPLICAS_PROP))
+    assertEquals("2", log.config.originals().get(MIN_IN_SYNC_REPLICAS_PROP).toString)
 
     val props = new Properties
-    props.put(KafkaConfig.MinInSyncReplicasProp, "3")
+    props.put(MIN_IN_SYNC_REPLICAS_PROP, "3")
     // Make a broker-default config
-    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.MinInSyncReplicasProp, "3"))
+    reconfigureServers(props, perBrokerConfig = false, (MIN_IN_SYNC_REPLICAS_PROP, "3"))
     // Verify that all broker defaults have been updated again
     servers.foreach { server =>
       props.forEach { (k, v) =>
@@ -606,16 +607,16 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     }
 
     log = getLogOrThrow(new TopicPartition(topic2, 0))
-    assertTrue(log.config.overriddenConfigs.contains(KafkaConfig.MinInSyncReplicasProp))
-    assertEquals("2", log.config.originals().get(KafkaConfig.MinInSyncReplicasProp).toString) // Verify topic-level config survives
+    assertTrue(log.config.overriddenConfigs.contains(MIN_IN_SYNC_REPLICAS_PROP))
+    assertEquals("2", log.config.originals().get(MIN_IN_SYNC_REPLICAS_PROP).toString) // Verify topic-level config survives
 
     // Make a second broker-default change
     props.clear()
-    props.put(KafkaConfig.LogRetentionTimeMillisProp, "604800000")
-    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.LogRetentionTimeMillisProp, "604800000"))
+    props.put(LOG_RETENTION_TIME_MILLIS_PROP, "604800000")
+    reconfigureServers(props, perBrokerConfig = false, (LOG_RETENTION_TIME_MILLIS_PROP, "604800000"))
     log = getLogOrThrow(new TopicPartition(topic2, 0))
-    assertTrue(log.config.overriddenConfigs.contains(KafkaConfig.MinInSyncReplicasProp))
-    assertEquals("2", log.config.originals().get(KafkaConfig.MinInSyncReplicasProp).toString) // Verify topic-level config still survives
+    assertTrue(log.config.overriddenConfigs.contains(MIN_IN_SYNC_REPLICAS_PROP))
+    assertEquals("2", log.config.originals().get(MIN_IN_SYNC_REPLICAS_PROP).toString) // Verify topic-level config still survives
   }
 
   @Test
@@ -625,31 +626,31 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     val (producerThread, consumerThread) = startProduceConsume(retries = 0)
 
     val props = new Properties
-    props.put(KafkaConfig.LogSegmentBytesProp, "4000")
-    props.put(KafkaConfig.LogRollTimeMillisProp, TimeUnit.HOURS.toMillis(2).toString)
-    props.put(KafkaConfig.LogRollTimeJitterMillisProp, TimeUnit.HOURS.toMillis(1).toString)
-    props.put(KafkaConfig.LogIndexSizeMaxBytesProp, "100000")
-    props.put(KafkaConfig.LogFlushIntervalMessagesProp, "1000")
-    props.put(KafkaConfig.LogFlushIntervalMsProp, "60000")
-    props.put(KafkaConfig.LogRetentionBytesProp, "10000000")
-    props.put(KafkaConfig.LogRetentionTimeMillisProp, TimeUnit.DAYS.toMillis(1).toString)
-    props.put(KafkaConfig.MessageMaxBytesProp, "100000")
-    props.put(KafkaConfig.LogIndexIntervalBytesProp, "10000")
+    props.put(LOG_SEGMENT_BYTES_PROP, "4000")
+    props.put(LOG_ROLL_TIME_MILLIS_PROP, TimeUnit.HOURS.toMillis(2).toString)
+    props.put(LOG_ROLL_TIME_JITTER_MILLIS_PROP, TimeUnit.HOURS.toMillis(1).toString)
+    props.put(LOG_INDEX_SIZE_MAX_BYTES_PROP, "100000")
+    props.put(LOG_FLUSH_INTERVAL_MESSAGES_PROP, "1000")
+    props.put(LOG_FLUSH_INTERVAL_MS_PROP, "60000")
+    props.put(LOG_RETENTION_BYTES_PROP, "10000000")
+    props.put(LOG_RETENTION_TIME_MILLIS_PROP, TimeUnit.DAYS.toMillis(1).toString)
+    props.put(MESSAGE_MAX_BYTES_PROP, "100000")
+    props.put(LOG_INDEX_INTERVAL_BYTES_PROP, "10000")
     props.put(CleanerConfig.LOG_CLEANER_DELETE_RETENTION_MS_PROP, TimeUnit.DAYS.toMillis(1).toString)
     props.put(CleanerConfig.LOG_CLEANER_MIN_COMPACTION_LAG_MS_PROP, "60000")
-    props.put(KafkaConfig.LogDeleteDelayMsProp, "60000")
+    props.put(LOG_DELETE_DELAY_MS_PROP, "60000")
     props.put(CleanerConfig.LOG_CLEANER_MIN_CLEAN_RATIO_PROP, "0.3")
-    props.put(KafkaConfig.LogCleanupPolicyProp, "delete")
-    props.put(KafkaConfig.UncleanLeaderElectionEnableProp, "false")
-    props.put(KafkaConfig.MinInSyncReplicasProp, "2")
-    props.put(KafkaConfig.CompressionTypeProp, "gzip")
-    props.put(KafkaConfig.LogPreAllocateProp, true.toString)
-    props.put(KafkaConfig.LogMessageTimestampTypeProp, TimestampType.LOG_APPEND_TIME.toString)
-    props.put(KafkaConfig.LogMessageTimestampDifferenceMaxMsProp, "1000")
-    props.put(KafkaConfig.LogMessageTimestampBeforeMaxMsProp, "1000")
-    props.put(KafkaConfig.LogMessageTimestampAfterMaxMsProp, "1000")
-    props.put(KafkaConfig.LogMessageDownConversionEnableProp, "false")
-    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.LogSegmentBytesProp, "4000"))
+    props.put(LOG_CLEANUP_POLICY_PROP, "delete")
+    props.put(UNCLEAN_LEADER_ELECTION_ENABLE_PROP, "false")
+    props.put(MIN_IN_SYNC_REPLICAS_PROP, "2")
+    props.put(COMPRESSION_TYPE_PROP, "gzip")
+    props.put(LOG_PRE_ALLOCATE_PROP, true.toString)
+    props.put(LOG_MESSAGE_TIMESTAMP_TYPE_PROP, TimestampType.LOG_APPEND_TIME.toString)
+    props.put(LOG_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_PROP, "1000")
+    props.put(LOG_MESSAGE_TIMESTAMP_BEFORE_MAX_MS_PROP, "1000")
+    props.put(LOG_MESSAGE_TIMESTAMP_AFTER_MAX_MS_PROP, "1000")
+    props.put(LOG_MESSAGE_DOWN_CONVERSION_ENABLE_PROP, "false")
+    reconfigureServers(props, perBrokerConfig = false, (LOG_SEGMENT_BYTES_PROP, "4000"))
 
     // Verify that all broker defaults have been updated
     servers.foreach { server =>
@@ -667,7 +668,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     TestUtils.waitUntilTrue(() => log.config.segmentSize == 4000, "Existing topic config using defaults not updated")
     props.asScala.foreach { case (k, v) =>
       val logConfigName = DynamicLogConfig.KafkaConfigToLogConfigName(k)
-      val expectedValue = if (k == KafkaConfig.LogCleanupPolicyProp) s"[$v]" else v
+      val expectedValue = if (k == LOG_CLEANUP_POLICY_PROP) s"[$v]" else v
       assertEquals(expectedValue, log.config.originals.get(logConfigName).toString,
         s"Not reconfigured $logConfigName for existing log")
     }
@@ -684,19 +685,19 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     // Verify that we can alter subset of log configs
     props.clear()
-    props.put(KafkaConfig.LogMessageTimestampTypeProp, TimestampType.CREATE_TIME.toString)
-    props.put(KafkaConfig.LogMessageTimestampDifferenceMaxMsProp, "1000")
-    props.put(KafkaConfig.LogMessageTimestampBeforeMaxMsProp, "1000")
-    props.put(KafkaConfig.LogMessageTimestampAfterMaxMsProp, "1000")
-    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.LogMessageTimestampTypeProp, TimestampType.CREATE_TIME.toString))
+    props.put(LOG_MESSAGE_TIMESTAMP_TYPE_PROP, TimestampType.CREATE_TIME.toString)
+    props.put(LOG_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_PROP, "1000")
+    props.put(LOG_MESSAGE_TIMESTAMP_BEFORE_MAX_MS_PROP, "1000")
+    props.put(LOG_MESSAGE_TIMESTAMP_AFTER_MAX_MS_PROP, "1000")
+    reconfigureServers(props, perBrokerConfig = false, (LOG_MESSAGE_TIMESTAMP_TYPE_PROP, TimestampType.CREATE_TIME.toString))
     consumerThread.waitForMatchingRecords(record => record.timestampType == TimestampType.CREATE_TIME)
     // Verify that invalid configs are not applied
     val invalidProps = Map(
-      KafkaConfig.LogMessageTimestampDifferenceMaxMsProp -> "abc", // Invalid type
-      KafkaConfig.LogMessageTimestampBeforeMaxMsProp -> "abc", // Invalid type
-      KafkaConfig.LogMessageTimestampAfterMaxMsProp -> "abc", // Invalid type
-      KafkaConfig.LogMessageTimestampTypeProp -> "invalid", // Invalid value
-      KafkaConfig.LogRollTimeMillisProp -> "0" // Fails KafkaConfig validation
+      LOG_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_PROP -> "abc", // Invalid type
+      LOG_MESSAGE_TIMESTAMP_BEFORE_MAX_MS_PROP -> "abc", // Invalid type
+      LOG_MESSAGE_TIMESTAMP_AFTER_MAX_MS_PROP -> "abc", // Invalid type
+      LOG_MESSAGE_TIMESTAMP_TYPE_PROP -> "invalid", // Invalid value
+      LOG_ROLL_TIME_MILLIS_PROP -> "0" // Fails KafkaConfig validation
     )
     invalidProps.foreach { case (k, v) =>
       val newProps = new Properties
@@ -708,14 +709,14 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     // Verify that even though broker defaults can be defined at default cluster level for consistent
     // configuration across brokers, they can also be defined at per-broker level for testing
     props.clear()
-    props.put(KafkaConfig.LogIndexSizeMaxBytesProp, "500000")
-    props.put(KafkaConfig.LogRetentionTimeMillisProp, TimeUnit.DAYS.toMillis(2).toString)
+    props.put(LOG_INDEX_SIZE_MAX_BYTES_PROP, "500000")
+    props.put(LOG_RETENTION_TIME_MILLIS_PROP, TimeUnit.DAYS.toMillis(2).toString)
     alterConfigsOnServer(servers.head, props)
-    assertEquals(500000, servers.head.config.values.get(KafkaConfig.LogIndexSizeMaxBytesProp))
-    assertEquals(TimeUnit.DAYS.toMillis(2), servers.head.config.values.get(KafkaConfig.LogRetentionTimeMillisProp))
+    assertEquals(500000, servers.head.config.values.get(LOG_INDEX_SIZE_MAX_BYTES_PROP))
+    assertEquals(TimeUnit.DAYS.toMillis(2), servers.head.config.values.get(LOG_RETENTION_TIME_MILLIS_PROP))
     servers.tail.foreach { server =>
-      assertEquals(LogConfig.DEFAULT_SEGMENT_INDEX_BYTES, server.config.values.get(KafkaConfig.LogIndexSizeMaxBytesProp))
-      assertEquals(1680000000L, server.config.values.get(KafkaConfig.LogRetentionTimeMillisProp))
+      assertEquals(LogConfig.DEFAULT_SEGMENT_INDEX_BYTES, server.config.values.get(LOG_INDEX_SIZE_MAX_BYTES_PROP))
+      assertEquals(1680000000L, server.config.values.get(LOG_RETENTION_TIME_MILLIS_PROP))
     }
 
     // Verify that produce/consume worked throughout this test without any retries in producer
@@ -724,12 +725,12 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     // Verify that configuration at both per-broker level and default cluster level could be deleted and
     // the default value should be restored
     props.clear()
-    props.put(KafkaConfig.LogRetentionTimeMillisProp, "")
-    props.put(KafkaConfig.LogIndexSizeMaxBytesProp, "")
+    props.put(LOG_RETENTION_TIME_MILLIS_PROP, "")
+    props.put(LOG_INDEX_SIZE_MAX_BYTES_PROP, "")
     TestUtils.incrementalAlterConfigs(servers.take(1), adminClients.head, props, perBrokerConfig = true, opType = OpType.DELETE).all.get
     TestUtils.incrementalAlterConfigs(servers, adminClients.head, props, perBrokerConfig = false, opType = OpType.DELETE).all.get
     servers.foreach { server =>
-      waitForConfigOnServer(server, KafkaConfig.LogRetentionTimeMillisProp, 1680000000.toString)
+      waitForConfigOnServer(server, LOG_RETENTION_TIME_MILLIS_PROP, 1680000000.toString)
     }
     servers.foreach { server =>
       val log = server.logManager.getLog(new TopicPartition(topic, 0)).getOrElse(throw new IllegalStateException("Log not found"))
@@ -780,9 +781,9 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     // Enable unclean leader election
     val newProps = new Properties
-    newProps.put(KafkaConfig.UncleanLeaderElectionEnableProp, "true")
+    newProps.put(UNCLEAN_LEADER_ELECTION_ENABLE_PROP, "true")
     TestUtils.incrementalAlterConfigs(servers, adminClients.head, newProps, perBrokerConfig = false).all.get
-    waitForConfigOnServer(controller, KafkaConfig.UncleanLeaderElectionEnableProp, "true")
+    waitForConfigOnServer(controller, UNCLEAN_LEADER_ELECTION_ENABLE_PROP, "true")
 
     // Verify that the old follower with missing records is elected as the new leader
     val (newLeader, elected) = TestUtils.computeUntilTrue(partitionInfo.leader)(leader => leader != null)
@@ -868,15 +869,15 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     }
 
     val config = servers.head.config
-    verifyThreadPoolResize(KafkaConfig.NumIoThreadsProp, config.numIoThreads,
+    verifyThreadPoolResize(NUM_IO_THREADS_PROP, config.numIoThreads,
       requestHandlerPrefix, mayReceiveDuplicates = false)
-    verifyThreadPoolResize(KafkaConfig.NumReplicaFetchersProp, config.numReplicaFetchers,
+    verifyThreadPoolResize(NUM_REPLICA_FETCHERS_PROP, config.numReplicaFetchers,
       fetcherThreadPrefix, mayReceiveDuplicates = false)
-    verifyThreadPoolResize(KafkaConfig.BackgroundThreadsProp, config.backgroundThreads,
+    verifyThreadPoolResize(BACKGROUND_THREADS_PROP, config.backgroundThreads,
       "kafka-scheduler-", mayReceiveDuplicates = false)
-    verifyThreadPoolResize(KafkaConfig.NumRecoveryThreadsPerDataDirProp, config.numRecoveryThreadsPerDataDir,
+    verifyThreadPoolResize(NUM_RECOVERY_THREADS_PER_DATA_DIR_PROP, config.numRecoveryThreadsPerDataDir,
       "", mayReceiveDuplicates = false)
-    verifyThreadPoolResize(KafkaConfig.NumNetworkThreadsProp, config.numNetworkThreads,
+    verifyThreadPoolResize(NUM_NETWORK_THREADS_PROP, config.numNetworkThreads,
       networkThreadPrefix, mayReceiveDuplicates = true)
     verifyThreads("data-plane-kafka-socket-acceptor-", config.listeners.size)
 
@@ -989,10 +990,10 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     newReporters.foreach(_.verifyState(reconfigureCount = 0, deleteCount = 0, pollingInterval = 2000))
 
     // Verify that validation failure of metrics reporter fails reconfiguration and leaves config unchanged
-    newProps.put(KafkaConfig.MetricReporterClassesProp, "unknownMetricsReporter")
+    newProps.put(METRIC_REPORTER_CLASSES_PROP, "unknownMetricsReporter")
     reconfigureServers(newProps, perBrokerConfig = false, (TestMetricsReporter.PollingIntervalProp, "2000"), expectFailure = true)
     servers.foreach { server =>
-      assertEquals(classOf[TestMetricsReporter].getName, server.config.originals.get(KafkaConfig.MetricReporterClassesProp))
+      assertEquals(classOf[TestMetricsReporter].getName, server.config.originals.get(METRIC_REPORTER_CLASSES_PROP))
     }
     newReporters.foreach(_.verifyState(reconfigureCount = 0, deleteCount = 0, pollingInterval = 2000))
 
@@ -1007,7 +1008,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     // Verify that even though metrics reporters can be defined at default cluster level for consistent
     // configuration across brokers, they can also be defined at per-broker level for testing
-    newProps.put(KafkaConfig.MetricReporterClassesProp, classOf[TestMetricsReporter].getName)
+    newProps.put(METRIC_REPORTER_CLASSES_PROP, classOf[TestMetricsReporter].getName)
     newProps.put(TestMetricsReporter.PollingIntervalProp, "4000")
     alterConfigsOnServer(servers.head, newProps)
     TestUtils.waitUntilTrue(() => !TestMetricsReporter.testReporters.isEmpty, "Metrics reporter not created")
@@ -1019,7 +1020,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     alterConfigsOnServer(servers.head, newProps)
     perBrokerReporter.verifyState(reconfigureCount = 1, deleteCount = 0, pollingInterval = 3000)
 
-    servers.tail.foreach { server => assertEquals("", server.config.originals.get(KafkaConfig.MetricReporterClassesProp)) }
+    servers.tail.foreach { server => assertEquals("", server.config.originals.get(METRIC_REPORTER_CLASSES_PROP)) }
 
     // Verify that produce/consume worked throughout this test without any retries in producer
     stopAndVerifyProduceConsume(producerThread, consumerThread)
@@ -1090,8 +1091,8 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     // Verify updating inter-broker listener
     val props = new Properties
-    props.put(KafkaConfig.InterBrokerListenerNameProp, SecureExternal)
-    val e = assertThrows(classOf[ExecutionException], () => reconfigureServers(props, perBrokerConfig = true, (KafkaConfig.InterBrokerListenerNameProp, SecureExternal)))
+    props.put(INTER_BROKER_LISTENER_NAME_PROP, SecureExternal)
+    val e = assertThrows(classOf[ExecutionException], () => reconfigureServers(props, perBrokerConfig = true, (INTER_BROKER_LISTENER_NAME_PROP, SecureExternal)))
     assertTrue(e.getCause.isInstanceOf[InvalidRequestException], s"Unexpected exception ${e.getCause}")
     servers.foreach(server => assertEquals(SecureInternal, server.config.interBrokerListenerName.value))
   }
@@ -1115,7 +1116,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
       val propsEncodedWithOldSecret = props.clone().asInstanceOf[Properties]
       val config = server.config
       val oldSecret = "old-dynamic-config-secret"
-      config.dynamicConfig.staticBrokerConfigs.put(KafkaConfig.PasswordEncoderOldSecretProp, oldSecret)
+      config.dynamicConfig.staticBrokerConfigs.put(PASSWORD_ENCODER_OLD_SECRET_PROP, oldSecret)
       val passwordConfigs = props.asScala.filter { case (k, _) => DynamicBrokerConfig.isPasswordConfig(k) }
       assertTrue(passwordConfigs.nonEmpty, "Password configs not found")
       val passwordDecoder = createPasswordEncoder(config, config.passwordEncoderSecret)
@@ -1189,7 +1190,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     // add new PLAINTEXT listener
     client.incrementalAlterConfigs(Map(broker0Resource ->
-      Seq(new AlterConfigOp(new ConfigEntry(KafkaConfig.ListenersProp,
+      Seq(new AlterConfigOp(new ConfigEntry(LISTENERS_PROP,
         s"PLAINTEXT://localhost:0, $SecureInternal://localhost:0, $SecureExternal://localhost:0"), AlterConfigOp.OpType.SET)
       ).asJavaCollection).asJava).all().get()
 
@@ -1197,7 +1198,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
 
     // remove PLAINTEXT listener
     client.incrementalAlterConfigs(Map(broker0Resource ->
-      Seq(new AlterConfigOp(new ConfigEntry(KafkaConfig.ListenersProp,
+      Seq(new AlterConfigOp(new ConfigEntry(LISTENERS_PROP,
         s"$SecureInternal://localhost:0, $SecureExternal://localhost:0"), AlterConfigOp.OpType.SET)
       ).asJavaCollection).asJava).all().get()
 
@@ -1217,8 +1218,8 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
       .mkString(",") + s",$listenerName:${securityProtocol.name}"
 
     val props = fetchBrokerConfigsFromZooKeeper(servers.head)
-    props.put(KafkaConfig.ListenersProp, listeners)
-    props.put(KafkaConfig.ListenerSecurityProtocolMapProp, listenerMap)
+    props.put(LISTENERS_PROP, listeners)
+    props.put(LISTENER_SECURITY_PROTOCOL_MAP_PROP, listenerMap)
     securityProtocol match {
       case SecurityProtocol.SSL =>
         addListenerPropsSsl(listenerName, props)
@@ -1271,7 +1272,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     // Dynamically turn verification off.
     val configPrefix = listenerPrefix(SecureExternal)
     val updatedProps = securityProps(sslProperties1, KEYSTORE_PROPS, configPrefix)
-    updatedProps.put(KafkaConfig.TransactionPartitionVerificationEnableProp, "false")
+    updatedProps.put(TRANSACTION_PARTITION_VERIFICATION_ENABLE_PROP, "false")
     alterConfigsUsingConfigCommand(updatedProps)
     verifyConfiguration(false)
 
@@ -1283,7 +1284,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     verifyConfiguration(false)
 
     // Turn verification back on.
-    updatedProps.put(KafkaConfig.TransactionPartitionVerificationEnableProp, "true")
+    updatedProps.put(TRANSACTION_PARTITION_VERIFICATION_ENABLE_PROP, "true")
     alterConfigsUsingConfigCommand(updatedProps)
     verifyConfiguration(true)
   }
@@ -1334,8 +1335,8 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     TestUtils.incrementalAlterConfigs(servers, adminClients.head, deleteListenerProps, perBrokerConfig = true, opType = OpType.DELETE).all.get
 
     props.clear()
-    props.put(KafkaConfig.ListenersProp, listeners)
-    props.put(KafkaConfig.ListenerSecurityProtocolMapProp, listenerMap)
+    props.put(LISTENERS_PROP, listeners)
+    props.put(LISTENER_SECURITY_PROTOCOL_MAP_PROP, listenerMap)
     TestUtils.incrementalAlterConfigs(servers, adminClients.head, props, perBrokerConfig = true).all.get
 
     TestUtils.waitUntilTrue(() => servers.forall(server => server.config.listeners.size == existingListenerCount - 1),
@@ -1519,7 +1520,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
         else
           s"${e.listenerName.value}://${e.host}:${server.boundPort(e.listenerName)}"
       }.mkString(",")
-      val configEntry = new ConfigEntry(KafkaConfig.AdvertisedListenersProp, newListeners)
+      val configEntry = new ConfigEntry(ADVERTISED_LISTENERS_PROP, newListeners)
       (resource, new Config(Collections.singleton(configEntry)))
     }.toMap.asJava
     adminClient.alterConfigs(configs).all.get
@@ -1593,7 +1594,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     val externalListenerPrefix = listenerPrefix(SecureExternal)
     val sslStoreProps = new Properties
     sslStoreProps ++= securityProps(sslProperties, KEYSTORE_PROPS, externalListenerPrefix)
-    sslStoreProps.put(KafkaConfig.PasswordEncoderSecretProp, kafkaConfig.passwordEncoderSecret.map(_.value).orNull)
+    sslStoreProps.put(PASSWORD_ENCODER_SECRET_PROP, kafkaConfig.passwordEncoderSecret.map(_.value).orNull)
     zkClient.makeSurePersistentPathExists(ConfigEntityChangeNotificationZNode.path)
 
     val entityType = ConfigType.BROKER
@@ -1608,7 +1609,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
         sslStoreProps.setProperty(configName, encodedValue)
       }
     }
-    sslStoreProps.remove(KafkaConfig.PasswordEncoderSecretProp)
+    sslStoreProps.remove(PASSWORD_ENCODER_SECRET_PROP)
     adminZkClient.changeConfigs(entityType, entityName, sslStoreProps)
 
     val brokerProps = adminZkClient.fetchEntityConfig("brokers", kafkaConfig.brokerId.toString)
@@ -1645,8 +1646,8 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
   private def configureMetricsReporters(reporters: Seq[Class[_]], props: Properties,
                                         perBrokerConfig: Boolean = false): Unit = {
     val reporterStr = reporters.map(_.getName).mkString(",")
-    props.put(KafkaConfig.MetricReporterClassesProp, reporterStr)
-    reconfigureServers(props, perBrokerConfig, (KafkaConfig.MetricReporterClassesProp, reporterStr))
+    props.put(METRIC_REPORTER_CLASSES_PROP, reporterStr)
+    reconfigureServers(props, perBrokerConfig, (METRIC_REPORTER_CLASSES_PROP, reporterStr))
   }
 
   private def invalidSslConfigs: Properties = {
@@ -1742,12 +1743,12 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
   private def addListenerPropsSasl(listener: String, mechanisms: Seq[String], props: Properties): Unit = {
     val listenerName = new ListenerName(listener)
     val prefix = listenerName.configPrefix
-    props.put(prefix + KafkaConfig.SaslEnabledMechanismsProp, mechanisms.mkString(","))
-    props.put(prefix + KafkaConfig.SaslKerberosServiceNameProp, "kafka")
+    props.put(prefix + SASL_ENABLED_MECHANISMS_PROP, mechanisms.mkString(","))
+    props.put(prefix + SASL_KERBEROS_SERVICE_NAME_PROP, "kafka")
     mechanisms.foreach { mechanism =>
       val jaasSection = jaasSections(Seq(mechanism), None, KafkaSasl, "").head
       val jaasConfig = jaasSection.modules.head.toString
-      props.put(listenerName.saslMechanismConfigPrefix(mechanism) + KafkaConfig.SaslJaasConfigProp, jaasConfig)
+      props.put(listenerName.saslMechanismConfigPrefix(mechanism) + SASL_JAAS_CONFIG_PROP, jaasConfig)
     }
   }
 
@@ -1962,7 +1963,7 @@ class TestMetricsReporter extends MetricsReporter with Reconfigurable with Close
   }
 
   override def configure(configs: util.Map[String, _]): Unit = {
-    configuredBrokers += configs.get(KafkaConfig.BrokerIdProp).toString.toInt
+    configuredBrokers += configs.get(BROKER_ID_PROP).toString.toInt
     configureCount += 1
     pollingInterval = configs.get(PollingIntervalProp).toString.toInt
   }

--- a/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchFromFollowerIntegrationTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.FetchResponse
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.apache.kafka.server.config.KafkaConfig.{NUM_PARTITIONS_PROP, OFFSETS_TOPIC_REPLICATION_FACTOR_PROP}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{Disabled, Timeout}
 import org.junit.jupiter.params.ParameterizedTest
@@ -44,8 +45,8 @@ class FetchFromFollowerIntegrationTest extends BaseFetchRequestTest {
 
   def overridingProps: Properties = {
     val props = new Properties
-    props.put(KafkaConfig.NumPartitionsProp, numParts.toString)
-    props.put(KafkaConfig.OffsetsTopicReplicationFactorProp, numNodes.toString)
+    props.put(NUM_PARTITIONS_PROP, numParts.toString)
+    props.put(OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, numNodes.toString)
     props
   }
 

--- a/core/src/test/scala/integration/kafka/server/FetchRequestBetweenDifferentIbpTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchRequestBetweenDifferentIbpTest.scala
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.common.MetadataVersion.{IBP_2_7_IV0, IBP_2_8_IV1, IBP_3_1_IV0}
+import org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_PROTOCOL_VERSION_PROP
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
@@ -146,7 +147,7 @@ class FetchRequestBetweenDifferentIbpTest extends BaseRequestTest {
 
   private def createConfig(nodeId: Int, interBrokerVersion: MetadataVersion): KafkaConfig = {
     val props = TestUtils.createBrokerConfig(nodeId, zkConnect)
-    props.put(KafkaConfig.InterBrokerProtocolVersionProp, interBrokerVersion.version)
+    props.put(INTER_BROKER_PROTOCOL_VERSION_PROP, interBrokerVersion.version)
     KafkaConfig.fromProps(props)
   }
 

--- a/core/src/test/scala/integration/kafka/server/FetchRequestTestDowngrade.scala
+++ b/core/src/test/scala/integration/kafka/server/FetchRequestTestDowngrade.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.common.MetadataVersion.{IBP_2_7_IV0, IBP_3_1_IV0}
 import org.junit.jupiter.api.Assertions._
+import org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_PROTOCOL_VERSION_PROP
 import org.junit.jupiter.api.Test
 
 import scala.collection.{Map, Seq}
@@ -74,7 +75,7 @@ class FetchRequestTestDowngrade extends BaseRequestTest {
 
     private def createConfig(nodeId: Int, interBrokerVersion: MetadataVersion): KafkaConfig = {
         val props = TestUtils.createBrokerConfig(nodeId, zkConnect)
-        props.put(KafkaConfig.InterBrokerProtocolVersionProp, interBrokerVersion.version)
+        props.put(INTER_BROKER_PROTOCOL_VERSION_PROP, interBrokerVersion.version)
         KafkaConfig.fromProps(props)
     }
 

--- a/core/src/test/scala/integration/kafka/server/GssapiAuthenticationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/GssapiAuthenticationTest.scala
@@ -36,6 +36,7 @@ import org.apache.kafka.common.security.{JaasContext, TestSecurityConfig}
 import org.apache.kafka.common.security.auth.{Login, SecurityProtocol}
 import org.apache.kafka.common.security.kerberos.KerberosLogin
 import org.apache.kafka.common.utils.{LogContext, MockTime}
+import org.apache.kafka.server.config.KafkaConfig.{SSL_CLIENT_AUTH_PROP, FAILED_AUTHENTICATION_DELAY_MS_PROP}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
 
@@ -62,8 +63,8 @@ class GssapiAuthenticationTest extends IntegrationTestHarness with SaslSetup {
   override def setUp(testInfo: TestInfo): Unit = {
     TestableKerberosLogin.reset()
     startSasl(jaasSections(kafkaServerSaslMechanisms, Option(kafkaClientSaslMechanism), Both))
-    serverConfig.put(KafkaConfig.SslClientAuthProp, "required")
-    serverConfig.put(KafkaConfig.FailedAuthenticationDelayMsProp, failedAuthenticationDelayMs.toString)
+    serverConfig.put(SSL_CLIENT_AUTH_PROP, "required")
+    serverConfig.put(FAILED_AUTHENTICATION_DELAY_MS_PROP, failedAuthenticationDelayMs.toString)
     super.setUp(testInfo)
     serverAddr = new InetSocketAddress("localhost",
       servers.head.boundPort(ListenerName.forSecurityProtocol(SecurityProtocol.SASL_PLAINTEXT)))

--- a/core/src/test/scala/integration/kafka/server/KafkaServerKRaftRegistrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KafkaServerKRaftRegistrationTest.scala
@@ -24,6 +24,7 @@ import kafka.test.junit.ZkClusterInvocationContext.ZkClusterInstance
 import kafka.testkit.{KafkaClusterTestKit, TestKitNodes}
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.raft.RaftConfig
+import org.apache.kafka.server.config.KafkaConfig
 import org.apache.kafka.server.common.MetadataVersion
 import org.junit.jupiter.api.Assertions.{assertThrows, fail}
 import org.junit.jupiter.api.extension.ExtendWith
@@ -60,8 +61,8 @@ class KafkaServerKRaftRegistrationTest {
         setClusterId(Uuid.fromString(clusterId)).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())
-      .setConfigProp(KafkaConfig.MigrationEnabledProp, "true")
-      .setConfigProp(KafkaConfig.ZkConnectProp, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
+      .setConfigProp(KafkaConfig.MIGRATION_ENABLED_PROP, "true")
+      .setConfigProp(KafkaConfig.ZK_CONNECT_PROP, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
       .build()
     try {
       kraftCluster.format()
@@ -69,10 +70,10 @@ class KafkaServerKRaftRegistrationTest {
       val readyFuture = kraftCluster.controllers().values().asScala.head.controller.waitForReadyBrokers(3)
 
       // Enable migration configs and restart brokers
-      zkCluster.config().serverProperties().put(KafkaConfig.MigrationEnabledProp, "true")
+      zkCluster.config().serverProperties().put(KafkaConfig.MIGRATION_ENABLED_PROP, "true")
       zkCluster.config().serverProperties().put(RaftConfig.QUORUM_VOTERS_CONFIG, kraftCluster.quorumVotersConfig())
-      zkCluster.config().serverProperties().put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
-      zkCluster.config().serverProperties().put(KafkaConfig.ListenerSecurityProtocolMapProp, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
+      zkCluster.config().serverProperties().put(KafkaConfig.CONTROLLER_LISTENER_NAMES_PROP, "CONTROLLER")
+      zkCluster.config().serverProperties().put(KafkaConfig.LISTENER_SECURITY_PROTOCOL_MAP_PROP, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
       zkCluster.rollingBrokerRestart()
       zkCluster.waitForReadyBrokers()
 
@@ -98,18 +99,18 @@ class KafkaServerKRaftRegistrationTest {
         setClusterId(Uuid.fromString(clusterId)).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())
-      .setConfigProp(KafkaConfig.MigrationEnabledProp, "true")
-      .setConfigProp(KafkaConfig.ZkConnectProp, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
+      .setConfigProp(KafkaConfig.MIGRATION_ENABLED_PROP, "true")
+      .setConfigProp(KafkaConfig.ZK_CONNECT_PROP, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
       .build()
     try {
       kraftCluster.format()
       kraftCluster.startup()
 
       // Enable migration configs and restart brokers
-      zkCluster.config().serverProperties().put(KafkaConfig.MigrationEnabledProp, "true")
+      zkCluster.config().serverProperties().put(KafkaConfig.MIGRATION_ENABLED_PROP, "true")
       zkCluster.config().serverProperties().put(RaftConfig.QUORUM_VOTERS_CONFIG, kraftCluster.quorumVotersConfig())
-      zkCluster.config().serverProperties().put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
-      zkCluster.config().serverProperties().put(KafkaConfig.ListenerSecurityProtocolMapProp, "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT")
+      zkCluster.config().serverProperties().put(KafkaConfig.CONTROLLER_LISTENER_NAMES_PROP, "CONTROLLER")
+      zkCluster.config().serverProperties().put(KafkaConfig.LISTENER_SECURITY_PROTOCOL_MAP_PROP, "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT")
       assertThrows(classOf[IllegalArgumentException], () => zkCluster.rollingBrokerRestart())
     } finally {
       shutdownInSequence(zkCluster, kraftCluster)

--- a/core/src/test/scala/integration/kafka/server/MetadataRequestBetweenDifferentIbpTest.scala
+++ b/core/src/test/scala/integration/kafka/server/MetadataRequestBetweenDifferentIbpTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.message.MetadataRequestData
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{MetadataRequest, MetadataResponse}
+import org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_PROTOCOL_VERSION_PROP
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.common.MetadataVersion.IBP_2_8_IV0
 import org.junit.jupiter.api.Assertions._
@@ -80,7 +81,7 @@ class MetadataRequestBetweenDifferentIbpTest extends BaseRequestTest {
 
   private def createConfig(nodeId: Int, interBrokerVersion: MetadataVersion): KafkaConfig = {
     val props = TestUtils.createBrokerConfig(nodeId, zkConnect)
-    props.put(KafkaConfig.InterBrokerProtocolVersionProp, interBrokerVersion.version)
+    props.put(INTER_BROKER_PROTOCOL_VERSION_PROP, interBrokerVersion.version)
     KafkaConfig.fromProps(props)
   }
 

--- a/core/src/test/scala/integration/kafka/server/MultipleListenersWithSameSecurityProtocolBaseTest.scala
+++ b/core/src/test/scala/integration/kafka/server/MultipleListenersWithSameSecurityProtocolBaseTest.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.network.{ListenerName, Mode}
 import org.apache.kafka.coordinator.group.OffsetConfig
+import org.apache.kafka.server.config.KafkaConfig.{LISTENERS_PROP, LISTENER_SECURITY_PROTOCOL_MAP_PROP, INTER_BROKER_LISTENER_NAME_PROP, ZK_ENABLE_SECURE_ACLS_PROP, SASL_MECHANISM_INTER_BROKER_PROTOCOL_PROP, SASL_ENABLED_MECHANISMS_PROP, SASL_JAAS_CONFIG_PROP, SASL_KERBEROS_SERVICE_NAME_PROP}
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
 
@@ -74,18 +75,18 @@ abstract class MultipleListenersWithSameSecurityProtocolBaseTest extends QuorumT
 
       val props = TestUtils.createBrokerConfig(brokerId, zkConnect, trustStoreFile = Some(trustStoreFile))
       // Ensure that we can support multiple listeners per security protocol and multiple security protocols
-      props.put(KafkaConfig.ListenersProp, s"$SecureInternal://localhost:0, $Internal://localhost:0, " +
+      props.put(LISTENERS_PROP, s"$SecureInternal://localhost:0, $Internal://localhost:0, " +
         s"$SecureExternal://localhost:0, $External://localhost:0")
-      props.put(KafkaConfig.ListenerSecurityProtocolMapProp, s"$Internal:PLAINTEXT, $SecureInternal:SASL_SSL," +
+      props.put(LISTENER_SECURITY_PROTOCOL_MAP_PROP, s"$Internal:PLAINTEXT, $SecureInternal:SASL_SSL," +
         s"$External:PLAINTEXT, $SecureExternal:SASL_SSL")
-      props.put(KafkaConfig.InterBrokerListenerNameProp, Internal)
-      props.put(KafkaConfig.ZkEnableSecureAclsProp, "true")
-      props.put(KafkaConfig.SaslMechanismInterBrokerProtocolProp, kafkaClientSaslMechanism)
-      props.put(s"${new ListenerName(SecureInternal).configPrefix}${KafkaConfig.SaslEnabledMechanismsProp}",
+      props.put(INTER_BROKER_LISTENER_NAME_PROP, Internal)
+      props.put(ZK_ENABLE_SECURE_ACLS_PROP, "true")
+      props.put(SASL_MECHANISM_INTER_BROKER_PROTOCOL_PROP, kafkaClientSaslMechanism)
+      props.put(s"${new ListenerName(SecureInternal).configPrefix}${SASL_ENABLED_MECHANISMS_PROP}",
         kafkaServerSaslMechanisms(SecureInternal).mkString(","))
-      props.put(s"${new ListenerName(SecureExternal).configPrefix}${KafkaConfig.SaslEnabledMechanismsProp}",
+      props.put(s"${new ListenerName(SecureExternal).configPrefix}${SASL_ENABLED_MECHANISMS_PROP}",
         kafkaServerSaslMechanisms(SecureExternal).mkString(","))
-      props.put(KafkaConfig.SaslKerberosServiceNameProp, "kafka")
+      props.put(SASL_KERBEROS_SERVICE_NAME_PROP, "kafka")
       props ++= dynamicJaasSections
 
       props ++= TestUtils.sslConfigs(Mode.SERVER, false, Some(trustStoreFile), s"server$brokerId")
@@ -104,7 +105,7 @@ abstract class MultipleListenersWithSameSecurityProtocolBaseTest extends QuorumT
       assertEquals(4, config.listeners.size, s"Unexpected listener count for broker ${config.brokerId}")
       // KAFKA-5184 seems to show that this value can sometimes be PLAINTEXT, so verify it here
       assertEquals(Internal, config.interBrokerListenerName.value,
-        s"Unexpected ${KafkaConfig.InterBrokerListenerNameProp} for broker ${config.brokerId}")
+        s"Unexpected ${INTER_BROKER_LISTENER_NAME_PROP} for broker ${config.brokerId}")
     }
 
     TestUtils.createTopic(zkClient, Topic.GROUP_METADATA_TOPIC_NAME, OffsetConfig.DEFAULT_OFFSETS_TOPIC_NUM_PARTITIONS,
@@ -174,7 +175,7 @@ abstract class MultipleListenersWithSameSecurityProtocolBaseTest extends QuorumT
     val listenerName = new ListenerName(listener)
     val prefix = listenerName.saslMechanismConfigPrefix(mechanism)
     val jaasConfig = jaasSection.modules.head.toString
-    props.put(s"${prefix}${KafkaConfig.SaslJaasConfigProp}", jaasConfig)
+    props.put(s"${prefix}${SASL_JAAS_CONFIG_PROP}", jaasConfig)
   }
 
   case class ClientMetadata(listenerName: ListenerName, saslMechanism: String, topic: String) {

--- a/core/src/test/scala/integration/kafka/server/RaftClusterSnapshotTest.scala
+++ b/core/src/test/scala/integration/kafka/server/RaftClusterSnapshotTest.scala
@@ -21,7 +21,7 @@ import java.util.Collections
 import kafka.testkit.KafkaClusterTestKit
 import kafka.testkit.TestKitNodes
 import kafka.utils.TestUtils
-import kafka.server.KafkaConfig.{MetadataMaxIdleIntervalMsProp, MetadataSnapshotMaxNewRecordBytesProp}
+import org.apache.kafka.server.config.KafkaConfig.{METADATA_MAX_IDLE_INTERVAL_MS_PROP, METADATA_SNAPSHOT_MAX_NEW_RECORD_BYTES_PROP}
 import org.apache.kafka.common.utils.BufferSupplier
 import org.apache.kafka.metadata.MetadataRecordSerde
 import org.apache.kafka.snapshot.RecordsSnapshotReader
@@ -48,8 +48,8 @@ class RaftClusterSnapshotTest {
             .setNumControllerNodes(numberOfControllers)
             .build()
         )
-        .setConfigProp(MetadataSnapshotMaxNewRecordBytesProp, "10")
-        .setConfigProp(MetadataMaxIdleIntervalMsProp, "0")
+        .setConfigProp(METADATA_SNAPSHOT_MAX_NEW_RECORD_BYTES_PROP, "10")
+        .setConfigProp(METADATA_MAX_IDLE_INTERVAL_MS_PROP, "0")
         .build()
     ) { cluster =>
       cluster.format()

--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -17,7 +17,6 @@
 package kafka.zk
 
 import kafka.security.authorizer.AclEntry.{WildcardHost, WildcardPrincipalString}
-import kafka.server.KafkaConfig
 import kafka.test.{ClusterConfig, ClusterGenerator, ClusterInstance}
 import kafka.test.annotation.{AutoStart, ClusterConfigProperty, ClusterTemplate, ClusterTest, Type}
 import kafka.test.junit.ClusterTestExtensions
@@ -46,6 +45,7 @@ import org.apache.kafka.metadata.authorizer.StandardAcl
 import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
 import org.apache.kafka.raft.RaftConfig
 import org.apache.kafka.security.PasswordEncoder
+import org.apache.kafka.server.config.KafkaConfig.{MIGRATION_ENABLED_PROP, ZK_CONNECT_PROP, CONTROLLER_LISTENER_NAMES_PROP, LISTENER_SECURITY_PROTOCOL_MAP_PROP}
 import org.apache.kafka.server.ControllerRequestCompletionHandler
 import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion, ProducerIdsBlock}
 import org.apache.kafka.server.config.ConfigType
@@ -176,8 +176,8 @@ class ZkMigrationIntegrationTest {
         setClusterId(Uuid.fromString(clusterId)).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())
-      .setConfigProp(KafkaConfig.MigrationEnabledProp, "true")
-      .setConfigProp(KafkaConfig.ZkConnectProp, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
+      .setConfigProp(MIGRATION_ENABLED_PROP, "true")
+      .setConfigProp(ZK_CONNECT_PROP, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
       .build()
     try {
       kraftCluster.format()
@@ -186,10 +186,10 @@ class ZkMigrationIntegrationTest {
 
       // Enable migration configs and restart brokers
       log.info("Restart brokers in migration mode")
-      zkCluster.config().serverProperties().put(KafkaConfig.MigrationEnabledProp, "true")
+      zkCluster.config().serverProperties().put(MIGRATION_ENABLED_PROP, "true")
       zkCluster.config().serverProperties().put(RaftConfig.QUORUM_VOTERS_CONFIG, kraftCluster.quorumVotersConfig())
-      zkCluster.config().serverProperties().put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
-      zkCluster.config().serverProperties().put(KafkaConfig.ListenerSecurityProtocolMapProp, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
+      zkCluster.config().serverProperties().put(CONTROLLER_LISTENER_NAMES_PROP, "CONTROLLER")
+      zkCluster.config().serverProperties().put(LISTENER_SECURITY_PROTOCOL_MAP_PROP, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
       zkCluster.rollingBrokerRestart() // This would throw if authorizers weren't allowed
       zkCluster.waitForReadyBrokers()
       readyFuture.get(30, TimeUnit.SECONDS)
@@ -298,8 +298,8 @@ class ZkMigrationIntegrationTest {
         setClusterId(Uuid.fromString(clusterId)).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())
-      .setConfigProp(KafkaConfig.MigrationEnabledProp, "true")
-      .setConfigProp(KafkaConfig.ZkConnectProp, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
+      .setConfigProp(MIGRATION_ENABLED_PROP, "true")
+      .setConfigProp(ZK_CONNECT_PROP, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
       .build()
     try {
       kraftCluster.format()
@@ -308,10 +308,10 @@ class ZkMigrationIntegrationTest {
 
       // Enable migration configs and restart brokers
       log.info("Restart brokers in migration mode")
-      zkCluster.config().serverProperties().put(KafkaConfig.MigrationEnabledProp, "true")
+      zkCluster.config().serverProperties().put(MIGRATION_ENABLED_PROP, "true")
       zkCluster.config().serverProperties().put(RaftConfig.QUORUM_VOTERS_CONFIG, kraftCluster.quorumVotersConfig())
-      zkCluster.config().serverProperties().put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
-      zkCluster.config().serverProperties().put(KafkaConfig.ListenerSecurityProtocolMapProp, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
+      zkCluster.config().serverProperties().put(CONTROLLER_LISTENER_NAMES_PROP, "CONTROLLER")
+      zkCluster.config().serverProperties().put(LISTENER_SECURITY_PROTOCOL_MAP_PROP, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
       zkCluster.rollingBrokerRestart()
 
       // Emulate a ZK topic deletion
@@ -432,8 +432,8 @@ class ZkMigrationIntegrationTest {
         setClusterId(Uuid.fromString(clusterId)).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())
-      .setConfigProp(KafkaConfig.MigrationEnabledProp, "true")
-      .setConfigProp(KafkaConfig.ZkConnectProp, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
+      .setConfigProp(MIGRATION_ENABLED_PROP, "true")
+      .setConfigProp(ZK_CONNECT_PROP, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
       .build()
     try {
       kraftCluster.format()
@@ -442,10 +442,10 @@ class ZkMigrationIntegrationTest {
 
       // Enable migration configs and restart brokers
       log.info("Restart brokers in migration mode")
-      zkCluster.config().serverProperties().put(KafkaConfig.MigrationEnabledProp, "true")
+      zkCluster.config().serverProperties().put(MIGRATION_ENABLED_PROP, "true")
       zkCluster.config().serverProperties().put(RaftConfig.QUORUM_VOTERS_CONFIG, kraftCluster.quorumVotersConfig())
-      zkCluster.config().serverProperties().put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
-      zkCluster.config().serverProperties().put(KafkaConfig.ListenerSecurityProtocolMapProp, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
+      zkCluster.config().serverProperties().put(CONTROLLER_LISTENER_NAMES_PROP, "CONTROLLER")
+      zkCluster.config().serverProperties().put(LISTENER_SECURITY_PROTOCOL_MAP_PROP, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
       zkCluster.rollingBrokerRestart()
       zkCluster.waitForReadyBrokers()
       readyFuture.get(30, TimeUnit.SECONDS)
@@ -497,8 +497,8 @@ class ZkMigrationIntegrationTest {
         setClusterId(Uuid.fromString(clusterId)).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())
-      .setConfigProp(KafkaConfig.MigrationEnabledProp, "true")
-      .setConfigProp(KafkaConfig.ZkConnectProp, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
+      .setConfigProp(MIGRATION_ENABLED_PROP, "true")
+      .setConfigProp(ZK_CONNECT_PROP, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
       .build()
     try {
       kraftCluster.format()
@@ -510,10 +510,10 @@ class ZkMigrationIntegrationTest {
 
       // Enable migration configs and restart brokers
       log.info("Restart brokers in migration mode")
-      zkCluster.config().serverProperties().put(KafkaConfig.MigrationEnabledProp, "true")
+      zkCluster.config().serverProperties().put(MIGRATION_ENABLED_PROP, "true")
       zkCluster.config().serverProperties().put(RaftConfig.QUORUM_VOTERS_CONFIG, kraftCluster.quorumVotersConfig())
-      zkCluster.config().serverProperties().put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
-      zkCluster.config().serverProperties().put(KafkaConfig.ListenerSecurityProtocolMapProp, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
+      zkCluster.config().serverProperties().put(CONTROLLER_LISTENER_NAMES_PROP, "CONTROLLER")
+      zkCluster.config().serverProperties().put(LISTENER_SECURITY_PROTOCOL_MAP_PROP, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
       zkCluster.rollingBrokerRestart()
       zkCluster.waitForReadyBrokers()
       readyFuture.get(30, TimeUnit.SECONDS)
@@ -565,8 +565,8 @@ class ZkMigrationIntegrationTest {
         setClusterId(Uuid.fromString(clusterId)).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())
-      .setConfigProp(KafkaConfig.MigrationEnabledProp, "true")
-      .setConfigProp(KafkaConfig.ZkConnectProp, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
+      .setConfigProp(MIGRATION_ENABLED_PROP, "true")
+      .setConfigProp(ZK_CONNECT_PROP, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
       .build()
     try {
       kraftCluster.format()
@@ -575,10 +575,10 @@ class ZkMigrationIntegrationTest {
 
       // Enable migration configs and restart brokers
       log.info("Restart brokers in migration mode")
-      zkCluster.config().serverProperties().put(KafkaConfig.MigrationEnabledProp, "true")
+      zkCluster.config().serverProperties().put(MIGRATION_ENABLED_PROP, "true")
       zkCluster.config().serverProperties().put(RaftConfig.QUORUM_VOTERS_CONFIG, kraftCluster.quorumVotersConfig())
-      zkCluster.config().serverProperties().put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
-      zkCluster.config().serverProperties().put(KafkaConfig.ListenerSecurityProtocolMapProp, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
+      zkCluster.config().serverProperties().put(CONTROLLER_LISTENER_NAMES_PROP, "CONTROLLER")
+      zkCluster.config().serverProperties().put(LISTENER_SECURITY_PROTOCOL_MAP_PROP, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
       zkCluster.rollingBrokerRestart()
       zkCluster.waitForReadyBrokers()
       readyFuture.get(30, TimeUnit.SECONDS)
@@ -625,8 +625,8 @@ class ZkMigrationIntegrationTest {
         setClusterId(Uuid.fromString(clusterId)).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())
-      .setConfigProp(KafkaConfig.MigrationEnabledProp, "true")
-      .setConfigProp(KafkaConfig.ZkConnectProp, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
+      .setConfigProp(MIGRATION_ENABLED_PROP, "true")
+      .setConfigProp(ZK_CONNECT_PROP, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
       .build()
     try {
       kraftCluster.format()
@@ -635,10 +635,10 @@ class ZkMigrationIntegrationTest {
 
       // Enable migration configs and restart brokers
       log.info("Restart brokers in migration mode")
-      zkCluster.config().serverProperties().put(KafkaConfig.MigrationEnabledProp, "true")
+      zkCluster.config().serverProperties().put(MIGRATION_ENABLED_PROP, "true")
       zkCluster.config().serverProperties().put(RaftConfig.QUORUM_VOTERS_CONFIG, kraftCluster.quorumVotersConfig())
-      zkCluster.config().serverProperties().put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
-      zkCluster.config().serverProperties().put(KafkaConfig.ListenerSecurityProtocolMapProp, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
+      zkCluster.config().serverProperties().put(CONTROLLER_LISTENER_NAMES_PROP, "CONTROLLER")
+      zkCluster.config().serverProperties().put(LISTENER_SECURITY_PROTOCOL_MAP_PROP, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
       zkCluster.rollingBrokerRestart()
       zkCluster.waitForReadyBrokers()
       readyFuture.get(30, TimeUnit.SECONDS)
@@ -700,8 +700,8 @@ class ZkMigrationIntegrationTest {
         setClusterId(Uuid.fromString(clusterId)).
         setNumBrokerNodes(0).
         setNumControllerNodes(1).build())
-      .setConfigProp(KafkaConfig.MigrationEnabledProp, "true")
-      .setConfigProp(KafkaConfig.ZkConnectProp, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
+      .setConfigProp(MIGRATION_ENABLED_PROP, "true")
+      .setConfigProp(ZK_CONNECT_PROP, zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.zkConnect)
       .build()
     try {
       kraftCluster.format()
@@ -710,10 +710,10 @@ class ZkMigrationIntegrationTest {
 
       // Enable migration configs and restart brokers
       log.info("Restart brokers in migration mode")
-      zkCluster.config().serverProperties().put(KafkaConfig.MigrationEnabledProp, "true")
+      zkCluster.config().serverProperties().put(MIGRATION_ENABLED_PROP, "true")
       zkCluster.config().serverProperties().put(RaftConfig.QUORUM_VOTERS_CONFIG, kraftCluster.quorumVotersConfig())
-      zkCluster.config().serverProperties().put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
-      zkCluster.config().serverProperties().put(KafkaConfig.ListenerSecurityProtocolMapProp, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
+      zkCluster.config().serverProperties().put(CONTROLLER_LISTENER_NAMES_PROP, "CONTROLLER")
+      zkCluster.config().serverProperties().put(LISTENER_SECURITY_PROTOCOL_MAP_PROP, "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
       zkCluster.rollingBrokerRestart()
       zkCluster.waitForReadyBrokers()
       readyFuture.get(30, TimeUnit.SECONDS)

--- a/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
@@ -17,7 +17,7 @@
 package kafka.raft
 
 import kafka.log.UnifiedLog
-import kafka.server.KafkaConfig.{MetadataLogSegmentBytesProp, MetadataLogSegmentMillisProp, MetadataLogSegmentMinBytesProp, NodeIdProp, ProcessRolesProp, QuorumVotersProp}
+import org.apache.kafka.server.config.KafkaConfig.{METADATA_LOG_SEGMENT_BYTES_PROP, METADATA_LOG_SEGMENT_MILLIS_PROP, METADATA_LOG_SEGMENT_MIN_BYTES_PROP, NODE_ID_PROP, PROCESS_ROLES_PROP, QUORUM_VOTERS_PROP, CONTROLLER_LISTENER_NAMES_PROP}
 import kafka.server.{KafkaConfig, KafkaRaftServer}
 import kafka.utils.TestUtils
 import org.apache.kafka.common.errors.{InvalidConfigurationException, RecordTooLargeException}
@@ -61,19 +61,19 @@ final class KafkaMetadataLogTest {
   @Test
   def testConfig(): Unit = {
     val props = new Properties()
-    props.put(ProcessRolesProp, util.Arrays.asList("broker"))
-    props.put(QuorumVotersProp, "1@localhost:9093")
-    props.put(NodeIdProp, Int.box(2))
-    props.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
-    props.put(MetadataLogSegmentBytesProp, Int.box(10240))
-    props.put(MetadataLogSegmentMillisProp, Int.box(10 * 1024))
+    props.put(PROCESS_ROLES_PROP, util.Arrays.asList("broker"))
+    props.put(QUORUM_VOTERS_PROP, "1@localhost:9093")
+    props.put(NODE_ID_PROP, Int.box(2))
+    props.put(CONTROLLER_LISTENER_NAMES_PROP, "SSL")
+    props.put(METADATA_LOG_SEGMENT_BYTES_PROP, Int.box(10240))
+    props.put(METADATA_LOG_SEGMENT_MILLIS_PROP, Int.box(10 * 1024))
     assertThrows(classOf[InvalidConfigurationException], () => {
       val kafkaConfig = KafkaConfig.fromProps(props)
       val metadataConfig = MetadataLogConfig(kafkaConfig, KafkaRaftClient.MAX_BATCH_SIZE_BYTES, KafkaRaftClient.MAX_FETCH_SIZE_BYTES)
       buildMetadataLog(tempDir, mockTime, metadataConfig)
     })
 
-    props.put(MetadataLogSegmentMinBytesProp, Int.box(10240))
+    props.put(METADATA_LOG_SEGMENT_MIN_BYTES_PROP, Int.box(10240))
     val kafkaConfig = KafkaConfig.fromProps(props)
     val metadataConfig = MetadataLogConfig(kafkaConfig, KafkaRaftClient.MAX_BATCH_SIZE_BYTES, KafkaRaftClient.MAX_FETCH_SIZE_BYTES)
     buildMetadataLog(tempDir, mockTime, metadataConfig)

--- a/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
@@ -25,6 +25,7 @@ import kafka.utils.TestUtils.assertBadConfigContainingMessage
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs
 import org.apache.kafka.common.config.types.Password
 import org.apache.kafka.common.internals.FatalExitError
+import org.apache.kafka.server.config.KafkaConfig._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.api.Assertions._
 
@@ -83,15 +84,15 @@ class KafkaTest {
   def testBrokerRoleNodeIdValidation(): Unit = {
     // Ensure that validation is happening at startup to check that brokers do not use their node.id as a voter in controller.quorum.voters 
     val propertiesFile = new Properties
-    propertiesFile.setProperty(KafkaConfig.ProcessRolesProp, "broker")
-    propertiesFile.setProperty(KafkaConfig.NodeIdProp, "1")
-    propertiesFile.setProperty(KafkaConfig.QuorumVotersProp, "1@localhost:9092")
+    propertiesFile.setProperty(PROCESS_ROLES_PROP, "broker")
+    propertiesFile.setProperty(NODE_ID_PROP, "1")
+    propertiesFile.setProperty(QUORUM_VOTERS_PROP, "1@localhost:9092")
     setListenerProps(propertiesFile)
     assertBadConfigContainingMessage(propertiesFile,
       "If process.roles contains just the 'broker' role, the node id 1 must not be included in the set of voters")
 
     // Ensure that with a valid config no exception is thrown
-    propertiesFile.setProperty(KafkaConfig.NodeIdProp, "2")
+    propertiesFile.setProperty(NODE_ID_PROP, "2")
     KafkaConfig.fromProps(propertiesFile)
   }
 
@@ -99,15 +100,15 @@ class KafkaTest {
   def testControllerRoleNodeIdValidation(): Unit = {
     // Ensure that validation is happening at startup to check that controllers use their node.id as a voter in controller.quorum.voters 
     val propertiesFile = new Properties
-    propertiesFile.setProperty(KafkaConfig.ProcessRolesProp, "controller")
-    propertiesFile.setProperty(KafkaConfig.NodeIdProp, "1")
-    propertiesFile.setProperty(KafkaConfig.QuorumVotersProp, "2@localhost:9092")
+    propertiesFile.setProperty(PROCESS_ROLES_PROP, "controller")
+    propertiesFile.setProperty(NODE_ID_PROP, "1")
+    propertiesFile.setProperty(QUORUM_VOTERS_PROP, "2@localhost:9092")
     setListenerProps(propertiesFile)
     assertBadConfigContainingMessage(propertiesFile,
       "If process.roles contains the 'controller' role, the node id 1 must be included in the set of voters")
 
     // Ensure that with a valid config no exception is thrown
-    propertiesFile.setProperty(KafkaConfig.NodeIdProp, "2")
+    propertiesFile.setProperty(NODE_ID_PROP, "2")
     KafkaConfig.fromProps(propertiesFile)
   }
 
@@ -115,24 +116,24 @@ class KafkaTest {
   def testCombinedRoleNodeIdValidation(): Unit = {
     // Ensure that validation is happening at startup to check that combined processes use their node.id as a voter in controller.quorum.voters
     val propertiesFile = new Properties
-    propertiesFile.setProperty(KafkaConfig.ProcessRolesProp, "controller,broker")
-    propertiesFile.setProperty(KafkaConfig.NodeIdProp, "1")
-    propertiesFile.setProperty(KafkaConfig.QuorumVotersProp, "2@localhost:9092")
+    propertiesFile.setProperty(PROCESS_ROLES_PROP, "controller,broker")
+    propertiesFile.setProperty(NODE_ID_PROP, "1")
+    propertiesFile.setProperty(QUORUM_VOTERS_PROP, "2@localhost:9092")
     setListenerProps(propertiesFile)
     assertBadConfigContainingMessage(propertiesFile,
       "If process.roles contains the 'controller' role, the node id 1 must be included in the set of voters")
 
     // Ensure that with a valid config no exception is thrown
-    propertiesFile.setProperty(KafkaConfig.NodeIdProp, "2")
+    propertiesFile.setProperty(NODE_ID_PROP, "2")
     KafkaConfig.fromProps(propertiesFile)
   }
 
   @Test
   def testIsKRaftCombinedMode(): Unit = {
     val propertiesFile = new Properties
-    propertiesFile.setProperty(KafkaConfig.ProcessRolesProp, "controller,broker")
-    propertiesFile.setProperty(KafkaConfig.NodeIdProp, "1")
-    propertiesFile.setProperty(KafkaConfig.QuorumVotersProp, "1@localhost:9092")
+    propertiesFile.setProperty(PROCESS_ROLES_PROP, "controller,broker")
+    propertiesFile.setProperty(NODE_ID_PROP, "1")
+    propertiesFile.setProperty(QUORUM_VOTERS_PROP, "1@localhost:9092")
     setListenerProps(propertiesFile)
     val config = KafkaConfig.fromProps(propertiesFile)
     assertTrue(config.isKRaftCombinedMode)
@@ -142,45 +143,45 @@ class KafkaTest {
   def testMustContainQuorumVotersIfUsingProcessRoles(): Unit = {
     // Ensure that validation is happening at startup to check that if process.roles is set controller.quorum.voters is not empty
     val propertiesFile = new Properties
-    propertiesFile.setProperty(KafkaConfig.ProcessRolesProp, "controller,broker")
-    propertiesFile.setProperty(KafkaConfig.NodeIdProp, "1")
-    propertiesFile.setProperty(KafkaConfig.QuorumVotersProp, "")
+    propertiesFile.setProperty(PROCESS_ROLES_PROP, "controller,broker")
+    propertiesFile.setProperty(NODE_ID_PROP, "1")
+    propertiesFile.setProperty(QUORUM_VOTERS_PROP, "")
     setListenerProps(propertiesFile)
     assertBadConfigContainingMessage(propertiesFile,
       "If using process.roles, controller.quorum.voters must contain a parseable set of voters.")
 
     // Ensure that if neither process.roles nor controller.quorum.voters is populated, then an exception is thrown if zookeeper.connect is not defined
-    propertiesFile.setProperty(KafkaConfig.ProcessRolesProp, "")
+    propertiesFile.setProperty(PROCESS_ROLES_PROP, "")
     assertBadConfigContainingMessage(propertiesFile,
       "Missing required configuration `zookeeper.connect` which has no default value.")
 
     // Ensure that no exception is thrown once zookeeper.connect is defined (and we clear controller.listener.names)
-    propertiesFile.setProperty(KafkaConfig.ZkConnectProp, "localhost:2181")
-    propertiesFile.setProperty(KafkaConfig.ControllerListenerNamesProp, "")
+    propertiesFile.setProperty(ZK_CONNECT_PROP, "localhost:2181")
+    propertiesFile.setProperty(CONTROLLER_LISTENER_NAMES_PROP, "")
     KafkaConfig.fromProps(propertiesFile)
   }
 
   private def setListenerProps(props: Properties): Unit = {
-    val hasBrokerRole = props.getProperty(KafkaConfig.ProcessRolesProp).contains("broker")
-    val hasControllerRole = props.getProperty(KafkaConfig.ProcessRolesProp).contains("controller")
+    val hasBrokerRole = props.getProperty(PROCESS_ROLES_PROP).contains("broker")
+    val hasControllerRole = props.getProperty(PROCESS_ROLES_PROP).contains("controller")
     val controllerListener = "SASL_PLAINTEXT://localhost:9092"
     val brokerListener = "PLAINTEXT://localhost:9093"
 
     if (hasBrokerRole || hasControllerRole) { // KRaft
-      props.setProperty(KafkaConfig.ControllerListenerNamesProp, "SASL_PLAINTEXT")
+      props.setProperty(CONTROLLER_LISTENER_NAMES_PROP, "SASL_PLAINTEXT")
       if (hasBrokerRole && hasControllerRole) {
-        props.setProperty(KafkaConfig.ListenersProp, s"$brokerListener,$controllerListener")
+        props.setProperty(LISTENERS_PROP, s"$brokerListener,$controllerListener")
       } else if (hasControllerRole) {
-        props.setProperty(KafkaConfig.ListenersProp, controllerListener)
+        props.setProperty(LISTENERS_PROP, controllerListener)
       } else if (hasBrokerRole) {
-        props.setProperty(KafkaConfig.ListenersProp, brokerListener)
+        props.setProperty(LISTENERS_PROP, brokerListener)
       }
     } else { // ZK-based
-       props.setProperty(KafkaConfig.ListenersProp, brokerListener)
+       props.setProperty(LISTENERS_PROP, brokerListener)
     }
     if (!(hasControllerRole & !hasBrokerRole)) { // not controller-only
-      props.setProperty(KafkaConfig.InterBrokerListenerNameProp, "PLAINTEXT")
-      props.setProperty(KafkaConfig.AdvertisedListenersProp, "PLAINTEXT://localhost:9092") 
+      props.setProperty(INTER_BROKER_LISTENER_NAME_PROP, "PLAINTEXT")
+      props.setProperty(ADVERTISED_LISTENERS_PROP, "PLAINTEXT://localhost:9092")
     }
   }
 
@@ -193,19 +194,19 @@ class KafkaTest {
                                                                                     "--override", "ssl.keystore.certificate.chain=certificate_chain",
                                                                                     "--override", "ssl.keystore.key=private_key",
                                                                                     "--override", "ssl.truststore.certificates=truststore_certificates")))
-    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslKeyPasswordProp).toString)
-    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslKeystorePasswordProp).toString)
-    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslTruststorePasswordProp).toString)
-    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslKeystoreKeyProp).toString)
-    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslKeystoreCertificateChainProp).toString)
-    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslTruststoreCertificatesProp).toString)
+    assertEquals(Password.HIDDEN, config.getPassword(SSL_KEY_PASSWORD_PROP).toString)
+    assertEquals(Password.HIDDEN, config.getPassword(SSL_KEYSTORE_PASSWORD_PROP).toString)
+    assertEquals(Password.HIDDEN, config.getPassword(SSL_TRUSTSTORE_PASSWORD_PROP).toString)
+    assertEquals(Password.HIDDEN, config.getPassword(SSL_KEYSTORE_KEY_PROP).toString)
+    assertEquals(Password.HIDDEN, config.getPassword(SSL_KEYSTORE_CERTIFICATE_CHAIN_PROP).toString)
+    assertEquals(Password.HIDDEN, config.getPassword(SSL_TRUSTSTORE_CERTIFICATES_PROP).toString)
 
-    assertEquals("key_password", config.getPassword(KafkaConfig.SslKeyPasswordProp).value)
-    assertEquals("keystore_password", config.getPassword(KafkaConfig.SslKeystorePasswordProp).value)
-    assertEquals("truststore_password", config.getPassword(KafkaConfig.SslTruststorePasswordProp).value)
-    assertEquals("private_key", config.getPassword(KafkaConfig.SslKeystoreKeyProp).value)
-    assertEquals("certificate_chain", config.getPassword(KafkaConfig.SslKeystoreCertificateChainProp).value)
-    assertEquals("truststore_certificates", config.getPassword(KafkaConfig.SslTruststoreCertificatesProp).value)
+    assertEquals("key_password", config.getPassword(SSL_KEY_PASSWORD_PROP).value)
+    assertEquals("keystore_password", config.getPassword(SSL_KEYSTORE_PASSWORD_PROP).value)
+    assertEquals("truststore_password", config.getPassword(SSL_TRUSTSTORE_PASSWORD_PROP).value)
+    assertEquals("private_key", config.getPassword(SSL_KEYSTORE_KEY_PROP).value)
+    assertEquals("certificate_chain", config.getPassword(SSL_KEYSTORE_CERTIFICATE_CHAIN_PROP).value)
+    assertEquals("truststore_certificates", config.getPassword(SSL_TRUSTSTORE_CERTIFICATES_PROP).value)
   }
 
   @Test
@@ -216,13 +217,13 @@ class KafkaTest {
       "--override", "ssl.keystore.password=" + password,
       "--override", "ssl.key.password=" + password,
       "--override", "ssl.truststore.password=" + password)))
-    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslKeyPasswordProp).toString)
-    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslKeystorePasswordProp).toString)
-    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslTruststorePasswordProp).toString)
+    assertEquals(Password.HIDDEN, config.getPassword(SSL_KEY_PASSWORD_PROP).toString)
+    assertEquals(Password.HIDDEN, config.getPassword(SSL_KEYSTORE_PASSWORD_PROP).toString)
+    assertEquals(Password.HIDDEN, config.getPassword(SSL_TRUSTSTORE_PASSWORD_PROP).toString)
 
-    assertEquals(password, config.getPassword(KafkaConfig.SslKeystorePasswordProp).value)
-    assertEquals(password, config.getPassword(KafkaConfig.SslKeyPasswordProp).value)
-    assertEquals(password, config.getPassword(KafkaConfig.SslTruststorePasswordProp).value)
+    assertEquals(password, config.getPassword(SSL_KEYSTORE_PASSWORD_PROP).value)
+    assertEquals(password, config.getPassword(SSL_KEY_PASSWORD_PROP).value)
+    assertEquals(password, config.getPassword(SSL_TRUSTSTORE_PASSWORD_PROP).value)
   }
 
   private val booleanPropValueToSet = true
@@ -232,61 +233,61 @@ class KafkaTest {
 
   @Test
   def testZkSslClientEnable(): Unit = {
-    testZkConfig(KafkaConfig.ZkSslClientEnableProp, "zookeeper.ssl.client.enable",
+    testZkConfig(ZK_SSL_CLIENT_ENABLE_PROP, "zookeeper.ssl.client.enable",
       "zookeeper.client.secure", booleanPropValueToSet, config => Some(config.zkSslClientEnable), booleanPropValueToSet, Some(false))
   }
 
   @Test
   def testZkSslKeyStoreLocation(): Unit = {
-    testZkConfig(KafkaConfig.ZkSslKeyStoreLocationProp, "zookeeper.ssl.keystore.location",
+    testZkConfig(ZK_SSL_KEYSTORE_LOCATION_PROP, "zookeeper.ssl.keystore.location",
       "zookeeper.ssl.keyStore.location", stringPropValueToSet, config => config.zkSslKeyStoreLocation, stringPropValueToSet)
   }
 
   @Test
   def testZkSslTrustStoreLocation(): Unit = {
-    testZkConfig(KafkaConfig.ZkSslTrustStoreLocationProp, "zookeeper.ssl.truststore.location",
+    testZkConfig(ZK_SSL_TRUSTSTORE_LOCATION_PROP, "zookeeper.ssl.truststore.location",
       "zookeeper.ssl.trustStore.location", stringPropValueToSet, config => config.zkSslTrustStoreLocation, stringPropValueToSet)
   }
 
   @Test
   def testZookeeperKeyStorePassword(): Unit = {
-    testZkConfig(KafkaConfig.ZkSslKeyStorePasswordProp, "zookeeper.ssl.keystore.password",
+    testZkConfig(ZK_SSL_KEYSTORE_PASSWORD_PROP, "zookeeper.ssl.keystore.password",
       "zookeeper.ssl.keyStore.password", passwordPropValueToSet, config => config.zkSslKeyStorePassword, new Password(passwordPropValueToSet))
   }
 
   @Test
   def testZookeeperTrustStorePassword(): Unit = {
-    testZkConfig(KafkaConfig.ZkSslTrustStorePasswordProp, "zookeeper.ssl.truststore.password",
+    testZkConfig(ZK_SSL_TRUSTSTORE_PASSWORD_PROP, "zookeeper.ssl.truststore.password",
       "zookeeper.ssl.trustStore.password", passwordPropValueToSet, config => config.zkSslTrustStorePassword, new Password(passwordPropValueToSet))
   }
 
   @Test
   def testZkSslKeyStoreType(): Unit = {
-    testZkConfig(KafkaConfig.ZkSslKeyStoreTypeProp, "zookeeper.ssl.keystore.type",
+    testZkConfig(ZK_SSL_KEYSTORE_TYPE_PROP, "zookeeper.ssl.keystore.type",
       "zookeeper.ssl.keyStore.type", stringPropValueToSet, config => config.zkSslKeyStoreType, stringPropValueToSet)
   }
 
   @Test
   def testZkSslTrustStoreType(): Unit = {
-    testZkConfig(KafkaConfig.ZkSslTrustStoreTypeProp, "zookeeper.ssl.truststore.type",
+    testZkConfig(ZK_SSL_TRUSTSTORE_TYPE_PROP, "zookeeper.ssl.truststore.type",
       "zookeeper.ssl.trustStore.type", stringPropValueToSet, config => config.zkSslTrustStoreType, stringPropValueToSet)
   }
 
   @Test
   def testZkSslProtocol(): Unit = {
-    testZkConfig(KafkaConfig.ZkSslProtocolProp, "zookeeper.ssl.protocol",
+    testZkConfig(ZK_SSL_PROTOCOL_PROP, "zookeeper.ssl.protocol",
       "zookeeper.ssl.protocol", stringPropValueToSet, config => Some(config.ZkSslProtocol), stringPropValueToSet, Some("TLSv1.2"))
   }
 
   @Test
   def testZkSslEnabledProtocols(): Unit = {
-    testZkConfig(KafkaConfig.ZkSslEnabledProtocolsProp, "zookeeper.ssl.enabled.protocols",
+    testZkConfig(ZK_SSL_ENABLED_PROTOCOLS_PROP, "zookeeper.ssl.enabled.protocols",
       "zookeeper.ssl.enabledProtocols", listPropValueToSet.mkString(","), config => config.ZkSslEnabledProtocols, listPropValueToSet.asJava)
   }
 
   @Test
   def testZkSslCipherSuites(): Unit = {
-    testZkConfig(KafkaConfig.ZkSslCipherSuitesProp, "zookeeper.ssl.cipher.suites",
+    testZkConfig(ZK_SSL_CIPHER_SUITES_PROP, "zookeeper.ssl.cipher.suites",
       "zookeeper.ssl.ciphersuites", listPropValueToSet.mkString(","), config => config.ZkSslCipherSuites, listPropValueToSet.asJava)
   }
 
@@ -294,7 +295,7 @@ class KafkaTest {
   def testZkSslEndpointIdentificationAlgorithm(): Unit = {
     // this property is different than the others
     // because the system property values and the Kafka property values don't match
-    val kafkaPropName = KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp
+    val kafkaPropName = ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP
     assertEquals("zookeeper.ssl.endpoint.identification.algorithm", kafkaPropName)
     val sysProp = "zookeeper.ssl.hostnameVerification"
     val expectedDefaultValue = "HTTPS"
@@ -327,13 +328,13 @@ class KafkaTest {
 
   @Test
   def testZkSslCrlEnable(): Unit = {
-    testZkConfig(KafkaConfig.ZkSslCrlEnableProp, "zookeeper.ssl.crl.enable",
+    testZkConfig(ZK_SSL_CRL_ENABLE_PROP, "zookeeper.ssl.crl.enable",
       "zookeeper.ssl.crl", booleanPropValueToSet, config => Some(config.ZkSslCrlEnable), booleanPropValueToSet, Some(false))
   }
 
   @Test
   def testZkSslOcspEnable(): Unit = {
-    testZkConfig(KafkaConfig.ZkSslOcspEnableProp, "zookeeper.ssl.ocsp.enable",
+    testZkConfig(ZK_SSL_OCSP_ENABLE_PROP, "zookeeper.ssl.ocsp.enable",
       "zookeeper.ssl.ocsp", booleanPropValueToSet, config => Some(config.ZkSslOcspEnable), booleanPropValueToSet, Some(false))
   }
 

--- a/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
@@ -34,6 +34,7 @@ import org.apache.kafka.common.resource.PatternType.{LITERAL, PREFIXED}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.utils.{AppInfoParser, SecurityUtils}
 import org.apache.kafka.server.authorizer.Authorizer
+import org.apache.kafka.server.config.KafkaConfig.AUTHORIZER_CLASS_NAME_PROP
 import org.apache.log4j.Level
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
@@ -109,7 +110,7 @@ class AclCommandTest extends QuorumTestHarness with Logging {
     super.setUp(testInfo)
 
     brokerProps = TestUtils.createBrokerConfig(0, zkConnect)
-    brokerProps.put(KafkaConfig.AuthorizerClassNameProp, classOf[AclAuthorizer].getName)
+    brokerProps.put(AUTHORIZER_CLASS_NAME_PROP, classOf[AclAuthorizer].getName)
     brokerProps.put(AclAuthorizer.SuperUsersProp, "User:ANONYMOUS")
 
     zkArgs = Array("--authorizer-properties", "zookeeper.connect=" + zkConnect)

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -35,6 +35,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.{TopicDeletionDisabledException, UnknownTopicOrPartitionException}
 import org.apache.kafka.metadata.BrokerState
+import org.apache.kafka.server.config.KafkaConfig.DELETE_TOPIC_ENABLE_PROP
 
 import scala.jdk.CollectionConverters._
 
@@ -487,7 +488,7 @@ class DeleteTopicTest extends QuorumTestHarness {
     if (isKRaftTest()) {
       // Restart KRaft quorum with the updated config
       val overridingProps = new Properties()
-      overridingProps.put(KafkaConfig.DeleteTopicEnableProp, false.toString)
+      overridingProps.put(DELETE_TOPIC_ENABLE_PROP, false.toString)
       if (implementation != null)
         implementation.shutdown()
       implementation = newKRaftQuorum(overridingProps)

--- a/core/src/test/scala/unit/kafka/admin/ReplicationQuotaUtils.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReplicationQuotaUtils.scala
@@ -12,10 +12,11 @@
   */
 package kafka.admin
 
-import kafka.server.{DynamicConfig, KafkaServer}
+import kafka.server.KafkaServer
 import kafka.utils.TestUtils
 import kafka.zk.AdminZkClient
 import org.apache.kafka.server.config.ConfigType
+import org.apache.kafka.server.config.dynamic.BrokerDynamicConfigs
 import org.apache.kafka.storage.internals.log.LogConfig
 
 import scala.collection.Seq
@@ -26,8 +27,8 @@ object ReplicationQuotaUtils {
     TestUtils.waitUntilTrue(() => {
       val hasRateProp = servers.forall { server =>
         val brokerConfig = adminZkClient.fetchEntityConfig(ConfigType.BROKER, server.config.brokerId.toString)
-        brokerConfig.contains(DynamicConfig.Broker.LeaderReplicationThrottledRateProp) ||
-          brokerConfig.contains(DynamicConfig.Broker.FollowerReplicationThrottledRateProp)
+        brokerConfig.contains(BrokerDynamicConfigs.LEADER_REPLICATION_THROTTLED_RATE_PROP) ||
+          brokerConfig.contains(BrokerDynamicConfigs.FOLLOWER_REPLICATION_THROTTLED_RATE_PROP)
       }
       val topicConfig = adminZkClient.fetchEntityConfig(ConfigType.TOPIC, topic)
       val hasReplicasProp = topicConfig.contains(LogConfig.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG) ||
@@ -41,8 +42,8 @@ object ReplicationQuotaUtils {
       //Check for limit in ZK
       val brokerConfigAvailable = servers.forall { server =>
         val configInZk = adminZkClient.fetchEntityConfig(ConfigType.BROKER, server.config.brokerId.toString)
-        val zkLeaderRate = configInZk.getProperty(DynamicConfig.Broker.LeaderReplicationThrottledRateProp)
-        val zkFollowerRate = configInZk.getProperty(DynamicConfig.Broker.FollowerReplicationThrottledRateProp)
+        val zkLeaderRate = configInZk.getProperty(BrokerDynamicConfigs.LEADER_REPLICATION_THROTTLED_RATE_PROP)
+        val zkFollowerRate = configInZk.getProperty(BrokerDynamicConfigs.FOLLOWER_REPLICATION_THROTTLED_RATE_PROP)
         zkLeaderRate != null && expectedThrottleRate == zkLeaderRate.toLong &&
           zkFollowerRate != null && expectedThrottleRate == zkFollowerRate.toLong
       }

--- a/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
@@ -32,6 +32,7 @@ import org.apache.kafka.common.requests.{AbstractControlRequest, AbstractRespons
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.metadata.LeaderRecoveryState
+import org.apache.kafka.server.config.KafkaConfig.{BROKER_ID_PROP, ZK_CONNECT_PROP}
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.common.MetadataVersion.{IBP_0_10_0_IV1, IBP_0_10_2_IV0, IBP_0_9_0, IBP_1_0_IV0, IBP_2_2_IV0, IBP_2_4_IV0, IBP_2_4_IV1, IBP_2_6_IV0, IBP_2_8_IV1, IBP_3_2_IV0, IBP_3_4_IV0}
 import org.junit.jupiter.api.Assertions._
@@ -894,8 +895,8 @@ class ControllerChannelManagerTest {
 
   private def createConfig(interBrokerVersion: MetadataVersion): KafkaConfig = {
     val props = new Properties()
-    props.put(KafkaConfig.BrokerIdProp, controllerId.toString)
-    props.put(KafkaConfig.ZkConnectProp, "zkConnect")
+    props.put(BROKER_ID_PROP, controllerId.toString)
+    props.put(ZK_CONNECT_PROP, "zkConnect")
     TestUtils.setIbpAndMessageFormatVersions(props, interBrokerVersion)
     KafkaConfig.fromProps(props)
   }

--- a/core/src/test/scala/unit/kafka/controller/ControllerFailoverTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerFailoverTest.scala
@@ -26,6 +26,7 @@ import kafka.server.KafkaConfig
 import kafka.utils._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.server.config.KafkaConfig.NUM_PARTITIONS_PROP
 import org.apache.log4j.Logger
 import org.junit.jupiter.api.{AfterEach, Test}
 import org.junit.jupiter.api.Assertions._
@@ -38,7 +39,7 @@ class ControllerFailoverTest extends KafkaServerTestHarness with Logging {
   val topic = "topic1"
   val overridingProps = new Properties()
   val metrics = new Metrics()
-  overridingProps.put(KafkaConfig.NumPartitionsProp, numParts.toString)
+  overridingProps.put(NUM_PARTITIONS_PROP, numParts.toString)
 
   override def generateConfigs = TestUtils.createBrokerConfigs(numNodes, zkConnect)
     .map(KafkaConfig.fromProps(_, overridingProps))

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -24,7 +24,7 @@ import com.yammer.metrics.core.Timer
 import kafka.api.LeaderAndIsr
 import kafka.server.{KafkaConfig, KafkaServer, QuorumTestHarness}
 import kafka.utils.{LogCaptureAppender, TestUtils}
-import kafka.zk.{FeatureZNodeStatus, _}
+import kafka.zk._
 import org.apache.kafka.common.errors.{ControllerMovedException, StaleBrokerEpochException}
 import org.apache.kafka.common.message.{AlterPartitionRequestData, AlterPartitionResponseData}
 import org.apache.kafka.common.metrics.KafkaMetric
@@ -37,6 +37,7 @@ import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.common.MetadataVersion.{IBP_2_6_IV0, IBP_2_7_IV0, IBP_3_2_IV0}
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
+import org.apache.kafka.server.config.KafkaConfig.{AUTO_LEADER_REBALANCE_ENABLE_PROP, UNCLEAN_LEADER_ELECTION_ENABLE_PROP, LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS_PROP, LISTENERS_PROP, LISTENER_SECURITY_PROTOCOL_MAP_PROP, CONTROL_PLANE_LISTENER_NAME_PROP, INTER_BROKER_PROTOCOL_VERSION_PROP}
 import org.apache.log4j.Level
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
@@ -1941,13 +1942,13 @@ class ControllerIntegrationTest extends QuorumTestHarness {
                           startingIdNumber: Int = 0): Seq[KafkaServer] = {
     val configs = TestUtils.createBrokerConfigs(numConfigs, zkConnect, enableControlledShutdown = enableControlledShutdown, logDirCount = logDirCount, startingIdNumber = startingIdNumber)
     configs.foreach { config =>
-      config.setProperty(KafkaConfig.AutoLeaderRebalanceEnableProp, autoLeaderRebalanceEnable.toString)
-      config.setProperty(KafkaConfig.UncleanLeaderElectionEnableProp, uncleanLeaderElectionEnable.toString)
-      config.setProperty(KafkaConfig.LeaderImbalanceCheckIntervalSecondsProp, "1")
-      listeners.foreach(listener => config.setProperty(KafkaConfig.ListenersProp, listener))
-      listenerSecurityProtocolMap.foreach(listenerMap => config.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, listenerMap))
-      controlPlaneListenerName.foreach(controlPlaneListener => config.setProperty(KafkaConfig.ControlPlaneListenerNameProp, controlPlaneListener))
-      interBrokerProtocolVersion.foreach(ibp => config.setProperty(KafkaConfig.InterBrokerProtocolVersionProp, ibp.toString))
+      config.setProperty(AUTO_LEADER_REBALANCE_ENABLE_PROP, autoLeaderRebalanceEnable.toString)
+      config.setProperty(UNCLEAN_LEADER_ELECTION_ENABLE_PROP, uncleanLeaderElectionEnable.toString)
+      config.setProperty(LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS_PROP, "1")
+      listeners.foreach(listener => config.setProperty(LISTENERS_PROP, listener))
+      listenerSecurityProtocolMap.foreach(listenerMap => config.setProperty(LISTENER_SECURITY_PROTOCOL_MAP_PROP, listenerMap))
+      controlPlaneListenerName.foreach(controlPlaneListener => config.setProperty(CONTROL_PLANE_LISTENER_NAME_PROP, controlPlaneListener))
+      interBrokerProtocolVersion.foreach(ibp => config.setProperty(INTER_BROKER_PROTOCOL_VERSION_PROP, ibp.toString))
     }
     configs.map(config => TestUtils.createServer(KafkaConfig.fromProps(config)))
   }

--- a/core/src/test/scala/unit/kafka/controller/PartitionStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/PartitionStateMachineTest.scala
@@ -23,6 +23,7 @@ import kafka.zk.KafkaZkClient.UpdateLeaderAndIsrResult
 import kafka.zk.{KafkaZkClient, TopicPartitionStateZNode}
 import kafka.zookeeper._
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_PROTOCOL_VERSION_PROP
 import org.apache.kafka.server.common.MetadataVersion.{IBP_3_1_IV0, IBP_3_2_IV0}
 import org.apache.kafka.storage.internals.log.LogConfig
 import org.apache.zookeeper.KeeperException.Code
@@ -298,7 +299,7 @@ class PartitionStateMachineTest {
       val apiVersion = if (isLeaderRecoverySupported) IBP_3_2_IV0 else IBP_3_1_IV0
       val properties = TestUtils.createBrokerConfig(brokerId, "zkConnect")
 
-      properties.setProperty(KafkaConfig.InterBrokerProtocolVersionProp, apiVersion.toString)
+      properties.setProperty(INTER_BROKER_PROTOCOL_VERSION_PROP, apiVersion.toString)
 
       new ZkPartitionStateMachine(
         KafkaConfig.fromProps(properties),

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
@@ -33,6 +33,7 @@ import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{JoinGroupRequest, OffsetFetchResponse}
 import org.apache.kafka.common.utils.Time
+import org.apache.kafka.server.config.KafkaConfig.{GROUP_MIN_SESSION_TIMEOUT_MS_PROP, GROUP_MAX_SESSION_TIMEOUT_MS_PROP, GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, GROUP_MAX_SIZE_PROP}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.mockito.Mockito.when
@@ -72,9 +73,9 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
     when(zkClient.getTopicPartitionCount(Topic.GROUP_METADATA_TOPIC_NAME))
       .thenReturn(Some(numPartitions))
 
-    serverProps.setProperty(KafkaConfig.GroupMinSessionTimeoutMsProp, ConsumerMinSessionTimeout.toString)
-    serverProps.setProperty(KafkaConfig.GroupMaxSessionTimeoutMsProp, ConsumerMaxSessionTimeout.toString)
-    serverProps.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, GroupInitialRebalanceDelay.toString)
+    serverProps.setProperty(GROUP_MIN_SESSION_TIMEOUT_MS_PROP, ConsumerMinSessionTimeout.toString)
+    serverProps.setProperty(GROUP_MAX_SESSION_TIMEOUT_MS_PROP, ConsumerMaxSessionTimeout.toString)
+    serverProps.setProperty(GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, GroupInitialRebalanceDelay.toString)
 
     val config = KafkaConfig.fromProps(serverProps)
 
@@ -147,7 +148,7 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
   def testConcurrentJoinGroupEnforceGroupMaxSize(): Unit = {
     val groupMaxSize = 1
     val newProperties = new Properties
-    newProperties.put(KafkaConfig.GroupMaxSizeProp, groupMaxSize.toString)
+    newProperties.put(GROUP_MAX_SIZE_PROP, groupMaxSize.toString)
     val config = KafkaConfig.fromProps(serverProps, newProperties)
 
     if (groupCoordinator != null)

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -26,7 +26,7 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.{MemoryRecords, RecordBatch}
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.{JoinGroupRequest, OffsetCommitRequest, OffsetFetchResponse, TransactionResult}
-
+import org.apache.kafka.server.config.KafkaConfig.{GROUP_MIN_SESSION_TIMEOUT_MS_PROP, GROUP_MAX_SESSION_TIMEOUT_MS_PROP, GROUP_MAX_SIZE_PROP, GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, OFFSETS_RETENTION_MINUTES_PROP}
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 import kafka.cluster.Partition
@@ -99,10 +99,10 @@ class GroupCoordinatorTest {
   @BeforeEach
   def setUp(): Unit = {
     val props = TestUtils.createBrokerConfig(nodeId = 0, zkConnect = "")
-    props.setProperty(KafkaConfig.GroupMinSessionTimeoutMsProp, GroupMinSessionTimeout.toString)
-    props.setProperty(KafkaConfig.GroupMaxSessionTimeoutMsProp, GroupMaxSessionTimeout.toString)
-    props.setProperty(KafkaConfig.GroupMaxSizeProp, GroupMaxSize.toString)
-    props.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, GroupInitialRebalanceDelay.toString)
+    props.setProperty(GROUP_MIN_SESSION_TIMEOUT_MS_PROP, GroupMinSessionTimeout.toString)
+    props.setProperty(GROUP_MAX_SESSION_TIMEOUT_MS_PROP, GroupMaxSessionTimeout.toString)
+    props.setProperty(GROUP_MAX_SIZE_PROP, GroupMaxSize.toString)
+    props.setProperty(GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, GroupInitialRebalanceDelay.toString)
     // make two partitions of the group topic to make sure some partitions are not owned by the coordinator
     val ret = mutable.Map[String, Map[Int, Seq[Int]]]()
     ret += (Topic.GROUP_METADATA_TOPIC_NAME -> Map(0 -> Seq(1), 1 -> Seq(1)))
@@ -199,7 +199,7 @@ class GroupCoordinatorTest {
   @Test
   def testOffsetsRetentionMsIntegerOverflow(): Unit = {
     val props = TestUtils.createBrokerConfig(nodeId = 0, zkConnect = "")
-    props.setProperty(KafkaConfig.OffsetsRetentionMinutesProp, Integer.MAX_VALUE.toString)
+    props.setProperty(OFFSETS_RETENTION_MINUTES_PROP, Integer.MAX_VALUE.toString)
     val config = KafkaConfig.fromProps(props)
     val offsetConfig = GroupCoordinator.offsetConfig(config)
     assertEquals(offsetConfig.offsetsRetentionMs, Integer.MAX_VALUE * 60L * 1000L)

--- a/core/src/test/scala/unit/kafka/integration/MetricsDuringTopicCreationDeletionTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/MetricsDuringTopicCreationDeletionTest.scala
@@ -24,6 +24,7 @@ import kafka.utils.{Logging, TestInfoUtils, TestUtils}
 import scala.jdk.CollectionConverters._
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 import com.yammer.metrics.core.Gauge
+import org.apache.kafka.server.config.KafkaConfig.{DELETE_TOPIC_ENABLE_PROP, AUTO_CREATE_TOPICS_ENABLE_PROP, REPLICA_LAG_TIME_MAX_MS_PROP}
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -38,11 +39,11 @@ class MetricsDuringTopicCreationDeletionTest extends KafkaServerTestHarness with
   private val createDeleteIterations = 3
 
   private val overridingProps = new Properties
-  overridingProps.put(KafkaConfig.DeleteTopicEnableProp, "true")
-  overridingProps.put(KafkaConfig.AutoCreateTopicsEnableProp, "false")
+  overridingProps.put(DELETE_TOPIC_ENABLE_PROP, "true")
+  overridingProps.put(AUTO_CREATE_TOPICS_ENABLE_PROP, "false")
   // speed up the test for UnderReplicatedPartitions, which relies on the ISR expiry thread to execute concurrently with topic creation
   // But the replica.lag.time.max.ms value still need to consider the slow Jenkins testing environment
-  overridingProps.put(KafkaConfig.ReplicaLagTimeMaxMsProp, "4000")
+  overridingProps.put(REPLICA_LAG_TIME_MAX_MS_PROP, "4000")
 
   private val testedMetrics = List("OfflinePartitionsCount","PreferredReplicaImbalanceCount","UnderReplicatedPartitions")
   private val topics = List.tabulate(topicNum) (n => topicName + n)

--- a/core/src/test/scala/unit/kafka/integration/MinIsrConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/MinIsrConfigTest.scala
@@ -22,12 +22,13 @@ import scala.collection.Seq
 
 import kafka.server.KafkaConfig
 import kafka.utils.{TestInfoUtils, TestUtils}
+import org.apache.kafka.server.config.KafkaConfig.MIN_IN_SYNC_REPLICAS_PROP
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 class MinIsrConfigTest extends KafkaServerTestHarness {
   val overridingProps = new Properties()
-  overridingProps.put(KafkaConfig.MinInSyncReplicasProp, "5")
+  overridingProps.put(MIN_IN_SYNC_REPLICAS_PROP, "5")
   def generateConfigs: Seq[KafkaConfig] = TestUtils.createBrokerConfigs(1, zkConnectOrNull).map(KafkaConfig.fromProps(_, overridingProps))
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)

--- a/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
@@ -35,6 +35,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, AlterConfigsResult, Config, ConfigEntry}
+import org.apache.kafka.server.config.KafkaConfig.UNCLEAN_LEADER_ELECTION_ENABLE_PROP
 import org.junit.jupiter.api.Assertions._
 
 import scala.annotation.nowarn
@@ -325,7 +326,7 @@ class UncleanLeaderElectionTest extends QuorumTestHarness {
     // Enable unclean leader election for topic
     val adminClient = createAdminClient()
     val newProps = new Properties
-    newProps.put(KafkaConfig.UncleanLeaderElectionEnableProp, "true")
+    newProps.put(UNCLEAN_LEADER_ELECTION_ENABLE_PROP, "true")
     alterTopicConfigs(adminClient, topic, newProps).all.get
     adminClient.close()
 

--- a/core/src/test/scala/unit/kafka/log/LogCleanerParameterizedIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerParameterizedIntegrationTest.scala
@@ -25,6 +25,7 @@ import kafka.utils._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.record._
+import org.apache.kafka.server.config.KafkaConfig.MESSAGE_MAX_BYTES_PROP
 import org.apache.kafka.server.common.MetadataVersion.{IBP_0_10_0_IV1, IBP_0_11_0_IV0, IBP_0_9_0}
 import org.apache.kafka.server.util.MockTime
 import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig}
@@ -255,7 +256,7 @@ class LogCleanerParameterizedIntegrationTest extends AbstractLogCleanerIntegrati
       props.put(CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE_PROP, cleanerConfig.dedupeBufferSize.toString)
       props.put(CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_LOAD_FACTOR_PROP, cleanerConfig.dedupeBufferLoadFactor.toString)
       props.put(CleanerConfig.LOG_CLEANER_IO_BUFFER_SIZE_PROP, cleanerConfig.ioBufferSize.toString)
-      props.put(KafkaConfig.MessageMaxBytesProp, cleanerConfig.maxMessageSize.toString)
+      props.put(MESSAGE_MAX_BYTES_PROP, cleanerConfig.maxMessageSize.toString)
       props.put(CleanerConfig.LOG_CLEANER_BACKOFF_MS_PROP, cleanerConfig.backoffMs.toString)
       props.put(CleanerConfig.LOG_CLEANER_IO_MAX_BYTES_PER_SECOND_PROP, cleanerConfig.maxIoBytesPerSecond.toString)
       KafkaConfig.fromProps(props)

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
 import java.util.{Collections, Properties}
+import org.apache.kafka.server.config.KafkaConfig._
 import org.apache.kafka.server.common.MetadataVersion.IBP_3_0_IV1
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.storage.internals.log.{LogConfig, ThrottledReplicaListValidator}
@@ -47,7 +48,7 @@ class LogConfigTest {
   @Test
   def ensureNoStaticInitializationOrderDependency(): Unit = {
     // Access any KafkaConfig val to load KafkaConfig object before LogConfig.
-    assertNotNull(KafkaConfig.LogRetentionTimeMillisProp)
+    assertNotNull(LOG_RETENTION_TIME_MILLIS_PROP)
     assertTrue(LogConfig.configNames.asScala
       .filter(config => !LogConfig.CONFIGS_WITH_NO_SERVER_DEFAULTS.contains(config))
       .forall { config =>
@@ -63,10 +64,10 @@ class LogConfigTest {
     val millisInDay = 24L * millisInHour
     val bytesInGB: Long = 1024 * 1024 * 1024
     val kafkaProps = TestUtils.createBrokerConfig(nodeId = 0, zkConnect = "")
-    kafkaProps.put(KafkaConfig.LogRollTimeHoursProp, "2")
-    kafkaProps.put(KafkaConfig.LogRollTimeJitterHoursProp, "2")
-    kafkaProps.put(KafkaConfig.LogRetentionTimeHoursProp, "960") // 40 days
-    kafkaProps.put(KafkaConfig.LogMessageFormatVersionProp, "0.11.0")
+    kafkaProps.put(LOG_ROLL_TIME_HOURS_PROP, "2")
+    kafkaProps.put(LOG_ROLL_TIME_JITTER_HOURS_PROP, "2")
+    kafkaProps.put(LOG_RETENTION_TIME_HOURS_PROP, "960") // 40 days
+    kafkaProps.put(LOG_MESSAGE_FORMAT_VERSION_PROP, "0.11.0")
     kafkaProps.put(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP, "2592000000") // 30 days
     kafkaProps.put(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP, "4294967296") // 4 GB
 
@@ -172,7 +173,7 @@ class LogConfigTest {
 
     val deleteDelayKey = configDef.configKeys.get(TopicConfig.FILE_DELETE_DELAY_MS_CONFIG)
     val deleteDelayServerDefault = configDef.getConfigValue(deleteDelayKey, LogConfig.SERVER_DEFAULT_HEADER_NAME)
-    assertEquals(KafkaConfig.LogDeleteDelayMsProp, deleteDelayServerDefault)
+    assertEquals(LOG_DELETE_DELAY_MS_PROP, deleteDelayServerDefault)
 
     val keyWithNoServerMapping = configDef.configKeys.get(configNameWithNoServerMapping)
     val nullServerDefault = configDef.getConfigValue(keyWithNoServerMapping, LogConfig.SERVER_DEFAULT_HEADER_NAME)
@@ -183,8 +184,8 @@ class LogConfigTest {
   def testOverriddenConfigsAsLoggableString(): Unit = {
     val kafkaProps = TestUtils.createBrokerConfig(nodeId = 0, zkConnect = "")
     kafkaProps.put("unknown.broker.password.config", "aaaaa")
-    kafkaProps.put(KafkaConfig.SslKeyPasswordProp, "somekeypassword")
-    kafkaProps.put(KafkaConfig.LogRetentionBytesProp, "50")
+    kafkaProps.put(SSL_KEY_PASSWORD_PROP, "somekeypassword")
+    kafkaProps.put(LOG_RETENTION_BYTES_PROP, "50")
     val kafkaConfig = KafkaConfig.fromProps(kafkaProps)
     val topicOverrides = new Properties
     // Only set as a topic config
@@ -192,7 +193,7 @@ class LogConfigTest {
     // Overrides value from broker config
     topicOverrides.setProperty(TopicConfig.RETENTION_BYTES_CONFIG, "100")
     // Unknown topic config, but known broker config
-    topicOverrides.setProperty(KafkaConfig.SslTruststorePasswordProp, "sometrustpasswrd")
+    topicOverrides.setProperty(SSL_TRUSTSTORE_PASSWORD_PROP, "sometrustpasswrd")
     // Unknown config
     topicOverrides.setProperty("unknown.topic.password.config", "bbbb")
     // We don't currently have any sensitive topic configs, if we add them, we should set one here
@@ -341,7 +342,7 @@ class LogConfigTest {
   def testTopicCreationWithInvalidRetentionTime(sysRemoteStorageEnabled: Boolean): Unit = {
     val kafkaProps = TestUtils.createDummyBrokerConfig()
     kafkaProps.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, sysRemoteStorageEnabled.toString)
-    kafkaProps.put(KafkaConfig.LogRetentionTimeMillisProp, "1000")
+    kafkaProps.put(LOG_RETENTION_TIME_MILLIS_PROP, "1000")
     kafkaProps.put(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP, "900")
     val kafkaConfig = KafkaConfig.fromProps(kafkaProps)
 
@@ -363,7 +364,7 @@ class LogConfigTest {
   def testTopicCreationWithInvalidRetentionSize(sysRemoteStorageEnabled: Boolean): Unit = {
     val props = TestUtils.createDummyBrokerConfig()
     props.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, sysRemoteStorageEnabled.toString)
-    props.put(KafkaConfig.LogRetentionBytesProp, "1024")
+    props.put(LOG_RETENTION_BYTES_PROP, "1024")
     props.put(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP, "512")
     val kafkaConfig = KafkaConfig.fromProps(props)
 
@@ -385,7 +386,7 @@ class LogConfigTest {
   def testValidateBrokerLogConfigs(sysRemoteStorageEnabled: Boolean): Unit = {
     val props = TestUtils.createDummyBrokerConfig()
     props.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, sysRemoteStorageEnabled.toString)
-    props.put(KafkaConfig.LogRetentionBytesProp, "1024")
+    props.put(LOG_RETENTION_BYTES_PROP, "1024")
     props.put(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP, "2048")
     val kafkaConfig = KafkaConfig.fromProps(props)
 
@@ -407,9 +408,9 @@ class LogConfigTest {
   def testTimestampBeforeMaxMsUsesDeprecatedConfig(): Unit = {
     val oneDayInMillis = 24 * 60 * 60 * 1000L
     val kafkaProps = TestUtils.createBrokerConfig(nodeId = 0, zkConnect = "")
-    kafkaProps.put(KafkaConfig.LogMessageTimestampBeforeMaxMsProp, Long.MaxValue.toString)
-    kafkaProps.put(KafkaConfig.LogMessageTimestampAfterMaxMsProp, Long.MaxValue.toString)
-    kafkaProps.put(KafkaConfig.LogMessageTimestampDifferenceMaxMsProp, oneDayInMillis.toString)
+    kafkaProps.put(LOG_MESSAGE_TIMESTAMP_BEFORE_MAX_MS_PROP, Long.MaxValue.toString)
+    kafkaProps.put(LOG_MESSAGE_TIMESTAMP_AFTER_MAX_MS_PROP, Long.MaxValue.toString)
+    kafkaProps.put(LOG_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_PROP, oneDayInMillis.toString)
 
     val logProps = KafkaConfig.fromProps(kafkaProps).extractLogConfigMap
     assertEquals(oneDayInMillis, logProps.get(TopicConfig.MESSAGE_TIMESTAMP_BEFORE_MAX_MS_CONFIG))

--- a/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
@@ -33,6 +33,7 @@ import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.metrics.JmxReporter
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.metadata.migration.ZkMigrationState
+import org.apache.kafka.server.config.KafkaConfig.NUM_PARTITIONS_PROP
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.junit.jupiter.api.Timeout
@@ -46,7 +47,7 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
 
   val requiredKafkaServerPrefix = "kafka.server:type=KafkaServer,name"
   val overridingProps = new Properties
-  overridingProps.put(KafkaConfig.NumPartitionsProp, numParts.toString)
+  overridingProps.put(NUM_PARTITIONS_PROP, numParts.toString)
   overridingProps.put(JmxReporter.EXCLUDE_CONFIG, s"$requiredKafkaServerPrefix=ClusterId")
 
   def generateConfigs: Seq[KafkaConfig] =

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -46,6 +46,7 @@ import org.apache.kafka.common.requests._
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.utils.{AppInfoParser, LogContext, MockTime, Time, Utils}
+import org.apache.kafka.server.config.KafkaConfig._
 import org.apache.kafka.server.common.{Features, MetadataVersion}
 import org.apache.kafka.test.{TestSslUtils, TestUtils => JTestUtils}
 import org.apache.log4j.Level
@@ -525,7 +526,7 @@ class SocketServerTest {
   def testIdleConnection(): Unit = {
     val idleTimeMs = 60000
     val time = new MockTime()
-    props.put(KafkaConfig.ConnectionsMaxIdleMsProp, idleTimeMs.toString)
+    props.put(CONNECTIONS_MAX_IDLE_MS_PROP, idleTimeMs.toString)
     val serverMetrics = new Metrics
     val overrideServer = new SocketServer(KafkaConfig.fromProps(props), serverMetrics,
       time, credentialProvider, apiVersionManager)
@@ -578,7 +579,7 @@ class SocketServerTest {
   @Test
   def testConnectionIdReuse(): Unit = {
     val idleTimeMs = 60000
-    props.put(KafkaConfig.ConnectionsMaxIdleMsProp, idleTimeMs.toString)
+    props.put(CONNECTIONS_MAX_IDLE_MS_PROP, idleTimeMs.toString)
     props ++= sslServerProps
     val overrideConnectionId = "127.0.0.1:1-127.0.0.1:2-0"
     val overrideServer = new TestableSocketServer(KafkaConfig.fromProps(props))
@@ -863,8 +864,8 @@ class SocketServerTest {
   @Test
   def testZeroMaxConnectionsPerIp(): Unit = {
     val newProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 0)
-    newProps.setProperty(KafkaConfig.MaxConnectionsPerIpProp, "0")
-    newProps.setProperty(KafkaConfig.MaxConnectionsPerIpOverridesProp, "%s:%s".format("127.0.0.1", "5"))
+    newProps.setProperty(MAX_CONNECTIONS_PER_IP_PROP, "0")
+    newProps.setProperty(MAX_CONNECTIONS_PER_IP_OVERRIDES_PROP, "%s:%s".format("127.0.0.1", "5"))
     val server = new SocketServer(KafkaConfig.fromProps(newProps), new Metrics(),
       Time.SYSTEM, credentialProvider, apiVersionManager)
     try {
@@ -902,7 +903,7 @@ class SocketServerTest {
   def testMaxConnectionsPerIpOverrides(): Unit = {
     val overrideNum = server.config.maxConnectionsPerIp + 1
     val overrideProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 0)
-    overrideProps.put(KafkaConfig.MaxConnectionsPerIpOverridesProp, s"localhost:$overrideNum")
+    overrideProps.put(MAX_CONNECTIONS_PER_IP_OVERRIDES_PROP, s"localhost:$overrideNum")
     val serverMetrics = new Metrics()
     val overrideServer = new SocketServer(KafkaConfig.fromProps(overrideProps), serverMetrics,
       Time.SYSTEM, credentialProvider, apiVersionManager)
@@ -961,8 +962,8 @@ class SocketServerTest {
   def testConnectionRatePerIp(): Unit = {
     val defaultTimeoutMs = 2000
     val overrideProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 0)
-    overrideProps.remove(KafkaConfig.MaxConnectionsPerIpProp)
-    overrideProps.put(KafkaConfig.NumQuotaSamplesProp, String.valueOf(2))
+    overrideProps.remove(MAX_CONNECTIONS_PER_IP_PROP)
+    overrideProps.put(NUM_QUOTA_SAMPLES_PROP, String.valueOf(2))
     val connectionRate = 5
     val time = new MockTime()
     val overrideServer = new SocketServer(KafkaConfig.fromProps(overrideProps), new Metrics(),
@@ -1013,7 +1014,7 @@ class SocketServerTest {
   def testThrottledSocketsClosedOnShutdown(): Unit = {
     val overrideProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 0)
     overrideProps.remove("max.connections.per.ip")
-    overrideProps.put(KafkaConfig.NumQuotaSamplesProp, String.valueOf(2))
+    overrideProps.put(NUM_QUOTA_SAMPLES_PROP, String.valueOf(2))
     val connectionRate = 5
     val time = new MockTime()
     val overrideServer = new SocketServer(KafkaConfig.fromProps(overrideProps), new Metrics(),
@@ -1235,7 +1236,7 @@ class SocketServerTest {
    */
   @Test
   def testBrokerSendAfterChannelClosedUpdatesRequestMetrics(): Unit = {
-    props.setProperty(KafkaConfig.ConnectionsMaxIdleMsProp, "110")
+    props.setProperty(CONNECTIONS_MAX_IDLE_MS_PROP, "110")
     val serverMetrics = new Metrics
     var conn: Socket = null
     val overrideServer = new SocketServer(KafkaConfig.fromProps(props), serverMetrics,
@@ -1619,7 +1620,7 @@ class SocketServerTest {
     shutdownServerAndMetrics(server)
     val idleTimeMs = 60000
     val time = new MockTime()
-    props.put(KafkaConfig.ConnectionsMaxIdleMsProp, idleTimeMs.toString)
+    props.put(CONNECTIONS_MAX_IDLE_MS_PROP, idleTimeMs.toString)
     props ++= sslServerProps
     val testableServer = new TestableSocketServer(time = time)
     testableServer.enableRequestProcessing(Map.empty).get(1, TimeUnit.MINUTES)
@@ -2038,8 +2039,8 @@ class SocketServerTest {
     val trustStoreFile = TestUtils.tempFile("truststore", ".jks")
     val sslProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, interBrokerSecurityProtocol = Some(SecurityProtocol.SSL),
       trustStoreFile = Some(trustStoreFile))
-    sslProps.put(KafkaConfig.ListenersProp, "SSL://localhost:0")
-    sslProps.put(KafkaConfig.NumNetworkThreadsProp, "1")
+    sslProps.put(LISTENERS_PROP, "SSL://localhost:0")
+    sslProps.put(NUM_NETWORK_THREADS_PROP, "1")
     sslProps
   }
 

--- a/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
@@ -31,6 +31,7 @@ import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.raft.RaftConfig
+import org.apache.kafka.server.config.KafkaConfig._
 import org.apache.kafka.server.ProcessRole
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
@@ -48,26 +49,26 @@ class RaftManagerTest {
   ): KafkaConfig = {
     val props = new Properties
     logDir.foreach { value =>
-      props.setProperty(KafkaConfig.LogDirProp, value.toString)
+      props.setProperty(LOG_DIR_PROP, value.toString)
     }
     metadataDir.foreach { value =>
-      props.setProperty(KafkaConfig.MetadataLogDirProp, value.toString)
+      props.setProperty(METADATA_LOG_DIR_PROP, value.toString)
     }
-    props.setProperty(KafkaConfig.ProcessRolesProp, processRoles.mkString(","))
-    props.setProperty(KafkaConfig.NodeIdProp, nodeId.toString)
-    props.setProperty(KafkaConfig.ControllerListenerNamesProp, "SSL")
+    props.setProperty(PROCESS_ROLES_PROP, processRoles.mkString(","))
+    props.setProperty(NODE_ID_PROP, nodeId.toString)
+    props.setProperty(CONTROLLER_LISTENER_NAMES_PROP, "SSL")
     if (processRoles.contains(ProcessRole.BrokerRole)) {
-      props.setProperty(KafkaConfig.InterBrokerListenerNameProp, "PLAINTEXT")
+      props.setProperty(INTER_BROKER_LISTENER_NAME_PROP, "PLAINTEXT")
       if (processRoles.contains(ProcessRole.ControllerRole)) { // co-located
-        props.setProperty(KafkaConfig.ListenersProp, "PLAINTEXT://localhost:9092,SSL://localhost:9093")
-        props.setProperty(KafkaConfig.QuorumVotersProp, s"${nodeId}@localhost:9093")
+        props.setProperty(LISTENERS_PROP, "PLAINTEXT://localhost:9092,SSL://localhost:9093")
+        props.setProperty(QUORUM_VOTERS_PROP, s"${nodeId}@localhost:9093")
       } else { // broker-only
         val voterId = nodeId + 1
-        props.setProperty(KafkaConfig.QuorumVotersProp, s"${voterId}@localhost:9093")
+        props.setProperty(QUORUM_VOTERS_PROP, s"${voterId}@localhost:9093")
       }
     } else if (processRoles.contains(ProcessRole.ControllerRole)) { // controller-only
-      props.setProperty(KafkaConfig.ListenersProp, "SSL://localhost:9093")
-      props.setProperty(KafkaConfig.QuorumVotersProp, s"${nodeId}@localhost:9093")
+      props.setProperty(LISTENERS_PROP, "SSL://localhost:9093")
+      props.setProperty(QUORUM_VOTERS_PROP, s"${nodeId}@localhost:9093")
     }
 
     new KafkaConfig(props)

--- a/core/src/test/scala/unit/kafka/security/authorizer/AuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/authorizer/AuthorizerTest.scala
@@ -870,7 +870,7 @@ class AuthorizerTest extends QuorumTestHarness with BaseAuthorizerTest {
     val zkClientConfig = AclAuthorizer.zkClientConfigFromKafkaConfigAndMap(
       KafkaConfig.fromProps(noTlsProps),
       noTlsProps.asInstanceOf[java.util.Map[String, Any]].asScala)
-    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().forEach { propName =>
+    zkSslConfigToSystemPropertyMap.keySet().forEach { propName =>
       assertNull(zkClientConfig.getProperty(propName))
     }
   }
@@ -895,7 +895,7 @@ class AuthorizerTest extends QuorumTestHarness with BaseAuthorizerTest {
     val zkClientConfig = AclAuthorizer.zkClientConfigFromKafkaConfigAndMap(
       KafkaConfig.fromProps(props), mutable.Map(configs.toSeq: _*))
     // confirm we get all the values we expect
-    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().forEach(prop => prop match {
+    zkSslConfigToSystemPropertyMap.keySet().forEach(prop => prop match {
       case ZK_SSL_CLIENT_ENABLE_PROP | ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP =>
         assertEquals("true", zooKeeperClientProperty(zkClientConfig, prop).orElse("<None>"))
       case ZK_SSL_CRL_ENABLE_PROP | ZK_SSL_OCSP_ENABLE_PROP =>
@@ -930,7 +930,7 @@ class AuthorizerTest extends QuorumTestHarness with BaseAuthorizerTest {
     val zkClientConfig = AclAuthorizer.zkClientConfigFromKafkaConfigAndMap(
       KafkaConfig.fromProps(props), mutable.Map(configs.toSeq: _*))
     // confirm we get all the values we expect
-    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.asScala.keys.foreach(prop => prop match {
+    zkSslConfigToSystemPropertyMap.asScala.keys.foreach(prop => prop match {
         case ZK_SSL_CLIENT_ENABLE_PROP | ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP =>
           assertEquals("true", zooKeeperClientProperty(zkClientConfig, prop).orElse("<None>"))
         case ZK_SSL_CRL_ENABLE_PROP | ZK_SSL_OCSP_ENABLE_PROP =>
@@ -979,7 +979,7 @@ class AuthorizerTest extends QuorumTestHarness with BaseAuthorizerTest {
     val zkClientConfig = AclAuthorizer.zkClientConfigFromKafkaConfigAndMap(
       KafkaConfig.fromProps(props), mutable.Map(configs.toSeq: _*))
     // confirm we get all the values we expect
-    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet.forEach(prop => prop match {
+    zkSslConfigToSystemPropertyMap.keySet.forEach(prop => prop match {
       case ZK_SSL_CLIENT_ENABLE_PROP | ZK_SSL_CRL_ENABLE_PROP | ZK_SSL_OCSP_ENABLE_PROP =>
         assertEquals("true", zooKeeperClientProperty(zkClientConfig, prop).orElse("<None>"))
       case ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP =>

--- a/core/src/test/scala/unit/kafka/security/authorizer/AuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/authorizer/AuthorizerTest.scala
@@ -39,6 +39,7 @@ import org.apache.kafka.controller.MockAclMutator
 import org.apache.kafka.metadata.authorizer.StandardAuthorizerTest.AuthorizerTestServerInfo
 import org.apache.kafka.metadata.authorizer.StandardAuthorizer
 import org.apache.kafka.server.authorizer._
+import org.apache.kafka.server.config.KafkaConfig._
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.common.MetadataVersion.{IBP_2_0_IV0, IBP_2_0_IV1}
 import org.apache.zookeeper.client.ZKClientConfig
@@ -869,7 +870,7 @@ class AuthorizerTest extends QuorumTestHarness with BaseAuthorizerTest {
     val zkClientConfig = AclAuthorizer.zkClientConfigFromKafkaConfigAndMap(
       KafkaConfig.fromProps(noTlsProps),
       noTlsProps.asInstanceOf[java.util.Map[String, Any]].asScala)
-    KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.foreach { propName =>
+    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().forEach { propName =>
       assertNull(zkClientConfig.getProperty(propName))
     }
   }
@@ -879,29 +880,29 @@ class AuthorizerTest extends QuorumTestHarness with BaseAuthorizerTest {
     val props = new java.util.Properties()
     val kafkaValue = "kafkaValue"
     val configs = Map("zookeeper.connect" -> "somewhere", // required, otherwise we would omit it
-      KafkaConfig.ZkSslClientEnableProp -> "true",
-      KafkaConfig.ZkClientCnxnSocketProp -> kafkaValue,
-      KafkaConfig.ZkSslKeyStoreLocationProp -> kafkaValue,
-      KafkaConfig.ZkSslKeyStorePasswordProp -> kafkaValue,
-      KafkaConfig.ZkSslKeyStoreTypeProp -> kafkaValue,
-      KafkaConfig.ZkSslTrustStoreLocationProp -> kafkaValue,
-      KafkaConfig.ZkSslTrustStorePasswordProp -> kafkaValue,
-      KafkaConfig.ZkSslTrustStoreTypeProp -> kafkaValue,
-      KafkaConfig.ZkSslEnabledProtocolsProp -> kafkaValue,
-      KafkaConfig.ZkSslCipherSuitesProp -> kafkaValue)
+      ZK_SSL_CLIENT_ENABLE_PROP -> "true",
+      ZK_CLIENT_CNXN_SOCKET_PROP -> kafkaValue,
+      ZK_SSL_KEYSTORE_LOCATION_PROP -> kafkaValue,
+      ZK_SSL_KEYSTORE_PASSWORD_PROP -> kafkaValue,
+      ZK_SSL_KEYSTORE_TYPE_PROP -> kafkaValue,
+      ZK_SSL_TRUSTSTORE_LOCATION_PROP -> kafkaValue,
+      ZK_SSL_TRUSTSTORE_PASSWORD_PROP -> kafkaValue,
+      ZK_SSL_TRUSTSTORE_TYPE_PROP -> kafkaValue,
+      ZK_SSL_ENABLED_PROTOCOLS_PROP -> kafkaValue,
+      ZK_SSL_CIPHER_SUITES_PROP -> kafkaValue)
     configs.foreach { case (key, value) => props.put(key, value) }
 
     val zkClientConfig = AclAuthorizer.zkClientConfigFromKafkaConfigAndMap(
       KafkaConfig.fromProps(props), mutable.Map(configs.toSeq: _*))
     // confirm we get all the values we expect
-    KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.foreach(prop => prop match {
-      case KafkaConfig.ZkSslClientEnableProp | KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp =>
-        assertEquals("true", KafkaConfig.zooKeeperClientProperty(zkClientConfig, prop).getOrElse("<None>"))
-      case KafkaConfig.ZkSslCrlEnableProp | KafkaConfig.ZkSslOcspEnableProp =>
-        assertEquals("false", KafkaConfig.zooKeeperClientProperty(zkClientConfig, prop).getOrElse("<None>"))
-      case KafkaConfig.ZkSslProtocolProp =>
-        assertEquals("TLSv1.2", KafkaConfig.zooKeeperClientProperty(zkClientConfig, prop).getOrElse("<None>"))
-      case _ => assertEquals(kafkaValue, KafkaConfig.zooKeeperClientProperty(zkClientConfig, prop).getOrElse("<None>"))
+    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().forEach(prop => prop match {
+      case ZK_SSL_CLIENT_ENABLE_PROP | ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP =>
+        assertEquals("true", zooKeeperClientProperty(zkClientConfig, prop).orElse("<None>"))
+      case ZK_SSL_CRL_ENABLE_PROP | ZK_SSL_OCSP_ENABLE_PROP =>
+        assertEquals("false", zooKeeperClientProperty(zkClientConfig, prop).orElse("<None>"))
+      case ZK_SSL_PROTOCOL_PROP =>
+        assertEquals("TLSv1.2", zooKeeperClientProperty(zkClientConfig, prop).orElse("<None>"))
+      case _ => assertEquals(kafkaValue, zooKeeperClientProperty(zkClientConfig, prop).orElse("<None>"))
     })
   }
 
@@ -910,31 +911,31 @@ class AuthorizerTest extends QuorumTestHarness with BaseAuthorizerTest {
     val props = new java.util.Properties()
     val kafkaValue = "kafkaValue"
     val configs = Map("zookeeper.connect" -> "somewhere", // required, otherwise we would omit it
-      KafkaConfig.ZkSslClientEnableProp -> "true",
-      KafkaConfig.ZkClientCnxnSocketProp -> kafkaValue,
-      KafkaConfig.ZkSslKeyStoreLocationProp -> kafkaValue,
-      KafkaConfig.ZkSslKeyStorePasswordProp -> kafkaValue,
-      KafkaConfig.ZkSslKeyStoreTypeProp -> kafkaValue,
-      KafkaConfig.ZkSslTrustStoreLocationProp -> kafkaValue,
-      KafkaConfig.ZkSslTrustStorePasswordProp -> kafkaValue,
-      KafkaConfig.ZkSslTrustStoreTypeProp -> kafkaValue,
-      KafkaConfig.ZkSslProtocolProp -> kafkaValue,
-      KafkaConfig.ZkSslEnabledProtocolsProp -> kafkaValue,
-      KafkaConfig.ZkSslCipherSuitesProp -> kafkaValue,
-      KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp -> "HTTPS",
-      KafkaConfig.ZkSslCrlEnableProp -> "false",
-      KafkaConfig.ZkSslOcspEnableProp -> "false")
+      ZK_SSL_CLIENT_ENABLE_PROP -> "true",
+      ZK_CLIENT_CNXN_SOCKET_PROP -> kafkaValue,
+      ZK_SSL_KEYSTORE_LOCATION_PROP -> kafkaValue,
+      ZK_SSL_KEYSTORE_PASSWORD_PROP -> kafkaValue,
+      ZK_SSL_KEYSTORE_TYPE_PROP -> kafkaValue,
+      ZK_SSL_TRUSTSTORE_LOCATION_PROP -> kafkaValue,
+      ZK_SSL_TRUSTSTORE_PASSWORD_PROP -> kafkaValue,
+      ZK_SSL_TRUSTSTORE_TYPE_PROP -> kafkaValue,
+      ZK_SSL_PROTOCOL_PROP -> kafkaValue,
+      ZK_SSL_ENABLED_PROTOCOLS_PROP -> kafkaValue,
+      ZK_SSL_CIPHER_SUITES_PROP -> kafkaValue,
+      ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP -> "HTTPS",
+      ZK_SSL_CRL_ENABLE_PROP -> "false",
+      ZK_SSL_OCSP_ENABLE_PROP -> "false")
     configs.foreach{case (key, value) => props.put(key, value.toString) }
 
     val zkClientConfig = AclAuthorizer.zkClientConfigFromKafkaConfigAndMap(
       KafkaConfig.fromProps(props), mutable.Map(configs.toSeq: _*))
     // confirm we get all the values we expect
-    KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.foreach(prop => prop match {
-        case KafkaConfig.ZkSslClientEnableProp | KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp =>
-          assertEquals("true", KafkaConfig.zooKeeperClientProperty(zkClientConfig, prop).getOrElse("<None>"))
-        case KafkaConfig.ZkSslCrlEnableProp | KafkaConfig.ZkSslOcspEnableProp =>
-          assertEquals("false", KafkaConfig.zooKeeperClientProperty(zkClientConfig, prop).getOrElse("<None>"))
-        case _ => assertEquals(kafkaValue, KafkaConfig.zooKeeperClientProperty(zkClientConfig, prop).getOrElse("<None>"))
+    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.asScala.keys.foreach(prop => prop match {
+        case ZK_SSL_CLIENT_ENABLE_PROP | ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP =>
+          assertEquals("true", zooKeeperClientProperty(zkClientConfig, prop).orElse("<None>"))
+        case ZK_SSL_CRL_ENABLE_PROP | ZK_SSL_OCSP_ENABLE_PROP =>
+          assertEquals("false", zooKeeperClientProperty(zkClientConfig, prop).orElse("<None>"))
+        case _ => assertEquals(kafkaValue, zooKeeperClientProperty(zkClientConfig, prop).orElse("<None>"))
       })
   }
 
@@ -945,45 +946,45 @@ class AuthorizerTest extends QuorumTestHarness with BaseAuthorizerTest {
     val prefixedValue = "prefixedValue"
     val prefix = "authorizer."
     val configs = Map("zookeeper.connect" -> "somewhere", // required, otherwise we would omit it
-      KafkaConfig.ZkSslClientEnableProp -> "false",
-      KafkaConfig.ZkClientCnxnSocketProp -> kafkaValue,
-      KafkaConfig.ZkSslKeyStoreLocationProp -> kafkaValue,
-      KafkaConfig.ZkSslKeyStorePasswordProp -> kafkaValue,
-      KafkaConfig.ZkSslKeyStoreTypeProp -> kafkaValue,
-      KafkaConfig.ZkSslTrustStoreLocationProp -> kafkaValue,
-      KafkaConfig.ZkSslTrustStorePasswordProp -> kafkaValue,
-      KafkaConfig.ZkSslTrustStoreTypeProp -> kafkaValue,
-      KafkaConfig.ZkSslProtocolProp -> kafkaValue,
-      KafkaConfig.ZkSslEnabledProtocolsProp -> kafkaValue,
-      KafkaConfig.ZkSslCipherSuitesProp -> kafkaValue,
-      KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp -> "HTTPS",
-      KafkaConfig.ZkSslCrlEnableProp -> "false",
-      KafkaConfig.ZkSslOcspEnableProp -> "false",
-      prefix + KafkaConfig.ZkSslClientEnableProp -> "true",
-      prefix + KafkaConfig.ZkClientCnxnSocketProp -> prefixedValue,
-      prefix + KafkaConfig.ZkSslKeyStoreLocationProp -> prefixedValue,
-      prefix + KafkaConfig.ZkSslKeyStorePasswordProp -> prefixedValue,
-      prefix + KafkaConfig.ZkSslKeyStoreTypeProp -> prefixedValue,
-      prefix + KafkaConfig.ZkSslTrustStoreLocationProp -> prefixedValue,
-      prefix + KafkaConfig.ZkSslTrustStorePasswordProp -> prefixedValue,
-      prefix + KafkaConfig.ZkSslTrustStoreTypeProp -> prefixedValue,
-      prefix + KafkaConfig.ZkSslProtocolProp -> prefixedValue,
-      prefix + KafkaConfig.ZkSslEnabledProtocolsProp -> prefixedValue,
-      prefix + KafkaConfig.ZkSslCipherSuitesProp -> prefixedValue,
-      prefix + KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp -> "",
-      prefix + KafkaConfig.ZkSslCrlEnableProp -> "true",
-      prefix + KafkaConfig.ZkSslOcspEnableProp -> "true")
+      ZK_SSL_CLIENT_ENABLE_PROP -> "false",
+      ZK_CLIENT_CNXN_SOCKET_PROP -> kafkaValue,
+      ZK_SSL_KEYSTORE_LOCATION_PROP -> kafkaValue,
+      ZK_SSL_KEYSTORE_PASSWORD_PROP -> kafkaValue,
+      ZK_SSL_KEYSTORE_TYPE_PROP -> kafkaValue,
+      ZK_SSL_TRUSTSTORE_LOCATION_PROP -> kafkaValue,
+      ZK_SSL_TRUSTSTORE_PASSWORD_PROP -> kafkaValue,
+      ZK_SSL_TRUSTSTORE_TYPE_PROP -> kafkaValue,
+      ZK_SSL_PROTOCOL_PROP -> kafkaValue,
+      ZK_SSL_ENABLED_PROTOCOLS_PROP -> kafkaValue,
+      ZK_SSL_CIPHER_SUITES_PROP -> kafkaValue,
+      ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP -> "HTTPS",
+      ZK_SSL_CRL_ENABLE_PROP -> "false",
+      ZK_SSL_OCSP_ENABLE_PROP -> "false",
+      prefix + ZK_SSL_CLIENT_ENABLE_PROP -> "true",
+      prefix + ZK_CLIENT_CNXN_SOCKET_PROP -> prefixedValue,
+      prefix + ZK_SSL_KEYSTORE_LOCATION_PROP -> prefixedValue,
+      prefix + ZK_SSL_KEYSTORE_PASSWORD_PROP -> prefixedValue,
+      prefix + ZK_SSL_KEYSTORE_TYPE_PROP -> prefixedValue,
+      prefix + ZK_SSL_TRUSTSTORE_LOCATION_PROP -> prefixedValue,
+      prefix + ZK_SSL_TRUSTSTORE_PASSWORD_PROP -> prefixedValue,
+      prefix + ZK_SSL_TRUSTSTORE_TYPE_PROP -> prefixedValue,
+      prefix + ZK_SSL_PROTOCOL_PROP -> prefixedValue,
+      prefix + ZK_SSL_ENABLED_PROTOCOLS_PROP -> prefixedValue,
+      prefix + ZK_SSL_CIPHER_SUITES_PROP -> prefixedValue,
+      prefix + ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP -> "",
+      prefix + ZK_SSL_CRL_ENABLE_PROP -> "true",
+      prefix + ZK_SSL_OCSP_ENABLE_PROP -> "true")
     configs.foreach{case (key, value) => props.put(key, value.toString) }
 
     val zkClientConfig = AclAuthorizer.zkClientConfigFromKafkaConfigAndMap(
       KafkaConfig.fromProps(props), mutable.Map(configs.toSeq: _*))
     // confirm we get all the values we expect
-    KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.foreach(prop => prop match {
-      case KafkaConfig.ZkSslClientEnableProp | KafkaConfig.ZkSslCrlEnableProp | KafkaConfig.ZkSslOcspEnableProp =>
-        assertEquals("true", KafkaConfig.zooKeeperClientProperty(zkClientConfig, prop).getOrElse("<None>"))
-      case KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp =>
-        assertEquals("false", KafkaConfig.zooKeeperClientProperty(zkClientConfig, prop).getOrElse("<None>"))
-      case _ => assertEquals(prefixedValue, KafkaConfig.zooKeeperClientProperty(zkClientConfig, prop).getOrElse("<None>"))
+    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet.forEach(prop => prop match {
+      case ZK_SSL_CLIENT_ENABLE_PROP | ZK_SSL_CRL_ENABLE_PROP | ZK_SSL_OCSP_ENABLE_PROP =>
+        assertEquals("true", zooKeeperClientProperty(zkClientConfig, prop).orElse("<None>"))
+      case ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP =>
+        assertEquals("false", zooKeeperClientProperty(zkClientConfig, prop).orElse("<None>"))
+      case _ => assertEquals(prefixedValue, zooKeeperClientProperty(zkClientConfig, prop).orElse("<None>"))
     })
   }
 
@@ -1087,7 +1088,7 @@ class AuthorizerTest extends QuorumTestHarness with BaseAuthorizerTest {
 
     val props = TestUtils.createBrokerConfig(0, zkConnectOrNull)
     props.put(AclAuthorizer.SuperUsersProp, superUsers)
-    protocolVersion.foreach(version => props.put(KafkaConfig.InterBrokerProtocolVersionProp, version.toString))
+    protocolVersion.foreach(version => props.put(INTER_BROKER_PROTOCOL_VERSION_PROP, version.toString))
 
     config = KafkaConfig.fromProps(props)
 

--- a/core/src/test/scala/unit/kafka/security/token/delegation/DelegationTokenManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/token/delegation/DelegationTokenManagerTest.scala
@@ -41,6 +41,7 @@ import org.apache.kafka.network.Session
 import org.apache.kafka.security.authorizer.AuthorizerUtils
 import org.apache.kafka.server.authorizer._
 import org.apache.kafka.server.config.Defaults
+import org.apache.kafka.server.config.KafkaConfig.{SASL_ENABLED_MECHANISMS_PROP, DELEGATION_TOKEN_SECRET_KEY_PROP}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
 
@@ -72,8 +73,8 @@ class DelegationTokenManagerTest extends QuorumTestHarness  {
   override def setUp(testInfo: TestInfo): Unit = {
     super.setUp(testInfo)
     props = TestUtils.createBrokerConfig(0, zkConnect, enableToken = true)
-    props.put(KafkaConfig.SaslEnabledMechanismsProp, ScramMechanism.mechanismNames().asScala.mkString(","))
-    props.put(KafkaConfig.DelegationTokenSecretKeyProp, secretKey)
+    props.put(SASL_ENABLED_MECHANISMS_PROP, ScramMechanism.mechanismNames().asScala.mkString(","))
+    props.put(DELEGATION_TOKEN_SECRET_KEY_PROP, secretKey)
     tokenCache = new DelegationTokenCache(ScramMechanism.mechanismNames())
   }
 

--- a/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.record.RecordVersion
 import org.apache.kafka.common.requests.{ApiVersionsRequest, ApiVersionsResponse, RequestUtils}
 import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.server.config.KafkaConfig.{CONTROL_PLANE_LISTENER_NAME_PROP, LISTENER_SECURITY_PROTOCOL_MAP_PROP, ADVERTISED_LISTENERS_PROP}
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions._
@@ -52,10 +53,10 @@ abstract class AbstractApiVersionsRequestTest(cluster: ClusterInstance) {
     if (!cluster.isKRaftTest) {
       val controlPlaneListenerName = "CONTROL_PLANE"
       val securityProtocol = cluster.config().securityProtocol()
-      properties.setProperty(KafkaConfig.ControlPlaneListenerNameProp, controlPlaneListenerName)
-      properties.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, s"$controlPlaneListenerName:$securityProtocol,$securityProtocol:$securityProtocol")
+      properties.setProperty(CONTROL_PLANE_LISTENER_NAME_PROP, controlPlaneListenerName)
+      properties.setProperty(LISTENER_SECURITY_PROTOCOL_MAP_PROP, s"$controlPlaneListenerName:$securityProtocol,$securityProtocol:$securityProtocol")
       properties.setProperty("listeners", s"$securityProtocol://localhost:0,$controlPlaneListenerName://localhost:0")
-      properties.setProperty(KafkaConfig.AdvertisedListenersProp, s"$securityProtocol://localhost:0,${controlPlaneListenerName}://localhost:0")
+      properties.setProperty(ADVERTISED_LISTENERS_PROP, s"$securityProtocol://localhost:0,${controlPlaneListenerName}://localhost:0")
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData
 import org.apache.kafka.common.message.CreateTopicsRequestData._
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests._
+import org.apache.kafka.server.config.KafkaConfig.AUTO_CREATE_TOPICS_ENABLE_PROP
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotEquals, assertNotNull, assertTrue}
 
 import scala.jdk.CollectionConverters._
@@ -33,7 +34,7 @@ import scala.jdk.CollectionConverters._
 abstract class AbstractCreateTopicsRequestTest extends BaseRequestTest {
 
   override def brokerPropertyOverrides(properties: Properties): Unit =
-    properties.put(KafkaConfig.AutoCreateTopicsEnableProp, false.toString)
+    properties.put(AUTO_CREATE_TOPICS_ENABLE_PROP, false.toString)
 
   def topicsReq(topics: Seq[CreatableTopic],
                 timeout: Integer = 10000,

--- a/core/src/test/scala/unit/kafka/server/AbstractMetadataRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractMetadataRequestTest.scala
@@ -24,14 +24,15 @@ import kafka.utils.TestUtils
 import org.apache.kafka.common.message.MetadataRequestData
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{MetadataRequest, MetadataResponse}
+import org.apache.kafka.server.config.KafkaConfig.{OFFSETS_TOPIC_PARTITIONS_PROP, DEFAULT_REPLICATION_FACTOR_PROP, RACK_PROP, BROKER_ID_PROP}
 import org.junit.jupiter.api.Assertions.assertEquals
 
 abstract class AbstractMetadataRequestTest extends BaseRequestTest {
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.setProperty(KafkaConfig.OffsetsTopicPartitionsProp, "1")
-    properties.setProperty(KafkaConfig.DefaultReplicationFactorProp, "2")
-    properties.setProperty(KafkaConfig.RackProp, s"rack/${properties.getProperty(KafkaConfig.BrokerIdProp)}")
+    properties.setProperty(OFFSETS_TOPIC_PARTITIONS_PROP, "1")
+    properties.setProperty(DEFAULT_REPLICATION_FACTOR_PROP, "2")
+    properties.setProperty(RACK_PROP, s"rack/${properties.getProperty(BROKER_ID_PROP)}")
   }
 
   protected def requestData(topics: List[String], allowAutoTopicCreation: Boolean): MetadataRequestData = {

--- a/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnRequestServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnRequestServerTest.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.common.message.{FindCoordinatorRequestData, InitProducer
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType
 import org.apache.kafka.common.requests.{AddPartitionsToTxnRequest, AddPartitionsToTxnResponse, FindCoordinatorRequest, FindCoordinatorResponse, InitProducerIdRequest, InitProducerIdResponse}
+import org.apache.kafka.server.config.KafkaConfig.AUTO_CREATE_TOPICS_ENABLE_PROP
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{BeforeEach, Test, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -43,7 +44,7 @@ class AddPartitionsToTxnRequestServerTest extends BaseRequestTest {
   val numPartitions = 1
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.put(KafkaConfig.AutoCreateTopicsEnableProp, false.toString)
+    properties.put(AUTO_CREATE_TOPICS_ENABLE_PROP, false.toString)
   }
 
   @BeforeEach

--- a/core/src/test/scala/unit/kafka/server/AlterUserScramCredentialsRequestNotAuthorizedTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterUserScramCredentialsRequestNotAuthorizedTest.scala
@@ -22,6 +22,7 @@ import org.apache.kafka.common.message.AlterUserScramCredentialsRequestData
 import org.apache.kafka.common.message.AlterUserScramCredentialsResponseData.AlterUserScramCredentialsResult
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AlterUserScramCredentialsRequest, AlterUserScramCredentialsResponse}
+import org.apache.kafka.server.config.KafkaConfig.{CONTROLLED_SHUTDOWN_ENABLE_PROP, AUTHORIZER_CLASS_NAME_PROP, PRINCIPAL_BUILDER_CLASS_PROP}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
@@ -35,9 +36,9 @@ import scala.jdk.CollectionConverters._
 class AlterUserScramCredentialsRequestNotAuthorizedTest extends BaseRequestTest {
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.put(KafkaConfig.ControlledShutdownEnableProp, "false")
-    properties.put(KafkaConfig.AuthorizerClassNameProp, classOf[AlterCredentialsTest.TestAuthorizer].getName)
-    properties.put(KafkaConfig.PrincipalBuilderClassProp, classOf[AlterCredentialsTest.TestPrincipalBuilderReturningUnauthorized].getName)
+    properties.put(CONTROLLED_SHUTDOWN_ENABLE_PROP, "false")
+    properties.put(AUTHORIZER_CLASS_NAME_PROP, classOf[AlterCredentialsTest.TestAuthorizer].getName)
+    properties.put(PRINCIPAL_BUILDER_CLASS_PROP, classOf[AlterCredentialsTest.TestPrincipalBuilderReturningUnauthorized].getName)
   }
 
   private val user1 = "user1"

--- a/core/src/test/scala/unit/kafka/server/AlterUserScramCredentialsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterUserScramCredentialsRequestTest.scala
@@ -34,6 +34,7 @@ import org.apache.kafka.common.security.auth.{AuthenticationContext, KafkaPrinci
 import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder
 import org.apache.kafka.server.authorizer.{Action, AuthorizableRequestContext, AuthorizationResult}
 import org.apache.kafka.server.common.MetadataVersion
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.{Test, BeforeEach, TestInfo}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
@@ -54,16 +55,16 @@ class AlterUserScramCredentialsRequestTest extends BaseRequestTest {
   @BeforeEach
   override def setUp(testInfo: TestInfo): Unit = {
     if (TestInfoUtils.isKRaft(testInfo)) {
-      this.serverConfig.setProperty(KafkaConfig.AuthorizerClassNameProp, classOf[StandardAuthorizer].getName)
+      this.serverConfig.setProperty(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[StandardAuthorizer].getName)
       if (testInfo.getDisplayName().contains("quorum=kraft-IBP_3_4")) {
         testMetadataVersion = MetadataVersion.IBP_3_4_IV0
       }
     } else {
-      this.serverConfig.setProperty(KafkaConfig.AuthorizerClassNameProp, classOf[AlterCredentialsTest.TestAuthorizer].getName)
+      this.serverConfig.setProperty(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[AlterCredentialsTest.TestAuthorizer].getName)
 
     }
-    this.serverConfig.setProperty(KafkaConfig.PrincipalBuilderClassProp, classOf[AlterCredentialsTest.TestPrincipalBuilderReturningAuthorized].getName)
-    this.serverConfig.setProperty(KafkaConfig.ControlledShutdownEnableProp, "false")
+    this.serverConfig.setProperty(KafkaConfig.PRINCIPAL_BUILDER_CLASS_PROP, classOf[AlterCredentialsTest.TestPrincipalBuilderReturningAuthorized].getName)
+    this.serverConfig.setProperty(KafkaConfig.CONTROLLED_SHUTDOWN_ENABLE_PROP, "false")
 
     super.setUp(testInfo)
   }

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -38,6 +38,7 @@ import org.apache.kafka.common.security.auth.{KafkaPrincipal, KafkaPrincipalSerd
 import org.apache.kafka.common.utils.{SecurityUtils, Utils}
 import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.server.{ControllerRequestCompletionHandler, NodeToControllerChannelManager}
+import org.apache.kafka.server.config.KafkaConfig.{REQUEST_TIMEOUT_MS_PROP, OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, OFFSETS_TOPIC_PARTITIONS_PROP, TRANSACTIONS_TOPIC_PARTITIONS_PROP}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
 import org.mockito.ArgumentMatchers.any
@@ -64,13 +65,13 @@ class AutoTopicCreationManagerTest {
   @BeforeEach
   def setup(): Unit = {
     val props = TestUtils.createBrokerConfig(1, "localhost")
-    props.setProperty(KafkaConfig.RequestTimeoutMsProp, requestTimeout.toString)
+    props.setProperty(REQUEST_TIMEOUT_MS_PROP, requestTimeout.toString)
 
-    props.setProperty(KafkaConfig.OffsetsTopicReplicationFactorProp, internalTopicPartitions.toString)
-    props.setProperty(KafkaConfig.TransactionsTopicReplicationFactorProp, internalTopicPartitions.toString)
+    props.setProperty(OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, internalTopicPartitions.toString)
+    props.setProperty(TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, internalTopicPartitions.toString)
 
-    props.setProperty(KafkaConfig.OffsetsTopicPartitionsProp, internalTopicReplicationFactor.toString)
-    props.setProperty(KafkaConfig.TransactionsTopicPartitionsProp, internalTopicReplicationFactor.toString)
+    props.setProperty(OFFSETS_TOPIC_PARTITIONS_PROP, internalTopicReplicationFactor.toString)
+    props.setProperty(TRANSACTIONS_TOPIC_PARTITIONS_PROP, internalTopicReplicationFactor.toString)
 
     config = KafkaConfig.fromProps(props)
     val aliveBrokers = Seq(new Node(0, "host0", 0), new Node(1, "host1", 1))

--- a/core/src/test/scala/unit/kafka/server/BaseFetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseFetchRequestTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.record.Record
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse}
 import org.apache.kafka.common.serialization.StringSerializer
+import org.apache.kafka.server.config.KafkaConfig.FETCH_MAX_BYTES_PROP
 import org.junit.jupiter.api.AfterEach
 
 import java.util
@@ -36,7 +37,7 @@ class BaseFetchRequestTest extends BaseRequestTest {
   protected var producer: KafkaProducer[String, String] = _
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.put(KafkaConfig.FetchMaxBytes, Int.MaxValue.toString)
+    properties.put(FETCH_MAX_BYTES_PROP, Int.MaxValue.toString)
   }
 
   @AfterEach

--- a/core/src/test/scala/unit/kafka/server/BaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseRequestTest.scala
@@ -25,7 +25,7 @@ import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, RequestHeader, ResponseHeader}
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.metadata.BrokerState
-
+import org.apache.kafka.server.config.KafkaConfig.CONTROLLED_SHUTDOWN_ENABLE_PROP
 import java.io.{DataInputStream, DataOutputStream}
 import java.net.Socket
 import java.nio.ByteBuffer
@@ -45,7 +45,7 @@ abstract class BaseRequestTest extends IntegrationTestHarness {
 
   override def modifyConfigs(props: Seq[Properties]): Unit = {
     props.foreach { p =>
-      p.put(KafkaConfig.ControlledShutdownEnableProp, "false")
+      p.put(CONTROLLED_SHUTDOWN_ENABLE_PROP, "false")
       brokerPropertyOverrides(p)
     }
   }

--- a/core/src/test/scala/unit/kafka/server/BrokerEpochIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerEpochIntegrationTest.scala
@@ -35,6 +35,8 @@ import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.Time
+import org.apache.kafka.server.config.KafkaConfig.AUTO_LEADER_REBALANCE_ENABLE_PROP
+
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
 
@@ -54,7 +56,7 @@ class BrokerEpochIntegrationTest extends QuorumTestHarness {
       TestUtils.createBrokerConfig(brokerId2, zkConnect))
 
     configs.foreach { config =>
-        config.setProperty(KafkaConfig.AutoLeaderRebalanceEnableProp, false.toString)}
+        config.setProperty(AUTO_LEADER_REBALANCE_ENABLE_PROP, false.toString)}
 
     // start both servers
     servers = configs.map(config => TestUtils.createServer(KafkaConfig.fromProps(config)))

--- a/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
@@ -25,6 +25,7 @@ import org.apache.kafka.common.message.{BrokerHeartbeatResponseData, BrokerRegis
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, BrokerHeartbeatRequest, BrokerHeartbeatResponse, BrokerRegistrationRequest, BrokerRegistrationResponse}
 import org.apache.kafka.metadata.BrokerState
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{Test, Timeout}
 
@@ -35,13 +36,13 @@ import scala.jdk.CollectionConverters._
 class BrokerLifecycleManagerTest {
   def configProperties = {
     val properties = new Properties()
-    properties.setProperty(KafkaConfig.LogDirsProp, "/tmp/foo")
-    properties.setProperty(KafkaConfig.ProcessRolesProp, "broker")
-    properties.setProperty(KafkaConfig.NodeIdProp, "1")
-    properties.setProperty(KafkaConfig.QuorumVotersProp, s"2@localhost:9093")
-    properties.setProperty(KafkaConfig.ControllerListenerNamesProp, "SSL")
-    properties.setProperty(KafkaConfig.InitialBrokerRegistrationTimeoutMsProp, "300000")
-    properties.setProperty(KafkaConfig.BrokerHeartbeatIntervalMsProp, "100")
+    properties.setProperty(KafkaConfig.LOG_DIRS_PROP, "/tmp/foo")
+    properties.setProperty(KafkaConfig.PROCESS_ROLES_PROP, "broker")
+    properties.setProperty(KafkaConfig.NODE_ID_PROP, "1")
+    properties.setProperty(KafkaConfig.QUORUM_VOTERS_PROP, s"2@localhost:9093")
+    properties.setProperty(KafkaConfig.CONTROLLER_LISTENER_NAMES_PROP, "SSL")
+    properties.setProperty(KafkaConfig.INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_PROP, "300000")
+    properties.setProperty(KafkaConfig.BROKER_HEARTBEAT_INTERVAL_MS_PROP, "100")
     properties
   }
 

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -53,6 +53,7 @@ import org.apache.kafka.controller.ControllerRequestContextUtil.ANONYMOUS_CONTEX
 import org.apache.kafka.controller.{Controller, ControllerRequestContext, ResultOrError}
 import org.apache.kafka.image.publisher.ControllerRegistrationsPublisher
 import org.apache.kafka.server.authorizer.{Action, AuthorizableRequestContext, AuthorizationResult, Authorizer}
+import org.apache.kafka.server.config.KafkaConfig.{NODE_ID_PROP, PROCESS_ROLES_PROP, CONTROLLER_LISTENER_NAMES_PROP, QUORUM_VOTERS_PROP, DELETE_TOPIC_ENABLE_PROP}
 import org.apache.kafka.server.common.{ApiMessageAndVersion, Features, MetadataVersion, ProducerIdsBlock}
 import org.apache.kafka.server.util.FutureUtils
 import org.apache.kafka.storage.internals.log.CleanerConfig
@@ -151,10 +152,10 @@ class ControllerApisTest {
                                    controller: Controller,
                                    props: Properties = new Properties(),
                                    throttle: Boolean = false): ControllerApis = {
-    props.put(KafkaConfig.NodeIdProp, nodeId: java.lang.Integer)
-    props.put(KafkaConfig.ProcessRolesProp, "controller")
-    props.put(KafkaConfig.ControllerListenerNamesProp, "PLAINTEXT")
-    props.put(KafkaConfig.QuorumVotersProp, s"$nodeId@localhost:9092")
+    props.put(NODE_ID_PROP, nodeId: java.lang.Integer)
+    props.put(PROCESS_ROLES_PROP, "controller")
+    props.put(CONTROLLER_LISTENER_NAMES_PROP, "PLAINTEXT")
+    props.put(QUORUM_VOTERS_PROP, s"$nodeId@localhost:9092")
     new ControllerApis(
       requestChannel,
       authorizer,
@@ -890,7 +891,7 @@ class ControllerApisTest {
     val controller = new MockController.Builder().
       newInitialTopic("foo", fooId).build()
     val props = new Properties()
-    props.put(KafkaConfig.DeleteTopicEnableProp, "false")
+    props.put(DELETE_TOPIC_ENABLE_PROP, "false")
     controllerApis = createControllerApis(None, controller, props)
     val request = new DeleteTopicsRequestData()
     request.topics().add(new DeleteTopicState().setName("foo").setTopicId(ZERO_UUID))

--- a/core/src/test/scala/unit/kafka/server/ControllerMutationQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerMutationQuotaTest.scala
@@ -42,6 +42,7 @@ import org.apache.kafka.common.security.auth.AuthenticationContext
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder
 import org.apache.kafka.test.{TestUtils => JTestUtils}
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
@@ -94,14 +95,14 @@ class ControllerMutationQuotaTest extends BaseRequestTest {
   override def brokerCount: Int = 1
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.put(KafkaConfig.ControlledShutdownEnableProp, "false")
-    properties.put(KafkaConfig.OffsetsTopicReplicationFactorProp, "1")
-    properties.put(KafkaConfig.OffsetsTopicPartitionsProp, "1")
-    properties.put(KafkaConfig.PrincipalBuilderClassProp,
+    properties.put(KafkaConfig.CONTROLLED_SHUTDOWN_ENABLE_PROP, "false")
+    properties.put(KafkaConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, "1")
+    properties.put(KafkaConfig.OFFSETS_TOPIC_PARTITIONS_PROP, "1")
+    properties.put(KafkaConfig.PRINCIPAL_BUILDER_CLASS_PROP,
       classOf[ControllerMutationQuotaTest.TestPrincipalBuilder].getName)
     // Specify number of samples and window size.
-    properties.put(KafkaConfig.NumControllerQuotaSamplesProp, ControllerQuotaSamples.toString)
-    properties.put(KafkaConfig.ControllerQuotaWindowSizeSecondsProp, ControllerQuotaWindowSizeSeconds.toString)
+    properties.put(KafkaConfig.NUM_CONTROLLER_QUOTA_SAMPLES_PROP, ControllerQuotaSamples.toString)
+    properties.put(KafkaConfig.CONTROLLER_QUOTA_WINDOW_SIZE_SECONDS_PROP, ControllerQuotaWindowSizeSeconds.toString)
   }
 
   @BeforeEach

--- a/core/src/test/scala/unit/kafka/server/ControllerRegistrationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerRegistrationManagerTest.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.image.loader.{LogDeltaManifest, SnapshotManifest}
 import org.apache.kafka.image.{MetadataDelta, MetadataImage, MetadataProvenance}
 import org.apache.kafka.metadata.{ListenerInfo, RecordTestUtils, VersionRange}
 import org.apache.kafka.raft.LeaderAndEpoch
+import org.apache.kafka.server.config.KafkaConfig
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
@@ -45,13 +46,13 @@ class ControllerRegistrationManagerTest {
 
   private def configProperties = {
     val properties = new Properties()
-    properties.setProperty(KafkaConfig.LogDirsProp, "/tmp/foo")
-    properties.setProperty(KafkaConfig.ProcessRolesProp, "controller")
-    properties.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, s"CONTROLLER:PLAINTEXT")
-    properties.setProperty(KafkaConfig.ListenersProp, s"CONTROLLER://localhost:8001")
-    properties.setProperty(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
-    properties.setProperty(KafkaConfig.NodeIdProp, "1")
-    properties.setProperty(KafkaConfig.QuorumVotersProp, s"1@localhost:8000,2@localhost:5000,3@localhost:7000")
+    properties.setProperty(KafkaConfig.LOG_DIRS_PROP, "/tmp/foo")
+    properties.setProperty(KafkaConfig.PROCESS_ROLES_PROP, "controller")
+    properties.setProperty(KafkaConfig.LISTENER_SECURITY_PROTOCOL_MAP_PROP, s"CONTROLLER:PLAINTEXT")
+    properties.setProperty(KafkaConfig.LISTENERS_PROP, s"CONTROLLER://localhost:8001")
+    properties.setProperty(KafkaConfig.CONTROLLER_LISTENER_NAMES_PROP, "CONTROLLER")
+    properties.setProperty(KafkaConfig.NODE_ID_PROP, "1")
+    properties.setProperty(KafkaConfig.QUORUM_VOTERS_PROP, s"1@localhost:8000,2@localhost:5000,3@localhost:7000")
     properties
   }
 

--- a/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithPolicyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithPolicyTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.errors.PolicyViolationException
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.server.config.KafkaConfig.CREATE_TOPIC_POLICY_CLASS_NAME_PROP
 import org.apache.kafka.server.policy.CreateTopicPolicy
 import org.apache.kafka.server.policy.CreateTopicPolicy.RequestMetadata
 import org.junit.jupiter.params.ParameterizedTest
@@ -36,12 +37,12 @@ class CreateTopicsRequestWithPolicyTest extends AbstractCreateTopicsRequestTest 
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
     super.brokerPropertyOverrides(properties)
-    properties.put(KafkaConfig.CreateTopicPolicyClassNameProp, classOf[Policy].getName)
+    properties.put(CREATE_TOPIC_POLICY_CLASS_NAME_PROP, classOf[Policy].getName)
   }
 
   override def kraftControllerConfigs(): Seq[Properties] = {
     val properties = new Properties()
-    properties.put(KafkaConfig.CreateTopicPolicyClassNameProp, classOf[Policy].getName)
+    properties.put(CREATE_TOPIC_POLICY_CLASS_NAME_PROP, classOf[Policy].getName)
     Seq(properties)
   }
 

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.common.errors.InvalidPrincipalTypeException
 import org.apache.kafka.common.errors.DelegationTokenNotFoundException
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.SecurityUtils
+import org.apache.kafka.server.config.KafkaConfig.{DELEGATION_TOKEN_SECRET_KEY_PROP, DELEGATION_TOKEN_EXPIRY_CHECK_INTERVAL_MS_PROP}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -43,11 +44,11 @@ class DelegationTokenRequestsTest extends IntegrationTestHarness with SaslSetup 
 
   override def brokerCount = 1
 
-  this.serverConfig.setProperty(KafkaConfig.DelegationTokenSecretKeyProp, "testKey")
-  this.controllerConfig.setProperty(KafkaConfig.DelegationTokenSecretKeyProp, "testKey")
+  this.serverConfig.setProperty(DELEGATION_TOKEN_SECRET_KEY_PROP, "testKey")
+  this.controllerConfig.setProperty(DELEGATION_TOKEN_SECRET_KEY_PROP, "testKey")
   // Remove expired tokens every minute.
-  this.serverConfig.setProperty(KafkaConfig.DelegationTokenExpiryCheckIntervalMsProp, "60000")
-  this.controllerConfig.setProperty(KafkaConfig.DelegationTokenExpiryCheckIntervalMsProp, "60000")
+  this.serverConfig.setProperty(DELEGATION_TOKEN_EXPIRY_CHECK_INTERVAL_MS_PROP, "60000")
+  this.controllerConfig.setProperty(DELEGATION_TOKEN_EXPIRY_CHECK_INTERVAL_MS_PROP, "60000")
 
   @BeforeEach
   override def setUp(testInfo: TestInfo): Unit = {

--- a/core/src/test/scala/unit/kafka/server/DeleteTopicsRequestWithDeletionDisabledTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DeleteTopicsRequestWithDeletionDisabledTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.common.message.DeleteTopicsRequestData
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{DeleteTopicsRequest, DeleteTopicsResponse}
+import org.apache.kafka.server.config.KafkaConfig.DELETE_TOPIC_ENABLE_PROP
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -34,7 +35,7 @@ class DeleteTopicsRequestWithDeletionDisabledTest extends BaseRequestTest {
 
   override def kraftControllerConfigs() = {
     val props = super.kraftControllerConfigs()
-    props.head.setProperty(KafkaConfig.DeleteTopicEnableProp, "false")
+    props.head.setProperty(DELETE_TOPIC_ENABLE_PROP, "false")
     props
   }
 

--- a/core/src/test/scala/unit/kafka/server/DescribeClusterRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DescribeClusterRequestTest.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.requests.{DescribeClusterRequest, DescribeClusterResponse}
 import org.apache.kafka.common.resource.ResourceType
 import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -37,9 +38,9 @@ import scala.jdk.CollectionConverters._
 class DescribeClusterRequestTest extends BaseRequestTest {
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.setProperty(KafkaConfig.OffsetsTopicPartitionsProp, "1")
-    properties.setProperty(KafkaConfig.DefaultReplicationFactorProp, "2")
-    properties.setProperty(KafkaConfig.RackProp, s"rack/${properties.getProperty(KafkaConfig.BrokerIdProp)}")
+    properties.setProperty(KafkaConfig.OFFSETS_TOPIC_PARTITIONS_PROP, "1")
+    properties.setProperty(KafkaConfig.DEFAULT_REPLICATION_FACTOR_PROP, "2")
+    properties.setProperty(KafkaConfig.RACK_PROP, s"rack/${properties.getProperty(KafkaConfig.BROKER_ID_PROP)}")
   }
 
   @BeforeEach

--- a/core/src/test/scala/unit/kafka/server/DescribeUserScramCredentialsRequestNotAuthorizedTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DescribeUserScramCredentialsRequestNotAuthorizedTest.scala
@@ -21,6 +21,7 @@ import kafka.utils.TestInfoUtils
 import org.apache.kafka.common.message.DescribeUserScramCredentialsRequestData
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{DescribeUserScramCredentialsRequest, DescribeUserScramCredentialsResponse}
+import org.apache.kafka.server.config.KafkaConfig
 import org.apache.kafka.metadata.authorizer.StandardAuthorizer
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
@@ -33,13 +34,13 @@ import java.util.Properties
  */
 class DescribeUserScramCredentialsRequestNotAuthorizedTest extends BaseRequestTest {
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.put(KafkaConfig.ControlledShutdownEnableProp, "false")
+    properties.put(KafkaConfig.CONTROLLED_SHUTDOWN_ENABLE_PROP, "false")
     if (isKRaftTest()) {
-      properties.put(KafkaConfig.AuthorizerClassNameProp, classOf[StandardAuthorizer].getName)
+      properties.put(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[StandardAuthorizer].getName)
     } else {
-      properties.put(KafkaConfig.AuthorizerClassNameProp, classOf[DescribeCredentialsTest.TestAuthorizer].getName)
+      properties.put(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[DescribeCredentialsTest.TestAuthorizer].getName)
     }
-    properties.put(KafkaConfig.PrincipalBuilderClassProp, classOf[DescribeCredentialsTest.TestPrincipalBuilderReturningUnauthorized].getName)
+    properties.put(KafkaConfig.PRINCIPAL_BUILDER_CLASS_PROP, classOf[DescribeCredentialsTest.TestPrincipalBuilderReturningUnauthorized].getName)
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumName)

--- a/core/src/test/scala/unit/kafka/server/DescribeUserScramCredentialsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DescribeUserScramCredentialsRequestTest.scala
@@ -28,6 +28,7 @@ import org.apache.kafka.common.requests.{DescribeUserScramCredentialsRequest, De
 import org.apache.kafka.common.security.auth.{AuthenticationContext, KafkaPrincipal}
 import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder
 import org.apache.kafka.server.authorizer.{Action, AuthorizableRequestContext, AuthorizationResult}
+import org.apache.kafka.server.config.KafkaConfig
 import org.junit.jupiter.api.{Test, BeforeEach, TestInfo}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
@@ -44,13 +45,13 @@ class DescribeUserScramCredentialsRequestTest extends BaseRequestTest {
     @BeforeEach
   override def setUp(testInfo: TestInfo): Unit = {
     if (TestInfoUtils.isKRaft(testInfo)) {
-      this.serverConfig.setProperty(KafkaConfig.AuthorizerClassNameProp, classOf[StandardAuthorizer].getName)
+      this.serverConfig.setProperty(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[StandardAuthorizer].getName)
     } else {
-      this.serverConfig.setProperty(KafkaConfig.AuthorizerClassNameProp, classOf[AlterCredentialsTest.TestAuthorizer].getName)
+      this.serverConfig.setProperty(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[AlterCredentialsTest.TestAuthorizer].getName)
 
     }
-    this.serverConfig.setProperty(KafkaConfig.PrincipalBuilderClassProp, classOf[AlterCredentialsTest.TestPrincipalBuilderReturningAuthorized].getName)
-    this.serverConfig.setProperty(KafkaConfig.ControlledShutdownEnableProp, "false")
+    this.serverConfig.setProperty(KafkaConfig.PRINCIPAL_BUILDER_CLASS_PROP, classOf[AlterCredentialsTest.TestPrincipalBuilderReturningAuthorized].getName)
+    this.serverConfig.setProperty(KafkaConfig.CONTROLLED_SHUTDOWN_ENABLE_PROP, "false")
 
     super.setUp(testInfo)
   }

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -35,6 +35,7 @@ import org.apache.kafka.common.metrics.{JmxReporter, Metrics}
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.server.authorizer._
 import org.apache.kafka.server.config.Defaults
+import org.apache.kafka.server.config.KafkaConfig._
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.util.KafkaScheduler
@@ -83,7 +84,7 @@ class DynamicBrokerConfigTest {
       assertEquals(newKeystore,
         config.originalsWithPrefix("listener.name.external.").get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
 
-      assertEquals(oldKeystore, config.getString(KafkaConfig.SslKeystoreLocationProp))
+      assertEquals(oldKeystore, config.getString(SSL_KEYSTORE_LOCATION_PROP))
       assertEquals(oldKeystore, config.originals.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
       assertEquals(oldKeystore, config.values.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
       assertEquals(oldKeystore, config.originalsStrings.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
@@ -100,7 +101,7 @@ class DynamicBrokerConfigTest {
   @Test
   def testEnableDefaultUncleanLeaderElection(): Unit = {
     val origProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
-    origProps.put(KafkaConfig.UncleanLeaderElectionEnableProp, "false")
+    origProps.put(UNCLEAN_LEADER_ELECTION_ENABLE_PROP, "false")
 
     val config = KafkaConfig(origProps)
     val serverMock = Mockito.mock(classOf[KafkaServer])
@@ -122,7 +123,7 @@ class DynamicBrokerConfigTest {
 
     val props = new Properties()
 
-    props.put(KafkaConfig.UncleanLeaderElectionEnableProp, "true")
+    props.put(UNCLEAN_LEADER_ELECTION_ENABLE_PROP, "true")
     config.dynamicConfig.updateDefaultConfig(props)
     assertTrue(config.uncleanLeaderElectionEnable)
     Mockito.verify(controllerMock).enableDefaultUncleanLeaderElection()
@@ -131,11 +132,11 @@ class DynamicBrokerConfigTest {
   @Test
   def testUpdateDynamicThreadPool(): Unit = {
     val origProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
-    origProps.put(KafkaConfig.NumIoThreadsProp, "4")
-    origProps.put(KafkaConfig.NumNetworkThreadsProp, "2")
-    origProps.put(KafkaConfig.NumReplicaFetchersProp, "1")
-    origProps.put(KafkaConfig.NumRecoveryThreadsPerDataDirProp, "1")
-    origProps.put(KafkaConfig.BackgroundThreadsProp, "3")
+    origProps.put(NUM_IO_THREADS_PROP, "4")
+    origProps.put(NUM_NETWORK_THREADS_PROP, "2")
+    origProps.put(NUM_REPLICA_FETCHERS_PROP, "1")
+    origProps.put(NUM_RECOVERY_THREADS_PER_DATA_DIR_PROP, "1")
+    origProps.put(BACKGROUND_THREADS_PROP, "3")
 
     val config = KafkaConfig(origProps)
     val serverMock = Mockito.mock(classOf[KafkaBroker])
@@ -162,30 +163,30 @@ class DynamicBrokerConfigTest {
 
     val props = new Properties()
 
-    props.put(KafkaConfig.NumIoThreadsProp, "8")
+    props.put(NUM_IO_THREADS_PROP, "8")
     config.dynamicConfig.updateDefaultConfig(props)
     assertEquals(8, config.numIoThreads)
     Mockito.verify(handlerPoolMock).resizeThreadPool(newSize = 8)
 
-    props.put(KafkaConfig.NumNetworkThreadsProp, "4")
+    props.put(NUM_NETWORK_THREADS_PROP, "4")
     config.dynamicConfig.updateDefaultConfig(props)
     assertEquals(4, config.numNetworkThreads)
     val captor: ArgumentCaptor[JMap[String, String]] = ArgumentCaptor.forClass(classOf[JMap[String, String]])
     Mockito.verify(acceptorMock).reconfigure(captor.capture())
-    assertTrue(captor.getValue.containsKey(KafkaConfig.NumNetworkThreadsProp))
-    assertEquals(4, captor.getValue.get(KafkaConfig.NumNetworkThreadsProp))
+    assertTrue(captor.getValue.containsKey(NUM_NETWORK_THREADS_PROP))
+    assertEquals(4, captor.getValue.get(NUM_NETWORK_THREADS_PROP))
 
-    props.put(KafkaConfig.NumReplicaFetchersProp, "2")
+    props.put(NUM_REPLICA_FETCHERS_PROP, "2")
     config.dynamicConfig.updateDefaultConfig(props)
     assertEquals(2, config.numReplicaFetchers)
     Mockito.verify(replicaManagerMock).resizeFetcherThreadPool(newSize = 2)
 
-    props.put(KafkaConfig.NumRecoveryThreadsPerDataDirProp, "2")
+    props.put(NUM_RECOVERY_THREADS_PER_DATA_DIR_PROP, "2")
     config.dynamicConfig.updateDefaultConfig(props)
     assertEquals(2, config.numRecoveryThreadsPerDataDir)
     Mockito.verify(logManagerMock).resizeRecoveryThreadPool(newSize = 2)
 
-    props.put(KafkaConfig.BackgroundThreadsProp, "6")
+    props.put(BACKGROUND_THREADS_PROP, "6")
     config.dynamicConfig.updateDefaultConfig(props)
     assertEquals(6, config.backgroundThreads)
     Mockito.verify(schedulerMock).resizeThreadPool(6)
@@ -211,14 +212,14 @@ class DynamicBrokerConfigTest {
 
     val securityPropsWithoutListenerPrefix = Map(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG -> "PKCS12")
     verifyConfigUpdateWithInvalidConfig(config, origProps, validProps, securityPropsWithoutListenerPrefix)
-    val nonDynamicProps = Map(KafkaConfig.ZkConnectProp -> "somehost:2181")
+    val nonDynamicProps = Map(ZK_CONNECT_PROP -> "somehost:2181")
     verifyConfigUpdateWithInvalidConfig(config, origProps, validProps, nonDynamicProps)
 
     // Test update of configs with invalid type
     val invalidProps = Map(CleanerConfig.LOG_CLEANER_THREADS_PROP -> "invalid")
     verifyConfigUpdateWithInvalidConfig(config, origProps, validProps, invalidProps)
 
-    val excludedTopicConfig = Map(KafkaConfig.LogMessageFormatVersionProp -> "0.10.2")
+    val excludedTopicConfig = Map(LOG_MESSAGE_FORMAT_VERSION_PROP -> "0.10.2")
     verifyConfigUpdateWithInvalidConfig(config, origProps, validProps, excludedTopicConfig)
   }
 
@@ -260,7 +261,7 @@ class DynamicBrokerConfigTest {
   def testReconfigurableValidation(): Unit = {
     val origProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
     val config = KafkaConfig(origProps)
-    val invalidReconfigurableProps = Set(CleanerConfig.LOG_CLEANER_THREADS_PROP, KafkaConfig.BrokerIdProp, "some.prop")
+    val invalidReconfigurableProps = Set(CleanerConfig.LOG_CLEANER_THREADS_PROP, BROKER_ID_PROP, "some.prop")
     val validReconfigurableProps = Set(CleanerConfig.LOG_CLEANER_THREADS_PROP, CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE_PROP, "some.prop")
 
     def createReconfigurable(configs: Set[String]) = new Reconfigurable {
@@ -298,38 +299,38 @@ class DynamicBrokerConfigTest {
 
   @Test
   def testConnectionQuota(): Unit = {
-    verifyConfigUpdate(KafkaConfig.MaxConnectionsPerIpProp, "100", perBrokerConfig = true, expectFailure = false)
-    verifyConfigUpdate(KafkaConfig.MaxConnectionsPerIpProp, "100", perBrokerConfig = false, expectFailure = false)
+    verifyConfigUpdate(MAX_CONNECTIONS_PER_IP_PROP, "100", perBrokerConfig = true, expectFailure = false)
+    verifyConfigUpdate(MAX_CONNECTIONS_PER_IP_PROP, "100", perBrokerConfig = false, expectFailure = false)
     //MaxConnectionsPerIpProp can be set to zero only if MaxConnectionsPerIpOverridesProp property is set
-    verifyConfigUpdate(KafkaConfig.MaxConnectionsPerIpProp, "0", perBrokerConfig = false, expectFailure = true)
+    verifyConfigUpdate(MAX_CONNECTIONS_PER_IP_PROP, "0", perBrokerConfig = false, expectFailure = true)
 
-    verifyConfigUpdate(KafkaConfig.MaxConnectionsPerIpOverridesProp, "hostName1:100,hostName2:0", perBrokerConfig = true,
+    verifyConfigUpdate(MAX_CONNECTIONS_PER_IP_OVERRIDES_PROP, "hostName1:100,hostName2:0", perBrokerConfig = true,
       expectFailure = false)
-    verifyConfigUpdate(KafkaConfig.MaxConnectionsPerIpOverridesProp, "hostName1:100,hostName2:0", perBrokerConfig = false,
+    verifyConfigUpdate(MAX_CONNECTIONS_PER_IP_OVERRIDES_PROP, "hostName1:100,hostName2:0", perBrokerConfig = false,
       expectFailure = false)
     //test invalid address
-    verifyConfigUpdate(KafkaConfig.MaxConnectionsPerIpOverridesProp, "hostName#:100", perBrokerConfig = true,
+    verifyConfigUpdate(MAX_CONNECTIONS_PER_IP_OVERRIDES_PROP, "hostName#:100", perBrokerConfig = true,
       expectFailure = true)
 
-    verifyConfigUpdate(KafkaConfig.MaxConnectionsProp, "100", perBrokerConfig = true, expectFailure = false)
-    verifyConfigUpdate(KafkaConfig.MaxConnectionsProp, "100", perBrokerConfig = false, expectFailure = false)
-    val listenerMaxConnectionsProp = s"listener.name.external.${KafkaConfig.MaxConnectionsProp}"
+    verifyConfigUpdate(MAX_CONNECTIONS_PROP, "100", perBrokerConfig = true, expectFailure = false)
+    verifyConfigUpdate(MAX_CONNECTIONS_PROP, "100", perBrokerConfig = false, expectFailure = false)
+    val listenerMaxConnectionsProp = s"listener.name.external.${MAX_CONNECTIONS_PROP}"
     verifyConfigUpdate(listenerMaxConnectionsProp, "10", perBrokerConfig = true, expectFailure = false)
     verifyConfigUpdate(listenerMaxConnectionsProp, "10", perBrokerConfig = false, expectFailure = false)
   }
 
   @Test
   def testConnectionRateQuota(): Unit = {
-    verifyConfigUpdate(KafkaConfig.MaxConnectionCreationRateProp, "110", perBrokerConfig = true, expectFailure = false)
-    verifyConfigUpdate(KafkaConfig.MaxConnectionCreationRateProp, "120", perBrokerConfig = false, expectFailure = false)
-    val listenerMaxConnectionsProp = s"listener.name.external.${KafkaConfig.MaxConnectionCreationRateProp}"
+    verifyConfigUpdate(MAX_CONNECTION_CREATION_RATE_PROP, "110", perBrokerConfig = true, expectFailure = false)
+    verifyConfigUpdate(MAX_CONNECTION_CREATION_RATE_PROP, "120", perBrokerConfig = false, expectFailure = false)
+    val listenerMaxConnectionsProp = s"listener.name.external.${MAX_CONNECTION_CREATION_RATE_PROP}"
     verifyConfigUpdate(listenerMaxConnectionsProp, "20", perBrokerConfig = true, expectFailure = false)
     verifyConfigUpdate(listenerMaxConnectionsProp, "30", perBrokerConfig = false, expectFailure = false)
   }
 
   private def verifyConfigUpdate(name: String, value: Object, perBrokerConfig: Boolean, expectFailure: Boolean): Unit = {
     val configProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
-    configProps.put(KafkaConfig.PasswordEncoderSecretProp, "broker.secret")
+    configProps.put(PASSWORD_ENCODER_SECRET_PROP, "broker.secret")
     val config = KafkaConfig(configProps)
     config.dynamicConfig.initialize(None, None)
 
@@ -380,10 +381,10 @@ class DynamicBrokerConfigTest {
   def testPasswordConfigEncryption(): Unit = {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
     val configWithoutSecret = KafkaConfig(props)
-    props.put(KafkaConfig.PasswordEncoderSecretProp, "config-encoder-secret")
+    props.put(PASSWORD_ENCODER_SECRET_PROP, "config-encoder-secret")
     val configWithSecret = KafkaConfig(props)
     val dynamicProps = new Properties
-    dynamicProps.put(KafkaConfig.SaslJaasConfigProp, "myLoginModule required;")
+    dynamicProps.put(SASL_JAAS_CONFIG_PROP, "myLoginModule required;")
 
     try {
       configWithoutSecret.dynamicConfig.toPersistentProps(dynamicProps, perBrokerConfig = true)
@@ -391,46 +392,46 @@ class DynamicBrokerConfigTest {
       case _: ConfigException => // expected exception
     }
     val persistedProps = configWithSecret.dynamicConfig.toPersistentProps(dynamicProps, perBrokerConfig = true)
-    assertFalse(persistedProps.getProperty(KafkaConfig.SaslJaasConfigProp).contains("myLoginModule"),
+    assertFalse(persistedProps.getProperty(SASL_JAAS_CONFIG_PROP).contains("myLoginModule"),
       "Password not encoded")
     val decodedProps = configWithSecret.dynamicConfig.fromPersistentProps(persistedProps, perBrokerConfig = true)
-    assertEquals("myLoginModule required;", decodedProps.getProperty(KafkaConfig.SaslJaasConfigProp))
+    assertEquals("myLoginModule required;", decodedProps.getProperty(SASL_JAAS_CONFIG_PROP))
   }
 
   @Test
   def testPasswordConfigEncoderSecretChange(): Unit = {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
-    props.put(KafkaConfig.SaslJaasConfigProp, "staticLoginModule required;")
-    props.put(KafkaConfig.PasswordEncoderSecretProp, "config-encoder-secret")
+    props.put(SASL_JAAS_CONFIG_PROP, "staticLoginModule required;")
+    props.put(PASSWORD_ENCODER_SECRET_PROP, "config-encoder-secret")
     val config = KafkaConfig(props)
     config.dynamicConfig.initialize(None, None)
     val dynamicProps = new Properties
-    dynamicProps.put(KafkaConfig.SaslJaasConfigProp, "dynamicLoginModule required;")
+    dynamicProps.put(SASL_JAAS_CONFIG_PROP, "dynamicLoginModule required;")
 
     val persistedProps = config.dynamicConfig.toPersistentProps(dynamicProps, perBrokerConfig = true)
-    assertFalse(persistedProps.getProperty(KafkaConfig.SaslJaasConfigProp).contains("LoginModule"),
+    assertFalse(persistedProps.getProperty(SASL_JAAS_CONFIG_PROP).contains("LoginModule"),
       "Password not encoded")
     config.dynamicConfig.updateBrokerConfig(0, persistedProps)
-    assertEquals("dynamicLoginModule required;", config.values.get(KafkaConfig.SaslJaasConfigProp).asInstanceOf[Password].value)
+    assertEquals("dynamicLoginModule required;", config.values.get(SASL_JAAS_CONFIG_PROP).asInstanceOf[Password].value)
 
     // New config with same secret should use the dynamic password config
     val newConfigWithSameSecret = KafkaConfig(props)
     newConfigWithSameSecret.dynamicConfig.initialize(None, None)
     newConfigWithSameSecret.dynamicConfig.updateBrokerConfig(0, persistedProps)
-    assertEquals("dynamicLoginModule required;", newConfigWithSameSecret.values.get(KafkaConfig.SaslJaasConfigProp).asInstanceOf[Password].value)
+    assertEquals("dynamicLoginModule required;", newConfigWithSameSecret.values.get(SASL_JAAS_CONFIG_PROP).asInstanceOf[Password].value)
 
     // New config with new secret should use the dynamic password config if new and old secrets are configured in KafkaConfig
-    props.put(KafkaConfig.PasswordEncoderSecretProp, "new-encoder-secret")
-    props.put(KafkaConfig.PasswordEncoderOldSecretProp, "config-encoder-secret")
+    props.put(PASSWORD_ENCODER_SECRET_PROP, "new-encoder-secret")
+    props.put(PASSWORD_ENCODER_OLD_SECRET_PROP, "config-encoder-secret")
     val newConfigWithNewAndOldSecret = KafkaConfig(props)
     newConfigWithNewAndOldSecret.dynamicConfig.updateBrokerConfig(0, persistedProps)
-    assertEquals("dynamicLoginModule required;", newConfigWithSameSecret.values.get(KafkaConfig.SaslJaasConfigProp).asInstanceOf[Password].value)
+    assertEquals("dynamicLoginModule required;", newConfigWithSameSecret.values.get(SASL_JAAS_CONFIG_PROP).asInstanceOf[Password].value)
 
     // New config with new secret alone should revert to static password config since dynamic config cannot be decoded
-    props.put(KafkaConfig.PasswordEncoderSecretProp, "another-new-encoder-secret")
+    props.put(PASSWORD_ENCODER_SECRET_PROP, "another-new-encoder-secret")
     val newConfigWithNewSecret = KafkaConfig(props)
     newConfigWithNewSecret.dynamicConfig.updateBrokerConfig(0, persistedProps)
-    assertEquals("staticLoginModule required;", newConfigWithNewSecret.values.get(KafkaConfig.SaslJaasConfigProp).asInstanceOf[Password].value)
+    assertEquals("staticLoginModule required;", newConfigWithNewSecret.values.get(SASL_JAAS_CONFIG_PROP).asInstanceOf[Password].value)
   }
 
   @Test
@@ -440,7 +441,7 @@ class DynamicBrokerConfigTest {
     val kafkaServer: KafkaServer = mock(classOf[kafka.server.KafkaServer])
     when(kafkaServer.config).thenReturn(oldConfig)
 
-    props.put(KafkaConfig.ListenersProp, "PLAINTEXT://hostname:9092,SASL_PLAINTEXT://hostname:9093")
+    props.put(LISTENERS_PROP, "PLAINTEXT://hostname:9092,SASL_PLAINTEXT://hostname:9093")
     new DynamicListenerConfig(kafkaServer).validateReconfiguration(KafkaConfig(props))
 
     // it is illegal to update non-reconfiguable configs of existent listeners
@@ -515,10 +516,10 @@ class DynamicBrokerConfigTest {
       enableControlledShutdown = true,
       enableDeleteTopic = true,
       port)
-    retval.put(KafkaConfig.ProcessRolesProp, "broker,controller")
-    retval.put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
-    retval.put(KafkaConfig.ListenersProp, s"${retval.get(KafkaConfig.ListenersProp)},CONTROLLER://localhost:0")
-    retval.put(KafkaConfig.QuorumVotersProp, s"${nodeId}@localhost:0")
+    retval.put(PROCESS_ROLES_PROP, "broker,controller")
+    retval.put(CONTROLLER_LISTENER_NAMES_PROP, "CONTROLLER")
+    retval.put(LISTENERS_PROP, s"${retval.get(LISTENERS_PROP)},CONTROLLER://localhost:0")
+    retval.put(QUORUM_VOTERS_PROP, s"${nodeId}@localhost:0")
     retval
   }
 
@@ -559,12 +560,12 @@ class DynamicBrokerConfigTest {
       enableDeleteTopic = true,
       port
     )
-    retval.put(KafkaConfig.ProcessRolesProp, "controller")
-    retval.remove(KafkaConfig.AdvertisedListenersProp)
+    retval.put(PROCESS_ROLES_PROP, "controller")
+    retval.remove(ADVERTISED_LISTENERS_PROP)
 
-    retval.put(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
-    retval.put(KafkaConfig.ListenersProp, "CONTROLLER://localhost:0")
-    retval.put(KafkaConfig.QuorumVotersProp, s"${nodeId}@localhost:0")
+    retval.put(CONTROLLER_LISTENER_NAMES_PROP, "CONTROLLER")
+    retval.put(LISTENERS_PROP, "CONTROLLER://localhost:0")
+    retval.put(QUORUM_VOTERS_PROP, s"${nodeId}@localhost:0")
     retval
   }
 
@@ -596,32 +597,20 @@ class DynamicBrokerConfigTest {
   }
 
   @Test
-  def testSynonyms(): Unit = {
-    assertEquals(List("listener.name.secure.ssl.keystore.type", "ssl.keystore.type"),
-      DynamicBrokerConfig.brokerConfigSynonyms("listener.name.secure.ssl.keystore.type", matchListenerOverride = true))
-    assertEquals(List("listener.name.sasl_ssl.plain.sasl.jaas.config", "sasl.jaas.config"),
-      DynamicBrokerConfig.brokerConfigSynonyms("listener.name.sasl_ssl.plain.sasl.jaas.config", matchListenerOverride = true))
-    assertEquals(List("some.config"),
-      DynamicBrokerConfig.brokerConfigSynonyms("some.config", matchListenerOverride = true))
-    assertEquals(List(KafkaConfig.LogRollTimeMillisProp, KafkaConfig.LogRollTimeHoursProp),
-      DynamicBrokerConfig.brokerConfigSynonyms(KafkaConfig.LogRollTimeMillisProp, matchListenerOverride = true))
-  }
-
-  @Test
   def testDynamicConfigInitializationWithoutConfigsInZK(): Unit = {
     val zkClient: KafkaZkClient = mock(classOf[KafkaZkClient])
     when(zkClient.getEntityConfigs(anyString(), anyString())).thenReturn(new java.util.Properties())
 
     val initialProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 9092)
-    initialProps.remove(KafkaConfig.BackgroundThreadsProp)
+    initialProps.remove(BACKGROUND_THREADS_PROP)
     val oldConfig =  KafkaConfig.fromProps(initialProps)
     val dynamicBrokerConfig = new DynamicBrokerConfig(oldConfig)
     dynamicBrokerConfig.initialize(Some(zkClient), None)
     dynamicBrokerConfig.addBrokerReconfigurable(new TestDynamicThreadPool)
 
     val newprops = new Properties()
-    newprops.put(KafkaConfig.NumIoThreadsProp, "10")
-    newprops.put(KafkaConfig.BackgroundThreadsProp, "100")
+    newprops.put(NUM_IO_THREADS_PROP, "10")
+    newprops.put(BACKGROUND_THREADS_PROP, "100")
     dynamicBrokerConfig.updateBrokerConfig(0, newprops)
   }
 
@@ -635,16 +624,16 @@ class DynamicBrokerConfigTest {
     assertEquals(LogConfig.DEFAULT_MAX_MESSAGE_BYTES, config.messageMaxBytes)
 
     var newProps = new Properties()
-    newProps.put(KafkaConfig.MaxConnectionsProp, "9999")
-    newProps.put(KafkaConfig.MessageMaxBytesProp, "2222")
+    newProps.put(MAX_CONNECTIONS_PROP, "9999")
+    newProps.put(MESSAGE_MAX_BYTES_PROP, "2222")
 
     config.dynamicConfig.updateDefaultConfig(newProps)
     assertEquals(9999, config.maxConnections)
     assertEquals(2222, config.messageMaxBytes)
 
     newProps = new Properties()
-    newProps.put(KafkaConfig.MaxConnectionsProp, "INVALID_INT")
-    newProps.put(KafkaConfig.MessageMaxBytesProp, "1111")
+    newProps.put(MAX_CONNECTIONS_PROP, "INVALID_INT")
+    newProps.put(MESSAGE_MAX_BYTES_PROP, "1111")
 
     config.dynamicConfig.updateDefaultConfig(newProps)
     // Invalid value should be skipped and reassigned as default value
@@ -671,7 +660,7 @@ class DynamicBrokerConfigTest {
     assertEquals(classOf[JmxReporter].getName, m.currentReporters.keySet.head)
 
     val props = new Properties()
-    props.put(KafkaConfig.MetricReporterClassesProp, classOf[MockMetricsReporter].getName)
+    props.put(METRIC_REPORTER_CLASSES_PROP, classOf[MockMetricsReporter].getName)
     config.dynamicConfig.updateDefaultConfig(props)
     assertEquals(2, m.currentReporters.size)
     assertEquals(Set(classOf[JmxReporter].getName, classOf[MockMetricsReporter].getName), m.currentReporters.keySet)
@@ -682,7 +671,7 @@ class DynamicBrokerConfigTest {
   def testUpdateMetricReportersNoJmxReporter(): Unit = {
     val brokerId = 0
     val origProps = TestUtils.createBrokerConfig(brokerId, TestUtils.MockZkConnect, port = 8181)
-    origProps.put(KafkaConfig.AutoIncludeJmxReporterProp, "false")
+    origProps.put(AUTO_INCLUDE_JMX_REPORTER_PROP, "false")
 
     val config = KafkaConfig(origProps)
     val serverMock = Mockito.mock(classOf[KafkaBroker])
@@ -696,12 +685,12 @@ class DynamicBrokerConfigTest {
     assertTrue(m.currentReporters.isEmpty)
 
     val props = new Properties()
-    props.put(KafkaConfig.MetricReporterClassesProp, classOf[MockMetricsReporter].getName)
+    props.put(METRIC_REPORTER_CLASSES_PROP, classOf[MockMetricsReporter].getName)
     config.dynamicConfig.updateDefaultConfig(props)
     assertEquals(1, m.currentReporters.size)
     assertEquals(classOf[MockMetricsReporter].getName, m.currentReporters.keySet.head)
 
-    props.remove(KafkaConfig.MetricReporterClassesProp)
+    props.remove(METRIC_REPORTER_CLASSES_PROP)
     config.dynamicConfig.updateDefaultConfig(props)
     assertTrue(m.currentReporters.isEmpty)
   }
@@ -709,18 +698,18 @@ class DynamicBrokerConfigTest {
   @Test
   def testNonInternalValuesDoesNotExposeInternalConfigs(): Unit = {
     val props = new Properties()
-    props.put(KafkaConfig.ZkConnectProp, "localhost:2181")
-    props.put(KafkaConfig.MetadataLogSegmentMinBytesProp, "1024")
+    props.put(ZK_CONNECT_PROP, "localhost:2181")
+    props.put(METADATA_LOG_SEGMENT_MIN_BYTES_PROP, "1024")
     val config = new KafkaConfig(props)
-    assertFalse(config.nonInternalValues.containsKey(KafkaConfig.MetadataLogSegmentMinBytesProp))
+    assertFalse(config.nonInternalValues.containsKey(METADATA_LOG_SEGMENT_MIN_BYTES_PROP))
     config.updateCurrentConfig(new KafkaConfig(props))
-    assertFalse(config.nonInternalValues.containsKey(KafkaConfig.MetadataLogSegmentMinBytesProp))
+    assertFalse(config.nonInternalValues.containsKey(METADATA_LOG_SEGMENT_MIN_BYTES_PROP))
   }
 
   @Test
   def testDynamicLogLocalRetentionMsConfig(): Unit = {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
-    props.put(KafkaConfig.LogRetentionTimeMillisProp, "2592000000")
+    props.put(LOG_RETENTION_TIME_MILLIS_PROP, "2592000000")
     val config = KafkaConfig(props)
     val dynamicLogConfig = new DynamicLogConfig(mock(classOf[LogManager]), mock(classOf[KafkaServer]))
     config.dynamicConfig.initialize(None, None)
@@ -743,7 +732,7 @@ class DynamicBrokerConfigTest {
   @Test
   def testDynamicLogLocalRetentionSizeConfig(): Unit = {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
-    props.put(KafkaConfig.LogRetentionBytesProp, "4294967296")
+    props.put(LOG_RETENTION_BYTES_PROP, "4294967296")
     val config = KafkaConfig(props)
     val dynamicLogConfig = new DynamicLogConfig(mock(classOf[LogManager]), mock(classOf[KafkaServer]))
     config.dynamicConfig.initialize(None, None)
@@ -819,8 +808,8 @@ class DynamicBrokerConfigTest {
                                             logLocalRetentionBytes: Long,
                                             retentionBytes: Long): Unit = {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
-    props.put(KafkaConfig.LogRetentionTimeMillisProp, retentionMs.toString)
-    props.put(KafkaConfig.LogRetentionBytesProp, retentionBytes.toString)
+    props.put(LOG_RETENTION_TIME_MILLIS_PROP, retentionMs.toString)
+    props.put(LOG_RETENTION_BYTES_PROP, retentionBytes.toString)
     val config = KafkaConfig(props)
     val dynamicLogConfig = new DynamicLogConfig(mock(classOf[LogManager]), mock(classOf[KafkaServer]))
     config.dynamicConfig.initialize(None, None)

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -43,6 +43,7 @@ import org.apache.kafka.common.quota.ClientQuotaEntity.{CLIENT_ID, IP, USER}
 import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity}
 import org.apache.kafka.common.record.{CompressionType, RecordVersion}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
+import org.apache.kafka.server.config.KafkaConfig.LOG_FLUSH_INTERVAL_MS_PROP
 import org.apache.kafka.server.common.MetadataVersion.IBP_3_0_IV1
 import org.apache.kafka.server.config.{ConfigEntityName, ConfigType}
 import org.apache.kafka.storage.internals.log.LogConfig
@@ -87,7 +88,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
         val op = new AlterConfigOp(new ConfigEntry(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG, newVal.toString()),
           SET)
         val resource2 = new ConfigResource(ConfigResource.Type.BROKER, "")
-        val op2 = new AlterConfigOp(new ConfigEntry(KafkaConfig.LogFlushIntervalMsProp, newVal.toString()),
+        val op2 = new AlterConfigOp(new ConfigEntry(LOG_FLUSH_INTERVAL_MS_PROP, newVal.toString()),
           SET)
         admin.incrementalAlterConfigs(Map(
           resource -> List(op).asJavaCollection,

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigTest.scala
@@ -21,6 +21,7 @@ import kafka.server.QuorumTestHarness
 import org.apache.kafka.common.config._
 import org.apache.kafka.common.config.internals.QuotaConfigs
 import org.apache.kafka.server.common.AdminOperationException
+import org.apache.kafka.server.config.dynamic.BrokerDynamicConfigs
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
@@ -43,13 +44,13 @@ class DynamicConfigTest extends QuorumTestHarness {
   @Test
   def shouldFailLeaderConfigsWithInvalidValues(): Unit = {
     assertThrows(classOf[ConfigException], () => adminZkClient.changeBrokerConfig(Seq(0),
-      propsWith(DynamicConfig.Broker.LeaderReplicationThrottledRateProp, "-100")))
+      propsWith(BrokerDynamicConfigs.LEADER_REPLICATION_THROTTLED_RATE_PROP, "-100")))
   }
 
   @Test
   def shouldFailFollowerConfigsWithInvalidValues(): Unit = {
     assertThrows(classOf[ConfigException], () => adminZkClient.changeBrokerConfig(Seq(0),
-      propsWith(DynamicConfig.Broker.FollowerReplicationThrottledRateProp, "-100")))
+      propsWith(BrokerDynamicConfigs.FOLLOWER_REPLICATION_THROTTLED_RATE_PROP, "-100")))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/EdgeCaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/EdgeCaseRequestTest.scala
@@ -34,6 +34,7 @@ import org.apache.kafka.common.requests.{ProduceResponse, ResponseHeader}
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.ByteUtils
 import org.apache.kafka.common.{TopicPartition, requests}
+import org.apache.kafka.server.config.KafkaConfig.AUTO_CREATE_TOPICS_ENABLE_PROP
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -44,7 +45,7 @@ class EdgeCaseRequestTest extends KafkaServerTestHarness {
 
   def generateConfigs = {
     val props = TestUtils.createBrokerConfig(1, zkConnectOrNull)
-    props.setProperty(KafkaConfig.AutoCreateTopicsEnableProp, "false")
+    props.setProperty(AUTO_CREATE_TOPICS_ENABLE_PROP, "false")
     List(KafkaConfig.fromProps(props))
   }
 

--- a/core/src/test/scala/unit/kafka/server/FetchRequestDownConversionConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestDownConversionConfigTest.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse}
 import org.apache.kafka.common.serialization.StringSerializer
+import org.apache.kafka.server.config.KafkaConfig.LOG_MESSAGE_DOWN_CONVERSION_ENABLE_PROP
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -53,7 +54,7 @@ class FetchRequestDownConversionConfigTest extends BaseRequestTest {
 
   override protected def brokerPropertyOverrides(properties: Properties): Unit = {
     super.brokerPropertyOverrides(properties)
-    properties.put(KafkaConfig.LogMessageDownConversionEnableProp, "false")
+    properties.put(LOG_MESSAGE_DOWN_CONVERSION_ENABLE_PROP, "false")
   }
 
   private def initProducer(): Unit = {

--- a/core/src/test/scala/unit/kafka/server/FetchRequestMaxBytesTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestMaxBytesTest.scala
@@ -23,6 +23,7 @@ import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.common.requests.FetchRequest.PartitionData
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse}
+import org.apache.kafka.server.config.KafkaConfig.FETCH_MAX_BYTES_PROP
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -74,7 +75,7 @@ class FetchRequestMaxBytesTest extends BaseRequestTest {
 
   override protected def brokerPropertyOverrides(properties: Properties): Unit = {
     super.brokerPropertyOverrides(properties)
-    properties.put(KafkaConfig.FetchMaxBytes, "1024")
+    properties.put(FETCH_MAX_BYTES_PROP, "1024")
   }
 
   private def createTopics(): Unit = {

--- a/core/src/test/scala/unit/kafka/server/FetchRequestWithLegacyMessageFormatTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestWithLegacyMessageFormatTest.scala
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse}
+import org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_PROTOCOL_VERSION_PROP
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.Test
 
@@ -35,7 +36,7 @@ class FetchRequestWithLegacyMessageFormatTest extends BaseFetchRequestTest {
   override def brokerPropertyOverrides(properties: Properties): Unit = {
     super.brokerPropertyOverrides(properties)
     // legacy message formats are only supported with IBP < 3.0
-    properties.put(KafkaConfig.InterBrokerProtocolVersionProp, "2.8")
+    properties.put(INTER_BROKER_PROTOCOL_VERSION_PROP, "2.8")
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -28,6 +28,7 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.server.util.MockTime
+import org.apache.kafka.server.config.KafkaConfig.{REPLICA_LAG_TIME_MAX_MS_PROP, REPLICA_FETCH_WAIT_MAX_MS_PROP}
 import org.apache.kafka.storage.internals.log.{LogDirFailureChannel, LogOffsetMetadata}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
@@ -45,8 +46,8 @@ class IsrExpirationTest {
   val leaderLogHighWatermark = 20L
 
   val overridingProps = new Properties()
-  overridingProps.put(KafkaConfig.ReplicaLagTimeMaxMsProp, replicaLagTimeMaxMs.toString)
-  overridingProps.put(KafkaConfig.ReplicaFetchWaitMaxMsProp, replicaFetchWaitMaxMs.toString)
+  overridingProps.put(REPLICA_LAG_TIME_MAX_MS_PROP, replicaLagTimeMaxMs.toString)
+  overridingProps.put(REPLICA_FETCH_WAIT_MAX_MS_PROP, replicaFetchWaitMaxMs.toString)
   val configs = TestUtils.createBrokerConfigs(2, TestUtils.MockZkConnect).map(KafkaConfig.fromProps(_, overridingProps))
   val topic = "foo"
 

--- a/core/src/test/scala/unit/kafka/server/KafkaMetricReporterClusterIdTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaMetricReporterClusterIdTest.scala
@@ -22,6 +22,7 @@ import kafka.metrics.KafkaMetricsReporter
 import kafka.utils.{CoreUtils, TestUtils, VerifiableProperties}
 import kafka.server.QuorumTestHarness
 import org.apache.kafka.common.{ClusterResource, ClusterResourceListener}
+import org.apache.kafka.server.config.KafkaConfig.{KAFKA_METRICS_REPORTER_CLASSES_PROP, METRIC_REPORTER_CLASSES_PROP, BROKER_ID_GENERATION_ENABLE_PROP, BROKER_ID_PROP}
 import org.apache.kafka.test.MockMetricsReporter
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
@@ -61,7 +62,7 @@ object KafkaMetricReporterClusterIdTest {
       // Because this code is run during the test setUp phase, if we throw an exception here,
       // it just results in the test itself being declared "not found" rather than failing.
       // So we track an error message which we will check later in the test body.
-      val brokerId = configs.get(KafkaConfig.BrokerIdProp)
+      val brokerId = configs.get(BROKER_ID_PROP)
       if (brokerId == null)
         setupError.compareAndSet("", "No value was set for the broker id.")
       else if (!brokerId.isInstanceOf[String])
@@ -83,10 +84,10 @@ class KafkaMetricReporterClusterIdTest extends QuorumTestHarness {
   override def setUp(testInfo: TestInfo): Unit = {
     super.setUp(testInfo)
     val props = TestUtils.createBrokerConfig(1, zkConnect)
-    props.setProperty(KafkaConfig.KafkaMetricsReporterClassesProp, "kafka.server.KafkaMetricReporterClusterIdTest$MockKafkaMetricsReporter")
-    props.setProperty(KafkaConfig.MetricReporterClassesProp, "kafka.server.KafkaMetricReporterClusterIdTest$MockBrokerMetricsReporter")
-    props.setProperty(KafkaConfig.BrokerIdGenerationEnableProp, "true")
-    props.setProperty(KafkaConfig.BrokerIdProp, "-1")
+    props.setProperty(KAFKA_METRICS_REPORTER_CLASSES_PROP, "kafka.server.KafkaMetricReporterClusterIdTest$MockKafkaMetricsReporter")
+    props.setProperty(METRIC_REPORTER_CLASSES_PROP, "kafka.server.KafkaMetricReporterClusterIdTest$MockBrokerMetricsReporter")
+    props.setProperty(BROKER_ID_GENERATION_ENABLE_PROP, "true")
+    props.setProperty(BROKER_ID_PROP, "-1")
     config = KafkaConfig.fromProps(props)
     server = new KafkaServer(config, threadNamePrefix = Option(this.getClass.getName))
     server.startup()

--- a/core/src/test/scala/unit/kafka/server/KafkaMetricReporterExceptionHandlingTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaMetricReporterExceptionHandlingTest.scala
@@ -22,6 +22,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{ListGroupsRequest, ListGroupsResponse}
 import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.apache.kafka.server.config.KafkaConfig.METRIC_REPORTER_CLASSES_PROP
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
@@ -40,7 +41,7 @@ class KafkaMetricReporterExceptionHandlingTest extends BaseRequestTest {
   override def brokerCount: Int = 1
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.put(KafkaConfig.MetricReporterClassesProp, classOf[KafkaMetricReporterExceptionHandlingTest.BadReporter].getName + "," + classOf[KafkaMetricReporterExceptionHandlingTest.GoodReporter].getName)
+    properties.put(METRIC_REPORTER_CLASSES_PROP, classOf[KafkaMetricReporterExceptionHandlingTest.BadReporter].getName + "," + classOf[KafkaMetricReporterExceptionHandlingTest.GoodReporter].getName)
   }
 
   @BeforeEach

--- a/core/src/test/scala/unit/kafka/server/KafkaMetricsReporterTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaMetricsReporterTest.scala
@@ -20,6 +20,7 @@ import java.util
 import java.util.concurrent.atomic.AtomicReference
 import kafka.utils.{CoreUtils, TestInfoUtils, TestUtils}
 import org.apache.kafka.common.metrics.{KafkaMetric, MetricsContext, MetricsReporter}
+import org.apache.kafka.server.config.KafkaConfig.{METRIC_REPORTER_CLASSES_PROP, BROKER_ID_GENERATION_ENABLE_PROP, BROKER_ID_PROP}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
@@ -70,9 +71,9 @@ class KafkaMetricsReporterTest extends QuorumTestHarness {
   override def setUp(testInfo: TestInfo): Unit = {
     super.setUp(testInfo)
     val props = TestUtils.createBrokerConfig(1, zkConnectOrNull)
-    props.setProperty(KafkaConfig.MetricReporterClassesProp, "kafka.server.KafkaMetricsReporterTest$MockMetricsReporter")
-    props.setProperty(KafkaConfig.BrokerIdGenerationEnableProp, "true")
-    props.setProperty(KafkaConfig.BrokerIdProp, "1")
+    props.setProperty(METRIC_REPORTER_CLASSES_PROP, "kafka.server.KafkaMetricsReporterTest$MockMetricsReporter")
+    props.setProperty(BROKER_ID_GENERATION_ENABLE_PROP, "true")
+    props.setProperty(BROKER_ID_PROP, "1")
     config = KafkaConfig.fromProps(props)
     broker = createBroker(config, threadNamePrefix = Option(this.getClass.getName))
     broker.startup()

--- a/core/src/test/scala/unit/kafka/server/KafkaRaftServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaRaftServerTest.scala
@@ -25,6 +25,7 @@ import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.metadata.bootstrap.{BootstrapDirectory, BootstrapMetadata}
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, MetaPropertiesVersion, PropertiesUtils}
 import org.apache.kafka.server.common.MetadataVersion
+import org.apache.kafka.server.config.KafkaConfig._
 import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
@@ -43,11 +44,11 @@ class KafkaRaftServerTest {
       build()
 
     val configProperties = new Properties
-    configProperties.put(KafkaConfig.ProcessRolesProp, "broker,controller")
-    configProperties.put(KafkaConfig.NodeIdProp, nodeId.toString)
-    configProperties.put(KafkaConfig.ListenersProp, "PLAINTEXT://127.0.0.1:9092,SSL://127.0.0.1:9093")
-    configProperties.put(KafkaConfig.QuorumVotersProp, s"$nodeId@localhost:9093")
-    configProperties.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
+    configProperties.put(PROCESS_ROLES_PROP, "broker,controller")
+    configProperties.put(NODE_ID_PROP, nodeId.toString)
+    configProperties.put(LISTENERS_PROP, "PLAINTEXT://127.0.0.1:9092,SSL://127.0.0.1:9093")
+    configProperties.put(QUORUM_VOTERS_PROP, s"$nodeId@localhost:9093")
+    configProperties.put(CONTROLLER_LISTENER_NAMES_PROP, "SSL")
 
     val metaPropertiesEnsemble =
       invokeLoadMetaProperties(metaProperties, configProperties)._1
@@ -71,10 +72,10 @@ class KafkaRaftServerTest {
       build()
     val configProperties = new Properties
 
-    configProperties.put(KafkaConfig.ProcessRolesProp, "controller")
-    configProperties.put(KafkaConfig.NodeIdProp, configNodeId.toString)
-    configProperties.put(KafkaConfig.QuorumVotersProp, s"$configNodeId@localhost:9092")
-    configProperties.put(KafkaConfig.ControllerListenerNamesProp, "PLAINTEXT")
+    configProperties.put(PROCESS_ROLES_PROP, "controller")
+    configProperties.put(NODE_ID_PROP, configNodeId.toString)
+    configProperties.put(QUORUM_VOTERS_PROP, s"$configNodeId@localhost:9092")
+    configProperties.put(CONTROLLER_LISTENER_NAMES_PROP, "PLAINTEXT")
 
     assertThrows(classOf[RuntimeException], () =>
       invokeLoadMetaProperties(metaProperties, configProperties))
@@ -89,7 +90,7 @@ class KafkaRaftServerTest {
     try {
       writeMetaProperties(tempLogDir, metaProperties)
       metadataVersion.foreach(mv => writeBootstrapMetadata(tempLogDir, mv))
-      configProperties.put(KafkaConfig.LogDirProp, tempLogDir.getAbsolutePath)
+      configProperties.put(LOG_DIR_PROP, tempLogDir.getAbsolutePath)
       val config = KafkaConfig.fromProps(configProperties)
       KafkaRaftServer.initializeLogDirs(config, MetaPropertiesEnsemble.LOG, "")
     } finally {
@@ -126,11 +127,11 @@ class KafkaRaftServerTest {
       build())
 
     val configProperties = new Properties
-    configProperties.put(KafkaConfig.ProcessRolesProp, "broker")
-    configProperties.put(KafkaConfig.NodeIdProp, nodeId.toString)
-    configProperties.put(KafkaConfig.QuorumVotersProp, s"${(nodeId + 1)}@localhost:9092")
-    configProperties.put(KafkaConfig.LogDirProp, Seq(logDir1, logDir2).map(_.getAbsolutePath).mkString(","))
-    configProperties.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
+    configProperties.put(PROCESS_ROLES_PROP, "broker")
+    configProperties.put(NODE_ID_PROP, nodeId.toString)
+    configProperties.put(QUORUM_VOTERS_PROP, s"${(nodeId + 1)}@localhost:9092")
+    configProperties.put(LOG_DIR_PROP, Seq(logDir1, logDir2).map(_.getAbsolutePath).mkString(","))
+    configProperties.put(CONTROLLER_LISTENER_NAMES_PROP, "SSL")
     val config = KafkaConfig.fromProps(configProperties)
 
     assertThrows(classOf[RuntimeException],
@@ -153,12 +154,12 @@ class KafkaRaftServerTest {
     // Use a regular file as an invalid log dir to trigger an IO error
     val invalidDir = TestUtils.tempFile("blah")
     val configProperties = new Properties
-    configProperties.put(KafkaConfig.ProcessRolesProp, "broker")
-    configProperties.put(KafkaConfig.QuorumVotersProp, s"${(nodeId + 1)}@localhost:9092")
-    configProperties.put(KafkaConfig.NodeIdProp, nodeId.toString)
-    configProperties.put(KafkaConfig.MetadataLogDirProp, invalidDir.getAbsolutePath)
-    configProperties.put(KafkaConfig.LogDirProp, validDir.getAbsolutePath)
-    configProperties.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
+    configProperties.put(PROCESS_ROLES_PROP, "broker")
+    configProperties.put(QUORUM_VOTERS_PROP, s"${(nodeId + 1)}@localhost:9092")
+    configProperties.put(NODE_ID_PROP, nodeId.toString)
+    configProperties.put(METADATA_LOG_DIR_PROP, invalidDir.getAbsolutePath)
+    configProperties.put(LOG_DIR_PROP, validDir.getAbsolutePath)
+    configProperties.put(CONTROLLER_LISTENER_NAMES_PROP, "SSL")
     val config = KafkaConfig.fromProps(configProperties)
 
     assertThrows(classOf[RuntimeException],
@@ -183,12 +184,12 @@ class KafkaRaftServerTest {
     // Use a regular file as an invalid log dir to trigger an IO error
     val invalidDir = TestUtils.tempFile("blah")
     val configProperties = new Properties
-    configProperties.put(KafkaConfig.ProcessRolesProp, "broker")
-    configProperties.put(KafkaConfig.NodeIdProp, nodeId.toString)
-    configProperties.put(KafkaConfig.QuorumVotersProp, s"${(nodeId + 1)}@localhost:9092")
-    configProperties.put(KafkaConfig.MetadataLogDirProp, validDir.getAbsolutePath)
-    configProperties.put(KafkaConfig.LogDirProp, invalidDir.getAbsolutePath)
-    configProperties.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
+    configProperties.put(PROCESS_ROLES_PROP, "broker")
+    configProperties.put(NODE_ID_PROP, nodeId.toString)
+    configProperties.put(QUORUM_VOTERS_PROP, s"${(nodeId + 1)}@localhost:9092")
+    configProperties.put(METADATA_LOG_DIR_PROP, validDir.getAbsolutePath)
+    configProperties.put(LOG_DIR_PROP, invalidDir.getAbsolutePath)
+    configProperties.put(CONTROLLER_LISTENER_NAMES_PROP, "SSL")
     val config = KafkaConfig.fromProps(configProperties)
 
     val (metaPropertiesEnsemble, _) =
@@ -219,12 +220,12 @@ class KafkaRaftServerTest {
     Files.createDirectory(new File(dataDir, UnifiedLog.logDirName(KafkaRaftServer.MetadataPartition)).toPath)
 
     val configProperties = new Properties
-    configProperties.put(KafkaConfig.ProcessRolesProp, "broker")
-    configProperties.put(KafkaConfig.NodeIdProp, nodeId.toString)
-    configProperties.put(KafkaConfig.QuorumVotersProp, s"${(nodeId + 1)}@localhost:9092")
-    configProperties.put(KafkaConfig.MetadataLogDirProp, metadataDir.getAbsolutePath)
-    configProperties.put(KafkaConfig.LogDirProp, dataDir.getAbsolutePath)
-    configProperties.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
+    configProperties.put(PROCESS_ROLES_PROP, "broker")
+    configProperties.put(NODE_ID_PROP, nodeId.toString)
+    configProperties.put(QUORUM_VOTERS_PROP, s"${(nodeId + 1)}@localhost:9092")
+    configProperties.put(METADATA_LOG_DIR_PROP, metadataDir.getAbsolutePath)
+    configProperties.put(LOG_DIR_PROP, dataDir.getAbsolutePath)
+    configProperties.put(CONTROLLER_LISTENER_NAMES_PROP, "SSL")
     val config = KafkaConfig.fromProps(configProperties)
 
     assertThrows(classOf[KafkaException],
@@ -247,11 +248,11 @@ class KafkaRaftServerTest {
     }
 
     val configProperties = new Properties
-    configProperties.put(KafkaConfig.ProcessRolesProp, "broker")
-    configProperties.put(KafkaConfig.QuorumVotersProp, s"${(nodeId + 1)}@localhost:9092")
-    configProperties.put(KafkaConfig.NodeIdProp, nodeId.toString)
-    configProperties.put(KafkaConfig.LogDirProp, Seq(logDir1, logDir2).map(_.getAbsolutePath).mkString(","))
-    configProperties.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
+    configProperties.put(PROCESS_ROLES_PROP, "broker")
+    configProperties.put(QUORUM_VOTERS_PROP, s"${(nodeId + 1)}@localhost:9092")
+    configProperties.put(NODE_ID_PROP, nodeId.toString)
+    configProperties.put(LOG_DIR_PROP, Seq(logDir1, logDir2).map(_.getAbsolutePath).mkString(","))
+    configProperties.put(CONTROLLER_LISTENER_NAMES_PROP, "SSL")
     val config = KafkaConfig.fromProps(configProperties)
 
     assertThrows(classOf[RuntimeException],
@@ -270,12 +271,12 @@ class KafkaRaftServerTest {
       build()
 
     val configProperties = new Properties
-    configProperties.put(KafkaConfig.ProcessRolesProp, "broker,controller")
-    configProperties.put(KafkaConfig.NodeIdProp, nodeId.toString)
-    configProperties.put(KafkaConfig.ListenersProp, "PLAINTEXT://127.0.0.1:9092,SSL://127.0.0.1:9093")
-    configProperties.put(KafkaConfig.QuorumVotersProp, s"$nodeId@localhost:9093")
-    configProperties.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
-    configProperties.put(KafkaConfig.InterBrokerProtocolVersionProp, "3.3-IV1")
+    configProperties.put(PROCESS_ROLES_PROP, "broker,controller")
+    configProperties.put(NODE_ID_PROP, nodeId.toString)
+    configProperties.put(LISTENERS_PROP, "PLAINTEXT://127.0.0.1:9092,SSL://127.0.0.1:9093")
+    configProperties.put(QUORUM_VOTERS_PROP, s"$nodeId@localhost:9093")
+    configProperties.put(CONTROLLER_LISTENER_NAMES_PROP, "SSL")
+    configProperties.put(INTER_BROKER_PROTOCOL_VERSION_PROP, "3.3-IV1")
 
     val (metaPropertiesEnsemble, bootstrapMetadata) =
       invokeLoadMetaProperties(metaProperties, configProperties, None)
@@ -301,12 +302,12 @@ class KafkaRaftServerTest {
     writeMetaProperties(logDir, metaProperties)
 
     val configProperties = new Properties
-    configProperties.put(KafkaConfig.ProcessRolesProp, "broker,controller")
-    configProperties.put(KafkaConfig.NodeIdProp, nodeId.toString)
-    configProperties.put(KafkaConfig.ListenersProp, "PLAINTEXT://127.0.0.1:9092,SSL://127.0.0.1:9093")
-    configProperties.put(KafkaConfig.QuorumVotersProp, s"$nodeId@localhost:9093")
-    configProperties.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
-    configProperties.put(KafkaConfig.LogDirProp, logDir.getAbsolutePath)
+    configProperties.put(PROCESS_ROLES_PROP, "broker,controller")
+    configProperties.put(NODE_ID_PROP, nodeId.toString)
+    configProperties.put(LISTENERS_PROP, "PLAINTEXT://127.0.0.1:9092,SSL://127.0.0.1:9093")
+    configProperties.put(QUORUM_VOTERS_PROP, s"$nodeId@localhost:9093")
+    configProperties.put(CONTROLLER_LISTENER_NAMES_PROP, "SSL")
+    configProperties.put(LOG_DIR_PROP, logDir.getAbsolutePath)
 
     val (metaPropertiesEnsemble, bootstrapMetadata) =
       invokeLoadMetaProperties(metaProperties, configProperties, None)

--- a/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
@@ -57,7 +57,7 @@ class KafkaServerTest extends QuorumTestHarness {
     props.put(ZK_CONNECT_PROP, zkConnect) // required, otherwise we would leave it out
     props.put(ZK_SSL_CLIENT_ENABLE_PROP, "false")
     val zkClientConfig = KafkaServer.zkClientConfigFromKafkaConfig(KafkaConfig.fromProps(props))
-    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().forEach { propName =>
+    zkSslConfigToSystemPropertyMap.keySet().forEach { propName =>
       assertNull(zkClientConfig.getProperty(propName))
     }
   }
@@ -73,7 +73,7 @@ class KafkaServerTest extends QuorumTestHarness {
       case ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP => "HTTPS"
       case _ => someValue
     }
-    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().forEach(kafkaProp => props.put(kafkaProp, kafkaConfigValueToSet(kafkaProp)))
+    zkSslConfigToSystemPropertyMap.keySet().forEach(kafkaProp => props.put(kafkaProp, kafkaConfigValueToSet(kafkaProp)))
     val zkClientConfig = KafkaServer.zkClientConfigFromKafkaConfig(KafkaConfig.fromProps(props))
     // now check to make sure the values were set correctly
     def zkClientValueToExpect(kafkaProp: String) : String = kafkaProp match {
@@ -81,8 +81,8 @@ class KafkaServerTest extends QuorumTestHarness {
       case ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP => "true"
       case _ => someValue
     }
-    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().forEach(kafkaProp =>
-      assertEquals(zkClientValueToExpect(kafkaProp), zkClientConfig.getProperty(ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(kafkaProp))))
+    zkSslConfigToSystemPropertyMap.keySet().forEach(kafkaProp =>
+      assertEquals(zkClientValueToExpect(kafkaProp), zkClientConfig.getProperty(zkSslConfigToSystemPropertyMap.get(kafkaProp))))
   }
 
   @Test
@@ -98,7 +98,7 @@ class KafkaServerTest extends QuorumTestHarness {
       case ZK_SSL_ENABLED_PROTOCOLS_PROP | ZK_SSL_CIPHER_SUITES_PROP => "A,B"
       case _ => someValue
     }
-    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().forEach(kafkaProp => props.put(kafkaProp, kafkaConfigValueToSet(kafkaProp)))
+    zkSslConfigToSystemPropertyMap.keySet().forEach(kafkaProp => props.put(kafkaProp, kafkaConfigValueToSet(kafkaProp)))
     val zkClientConfig = KafkaServer.zkClientConfigFromKafkaConfig(KafkaConfig.fromProps(props))
     // now check to make sure the values were set correctly
     def zkClientValueToExpect(kafkaProp: String) : String = kafkaProp match {
@@ -108,8 +108,8 @@ class KafkaServerTest extends QuorumTestHarness {
       case ZK_SSL_ENABLED_PROTOCOLS_PROP | ZK_SSL_CIPHER_SUITES_PROP => "A,B"
       case _ => someValue
     }
-    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().forEach(kafkaProp =>
-      assertEquals(zkClientValueToExpect(kafkaProp), zkClientConfig.getProperty(ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(kafkaProp))))
+    zkSslConfigToSystemPropertyMap.keySet().forEach(kafkaProp =>
+      assertEquals(zkClientValueToExpect(kafkaProp), zkClientConfig.getProperty(zkSslConfigToSystemPropertyMap.get(kafkaProp))))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
@@ -19,6 +19,7 @@ package kafka.server
 
 import kafka.utils.TestUtils
 import org.apache.kafka.common.security.JaasUtils
+import org.apache.kafka.server.config.KafkaConfig._
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNull, assertThrows, fail}
 import org.junit.jupiter.api.Test
 import java.util.Properties
@@ -45,7 +46,7 @@ class KafkaServerTest extends QuorumTestHarness {
   @Test
   def testCreatesProperZkConfigWhenSaslDisabled(): Unit = {
     val props = new Properties
-    props.put(KafkaConfig.ZkConnectProp, zkConnect) // required, otherwise we would leave it out
+    props.put(ZK_CONNECT_PROP, zkConnect) // required, otherwise we would leave it out
     val zkClientConfig = KafkaServer.zkClientConfigFromKafkaConfig(KafkaConfig.fromProps(props))
     assertEquals("false", zkClientConfig.getProperty(JaasUtils.ZK_SASL_CLIENT))
   }
@@ -53,10 +54,10 @@ class KafkaServerTest extends QuorumTestHarness {
   @Test
   def testCreatesProperZkTlsConfigWhenDisabled(): Unit = {
     val props = new Properties
-    props.put(KafkaConfig.ZkConnectProp, zkConnect) // required, otherwise we would leave it out
-    props.put(KafkaConfig.ZkSslClientEnableProp, "false")
+    props.put(ZK_CONNECT_PROP, zkConnect) // required, otherwise we would leave it out
+    props.put(ZK_SSL_CLIENT_ENABLE_PROP, "false")
     val zkClientConfig = KafkaServer.zkClientConfigFromKafkaConfig(KafkaConfig.fromProps(props))
-    KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.foreach { propName =>
+    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().forEach { propName =>
       assertNull(zkClientConfig.getProperty(propName))
     }
   }
@@ -64,57 +65,57 @@ class KafkaServerTest extends QuorumTestHarness {
   @Test
   def testCreatesProperZkTlsConfigWithTrueValues(): Unit = {
     val props = new Properties
-    props.put(KafkaConfig.ZkConnectProp, zkConnect) // required, otherwise we would leave it out
+    props.put(ZK_CONNECT_PROP, zkConnect) // required, otherwise we would leave it out
     // should get correct config for all properties if TLS is enabled
     val someValue = "some_value"
     def kafkaConfigValueToSet(kafkaProp: String) : String = kafkaProp match {
-      case KafkaConfig.ZkSslClientEnableProp | KafkaConfig.ZkSslCrlEnableProp | KafkaConfig.ZkSslOcspEnableProp => "true"
-      case KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp => "HTTPS"
+      case ZK_SSL_CLIENT_ENABLE_PROP | ZK_SSL_CRL_ENABLE_PROP | ZK_SSL_OCSP_ENABLE_PROP => "true"
+      case ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP => "HTTPS"
       case _ => someValue
     }
-    KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.foreach(kafkaProp => props.put(kafkaProp, kafkaConfigValueToSet(kafkaProp)))
+    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().forEach(kafkaProp => props.put(kafkaProp, kafkaConfigValueToSet(kafkaProp)))
     val zkClientConfig = KafkaServer.zkClientConfigFromKafkaConfig(KafkaConfig.fromProps(props))
     // now check to make sure the values were set correctly
     def zkClientValueToExpect(kafkaProp: String) : String = kafkaProp match {
-      case KafkaConfig.ZkSslClientEnableProp | KafkaConfig.ZkSslCrlEnableProp | KafkaConfig.ZkSslOcspEnableProp => "true"
-      case KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp => "true"
+      case ZK_SSL_CLIENT_ENABLE_PROP | ZK_SSL_CRL_ENABLE_PROP | ZK_SSL_OCSP_ENABLE_PROP => "true"
+      case ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP => "true"
       case _ => someValue
     }
-    KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.foreach(kafkaProp =>
-      assertEquals(zkClientValueToExpect(kafkaProp), zkClientConfig.getProperty(KafkaConfig.ZkSslConfigToSystemPropertyMap(kafkaProp))))
+    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().forEach(kafkaProp =>
+      assertEquals(zkClientValueToExpect(kafkaProp), zkClientConfig.getProperty(ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(kafkaProp))))
   }
 
   @Test
   def testCreatesProperZkTlsConfigWithFalseAndListValues(): Unit = {
     val props = new Properties
-    props.put(KafkaConfig.ZkConnectProp, zkConnect) // required, otherwise we would leave it out
+    props.put(ZK_CONNECT_PROP, zkConnect) // required, otherwise we would leave it out
     // should get correct config for all properties if TLS is enabled
     val someValue = "some_value"
     def kafkaConfigValueToSet(kafkaProp: String) : String = kafkaProp match {
-      case KafkaConfig.ZkSslClientEnableProp => "true"
-      case KafkaConfig.ZkSslCrlEnableProp | KafkaConfig.ZkSslOcspEnableProp => "false"
-      case KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp => ""
-      case KafkaConfig.ZkSslEnabledProtocolsProp | KafkaConfig.ZkSslCipherSuitesProp => "A,B"
+      case ZK_SSL_CLIENT_ENABLE_PROP => "true"
+      case ZK_SSL_CRL_ENABLE_PROP | ZK_SSL_OCSP_ENABLE_PROP => "false"
+      case ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP => ""
+      case ZK_SSL_ENABLED_PROTOCOLS_PROP | ZK_SSL_CIPHER_SUITES_PROP => "A,B"
       case _ => someValue
     }
-    KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.foreach(kafkaProp => props.put(kafkaProp, kafkaConfigValueToSet(kafkaProp)))
+    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().forEach(kafkaProp => props.put(kafkaProp, kafkaConfigValueToSet(kafkaProp)))
     val zkClientConfig = KafkaServer.zkClientConfigFromKafkaConfig(KafkaConfig.fromProps(props))
     // now check to make sure the values were set correctly
     def zkClientValueToExpect(kafkaProp: String) : String = kafkaProp match {
-      case KafkaConfig.ZkSslClientEnableProp => "true"
-      case KafkaConfig.ZkSslCrlEnableProp | KafkaConfig.ZkSslOcspEnableProp => "false"
-      case KafkaConfig.ZkSslEndpointIdentificationAlgorithmProp => "false"
-      case KafkaConfig.ZkSslEnabledProtocolsProp | KafkaConfig.ZkSslCipherSuitesProp => "A,B"
+      case ZK_SSL_CLIENT_ENABLE_PROP => "true"
+      case ZK_SSL_CRL_ENABLE_PROP | ZK_SSL_OCSP_ENABLE_PROP => "false"
+      case ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP => "false"
+      case ZK_SSL_ENABLED_PROTOCOLS_PROP | ZK_SSL_CIPHER_SUITES_PROP => "A,B"
       case _ => someValue
     }
-    KafkaConfig.ZkSslConfigToSystemPropertyMap.keys.foreach(kafkaProp =>
-      assertEquals(zkClientValueToExpect(kafkaProp), zkClientConfig.getProperty(KafkaConfig.ZkSslConfigToSystemPropertyMap(kafkaProp))))
+    ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().forEach(kafkaProp =>
+      assertEquals(zkClientValueToExpect(kafkaProp), zkClientConfig.getProperty(ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(kafkaProp))))
   }
 
   @Test
   def testZkIsrManager(): Unit = {
     val props = TestUtils.createBrokerConfigs(1, zkConnect).head
-    props.put(KafkaConfig.InterBrokerProtocolVersionProp, "2.7-IV1")
+    props.put(INTER_BROKER_PROTOCOL_VERSION_PROP, "2.7-IV1")
 
     val server = TestUtils.createServer(KafkaConfig.fromProps(props))
     server.replicaManager.alterPartitionManager match {
@@ -127,7 +128,7 @@ class KafkaServerTest extends QuorumTestHarness {
   @Test
   def testAlterIsrManager(): Unit = {
     val props = TestUtils.createBrokerConfigs(1, zkConnect).head
-    props.put(KafkaConfig.InterBrokerProtocolVersionProp, MetadataVersion.latestTesting.toString)
+    props.put(INTER_BROKER_PROTOCOL_VERSION_PROP, MetadataVersion.latestTesting.toString)
 
     val server = TestUtils.createServer(KafkaConfig.fromProps(props))
     server.replicaManager.alterPartitionManager match {
@@ -156,7 +157,7 @@ class KafkaServerTest extends QuorumTestHarness {
 
   def createServer(nodeId: Int, hostName: String, port: Int): KafkaServer = {
     val props = TestUtils.createBrokerConfig(nodeId, zkConnect)
-    props.put(KafkaConfig.AdvertisedListenersProp, s"PLAINTEXT://$hostName:$port")
+    props.put(ADVERTISED_LISTENERS_PROP, s"PLAINTEXT://$hostName:$port")
     val kafkaConfig = KafkaConfig.fromProps(props)
     TestUtils.createServer(kafkaConfig)
   }

--- a/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
@@ -26,6 +26,7 @@ import kafka.utils.{CoreUtils, Exit, TestInfoUtils, TestUtils}
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.server.config.KafkaConfig.{INTER_BROKER_PROTOCOL_VERSION_PROP, REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS_PROP, NUM_REPLICA_FETCHERS_PROP, LOG_MESSAGE_FORMAT_VERSION_PROP}
 import org.apache.kafka.common.errors.{KafkaStorageException, NotLeaderOrFollowerException}
 import org.apache.kafka.common.utils.Utils
 import org.junit.jupiter.api.Assertions._
@@ -49,8 +50,8 @@ class LogDirFailureTest extends IntegrationTestHarness {
   private val partitionNum = 12
   override val logDirCount = 3
 
-  this.serverConfig.setProperty(KafkaConfig.ReplicaHighWatermarkCheckpointIntervalMsProp, "60000")
-  this.serverConfig.setProperty(KafkaConfig.NumReplicaFetchersProp, "1")
+  this.serverConfig.setProperty(REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS_PROP, "60000")
+  this.serverConfig.setProperty(NUM_REPLICA_FETCHERS_PROP, "1")
 
   @BeforeEach
   override def setUp(testInfo: TestInfo): Unit = {
@@ -84,8 +85,8 @@ class LogDirFailureTest extends IntegrationTestHarness {
     var server: KafkaServer = null
     try {
       val props = TestUtils.createBrokerConfig(brokerCount, zkConnect, logDirCount = 3)
-      props.put(KafkaConfig.InterBrokerProtocolVersionProp, "0.11.0")
-      props.put(KafkaConfig.LogMessageFormatVersionProp, "0.11.0")
+      props.put(INTER_BROKER_PROTOCOL_VERSION_PROP, "0.11.0")
+      props.put(LOG_MESSAGE_FORMAT_VERSION_PROP, "0.11.0")
       val kafkaConfig = KafkaConfig.fromProps(props)
       val logDir = new File(kafkaConfig.logDirs.head)
       // Make log directory of the partition on the leader broker inaccessible by replacing it with a file

--- a/core/src/test/scala/unit/kafka/server/LogRecoveryTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogRecoveryTest.scala
@@ -32,6 +32,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.serialization.{IntegerSerializer, StringSerializer}
+import org.apache.kafka.server.config.KafkaConfig.{REPLICA_LAG_TIME_MAX_MS_PROP, REPLICA_FETCH_WAIT_MAX_MS_PROP, REPLICA_FETCH_MIN_BYTES_PROP}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
@@ -45,9 +46,9 @@ class LogRecoveryTest extends QuorumTestHarness {
   val replicaFetchMinBytes = 20
 
   val overridingProps = new Properties()
-  overridingProps.put(KafkaConfig.ReplicaLagTimeMaxMsProp, replicaLagTimeMaxMs.toString)
-  overridingProps.put(KafkaConfig.ReplicaFetchWaitMaxMsProp, replicaFetchWaitMaxMs.toString)
-  overridingProps.put(KafkaConfig.ReplicaFetchMinBytesProp, replicaFetchMinBytes.toString)
+  overridingProps.put(REPLICA_LAG_TIME_MAX_MS_PROP, replicaLagTimeMaxMs.toString)
+  overridingProps.put(REPLICA_FETCH_WAIT_MAX_MS_PROP, replicaFetchWaitMaxMs.toString)
+  overridingProps.put(REPLICA_FETCH_MIN_BYTES_PROP, replicaFetchMinBytes.toString)
 
   var configs: Seq[KafkaConfig] = _
   val topic = "new-topic"

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -34,6 +34,7 @@ import org.apache.kafka.common.record.{CompressionType, MemoryRecords, RecordBat
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.{UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET}
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, UpdateMetadataRequest}
 import org.apache.kafka.common.utils.{LogContext, SystemTime}
+import org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_PROTOCOL_VERSION_PROP
 import org.apache.kafka.server.common.{MetadataVersion, OffsetAndEpoch}
 import org.apache.kafka.server.common.MetadataVersion.IBP_2_6_IV0
 import org.apache.kafka.storage.internals.log.LogAppendInfo
@@ -282,7 +283,7 @@ class ReplicaFetcherThreadTest {
 
   private def verifyFetchLeaderEpochOnFirstFetch(ibp: MetadataVersion, epochFetchCount: Int = 1): Unit = {
     val props = TestUtils.createBrokerConfig(1, "localhost:1234")
-    props.setProperty(KafkaConfig.InterBrokerProtocolVersionProp, ibp.version)
+    props.setProperty(INTER_BROKER_PROTOCOL_VERSION_PROP, ibp.version)
     val config = KafkaConfig.fromProps(props)
 
     metadataCache = new ZkMetadataCache(0, ibp, BrokerFeatures.createEmpty())
@@ -845,7 +846,7 @@ class ReplicaFetcherThreadTest {
     val truncateToCapture: ArgumentCaptor[Long] = ArgumentCaptor.forClass(classOf[Long])
 
     val props = TestUtils.createBrokerConfig(1, "localhost:1234")
-    props.put(KafkaConfig.InterBrokerProtocolVersionProp, "0.11.0")
+    props.put(INTER_BROKER_PROTOCOL_VERSION_PROP, "0.11.0")
     val config = KafkaConfig.fromProps(props)
 
     // Setup all dependencies
@@ -1432,7 +1433,7 @@ class ReplicaFetcherThreadTest {
 
   private def kafkaConfigNoTruncateOnFetch: KafkaConfig = {
     val props = TestUtils.createBrokerConfig(1, "localhost:1234")
-    props.setProperty(KafkaConfig.InterBrokerProtocolVersionProp, IBP_2_6_IV0.version)
+    props.setProperty(INTER_BROKER_PROTOCOL_VERSION_PROP, IBP_2_6_IV0.version)
     KafkaConfig.fromProps(props)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -40,6 +40,7 @@ import org.apache.kafka.image.{MetadataDelta, MetadataImage}
 import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.metadata.PartitionRegistration
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesVersion}
+import org.apache.kafka.server.config.KafkaConfig.{QUORUM_VOTERS_PROP, PROCESS_ROLES_PROP, NODE_ID_PROP, CONTROLLER_LISTENER_NAMES_PROP, LOG_DIR_PROP, REPLICA_LAG_TIME_MAX_MS_PROP}
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.util.{MockTime, ShutdownableThread}
 import org.apache.kafka.storage.internals.log.{AppendOrigin, FetchIsolation, FetchParams, FetchPartitionData, LogConfig, LogDirFailureChannel}
@@ -165,12 +166,12 @@ class ReplicaManagerConcurrencyTest extends Logging {
     TestUtils.formatDirectories(immutable.Seq(logDir.getAbsolutePath), metaProperties, MetadataVersion.latestTesting(), None)
 
     val props = new Properties
-    props.put(KafkaConfig.QuorumVotersProp, "100@localhost:12345")
-    props.put(KafkaConfig.ProcessRolesProp, "broker")
-    props.put(KafkaConfig.NodeIdProp, localId.toString)
-    props.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
-    props.put(KafkaConfig.LogDirProp, logDir.getAbsolutePath)
-    props.put(KafkaConfig.ReplicaLagTimeMaxMsProp, 5000.toString)
+    props.put(QUORUM_VOTERS_PROP, "100@localhost:12345")
+    props.put(PROCESS_ROLES_PROP, "broker")
+    props.put(NODE_ID_PROP, localId.toString)
+    props.put(CONTROLLER_LISTENER_NAMES_PROP, "SSL")
+    props.put(LOG_DIR_PROP, logDir.getAbsolutePath)
+    props.put(REPLICA_LAG_TIME_MAX_MS_PROP, 5000.toString)
 
     val config = new KafkaConfig(props, doLog = false)
 

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -20,7 +20,6 @@ package kafka.server
 import java.util.AbstractMap.SimpleImmutableEntry
 import java.util.{Collections, Properties}
 import java.util.Map.Entry
-import kafka.server.DynamicConfig.Broker
 import kafka.server.KafkaConfig.fromProps
 import kafka.server.QuotaType._
 import kafka.utils.TestUtils._
@@ -38,6 +37,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth.SecurityProtocol.PLAINTEXT
 import org.apache.kafka.controller.ControllerRequestContextUtil
 import org.apache.kafka.server.common.MetadataVersion
+import org.apache.kafka.server.config.dynamic.BrokerDynamicConfigs
 import org.apache.kafka.storage.internals.log.LogConfig
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.AfterEach
@@ -127,15 +127,15 @@ class ReplicationQuotasTest extends QuorumTestHarness {
           controllerServer.controller.incrementalAlterConfigs(
             ControllerRequestContextUtil.ANONYMOUS_CONTEXT,
             Map(new ConfigResource(BROKER, String.valueOf(brokerId)) -> Map(
-              Broker.LeaderReplicationThrottledRateProp -> entry,
-              Broker.FollowerReplicationThrottledRateProp -> entry).asJava).asJava,
+              BrokerDynamicConfigs.LEADER_REPLICATION_THROTTLED_RATE_PROP -> entry,
+              BrokerDynamicConfigs.FOLLOWER_REPLICATION_THROTTLED_RATE_PROP -> entry).asJava).asJava,
             false
           ).get()
         } else {
           adminZkClient.changeBrokerConfig(Seq(brokerId),
             propsWith(
-              (DynamicConfig.Broker.LeaderReplicationThrottledRateProp, throttle.toString),
-              (DynamicConfig.Broker.FollowerReplicationThrottledRateProp, throttle.toString)
+              (BrokerDynamicConfigs.LEADER_REPLICATION_THROTTLED_RATE_PROP, throttle.toString),
+              (BrokerDynamicConfigs.FOLLOWER_REPLICATION_THROTTLED_RATE_PROP, throttle.toString)
             ))
         }
       }
@@ -239,7 +239,7 @@ class ReplicationQuotasTest extends QuorumTestHarness {
       //Set the throttle to only limit leader
       val configs = Map(
         new ConfigResource(BROKER, "100") ->
-          Seq(new AlterConfigOp(new ConfigEntry(Broker.LeaderReplicationThrottledRateProp, throttle.toString), SET)).asJavaCollection,
+          Seq(new AlterConfigOp(new ConfigEntry(BrokerDynamicConfigs.LEADER_REPLICATION_THROTTLED_RATE_PROP, throttle.toString), SET)).asJavaCollection,
         new ConfigResource(TOPIC, topic) ->
           Seq(new AlterConfigOp(new ConfigEntry(LogConfig.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "0:100"), SET)).asJavaCollection
       ).asJava

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -43,6 +43,7 @@ import org.apache.kafka.common.security.auth._
 import org.apache.kafka.common.utils.{Sanitizer, SecurityUtils}
 import org.apache.kafka.metadata.authorizer.StandardAuthorizer
 import org.apache.kafka.network.Session
+import org.apache.kafka.server.config.KafkaConfig
 import org.apache.kafka.server.authorizer.{Action, AuthorizableRequestContext, AuthorizationResult}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
@@ -76,23 +77,23 @@ class RequestQuotaTest extends BaseRequestTest {
   private val tasks = new ListBuffer[Task]
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.put(KafkaConfig.ControlledShutdownEnableProp, "false")
-    properties.put(KafkaConfig.OffsetsTopicReplicationFactorProp, "1")
-    properties.put(KafkaConfig.OffsetsTopicPartitionsProp, "1")
-    properties.put(KafkaConfig.GroupMinSessionTimeoutMsProp, "100")
-    properties.put(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
-    properties.put(KafkaConfig.PrincipalBuilderClassProp, classOf[RequestQuotaTest.TestPrincipalBuilder].getName)
-    properties.put(KafkaConfig.UnstableApiVersionsEnableProp, "true")
+    properties.put(KafkaConfig.CONTROLLED_SHUTDOWN_ENABLE_PROP, "false")
+    properties.put(KafkaConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, "1")
+    properties.put(KafkaConfig.OFFSETS_TOPIC_PARTITIONS_PROP, "1")
+    properties.put(KafkaConfig.GROUP_MIN_SESSION_TIMEOUT_MS_PROP, "100")
+    properties.put(KafkaConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, "0")
+    properties.put(KafkaConfig.PRINCIPAL_BUILDER_CLASS_PROP, classOf[RequestQuotaTest.TestPrincipalBuilder].getName)
+    properties.put(KafkaConfig.UNSTABLE_API_VERSIONS_ENABLE_PROP, "true")
     if (isKRaftTest()) {
-      properties.put(KafkaConfig.AuthorizerClassNameProp, classOf[RequestQuotaTest.KraftTestAuthorizer].getName)
+      properties.put(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[RequestQuotaTest.KraftTestAuthorizer].getName)
     } else {
-      properties.put(KafkaConfig.AuthorizerClassNameProp, classOf[RequestQuotaTest.ZkTestAuthorizer].getName)
+      properties.put(KafkaConfig.AUTHORIZER_CLASS_NAME_PROP, classOf[RequestQuotaTest.ZkTestAuthorizer].getName)
     }
   }
 
   override def kraftControllerConfigs(): Seq[Properties] = {
     val properties = new Properties()
-    properties.put(KafkaConfig.PrincipalBuilderClassProp, classOf[RequestQuotaTest.TestPrincipalBuilder].getName)
+    properties.put(KafkaConfig.PRINCIPAL_BUILDER_CLASS_PROP, classOf[RequestQuotaTest.TestPrincipalBuilder].getName)
     Seq(properties)
   }
 

--- a/core/src/test/scala/unit/kafka/server/ServerGenerateBrokerIdTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerGenerateBrokerIdTest.scala
@@ -20,6 +20,7 @@ import java.util.{OptionalInt, Properties}
 import scala.collection.Seq
 import kafka.utils.TestUtils
 import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.server.config.KafkaConfig.{BROKER_ID_GENERATION_ENABLE_PROP, BROKER_ID_PROP, MAX_RESERVED_BROKER_ID_PROP}
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, PropertiesUtils}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
 import org.junit.jupiter.api.Assertions._
@@ -87,9 +88,9 @@ class ServerGenerateBrokerIdTest extends QuorumTestHarness {
   @Test
   def testDisableGeneratedBrokerId(): Unit = {
     val props3 = TestUtils.createBrokerConfig(3, zkConnect)
-    props3.put(KafkaConfig.BrokerIdGenerationEnableProp, "false")
+    props3.put(BROKER_ID_GENERATION_ENABLE_PROP, "false")
     // Set reserve broker ids to cause collision and ensure disabling broker id generation ignores the setting
-    props3.put(KafkaConfig.MaxReservedBrokerIdProp, "0")
+    props3.put(MAX_RESERVED_BROKER_ID_PROP, "0")
     val config3 = KafkaConfig.fromProps(props3)
     val server3 = TestUtils.createServer(config3, threadNamePrefix = Option(this.getClass.getName))
     servers = Seq(server3)
@@ -151,14 +152,14 @@ class ServerGenerateBrokerIdTest extends QuorumTestHarness {
     servers = Seq(serverA)
 
     // adjust the broker config and start again
-    propsB.setProperty(KafkaConfig.BrokerIdProp, "2")
+    propsB.setProperty(BROKER_ID_PROP, "2")
     val serverB2 = new KafkaServer(KafkaConfig.fromProps(propsB),
       threadNamePrefix = Option(this.getClass.getName))
     val startupException = assertThrows(classOf[RuntimeException], () => serverB2.startup())
     assertTrue(startupException.getMessage.startsWith("Stored node id 1 doesn't match previous node id 2"),
       "Unexpected exception message " + startupException.getMessage())
     serverB2.config.logDirs.foreach(logDir => Utils.delete(new File(logDir)))
-    propsB.setProperty(KafkaConfig.BrokerIdProp, "3")
+    propsB.setProperty(BROKER_ID_PROP, "3")
     val serverB3 = new KafkaServer(KafkaConfig.fromProps(propsB),
       threadNamePrefix = Option(this.getClass.getName))
     serverB3.startup()

--- a/core/src/test/scala/unit/kafka/server/ServerMetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerMetricsTest.scala
@@ -19,6 +19,7 @@ package kafka.server
 
 import kafka.utils.TestUtils
 import org.apache.kafka.common.metrics.Sensor
+import org.apache.kafka.server.config.KafkaConfig.METRIC_RECORDING_LEVEL_PROP
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
@@ -31,14 +32,14 @@ class ServerMetricsTest {
     val props = TestUtils.createBrokerConfig(0, "localhost:2818")
 
     for (recordingLevel <- recordingLevels) {
-      props.put(KafkaConfig.MetricRecordingLevelProp, recordingLevel.name)
+      props.put(METRIC_RECORDING_LEVEL_PROP, recordingLevel.name)
       val config = KafkaConfig.fromProps(props)
       val metricConfig = Server.buildMetricsConfig(config)
       assertEquals(recordingLevel, metricConfig.recordLevel)
     }
 
     for (illegalName <- illegalNames) {
-      props.put(KafkaConfig.MetricRecordingLevelProp, illegalName)
+      props.put(METRIC_RECORDING_LEVEL_PROP, illegalName)
       val config = KafkaConfig.fromProps(props)
       assertThrows(classOf[IllegalArgumentException], () => Server.buildMetricsConfig(config))
     }

--- a/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
@@ -37,6 +37,7 @@ import org.apache.kafka.common.requests.LeaderAndIsrRequest
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.serialization.{IntegerDeserializer, IntegerSerializer, StringDeserializer, StringSerializer}
 import org.apache.kafka.common.utils.Time
+import org.apache.kafka.server.config.KafkaConfig.{LOG_DIR_PROP, LOG_DIRS_PROP, INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_PROP, ZK_CONNECTION_TIMEOUT_MS_PROP, ZK_CONNECT_PROP}
 import org.apache.kafka.metadata.BrokerState
 import org.junit.jupiter.api.{BeforeEach, Disabled, TestInfo, Timeout}
 import org.junit.jupiter.api.Assertions._
@@ -62,11 +63,11 @@ class ServerShutdownTest extends KafkaServerTestHarness {
     priorConfig.foreach { config =>
       // keep the same log directory
       val originals = config.originals
-      val logDirsValue = originals.get(KafkaConfig.LogDirsProp)
+      val logDirsValue = originals.get(LOG_DIRS_PROP)
       if (logDirsValue != null) {
-        propsToChangeUponRestart.put(KafkaConfig.LogDirsProp, logDirsValue)
+        propsToChangeUponRestart.put(LOG_DIRS_PROP, logDirsValue)
       } else {
-        propsToChangeUponRestart.put(KafkaConfig.LogDirProp, originals.get(KafkaConfig.LogDirProp))
+        propsToChangeUponRestart.put(LOG_DIR_PROP, originals.get(LOG_DIR_PROP))
       }
     }
     priorConfig = Some(KafkaConfig.fromProps(TestUtils.createBrokerConfigs(1, zkConnectOrNull).head, propsToChangeUponRestart))
@@ -145,13 +146,13 @@ class ServerShutdownTest extends KafkaServerTestHarness {
   @ValueSource(strings = Array("zk", "kraft"))
   def testCleanShutdownAfterFailedStartup(quorum: String): Unit = {
     if (isKRaftTest()) {
-      propsToChangeUponRestart.setProperty(KafkaConfig.InitialBrokerRegistrationTimeoutMsProp, "1000")
+      propsToChangeUponRestart.setProperty(INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_PROP, "1000")
       shutdownBroker()
       shutdownKRaftController()
       verifyCleanShutdownAfterFailedStartup[CancellationException]
     } else {
-      propsToChangeUponRestart.setProperty(KafkaConfig.ZkConnectionTimeoutMsProp, "50")
-      propsToChangeUponRestart.setProperty(KafkaConfig.ZkConnectProp, "some.invalid.hostname.foo.bar.local:65535")
+      propsToChangeUponRestart.setProperty(ZK_CONNECTION_TIMEOUT_MS_PROP, "50")
+      propsToChangeUponRestart.setProperty(ZK_CONNECT_PROP, "some.invalid.hostname.foo.bar.local:65535")
       verifyCleanShutdownAfterFailedStartup[ZooKeeperClientTimeoutException]
     }
   }

--- a/core/src/test/scala/unit/kafka/server/ServerStartupTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerStartupTest.scala
@@ -20,6 +20,7 @@ package kafka.server
 import kafka.utils.TestUtils
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.metadata.BrokerState
+import org.apache.kafka.server.config.KafkaConfig.{MIGRATION_ENABLED_PROP, QUORUM_VOTERS_PROP, CONTROLLER_LISTENER_NAMES_PROP, LISTENER_SECURITY_PROTOCOL_MAP_PROP}
 import org.apache.kafka.server.log.remote.storage.{NoOpRemoteLogMetadataManager, NoOpRemoteStorageManager, RemoteLogManagerConfig}
 import org.apache.zookeeper.KeeperException.NodeExistsException
 import org.junit.jupiter.api.Assertions._
@@ -139,12 +140,12 @@ class ServerStartupTest extends QuorumTestHarness {
  @ValueSource(booleans = Array(false, true))
  def testDirectoryIdsCreatedOnlyForMigration(migrationEnabled: Boolean): Unit = {
    val props = TestUtils.createBrokerConfig(1, zkConnect)
-   props.setProperty(KafkaConfig.MigrationEnabledProp, migrationEnabled.toString)
+   props.setProperty(MIGRATION_ENABLED_PROP, migrationEnabled.toString)
    if (migrationEnabled) {
      // Create Controller properties needed when migration is enabled
-     props.setProperty(KafkaConfig.QuorumVotersProp, "3000@localhost:9093")
-     props.setProperty(KafkaConfig.ControllerListenerNamesProp, "CONTROLLER")
-     props.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp,
+     props.setProperty(QUORUM_VOTERS_PROP, "3000@localhost:9093")
+     props.setProperty(CONTROLLER_LISTENER_NAMES_PROP, "CONTROLLER")
+     props.setProperty(LISTENER_SECURITY_PROTOCOL_MAP_PROP,
        "CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT")
    }
    server = new KafkaServer(KafkaConfig.fromProps(props))

--- a/core/src/test/scala/unit/kafka/server/ServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerTest.scala
@@ -20,6 +20,7 @@ import java.util.Properties
 
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.metrics.MetricsContext
+import org.apache.kafka.server.config.KafkaConfig.{BROKER_ID_PROP, ZK_CONNECT_PROP, PROCESS_ROLES_PROP, NODE_ID_PROP, QUORUM_VOTERS_PROP, CONTROLLER_LISTENER_NAMES_PROP}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
@@ -33,10 +34,10 @@ class ServerTest {
     val clusterId = Uuid.randomUuid().toString
 
     val props = new Properties()
-    props.put(KafkaConfig.ProcessRolesProp, "broker")
-    props.put(KafkaConfig.NodeIdProp, nodeId.toString)
-    props.put(KafkaConfig.QuorumVotersProp, s"${(nodeId + 1)}@localhost:9093")
-    props.put(KafkaConfig.ControllerListenerNamesProp, "SSL")
+    props.put(PROCESS_ROLES_PROP, "broker")
+    props.put(NODE_ID_PROP, nodeId.toString)
+    props.put(QUORUM_VOTERS_PROP, s"${(nodeId + 1)}@localhost:9093")
+    props.put(CONTROLLER_LISTENER_NAMES_PROP, "SSL")
     val config = KafkaConfig.fromProps(props)
 
     val context = Server.createKafkaMetricsContext(config, clusterId)
@@ -53,8 +54,8 @@ class ServerTest {
     val clusterId = Uuid.randomUuid().toString
 
     val props = new Properties()
-    props.put(KafkaConfig.BrokerIdProp, brokerId.toString)
-    props.put(KafkaConfig.ZkConnectProp, "127.0.0.1:0")
+    props.put(BROKER_ID_PROP, brokerId.toString)
+    props.put(ZK_CONNECT_PROP, "127.0.0.1:0")
     val config = KafkaConfig.fromProps(props)
 
     val context = Server.createKafkaMetricsContext(config, clusterId)

--- a/core/src/test/scala/unit/kafka/server/TopicIdWithOldInterBrokerProtocolTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TopicIdWithOldInterBrokerProtocolTest.scala
@@ -26,7 +26,8 @@ import org.apache.kafka.common.message.DeleteTopicsRequestData
 import org.apache.kafka.common.message.DeleteTopicsRequestData.DeleteTopicState
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{DeleteTopicsRequest, DeleteTopicsResponse, FetchRequest, FetchResponse, MetadataRequest, MetadataResponse}
-import org.apache.kafka.server.common.MetadataVersion.{IBP_2_7_IV0}
+import org.apache.kafka.server.config.KafkaConfig.{INTER_BROKER_PROTOCOL_VERSION_PROP, OFFSETS_TOPIC_PARTITIONS_PROP, DEFAULT_REPLICATION_FACTOR_PROP, RACK_PROP, BROKER_ID_PROP}
+import org.apache.kafka.server.common.MetadataVersion.IBP_2_7_IV0
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test, TestInfo}
 
@@ -36,10 +37,10 @@ import scala.jdk.CollectionConverters._
 class TopicIdWithOldInterBrokerProtocolTest extends BaseRequestTest {
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {
-    properties.setProperty(KafkaConfig.InterBrokerProtocolVersionProp, IBP_2_7_IV0.toString)
-    properties.setProperty(KafkaConfig.OffsetsTopicPartitionsProp, "1")
-    properties.setProperty(KafkaConfig.DefaultReplicationFactorProp, "2")
-    properties.setProperty(KafkaConfig.RackProp, s"rack/${properties.getProperty(KafkaConfig.BrokerIdProp)}")
+    properties.setProperty(INTER_BROKER_PROTOCOL_VERSION_PROP, IBP_2_7_IV0.toString)
+    properties.setProperty(OFFSETS_TOPIC_PARTITIONS_PROP, "1")
+    properties.setProperty(DEFAULT_REPLICATION_FACTOR_PROP, "2")
+    properties.setProperty(RACK_PROP, s"rack/${properties.getProperty(BROKER_ID_PROP)}")
   }
 
   @BeforeEach

--- a/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
+++ b/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.common.message.UpdateFeaturesRequestData.FeatureUpdateKe
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{UpdateFeaturesRequest, UpdateFeaturesResponse}
 import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_PROTOCOL_VERSION_PROP
 import org.apache.kafka.server.common.MetadataVersion.{IBP_2_7_IV0, IBP_3_2_IV0}
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotEquals, assertNotNull, assertThrows, assertTrue}
@@ -43,7 +44,7 @@ class UpdateFeaturesTest extends BaseRequestTest {
   override def brokerCount = 3
 
   override def brokerPropertyOverrides(props: Properties): Unit = {
-    props.put(KafkaConfig.InterBrokerProtocolVersionProp, IBP_2_7_IV0.toString)
+    props.put(INTER_BROKER_PROTOCOL_VERSION_PROP, IBP_2_7_IV0.toString)
   }
 
   private def defaultSupportedFeatures(): Features[SupportedVersionRange] = {

--- a/core/src/test/scala/unit/kafka/server/epoch/EpochDrivenReplicationProtocolAcceptanceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/EpochDrivenReplicationProtocolAcceptanceTest.scala
@@ -19,7 +19,7 @@ package kafka.server.epoch
 
 import kafka.log.UnifiedLog
 import kafka.server.KafkaConfig._
-import kafka.server.{KafkaConfig, KafkaServer, QuorumTestHarness}
+import kafka.server.{KafkaServer, QuorumTestHarness}
 import kafka.tools.DumpLogSegments
 import kafka.utils.TestUtils._
 import kafka.utils.{CoreUtils, Logging, TestUtils}
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.apache.kafka.server.config.KafkaConfig.{MIN_IN_SYNC_REPLICAS_PROP, UNCLEAN_LEADER_ELECTION_ENABLE_PROP}
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.storage.internals.epoch.LeaderEpochFileCache
 import org.apache.kafka.storage.internals.log.EpochEntry
@@ -302,7 +303,7 @@ class EpochDrivenReplicationProtocolAcceptanceTest extends QuorumTestHarness wit
 
     // A single partition topic with 2 replicas, min.isr = 1
     TestUtils.createTopic(zkClient, topic, Map(0 -> Seq(100, 101)), brokers,
-      CoreUtils.propsWith((KafkaConfig.MinInSyncReplicasProp, "1")))
+      CoreUtils.propsWith((MIN_IN_SYNC_REPLICAS_PROP, "1")))
 
     producer = TestUtils.createProducer(plaintextBootstrapServers(brokers), acks = 1)
 
@@ -466,7 +467,7 @@ class EpochDrivenReplicationProtocolAcceptanceTest extends QuorumTestHarness wit
   private def createBrokerForId(id: Int, enableUncleanLeaderElection: Boolean = false): KafkaServer = {
     val config = createBrokerConfig(id, zkConnect)
     TestUtils.setIbpAndMessageFormatVersions(config, metadataVersion)
-    config.setProperty(KafkaConfig.UncleanLeaderElectionEnableProp, enableUncleanLeaderElection.toString)
+    config.setProperty(UNCLEAN_LEADER_ELECTION_ENABLE_PROP, enableUncleanLeaderElection.toString)
     createServer(fromProps(config))
   }
 }

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -36,6 +36,7 @@ import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.image.{MetadataDelta, MetadataImage, MetadataImageTest, MetadataProvenance}
 import org.apache.kafka.image.loader.LogDeltaManifest
 import org.apache.kafka.raft.LeaderAndEpoch
+import org.apache.kafka.server.config.KafkaConfig.MAX_CONNECTIONS_PROP
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.fault.FaultHandler
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue}
@@ -121,7 +122,7 @@ class BrokerMetadataPublisherTest {
         assertEquals(0, numTimesReloadCalled.get())
         admin.incrementalAlterConfigs(singletonMap(
           new ConfigResource(BROKER, ""),
-          singleton(new AlterConfigOp(new ConfigEntry(KafkaConfig.MaxConnectionsProp, "123"), SET)))).all().get()
+          singleton(new AlterConfigOp(new ConfigEntry(MAX_CONNECTIONS_PROP, "123"), SET)))).all().get()
         TestUtils.waitUntilTrue(() => numTimesReloadCalled.get() == 0,
           "numTimesConfigured never reached desired value")
 
@@ -129,7 +130,7 @@ class BrokerMetadataPublisherTest {
         // reloadUpdatedFilesWithoutConfigChange will be called.
         admin.incrementalAlterConfigs(singletonMap(
           new ConfigResource(BROKER, broker.config.nodeId.toString),
-          singleton(new AlterConfigOp(new ConfigEntry(KafkaConfig.MaxConnectionsProp, "123"), SET)))).all().get()
+          singleton(new AlterConfigOp(new ConfigEntry(MAX_CONNECTIONS_PROP, "123"), SET)))).all().get()
         TestUtils.waitUntilTrue(() => numTimesReloadCalled.get() == 1,
           "numTimesConfigured never reached desired value")
       } finally {

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -28,6 +28,7 @@ import kafka.utils.Exit
 import kafka.utils.TestUtils
 import org.apache.commons.io.output.NullOutputStream
 import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.server.config.KafkaConfig.{LOG_DIRS_PROP, PROCESS_ROLES_PROP, NODE_ID_PROP, QUORUM_VOTERS_PROP, CONTROLLER_LISTENER_NAMES_PROP, METADATA_LOG_DIR_PROP, UNSTABLE_METADATA_VERSIONS_ENABLE_PROP}
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.common.metadata.UserScramCredentialRecord
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, MetaPropertiesVersion, PropertiesUtils}
@@ -44,11 +45,11 @@ class StorageToolTest {
 
   private def newSelfManagedProperties() = {
     val properties = new Properties()
-    properties.setProperty(KafkaConfig.LogDirsProp, "/tmp/foo,/tmp/bar")
-    properties.setProperty(KafkaConfig.ProcessRolesProp, "controller")
-    properties.setProperty(KafkaConfig.NodeIdProp, "2")
-    properties.setProperty(KafkaConfig.QuorumVotersProp, s"2@localhost:9092")
-    properties.setProperty(KafkaConfig.ControllerListenerNamesProp, "PLAINTEXT")
+    properties.setProperty(LOG_DIRS_PROP, "/tmp/foo,/tmp/bar")
+    properties.setProperty(PROCESS_ROLES_PROP, "controller")
+    properties.setProperty(NODE_ID_PROP, "2")
+    properties.setProperty(QUORUM_VOTERS_PROP, s"2@localhost:9092")
+    properties.setProperty(CONTROLLER_LISTENER_NAMES_PROP, "PLAINTEXT")
     properties
   }
 
@@ -61,7 +62,7 @@ class StorageToolTest {
   @Test
   def testConfigToLogDirectoriesWithMetaLogDir(): Unit = {
     val properties = newSelfManagedProperties()
-    properties.setProperty(KafkaConfig.MetadataLogDirProp, "/tmp/baz")
+    properties.setProperty(METADATA_LOG_DIR_PROP, "/tmp/baz")
     val config = new KafkaConfig(properties)
     assertEquals(Seq("/tmp/bar", "/tmp/baz", "/tmp/foo"),
       StorageTool.configToLogDirectories(config))
@@ -354,7 +355,7 @@ Found problem:
     val propsFile = TestUtils.tempFile()
     val propsStream = Files.newOutputStream(propsFile.toPath)
     // This test does format the directory specified so use a tempdir
-    properties.setProperty(KafkaConfig.LogDirsProp, TestUtils.tempDir().toString)
+    properties.setProperty(LOG_DIRS_PROP, TestUtils.tempDir().toString)
     properties.store(propsStream, "config.props")
     propsStream.close()
 
@@ -408,8 +409,8 @@ Found problem:
     val propsFile = TestUtils.tempFile()
     val propsStream = Files.newOutputStream(propsFile.toPath)
     try {
-      properties.setProperty(KafkaConfig.LogDirsProp, TestUtils.tempDir().toString)
-      properties.setProperty(KafkaConfig.UnstableMetadataVersionsEnableProp, enableUnstable.toString)
+      properties.setProperty(LOG_DIRS_PROP, TestUtils.tempDir().toString)
+      properties.setProperty(UNSTABLE_METADATA_VERSIONS_ENABLE_PROP, enableUnstable.toString)
       properties.store(propsStream, "config.props")
     } finally {
       propsStream.close()

--- a/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
@@ -20,9 +20,9 @@ import java.io.{BufferedWriter, File, FileWriter}
 import java.util.Properties
 
 import scala.collection.Seq
-import kafka.server.KafkaConfig
 import org.apache.kafka.clients.admin.ScramMechanism
 import org.apache.kafka.common.utils.Java
+import org.apache.kafka.server.config.KafkaConfig.SASL_KERBEROS_SERVICE_NAME_PROP
 
 object JaasTestUtils {
 
@@ -161,8 +161,8 @@ object JaasTestUtils {
     val result = saslProperties.getOrElse(new Properties)
     // IBM Kerberos module doesn't support the serviceName JAAS property, hence it needs to be
     // passed as a Kafka property
-    if (isIbmSecurity && !result.contains(KafkaConfig.SaslKerberosServiceNameProp))
-      result.put(KafkaConfig.SaslKerberosServiceNameProp, serviceName)
+    if (isIbmSecurity && !result.contains(SASL_KERBEROS_SERVICE_NAME_PROP))
+      result.put(SASL_KERBEROS_SERVICE_NAME_PROP, serviceName)
     result
   }
 

--- a/core/src/test/scala/unit/kafka/zk/AdminZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/AdminZkClientTest.scala
@@ -19,7 +19,7 @@ package kafka.admin
 import java.util
 import java.util.{Optional, Properties}
 import kafka.controller.ReplicaAssignment
-import kafka.server.DynamicConfig.Broker._
+import org.apache.kafka.server.config.dynamic.BrokerDynamicConfigs._
 import kafka.server.KafkaConfig._
 import kafka.server.{KafkaConfig, KafkaServer, QuorumTestHarness}
 import kafka.utils.CoreUtils._
@@ -283,27 +283,27 @@ class AdminZkClientTest extends QuorumTestHarness with Logging with RackAwareTes
 
     // Set the limit & check it is applied to the log
     adminZkClient.changeBrokerConfig(brokerIds, propsWith(
-      (LeaderReplicationThrottledRateProp, limit.toString),
-      (FollowerReplicationThrottledRateProp, limit.toString)))
+      (LEADER_REPLICATION_THROTTLED_RATE_PROP, limit.toString),
+      (FOLLOWER_REPLICATION_THROTTLED_RATE_PROP, limit.toString)))
     checkConfig(limit)
 
     // Now double the config values for the topic and check that it is applied
     val newLimit = 2 * limit
     adminZkClient.changeBrokerConfig(brokerIds,  propsWith(
-      (LeaderReplicationThrottledRateProp, newLimit.toString),
-      (FollowerReplicationThrottledRateProp, newLimit.toString)))
+      (LEADER_REPLICATION_THROTTLED_RATE_PROP, newLimit.toString),
+      (FOLLOWER_REPLICATION_THROTTLED_RATE_PROP, newLimit.toString)))
     checkConfig(newLimit)
 
     // Verify that the same config can be read from ZK
     for (brokerId <- brokerIds) {
       val configInZk = adminZkClient.fetchEntityConfig(ConfigType.BROKER, brokerId.toString)
-      assertEquals(newLimit, configInZk.getProperty(LeaderReplicationThrottledRateProp).toInt)
-      assertEquals(newLimit, configInZk.getProperty(FollowerReplicationThrottledRateProp).toInt)
+      assertEquals(newLimit, configInZk.getProperty(LEADER_REPLICATION_THROTTLED_RATE_PROP).toInt)
+      assertEquals(newLimit, configInZk.getProperty(FOLLOWER_REPLICATION_THROTTLED_RATE_PROP).toInt)
     }
 
     //Now delete the config
     adminZkClient.changeBrokerConfig(brokerIds, new Properties)
-    checkConfig(DefaultReplicationThrottledRate)
+    checkConfig(DEFAULT_REPLICATION_THROTTLED_RATE)
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -23,7 +23,7 @@ import kafka.api.LeaderAndIsr
 import kafka.cluster.{Broker, EndPoint}
 import kafka.controller.{LeaderIsrAndControllerEpoch, ReplicaAssignment}
 import kafka.security.authorizer.AclEntry
-import kafka.server.{KafkaConfig, QuorumTestHarness}
+import kafka.server.QuorumTestHarness
 import kafka.utils.CoreUtils
 import kafka.zk.KafkaZkClient.UpdateLeaderAndIsrResult
 import kafka.zookeeper._
@@ -43,6 +43,7 @@ import org.apache.kafka.common.utils.{SecurityUtils, Time}
 import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
+import org.apache.kafka.server.config.KafkaConfig
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.config.ConfigType
 import org.apache.kafka.storage.internals.log.LogConfig
@@ -106,7 +107,7 @@ class KafkaZkClientTest extends QuorumTestHarness {
     // TLS connectivity itself is tested in system tests rather than here to avoid having to add TLS support
     // to kafka.zk.EmbeddedZookeeper
     val clientConfig = new ZKClientConfig()
-    val propKey = KafkaConfig.ZkClientCnxnSocketProp
+    val propKey = KafkaConfig.ZK_CLIENT_CNXN_SOCKET_PROP
     val propVal = "org.apache.zookeeper.ClientCnxnSocketNetty"
     KafkaConfig.setZooKeeperClientProperty(clientConfig, propKey, propVal)
     val client = KafkaZkClient(zkConnect, zkAclsEnabled.getOrElse(JaasUtils.isZkSaslEnabled), zkSessionTimeout,

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkConfigMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkConfigMigrationClientTest.scala
@@ -17,7 +17,7 @@
 package kafka.zk.migration
 
 import kafka.utils.CoreUtils
-import kafka.server.{KafkaConfig, ZkAdminManager}
+import kafka.server.ZkAdminManager
 import kafka.zk.{AdminZkClient, ZkMigrationClient}
 import org.apache.kafka.clients.admin.ScramMechanism
 import org.apache.kafka.common.config.internals.QuotaConfigs
@@ -39,6 +39,7 @@ import org.apache.kafka.metadata.migration.KRaftMigrationZkWriter
 import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
 import org.apache.kafka.server.common.ApiMessageAndVersion
 import org.apache.kafka.server.config.ConfigType
+import org.apache.kafka.server.config.KafkaConfig
 import org.apache.kafka.server.util.MockRandom
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue, fail}
 import org.junit.jupiter.api.Test
@@ -62,12 +63,12 @@ class ZkConfigMigrationClientTest extends ZkMigrationTestHarness {
 
     // Create some configs and persist in Zk.
     val props = new Properties()
-    props.put(KafkaConfig.DefaultReplicationFactorProp, "1") // normal config
-    props.put(KafkaConfig.SslKeystorePasswordProp, encoder.encode(new Password(SECRET))) // sensitive config
+    props.put(KafkaConfig.DEFAULT_REPLICATION_FACTOR_PROP, "1") // normal config
+    props.put(KafkaConfig.SSL_KEYSTORE_PASSWORD_PROP, encoder.encode(new Password(SECRET))) // sensitive config
     zkClient.setOrCreateEntityConfigs(ConfigType.BROKER, "1", props)
 
     val defaultProps = new Properties()
-    defaultProps.put(KafkaConfig.DefaultReplicationFactorProp, "3") // normal config
+    defaultProps.put(KafkaConfig.DEFAULT_REPLICATION_FACTOR_PROP, "3") // normal config
     zkClient.setOrCreateEntityConfigs(ConfigType.BROKER, "<default>", defaultProps)
 
     migrationClient.migrateBrokerConfigs(batch => batches.add(batch), brokerId => brokers.add(brokerId))
@@ -83,7 +84,7 @@ class ZkConfigMigrationClientTest extends ZkMigrationTestHarness {
 
       assertTrue(props.containsKey(name))
       // If the config is sensitive, compare it to the decoded value.
-      if (name == KafkaConfig.SslKeystorePasswordProp) {
+      if (name == KafkaConfig.SSL_KEYSTORE_PASSWORD_PROP) {
         assertEquals(SECRET, value)
       } else {
         assertEquals(props.getProperty(name), value)
@@ -93,20 +94,20 @@ class ZkConfigMigrationClientTest extends ZkMigrationTestHarness {
     val record = batches.get(1).get(0).message().asInstanceOf[ConfigRecord]
     assertEquals(ConfigResource.Type.BROKER.id(), record.resourceType())
     assertEquals("", record.resourceName())
-    assertEquals(KafkaConfig.DefaultReplicationFactorProp, record.name())
+    assertEquals(KafkaConfig.DEFAULT_REPLICATION_FACTOR_PROP, record.name())
     assertEquals("3", record.value())
 
     // Update the sensitive config value from the config client and check that the value
     // persisted in Zookeeper is encrypted.
     val newProps = new util.HashMap[String, String]()
-    newProps.put(KafkaConfig.DefaultReplicationFactorProp, "2") // normal config
-    newProps.put(KafkaConfig.SslKeystorePasswordProp, NEW_SECRET) // sensitive config
+    newProps.put(KafkaConfig.DEFAULT_REPLICATION_FACTOR_PROP, "2") // normal config
+    newProps.put(KafkaConfig.SSL_KEYSTORE_PASSWORD_PROP, NEW_SECRET) // sensitive config
     migrationState = migrationClient.configClient().writeConfigs(
       new ConfigResource(ConfigResource.Type.BROKER, "1"), newProps, migrationState)
     val actualPropsInZk = zkClient.getEntityConfigs(ConfigType.BROKER, "1")
     assertEquals(2, actualPropsInZk.size())
     actualPropsInZk.forEach { case (key, value) =>
-      if (key == KafkaConfig.SslKeystorePasswordProp) {
+      if (key == KafkaConfig.SSL_KEYSTORE_PASSWORD_PROP) {
         assertEquals(NEW_SECRET, encoder.decode(value.toString).value)
       } else {
         assertEquals(newProps.get(key), value)

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationClientTest.scala
@@ -19,7 +19,6 @@ package kafka.zk.migration
 import kafka.api.LeaderAndIsr
 import kafka.controller.{LeaderIsrAndControllerEpoch, ReplicaAssignment}
 import kafka.coordinator.transaction.{ProducerIdManager, ZkProducerIdManager}
-import kafka.server.KafkaConfig
 import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.errors.ControllerMovedException
 import org.apache.kafka.common.metadata.{ConfigRecord, MetadataRecordType, PartitionRecord, ProducerIdsRecord, TopicRecord}
@@ -27,6 +26,7 @@ import org.apache.kafka.common.{DirectoryId, TopicPartition, Uuid}
 import org.apache.kafka.image.{MetadataDelta, MetadataImage, MetadataProvenance}
 import org.apache.kafka.metadata.migration.{KRaftMigrationZkWriter, ZkMigrationLeadershipState}
 import org.apache.kafka.metadata.{LeaderRecoveryState, PartitionRegistration}
+import org.apache.kafka.server.config.KafkaConfig.{DEFAULT_REPLICATION_FACTOR_PROP, SSL_KEYSTORE_PASSWORD_PROP}
 import org.apache.kafka.server.common.ApiMessageAndVersion
 import org.apache.kafka.server.config.ConfigType
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue, fail}
@@ -330,8 +330,8 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     val replicas = List(1, 2, 3).map(int2Integer).asJava
     val topicId = Uuid.randomUuid()
     val props = new Properties()
-    props.put(KafkaConfig.DefaultReplicationFactorProp, "1") // normal config
-    props.put(KafkaConfig.SslKeystorePasswordProp, SECRET) // sensitive config
+    props.put(DEFAULT_REPLICATION_FACTOR_PROP, "1") // normal config
+    props.put(SSL_KEYSTORE_PASSWORD_PROP, SECRET) // sensitive config
 
     //    // Leave Zk in an incomplete state.
     //    zkClient.createTopicAssignment(topicName, Some(topicId), Map(tp -> Seq(1)))
@@ -402,7 +402,7 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     assertEquals(2, brokerProps.size())
 
     brokerProps.asScala.foreach { case (key, value) =>
-      if (key == KafkaConfig.SslKeystorePasswordProp) {
+      if (key == SSL_KEYSTORE_PASSWORD_PROP) {
         assertEquals(SECRET, encoder.decode(value).value)
       } else {
         assertEquals(props.getProperty(key), value)
@@ -410,7 +410,7 @@ class ZkMigrationClientTest extends ZkMigrationTestHarness {
     }
 
     topicProps.asScala.foreach { case (key, value) =>
-      if (key == KafkaConfig.SslKeystorePasswordProp) {
+      if (key == SSL_KEYSTORE_PASSWORD_PROP) {
         assertEquals(SECRET, encoder.decode(value).value)
       } else {
         assertEquals(props.getProperty(key), value)

--- a/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/zk/migration/ZkMigrationTestHarness.scala
@@ -21,6 +21,7 @@ import kafka.zk.ZkMigrationClient
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.metadata.migration.ZkMigrationLeadershipState
 import org.apache.kafka.security.PasswordEncoder
+import org.apache.kafka.server.config.KafkaConfig.{ZK_CONNECT_PROP, PASSWORD_ENCODER_SECRET_PROP}
 import org.junit.jupiter.api.{BeforeEach, TestInfo}
 
 import java.util.Properties
@@ -40,8 +41,8 @@ class ZkMigrationTestHarness extends QuorumTestHarness {
 
   val encoder: PasswordEncoder = {
     val encoderProps = new Properties()
-    encoderProps.put(KafkaConfig.ZkConnectProp, "localhost:1234") // Get around the config validation
-    encoderProps.put(KafkaConfig.PasswordEncoderSecretProp, SECRET) // Zk secret to encrypt the
+    encoderProps.put(ZK_CONNECT_PROP, "localhost:1234") // Get around the config validation
+    encoderProps.put(PASSWORD_ENCODER_SECRET_PROP, SECRET) // Zk secret to encrypt the
     val encoderConfig = new KafkaConfig(encoderProps)
     PasswordEncoder.encrypting(encoderConfig.passwordEncoderSecret.get,
       encoderConfig.passwordEncoderKeyFactoryAlgorithm,

--- a/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
@@ -22,12 +22,12 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import java.util.concurrent.{ArrayBlockingQueue, ConcurrentLinkedQueue, CountDownLatch, Executors, Semaphore, TimeUnit}
 import scala.collection.Seq
 import com.yammer.metrics.core.{Gauge, Meter, MetricName}
-import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
 import kafka.server.QuorumTestHarness
 import org.apache.kafka.common.security.JaasUtils
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
+import org.apache.kafka.server.config.KafkaConfig
 import org.apache.zookeeper.KeeperException.{Code, NoNodeException}
 import org.apache.zookeeper.Watcher.Event.{EventType, KeeperState}
 import org.apache.zookeeper.ZooKeeper.States
@@ -102,7 +102,7 @@ class ZooKeeperClientTest extends QuorumTestHarness {
     // TLS connectivity itself is tested in system tests rather than here to avoid having to add TLS support
     // to kafka.zk.EmbeddedZookeeper
     val clientConfig = new ZKClientConfig()
-    val propKey = KafkaConfig.ZkClientCnxnSocketProp
+    val propKey = KafkaConfig.ZK_CLIENT_CNXN_SOCKET_PROP
     val propVal = "org.apache.zookeeper.ClientCnxnSocketNetty"
     KafkaConfig.setZooKeeperClientProperty(clientConfig, propKey, propVal)
     val client = newZooKeeperClient(clientConfig = clientConfig)

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
@@ -29,7 +29,6 @@ import kafka.server.FetchManager;
 import kafka.server.ForwardingManager;
 import kafka.server.KafkaApis;
 import kafka.server.KafkaConfig;
-import kafka.server.KafkaConfig$;
 import kafka.server.MetadataCache;
 import kafka.server.QuotaFactory;
 import kafka.server.RaftSupport;
@@ -86,6 +85,10 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
+import static org.apache.kafka.server.config.KafkaConfig.NODE_ID_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.PROCESS_ROLES_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.QUORUM_VOTERS_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.CONTROLLER_LISTENER_NAMES_PROP;
 @State(Scope.Benchmark)
 @Fork(value = 1)
 @Warmup(iterations = 5)
@@ -174,10 +177,10 @@ public class KRaftMetadataRequestBenchmark {
 
     private KafkaApis createKafkaApis() {
         Properties kafkaProps =  new Properties();
-        kafkaProps.put(KafkaConfig$.MODULE$.NodeIdProp(), brokerId + "");
-        kafkaProps.put(KafkaConfig$.MODULE$.ProcessRolesProp(), "broker");
-        kafkaProps.put(KafkaConfig$.MODULE$.QuorumVotersProp(), "9000@foo:8092");
-        kafkaProps.put(KafkaConfig$.MODULE$.ControllerListenerNamesProp(), "CONTROLLER");
+        kafkaProps.put(NODE_ID_PROP, brokerId + "");
+        kafkaProps.put(PROCESS_ROLES_PROP, "broker");
+        kafkaProps.put(QUORUM_VOTERS_PROP, "9000@foo:8092");
+        kafkaProps.put(CONTROLLER_LISTENER_NAMES_PROP, "CONTROLLER");
         KafkaConfig config = new KafkaConfig(kafkaProps);
         return new KafkaApisBuilder().
                 setRequestChannel(requestChannel).

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
@@ -31,7 +31,6 @@ import kafka.server.ControllerMutationQuotaManager;
 import kafka.server.FetchManager;
 import kafka.server.KafkaApis;
 import kafka.server.KafkaConfig;
-import kafka.server.KafkaConfig$;
 import kafka.server.MetadataCache;
 import kafka.server.QuotaFactory;
 import kafka.server.ReplicaManager;
@@ -87,6 +86,9 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
+
+import static org.apache.kafka.server.config.KafkaConfig.ZK_CONNECT_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.BROKER_ID_PROP;
 
 @State(Scope.Benchmark)
 @Fork(value = 1)
@@ -176,8 +178,8 @@ public class MetadataRequestBenchmark {
 
     private KafkaApis createKafkaApis() {
         Properties kafkaProps =  new Properties();
-        kafkaProps.put(KafkaConfig$.MODULE$.ZkConnectProp(), "zk");
-        kafkaProps.put(KafkaConfig$.MODULE$.BrokerIdProp(), brokerId + "");
+        kafkaProps.put(ZK_CONNECT_PROP, "zk");
+        kafkaProps.put(BROKER_ID_PROP, brokerId + "");
         KafkaConfig config = new KafkaConfig(kafkaProps);
         return new KafkaApisBuilder().
             setRequestChannel(requestChannel).

--- a/server/src/main/java/org/apache/kafka/server/config/Defaults.java
+++ b/server/src/main/java/org/apache/kafka/server/config/Defaults.java
@@ -157,10 +157,10 @@ public class Defaults {
     public static final int CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS = 5000;
     public static final int CONSUMER_GROUP_MAX_HEARTBEAT_INTERVAL_MS = 15000;
     public static final int CONSUMER_GROUP_MAX_SIZE = Integer.MAX_VALUE;
-    public static final List<String> CONSUMER_GROUP_ASSIGNORS = Arrays.asList(
+    protected static final List<String> CONSUMER_GROUP_ASSIGNORS = Collections.unmodifiableList(Arrays.asList(
         UniformAssignor.class.getName(),
         RangeAssignor.class.getName()
-    );
+    ));
 
     /** ********* Offset management configuration *********/
     public static final int OFFSET_METADATA_MAX_SIZE = OffsetConfig.DEFAULT_MAX_METADATA_SIZE;

--- a/server/src/main/java/org/apache/kafka/server/config/DynamicBrokerConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/DynamicBrokerConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.config;
+
+import org.apache.kafka.common.utils.Utils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DynamicBrokerConfig {
+    public final static Set<String> LISTENER_MECHANISM_CONFIGS = Utils.mkSet(
+            KafkaConfig.SASL_JAAS_CONFIG_PROP,
+            KafkaConfig.SASL_LOGIN_CALLBACK_HANDLER_CLASS_PROP,
+            KafkaConfig.SASL_LOGIN_CLASS_PROP,
+            KafkaConfig.SASL_SERVER_CALLBACK_HANDLER_CLASS_PROP,
+            KafkaConfig.CONNECTIONS_MAX_REAUTH_MS_PROP
+    );
+
+    public final static Pattern LISTENER_CONFIG_REGEX = Pattern.compile("listener\\.name\\.[^.]*\\.(.*)");
+
+    public static List<String> brokerConfigSynonyms(String name, boolean matchListenerOverride) {
+        if (Arrays.asList(KafkaConfig.LOG_ROLL_TIME_MILLIS_PROP, KafkaConfig.LOG_ROLL_TIME_HOURS_PROP).contains(name)) {
+            return Arrays.asList(KafkaConfig.LOG_ROLL_TIME_MILLIS_PROP, KafkaConfig.LOG_ROLL_TIME_HOURS_PROP);
+        } else if (Arrays.asList(KafkaConfig.LOG_ROLL_TIME_JITTER_MILLIS_PROP, KafkaConfig.LOG_ROLL_TIME_JITTER_HOURS_PROP).contains(name)) {
+            return Arrays.asList(KafkaConfig.LOG_ROLL_TIME_JITTER_MILLIS_PROP, KafkaConfig.LOG_ROLL_TIME_JITTER_HOURS_PROP);
+        } else if (name.equals(KafkaConfig.LOG_FLUSH_INTERVAL_MS_PROP)) {
+            return Arrays.asList(KafkaConfig.LOG_FLUSH_INTERVAL_MS_PROP, KafkaConfig.LOG_FLUSH_SCHEDULER_INTERVAL_MS_PROP);
+        } else if (Arrays.asList(
+                KafkaConfig.LOG_RETENTION_TIME_MILLIS_PROP,
+                KafkaConfig.LOG_RETENTION_TIME_MINUTES_PROP,
+                KafkaConfig.LOG_RETENTION_TIME_HOURS_PROP
+        ).contains(name)) {
+            return Arrays.asList(
+                    KafkaConfig.LOG_RETENTION_TIME_MILLIS_PROP,
+                    KafkaConfig.LOG_RETENTION_TIME_MINUTES_PROP,
+                    KafkaConfig.LOG_RETENTION_TIME_HOURS_PROP
+            );
+        } else if (matchListenerOverride && name.matches(LISTENER_CONFIG_REGEX.pattern())) {
+            Matcher matcher = LISTENER_CONFIG_REGEX.matcher(name);
+            if (matcher.matches()) {
+                String baseName = matcher.group(1);
+                Optional<String> mechanismConfig = LISTENER_MECHANISM_CONFIGS.stream()
+                        .filter(config -> baseName.endsWith(config))
+                        .findFirst();
+                return Arrays.asList(name, mechanismConfig.orElse(baseName));
+            } else {
+                return Collections.singletonList(name);
+            }
+        } else {
+            return Collections.singletonList(name);
+        }
+    }
+}

--- a/server/src/main/java/org/apache/kafka/server/config/KafkaConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/KafkaConfig.java
@@ -94,7 +94,7 @@ public class KafkaConfig {
     public final static String ZK_SSL_OCSP_ENABLE_PROP = "zookeeper.ssl.ocsp.enable";
 
     // a map from the Kafka config to the corresponding ZooKeeper Java system property
-    public final static Map<String, String> ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP = new HashMap<String, String>() {{
+    private final static Map<String, String> ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP = new HashMap<String, String>() {{
             put(ZK_SSL_CLIENT_ENABLE_PROP, ZKClientConfig.SECURE_CLIENT);
             put(ZK_CLIENT_CNXN_SOCKET_PROP, ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET);
             put(ZK_SSL_KEYSTORE_LOCATION_PROP, "zookeeper.ssl.keyStore.location");
@@ -110,6 +110,10 @@ public class KafkaConfig {
             put(ZK_SSL_CRL_ENABLE_PROP, "zookeeper.ssl.crl");
             put(ZK_SSL_OCSP_ENABLE_PROP, "zookeeper.ssl.ocsp");
         }};
+
+    public final static Map<String, String> zkSslConfigToSystemPropertyMap() {
+        return ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP;
+    }
 
     /** ********* General Configuration ***********/
     public final static String BROKER_ID_GENERATION_ENABLE_PROP = "broker.id.generation.enable";

--- a/server/src/main/java/org/apache/kafka/server/config/KafkaConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/KafkaConfig.java
@@ -1,0 +1,1394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.config;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.coordinator.group.Group.GroupType;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SecurityConfig;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.record.LegacyRecord;
+import org.apache.kafka.common.record.Records;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.raft.RaftConfig;
+import org.apache.kafka.security.PasswordEncoderConfigs;
+import org.apache.kafka.server.common.MetadataVersionValidator;
+import org.apache.kafka.server.config.dynamic.BrokerDynamicConfigs;
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
+import org.apache.kafka.server.record.BrokerCompressionType;
+import org.apache.kafka.storage.internals.log.CleanerConfig;
+import org.apache.kafka.storage.internals.log.LogConfig;
+import org.apache.kafka.storage.internals.log.ProducerStateManagerConfig;
+import org.apache.kafka.server.authorizer.Authorizer;
+import org.apache.zookeeper.client.ZKClientConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.kafka.common.config.ConfigDef.Importance.HIGH;
+import static org.apache.kafka.common.config.ConfigDef.Importance.LOW;
+import static org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM;
+import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
+import static org.apache.kafka.common.config.ConfigDef.Range.between;
+import static org.apache.kafka.common.config.ConfigDef.Type.BOOLEAN;
+import static org.apache.kafka.common.config.ConfigDef.Type.CLASS;
+import static org.apache.kafka.common.config.ConfigDef.Type.DOUBLE;
+import static org.apache.kafka.common.config.ConfigDef.Type.INT;
+import static org.apache.kafka.common.config.ConfigDef.Type.LIST;
+import static org.apache.kafka.common.config.ConfigDef.Type.LONG;
+import static org.apache.kafka.common.config.ConfigDef.Type.PASSWORD;
+import static org.apache.kafka.common.config.ConfigDef.Type.SHORT;
+import static org.apache.kafka.common.config.ConfigDef.Type.STRING;
+import static org.apache.kafka.server.config.DynamicBrokerConfig.brokerConfigSynonyms;
+
+public class KafkaConfig {
+    private final static String LOG_CONFIG_PREFIX = "log.";
+
+    /** ********* Zookeeper Configuration ***********/
+    public final static String ZK_CONNECT_PROP = "zookeeper.connect";
+    public final static String ZK_SESSION_TIMEOUT_MS_PROP = "zookeeper.session.timeout.ms";
+    public final static String ZK_CONNECTION_TIMEOUT_MS_PROP = "zookeeper.connection.timeout.ms";
+    public final static String ZK_ENABLE_SECURE_ACLS_PROP = "zookeeper.set.acl";
+    public final static String ZK_MAX_IN_FLIGHT_REQUESTS_PROP = "zookeeper.max.in.flight.requests";
+    public final static String ZK_SSL_CLIENT_ENABLE_PROP = "zookeeper.ssl.client.enable";
+    public final static String ZK_CLIENT_CNXN_SOCKET_PROP = "zookeeper.clientCnxnSocket";
+    public final static String ZK_SSL_KEYSTORE_LOCATION_PROP = "zookeeper.ssl.keystore.location";
+    public final static String ZK_SSL_KEYSTORE_PASSWORD_PROP = "zookeeper.ssl.keystore.password";
+    public final static String ZK_SSL_KEYSTORE_TYPE_PROP = "zookeeper.ssl.keystore.type";
+    public final static String ZK_SSL_TRUSTSTORE_LOCATION_PROP = "zookeeper.ssl.truststore.location";
+    public final static String ZK_SSL_TRUSTSTORE_PASSWORD_PROP = "zookeeper.ssl.truststore.password";
+    public final static String ZK_SSL_TRUSTSTORE_TYPE_PROP = "zookeeper.ssl.truststore.type";
+    public final static String ZK_SSL_PROTOCOL_PROP = "zookeeper.ssl.protocol";
+    public final static String ZK_SSL_ENABLED_PROTOCOLS_PROP = "zookeeper.ssl.enabled.protocols";
+    public final static String ZK_SSL_CIPHER_SUITES_PROP = "zookeeper.ssl.cipher.suites";
+    public final static String ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP = "zookeeper.ssl.endpoint.identification.algorithm";
+    public final static String ZK_SSL_CRL_ENABLE_PROP = "zookeeper.ssl.crl.enable";
+    public final static String ZK_SSL_OCSP_ENABLE_PROP = "zookeeper.ssl.ocsp.enable";
+
+    // a map from the Kafka config to the corresponding ZooKeeper Java system property
+    public final static Map<String, String> ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP = new HashMap<String, String>() {{
+            put(ZK_SSL_CLIENT_ENABLE_PROP, ZKClientConfig.SECURE_CLIENT);
+            put(ZK_CLIENT_CNXN_SOCKET_PROP, ZKClientConfig.ZOOKEEPER_CLIENT_CNXN_SOCKET);
+            put(ZK_SSL_KEYSTORE_LOCATION_PROP, "zookeeper.ssl.keyStore.location");
+            put(ZK_SSL_KEYSTORE_PASSWORD_PROP, "zookeeper.ssl.keyStore.password");
+            put(ZK_SSL_KEYSTORE_TYPE_PROP, "zookeeper.ssl.keyStore.type");
+            put(ZK_SSL_TRUSTSTORE_LOCATION_PROP, "zookeeper.ssl.trustStore.location");
+            put(ZK_SSL_TRUSTSTORE_PASSWORD_PROP, "zookeeper.ssl.trustStore.password");
+            put(ZK_SSL_TRUSTSTORE_TYPE_PROP, "zookeeper.ssl.trustStore.type");
+            put(ZK_SSL_PROTOCOL_PROP, "zookeeper.ssl.protocol");
+            put(ZK_SSL_ENABLED_PROTOCOLS_PROP, "zookeeper.ssl.enabledProtocols");
+            put(ZK_SSL_CIPHER_SUITES_PROP, "zookeeper.ssl.ciphersuites");
+            put(ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP, "zookeeper.ssl.hostnameVerification");
+            put(ZK_SSL_CRL_ENABLE_PROP, "zookeeper.ssl.crl");
+            put(ZK_SSL_OCSP_ENABLE_PROP, "zookeeper.ssl.ocsp");
+        }};
+
+    /** ********* General Configuration ***********/
+    public final static String BROKER_ID_GENERATION_ENABLE_PROP = "broker.id.generation.enable";
+    public final static String MAX_RESERVED_BROKER_ID_PROP = "reserved.broker.max.id";
+    public final static String BROKER_ID_PROP = "broker.id";
+    public final static String MESSAGE_MAX_BYTES_PROP = "message.max.bytes";
+    public final static String NUM_NETWORK_THREADS_PROP = "num.network.threads";
+    public final static String NUM_IO_THREADS_PROP = "num.io.threads";
+    public final static String BACKGROUND_THREADS_PROP = "background.threads";
+    public final static String NUM_REPLICA_ALTER_LOG_DIRS_THREADS_PROP = "num.replica.alter.log.dirs.threads";
+    public final static String QUEUED_MAX_REQUESTS_PROP = "queued.max.requests";
+    public final static String QUEUED_MAX_BYTES_PROP = "queued.max.request.bytes";
+    public final static String REQUEST_TIMEOUT_MS_PROP = CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG;
+    public final static String CONNECTION_SETUP_TIMEOUT_MS_PROP = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG;
+    public final static String CONNECTION_SETUP_TIMEOUT_MAX_MS_PROP = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG;
+
+    /** KRaft mode configs */
+    public final static String PROCESS_ROLES_PROP = "process.roles";
+    public final static String INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_PROP = "initial.broker.registration.timeout.ms";
+    public final static String BROKER_HEARTBEAT_INTERVAL_MS_PROP = "broker.heartbeat.interval.ms";
+    public final static String BROKER_SESSION_TIMEOUT_MS_PROP = "broker.session.timeout.ms";
+    public final static String NODE_ID_PROP = "node.id";
+    public final static String METADATA_LOG_DIR_PROP = "metadata.log.dir";
+    public final static String METADATA_SNAPSHOT_MAX_NEW_RECORD_BYTES_PROP = "metadata.log.max.record.bytes.between.snapshots";
+    public final static String METADATA_SNAPSHOT_MAX_INTERVAL_MS_PROP = "metadata.log.max.snapshot.interval.ms";
+    public final static String CONTROLLER_LISTENER_NAMES_PROP = "controller.listener.names";
+    public final static String SASL_MECHANISM_CONTROLLER_PROTOCOL_PROP = "sasl.mechanism.controller.protocol";
+    public final static String METADATA_LOG_SEGMENT_MIN_BYTES_PROP = "metadata.log.segment.min.bytes";
+    public final static String METADATA_LOG_SEGMENT_BYTES_PROP = "metadata.log.segment.bytes";
+    public final static String METADATA_LOG_SEGMENT_MILLIS_PROP = "metadata.log.segment.ms";
+    public final static String METADATA_MAX_RETENTION_BYTES_PROP = "metadata.max.retention.bytes";
+    public final static String METADATA_MAX_RETENTION_MILLIS_PROP = "metadata.max.retention.ms";
+    public final static String QUORUM_VOTERS_PROP = RaftConfig.QUORUM_VOTERS_CONFIG;
+    public final static String METADATA_MAX_IDLE_INTERVAL_MS_PROP = "metadata.max.idle.interval.ms";
+    public final static String SERVER_MAX_STARTUP_TIME_MS_PROP = "server.max.startup.time.ms";
+
+    /** ZK to KRaft Migration configs */
+    public final static String MIGRATION_ENABLED_PROP = "zookeeper.metadata.migration.enable";
+    public final static String MIGRATION_METADATA_MIN_BATCH_SIZE_PROP = "zookeeper.metadata.migration.min.batch.size";
+
+    /** Enable eligible leader replicas configs */
+    public final static String ELR_ENABLED_PROP = "eligible.leader.replicas.enable";
+
+    /************* Authorizer Configuration ***********/
+    public final static String AUTHORIZER_CLASS_NAME_PROP = "authorizer.class.name";
+    public final static String EARLY_START_LISTENERS_PROP = "early.start.listeners";
+
+    /** ********* Socket Server Configuration ***********/
+    public final static String LISTENERS_PROP = "listeners";
+    public final static String ADVERTISED_LISTENERS_PROP = "advertised.listeners";
+    public final static String LISTENER_SECURITY_PROTOCOL_MAP_PROP = "listener.security.protocol.map";
+    public final static String CONTROL_PLANE_LISTENER_NAME_PROP = "control.plane.listener.name";
+    public final static String SOCKET_SEND_BUFFER_BYTES_PROP = "socket.send.buffer.bytes";
+    public final static String SOCKET_RECEIVE_BUFFER_BYTES_PROP = "socket.receive.buffer.bytes";
+    public final static String SOCKET_REQUEST_MAX_BYTES_PROP = "socket.request.max.bytes";
+    public final static String SOCKET_LISTEN_BACKLOG_SIZE_PROP = "socket.listen.backlog.size";
+    public final static String MAX_CONNECTIONS_PER_IP_PROP = "max.connections.per.ip";
+    public final static String MAX_CONNECTIONS_PER_IP_OVERRIDES_PROP = "max.connections.per.ip.overrides";
+    public final static String MAX_CONNECTIONS_PROP = "max.connections";
+    public final static String MAX_CONNECTION_CREATION_RATE_PROP = "max.connection.creation.rate";
+    public final static String CONNECTIONS_MAX_IDLE_MS_PROP = "connections.max.idle.ms";
+    public final static String FAILED_AUTHENTICATION_DELAY_MS_PROP = "connection.failed.authentication.delay.ms";
+
+    /***************** rack configuration *************/
+    public final static String RACK_PROP = "broker.rack";
+
+    /** ********* Log Configuration ***********/
+    public final static String NUM_PARTITIONS_PROP = "num.partitions";
+    public final static String LOG_DIRS_PROP = LOG_CONFIG_PREFIX + "dirs";
+    public final static String LOG_DIR_PROP = LOG_CONFIG_PREFIX + "dir";
+    public final static String LOG_SEGMENT_BYTES_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.SEGMENT_BYTES_CONFIG);
+
+    public final static String LOG_ROLL_TIME_MILLIS_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.SEGMENT_MS_CONFIG);
+    public final static String LOG_ROLL_TIME_HOURS_PROP = LOG_CONFIG_PREFIX + "roll.hours";
+
+    public final static String LOG_ROLL_TIME_JITTER_MILLIS_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.SEGMENT_JITTER_MS_CONFIG);
+    public final static String LOG_ROLL_TIME_JITTER_HOURS_PROP = LOG_CONFIG_PREFIX + "roll.jitter.hours";
+
+    public final static String LOG_RETENTION_TIME_MILLIS_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.RETENTION_MS_CONFIG);
+    public final static String LOG_RETENTION_TIME_MINUTES_PROP = LOG_CONFIG_PREFIX + "retention.minutes";
+    public final static String LOG_RETENTION_TIME_HOURS_PROP = LOG_CONFIG_PREFIX + "retention.hours";
+
+    public final static String LOG_RETENTION_BYTES_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.RETENTION_BYTES_CONFIG);
+    public final static String LOG_CLEANUP_INTERVAL_MS_PROP = LOG_CONFIG_PREFIX + "retention.check.interval.ms";
+    public final static String LOG_CLEANUP_POLICY_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.CLEANUP_POLICY_CONFIG);
+    public final static String LOG_INDEX_SIZE_MAX_BYTES_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG);
+    public final static String LOG_INDEX_INTERVAL_BYTES_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG);
+    public final static String LOG_FLUSH_INTERVAL_MESSAGES_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG);
+    public final static String LOG_DELETE_DELAY_MS_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.FILE_DELETE_DELAY_MS_CONFIG);
+    public final static String LOG_FLUSH_SCHEDULER_INTERVAL_MS_PROP = LOG_CONFIG_PREFIX + "flush.scheduler.interval.ms";
+    public final static String LOG_FLUSH_INTERVAL_MS_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.FLUSH_MS_CONFIG);
+    public final static String LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS_PROP = LOG_CONFIG_PREFIX + "flush.offset.checkpoint.interval.ms";
+    public final static String LOG_FLUSH_START_OFFSET_CHECKPOINT_INTERVAL_MS_PROP = LOG_CONFIG_PREFIX + "flush.start.offset.checkpoint.interval.ms";
+    public final static String LOG_PRE_ALLOCATE_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.PREALLOCATE_CONFIG);
+
+    /* See `TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG` for details */
+    /**
+     * @deprecated since "3.0"
+     */
+    @Deprecated
+    public final static String LOG_MESSAGE_FORMAT_VERSION_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG);
+
+    public final static String LOG_MESSAGE_TIMESTAMP_TYPE_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG);
+
+    /* See `TopicConfig.MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_CONFIG` for details */
+    /**
+     * @deprecated since "3.6"
+     */
+    @Deprecated
+    public final static String LOG_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_CONFIG);
+
+    public final static String LOG_MESSAGE_TIMESTAMP_BEFORE_MAX_MS_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.MESSAGE_TIMESTAMP_BEFORE_MAX_MS_CONFIG);
+    public final static String LOG_MESSAGE_TIMESTAMP_AFTER_MAX_MS_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.MESSAGE_TIMESTAMP_AFTER_MAX_MS_CONFIG);
+
+    public final static String NUM_RECOVERY_THREADS_PER_DATA_DIR_PROP = "num.recovery.threads.per.data.dir";
+    public final static String AUTO_CREATE_TOPICS_ENABLE_PROP = "auto.create.topics.enable";
+    public final static String MIN_IN_SYNC_REPLICAS_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG);
+    public final static String CREATE_TOPIC_POLICY_CLASS_NAME_PROP = "create.topic.policy.class.name";
+    public final static String ALTER_CONFIG_POLICY_CLASS_NAME_PROP = "alter.config.policy.class.name";
+    public final static String LOG_MESSAGE_DOWN_CONVERSION_ENABLE_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.MESSAGE_DOWNCONVERSION_ENABLE_CONFIG);
+    /** ********* Replication configuration ***********/
+    public final static String CONTROLLER_SOCKET_TIMEOUT_MS_PROP = "controller.socket.timeout.ms";
+    public final static String DEFAULT_REPLICATION_FACTOR_PROP = "default.replication.factor";
+    public final static String REPLICA_LAG_TIME_MAX_MS_PROP = "replica.lag.time.max.ms";
+    public final static String REPLICA_SOCKET_TIMEOUT_MS_PROP = "replica.socket.timeout.ms";
+    public final static String REPLICA_SOCKET_RECEIVE_BUFFER_BYTES_PROP = "replica.socket.receive.buffer.bytes";
+    public final static String REPLICA_FETCH_MAX_BYTES_PROP = "replica.fetch.max.bytes";
+    public final static String REPLICA_FETCH_WAIT_MAX_MS_PROP = "replica.fetch.wait.max.ms";
+    public final static String REPLICA_FETCH_MIN_BYTES_PROP = "replica.fetch.min.bytes";
+    public final static String REPLICA_FETCH_RESPONSE_MAX_BYTES_PROP = "replica.fetch.response.max.bytes";
+    public final static String REPLICA_FETCH_BACKOFF_MS_PROP = "replica.fetch.backoff.ms";
+    public final static String NUM_REPLICA_FETCHERS_PROP = "num.replica.fetchers";
+    public final static String REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS_PROP = "replica.high.watermark.checkpoint.interval.ms";
+    public final static String FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS_PROP = "fetch.purgatory.purge.interval.requests";
+    public final static String PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS_PROP = "producer.purgatory.purge.interval.requests";
+    public final static String DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS_PROP = "delete.records.purgatory.purge.interval.requests";
+    public final static String AUTO_LEADER_REBALANCE_ENABLE_PROP = "auto.leader.rebalance.enable";
+    public final static String LEADER_IMBALANCE_PER_BROKER_PERCENTAGE_PROP = "leader.imbalance.per.broker.percentage";
+    public final static String LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS_PROP = "leader.imbalance.check.interval.seconds";
+    public final static String UNCLEAN_LEADER_ELECTION_ENABLE_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG);
+    public final static String INTER_BROKER_SECURITY_PROTOCOL_PROP = "security.inter.broker.protocol";
+    public final static String INTER_BROKER_PROTOCOL_VERSION_PROP = "inter.broker.protocol.version";
+    public final static String INTER_BROKER_LISTENER_NAME_PROP = "inter.broker.listener.name";
+    public final static String REPLICA_SELECTOR_CLASS_PROP = "replica.selector.class";
+    /** ********* Controlled shutdown configuration ***********/
+    public final static String CONTROLLED_SHUTDOWN_MAX_RETRIES_PROP = "controlled.shutdown.max.retries";
+    public final static String CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS_PROP = "controlled.shutdown.retry.backoff.ms";
+    public final static String CONTROLLED_SHUTDOWN_ENABLE_PROP = "controlled.shutdown.enable";
+
+    /** ********* Group coordinator configuration ***********/
+    public final static String GROUP_MIN_SESSION_TIMEOUT_MS_PROP = "group.min.session.timeout.ms";
+    public final static String GROUP_MAX_SESSION_TIMEOUT_MS_PROP = "group.max.session.timeout.ms";
+    public final static String GROUP_INITIAL_REBALANCE_DELAY_MS_PROP = "group.initial.rebalance.delay.ms";
+    public final static String GROUP_MAX_SIZE_PROP = "group.max.size";
+
+    /** New group coordinator configs */
+    public final static String NEW_GROUP_COORDINATOR_ENABLE_PROP = "group.coordinator.new.enable";
+    public final static String GROUP_COORDINATOR_REBALANCE_PROTOCOLS_PROP = "group.coordinator.rebalance.protocols";
+    public final static String GROUP_COORDINATOR_NUM_THREADS_PROP = "group.coordinator.threads";
+
+    /** Consumer group configs */
+    public final static String CONSUMER_GROUP_SESSION_TIMEOUT_MS_PROP = "group.consumer.session.timeout.ms";
+    public final static String CONSUMER_GROUP_MIN_SESSION_TIMEOUT_MS_PROP = "group.consumer.min.session.timeout.ms";
+    public final static String CONSUMER_GROUP_MAX_SESSION_TIMEOUT_MS_PROP = "group.consumer.max.session.timeout.ms";
+    public final static String CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_PROP = "group.consumer.heartbeat.interval.ms";
+    public final static String CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_PROP = "group.consumer.min.heartbeat.interval.ms";
+    public final static String CONSUMER_GROUP_MAX_HEARTBEAT_INTERVAL_MS_PROP = "group.consumer.max.heartbeat.interval.ms";
+    public final static String CONSUMER_GROUP_MAX_SIZE_PROP = "group.consumer.max.size";
+    public final static String CONSUMER_GROUP_ASSIGNORS_PROP = "group.consumer.assignors";
+
+    /** ********* Offset management configuration ***********/
+    public final static String OFFSET_METADATA_MAX_SIZE_PROP = "offset.metadata.max.bytes";
+    public final static String OFFSETS_LOAD_BUFFER_SIZE_PROP = "offsets.load.buffer.size";
+    public final static String OFFSETS_TOPIC_REPLICATION_FACTOR_PROP = "offsets.topic.replication.factor";
+    public final static String OFFSETS_TOPIC_PARTITIONS_PROP = "offsets.topic.num.partitions";
+    public final static String OFFSETS_TOPIC_SEGMENT_BYTES_PROP = "offsets.topic.segment.bytes";
+    public final static String OFFSETS_TOPIC_COMPRESSION_CODEC_PROP = "offsets.topic.compression.codec";
+    public final static String OFFSETS_RETENTION_MINUTES_PROP = "offsets.retention.minutes";
+    public final static String OFFSETS_RETENTION_CHECK_INTERVAL_MS_PROP = "offsets.retention.check.interval.ms";
+    public final static String OFFSET_COMMIT_TIMEOUT_MS_PROP = "offsets.commit.timeout.ms";
+    public final static String OFFSET_COMMIT_REQUIRED_ACKS_PROP = "offsets.commit.required.acks";
+
+    /** ********* Transaction management configuration ***********/
+    public final static String TRANSACTIONAL_ID_EXPIRATION_MS_PROP = "transactional.id.expiration.ms";
+    public final static String TRANSACTIONS_MAX_TIMEOUT_MS_PROP = "transaction.max.timeout.ms";
+    public final static String TRANSACTIONS_TOPIC_MIN_ISR_PROP = "transaction.state.log.min.isr";
+    public final static String TRANSACTIONS_LOAD_BUFFER_SIZE_PROP = "transaction.state.log.load.buffer.size";
+    public final static String TRANSACTIONS_TOPIC_PARTITIONS_PROP = "transaction.state.log.num.partitions";
+    public final static String TRANSACTIONS_TOPIC_SEGMENT_BYTES_PROP = "transaction.state.log.segment.bytes";
+    public final static String TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP = "transaction.state.log.replication.factor";
+    public final static String TRANSACTIONS_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS_PROP = "transaction.abort.timed.out.transaction.cleanup.interval.ms";
+    public final static String TRANSACTIONS_REMOVE_EXPIRED_TRANSACTIONAL_ID_CLEANUP_INTERVAL_MS_PROP = "transaction.remove.expired.transaction.cleanup.interval.ms";
+
+    public final static String TRANSACTION_PARTITION_VERIFICATION_ENABLE_PROP = "transaction.partition.verification.enable";
+
+    public final static String PRODUCER_ID_EXPIRATION_MS_PROP = ProducerStateManagerConfig.PRODUCER_ID_EXPIRATION_MS;
+    public final static String PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS_PROP = "producer.id.expiration.check.interval.ms";
+
+    /** ********* Fetch Configuration **************/
+    public final static String MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS_PROP = "max.incremental.fetch.session.cache.slots";
+    public final static String FETCH_MAX_BYTES_PROP = "fetch.max.bytes";
+
+    /** ********* Request Limit Configuration **************/
+    public final static String MAX_REQUEST_PARTITION_SIZE_LIMIT_PROP = "max.request.partition.size.limit";
+
+    /** ********* Quota Configuration ***********/
+    public final static String NUM_QUOTA_SAMPLES_PROP = "quota.window.num";
+    public final static String NUM_REPLICATION_QUOTA_SAMPLES_PROP = "replication.quota.window.num";
+    public final static String NUM_ALTER_LOG_DIRS_REPLICATION_QUOTA_SAMPLES_PROP = "alter.log.dirs.replication.quota.window.num";
+    public final static String NUM_CONTROLLER_QUOTA_SAMPLES_PROP = "controller.quota.window.num";
+    public final static String QUOTA_WINDOW_SIZE_SECONDS_PROP = "quota.window.size.seconds";
+    public final static String REPLICATION_QUOTA_WINDOW_SIZE_SECONDS_PROP = "replication.quota.window.size.seconds";
+    public final static String ALTER_LOG_DIRS_REPLICATION_QUOTA_WINDOW_SIZE_SECONDS_PROP = "alter.log.dirs.replication.quota.window.size.seconds";
+    public final static String CONTROLLER_QUOTA_WINDOW_SIZE_SECONDS_PROP = "controller.quota.window.size.seconds";
+    public final static String CLIENT_QUOTA_CALLBACK_CLASS_PROP = "client.quota.callback.class";
+
+    public final static String DELETE_TOPIC_ENABLE_PROP = "delete.topic.enable";
+    public final static String COMPRESSION_TYPE_PROP = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.COMPRESSION_TYPE_CONFIG);
+
+    /** ********* Kafka Metrics Configuration ***********/
+    public final static String METRIC_SAMPLE_WINDOW_MS_PROP = CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG;
+    public final static String METRIC_NUM_SAMPLES_PROP = CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG;
+    public final static String METRIC_REPORTER_CLASSES_PROP = CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG;
+    public final static String METRIC_RECORDING_LEVEL_PROP = CommonClientConfigs.METRICS_RECORDING_LEVEL_CONFIG;
+    @Deprecated
+    public final static String AUTO_INCLUDE_JMX_REPORTER_PROP = CommonClientConfigs.AUTO_INCLUDE_JMX_REPORTER_CONFIG;
+
+    /** ********* Kafka Yammer Metrics Reporters Configuration ***********/
+    public final static String KAFKA_METRICS_REPORTER_CLASSES_PROP = "kafka.metrics.reporters";
+    public final static String KAFKA_METRICS_POLLING_INTERVAL_SECONDS_PROP = "kafka.metrics.polling.interval.secs";
+
+    /** ********* Kafka Client Telemetry Metrics Configuration ***********/
+    public final static String CLIENT_TELEMETRY_MAX_BYTES_PROP = "telemetry.max.bytes";
+
+    /** ******** Common Security Configuration *************/
+    public final static String PRINCIPAL_BUILDER_CLASS_PROP = BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG;
+    public final static String CONNECTIONS_MAX_REAUTH_MS_PROP = BrokerSecurityConfigs.CONNECTIONS_MAX_REAUTH_MS;
+    public final static String SASL_SERVER_MAX_RECEIVE_SIZE_PROP = BrokerSecurityConfigs.SASL_SERVER_MAX_RECEIVE_SIZE_CONFIG;
+    public final static String SECURITY_PROVIDER_CLASS_PROP = SecurityConfig.SECURITY_PROVIDERS_CONFIG;
+
+    /** ********* SSL Configuration ****************/
+    public final static String SSL_PROTOCOL_PROP = SslConfigs.SSL_PROTOCOL_CONFIG;
+    public final static String SSL_PROVIDER_PROP = SslConfigs.SSL_PROVIDER_CONFIG;
+    public final static String SSL_CIPHER_SUITES_PROP = SslConfigs.SSL_CIPHER_SUITES_CONFIG;
+    public final static String SSL_ENABLED_PROTOCOLS_PROP = SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG;
+    public final static String SSL_KEYSTORE_TYPE_PROP = SslConfigs.SSL_KEYSTORE_TYPE_CONFIG;
+    public final static String SSL_KEYSTORE_LOCATION_PROP = SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG;
+    public final static String SSL_KEYSTORE_PASSWORD_PROP = SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG;
+    public final static String SSL_KEY_PASSWORD_PROP = SslConfigs.SSL_KEY_PASSWORD_CONFIG;
+    public final static String SSL_KEYSTORE_KEY_PROP = SslConfigs.SSL_KEYSTORE_KEY_CONFIG;
+    public final static String SSL_KEYSTORE_CERTIFICATE_CHAIN_PROP = SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG;
+    public final static String SSL_TRUSTSTORE_TYPE_PROP = SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG;
+    public final static String SSL_TRUSTSTORE_LOCATION_PROP = SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG;
+    public final static String SSL_TRUSTSTORE_PASSWORD_PROP = SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG;
+    public final static String SSL_TRUSTSTORE_CERTIFICATES_PROP = SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG;
+    public final static String SSL_KEY_MANAGER_ALGORITHM_PROP = SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG;
+    public final static String SSL_TRUST_MANAGER_ALGORITHM_PROP = SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG;
+    public final static String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP = SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG;
+    public final static String SSL_SECURE_RANDOM_IMPLEMENTATION_PROP = SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG;
+    public final static String SSL_CLIENT_AUTH_PROP = BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG;
+    public final static String SSL_PRINCIPAL_MAPPING_RULES_PROP = BrokerSecurityConfigs.SSL_PRINCIPAL_MAPPING_RULES_CONFIG;
+    public final static String SSL_ENGINE_FACTORY_CLASS_PROP = SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG;
+    public final static String SSL_ALLOW_DN_CHANGES_PROP = BrokerSecurityConfigs.SSL_ALLOW_DN_CHANGES_CONFIG;
+    public final static String SSL_ALLOW_SAN_CHANGES_PROP = BrokerSecurityConfigs.SSL_ALLOW_SAN_CHANGES_CONFIG;
+
+    /** ********* SASL Configuration ****************/
+    public final static String SASL_MECHANISM_INTER_BROKER_PROTOCOL_PROP = "sasl.mechanism.inter.broker.protocol";
+    public final static String SASL_JAAS_CONFIG_PROP = SaslConfigs.SASL_JAAS_CONFIG;
+    public final static String SASL_ENABLED_MECHANISMS_PROP = BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG;
+    public final static String SASL_SERVER_CALLBACK_HANDLER_CLASS_PROP = BrokerSecurityConfigs.SASL_SERVER_CALLBACK_HANDLER_CLASS;
+    public final static String SASL_CLIENT_CALLBACK_HANDLER_CLASS_PROP = SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS;
+    public final static String SASL_LOGIN_CLASS_PROP = SaslConfigs.SASL_LOGIN_CLASS;
+    public final static String SASL_LOGIN_CALLBACK_HANDLER_CLASS_PROP = SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS;
+    public final static String SASL_KERBEROS_SERVICE_NAME_PROP = SaslConfigs.SASL_KERBEROS_SERVICE_NAME;
+    public final static String SASL_KERBEROS_KINIT_CMD_PROP = SaslConfigs.SASL_KERBEROS_KINIT_CMD;
+    public final static String SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR_PROP = SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR;
+    public final static String SASL_KERBEROS_TICKET_RENEW_JITTER_PROP = SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER;
+    public final static String SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN_PROP = SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN;
+    public final static String SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES_PROP = BrokerSecurityConfigs.SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES_CONFIG;
+    public final static String SASL_LOGIN_REFRESH_WINDOW_FACTOR_PROP = SaslConfigs.SASL_LOGIN_REFRESH_WINDOW_FACTOR;
+    public final static String SASL_LOGIN_REFRESH_WINDOW_JITTER_PROP = SaslConfigs.SASL_LOGIN_REFRESH_WINDOW_JITTER;
+    public final static String SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS_PROP = SaslConfigs.SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS;
+    public final static String SASL_LOGIN_REFRESH_BUFFER_SECONDS_PROP = SaslConfigs.SASL_LOGIN_REFRESH_BUFFER_SECONDS;
+
+    public final static String SASL_LOGIN_CONNECT_TIMEOUT_MS_PROP = SaslConfigs.SASL_LOGIN_CONNECT_TIMEOUT_MS;
+    public final static String SASL_LOGIN_READ_TIMEOUT_MS_PROP = SaslConfigs.SASL_LOGIN_READ_TIMEOUT_MS;
+    public final static String SASL_LOGIN_RETRY_BACKOFF_MAX_MS_PROP = SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MAX_MS;
+    public final static String SASL_LOGIN_RETRY_BACKOFF_MS_PROP = SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MS;
+    public final static String SASL_O_AUTH_BEARER_SCOPE_CLAIM_NAME_PROP = SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME;
+    public final static String SASL_O_AUTH_BEARER_SUB_CLAIM_NAME_PROP = SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME;
+    public final static String SASL_O_AUTH_BEARER_TOKEN_ENDPOINT_URL_PROP = SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL;
+    public final static String SASL_O_AUTH_BEARER_JWKS_ENDPOINT_URL_PROP = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL;
+    public final static String SASL_O_AUTH_BEARER_JWKS_ENDPOINT_REFRESH_MS_PROP = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS;
+    public final static String SASL_O_AUTH_BEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS_PROP = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS;
+    public final static String SASL_O_AUTH_BEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS_PROP = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS;
+    public final static String SASL_O_AUTH_BEARER_CLOCK_SKEW_SECONDS_PROP = SaslConfigs.SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS;
+    public final static String SASL_O_AUTH_BEARER_EXPECTED_AUDIENCE_PROP = SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE;
+    public final static String SASL_O_AUTH_BEARER_EXPECTED_ISSUER_PROP = SaslConfigs.SASL_OAUTHBEARER_EXPECTED_ISSUER;
+
+    /** ********* Delegation Token Configuration ****************/
+    public final static String DELEGATION_TOKEN_SECRET_KEY_ALIAS_PROP = "delegation.token.master.key";
+    public final static String DELEGATION_TOKEN_SECRET_KEY_PROP = "delegation.token.secret.key";
+    public final static String DELEGATION_TOKEN_MAX_LIFE_TIME_PROP = "delegation.token.max.lifetime.ms";
+    public final static String DELEGATION_TOKEN_EXPIRY_TIME_MS_PROP = "delegation.token.expiry.time.ms";
+    public final static String DELEGATION_TOKEN_EXPIRY_CHECK_INTERVAL_MS_PROP = "delegation.token.expiry.check.interval.ms";
+
+    /** ********* Password encryption configuration for dynamic configs *********/
+    public final static String PASSWORD_ENCODER_SECRET_PROP = PasswordEncoderConfigs.SECRET;
+    public final static String PASSWORD_ENCODER_OLD_SECRET_PROP = PasswordEncoderConfigs.OLD_SECRET;
+    public final static String PASSWORD_ENCODER_KEY_FACTORY_ALGORITHM_PROP = PasswordEncoderConfigs.KEYFACTORY_ALGORITHM;
+    public final static String PASSWORD_ENCODER_CIPHER_ALGORITHM_PROP = PasswordEncoderConfigs.CIPHER_ALGORITHM;
+    public final static String PASSWORD_ENCODER_KEY_LENGTH_PROP = PasswordEncoderConfigs.KEY_LENGTH;
+    public final static String PASSWORD_ENCODER_ITERATIONS_PROP = PasswordEncoderConfigs.ITERATIONS;
+
+    /** Internal Configurations **/
+    public final static String UNSTABLE_API_VERSIONS_ENABLE_PROP = "unstable.api.versions.enable";
+    public final static String UNSTABLE_METADATA_VERSIONS_ENABLE_PROP = "unstable.metadata.versions.enable";
+
+    /** ******** Common Security Configuration ************ */
+    public final static String PRINCIPAL_BUILDER_CLASS_DOC = BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_DOC;
+    public final static String CONNECTIONS_MAX_REAUTH_MS_DOC = BrokerSecurityConfigs.CONNECTIONS_MAX_REAUTH_MS_DOC;
+    public final static String SASL_SERVER_MAX_RECEIVE_SIZE_DOC = BrokerSecurityConfigs.SASL_SERVER_MAX_RECEIVE_SIZE_DOC;
+    public final static String SECURITY_PROVIDERS_DOC = SecurityConfig.SECURITY_PROVIDERS_DOC;
+
+    /** ********* SSL Configuration ****************/
+    public final static String SSL_PROTOCOL_DOC = SslConfigs.SSL_PROTOCOL_DOC;
+    public final static String SSL_PROVIDER_DOC = SslConfigs.SSL_PROVIDER_DOC;
+    public final static String SSL_CIPHER_SUITES_DOC = SslConfigs.SSL_CIPHER_SUITES_DOC;
+    public final static String SSL_ENABLED_PROTOCOLS_DOC = SslConfigs.SSL_ENABLED_PROTOCOLS_DOC;
+    public final static String SSL_KEYSTORE_TYPE_DOC = SslConfigs.SSL_KEYSTORE_TYPE_DOC;
+    public final static String SSL_KEYSTORE_LOCATION_DOC = SslConfigs.SSL_KEYSTORE_LOCATION_DOC;
+    public final static String SSL_KEYSTORE_PASSWORD_DOC = SslConfigs.SSL_KEYSTORE_PASSWORD_DOC;
+    public final static String SSL_KEY_PASSWORD_DOC = SslConfigs.SSL_KEY_PASSWORD_DOC;
+    public final static String SSL_KEYSTORE_KEY_DOC = SslConfigs.SSL_KEYSTORE_KEY_DOC;
+    public final static String SSL_KEYSTORE_CERTIFICATE_CHAIN_DOC = SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_DOC;
+    public final static String SSL_TRUSTSTORE_TYPE_DOC = SslConfigs.SSL_TRUSTSTORE_TYPE_DOC;
+    public final static String SSL_TRUSTSTORE_PASSWORD_DOC = SslConfigs.SSL_TRUSTSTORE_PASSWORD_DOC;
+    public final static String SSL_TRUSTSTORE_LOCATION_DOC = SslConfigs.SSL_TRUSTSTORE_LOCATION_DOC;
+    public final static String SSL_TRUSTSTORE_CERTIFICATES_DOC = SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_DOC;
+    public final static String SSL_KEYMANAGER_ALGORITHM_DOC = SslConfigs.SSL_KEYMANAGER_ALGORITHM_DOC;
+    public final static String SSL_TRUSTMANAGER_ALGORITHM_DOC = SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_DOC;
+    public final static String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC = SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC;
+    public final static String SSL_SECURE_RANDOM_IMPLEMENTATION_DOC = SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_DOC;
+    public final static String SSL_CLIENT_AUTH_DOC = BrokerSecurityConfigs.SSL_CLIENT_AUTH_DOC;
+    public final static String SSL_PRINCIPAL_MAPPING_RULES_DOC = BrokerSecurityConfigs.SSL_PRINCIPAL_MAPPING_RULES_DOC;
+    public final static String SSL_ENGINE_FACTORY_CLASS_DOC = SslConfigs.SSL_ENGINE_FACTORY_CLASS_DOC;
+    public final static String SSL_ALLOW_DN_CHANGES_DOC = BrokerSecurityConfigs.SSL_ALLOW_DN_CHANGES_DOC;
+    public final static String SSL_ALLOW_SAN_CHANGES_DOC = BrokerSecurityConfigs.SSL_ALLOW_SAN_CHANGES_DOC;
+
+    /** ********* Sasl Configuration ****************/
+    public final static String SASL_MECHANISM_INTER_BROKER_PROTOCOL_DOC = "SASL mechanism used for inter-broker communication. Default is GSSAPI.";
+    public final static String SASL_JAAS_CONFIG_DOC = SaslConfigs.SASL_JAAS_CONFIG_DOC;
+    public final static String SASL_ENABLED_MECHANISMS_DOC = BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_DOC;
+    public final static String SASL_SERVER_CALLBACK_HANDLER_CLASS_DOC = BrokerSecurityConfigs.SASL_SERVER_CALLBACK_HANDLER_CLASS_DOC;
+    public final static String SASL_CLIENT_CALLBACK_HANDLER_CLASS_DOC = SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS_DOC;
+    public final static String SASL_LOGIN_CLASS_DOC = SaslConfigs.SASL_LOGIN_CLASS_DOC;
+    public final static String SASL_LOGIN_CALLBACK_HANDLER_CLASS_DOC = SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS_DOC;
+    public final static String SASL_KERBEROS_SERVICE_NAME_DOC = SaslConfigs.SASL_KERBEROS_SERVICE_NAME_DOC;
+    public final static String SASL_KERBEROS_KINIT_CMD_DOC = SaslConfigs.SASL_KERBEROS_KINIT_CMD_DOC;
+    public final static String SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR_DOC = SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR_DOC;
+    public final static String SASL_KERBEROS_TICKET_RENEW_JITTER_DOC = SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER_DOC;
+    public final static String SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN_DOC = SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN_DOC;
+    public final static String SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES_DOC = BrokerSecurityConfigs.SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES_DOC;
+    public final static String SASL_LOGIN_REFRESH_WINDOW_FACTOR_DOC = SaslConfigs.SASL_LOGIN_REFRESH_WINDOW_FACTOR_DOC;
+    public final static String SASL_LOGIN_REFRESH_WINDOW_JITTER_DOC = SaslConfigs.SASL_LOGIN_REFRESH_WINDOW_JITTER_DOC;
+    public final static String SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS_DOC = SaslConfigs.SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS_DOC;
+    public final static String SASL_LOGIN_REFRESH_BUFFER_SECONDS_DOC = SaslConfigs.SASL_LOGIN_REFRESH_BUFFER_SECONDS_DOC;
+    public final static String SASL_LOGIN_CONNECT_TIMEOUT_MS_DOC = SaslConfigs.SASL_LOGIN_CONNECT_TIMEOUT_MS_DOC;
+    public final static String SASL_LOGIN_READ_TIMEOUT_MS_DOC = SaslConfigs.SASL_LOGIN_READ_TIMEOUT_MS_DOC;
+    public final static String SASL_LOGIN_RETRY_BACKOFF_MAX_MS_DOC = SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MAX_MS_DOC;
+    public final static String SASL_LOGIN_RETRY_BACKOFF_MS_DOC = SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MS_DOC;
+    public final static String SASL_OAUTHBEARER_SCOPE_CLAIM_NAME_DOC = SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME_DOC;
+    public final static String SASL_OAUTHBEARER_SUB_CLAIM_NAME_DOC = SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME_DOC;
+    public final static String SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL_DOC = SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL_DOC;
+    public final static String SASL_OAUTHBEARER_JWKS_ENDPOINT_URL_DOC = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL_DOC;
+    public final static String SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS_DOC = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS_DOC;
+    public final static String SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS_DOC = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS_DOC;
+    public final static String SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS_DOC = SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS_DOC;
+    public final static String SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS_DOC = SaslConfigs.SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS_DOC;
+    public final static String SASL_OAUTHBEARER_EXPECTED_AUDIENCE_DOC = SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE_DOC;
+    public final static String SASL_OAUTHBEARER_EXPECTED_ISSUER_DOC = SaslConfigs.SASL_OAUTHBEARER_EXPECTED_ISSUER_DOC;
+
+    /* Documentation */
+    /** ********* Zookeeper Configuration ********** */
+    public final static String ZK_CONNECT_DOC = "Specifies the ZooKeeper connection string in the form <code>hostname:port</code> where host and port are the " +
+            "host and port of a ZooKeeper server. To allow connecting through other ZooKeeper nodes when that ZooKeeper machine is " +
+            "down you can also specify multiple hosts in the form <code>hostname1:port1,hostname2:port2,hostname3:port3</code>.\n" +
+            "The server can also have a ZooKeeper chroot path as part of its ZooKeeper connection string which puts its data under some path in the global ZooKeeper namespace. " +
+            "For example to give a chroot path of <code>/chroot/path</code> you would give the connection string as <code>hostname1:port1,hostname2:port2,hostname3:port3/chroot/path</code>.";
+    public final static String ZK_SESSION_TIMEOUT_MS_DOC = "Zookeeper session timeout";
+    public final static String ZK_CONNECTION_TIMEOUT_MS_DOC = "The max time that the client waits to establish a connection to ZooKeeper. If not set, the value in " + ZK_SESSION_TIMEOUT_MS_PROP + " is used";
+    public final static String ZK_ENABLE_SECURE_ACLS_DOC = "Set client to use secure ACLs";
+    public final static String ZK_MAX_INFLIGHT_REQUESTS_DOC = "The maximum number of unacknowledged requests the client will send to ZooKeeper before blocking.";
+    public final static String ZK_SSL_CLIENT_ENABLE_DOC = String.format("Set client to use TLS when connecting to ZooKeeper." +
+            " An explicit value overrides any value set via the <code>zookeeper.client.secure</code> system property (note the different name)." +
+            " Defaults to false if neither is set; when true, <code>%s</code> must be set (typically to <code>org.apache.zookeeper.ClientCnxnSocketNetty</code>); other values to set may include ", ZK_CLIENT_CNXN_SOCKET_PROP) +
+            ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.keySet().stream().filter(x -> !x.equals(ZK_SSL_CLIENT_ENABLE_PROP) && !x.equals(ZK_CLIENT_CNXN_SOCKET_PROP)).sorted().collect(Collectors.joining("<code>", "</code>, <code>", "</code>"));
+    public final static String ZK_CLIENT_CNXN_SOCKET_DOC = String.format("Typically set to <code>org.apache.zookeeper.ClientCnxnSocketNetty</code> when using TLS connectivity to ZooKeeper." +
+            " Overrides any explicit value set via the same-named <code>%s</code> system property.", ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(ZK_CLIENT_CNXN_SOCKET_PROP));
+    public final static String ZK_SSL_KEYSTORE_LOCATION_DOC = String.format("Keystore location when using a client-side certificate with TLS connectivity to ZooKeeper." +
+            " Overrides any explicit value set via the <code>%s</code> system property (note the camelCase).", ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(ZK_SSL_KEYSTORE_LOCATION_PROP));
+    public final static String ZK_SSL_KEYSTORE_PASSWORD_DOC = String.format("Keystore password when using a client-side certificate with TLS connectivity to ZooKeeper." +
+            " Overrides any explicit value set via the <code>%s</code> system property (note the camelCase)." +
+            " Note that ZooKeeper does not support a key password different from the keystore password, so be sure to set the key password in the keystore to be identical to the keystore password; otherwise the connection attempt to Zookeeper will fail.",
+            ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(ZK_SSL_KEYSTORE_PASSWORD_PROP));
+    public final static String ZK_SSL_KEYSTORE_TYPE_DOC = String.format("Keystore type when using a client-side certificate with TLS connectivity to ZooKeeper." +
+            " Overrides any explicit value set via the <code>%s</code> system property (note the camelCase)." +
+            " The default value of <code>null</code> means the type will be auto-detected based on the filename extension of the keystore.",
+            ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(ZK_SSL_KEYSTORE_TYPE_PROP));
+    public final static String ZK_SSL_TRUSTSTORE_LOCATION_DOC = String.format("Truststore location when using TLS connectivity to ZooKeeper." +
+            " Overrides any explicit value set via the <code>%s</code> system property (note the camelCase).",
+            ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(ZK_SSL_TRUSTSTORE_LOCATION_PROP));
+    public final static String ZK_SSL_TRUSTSTORE_PASSWORD_DOC = String.format("Truststore password when using TLS connectivity to ZooKeeper." +
+            " Overrides any explicit value set via the <code>%s</code> system property (note the camelCase).",
+            ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(ZK_SSL_TRUSTSTORE_PASSWORD_PROP));
+    public final static String ZK_SSL_TRUSTSTORE_TYPE_DOC = String.format("Truststore type when using TLS connectivity to ZooKeeper." +
+            " Overrides any explicit value set via the <code>%s</code> system property (note the camelCase)." +
+            " The default value of <code>null</code> means the type will be auto-detected based on the filename extension of the truststore.",
+            ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(ZK_SSL_TRUSTSTORE_TYPE_PROP));
+    public final static String ZK_SSL_PROTOCOL_DOC = String.format("Specifies the protocol to be used in ZooKeeper TLS negotiation." +
+            " An explicit value overrides any value set via the same-named <code>%s</code> system property.",
+            ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(ZK_SSL_PROTOCOL_PROP));
+    public final static String ZK_SSL_ENABLED_PROTOCOLS_DOC = String.format("Specifies the enabled protocol(s) in ZooKeeper TLS negotiation (csv)." +
+            " Overrides any explicit value set via the <code>%s</code> system property (note the camelCase)." +
+            " The default value of <code>null</code> means the enabled protocol will be the value of the <code>%s</code> configuration property.",
+            ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(ZK_SSL_ENABLED_PROTOCOLS_PROP), ZK_SSL_PROTOCOL_PROP);
+    public final static String ZK_SSL_CIPHER_SUITES_DOC = String.format("Specifies the enabled cipher suites to be used in ZooKeeper TLS negotiation (csv)." +
+            " Overrides any explicit value set via the <code>%s</code> system property (note the single word \"ciphersuites\")." +
+            " The default value of <code>null</code> means the list of enabled cipher suites is determined by the Java runtime being used.",
+            ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(ZK_SSL_CIPHER_SUITES_PROP));
+    public final static String ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC = String.format("Specifies whether to enable hostname verification in the ZooKeeper TLS negotiation process, with (case-insensitively) \"https\" meaning ZooKeeper hostname verification is enabled and an explicit blank value meaning it is disabled (disabling it is only recommended for testing purposes)." +
+            " An explicit value overrides any \"true\" or \"false\" value set via the <code>%s</code> system property (note the different name and values; true implies https and false implies blank).",
+            ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP));
+    public final static String ZK_SSL_CRL_ENABLE_DOC = String.format("Specifies whether to enable Certificate Revocation List in the ZooKeeper TLS protocols." +
+            " Overrides any explicit value set via the <code>%s</code> system property (note the shorter name).",
+            ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(ZK_SSL_CRL_ENABLE_PROP));
+    public final static String ZK_SSL_OCSP_ENABLE_DOC = String.format("Specifies whether to enable Online Certificate Status Protocol in the ZooKeeper TLS protocols." +
+            " Overrides any explicit value set via the <code>%s</code> system property (note the shorter name).",
+            ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(ZK_SSL_OCSP_ENABLE_PROP));
+
+    /** ********* General Configuration ********** */
+    public final static String BROKER_ID_GENERATION_ENABLE_DOC = String.format("Enable automatic broker id generation on the server. When enabled the value configured for %s should be reviewed.", MAX_RESERVED_BROKER_ID_PROP);
+    public final static String MAX_RESERVED_BROKER_ID_DOC = "Max number that can be used for a broker.id";
+    public final static String BROKER_ID_DOC = "The broker id for this server. If unset, a unique broker id will be generated." +
+            "To avoid conflicts between ZooKeeper generated broker id's and user configured broker id's, generated broker ids " +
+            "start from " + MAX_RESERVED_BROKER_ID_PROP + " + 1.";
+    public final static String MESSAGE_MAX_BYTES_DOC = TopicConfig.MAX_MESSAGE_BYTES_DOC +
+            String.format("This can be set per topic with the topic level <code>%s</code> config.", TopicConfig.MAX_MESSAGE_BYTES_CONFIG);
+    public final static String NUM_NETWORK_THREADS_DOC = "The number of threads that the server uses for receiving requests from the network and sending responses to the network. Noted: each listener (except for controller listener) creates its own thread pool.";
+    public final static String NUM_IO_THREADS_DOC = "The number of threads that the server uses for processing requests, which may include disk I/O";
+    public final static String NUM_REPLICA_ALTER_LOG_DIRS_THREADS_DOC = "The number of threads that can move replicas between log directories, which may include disk I/O";
+    public final static String BACKGROUND_THREADS_DOC = "The number of threads to use for various background processing tasks";
+    public final static String QUEUED_MAX_REQUESTS_DOC = "The number of queued requests allowed for data-plane, before blocking the network threads";
+    public final static String QUEUED_MAX_REQUEST_BYTES_DOC = "The number of queued bytes allowed before no more requests are read";
+    public final static String REQUEST_TIMEOUT_MS_DOC = CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC;
+    public final static String CONNECTION_SETUP_TIMEOUT_MS_DOC = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_DOC;
+    public final static String CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC;
+
+    /** KRaft mode configs */
+    public final static String PROCESS_ROLES_DOC = "The roles that this process plays: 'broker', 'controller', or 'broker,controller' if it is both. " +
+            "This configuration is only applicable for clusters in KRaft (Kafka Raft) mode (instead of ZooKeeper). Leave this config undefined or empty for ZooKeeper clusters.";
+    public final static String INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_DOC = "When initially registering with the controller quorum, the number of milliseconds to wait before declaring failure and exiting the broker process.";
+    public final static String BROKER_HEARTBEAT_INTERVAL_MS_DOC = "The length of time in milliseconds between broker heartbeats. Used when running in KRaft mode.";
+    public final static String BROKER_SESSION_TIMEOUT_MS_DOC = "The length of time in milliseconds that a broker lease lasts if no heartbeats are made. Used when running in KRaft mode.";
+    public final static String NODE_ID_DOC = "The node ID associated with the roles this process is playing when <code>process.roles</code> is non-empty. " +
+            "This is required configuration when running in KRaft mode.";
+    public final static String METADATA_LOG_DIR_DOC = "This configuration determines where we put the metadata log for clusters in KRaft mode. " +
+            "If it is not set, the metadata log is placed in the first log directory from log.dirs.";
+    public final static String METADATA_SNAPSHOT_MAX_NEW_RECORD_BYTES_DOC = "This is the maximum number of bytes in the log between the latest " +
+            "snapshot and the high-watermark needed before generating a new snapshot. The default value is " +
+            Defaults.METADATA_SNAPSHOT_MAX_NEW_RECORD_BYTES + ". To generate snapshots based on the time elapsed, see " +
+            String.format("the <code>%s</code> configuration. The Kafka node will generate a snapshot when ", METADATA_SNAPSHOT_MAX_INTERVAL_MS_PROP) +
+            "either the maximum time interval is reached or the maximum bytes limit is reached.";
+    public final static String METADATA_SNAPSHOT_MAX_INTERVAL_MS_DOC = String.format("This is the maximum number of milliseconds to wait to generate a snapshot " +
+            "if there are committed records in the log that are not included in the latest snapshot. A value of zero disables " +
+            "time based snapshot generation. The default value is %s. To generate " +
+            "snapshots based on the number of metadata bytes, see the <code>%s</code> " +
+            "configuration. The Kafka node will generate a snapshot when either the maximum time interval is reached or the " +
+            "maximum bytes limit is reached.",
+            Defaults.METADATA_SNAPSHOT_MAX_INTERVAL_MS, METADATA_SNAPSHOT_MAX_NEW_RECORD_BYTES_PROP
+            );
+    public final static String METADATA_MAX_IDLE_INTERVAL_MS_DOC = "This configuration controls how often the active " +
+            "controller should write no-op records to the metadata partition. If the value is 0, no-op records " +
+            "are not appended to the metadata partition. The default value is " + Defaults.METADATA_MAX_IDLE_INTERVAL_MS;
+    public final static String CONTROLLER_LISTENER_NAMES_DOC = "A comma-separated list of the names of the listeners used by the controller. This is required " +
+            "if running in KRaft mode. When communicating with the controller quorum, the broker will always use the first listener in this list.\n " +
+            "Note: The ZooKeeper-based controller should not set this configuration.";
+    public final static String SASL_MECHANISM_CONTROLLER_PROTOCOL_DOC = "SASL mechanism used for communication with controllers. Default is GSSAPI.";
+    public final static String METADATA_LOG_SEGMENT_BYTES_DOC = "The maximum size of a single metadata log file.";
+    public final static String METADATA_LOG_SEGMENT_MIN_BYTES_DOC = "Override the minimum size for a single metadata log file. This should be used for testing only.";
+    public final static String SERVER_MAX_STARTUP_TIME_MS_DOC = "The maximum number of milliseconds we will wait for the server to come up. " +
+            "By default there is no limit. This should be used for testing only.";
+
+    public final static String METADATA_LOG_SEGMENT_MILLIS_DOC = "The maximum time before a new metadata log file is rolled out (in milliseconds).";
+    public final static String METADATA_MAX_RETENTION_BYTES_DOC = "The maximum combined size of the metadata log and snapshots before deleting old " +
+            "snapshots and log files. Since at least one snapshot must exist before any logs can be deleted, this is a soft limit.";
+    public final static String METADATA_MAX_RETENTION_MILLIS_DOC = "The number of milliseconds to keep a metadata log file or snapshot before " +
+            "deleting it. Since at least one snapshot must exist before any logs can be deleted, this is a soft limit.";
+
+    /** *********** Authorizer Configuration ********** */
+    public final static String AUTHORIZER_CLASS_NAME_DOC = "The fully qualified name of a class that implements <code>" + Authorizer.class.getName() + "</code>" +
+            " interface, which is used by the broker for authorization.";
+    public final static String EARLY_START_LISTENERS_DOC = "A comma-separated list of listener names which may be started before the authorizer has finished " +
+            "initialization. This is useful when the authorizer is dependent on the cluster itself for bootstrapping, as is the case for " +
+            "the StandardAuthorizer (which stores ACLs in the metadata log.) By default, all listeners included in controller.listener.names " +
+            "will also be early start listeners. A listener should not appear in this list if it accepts external traffic.";
+
+    /** ********* Socket Server Configuration ********** */
+    public final static String LISTENERS_DOC = "Listener List - Comma-separated list of URIs we will listen on and the listener names." +
+            " If the listener name is not a security protocol, <code>" + LISTENER_SECURITY_PROTOCOL_MAP_PROP + "</code> must also be set.\n" +
+            " Listener names and port numbers must be unique unless \n" +
+            " one listener is an IPv4 address and the other listener is \n" +
+            " an IPv6 address (for the same port).\n" +
+            " Specify hostname as 0.0.0.0 to bind to all interfaces.\n" +
+            " Leave hostname empty to bind to default interface.\n" +
+            " Examples of legal listener lists:\n" +
+            " <code>PLAINTEXT://myhost:9092,SSL://:9091</code>\n" +
+            " <code>CLIENT://0.0.0.0:9092,REPLICATION://localhost:9093</code>\n" +
+            " <code>PLAINTEXT://127.0.0.1:9092,SSL://[::1]:9092</code>\n";
+    public final static String ADVERTISED_LISTENERS_DOC = "Listeners to publish to ZooKeeper for clients to use, if different than the <code>" + LISTENERS_PROP + "</code> config property." +
+            " In IaaS environments, this may need to be different from the interface to which the broker binds." +
+            " If this is not set, the value for <code>" + LISTENERS_PROP + "</code> will be used." +
+            " Unlike <code>" + LISTENERS_PROP + "</code>, it is not valid to advertise the 0.0.0.0 meta-address.\n" +
+            " Also unlike <code>" + LISTENERS_PROP + "</code>, there can be duplicated ports in this property," +
+            " so that one listener can be configured to advertise another listener's address." +
+            " This can be useful in some cases where external load balancers are used.";
+    public final static String LISTENER_SECURITY_PROTOCOL_MAP_DOC = "Map between listener names and security protocols. This must be defined for " +
+            "the same security protocol to be usable in more than one port or IP. For example, internal and " +
+            "external traffic can be separated even if SSL is required for both. Concretely, the user could define listeners " +
+            "with names INTERNAL and EXTERNAL and this property as: <code>INTERNAL:SSL,EXTERNAL:SSL</code>. As shown, key and value are " +
+            "separated by a colon and map entries are separated by commas. Each listener name should only appear once in the map. " +
+            "Different security (SSL and SASL) settings can be configured for each listener by adding a normalised " +
+            "prefix (the listener name is lowercased) to the config name. For example, to set a different keystore for the " +
+            "INTERNAL listener, a config with name <code>listener.name.internal.ssl.keystore.location</code> would be set. " +
+            "If the config for the listener name is not set, the config will fallback to the generic config (i.e. <code>ssl.keystore.location</code>). " +
+            "Note that in KRaft a default mapping from the listener names defined by <code>controller.listener.names</code> to PLAINTEXT " +
+            "is assumed if no explicit mapping is provided and no other security protocol is in use.";
+    public final static String CONTROL_PLANE_LISTENER_NAME_DOC = "Name of listener used for communication between controller and brokers. " +
+            "A broker will use the <code>" + CONTROL_PLANE_LISTENER_NAME_PROP + "</code> to locate the endpoint in " + LISTENERS_PROP + " list, to listen for connections from the controller. " +
+            "For example, if a broker's config is:\n" +
+            "<code>listeners = INTERNAL://192.1.1.8:9092, EXTERNAL://10.1.1.5:9093, CONTROLLER://192.1.1.8:9094" +
+            "listener.security.protocol.map = INTERNAL:PLAINTEXT, EXTERNAL:SSL, CONTROLLER:SSL" +
+            "control.plane.listener.name = CONTROLLER</code>\n" +
+            "On startup, the broker will start listening on \"192.1.1.8:9094\" with security protocol \"SSL\".\n" +
+            "On the controller side, when it discovers a broker's published endpoints through ZooKeeper, it will use the <code>%s</code> " +
+            "to find the endpoint, which it will use to establish connection to the broker.\n" +
+            "For example, if the broker's published endpoints on ZooKeeper are:\n" +
+            " <code>\"endpoints\" : [\"INTERNAL://broker1.example.com:9092\",\"EXTERNAL://broker1.example.com:9093\",\"CONTROLLER://broker1.example.com:9094\"]</code>\n" +
+            " and the controller's config is:\n" +
+            "<code>listener.security.protocol.map = INTERNAL:PLAINTEXT, EXTERNAL:SSL, CONTROLLER:SSL" +
+            "control.plane.listener.name = CONTROLLER</code>\n" +
+            "then the controller will use \"broker1.example.com:9094\" with security protocol \"SSL\" to connect to the broker.\n" +
+            "If not explicitly configured, the default value will be null and there will be no dedicated endpoints for controller connections.\n" +
+            "If explicitly configured, the value cannot be the same as the value of <code>" + INTER_BROKER_LISTENER_NAME_PROP + "</code>.";
+
+    public final static String SOCKET_SEND_BUFFER_BYTES_DOC = "The SO_SNDBUF buffer of the socket server sockets. If the value is -1, the OS default will be used.";
+    public final static String SOCKET_RECEIVE_BUFFER_BYTES_DOC = "The SO_RCVBUF buffer of the socket server sockets. If the value is -1, the OS default will be used.";
+    public final static String SOCKET_REQUEST_MAX_BYTES_DOC = "The maximum number of bytes in a socket request";
+    public final static String SOCKET_LISTEN_BACKLOG_SIZE_DOC = "The maximum number of pending connections on the socket. " +
+            "In Linux, you may also need to configure <code>somaxconn</code> and <code>tcp_max_syn_backlog</code> kernel parameters " +
+            "accordingly to make the configuration takes effect.";
+    public final static String MAX_CONNECTIONS_PER_IP_DOC = "The maximum number of connections we allow from each ip address. This can be set to 0 if there are overrides " +
+            "configured using " + MAX_CONNECTIONS_PER_IP_OVERRIDES_PROP + " property. New connections from the ip address are dropped if the limit is reached.";
+    public final static String MAX_CONNECTIONS_PER_IP_OVERRIDES_DOC = "A comma-separated list of per-ip or hostname overrides to the default maximum number of connections. " +
+            "An example value is \"hostName:100,127.0.0.1:200\"";
+    public final static String MAX_CONNECTIONS_DOC = String.format("The maximum number of connections we allow in the broker at any time. This limit is applied in addition " +
+            "to any per-ip limits configured using %s. Listener-level limits may also be configured by prefixing the " +
+            "config name with the listener prefix, for example, <code>listener.name.internal.%s</code>. Broker-wide limit " +
+            "should be configured based on broker capacity while listener limits should be configured based on application requirements. " +
+            "New connections are blocked if either the listener or broker limit is reached. Connections on the inter-broker listener are " +
+            "permitted even if broker-wide limit is reached. The least recently used connection on another listener will be closed in this case.",
+            MAX_CONNECTIONS_PER_IP_PROP, MAX_CONNECTIONS_PROP
+            );
+    public final static String MAX_CONNECTION_CREATION_RATE_DOC = "The maximum connection creation rate we allow in the broker at any time. Listener-level limits " +
+            String.format("may also be configured by prefixing the config name with the listener prefix, for example, <code>listener.name.internal.%s</code>.", MAX_CONNECTION_CREATION_RATE_PROP) +
+            "Broker-wide connection rate limit should be configured based on broker capacity while listener limits should be configured based on " +
+            "application requirements. New connections will be throttled if either the listener or the broker limit is reached, with the exception " +
+            "of inter-broker listener. Connections on the inter-broker listener will be throttled only when the listener-level rate limit is reached.";
+    public final static String CONNECTIONS_MAX_IDLE_MS_DOC = "Idle connections timeout: the server socket processor threads close the connections that idle more than this";
+    public final static String FAILED_AUTHENTICATION_DELAY_MS_DOC = "Connection close delay on failed authentication: this is the time (in milliseconds) by which connection close will be delayed on authentication failure. " +
+            String.format("This must be configured to be less than %s to prevent connection timeout.", CONNECTIONS_MAX_IDLE_MS_PROP);
+    /** *********** Rack Configuration ************* */
+    public final static String RACK_DOC = "Rack of the broker. This will be used in rack aware replication assignment for fault tolerance. Examples: <code>RACK1</code>, <code>us-east-1d</code>";
+    /** ********* Log Configuration ********** */
+    public final static String NUM_PARTITIONS_DOC = "The default number of log partitions per topic";
+    public final static String LOG_DIR_DOC = "The directory in which the log data is kept (supplemental for " + LOG_DIRS_PROP + " property)";
+    public final static String LOG_DIRS_DOC = "A comma-separated list of the directories where the log data is stored. If not set, the value in " + LOG_DIR_PROP + " is used.";
+    public final static String LOG_SEGMENT_BYTES_DOC = "The maximum size of a single log file";
+    public final static String LOG_ROLL_TIME_MILLIS_DOC = "The maximum time before a new log segment is rolled out (in milliseconds). If not set, the value in " + LOG_ROLL_TIME_HOURS_PROP + " is used";
+    public final static String LOG_ROLL_TIME_HOURS_DOC = "The maximum time before a new log segment is rolled out (in hours), secondary to " + LOG_ROLL_TIME_MILLIS_PROP + " property";
+
+    public final static String LOG_ROLL_TIME_JITTER_MILLIS_DOC = "The maximum jitter to subtract from logRollTimeMillis (in milliseconds). If not set, the value in " + LOG_ROLL_TIME_JITTER_HOURS_PROP + " is used";
+    public final static String LOG_ROLL_TIME_JITTER_HOURS_DOC = "The maximum jitter to subtract from logRollTimeMillis (in hours), secondary to " + LOG_ROLL_TIME_JITTER_MILLIS_PROP + " property";
+
+    public final static String LOG_RETENTION_TIME_MILLIS_DOC = "The number of milliseconds to keep a log file before deleting it (in milliseconds), If not set, the value in " + LOG_RETENTION_TIME_MINUTES_PROP + " is used. If set to -1, no time limit is applied.";
+    public final static String LOG_RETENTION_TIME_MINS_DOC = "The number of minutes to keep a log file before deleting it (in minutes), secondary to " + LOG_RETENTION_TIME_MILLIS_PROP + " property. If not set, the value in " + LOG_RETENTION_TIME_HOURS_PROP + " is used";
+    public final static String LOG_RETENTION_TIME_HOURS_DOC = "The number of hours to keep a log file before deleting it (in hours), tertiary to " + LOG_RETENTION_TIME_MILLIS_PROP + " property";
+
+    public final static String LOG_RETENTION_BYTES_DOC = "The maximum size of the log before deleting it";
+    public final static String LOG_CLEANUP_INTERVAL_MS_DOC = "The frequency in milliseconds that the log cleaner checks whether any log is eligible for deletion";
+    public final static String LOG_CLEANUP_POLICY_DOC = "The default cleanup policy for segments beyond the retention window. A comma separated list of valid policies. Valid policies are: \"delete\" and \"compact\"";
+    public final static String LOG_INDEX_SIZE_MAX_BYTES_DOC = "The maximum size in bytes of the offset index";
+    public final static String LOG_INDEX_INTERVAL_BYTES_DOC = "The interval with which we add an entry to the offset index.";
+    public final static String LOG_FLUSH_INTERVAL_MESSAGES_DOC = "The number of messages accumulated on a log partition before messages are flushed to disk.";
+    public final static String LOG_DELETE_DELAY_MS_DOC = "The amount of time to wait before deleting a file from the filesystem";
+    public final static String LOG_FLUSH_SCHEDULER_INTERVAL_MS_DOC = "The frequency in ms that the log flusher checks whether any log needs to be flushed to disk";
+    public final static String LOG_FLUSH_INTERVAL_MS_DOC = "The maximum time in ms that a message in any topic is kept in memory before flushed to disk. If not set, the value in " + LOG_FLUSH_SCHEDULER_INTERVAL_MS_PROP + " is used";
+    public final static String LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS_DOC = "The frequency with which we update the persistent record of the last flush which acts as the log recovery point.";
+    public final static String LOG_FLUSH_START_OFFSET_CHECKPOINT_INTERVAL_MS_DOC = "The frequency with which we update the persistent record of log start offset";
+    public final static String LOG_PRE_ALLOCATE_ENABLE_DOC = "Should pre allocate file when create new segment? If you are using Kafka on Windows, you probably need to set it to true.";
+    public final static String LOG_MESSAGE_FORMAT_VERSION_DOC = "Specify the message format version the broker will use to append messages to the logs. The value should be a valid MetadataVersion. " +
+            "Some examples are: 0.8.2, 0.9.0.0, 0.10.0, check MetadataVersion for more details. By setting a particular message format version, the " +
+            "user is certifying that all the existing messages on disk are smaller or equal than the specified version. Setting this value incorrectly " +
+            "will cause consumers with older versions to break as they will receive messages with a format that they don't understand.";
+    public final static String LOG_MESSAGE_TIMESTAMP_TYPE_DOC = "Define whether the timestamp in the message is message create time or log append time. The value should be either " +
+            "<code>CreateTime</code> or <code>LogAppendTime</code>.";
+    public final static String LOG_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_DOC = "[DEPRECATED] The maximum difference allowed between the timestamp when a broker receives " +
+            "a message and the timestamp specified in the message. If log.message.timestamp.type=CreateTime, a message will be rejected " +
+            "if the difference in timestamp exceeds this threshold. This configuration is ignored if log.message.timestamp.type=LogAppendTime." +
+            "The maximum timestamp difference allowed should be no greater than log.retention.ms to avoid unnecessarily frequent log rolling.";
+    public final static String LOG_MESSAGE_TIMESTAMP_BEFORE_MAX_MS_DOC = "This configuration sets the allowable timestamp difference between the " +
+            "broker's timestamp and the message timestamp. The message timestamp can be earlier than or equal to the broker's " +
+            "timestamp, with the maximum allowable difference determined by the value set in this configuration. " +
+            "If log.message.timestamp.type=CreateTime, the message will be rejected if the difference in timestamps exceeds " +
+            "this specified threshold. This configuration is ignored if log.message.timestamp.type=LogAppendTime.";
+    public final static String LOG_MESSAGE_TIMESTAMP_AFTER_MAX_MS_DOC = "This configuration sets the allowable timestamp difference between the " +
+            "message timestamp and the broker's timestamp. The message timestamp can be later than or equal to the broker's " +
+            "timestamp, with the maximum allowable difference determined by the value set in this configuration. " +
+            "If log.message.timestamp.type=CreateTime, the message will be rejected if the difference in timestamps exceeds " +
+            "this specified threshold. This configuration is ignored if log.message.timestamp.type=LogAppendTime.";
+    public final static String NUM_RECOVERY_THREADS_PER_DATA_DIR_DOC = "The number of threads per data directory to be used for log recovery at startup and flushing at shutdown";
+    public final static String AUTO_CREATE_TOPICS_ENABLE_DOC = "Enable auto creation of topic on the server.";
+    public final static String MIN_IN_SYNC_REPLICAS_DOC = "When a producer sets acks to \"all\" (or \"-1\"), " +
+            "<code>min.insync.replicas</code> specifies the minimum number of replicas that must acknowledge " +
+            "a write for the write to be considered successful. If this minimum cannot be met, " +
+            "then the producer will raise an exception (either <code>NotEnoughReplicas</code> or " +
+            "<code>NotEnoughReplicasAfterAppend</code>).<br>When used together, <code>min.insync.replicas</code> and acks " +
+            "allow you to enforce greater durability guarantees. A typical scenario would be to " +
+            "create a topic with a replication factor of 3, set <code>min.insync.replicas</code> to 2, and " +
+            "produce with acks of \"all\". This will ensure that the producer raises an exception " +
+            "if a majority of replicas do not receive a write.";
+    public final static String CREATE_TOPIC_POLICY_CLASS_NAME_DOC = "The create topic policy class that should be used for validation. The class should " +
+            "implement the <code>org.apache.kafka.server.policy.CreateTopicPolicy</code> interface.";
+    public final static String ALTER_CONFIG_POLICY_CLASS_NAME_DOC = "The alter configs policy class that should be used for validation. The class should " +
+            "implement the <code>org.apache.kafka.server.policy.AlterConfigPolicy</code> interface.";
+    public final static String LOG_MESSAGE_DOWN_CONVERSION_ENABLE_DOC = TopicConfig.MESSAGE_DOWNCONVERSION_ENABLE_DOC;
+
+    /** ********* Replication configuration ********** */
+    public final static String CONTROLLER_SOCKET_TIMEOUT_MS_DOC = "The socket timeout for controller-to-broker channels.";
+    public final static String DEFAULT_REPLICATION_FACTOR_DOC = "The default replication factors for automatically created topics.";
+    public final static String REPLICA_LAG_TIME_MAX_MS_DOC = "If a follower hasn't sent any fetch requests or hasn't consumed up to the leaders log end offset for at least this time," +
+            " the leader will remove the follower from isr";
+    public final static String REPLICA_SOCKET_TIMEOUT_MS_DOC = "The socket timeout for network requests. Its value should be at least replica.fetch.wait.max.ms";
+    public final static String REPLICA_SOCKET_RECEIVE_BUFFER_BYTES_DOC = "The socket receive buffer for network requests to the leader for replicating data";
+    public final static String REPLICA_FETCH_MAX_BYTES_DOC = "The number of bytes of messages to attempt to fetch for each partition. This is not an absolute maximum, " +
+            "if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned " +
+            "to ensure that progress can be made. The maximum record batch size accepted by the broker is defined via " +
+            "<code>message.max.bytes</code> (broker config) or <code>max.message.bytes</code> (topic config).";
+    public final static String REPLICA_FETCH_WAIT_MAX_MS_DOC = "The maximum wait time for each fetcher request issued by follower replicas. This value should always be less than the " +
+            "replica.lag.time.max.ms at all times to prevent frequent shrinking of ISR for low throughput topics";
+    public final static String REPLICA_FETCH_MIN_BYTES_DOC = "Minimum bytes expected for each fetch response. If not enough bytes, wait up to <code>replica.fetch.wait.max.ms</code> (broker config).";
+    public final static String REPLICA_FETCH_RESPONSE_MAX_BYTES_DOC = "Maximum bytes expected for the entire fetch response. Records are fetched in batches, " +
+            "and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch " +
+            "will still be returned to ensure that progress can be made. As such, this is not an absolute maximum. The maximum " +
+            "record batch size accepted by the broker is defined via <code>message.max.bytes</code> (broker config) or " +
+            "<code>max.message.bytes</code> (topic config).";
+    public final static String NUM_REPLICA_FETCHERS_DOC = "Number of fetcher threads used to replicate records from each source broker. The total number of fetchers " +
+            "on each broker is bound by <code>num.replica.fetchers</code> multiplied by the number of brokers in the cluster." +
+            "Increasing this value can increase the degree of I/O parallelism in the follower and leader broker at the cost " +
+            "of higher CPU and memory utilization.";
+    public final static String REPLICA_FETCH_BACKOFF_MS_DOC = "The amount of time to sleep when fetch partition error occurs.";
+    public final static String REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS_DOC = "The frequency with which the high watermark is saved out to disk";
+    public final static String FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS_DOC = "The purge interval (in number of requests) of the fetch request purgatory";
+    public final static String PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS_DOC = "The purge interval (in number of requests) of the producer request purgatory";
+    public final static String DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS_DOC = "The purge interval (in number of requests) of the delete records request purgatory";
+    public final static String AUTO_LEADER_REBALANCE_ENABLE_DOC = String.format("Enables auto leader balancing. A background thread checks the distribution of partition leaders at regular intervals, configurable by %s. If the leader imbalance exceeds %s, leader rebalance to the preferred leader for partitions is triggered.",
+            LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS_PROP, LEADER_IMBALANCE_PER_BROKER_PERCENTAGE_PROP);
+    public final static String LEADER_IMBALANCE_PER_BROKER_PERCENTAGE_DOC = "The ratio of leader imbalance allowed per broker. The controller would trigger a leader balance if it goes above this value per broker. The value is specified in percentage.";
+    public final static String LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS_DOC = "The frequency with which the partition rebalance check is triggered by the controller";
+    public final static String UNCLEAN_LEADER_ELECTION_ENABLE_DOC = "Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss";
+    public final static String INTER_BROKER_SECURITY_PROTOCOL_DOC = "Security protocol used to communicate between brokers. Valid values are: " +
+            Utils.join(SecurityProtocol.names(), ", ") + ". It is an error to set this and " + INTER_BROKER_LISTENER_NAME_PROP +
+            " properties at the same time.";
+    public final static String INTER_BROKER_PROTOCOL_VERSION_DOC = "Specify which version of the inter-broker protocol will be used.\n" +
+            " This is typically bumped after all brokers were upgraded to a new version.\n" +
+            " Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.";
+    public final static String INTER_BROKER_LISTENER_NAME_DOC = "Name of listener used for communication between brokers. If this is unset, the listener name is defined by $InterBrokerSecurityProtocolProp. " +
+            "It is an error to set this and " + INTER_BROKER_SECURITY_PROTOCOL_PROP + " properties at the same time.";
+    public final static String REPLICA_SELECTOR_CLASS_DOC = "The fully qualified class name that implements ReplicaSelector. This is used by the broker to find the preferred read replica. By default, we use an implementation that returns the leader.";
+    /** ********* Controlled shutdown configuration ********** */
+    public final static String CONTROLLED_SHUTDOWN_MAX_RETRIES_DOC = "Controlled shutdown can fail for multiple reasons. This determines the number of retries when such failure happens";
+    public final static String CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS_DOC = "Before each retry, the system needs time to recover from the state that caused the previous failure (Controller fail over, replica lag etc). This config determines the amount of time to wait before retrying.";
+    public final static String CONTROLLED_SHUTDOWN_ENABLE_DOC = "Enable controlled shutdown of the server.";
+
+    /** ********* Group coordinator configuration ********** */
+    public final static String GROUP_MIN_SESSION_TIMEOUT_MS_DOC = "The minimum allowed session timeout for registered consumers. Shorter timeouts result in quicker failure detection at the cost of more frequent consumer heartbeating, which can overwhelm broker resources.";
+    public final static String GROUP_MAX_SESSION_TIMEOUT_MS_DOC = "The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.";
+    public final static String GROUP_INITIAL_REBALANCE_DELAY_MS_DOC = "The amount of time the group coordinator will wait for more consumers to join a new group before performing the first rebalance. A longer delay means potentially fewer rebalances, but increases the time until processing begins.";
+    public final static String GROUP_MAX_SIZE_DOC = "The maximum number of consumers that a single consumer group can accommodate.";
+
+    /** New group coordinator configs */
+    public final static String NEW_GROUP_COORDINATOR_ENABLE_DOC = "Enable the new group coordinator.";
+    public final static String GROUP_COORDINATOR_REBALANCE_PROTOCOLS_DOC = String.format("The list of enabled rebalance protocols. Supported protocols: %s. " +
+            "The %s rebalance protocol is in early access and therefore must not be used in production.",
+            Utils.join(Stream.of(GroupType.values()).map(GroupType::toString).collect(Collectors.toList()), ","),
+            GroupType.CONSUMER);
+    public final static String GROUP_COORDINATOR_NUM_THREADS_DOC = "The number of threads used by the group coordinator.";
+
+    /** Consumer group configs */
+    public final static String CONSUMER_GROUP_SESSION_TIMEOUT_MS_DOC = "The timeout to detect client failures when using the consumer group protocol.";
+    public final static String CONSUMER_GROUP_MIN_SESSION_TIMEOUT_MS_DOC = "The minimum allowed session timeout for registered consumers.";
+    public final static String CONSUMER_GROUP_MAX_SESSION_TIMEOUT_MS_DOC = "The maximum allowed session timeout for registered consumers.";
+    public final static String CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_DOC = "The heartbeat interval given to the members of a consumer group.";
+    public final static String CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_DOC = "The minimum heartbeat interval for registered consumers.";
+    public final static String CONSUMER_GROUP_MAX_HEARTBEAT_INTERVAL_MS_DOC = "The maximum heartbeat interval for registered consumers.";
+    public final static String CONSUMER_GROUP_MAX_SIZE_DOC = "The maximum number of consumers that a single consumer group can accommodate.";
+    public final static String CONSUMER_GROUP_ASSIGNORS_DOC = "The server side assignors as a list of full class names. The first one in the list is considered as the default assignor to be used in the case where the consumer does not specify an assignor.";
+
+    /** ********* Offset management configuration ********** */
+    public final static String OFFSET_METADATA_MAX_SIZE_DOC = "The maximum size for a metadata entry associated with an offset commit.";
+    public final static String OFFSETS_LOAD_BUFFER_SIZE_DOC = "Batch size for reading from the offsets segments when loading offsets into the cache (soft-limit, overridden if records are too large).";
+    public final static String OFFSETS_TOPIC_REPLICATION_FACTOR_DOC = "The replication factor for the offsets topic (set higher to ensure availability). " +
+            "Internal topic creation will fail until the cluster size meets this replication factor requirement.";
+    public final static String OFFSETS_TOPIC_PARTITIONS_DOC = "The number of partitions for the offset commit topic (should not change after deployment).";
+    public final static String OFFSETS_TOPIC_SEGMENT_BYTES_DOC = "The offsets topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads.";
+    public final static String OFFSETS_TOPIC_COMPRESSION_CODEC_DOC = "Compression codec for the offsets topic - compression may be used to achieve \"atomic\" commits.";
+    public final static String OFFSETS_RETENTION_MINUTES_DOC = "For subscribed consumers, committed offset of a specific partition will be expired and discarded when 1) this retention period has elapsed after the consumer group loses all its consumers (i.e. becomes empty); " +
+            "2) this retention period has elapsed since the last time an offset is committed for the partition and the group is no longer subscribed to the corresponding topic. " +
+            "For standalone consumers (using manual assignment), offsets will be expired after this retention period has elapsed since the time of last commit. " +
+            "Note that when a group is deleted via the delete-group request, its committed offsets will also be deleted without extra retention period; " +
+            "also when a topic is deleted via the delete-topic request, upon propagated metadata update any group's committed offsets for that topic will also be deleted without extra retention period.";
+    public final static String OFFSETS_RETENTION_CHECK_INTERVAL_MS_DOC = "Frequency at which to check for stale offsets";
+    public final static String OFFSET_COMMIT_TIMEOUT_MS_DOC = "Offset commit will be delayed until all replicas for the offsets topic receive the commit " +
+            "or this timeout is reached. This is similar to the producer request timeout.";
+    public final static String OFFSET_COMMIT_REQUIRED_ACKS_DOC = "The required acks before the commit can be accepted. In general, the default (-1) should not be overridden.";
+    /** ********* Transaction management configuration ********** */
+    public final static String TRANSACTIONAL_ID_EXPIRATION_MS_DOC = "The time in ms that the transaction coordinator will wait without receiving any transaction status updates " +
+            "for the current transaction before expiring its transactional id. Transactional IDs will not expire while a the transaction is still ongoing.";
+    public final static String TRANSACTIONS_MAX_TIMEOUT_MS_DOC = "The maximum allowed timeout for transactions. " +
+            "If a client’s requested transaction time exceed this, then the broker will return an error in InitProducerIdRequest. This prevents a client from too large of a timeout, which can stall consumers reading from topics included in the transaction.";
+    public final static String TRANSACTIONS_TOPIC_MIN_ISR_DOC = "Overridden " + MIN_IN_SYNC_REPLICAS_PROP + " config for the transaction topic.";
+    public final static String TRANSACTIONS_LOAD_BUFFER_SIZE_DOC = "Batch size for reading from the transaction log segments when loading producer ids and transactions into the cache (soft-limit, overridden if records are too large).";
+    public final static String TRANSACTIONS_TOPIC_REPLICATION_FACTOR_DOC = "The replication factor for the transaction topic (set higher to ensure availability). " +
+            "Internal topic creation will fail until the cluster size meets this replication factor requirement.";
+    public final static String TRANSACTIONS_TOPIC_PARTITIONS_DOC = "The number of partitions for the transaction topic (should not change after deployment).";
+    public final static String TRANSACTIONS_TOPIC_SEGMENT_BYTES_DOC = "The transaction topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads";
+    public final static String TRANSACTIONS_ABORT_TIMED_OUT_TRANSACTIONS_INTERVAL_MS_DOC = "The interval at which to rollback transactions that have timed out";
+    public final static String TRANSACTIONS_REMOVE_EXPIRED_TRANSACTIONS_INTERVAL_MS_DOC = "The interval at which to remove transactions that have expired due to <code>transactional.id.expiration.ms</code> passing";
+
+    public final static String TRANSACTION_PARTITION_VERIFICATION_ENABLE_DOC = "Enable verification that checks that the partition has been added to the transaction before writing transactional records to the partition";
+
+    public final static String PRODUCER_ID_EXPIRATION_MS_DOC = "The time in ms that a topic partition leader will wait before expiring producer IDs. Producer IDs will not expire while a transaction associated to them is still ongoing. " +
+            "Note that producer IDs may expire sooner if the last write from the producer ID is deleted due to the topic's retention settings. Setting this value the same or higher than " +
+            "<code>delivery.timeout.ms</code> can help prevent expiration during retries and protect against message duplication, but the default should be reasonable for most use cases.";
+    public final static String PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS_DOC = "The interval at which to remove producer IDs that have expired due to <code>producer.id.expiration.ms</code> passing.";
+
+    /** ********* Fetch Configuration ************* */
+    public final static String MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS_DOC = "The maximum number of incremental fetch sessions that we will maintain.";
+    public final static String FETCH_MAX_BYTES_DOC = "The maximum number of bytes we will return for a fetch request. Must be at least 1024.";
+
+    /** ********* Request Limit Configuration ************* */
+    public final static String MAX_REQUEST_PARTITION_SIZE_LIMIT_DOC = "The maximum number of partitions can be served in one request.";
+
+    /** ********* Quota Configuration ********** */
+    public final static String NUM_QUOTA_SAMPLES_DOC = "The number of samples to retain in memory for client quotas";
+    public final static String NUM_REPLICATION_QUOTA_SAMPLES_DOC = "The number of samples to retain in memory for replication quotas";
+    public final static String NUM_ALTER_LOG_DIRS_REPLICATION_QUOTA_SAMPLES_DOC = "The number of samples to retain in memory for alter log dirs replication quotas";
+    public final static String NUM_CONTROLLER_QUOTA_SAMPLES_DOC = "The number of samples to retain in memory for controller mutation quotas";
+    public final static String QUOTA_WINDOW_SIZE_SECONDS_DOC = "The time span of each sample for client quotas";
+    public final static String REPLICATION_QUOTA_WINDOW_SIZE_SECONDS_DOC = "The time span of each sample for replication quotas";
+    public final static String ALTER_LOG_DIRS_REPLICATION_QUOTA_WINDOW_SIZE_SECONDS_DOC = "The time span of each sample for alter log dirs replication quotas";
+    public final static String CONTROLLER_QUOTA_WINDOW_SIZE_SECONDS_DOC = "The time span of each sample for controller mutations quotas";
+
+    public final static String CLIENT_QUOTA_CALLBACK_CLASS_DOC = "The fully qualified name of a class that implements the ClientQuotaCallback interface, " +
+            "which is used to determine quota limits applied to client requests. By default, the &lt;user&gt; and &lt;client-id&gt; " +
+            "quotas that are stored in ZooKeeper are applied. For any given request, the most specific quota that matches the user principal " +
+            "of the session and the client-id of the request is applied.";
+
+    public final static String DELETE_TOPIC_ENABLE_DOC = "Enables delete topic. Delete topic through the admin tool will have no effect if this config is turned off";
+    public final static String COMPRESSION_TYPE_DOC = "Specify the final compression type for a given topic. This configuration accepts the standard compression codecs " +
+            "('gzip', 'snappy', 'lz4', 'zstd'). It additionally accepts 'uncompressed' which is equivalent to no compression; and " +
+            "'producer' which means retain the original compression codec set by the producer.";
+
+    /** ********* Kafka Metrics Configuration ********** */
+    public final static String METRIC_SAMPLE_WINDOW_MS_DOC = CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_DOC;
+    public final static String METRIC_NUM_SAMPLES_DOC = CommonClientConfigs.METRICS_NUM_SAMPLES_DOC;
+    public final static String METRIC_REPORTER_CLASSES_DOC = CommonClientConfigs.METRIC_REPORTER_CLASSES_DOC;
+    public final static String METRICS_RECORDING_LEVEL_DOC = CommonClientConfigs.METRICS_RECORDING_LEVEL_DOC;
+    public final static String AUTO_INCLUDE_JMX_REPORTER_DOC = CommonClientConfigs.AUTO_INCLUDE_JMX_REPORTER_DOC;
+
+
+    /** ********* Kafka Yammer Metrics Reporter Configuration ********** */
+    public final static String KAFKA_METRICS_REPORTER_CLASSES_DOC = "A list of classes to use as Yammer metrics custom reporters." +
+            " The reporters should implement <code>kafka.metrics.KafkaMetricsReporter</code> trait. If a client wants" +
+            " to expose JMX operations on a custom reporter, the custom reporter needs to additionally implement an MBean" +
+            " trait that extends <code>kafka.metrics.KafkaMetricsReporterMBean</code> trait so that the registered MBean is compliant with" +
+            " the standard MBean convention.";
+
+    public final static String KAFKA_METRICS_POLLING_INTERVAL_SECONDS_DOC = "The metrics polling interval (in seconds) which can be used in " +
+            KAFKA_METRICS_REPORTER_CLASSES_PROP + " implementations.";
+
+    /** ********* Kafka Client Telemetry Metrics Configuration ********** */
+    public final static String CLIENT_TELEMETRY_MAX_BYTES_DOC = "The maximum size (after compression if compression is used) of" +
+            " telemetry metrics pushed from a client to the broker. The default value is 1048576 (1 MB).";
+
+
+    /** ********* Delegation Token Configuration ****************/
+    public final static String DELEGATION_TOKEN_SECRET_KEY_ALIAS_DOC = "DEPRECATED: An alias for " + DELEGATION_TOKEN_SECRET_KEY_PROP + ", which should be used instead of this config.";
+    public final static String DELEGATION_TOKEN_SECRET_KEY_DOC = "Secret key to generate and verify delegation tokens. The same key must be configured across all the brokers. " +
+            " If using Kafka with KRaft, the key must also be set across all controllers. " +
+            " If the key is not set or set to empty string, brokers will disable the delegation token support.";
+    public final static String DELEGATION_TOKEN_MAX_LIFE_TIME_DOC = "The token has a maximum lifetime beyond which it cannot be renewed anymore. Default value 7 days.";
+    public final static String DELEGATION_TOKEN_EXPIRY_TIME_MS_DOC = "The token validity time in milliseconds before the token needs to be renewed. Default value 1 day.";
+    public final static String DELEGATION_TOKEN_EXPIRY_CHECK_INTERVAL_DOC = "Scan interval to remove expired delegation tokens.";
+
+    /** ********* Password encryption configuration for dynamic configs *********/
+    public final static String PASSWORD_ENCODER_SECRET_DOC = "The secret used for encoding dynamically configured passwords for this broker.";
+    public final static String PASSWORD_ENCODER_OLD_SECRET_DOC = "The old secret that was used for encoding dynamically configured passwords. " +
+            "This is required only when the secret is updated. If specified, all dynamically encoded passwords are " +
+            "decoded using this old secret and re-encoded using " + PASSWORD_ENCODER_SECRET_PROP + " when broker starts up.";
+    public final static String PASSWORD_ENCODER_KEY_FACTORY_ALGORITHM_DOC = "The SecretKeyFactory algorithm used for encoding dynamically configured passwords. " +
+            "Default is PBKDF2WithHmacSHA512 if available and PBKDF2WithHmacSHA1 otherwise.";
+    public final static String PASSWORD_ENCODER_CIPHER_ALGORITHM_DOC = "The Cipher algorithm used for encoding dynamically configured passwords.";
+    public final static String PASSWORD_ENCODER_KEY_LENGTH_DOC =  "The key length used for encoding dynamically configured passwords.";
+    public final static String PASSWORD_ENCODER_ITERATIONS_DOC =  "The iteration count used for encoding dynamically configured passwords.";
+
+    @SuppressWarnings("deprecation")
+    public final static ConfigDef CONFIG_DEF = new ConfigDef()
+        /** ********* Zookeeper Configuration ***********/
+        .define(ZK_CONNECT_PROP, STRING, null, HIGH, ZK_CONNECT_DOC)
+        .define(ZK_SESSION_TIMEOUT_MS_PROP, INT, Defaults.ZK_SESSION_TIMEOUT_MS, HIGH, ZK_SESSION_TIMEOUT_MS_DOC)
+        .define(ZK_CONNECTION_TIMEOUT_MS_PROP, INT, null, HIGH, ZK_CONNECTION_TIMEOUT_MS_DOC)
+        .define(ZK_ENABLE_SECURE_ACLS_PROP, BOOLEAN, Defaults.ZK_ENABLE_SECURE_ACLS, HIGH, ZK_ENABLE_SECURE_ACLS_DOC)
+        .define(ZK_MAX_IN_FLIGHT_REQUESTS_PROP, INT, Defaults.ZK_MAX_IN_FLIGHT_REQUESTS, atLeast(1), HIGH, ZK_MAX_INFLIGHT_REQUESTS_DOC)
+        .define(ZK_SSL_CLIENT_ENABLE_PROP, BOOLEAN, Defaults.ZK_SSL_CLIENT_ENABLE, MEDIUM, ZK_SSL_CLIENT_ENABLE_DOC)
+        .define(ZK_CLIENT_CNXN_SOCKET_PROP, STRING, null, MEDIUM, ZK_CLIENT_CNXN_SOCKET_DOC)
+        .define(ZK_SSL_KEYSTORE_LOCATION_PROP, STRING, null, MEDIUM, ZK_SSL_KEYSTORE_LOCATION_DOC)
+        .define(ZK_SSL_KEYSTORE_PASSWORD_PROP, PASSWORD, null, MEDIUM, ZK_SSL_KEYSTORE_PASSWORD_DOC)
+        .define(ZK_SSL_KEYSTORE_TYPE_PROP, STRING, null, MEDIUM, ZK_SSL_KEYSTORE_TYPE_DOC)
+        .define(ZK_SSL_TRUSTSTORE_LOCATION_PROP, STRING, null, MEDIUM, ZK_SSL_TRUSTSTORE_LOCATION_DOC)
+        .define(ZK_SSL_TRUSTSTORE_PASSWORD_PROP, PASSWORD, null, MEDIUM, ZK_SSL_TRUSTSTORE_PASSWORD_DOC)
+        .define(ZK_SSL_TRUSTSTORE_TYPE_PROP, STRING, null, MEDIUM, ZK_SSL_TRUSTSTORE_TYPE_DOC)
+        .define(ZK_SSL_PROTOCOL_PROP, STRING, Defaults.ZK_SSL_PROTOCOL, LOW, ZK_SSL_PROTOCOL_DOC)
+        .define(ZK_SSL_ENABLED_PROTOCOLS_PROP, LIST, null, LOW, ZK_SSL_ENABLED_PROTOCOLS_DOC)
+        .define(ZK_SSL_CIPHER_SUITES_PROP, LIST, null, LOW, ZK_SSL_CIPHER_SUITES_DOC)
+        .define(ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP, STRING, Defaults.ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, LOW, ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC)
+        .define(ZK_SSL_CRL_ENABLE_PROP, BOOLEAN, Defaults.ZK_SSL_CRL_ENABLE, LOW, ZK_SSL_CRL_ENABLE_DOC)
+        .define(ZK_SSL_OCSP_ENABLE_PROP, BOOLEAN, Defaults.ZK_SSL_OCSP_ENABLE, LOW, ZK_SSL_OCSP_ENABLE_DOC)
+
+        /** ********* General Configuration ***********/
+        .define(BROKER_ID_GENERATION_ENABLE_PROP, BOOLEAN, Defaults.BROKER_ID_GENERATION_ENABLE, MEDIUM, BROKER_ID_GENERATION_ENABLE_DOC)
+        .define(MAX_RESERVED_BROKER_ID_PROP, INT, Defaults.MAX_RESERVED_BROKER_ID, atLeast(0), MEDIUM, MAX_RESERVED_BROKER_ID_DOC)
+        .define(BROKER_ID_PROP, INT, Defaults.BROKER_ID, HIGH, BROKER_ID_DOC)
+        .define(MESSAGE_MAX_BYTES_PROP, INT, LogConfig.DEFAULT_MAX_MESSAGE_BYTES, atLeast(0), HIGH, MESSAGE_MAX_BYTES_DOC)
+        .define(NUM_NETWORK_THREADS_PROP, INT, Defaults.NUM_NETWORK_THREADS, atLeast(1), HIGH, NUM_NETWORK_THREADS_DOC)
+        .define(NUM_IO_THREADS_PROP, INT, Defaults.NUM_IO_THREADS, atLeast(1), HIGH, NUM_IO_THREADS_DOC)
+        .define(NUM_REPLICA_ALTER_LOG_DIRS_THREADS_PROP, INT, null, HIGH, NUM_REPLICA_ALTER_LOG_DIRS_THREADS_DOC)
+        .define(BACKGROUND_THREADS_PROP, INT, Defaults.BACKGROUND_THREADS, atLeast(1), HIGH, BACKGROUND_THREADS_DOC)
+        .define(QUEUED_MAX_REQUESTS_PROP, INT, Defaults.QUEUED_MAX_REQUESTS, atLeast(1), HIGH, QUEUED_MAX_REQUESTS_DOC)
+        .define(QUEUED_MAX_BYTES_PROP, LONG, Defaults.QUEUED_MAX_REQUEST_BYTES, MEDIUM, QUEUED_MAX_REQUEST_BYTES_DOC)
+        .define(REQUEST_TIMEOUT_MS_PROP, INT, Defaults.REQUEST_TIMEOUT_MS, HIGH, REQUEST_TIMEOUT_MS_DOC)
+        .define(CONNECTION_SETUP_TIMEOUT_MS_PROP, LONG, Defaults.CONNECTION_SETUP_TIMEOUT_MS, MEDIUM, CONNECTION_SETUP_TIMEOUT_MS_DOC)
+        .define(CONNECTION_SETUP_TIMEOUT_MAX_MS_PROP, LONG, Defaults.CONNECTION_SETUP_TIMEOUT_MAX_MS, MEDIUM, CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC)
+
+        /*
+        * KRaft mode configs.
+        */
+        .define(METADATA_SNAPSHOT_MAX_NEW_RECORD_BYTES_PROP, LONG, Defaults.METADATA_SNAPSHOT_MAX_NEW_RECORD_BYTES, atLeast(1), HIGH, METADATA_SNAPSHOT_MAX_NEW_RECORD_BYTES_DOC)
+        .define(METADATA_SNAPSHOT_MAX_INTERVAL_MS_PROP, LONG, Defaults.METADATA_SNAPSHOT_MAX_INTERVAL_MS, atLeast(0), HIGH, METADATA_SNAPSHOT_MAX_INTERVAL_MS_DOC)
+        .define(PROCESS_ROLES_PROP, LIST, Collections.emptyList(), ConfigDef.ValidList.in("broker", "controller"), HIGH, PROCESS_ROLES_DOC)
+        .define(NODE_ID_PROP, INT, Defaults.EMPTY_NODE_ID, null, HIGH, NODE_ID_DOC)
+        .define(INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_PROP, INT, Defaults.INITIAL_BROKER_REGISTRATION_TIMEOUT_MS, null, MEDIUM, INITIAL_BROKER_REGISTRATION_TIMEOUT_MS_DOC)
+        .define(BROKER_HEARTBEAT_INTERVAL_MS_PROP, INT, Defaults.BROKER_HEARTBEAT_INTERVAL_MS, null, MEDIUM, BROKER_HEARTBEAT_INTERVAL_MS_DOC)
+        .define(BROKER_SESSION_TIMEOUT_MS_PROP, INT, Defaults.BROKER_SESSION_TIMEOUT_MS, null, MEDIUM, BROKER_SESSION_TIMEOUT_MS_DOC)
+        .define(CONTROLLER_LISTENER_NAMES_PROP, STRING, null, null, HIGH, CONTROLLER_LISTENER_NAMES_DOC)
+        .define(SASL_MECHANISM_CONTROLLER_PROTOCOL_PROP, STRING, SaslConfigs.DEFAULT_SASL_MECHANISM, null, HIGH, SASL_MECHANISM_CONTROLLER_PROTOCOL_DOC)
+        .define(METADATA_LOG_DIR_PROP, STRING, null, null, HIGH, METADATA_LOG_DIR_DOC)
+        .define(METADATA_LOG_SEGMENT_BYTES_PROP, INT, LogConfig.DEFAULT_SEGMENT_BYTES, atLeast(Records.LOG_OVERHEAD), HIGH, METADATA_LOG_SEGMENT_BYTES_DOC)
+        .defineInternal(METADATA_LOG_SEGMENT_MIN_BYTES_PROP, INT, 8 * 1024 * 1024, atLeast(Records.LOG_OVERHEAD), HIGH, METADATA_LOG_SEGMENT_MIN_BYTES_DOC)
+        .define(METADATA_LOG_SEGMENT_MILLIS_PROP, LONG, LogConfig.DEFAULT_SEGMENT_MS, null, HIGH, METADATA_LOG_SEGMENT_MILLIS_DOC)
+        .define(METADATA_MAX_RETENTION_BYTES_PROP, LONG, Defaults.METADATA_MAX_RETENTION_BYTES, null, HIGH, METADATA_MAX_RETENTION_BYTES_DOC)
+        .define(METADATA_MAX_RETENTION_MILLIS_PROP, LONG, LogConfig.DEFAULT_RETENTION_MS, null, HIGH, METADATA_MAX_RETENTION_MILLIS_DOC)
+        .define(METADATA_MAX_IDLE_INTERVAL_MS_PROP, INT, Defaults.METADATA_MAX_IDLE_INTERVAL_MS, atLeast(0), LOW, METADATA_MAX_IDLE_INTERVAL_MS_DOC)
+        .defineInternal(SERVER_MAX_STARTUP_TIME_MS_PROP, LONG, Defaults.SERVER_MAX_STARTUP_TIME_MS, atLeast(0), MEDIUM, SERVER_MAX_STARTUP_TIME_MS_DOC)
+        .define(MIGRATION_ENABLED_PROP, BOOLEAN, false, HIGH, "Enable ZK to KRaft migration")
+        .define(ELR_ENABLED_PROP, BOOLEAN, false, HIGH, "Enable the Eligible leader replicas")
+        .defineInternal(MIGRATION_METADATA_MIN_BATCH_SIZE_PROP, INT, Defaults.MIGRATION_METADATA_MIN_BATCH_SIZE, atLeast(1),
+        MEDIUM, "Soft minimum batch size to use when migrating metadata from ZooKeeper to KRaft")
+
+        /************* Authorizer Configuration ***********/
+        .define(AUTHORIZER_CLASS_NAME_PROP, STRING, Defaults.AUTHORIZER_CLASS_NAME, new ConfigDef.NonNullValidator(), LOW, AUTHORIZER_CLASS_NAME_DOC)
+        .define(EARLY_START_LISTENERS_PROP, STRING, null,  HIGH, EARLY_START_LISTENERS_DOC)
+
+        /** ********* Socket Server Configuration ***********/
+        .define(LISTENERS_PROP, STRING, Defaults.LISTENERS, HIGH, LISTENERS_DOC)
+        .define(ADVERTISED_LISTENERS_PROP, STRING, null, HIGH, ADVERTISED_LISTENERS_DOC)
+        .define(LISTENER_SECURITY_PROTOCOL_MAP_PROP, STRING, Defaults.LISTENER_SECURITY_PROTOCOL_MAP, LOW, LISTENER_SECURITY_PROTOCOL_MAP_DOC)
+        .define(CONTROL_PLANE_LISTENER_NAME_PROP, STRING, null, HIGH, CONTROL_PLANE_LISTENER_NAME_DOC)
+        .define(SOCKET_SEND_BUFFER_BYTES_PROP, INT, Defaults.SOCKET_SEND_BUFFER_BYTES, HIGH, SOCKET_SEND_BUFFER_BYTES_DOC)
+        .define(SOCKET_RECEIVE_BUFFER_BYTES_PROP, INT, Defaults.SOCKET_RECEIVE_BUFFER_BYTES, HIGH, SOCKET_RECEIVE_BUFFER_BYTES_DOC)
+        .define(SOCKET_REQUEST_MAX_BYTES_PROP, INT, Defaults.SOCKET_REQUEST_MAX_BYTES, atLeast(1), HIGH, SOCKET_REQUEST_MAX_BYTES_DOC)
+        .define(SOCKET_LISTEN_BACKLOG_SIZE_PROP, INT, Defaults.SOCKET_LISTEN_BACKLOG_SIZE, atLeast(1), MEDIUM, SOCKET_LISTEN_BACKLOG_SIZE_DOC)
+        .define(MAX_CONNECTIONS_PER_IP_PROP, INT, Defaults.MAX_CONNECTIONS_PER_IP, atLeast(0), MEDIUM, MAX_CONNECTIONS_PER_IP_DOC)
+        .define(MAX_CONNECTIONS_PER_IP_OVERRIDES_PROP, STRING, Defaults.MAX_CONNECTIONS_PER_IP_OVERRIDES, MEDIUM, MAX_CONNECTIONS_PER_IP_OVERRIDES_DOC)
+        .define(MAX_CONNECTIONS_PROP, INT, Defaults.MAX_CONNECTIONS, atLeast(0), MEDIUM, MAX_CONNECTIONS_DOC)
+        .define(MAX_CONNECTION_CREATION_RATE_PROP, INT, Defaults.MAX_CONNECTION_CREATION_RATE, atLeast(0), MEDIUM, MAX_CONNECTION_CREATION_RATE_DOC)
+        .define(CONNECTIONS_MAX_IDLE_MS_PROP, LONG, Defaults.CONNECTIONS_MAX_IDLE_MS, MEDIUM, CONNECTIONS_MAX_IDLE_MS_DOC)
+        .define(FAILED_AUTHENTICATION_DELAY_MS_PROP, INT, Defaults.FAILED_AUTHENTICATION_DELAY_MS, atLeast(0), LOW, FAILED_AUTHENTICATION_DELAY_MS_DOC)
+
+        /************ Rack Configuration ******************/
+        .define(RACK_PROP, STRING, null, MEDIUM, RACK_DOC)
+
+        /** ********* Log Configuration ***********/
+        .define(NUM_PARTITIONS_PROP, INT, Defaults.NUM_PARTITIONS, atLeast(1), MEDIUM, NUM_PARTITIONS_DOC)
+        .define(LOG_DIR_PROP, STRING, Defaults.LOG_DIR, HIGH, LOG_DIR_DOC)
+        .define(LOG_DIRS_PROP, STRING, null, HIGH, LOG_DIRS_DOC)
+        .define(LOG_SEGMENT_BYTES_PROP, INT, LogConfig.DEFAULT_SEGMENT_BYTES, atLeast(LegacyRecord.RECORD_OVERHEAD_V0), HIGH, LOG_SEGMENT_BYTES_DOC)
+
+        .define(LOG_ROLL_TIME_MILLIS_PROP, LONG, null, HIGH, LOG_ROLL_TIME_MILLIS_DOC)
+        .define(LOG_ROLL_TIME_HOURS_PROP, INT, (int) TimeUnit.MILLISECONDS.toHours(LogConfig.DEFAULT_SEGMENT_MS), atLeast(1), HIGH, LOG_ROLL_TIME_HOURS_DOC)
+
+        .define(LOG_ROLL_TIME_JITTER_MILLIS_PROP, LONG, null, HIGH, LOG_ROLL_TIME_JITTER_MILLIS_DOC)
+        .define(LOG_ROLL_TIME_JITTER_HOURS_PROP, INT, (int) TimeUnit.MILLISECONDS.toHours(LogConfig.DEFAULT_SEGMENT_JITTER_MS), atLeast(0), HIGH, LOG_ROLL_TIME_JITTER_HOURS_DOC)
+
+        .define(LOG_RETENTION_TIME_MILLIS_PROP, LONG, null, HIGH, LOG_RETENTION_TIME_MILLIS_DOC)
+        .define(LOG_RETENTION_TIME_MINUTES_PROP, INT, null, HIGH, LOG_RETENTION_TIME_MINS_DOC)
+        .define(LOG_RETENTION_TIME_HOURS_PROP, INT, (int) TimeUnit.MILLISECONDS.toHours(LogConfig.DEFAULT_RETENTION_MS), HIGH, LOG_RETENTION_TIME_HOURS_DOC)
+
+        .define(LOG_RETENTION_BYTES_PROP, LONG, LogConfig.DEFAULT_RETENTION_BYTES, HIGH, LOG_RETENTION_BYTES_DOC)
+        .define(LOG_CLEANUP_INTERVAL_MS_PROP, LONG, Defaults.LOG_CLEANUP_INTERVAL_MS, atLeast(1), MEDIUM, LOG_CLEANUP_INTERVAL_MS_DOC)
+        .define(LOG_CLEANUP_POLICY_PROP, LIST, LogConfig.DEFAULT_CLEANUP_POLICY, ConfigDef.ValidList.in(TopicConfig.CLEANUP_POLICY_COMPACT, TopicConfig.CLEANUP_POLICY_DELETE), MEDIUM, LOG_CLEANUP_POLICY_DOC)
+        .define(CleanerConfig.LOG_CLEANER_THREADS_PROP, INT, CleanerConfig.LOG_CLEANER_THREADS, atLeast(0), MEDIUM, CleanerConfig.LOG_CLEANER_THREADS_DOC)
+        .define(CleanerConfig.LOG_CLEANER_IO_MAX_BYTES_PER_SECOND_PROP, DOUBLE, CleanerConfig.LOG_CLEANER_IO_MAX_BYTES_PER_SECOND, MEDIUM, CleanerConfig.LOG_CLEANER_IO_MAX_BYTES_PER_SECOND_DOC)
+        .define(CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE_PROP, LONG, CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE, MEDIUM, CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE_DOC)
+        .define(CleanerConfig.LOG_CLEANER_IO_BUFFER_SIZE_PROP, INT, CleanerConfig.LOG_CLEANER_IO_BUFFER_SIZE, atLeast(0), MEDIUM, CleanerConfig.LOG_CLEANER_IO_BUFFER_SIZE_DOC)
+        .define(CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_LOAD_FACTOR_PROP, DOUBLE, CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_LOAD_FACTOR, MEDIUM, CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_LOAD_FACTOR_DOC)
+        .define(CleanerConfig.LOG_CLEANER_BACKOFF_MS_PROP, LONG, CleanerConfig.LOG_CLEANER_BACKOFF_MS, atLeast(0), MEDIUM, CleanerConfig.LOG_CLEANER_BACKOFF_MS_DOC)
+        .define(CleanerConfig.LOG_CLEANER_MIN_CLEAN_RATIO_PROP, DOUBLE, LogConfig.DEFAULT_MIN_CLEANABLE_DIRTY_RATIO, between(0, 1), MEDIUM, CleanerConfig.LOG_CLEANER_MIN_CLEAN_RATIO_DOC)
+        .define(CleanerConfig.LOG_CLEANER_ENABLE_PROP, BOOLEAN, CleanerConfig.LOG_CLEANER_ENABLE, MEDIUM, CleanerConfig.LOG_CLEANER_ENABLE_DOC)
+        .define(CleanerConfig.LOG_CLEANER_DELETE_RETENTION_MS_PROP, LONG, LogConfig.DEFAULT_DELETE_RETENTION_MS, atLeast(0), MEDIUM, CleanerConfig.LOG_CLEANER_DELETE_RETENTION_MS_DOC)
+        .define(CleanerConfig.LOG_CLEANER_MIN_COMPACTION_LAG_MS_PROP, LONG, LogConfig.DEFAULT_MIN_COMPACTION_LAG_MS, atLeast(0), MEDIUM, CleanerConfig.LOG_CLEANER_MIN_COMPACTION_LAG_MS_DOC)
+        .define(CleanerConfig.LOG_CLEANER_MAX_COMPACTION_LAG_MS_PROP, LONG, LogConfig.DEFAULT_MAX_COMPACTION_LAG_MS, atLeast(1), MEDIUM, CleanerConfig.LOG_CLEANER_MAX_COMPACTION_LAG_MS_DOC)
+        .define(LOG_INDEX_SIZE_MAX_BYTES_PROP, INT, LogConfig.DEFAULT_SEGMENT_INDEX_BYTES, atLeast(4), MEDIUM, LOG_INDEX_SIZE_MAX_BYTES_DOC)
+        .define(LOG_INDEX_INTERVAL_BYTES_PROP, INT, LogConfig.DEFAULT_INDEX_INTERVAL_BYTES, atLeast(0), MEDIUM, LOG_INDEX_INTERVAL_BYTES_DOC)
+        .define(LOG_FLUSH_INTERVAL_MESSAGES_PROP, LONG, LogConfig.DEFAULT_FLUSH_MESSAGES_INTERVAL, atLeast(1), HIGH, LOG_FLUSH_INTERVAL_MESSAGES_DOC)
+        .define(LOG_DELETE_DELAY_MS_PROP, LONG, LogConfig.DEFAULT_FILE_DELETE_DELAY_MS, atLeast(0), HIGH, LOG_DELETE_DELAY_MS_DOC)
+        .define(LOG_FLUSH_SCHEDULER_INTERVAL_MS_PROP, LONG, LogConfig.DEFAULT_FLUSH_MS, HIGH, LOG_FLUSH_SCHEDULER_INTERVAL_MS_DOC)
+        .define(LOG_FLUSH_INTERVAL_MS_PROP, LONG, null, HIGH, LOG_FLUSH_INTERVAL_MS_DOC)
+        .define(LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS_PROP, INT, Defaults.LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS, atLeast(0), HIGH, LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS_DOC)
+        .define(LOG_FLUSH_START_OFFSET_CHECKPOINT_INTERVAL_MS_PROP, INT, Defaults.LOG_FLUSH_START_OFFSET_CHECKPOINT_INTERVAL_MS, atLeast(0), HIGH, LOG_FLUSH_START_OFFSET_CHECKPOINT_INTERVAL_MS_DOC)
+        .define(LOG_PRE_ALLOCATE_PROP, BOOLEAN, LogConfig.DEFAULT_PREALLOCATE, MEDIUM, LOG_PRE_ALLOCATE_ENABLE_DOC)
+        .define(NUM_RECOVERY_THREADS_PER_DATA_DIR_PROP, INT, Defaults.NUM_RECOVERY_THREADS_PER_DATA_DIR, atLeast(1), HIGH, NUM_RECOVERY_THREADS_PER_DATA_DIR_DOC)
+        .define(AUTO_CREATE_TOPICS_ENABLE_PROP, BOOLEAN, Defaults.AUTO_CREATE_TOPICS_ENABLE, HIGH, AUTO_CREATE_TOPICS_ENABLE_DOC)
+        .define(MIN_IN_SYNC_REPLICAS_PROP, INT, LogConfig.DEFAULT_MIN_IN_SYNC_REPLICAS, atLeast(1), HIGH, MIN_IN_SYNC_REPLICAS_DOC)
+        .define(LOG_MESSAGE_FORMAT_VERSION_PROP, STRING, LogConfig.DEFAULT_MESSAGE_FORMAT_VERSION, new MetadataVersionValidator(), MEDIUM, LOG_MESSAGE_FORMAT_VERSION_DOC)
+        .define(LOG_MESSAGE_TIMESTAMP_TYPE_PROP, STRING, LogConfig.DEFAULT_MESSAGE_TIMESTAMP_TYPE, ConfigDef.ValidString.in("CreateTime", "LogAppendTime"), MEDIUM, LOG_MESSAGE_TIMESTAMP_TYPE_DOC)
+        .define(LOG_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_PROP, LONG, LogConfig.DEFAULT_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS, atLeast(0), MEDIUM, LOG_MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_DOC)
+        .define(LOG_MESSAGE_TIMESTAMP_BEFORE_MAX_MS_PROP, LONG, LogConfig.DEFAULT_MESSAGE_TIMESTAMP_BEFORE_MAX_MS, atLeast(0), MEDIUM, LOG_MESSAGE_TIMESTAMP_BEFORE_MAX_MS_DOC)
+        .define(LOG_MESSAGE_TIMESTAMP_AFTER_MAX_MS_PROP, LONG, LogConfig.DEFAULT_MESSAGE_TIMESTAMP_AFTER_MAX_MS, atLeast(0), MEDIUM, LOG_MESSAGE_TIMESTAMP_AFTER_MAX_MS_DOC)
+        .define(CREATE_TOPIC_POLICY_CLASS_NAME_PROP, CLASS, null, LOW, CREATE_TOPIC_POLICY_CLASS_NAME_DOC)
+        .define(ALTER_CONFIG_POLICY_CLASS_NAME_PROP, CLASS, null, LOW, ALTER_CONFIG_POLICY_CLASS_NAME_DOC)
+        .define(LOG_MESSAGE_DOWN_CONVERSION_ENABLE_PROP, BOOLEAN, LogConfig.DEFAULT_MESSAGE_DOWNCONVERSION_ENABLE, LOW, LOG_MESSAGE_DOWN_CONVERSION_ENABLE_DOC)
+
+        /** ********* Replication configuration ***********/
+        .define(CONTROLLER_SOCKET_TIMEOUT_MS_PROP, INT, Defaults.CONTROLLER_SOCKET_TIMEOUT_MS, MEDIUM, CONTROLLER_SOCKET_TIMEOUT_MS_DOC)
+        .define(DEFAULT_REPLICATION_FACTOR_PROP, INT, Defaults.REPLICATION_FACTOR, MEDIUM, DEFAULT_REPLICATION_FACTOR_DOC)
+        .define(REPLICA_LAG_TIME_MAX_MS_PROP, LONG, Defaults.REPLICA_LAG_TIME_MAX_MS, HIGH, REPLICA_LAG_TIME_MAX_MS_DOC)
+        .define(REPLICA_SOCKET_TIMEOUT_MS_PROP, INT, Defaults.REPLICA_SOCKET_TIMEOUT_MS, HIGH, REPLICA_SOCKET_TIMEOUT_MS_DOC)
+        .define(REPLICA_SOCKET_RECEIVE_BUFFER_BYTES_PROP, INT, Defaults.REPLICA_SOCKET_RECEIVE_BUFFER_BYTES, HIGH, REPLICA_SOCKET_RECEIVE_BUFFER_BYTES_DOC)
+        .define(REPLICA_FETCH_MAX_BYTES_PROP, INT, Defaults.REPLICA_FETCH_MAX_BYTES, atLeast(0), MEDIUM, REPLICA_FETCH_MAX_BYTES_DOC)
+        .define(REPLICA_FETCH_WAIT_MAX_MS_PROP, INT, Defaults.REPLICA_FETCH_WAIT_MAX_MS, HIGH, REPLICA_FETCH_WAIT_MAX_MS_DOC)
+        .define(REPLICA_FETCH_BACKOFF_MS_PROP, INT, Defaults.REPLICA_FETCH_BACKOFF_MS, atLeast(0), MEDIUM, REPLICA_FETCH_BACKOFF_MS_DOC)
+        .define(REPLICA_FETCH_MIN_BYTES_PROP, INT, Defaults.REPLICA_FETCH_MIN_BYTES, HIGH, REPLICA_FETCH_MIN_BYTES_DOC)
+        .define(REPLICA_FETCH_RESPONSE_MAX_BYTES_PROP, INT, Defaults.REPLICA_FETCH_RESPONSE_MAX_BYTES, atLeast(0), MEDIUM, REPLICA_FETCH_RESPONSE_MAX_BYTES_DOC)
+        .define(NUM_REPLICA_FETCHERS_PROP, INT, Defaults.NUM_REPLICA_FETCHERS, HIGH, NUM_REPLICA_FETCHERS_DOC)
+        .define(REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS_PROP, LONG, Defaults.REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS, HIGH, REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS_DOC)
+        .define(FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS_PROP, INT, Defaults.FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS, MEDIUM, FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS_DOC)
+        .define(PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS_PROP, INT, Defaults.PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS, MEDIUM, PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS_DOC)
+        .define(DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS_PROP, INT, Defaults.DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS, MEDIUM, DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS_DOC)
+        .define(AUTO_LEADER_REBALANCE_ENABLE_PROP, BOOLEAN, Defaults.AUTO_LEADER_REBALANCE_ENABLE, HIGH, AUTO_LEADER_REBALANCE_ENABLE_DOC)
+        .define(LEADER_IMBALANCE_PER_BROKER_PERCENTAGE_PROP, INT, Defaults.LEADER_IMBALANCE_PER_BROKER_PERCENTAGE, HIGH, LEADER_IMBALANCE_PER_BROKER_PERCENTAGE_DOC)
+        .define(LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS_PROP, LONG, Defaults.LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS, atLeast(1), HIGH, LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS_DOC)
+        .define(UNCLEAN_LEADER_ELECTION_ENABLE_PROP, BOOLEAN, LogConfig.DEFAULT_UNCLEAN_LEADER_ELECTION_ENABLE, HIGH, UNCLEAN_LEADER_ELECTION_ENABLE_DOC)
+        .define(INTER_BROKER_SECURITY_PROTOCOL_PROP, STRING, Defaults.INTER_BROKER_SECURITY_PROTOCOL, ConfigDef.ValidString.in(Utils.enumOptions(SecurityProtocol.class)), MEDIUM, INTER_BROKER_SECURITY_PROTOCOL_DOC)
+        .define(INTER_BROKER_PROTOCOL_VERSION_PROP, STRING, Defaults.INTER_BROKER_PROTOCOL_VERSION, new MetadataVersionValidator(), MEDIUM, INTER_BROKER_PROTOCOL_VERSION_DOC)
+        .define(INTER_BROKER_LISTENER_NAME_PROP, STRING, null, MEDIUM, INTER_BROKER_LISTENER_NAME_DOC)
+        .define(REPLICA_SELECTOR_CLASS_PROP, STRING, null, MEDIUM, REPLICA_SELECTOR_CLASS_DOC)
+
+        /** ********* Controlled shutdown configuration ***********/
+        .define(CONTROLLED_SHUTDOWN_MAX_RETRIES_PROP, INT, Defaults.CONTROLLED_SHUTDOWN_MAX_RETRIES, MEDIUM, CONTROLLED_SHUTDOWN_MAX_RETRIES_DOC)
+        .define(CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS_PROP, LONG, Defaults.CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS, MEDIUM, CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS_DOC)
+        .define(CONTROLLED_SHUTDOWN_ENABLE_PROP, BOOLEAN, Defaults.CONTROLLED_SHUTDOWN_ENABLE, MEDIUM, CONTROLLED_SHUTDOWN_ENABLE_DOC)
+
+        /** ********* Group coordinator configuration ***********/
+        .define(GROUP_MIN_SESSION_TIMEOUT_MS_PROP, INT, Defaults.GROUP_MIN_SESSION_TIMEOUT_MS, MEDIUM, GROUP_MIN_SESSION_TIMEOUT_MS_DOC)
+        .define(GROUP_MAX_SESSION_TIMEOUT_MS_PROP, INT, Defaults.GROUP_MAX_SESSION_TIMEOUT_MS, MEDIUM, GROUP_MAX_SESSION_TIMEOUT_MS_DOC)
+        .define(GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, INT, Defaults.GROUP_INITIAL_REBALANCE_DELAY_MS, MEDIUM, GROUP_INITIAL_REBALANCE_DELAY_MS_DOC)
+        .define(GROUP_MAX_SIZE_PROP, INT, Defaults.GROUP_MAX_SIZE, atLeast(1), MEDIUM, GROUP_MAX_SIZE_DOC)
+
+        /** New group coordinator configs */
+        .define(GROUP_COORDINATOR_REBALANCE_PROTOCOLS_PROP, LIST, Defaults.GROUP_COORDINATOR_REBALANCE_PROTOCOLS, ConfigDef.ValidList.in(Utils.enumOptions(GroupType.class)), MEDIUM, GROUP_COORDINATOR_REBALANCE_PROTOCOLS_DOC)
+        .define(GROUP_COORDINATOR_NUM_THREADS_PROP, INT, Defaults.GROUP_COORDINATOR_NUM_THREADS, atLeast(1), MEDIUM, GROUP_COORDINATOR_NUM_THREADS_DOC)
+        // Internal configuration used by integration and system tests.
+        .defineInternal(NEW_GROUP_COORDINATOR_ENABLE_PROP, BOOLEAN, Defaults.NEW_GROUP_COORDINATOR_ENABLE, null, MEDIUM, NEW_GROUP_COORDINATOR_ENABLE_DOC)
+
+        /** Consumer groups configs */
+        .define(CONSUMER_GROUP_SESSION_TIMEOUT_MS_PROP, INT, Defaults.CONSUMER_GROUP_SESSION_TIMEOUT_MS, atLeast(1), MEDIUM, CONSUMER_GROUP_SESSION_TIMEOUT_MS_DOC)
+        .define(CONSUMER_GROUP_MIN_SESSION_TIMEOUT_MS_PROP, INT, Defaults.CONSUMER_GROUP_MIN_SESSION_TIMEOUT_MS, atLeast(1), MEDIUM, CONSUMER_GROUP_MIN_SESSION_TIMEOUT_MS_DOC)
+        .define(CONSUMER_GROUP_MAX_SESSION_TIMEOUT_MS_PROP, INT, Defaults.CONSUMER_GROUP_MAX_SESSION_TIMEOUT_MS, atLeast(1), MEDIUM, CONSUMER_GROUP_MAX_SESSION_TIMEOUT_MS_DOC)
+        .define(CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_PROP, INT, Defaults.CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS, atLeast(1), MEDIUM, CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_DOC)
+        .define(CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_PROP, INT, Defaults.CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS, atLeast(1), MEDIUM, CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_DOC)
+        .define(CONSUMER_GROUP_MAX_HEARTBEAT_INTERVAL_MS_PROP, INT, Defaults.CONSUMER_GROUP_MAX_HEARTBEAT_INTERVAL_MS, atLeast(1), MEDIUM, CONSUMER_GROUP_MAX_HEARTBEAT_INTERVAL_MS_DOC)
+        .define(CONSUMER_GROUP_MAX_SIZE_PROP, INT, Defaults.CONSUMER_GROUP_MAX_SIZE, atLeast(1), MEDIUM, CONSUMER_GROUP_MAX_SIZE_DOC)
+        .define(CONSUMER_GROUP_ASSIGNORS_PROP, LIST, Defaults.CONSUMER_GROUP_ASSIGNORS, null, MEDIUM, CONSUMER_GROUP_ASSIGNORS_DOC)
+
+        /** ********* Offset management configuration ***********/
+        .define(OFFSET_METADATA_MAX_SIZE_PROP, INT, Defaults.OFFSET_METADATA_MAX_SIZE, HIGH, OFFSET_METADATA_MAX_SIZE_DOC)
+        .define(OFFSETS_LOAD_BUFFER_SIZE_PROP, INT, Defaults.OFFSETS_LOAD_BUFFER_SIZE, atLeast(1), HIGH, OFFSETS_LOAD_BUFFER_SIZE_DOC)
+        .define(OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, SHORT, Defaults.OFFSETS_TOPIC_REPLICATION_FACTOR, atLeast(1), HIGH, OFFSETS_TOPIC_REPLICATION_FACTOR_DOC)
+        .define(OFFSETS_TOPIC_PARTITIONS_PROP, INT, Defaults.OFFSETS_TOPIC_PARTITIONS, atLeast(1), HIGH, OFFSETS_TOPIC_PARTITIONS_DOC)
+        .define(OFFSETS_TOPIC_SEGMENT_BYTES_PROP, INT, Defaults.OFFSETS_TOPIC_SEGMENT_BYTES, atLeast(1), HIGH, OFFSETS_TOPIC_SEGMENT_BYTES_DOC)
+        .define(OFFSETS_TOPIC_COMPRESSION_CODEC_PROP, INT, Defaults.OFFSETS_TOPIC_COMPRESSION_CODEC, HIGH, OFFSETS_TOPIC_COMPRESSION_CODEC_DOC)
+        .define(OFFSETS_RETENTION_MINUTES_PROP, INT, Defaults.OFFSETS_RETENTION_MINUTES, atLeast(1), HIGH, OFFSETS_RETENTION_MINUTES_DOC)
+        .define(OFFSETS_RETENTION_CHECK_INTERVAL_MS_PROP, LONG, Defaults.OFFSETS_RETENTION_CHECK_INTERVAL_MS, atLeast(1), HIGH, OFFSETS_RETENTION_CHECK_INTERVAL_MS_DOC)
+        .define(OFFSET_COMMIT_TIMEOUT_MS_PROP, INT, Defaults.OFFSET_COMMIT_TIMEOUT_MS, atLeast(1), HIGH, OFFSET_COMMIT_TIMEOUT_MS_DOC)
+        .define(OFFSET_COMMIT_REQUIRED_ACKS_PROP, SHORT, Defaults.OFFSET_COMMIT_REQUIRED_ACKS, HIGH, OFFSET_COMMIT_REQUIRED_ACKS_DOC)
+        .define(DELETE_TOPIC_ENABLE_PROP, BOOLEAN, Defaults.DELETE_TOPIC_ENABLE, HIGH, DELETE_TOPIC_ENABLE_DOC)
+        .define(COMPRESSION_TYPE_PROP, STRING, LogConfig.DEFAULT_COMPRESSION_TYPE, ConfigDef.ValidString.in(BrokerCompressionType.names().toArray(new String[0])), HIGH, COMPRESSION_TYPE_DOC)
+
+        /** ********* Transaction management configuration ***********/
+        .define(TRANSACTIONAL_ID_EXPIRATION_MS_PROP, INT, Defaults.TRANSACTIONAL_ID_EXPIRATION_MS, atLeast(1), HIGH, TRANSACTIONAL_ID_EXPIRATION_MS_DOC)
+        .define(TRANSACTIONS_MAX_TIMEOUT_MS_PROP, INT, Defaults.TRANSACTIONS_MAX_TIMEOUT_MS, atLeast(1), HIGH, TRANSACTIONS_MAX_TIMEOUT_MS_DOC)
+        .define(TRANSACTIONS_TOPIC_MIN_ISR_PROP, INT, Defaults.TRANSACTIONS_TOPIC_MIN_ISR, atLeast(1), HIGH, TRANSACTIONS_TOPIC_MIN_ISR_DOC)
+        .define(TRANSACTIONS_LOAD_BUFFER_SIZE_PROP, INT, Defaults.TRANSACTIONS_LOAD_BUFFER_SIZE, atLeast(1), HIGH, TRANSACTIONS_LOAD_BUFFER_SIZE_DOC)
+        .define(TRANSACTIONS_TOPIC_REPLICATION_FACTOR_PROP, SHORT, Defaults.TRANSACTIONS_TOPIC_REPLICATION_FACTOR, atLeast(1), HIGH, TRANSACTIONS_TOPIC_REPLICATION_FACTOR_DOC)
+        .define(TRANSACTIONS_TOPIC_PARTITIONS_PROP, INT, Defaults.TRANSACTIONS_TOPIC_PARTITIONS, atLeast(1), HIGH, TRANSACTIONS_TOPIC_PARTITIONS_DOC)
+        .define(TRANSACTIONS_TOPIC_SEGMENT_BYTES_PROP, INT, Defaults.TRANSACTIONS_TOPIC_SEGMENT_BYTES, atLeast(1), HIGH, TRANSACTIONS_TOPIC_SEGMENT_BYTES_DOC)
+        .define(TRANSACTIONS_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS_PROP, INT, Defaults.TRANSACTIONS_ABORT_TIMED_OUT_CLEANUP_INTERVAL_MS, atLeast(1), LOW, TRANSACTIONS_ABORT_TIMED_OUT_TRANSACTIONS_INTERVAL_MS_DOC)
+        .define(TRANSACTIONS_REMOVE_EXPIRED_TRANSACTIONAL_ID_CLEANUP_INTERVAL_MS_PROP, INT, Defaults.TRANSACTIONS_REMOVE_EXPIRED_CLEANUP_INTERVAL_MS, atLeast(1), LOW, TRANSACTIONS_REMOVE_EXPIRED_TRANSACTIONS_INTERVAL_MS_DOC)
+
+        .define(TRANSACTION_PARTITION_VERIFICATION_ENABLE_PROP, BOOLEAN, Defaults.TRANSACTION_PARTITION_VERIFICATION_ENABLE, LOW, TRANSACTION_PARTITION_VERIFICATION_ENABLE_DOC)
+
+        .define(PRODUCER_ID_EXPIRATION_MS_PROP, INT, Defaults.PRODUCER_ID_EXPIRATION_MS, atLeast(1), LOW, PRODUCER_ID_EXPIRATION_MS_DOC)
+        // Configuration for testing only as default value should be sufficient for typical usage
+        .defineInternal(PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS_PROP, INT, Defaults.PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS, atLeast(1), LOW, PRODUCER_ID_EXPIRATION_CHECK_INTERVAL_MS_DOC)
+
+        /** ********* Fetch Configuration **************/
+        .define(MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS_PROP, INT, Defaults.MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS, atLeast(0), MEDIUM, MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS_DOC)
+        .define(FETCH_MAX_BYTES_PROP, INT, Defaults.FETCH_MAX_BYTES, atLeast(1024), MEDIUM, FETCH_MAX_BYTES_DOC)
+
+        /** ********* Request Limit Configuration ***********/
+        .define(MAX_REQUEST_PARTITION_SIZE_LIMIT_PROP, INT, Defaults.MAX_REQUEST_PARTITION_SIZE_LIMIT, atLeast(1), MEDIUM, MAX_REQUEST_PARTITION_SIZE_LIMIT_DOC)
+
+        /** ********* Kafka Metrics Configuration ***********/
+        .define(METRIC_NUM_SAMPLES_PROP, INT, Defaults.METRIC_NUM_SAMPLES, atLeast(1), LOW, METRIC_NUM_SAMPLES_DOC)
+        .define(METRIC_SAMPLE_WINDOW_MS_PROP, LONG, Defaults.METRIC_SAMPLE_WINDOW_MS, atLeast(1), LOW, METRIC_SAMPLE_WINDOW_MS_DOC)
+        .define(METRIC_REPORTER_CLASSES_PROP, LIST, Defaults.METRIC_REPORTER_CLASSES, LOW, METRIC_REPORTER_CLASSES_DOC)
+        .define(METRIC_RECORDING_LEVEL_PROP, STRING, Defaults.METRIC_RECORDING_LEVEL, LOW, METRICS_RECORDING_LEVEL_DOC)
+        .define(AUTO_INCLUDE_JMX_REPORTER_PROP, BOOLEAN, Defaults.AUTO_INCLUDE_JMX_REPORTER, LOW, AUTO_INCLUDE_JMX_REPORTER_DOC)
+
+        /** ********* Kafka Yammer Metrics Reporter Configuration for docs ***********/
+        .define(KAFKA_METRICS_REPORTER_CLASSES_PROP, LIST, Defaults.KAFKA_METRIC_REPORTER_CLASSES, LOW, KAFKA_METRICS_REPORTER_CLASSES_DOC)
+        .define(KAFKA_METRICS_POLLING_INTERVAL_SECONDS_PROP, INT, Defaults.KAFKA_METRICS_POLLING_INTERVAL_SECONDS, atLeast(1), LOW, KAFKA_METRICS_POLLING_INTERVAL_SECONDS_DOC)
+
+        /** ********* Kafka Client Telemetry Metrics Configuration ***********/
+        .define(CLIENT_TELEMETRY_MAX_BYTES_PROP, INT, Defaults.CLIENT_TELEMETRY_MAX_BYTES, atLeast(1), LOW, CLIENT_TELEMETRY_MAX_BYTES_DOC)
+
+        /** ********* Quota configuration ***********/
+        .define(NUM_QUOTA_SAMPLES_PROP, INT, Defaults.NUM_QUOTA_SAMPLES, atLeast(1), LOW, NUM_QUOTA_SAMPLES_DOC)
+        .define(NUM_REPLICATION_QUOTA_SAMPLES_PROP, INT, Defaults.NUM_REPLICATION_QUOTA_SAMPLES, atLeast(1), LOW, NUM_REPLICATION_QUOTA_SAMPLES_DOC)
+        .define(NUM_ALTER_LOG_DIRS_REPLICATION_QUOTA_SAMPLES_PROP, INT, Defaults.NUM_ALTER_LOG_DIRS_REPLICATION_QUOTA_SAMPLES, atLeast(1), LOW, NUM_ALTER_LOG_DIRS_REPLICATION_QUOTA_SAMPLES_DOC)
+        .define(NUM_CONTROLLER_QUOTA_SAMPLES_PROP, INT, Defaults.NUM_CONTROLLER_QUOTA_SAMPLES, atLeast(1), LOW, NUM_CONTROLLER_QUOTA_SAMPLES_DOC)
+        .define(QUOTA_WINDOW_SIZE_SECONDS_PROP, INT, Defaults.QUOTA_WINDOW_SIZE_SECONDS, atLeast(1), LOW, QUOTA_WINDOW_SIZE_SECONDS_DOC)
+        .define(REPLICATION_QUOTA_WINDOW_SIZE_SECONDS_PROP, INT, Defaults.REPLICATION_QUOTA_WINDOW_SIZE_SECONDS, atLeast(1), LOW, REPLICATION_QUOTA_WINDOW_SIZE_SECONDS_DOC)
+        .define(ALTER_LOG_DIRS_REPLICATION_QUOTA_WINDOW_SIZE_SECONDS_PROP, INT, Defaults.ALTER_LOG_DIRS_REPLICATION_QUOTA_WINDOW_SIZE_SECONDS, atLeast(1), LOW, ALTER_LOG_DIRS_REPLICATION_QUOTA_WINDOW_SIZE_SECONDS_DOC)
+        .define(CONTROLLER_QUOTA_WINDOW_SIZE_SECONDS_PROP, INT, Defaults.CONTROLLER_QUOTA_WINDOW_SIZE_SECONDS, atLeast(1), LOW, CONTROLLER_QUOTA_WINDOW_SIZE_SECONDS_DOC)
+        .define(CLIENT_QUOTA_CALLBACK_CLASS_PROP, CLASS, null, LOW, CLIENT_QUOTA_CALLBACK_CLASS_DOC)
+
+        /** ********* General Security Configuration ****************/
+        .define(CONNECTIONS_MAX_REAUTH_MS_PROP, LONG, Defaults.CONNECTIONS_MAX_REAUTH_MS, MEDIUM, CONNECTIONS_MAX_REAUTH_MS_DOC)
+        .define(SASL_SERVER_MAX_RECEIVE_SIZE_PROP, INT, Defaults.SERVER_MAX_RECEIVE_SIZE, MEDIUM, SASL_SERVER_MAX_RECEIVE_SIZE_DOC)
+        .define(SECURITY_PROVIDER_CLASS_PROP, STRING, null, LOW, SECURITY_PROVIDERS_DOC)
+
+        /** ********* SSL Configuration ****************/
+        .define(PRINCIPAL_BUILDER_CLASS_PROP, CLASS, Defaults.PRINCIPAL_BUILDER, MEDIUM, PRINCIPAL_BUILDER_CLASS_DOC)
+        .define(SSL_PROTOCOL_PROP, STRING, Defaults.SSL_PROTOCOL, MEDIUM, SSL_PROTOCOL_DOC)
+        .define(SSL_PROVIDER_PROP, STRING, null, MEDIUM, SSL_PROVIDER_DOC)
+        .define(SSL_ENABLED_PROTOCOLS_PROP, LIST, Defaults.SSL_ENABLED_PROTOCOLS, MEDIUM, SSL_ENABLED_PROTOCOLS_DOC)
+        .define(SSL_KEYSTORE_TYPE_PROP, STRING, Defaults.SSL_KEYSTORE_TYPE, MEDIUM, SSL_KEYSTORE_TYPE_DOC)
+        .define(SSL_KEYSTORE_LOCATION_PROP, STRING, null, MEDIUM, SSL_KEYSTORE_LOCATION_DOC)
+        .define(SSL_KEYSTORE_PASSWORD_PROP, PASSWORD, null, MEDIUM, SSL_KEYSTORE_PASSWORD_DOC)
+        .define(SSL_KEY_PASSWORD_PROP, PASSWORD, null, MEDIUM, SSL_KEY_PASSWORD_DOC)
+        .define(SSL_KEYSTORE_KEY_PROP, PASSWORD, null, MEDIUM, SSL_KEYSTORE_KEY_DOC)
+        .define(SSL_KEYSTORE_CERTIFICATE_CHAIN_PROP, PASSWORD, null, MEDIUM, SSL_KEYSTORE_CERTIFICATE_CHAIN_DOC)
+        .define(SSL_TRUSTSTORE_TYPE_PROP, STRING, Defaults.SSL_TRUSTSTORE_TYPE, MEDIUM, SSL_TRUSTSTORE_TYPE_DOC)
+        .define(SSL_TRUSTSTORE_LOCATION_PROP, STRING, null, MEDIUM, SSL_TRUSTSTORE_LOCATION_DOC)
+        .define(SSL_TRUSTSTORE_PASSWORD_PROP, PASSWORD, null, MEDIUM, SSL_TRUSTSTORE_PASSWORD_DOC)
+        .define(SSL_TRUSTSTORE_CERTIFICATES_PROP, PASSWORD, null, MEDIUM, SSL_TRUSTSTORE_CERTIFICATES_DOC)
+        .define(SSL_KEY_MANAGER_ALGORITHM_PROP, STRING, Defaults.SSL_KEY_MANAGER_ALGORITHM, MEDIUM, SSL_KEYMANAGER_ALGORITHM_DOC)
+        .define(SSL_TRUST_MANAGER_ALGORITHM_PROP, STRING, Defaults.SSL_TRUST_MANAGER_ALGORITHM, MEDIUM, SSL_TRUSTMANAGER_ALGORITHM_DOC)
+        .define(SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP, STRING, Defaults.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, LOW, SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC)
+        .define(SSL_SECURE_RANDOM_IMPLEMENTATION_PROP, STRING, null, LOW, SSL_SECURE_RANDOM_IMPLEMENTATION_DOC)
+        .define(SSL_CLIENT_AUTH_PROP, STRING, Defaults.SSL_CLIENT_AUTHENTICATION, ConfigDef.ValidString.in(Defaults.SSL_CLIENT_AUTHENTICATION_VALID_VALUES), MEDIUM, SSL_CLIENT_AUTH_DOC)
+        .define(SSL_CIPHER_SUITES_PROP, LIST, Collections.emptyList(), MEDIUM, SSL_CIPHER_SUITES_DOC)
+        .define(SSL_PRINCIPAL_MAPPING_RULES_PROP, STRING, Defaults.SSL_PRINCIPAL_MAPPING_RULES, LOW, SSL_PRINCIPAL_MAPPING_RULES_DOC)
+        .define(SSL_ENGINE_FACTORY_CLASS_PROP, CLASS, null, LOW, SSL_ENGINE_FACTORY_CLASS_DOC)
+        .define(SSL_ALLOW_DN_CHANGES_PROP, BOOLEAN, BrokerSecurityConfigs.DEFAULT_SSL_ALLOW_DN_CHANGES_VALUE, LOW, SSL_ALLOW_DN_CHANGES_DOC)
+        .define(SSL_ALLOW_SAN_CHANGES_PROP, BOOLEAN, BrokerSecurityConfigs.DEFAULT_SSL_ALLOW_SAN_CHANGES_VALUE, LOW, SSL_ALLOW_SAN_CHANGES_DOC)
+
+        /** ********* Sasl Configuration ****************/
+        .define(SASL_MECHANISM_INTER_BROKER_PROTOCOL_PROP, STRING, Defaults.SASL_MECHANISM_INTER_BROKER_PROTOCOL, MEDIUM, SASL_MECHANISM_INTER_BROKER_PROTOCOL_DOC)
+        .define(SASL_JAAS_CONFIG_PROP, PASSWORD, null, MEDIUM, SASL_JAAS_CONFIG_DOC)
+        .define(SASL_ENABLED_MECHANISMS_PROP, LIST, Defaults.SASL_ENABLED_MECHANISMS, MEDIUM, SASL_ENABLED_MECHANISMS_DOC)
+        .define(SASL_SERVER_CALLBACK_HANDLER_CLASS_PROP, CLASS, null, MEDIUM, SASL_SERVER_CALLBACK_HANDLER_CLASS_DOC)
+        .define(SASL_CLIENT_CALLBACK_HANDLER_CLASS_PROP, CLASS, null, MEDIUM, SASL_CLIENT_CALLBACK_HANDLER_CLASS_DOC)
+        .define(SASL_LOGIN_CLASS_PROP, CLASS, null, MEDIUM, SASL_LOGIN_CLASS_DOC)
+        .define(SASL_LOGIN_CALLBACK_HANDLER_CLASS_PROP, CLASS, null, MEDIUM, SASL_LOGIN_CALLBACK_HANDLER_CLASS_DOC)
+        .define(SASL_KERBEROS_SERVICE_NAME_PROP, STRING, null, MEDIUM, SASL_KERBEROS_SERVICE_NAME_DOC)
+        .define(SASL_KERBEROS_KINIT_CMD_PROP, STRING, Defaults.SASL_KERBEROS_KINIT_CMD, MEDIUM, SASL_KERBEROS_KINIT_CMD_DOC)
+        .define(SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR_PROP, DOUBLE, Defaults.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR, MEDIUM, SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR_DOC)
+        .define(SASL_KERBEROS_TICKET_RENEW_JITTER_PROP, DOUBLE, Defaults.SASL_KERBEROS_TICKET_RENEW_JITTER, MEDIUM, SASL_KERBEROS_TICKET_RENEW_JITTER_DOC)
+        .define(SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN_PROP, LONG, Defaults.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN, MEDIUM, SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN_DOC)
+        .define(SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES_PROP, LIST, Defaults.SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES, MEDIUM, SASL_KERBEROS_PRINCIPAL_TO_LOCAL_RULES_DOC)
+        .define(SASL_LOGIN_REFRESH_WINDOW_FACTOR_PROP, DOUBLE, Defaults.SASL_LOGIN_REFRESH_WINDOW_FACTOR, MEDIUM, SASL_LOGIN_REFRESH_WINDOW_FACTOR_DOC)
+        .define(SASL_LOGIN_REFRESH_WINDOW_JITTER_PROP, DOUBLE, Defaults.SASL_LOGIN_REFRESH_WINDOW_JITTER, MEDIUM, SASL_LOGIN_REFRESH_WINDOW_JITTER_DOC)
+        .define(SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS_PROP, SHORT, Defaults.SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS, MEDIUM, SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS_DOC)
+        .define(SASL_LOGIN_REFRESH_BUFFER_SECONDS_PROP, SHORT, Defaults.SASL_LOGIN_REFRESH_BUFFER_SECONDS, MEDIUM, SASL_LOGIN_REFRESH_BUFFER_SECONDS_DOC)
+        .define(SASL_LOGIN_CONNECT_TIMEOUT_MS_PROP, INT, null, LOW, SASL_LOGIN_CONNECT_TIMEOUT_MS_DOC)
+        .define(SASL_LOGIN_READ_TIMEOUT_MS_PROP, INT, null, LOW, SASL_LOGIN_READ_TIMEOUT_MS_DOC)
+        .define(SASL_LOGIN_RETRY_BACKOFF_MAX_MS_PROP, LONG, Defaults.SASL_LOGIN_RETRY_BACKOFF_MAX_MS, LOW, SASL_LOGIN_RETRY_BACKOFF_MAX_MS_DOC)
+        .define(SASL_LOGIN_RETRY_BACKOFF_MS_PROP, LONG, Defaults.SASL_LOGIN_RETRY_BACKOFF_MS, LOW, SASL_LOGIN_RETRY_BACKOFF_MS_DOC)
+        .define(SASL_O_AUTH_BEARER_SCOPE_CLAIM_NAME_PROP, STRING, Defaults.SASL_OAUTH_BEARER_SCOPE_CLAIM_NAME, LOW, SASL_OAUTHBEARER_SCOPE_CLAIM_NAME_DOC)
+        .define(SASL_O_AUTH_BEARER_SUB_CLAIM_NAME_PROP, STRING, Defaults.SASL_OAUTH_BEARER_SUB_CLAIM_NAME, LOW, SASL_OAUTHBEARER_SUB_CLAIM_NAME_DOC)
+        .define(SASL_O_AUTH_BEARER_TOKEN_ENDPOINT_URL_PROP, STRING, null, MEDIUM, SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL_DOC)
+        .define(SASL_O_AUTH_BEARER_JWKS_ENDPOINT_URL_PROP, STRING, null, MEDIUM, SASL_OAUTHBEARER_JWKS_ENDPOINT_URL_DOC)
+        .define(SASL_O_AUTH_BEARER_JWKS_ENDPOINT_REFRESH_MS_PROP, LONG, Defaults.SASL_OAUTH_BEARER_JWKS_ENDPOINT_REFRESH_MS, LOW, SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS_DOC)
+        .define(SASL_O_AUTH_BEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS_PROP, LONG, Defaults.SASL_OAUTH_BEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS, LOW, SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS_DOC)
+        .define(SASL_O_AUTH_BEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS_PROP, LONG, Defaults.SASL_OAUTH_BEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS, LOW, SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS_DOC)
+        .define(SASL_O_AUTH_BEARER_CLOCK_SKEW_SECONDS_PROP, INT, Defaults.SASL_OAUTH_BEARER_CLOCK_SKEW_SECONDS, LOW, SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS_DOC)
+        .define(SASL_O_AUTH_BEARER_EXPECTED_AUDIENCE_PROP, LIST, null, LOW, SASL_OAUTHBEARER_EXPECTED_AUDIENCE_DOC)
+        .define(SASL_O_AUTH_BEARER_EXPECTED_ISSUER_PROP, STRING, null, LOW, SASL_OAUTHBEARER_EXPECTED_ISSUER_DOC)
+
+        /** ********* Delegation Token Configuration ****************/
+        .define(DELEGATION_TOKEN_SECRET_KEY_ALIAS_PROP, PASSWORD, null, MEDIUM, DELEGATION_TOKEN_SECRET_KEY_ALIAS_DOC)
+        .define(DELEGATION_TOKEN_SECRET_KEY_PROP, PASSWORD, null, MEDIUM, DELEGATION_TOKEN_SECRET_KEY_DOC)
+        .define(DELEGATION_TOKEN_MAX_LIFE_TIME_PROP, LONG, Defaults.DELEGATION_TOKEN_MAX_LIFE_TIME_MS, atLeast(1), MEDIUM, DELEGATION_TOKEN_MAX_LIFE_TIME_DOC)
+        .define(DELEGATION_TOKEN_EXPIRY_TIME_MS_PROP, LONG, Defaults.DELEGATION_TOKEN_EXPIRY_TIME_MS, atLeast(1), MEDIUM, DELEGATION_TOKEN_EXPIRY_TIME_MS_DOC)
+        .define(DELEGATION_TOKEN_EXPIRY_CHECK_INTERVAL_MS_PROP, LONG, Defaults.DELEGATION_TOKEN_EXPIRY_CHECK_INTERVAL_MS, atLeast(1), LOW, DELEGATION_TOKEN_EXPIRY_CHECK_INTERVAL_DOC)
+
+        /** ********* Password encryption configuration for dynamic configs *********/
+        .define(PASSWORD_ENCODER_SECRET_PROP, PASSWORD, null, MEDIUM, PASSWORD_ENCODER_SECRET_DOC)
+        .define(PASSWORD_ENCODER_OLD_SECRET_PROP, PASSWORD, null, MEDIUM, PASSWORD_ENCODER_OLD_SECRET_DOC)
+        .define(PASSWORD_ENCODER_KEY_FACTORY_ALGORITHM_PROP, STRING, null, LOW, PASSWORD_ENCODER_KEY_FACTORY_ALGORITHM_DOC)
+        .define(PASSWORD_ENCODER_CIPHER_ALGORITHM_PROP, STRING, Defaults.PASSWORD_ENCODER_CIPHER_ALGORITHM, LOW, PASSWORD_ENCODER_CIPHER_ALGORITHM_DOC)
+        .define(PASSWORD_ENCODER_KEY_LENGTH_PROP, INT, Defaults.PASSWORD_ENCODER_KEY_LENGTH, atLeast(8), LOW, PASSWORD_ENCODER_KEY_LENGTH_DOC)
+        .define(PASSWORD_ENCODER_ITERATIONS_PROP, INT, Defaults.PASSWORD_ENCODER_ITERATIONS, atLeast(1024), LOW, PASSWORD_ENCODER_ITERATIONS_DOC)
+
+        /** ********* Raft Quorum Configuration *********/
+        .define(RaftConfig.QUORUM_VOTERS_CONFIG, LIST, Defaults.QUORUM_VOTERS, new RaftConfig.ControllerQuorumVotersValidator(), HIGH, RaftConfig.QUORUM_VOTERS_DOC)
+        .define(RaftConfig.QUORUM_ELECTION_TIMEOUT_MS_CONFIG, INT, Defaults.QUORUM_ELECTION_TIMEOUT_MS, null, HIGH, RaftConfig.QUORUM_ELECTION_TIMEOUT_MS_DOC)
+        .define(RaftConfig.QUORUM_FETCH_TIMEOUT_MS_CONFIG, INT, Defaults.QUORUM_FETCH_TIMEOUT_MS, null, HIGH, RaftConfig.QUORUM_FETCH_TIMEOUT_MS_DOC)
+        .define(RaftConfig.QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG, INT, Defaults.QUORUM_ELECTION_BACKOFF_MS, null, HIGH, RaftConfig.QUORUM_ELECTION_BACKOFF_MAX_MS_DOC)
+        .define(RaftConfig.QUORUM_LINGER_MS_CONFIG, INT, Defaults.QUORUM_LINGER_MS, null, MEDIUM, RaftConfig.QUORUM_LINGER_MS_DOC)
+        .define(RaftConfig.QUORUM_REQUEST_TIMEOUT_MS_CONFIG, INT, Defaults.QUORUM_REQUEST_TIMEOUT_MS, null, MEDIUM, RaftConfig.QUORUM_REQUEST_TIMEOUT_MS_DOC)
+        .define(RaftConfig.QUORUM_RETRY_BACKOFF_MS_CONFIG, INT, Defaults.QUORUM_RETRY_BACKOFF_MS, null, LOW, RaftConfig.QUORUM_RETRY_BACKOFF_MS_DOC)
+        /** Internal Configurations **/
+        // This indicates whether unreleased APIs should be advertised by this node.
+        .defineInternal(UNSTABLE_API_VERSIONS_ENABLE_PROP, BOOLEAN, false, HIGH)
+        // This indicates whether unreleased MetadataVersions should be enabled on this node.
+        .defineInternal(UNSTABLE_METADATA_VERSIONS_ENABLE_PROP, BOOLEAN, false, HIGH);
+
+
+    public static List<String> configNames() {
+        return new ArrayList<>(CONFIG_DEF.names());
+    }
+
+    public static Map<String, Object> defaultValues() {
+        return CONFIG_DEF.defaultValues();
+    }
+
+    public static Map<String, ConfigDef.ConfigKey> configKeys() {
+        return CONFIG_DEF.configKeys();
+    }
+
+    static {
+        /** ********* Remote Log Management Configuration *********/
+        RemoteLogManagerConfig.CONFIG_DEF.configKeys().values().forEach(key -> CONFIG_DEF.define(key));
+    }
+
+    public static Optional<String> zooKeeperClientProperty(ZKClientConfig clientConfig, String kafkaPropName) {
+        return Optional.ofNullable(clientConfig.getProperty(ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(kafkaPropName)));
+    }
+
+    public static void setZooKeeperClientProperty(ZKClientConfig clientConfig, String kafkaPropName, Object kafkaPropValue) {
+        clientConfig.setProperty(ZK_SSL_CONFIG_TO_SYSTEM_PROPERTY_MAP.get(kafkaPropName),
+                (kafkaPropName.equals(ZK_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_PROP) && kafkaPropValue.toString().equalsIgnoreCase("HTTPS"))
+                        ? String.valueOf(kafkaPropValue.toString().equalsIgnoreCase("HTTPS"))
+                        : (kafkaPropName.equals(ZK_SSL_ENABLED_PROTOCOLS_PROP) || kafkaPropName.equals(ZK_SSL_CIPHER_SUITES_PROP))
+                        ? ((List<?>) kafkaPropValue).stream().map(Object::toString).collect(Collectors.joining(","))
+                        : kafkaPropValue.toString());
+    }
+
+    // For ZooKeeper TLS client authentication to be enabled, the client must (at a minimum)
+    // configure itself as using TLS with both a client connection socket and a key store location explicitly set.
+    public static boolean zkTlsClientAuthEnabled(ZKClientConfig zkClientConfig) {
+        return zooKeeperClientProperty(zkClientConfig, ZK_SSL_CLIENT_ENABLE_PROP).filter(value -> value.equals("true")).isPresent() &&
+                zooKeeperClientProperty(zkClientConfig, ZK_CLIENT_CNXN_SOCKET_PROP).isPresent() &&
+                zooKeeperClientProperty(zkClientConfig, ZK_SSL_KEYSTORE_LOCATION_PROP).isPresent();
+    }
+
+    public static Optional<ConfigDef.Type> configType(String configName) {
+        Optional<ConfigDef.Type> configType = configTypeExact(configName);
+        if (configType.isPresent()) {
+            return configType;
+        }
+
+        Optional<ConfigDef.Type> typeFromTypeOf = typeOf(configName);
+        if (typeFromTypeOf.isPresent()) {
+            return typeFromTypeOf;
+        }
+
+        return brokerConfigSynonyms(configName, true)
+                .stream()
+                .findFirst()
+                .flatMap(conf -> typeOf(conf));
+    }
+
+    private static Optional<ConfigDef.Type> configTypeExact(String exactName) {
+        return typeOf(exactName)
+                .map(Optional::of)
+                .orElseGet(() -> {
+                    Map<String, ConfigDef.ConfigKey> configKeys = BrokerDynamicConfigs.BROKER_CONFIG_DEF.configKeys();
+                    return Optional.ofNullable(configKeys.get(exactName)).map(key -> key.type);
+                });
+    }
+
+    private static Optional<ConfigDef.Type> typeOf(String name) {
+        Map<String, ConfigDef.ConfigKey> configKeys = CONFIG_DEF.configKeys();
+        return Optional.ofNullable(configKeys.get(name)).map(configKey -> configKey.type);
+    }
+
+    public static boolean maybeSensitive(Optional<ConfigDef.Type> configType) {
+        // If we can't determine the config entry type, treat it as a sensitive config to be safe
+        return !configType.isPresent() || configType.get().equals(ConfigDef.Type.PASSWORD);
+    }
+
+    public static String loggableValue(ConfigResource.Type resourceType, String name, String value) {
+        boolean maybeSensitive;
+        switch (resourceType) {
+            case BROKER:
+                maybeSensitive = maybeSensitive(configType(name));
+                break;
+            case TOPIC:
+                maybeSensitive = maybeSensitive(LogConfig.configType(name));
+                break;
+            case BROKER_LOGGER:
+                maybeSensitive = false;
+                break;
+            default:
+                maybeSensitive = true;
+        }
+
+        return maybeSensitive ? Password.HIDDEN : value;
+    }
+
+    /**
+     * Copy a configuration map, populating some keys that we want to treat as synonyms.
+     */
+    public static Map<Object, Object> populateSynonyms(Map<?, ?> input) {
+        Map<Object, Object> output = new HashMap<>(input);
+        Object brokerId = output.get(BROKER_ID_PROP);
+        Object nodeId = output.get(NODE_ID_PROP);
+
+        if (brokerId == null && nodeId != null) {
+            output.put(BROKER_ID_PROP, nodeId);
+        } else if (brokerId != null && nodeId == null) {
+            output.put(NODE_ID_PROP, brokerId);
+        }
+
+        return output;
+    }
+}

--- a/server/src/main/java/org/apache/kafka/server/config/dynamic/BrokerDynamicConfigs.java
+++ b/server/src/main/java/org/apache/kafka/server/config/dynamic/BrokerDynamicConfigs.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.config.dynamic;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.server.config.ReplicationQuotaManagerConfig;
+import org.apache.kafka.storage.internals.log.LogConfig;
+
+import static org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM;
+import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
+import static org.apache.kafka.common.config.ConfigDef.Type.LONG;
+
+public class BrokerDynamicConfigs {
+    // Properties
+    public final static String LEADER_REPLICATION_THROTTLED_RATE_PROP = "leader.replication.throttled.rate";
+    public final static String FOLLOWER_REPLICATION_THROTTLED_RATE_PROP = "follower.replication.throttled.rate";
+    public final static String REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_PROP = "replica.alter.log.dirs.io.max.bytes.per.second";
+
+    // Defaults
+    public final static long DEFAULT_REPLICATION_THROTTLED_RATE = ReplicationQuotaManagerConfig.DEFAULT_QUOTA_BYTES_PER_SECOND;
+
+    // Documentation
+    public final static String LEADER_REPLICATION_THROTTLED_RATE_DOC = "A long representing the upper bound (bytes/sec) on replication traffic for leaders enumerated in the " +
+            "property " + LogConfig.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG + " (for each topic). This property can be only set dynamically. It is suggested that the " +
+            "limit be kept above 1MB/s for accurate behaviour.";
+    public final static String FOLLOWER_REPLICATION_THROTTLED_RATE_DOC = "A long representing the upper bound (bytes/sec) on replication traffic for followers enumerated in the " +
+            "property " + LogConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG + " (for each topic). This property can be only set dynamically. It is suggested that the " +
+            "limit be kept above 1MB/s for accurate behaviour.";
+    public final static String REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_DOC = "A long representing the upper bound (bytes/sec) on disk IO used for moving replica between log directories on the same broker. " +
+            "This property can be only set dynamically. It is suggested that the limit be kept above 1MB/s for accurate behaviour.";
+
+    // Definitions
+    public final static ConfigDef BROKER_CONFIG_DEF = new ConfigDef()
+            // Round minimum value down, to make it easier for users.
+            .define(LEADER_REPLICATION_THROTTLED_RATE_PROP, LONG, DEFAULT_REPLICATION_THROTTLED_RATE, atLeast(0), MEDIUM, LEADER_REPLICATION_THROTTLED_RATE_DOC)
+            .define(FOLLOWER_REPLICATION_THROTTLED_RATE_PROP, LONG, DEFAULT_REPLICATION_THROTTLED_RATE, atLeast(0), MEDIUM, FOLLOWER_REPLICATION_THROTTLED_RATE_DOC)
+            .define(REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_PROP, LONG, DEFAULT_REPLICATION_THROTTLED_RATE, atLeast(0), MEDIUM, REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_DOC);
+}

--- a/server/src/test/java/org/apache/kafka/server/config/DynamicBrokerConfigTest.java
+++ b/server/src/test/java/org/apache/kafka/server/config/DynamicBrokerConfigTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DynamicBrokerConfigTest {
+    @Test
+    public void testSynonyms() {
+        assertEquals(Arrays.asList("listener.name.secure.ssl.keystore.type", "ssl.keystore.type"),
+                DynamicBrokerConfig.brokerConfigSynonyms("listener.name.secure.ssl.keystore.type", true));
+        assertEquals(Arrays.asList("listener.name.sasl_ssl.plain.sasl.jaas.config", "sasl.jaas.config"),
+                DynamicBrokerConfig.brokerConfigSynonyms("listener.name.sasl_ssl.plain.sasl.jaas.config", true));
+        assertEquals(Arrays.asList("some.config"),
+                DynamicBrokerConfig.brokerConfigSynonyms("some.config",  true));
+        assertEquals(Arrays.asList(KafkaConfig.LOG_ROLL_TIME_MILLIS_PROP, KafkaConfig.LOG_ROLL_TIME_HOURS_PROP),
+                DynamicBrokerConfig.brokerConfigSynonyms(KafkaConfig.LOG_ROLL_TIME_MILLIS_PROP,  true));
+    }
+
+}

--- a/server/src/test/java/org/apache/kafka/server/config/KafkaConfigTest.java
+++ b/server/src/test/java/org/apache/kafka/server/config/KafkaConfigTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KafkaConfigTest {
+    @Test
+    public void testPopulateSynonymsOnEmptyMap() {
+        assertEquals(Collections.emptyMap(), KafkaConfig.populateSynonyms(Collections.emptyMap()));
+    }
+
+    @Test
+    public void testPopulateSynonymsOnMapWithoutNodeId() {
+        Map<String, String> input =  new HashMap<>();
+        input.put(KafkaConfig.BROKER_ID_PROP, "4");
+        Map<String, String>  expectedOutput = new HashMap<>();
+        expectedOutput.put(KafkaConfig.BROKER_ID_PROP, "4");
+        expectedOutput.put(KafkaConfig.NODE_ID_PROP, "4");
+        assertEquals(expectedOutput, KafkaConfig.populateSynonyms(input));
+    }
+
+    @Test
+    public void testPopulateSynonymsOnMapWithoutBrokerId() {
+        Map<String, String> input =  new HashMap<>();
+        input.put(KafkaConfig.NODE_ID_PROP, "4");
+        Map<String, String> expectedOutput = new HashMap<>();
+        expectedOutput.put(KafkaConfig.BROKER_ID_PROP, "4");
+        expectedOutput.put(KafkaConfig.NODE_ID_PROP, "4");
+        assertEquals(expectedOutput, KafkaConfig.populateSynonyms(input));
+    }
+
+}

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestHarness.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestHarness.java
@@ -19,7 +19,6 @@ package org.apache.kafka.tiered.storage;
 import kafka.api.IntegrationTestHarness;
 import kafka.log.remote.RemoteLogManager;
 import kafka.server.KafkaBroker;
-import kafka.server.KafkaConfig;
 import org.apache.kafka.common.replica.ReplicaSelector;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager;
@@ -45,6 +44,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.server.config.KafkaConfig.REPLICA_SELECTOR_CLASS_PROP;
 import static org.apache.kafka.tiered.storage.utils.TieredStorageTestUtils.STORAGE_WAIT_TIMEOUT_SEC;
 import static org.apache.kafka.tiered.storage.utils.TieredStorageTestUtils.createPropsForRemoteStorage;
 
@@ -82,7 +82,7 @@ public abstract class TieredStorageTestHarness extends IntegrationTestHarness {
         Properties overridingProps = createPropsForRemoteStorage(testClassName, storageDirPath, brokerCount(),
                 numRemoteLogMetadataPartitions(), new Properties());
         readReplicaSelectorClass()
-                .ifPresent(c -> overridingProps.put(KafkaConfig.ReplicaSelectorClassProp(), c.getName()));
+                .ifPresent(c -> overridingProps.put(REPLICA_SELECTOR_CLASS_PROP, c.getName()));
         return overridingProps;
     }
 

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/utils/TieredStorageTestUtils.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/utils/TieredStorageTestUtils.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.tiered.storage.utils;
 
-import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.TopicConfig;
@@ -39,6 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.server.config.KafkaConfig.LOG_CLEANUP_INTERVAL_MS_PROP;
 import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_INITIALIZATION_RETRY_INTERVAL_MS_PROP;
 import static org.apache.kafka.server.log.remote.storage.LocalTieredStorage.DELETE_ON_CLOSE_CONFIG;
 import static org.apache.kafka.server.log.remote.storage.LocalTieredStorage.STORAGE_DIR_CONFIG;
@@ -137,7 +137,7 @@ public class TieredStorageTestUtils {
         // the integration tests can confirm a given log segment is present only in the second-tier storage.
         // Note that this does not impact the eligibility of a log segment to be offloaded to the
         // second-tier storage.
-        overridingProps.setProperty(KafkaConfig.LogCleanupIntervalMsProp(), LOG_CLEANUP_INTERVAL_MS.toString());
+        overridingProps.setProperty(LOG_CLEANUP_INTERVAL_MS_PROP, LOG_CLEANUP_INTERVAL_MS.toString());
         // The directory of the second-tier storage needs to be constant across all instances of storage managers
         // in every broker and throughout the test. Indeed, as brokers are restarted during the test.
         // You can override this property with a fixed path of your choice if you wish to use a non-temporary

--- a/streams/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.integration;
 
 import java.util.stream.Stream;
-import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -74,6 +73,7 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.server.config.KafkaConfig.RACK_PROP;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -85,13 +85,13 @@ public class HighAvailabilityTaskAssignorIntegrationTest {
         new Properties(),
         asList(
             new Properties() {{
-                    setProperty(KafkaConfig.RackProp(), AssignmentTestUtils.RACK_0);
+                    setProperty(RACK_PROP, AssignmentTestUtils.RACK_0);
                 }},
             new Properties() {{
-                    setProperty(KafkaConfig.RackProp(), AssignmentTestUtils.RACK_1);
+                    setProperty(RACK_PROP, AssignmentTestUtils.RACK_1);
                 }},
             new Properties() {{
-                    setProperty(KafkaConfig.RackProp(), AssignmentTestUtils.RACK_2);
+                    setProperty(RACK_PROP, AssignmentTestUtils.RACK_2);
                 }}
         )
     );

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsCloseOptionsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsCloseOptionsIntegrationTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.integration;
 
-import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -58,6 +57,7 @@ import java.util.List;
 import java.util.Properties;
 
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForEmptyConsumerGroup;
+import static org.apache.kafka.server.config.KafkaConfig.GROUP_MAX_SESSION_TIMEOUT_MS_PROP;
 
 @Category({IntegrationTest.class})
 public class KafkaStreamsCloseOptionsIntegrationTest {
@@ -84,7 +84,7 @@ public class KafkaStreamsCloseOptionsIntegrationTest {
 
     static {
         final Properties brokerProps = new Properties();
-        brokerProps.setProperty(KafkaConfig.GroupMaxSessionTimeoutMsProp(), Integer.toString(Integer.MAX_VALUE));
+        brokerProps.setProperty(GROUP_MAX_SESSION_TIMEOUT_MS_PROP, Integer.toString(Integer.MAX_VALUE));
         CLUSTER = new EmbeddedKafkaCluster(1, brokerProps);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.integration;
 
-import kafka.server.KafkaConfig$;
 import org.apache.kafka.tools.StreamsResetter;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -50,6 +49,7 @@ import java.util.Properties;
 
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.isEmptyConsumerGroup;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForEmptyConsumerGroup;
+import static org.apache.kafka.server.config.KafkaConfig.CONNECTIONS_MAX_IDLE_MS_PROP;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -69,7 +69,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         // we double the value passed to `time.sleep` in each iteration in one of the map functions, so we disable
         // expiration of connections by the brokers to avoid errors when `AdminClient` sends requests after potentially
         // very long sleep times
-        brokerProps.put(KafkaConfig$.MODULE$.ConnectionsMaxIdleMsProp(), -1L);
+        brokerProps.put(CONNECTIONS_MAX_IDLE_MS_PROP, -1L);
         CLUSTER = new EmbeddedKafkaCluster(1, brokerProps);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.integration;
 
-import kafka.server.KafkaConfig$;
 import org.apache.kafka.common.network.Mode;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.test.IntegrationTest;
@@ -27,6 +26,9 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
+import static org.apache.kafka.server.config.KafkaConfig.CONNECTIONS_MAX_IDLE_MS_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.LISTENERS_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_LISTENER_NAME_PROP;
 
 import java.io.IOException;
 import java.util.Map;
@@ -47,13 +49,13 @@ public class ResetIntegrationWithSslTest extends AbstractResetIntegrationTest {
         // we double the value passed to `time.sleep` in each iteration in one of the map functions, so we disable
         // expiration of connections by the brokers to avoid errors when `AdminClient` sends requests after potentially
         // very long sleep times
-        brokerProps.put(KafkaConfig$.MODULE$.ConnectionsMaxIdleMsProp(), -1L);
+        brokerProps.put(CONNECTIONS_MAX_IDLE_MS_PROP, -1L);
 
         try {
             SSL_CONFIG = TestSslUtils.createSslConfig(false, true, Mode.SERVER, TestUtils.tempFile(), "testCert");
 
-            brokerProps.put(KafkaConfig$.MODULE$.ListenersProp(), "SSL://localhost:0");
-            brokerProps.put(KafkaConfig$.MODULE$.InterBrokerListenerNameProp(), "SSL");
+            brokerProps.put(LISTENERS_PROP, "SSL://localhost:0");
+            brokerProps.put(INTER_BROKER_LISTENER_NAME_PROP, "SSL");
             brokerProps.putAll(SSL_CONFIG);
         } catch (final Exception e) {
             throw new RuntimeException(e);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/EmbeddedKafkaCluster.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/EmbeddedKafkaCluster.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.integration.utils;
 
-import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
 import kafka.zk.EmbeddedZookeeper;
 import org.apache.kafka.clients.admin.Admin;
@@ -27,6 +26,7 @@ import org.apache.kafka.server.util.MockTime;
 import org.apache.kafka.storage.internals.log.CleanerConfig;
 import org.apache.kafka.test.TestCondition;
 import org.apache.kafka.test.TestUtils;
+import org.apache.kafka.server.config.KafkaConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,20 +109,20 @@ public class EmbeddedKafkaCluster {
         zookeeper = new EmbeddedZookeeper();
         log.debug("ZooKeeper instance is running at {}", zKConnectString());
 
-        brokerConfig.put(KafkaConfig.ZkConnectProp(), zKConnectString());
-        putIfAbsent(brokerConfig, KafkaConfig.ListenersProp(), "PLAINTEXT://localhost:" + DEFAULT_BROKER_PORT);
-        putIfAbsent(brokerConfig, KafkaConfig.DeleteTopicEnableProp(), true);
+        brokerConfig.put(KafkaConfig.ZK_CONNECT_PROP, zKConnectString());
+        putIfAbsent(brokerConfig, KafkaConfig.LISTENERS_PROP, "PLAINTEXT://localhost:" + DEFAULT_BROKER_PORT);
+        putIfAbsent(brokerConfig, KafkaConfig.DELETE_TOPIC_ENABLE_PROP, true);
         putIfAbsent(brokerConfig, CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE_PROP, 2 * 1024 * 1024L);
-        putIfAbsent(brokerConfig, KafkaConfig.GroupMinSessionTimeoutMsProp(), 0);
-        putIfAbsent(brokerConfig, KafkaConfig.GroupInitialRebalanceDelayMsProp(), 0);
-        putIfAbsent(brokerConfig, KafkaConfig.OffsetsTopicReplicationFactorProp(), (short) 1);
-        putIfAbsent(brokerConfig, KafkaConfig.OffsetsTopicPartitionsProp(), 5);
-        putIfAbsent(brokerConfig, KafkaConfig.TransactionsTopicPartitionsProp(), 5);
-        putIfAbsent(brokerConfig, KafkaConfig.AutoCreateTopicsEnableProp(), true);
+        putIfAbsent(brokerConfig, KafkaConfig.GROUP_MIN_SESSION_TIMEOUT_MS_PROP, 0);
+        putIfAbsent(brokerConfig, KafkaConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_PROP, 0);
+        putIfAbsent(brokerConfig, KafkaConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_PROP, (short) 1);
+        putIfAbsent(brokerConfig, KafkaConfig.OFFSETS_TOPIC_PARTITIONS_PROP, 5);
+        putIfAbsent(brokerConfig, KafkaConfig.TRANSACTIONS_TOPIC_PARTITIONS_PROP, 5);
+        putIfAbsent(brokerConfig, KafkaConfig.AUTO_CREATE_TOPICS_ENABLE_PROP, true);
 
         for (int i = 0; i < brokers.length; i++) {
-            brokerConfig.put(KafkaConfig.BrokerIdProp(), i);
-            log.debug("Starting a Kafka instance on {} ...", brokerConfig.get(KafkaConfig.ListenersProp()));
+            brokerConfig.put(KafkaConfig.BROKER_ID_PROP, i);
+            log.debug("Starting a Kafka instance on {} ...", brokerConfig.get(KafkaConfig.LISTENERS_PROP));
 
             final Properties effectiveConfig = new Properties();
             effectiveConfig.putAll(brokerConfig);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/KafkaEmbedded.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/KafkaEmbedded.java
@@ -39,6 +39,15 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
+import static org.apache.kafka.server.config.KafkaConfig.AUTO_CREATE_TOPICS_ENABLE_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.BROKER_ID_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.CONTROLLED_SHUTDOWN_ENABLE_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.LOG_DIR_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.MESSAGE_MAX_BYTES_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.NUM_PARTITIONS_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.ZK_SESSION_TIMEOUT_MS_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.LISTENERS_PROP;
+
 /**
  * Runs an in-memory, "embedded" instance of a Kafka broker, which listens at `127.0.0.1:9092` by
  * default.
@@ -85,15 +94,15 @@ public class KafkaEmbedded {
      */
     private Properties effectiveConfigFrom(final Properties initialConfig) {
         final Properties effectiveConfig = new Properties();
-        effectiveConfig.put(KafkaConfig.BrokerIdProp(), 0);
-        effectiveConfig.put(KafkaConfig.NumPartitionsProp(), 1);
-        effectiveConfig.put(KafkaConfig.AutoCreateTopicsEnableProp(), true);
-        effectiveConfig.put(KafkaConfig.MessageMaxBytesProp(), 1000000);
-        effectiveConfig.put(KafkaConfig.ControlledShutdownEnableProp(), true);
-        effectiveConfig.put(KafkaConfig.ZkSessionTimeoutMsProp(), 10000);
+        effectiveConfig.put(BROKER_ID_PROP, 0);
+        effectiveConfig.put(NUM_PARTITIONS_PROP, 1);
+        effectiveConfig.put(AUTO_CREATE_TOPICS_ENABLE_PROP, true);
+        effectiveConfig.put(MESSAGE_MAX_BYTES_PROP, 1000000);
+        effectiveConfig.put(CONTROLLED_SHUTDOWN_ENABLE_PROP, true);
+        effectiveConfig.put(ZK_SESSION_TIMEOUT_MS_PROP, 10000);
 
         effectiveConfig.putAll(initialConfig);
-        effectiveConfig.setProperty(KafkaConfig.LogDirProp(), logDir.getAbsolutePath());
+        effectiveConfig.setProperty(LOG_DIR_PROP, logDir.getAbsolutePath());
         return effectiveConfig;
     }
 
@@ -185,7 +194,7 @@ public class KafkaEmbedded {
     public Admin createAdminClient() {
         final Properties adminClientConfig = new Properties();
         adminClientConfig.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList());
-        final Object listeners = effectiveConfig.get(KafkaConfig.ListenersProp());
+        final Object listeners = effectiveConfig.get(LISTENERS_PROP);
         if (listeners != null && listeners.toString().contains("SSL")) {
             adminClientConfig.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, effectiveConfig.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
             adminClientConfig.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, ((Password) effectiveConfig.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG)).value());

--- a/tools/src/test/java/org/apache/kafka/tools/ToolsTestUtils.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ToolsTestUtils.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.tools;
 
 import kafka.utils.TestInfoUtils;
-import kafka.server.DynamicConfig;
 import kafka.utils.TestUtils;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterConfigOp;
@@ -25,6 +24,7 @@ import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.server.config.dynamic.BrokerDynamicConfigs;
 import org.apache.kafka.storage.internals.log.LogConfig;
 
 import java.io.ByteArrayOutputStream;
@@ -132,9 +132,9 @@ public class ToolsTestUtils {
      */
     public static void throttleAllBrokersReplication(Admin adminClient, List<Integer> brokerIds, int throttleBytes) throws ExecutionException, InterruptedException {
         List<AlterConfigOp> throttleConfigs = new ArrayList<>();
-        throttleConfigs.add(new AlterConfigOp(new ConfigEntry(DynamicConfig.Broker$.MODULE$.LeaderReplicationThrottledRateProp(),
+        throttleConfigs.add(new AlterConfigOp(new ConfigEntry(BrokerDynamicConfigs.LEADER_REPLICATION_THROTTLED_RATE_PROP,
             Integer.toString(throttleBytes)), AlterConfigOp.OpType.SET));
-        throttleConfigs.add(new AlterConfigOp(new ConfigEntry(DynamicConfig.Broker$.MODULE$.FollowerReplicationThrottledRateProp(),
+        throttleConfigs.add(new AlterConfigOp(new ConfigEntry(BrokerDynamicConfigs.FOLLOWER_REPLICATION_THROTTLED_RATE_PROP,
             Integer.toString(throttleBytes)), AlterConfigOp.OpType.SET));
 
         Map<ConfigResource, Collection<AlterConfigOp>> configs = new HashMap<>();

--- a/tools/src/test/java/org/apache/kafka/tools/TopicCommandIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TopicCommandIntegrationTest.java
@@ -71,6 +71,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.kafka.server.config.KafkaConfig.REPLICA_FETCH_MAX_BYTES_PROP;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -116,7 +117,7 @@ public class TopicCommandIntegrationTest extends kafka.integration.KafkaServerTe
 
         List<KafkaConfig> configs = new ArrayList<>();
         for (Properties props : brokerConfigs) {
-            props.put(KafkaConfig.ReplicaFetchMaxBytesProp(), "1");
+            props.put(REPLICA_FETCH_MAX_BYTES_PROP, "1");
             configs.add(KafkaConfig.fromProps(props));
         }
         return JavaConverters.asScalaBuffer(configs).toSeq();

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommandTest.java
@@ -55,6 +55,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static org.apache.kafka.server.config.KafkaConfig.NEW_GROUP_COORDINATOR_ENABLE_PROP;
 public class ConsumerGroupCommandTest extends kafka.integration.KafkaServerTestHarness {
     public static final String TOPIC = "foo";
     public static final String GROUP = "test.group";
@@ -87,7 +88,7 @@ public class ConsumerGroupCommandTest extends kafka.integration.KafkaServerTestH
             0,
             false
         ).foreach(props -> {
-            props.setProperty(KafkaConfig.NewGroupCoordinatorEnableProp(), isNewGroupCoordinatorEnabled() + "");
+            props.setProperty(NEW_GROUP_COORDINATOR_ENABLE_PROP, isNewGroupCoordinatorEnabled() + "");
             cfgs.add(KafkaConfig.fromProps(props));
             return null;
         });

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsIntegrationTest.java
@@ -82,6 +82,11 @@ import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.BROKER_L
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.cancelAssignment;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.executeAssignment;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.verifyAssignment;
+import static org.apache.kafka.server.config.KafkaConfig.INTER_BROKER_PROTOCOL_VERSION_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.REPLICA_FETCH_BACKOFF_MS_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.AUTO_LEADER_REBALANCE_ENABLE_PROP;
+import static org.apache.kafka.server.config.KafkaConfig.REPLICA_LAG_TIME_MAX_MS_PROP;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -123,7 +128,7 @@ public class ReassignPartitionsIntegrationTest extends QuorumTestHarness {
         // the `AlterPartition` API. In this case, the controller will register individual
         // watches for each reassigning partition so that the reassignment can be
         // completed as soon as the ISR is expanded.
-        Map<String, String> configOverrides = Collections.singletonMap(KafkaConfig.InterBrokerProtocolVersionProp(), IBP_2_7_IV1.version());
+        Map<String, String> configOverrides = Collections.singletonMap(INTER_BROKER_PROTOCOL_VERSION_PROP, IBP_2_7_IV1.version());
         cluster = new ReassignPartitionsTestCluster(configOverrides, Collections.emptyMap());
         cluster.setup();
         executeAndVerifyReassignment();
@@ -143,7 +148,7 @@ public class ReassignPartitionsIntegrationTest extends QuorumTestHarness {
         // change notification delay
         ZkAlterPartitionManager.DefaultIsrPropagationConfig_$eq(new IsrChangePropagationConfig(500, 100, 500));
 
-        Map<String, String> oldIbpConfig = Collections.singletonMap(KafkaConfig.InterBrokerProtocolVersionProp(), IBP_2_7_IV1.version());
+        Map<String, String> oldIbpConfig = Collections.singletonMap(INTER_BROKER_PROTOCOL_VERSION_PROP, IBP_2_7_IV1.version());
         Map<Integer, Map<String, String>> brokerConfigOverrides = new HashMap<>();
         brokerConfigOverrides.put(1, oldIbpConfig);
         brokerConfigOverrides.put(2, oldIbpConfig);
@@ -794,10 +799,10 @@ public class ReassignPartitionsIntegrationTest extends QuorumTestHarness {
                     (short) 1,
                     false);
                 // shorter backoff to reduce test durations when no active partitions are eligible for fetching due to throttling
-                config.setProperty(KafkaConfig.ReplicaFetchBackoffMsProp(), "100");
+                config.setProperty(REPLICA_FETCH_BACKOFF_MS_PROP, "100");
                 // Don't move partition leaders automatically.
-                config.setProperty(KafkaConfig.AutoLeaderRebalanceEnableProp(), "false");
-                config.setProperty(KafkaConfig.ReplicaLagTimeMaxMsProp(), "1000");
+                config.setProperty(AUTO_LEADER_REBALANCE_ENABLE_PROP, "false");
+                config.setProperty(REPLICA_LAG_TIME_MAX_MS_PROP, "1000");
                 configOverrides.forEach(config::setProperty);
                 brokerConfigOverrides.getOrDefault(brokerId, Collections.emptyMap()).forEach(config::setProperty);
 


### PR DESCRIPTION
Moving KafkaConfig props out of core. The pr is big however it's mostly renaming the props to match Java constant patterns and switching to `org.apache.kafka.server.config.KafkaConfig` instead of the object companion `kafka.server.KafkaConfig`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
