### PR TITLE
KAFKA-16346: Fix flaky MetricsTest.testMetrics

### DIFF
--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -213,7 +213,8 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
     assertTrue(tempBytes >= recordSize, s"Unexpected temporary memory size requestBytes $requestBytes tempBytes $tempBytes")
 
     verifyYammerMetricRecorded(s"kafka.server:type=BrokerTopicMetrics,name=ProduceMessageConversionsPerSec")
-    verifyYammerMetricRecorded(s"$requestMetricsPrefix,name=MessageConversionsTimeMs,request=Produce", value => value > 0.0)
+    // if message conversion run too fast, the Math.round(value) may be 0.0, so using count to check whether the metric is updated
+    assertTrue(yammerHistogram(s"$requestMetricsPrefix,name=MessageConversionsTimeMs,request=Produce").count() > 0, "MessageConversionsTimeMs count should be > 0")
     verifyYammerMetricRecorded(s"$requestMetricsPrefix,name=RequestBytes,request=Fetch")
     verifyYammerMetricRecorded(s"$requestMetricsPrefix,name=TemporaryMemoryBytes,request=Fetch", value => value == 0.0)
 


### PR DESCRIPTION
The `MessageConversionsTimeMs` is calculated by `Math.round` before updating metrics, so it could be zero if it run too fast.

~Modify updating logic as only updating metrics if `messageConversionsTimeMs` is greater than 0.~

Modify unit test to check whether the metric is updated.

I run the test 100 times and there is no flaky result.

```
I=1; while [ $I -le 100 ] && ./gradlew cleanTest core:test --tests MetricsTest.testMetrics; do echo "Completed run: $I"; (( I=$I+1 )); sleep 1; done
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
