### PR TITLE
KAFKA-16348 [WIP]: add logs to observe

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/TopicCommandIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TopicCommandIntegrationTest.java
@@ -817,6 +817,7 @@ public class TopicCommandIntegrationTest extends kafka.integration.KafkaServerTe
 
         // describe the topic and test if it's under-replicated
         String simpleDescribeOutput = captureDescribeTopicStandardOut(buildTopicCommandOptionsWithBootstrap("--describe", "--topic", testTopicName));
+        System.err.println("[Johnny] simpleDescribeOutput is: " + simpleDescribeOutput);
         String[] simpleDescribeOutputRows = simpleDescribeOutput.split(System.lineSeparator());
         assertTrue(simpleDescribeOutputRows[0].startsWith(String.format("Topic: %s", testTopicName)),
                 "Unexpected describe output: " + simpleDescribeOutputRows[0]);


### PR DESCRIPTION
## Context
TopicCommandIntegrationTest.testDescribeUnderReplicatedPartitionsWhenReassignmentIsInProgress is flaky, I would like to fix this.
Jira ticket: [KAFKA-16348](https://issues.apache.org/jira/browse/KAFKA-16348)

## Solution
Add some logs to observe first.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
