### PR TITLE
MINOR: change inter.broker.protocol version to inter.broker.protocol.version

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3826,7 +3826,7 @@ foo
   <h3>Limitations</h3>
   <ul>
     <li>While a cluster is being migrated from ZK mode to KRaft mode, we do not support changing the <i>metadata
-      version</i> (also known as the <i>inter.broker.protocol</i> version.) Please do not attempt to do this during
+      version</i> (also known as the <i>inter.broker.protocol.version</i>.) Please do not attempt to do this during
       a migration, or you may break the cluster.</li>
     <li>After the migration has been finalized, it is not possible to revert back to ZooKeeper mode.</li>
     <li><a href="#kraft_missing">As noted above</a>, some features are not fully implemented in KRaft mode. If you are


### PR DESCRIPTION
It looks like there is no `inter.broker.protocol` config.

Change the name to `inter.broker.protocol.version`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
