### PR TITLE
KAFKA-14683 Cleanup WorkerSinkTaskTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -420,8 +420,7 @@ subprojects {
   if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
     testsToExclude.addAll([
       // connect tests
-      "**/KafkaConfigBackingStoreTest.*",
-      "**/WorkerSinkTaskTest.*"
+      "**/KafkaConfigBackingStoreTest.*"
     ])
   }
 

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -96,7 +96,7 @@
               files="(AbstractFetch|ClientTelemetryReporter|ConsumerCoordinator|CommitRequestManager|FetchCollector|OffsetFetcherUtils|KafkaProducer|Sender|ConfigDef|KerberosLogin|AbstractRequest|AbstractResponse|Selector|SslFactory|SslTransportLayer|SaslClientAuthenticator|SaslClientCallbackHandler|SaslServerAuthenticator|AbstractCoordinator|TransactionManager|AbstractStickyAssignor|DefaultSslEngineFactory|Authorizer|RecordAccumulator|MemoryRecords|FetchSessionHandler|MockAdminClient).java"/>
 
     <suppress checks="JavaNCSS"
-              files="(AbstractRequest|AbstractResponse|KerberosLogin|WorkerSinkTaskTest|WorkerSinkTaskMockitoTest|TransactionManagerTest|SenderTest|KafkaAdminClient|ConsumerCoordinatorTest|KafkaAdminClientTest|KafkaRaftClientTest).java"/>
+              files="(AbstractRequest|AbstractResponse|KerberosLogin|WorkerSinkTaskTest|TransactionManagerTest|SenderTest|KafkaAdminClient|ConsumerCoordinatorTest|KafkaAdminClientTest|KafkaRaftClientTest).java"/>
 
     <suppress checks="NPathComplexity"
               files="(ConsumerCoordinator|BufferPool|MetricName|Node|ConfigDef|RecordBatch|SslFactory|SslTransportLayer|MetadataResponse|KerberosLogin|Selector|Sender|Serdes|TokenInformation|Agent|Values|PluginUtils|MiniTrogdorCluster|TasksRequest|KafkaProducer|AbstractStickyAssignor|KafkaRaftClient|Authorizer|FetchSessionHandler|RecordAccumulator).java"/>

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -111,7 +111,7 @@ import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.OngoingStubbing;
 
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
-public class WorkerSinkTaskMockitoTest {
+public class WorkerSinkTaskTest {
     // These are fixed to keep this code simpler. In this example we assume byte[] raw values
     // with mix of integer/string in Connect
     private static final String TOPIC = "test";
@@ -316,9 +316,7 @@ public class WorkerSinkTaskMockitoTest {
         // And unpause
         verify(statusListener).onResume(taskId);
         verify(consumer, times(2)).wakeup();
-        INITIAL_ASSIGNMENT.forEach(tp -> {
-            verify(consumer).resume(singleton(tp));
-        });
+        INITIAL_ASSIGNMENT.forEach(tp -> verify(consumer).resume(singleton(tp)));
         verify(sinkTask, times(4)).put(anyList());
     }
 
@@ -419,9 +417,7 @@ public class WorkerSinkTaskMockitoTest {
         time.sleep(30000L);
 
         verify(sinkTask, times(3)).put(anyList());
-        INITIAL_ASSIGNMENT.forEach(tp -> {
-            verify(consumer).resume(Collections.singleton(tp));
-        });
+        INITIAL_ASSIGNMENT.forEach(tp -> verify(consumer).resume(Collections.singleton(tp)));
 
         assertSinkMetricValue("sink-record-read-total", 1.0);
         assertSinkMetricValue("sink-record-send-total", 1.0);
@@ -528,9 +524,7 @@ public class WorkerSinkTaskMockitoTest {
         verify(sinkTask).close(INITIAL_ASSIGNMENT);
 
         // All partitions are resumed, as all previously paused-for-redelivery partitions were revoked
-        newAssignment.forEach(tp -> {
-            verify(consumer).resume(Collections.singleton(tp));
-        });
+        newAssignment.forEach(tp -> verify(consumer).resume(Collections.singleton(tp)));
     }
 
     @Test
@@ -808,9 +802,7 @@ public class WorkerSinkTaskMockitoTest {
         verify(sinkTask).close(INITIAL_ASSIGNMENT);
         verify(sinkTask, times(2)).open(INITIAL_ASSIGNMENT);
 
-        INITIAL_ASSIGNMENT.forEach(tp -> {
-            verify(consumer).resume(Collections.singleton(tp));
-        });
+        INITIAL_ASSIGNMENT.forEach(tp -> verify(consumer).resume(Collections.singleton(tp)));
 
         verify(statusListener).onResume(taskId);
 
@@ -1091,7 +1083,7 @@ public class WorkerSinkTaskMockitoTest {
     // Test that the commitTimeoutMs timestamp is correctly computed and checked in WorkerSinkTask.iteration()
     // when there is a long running commit in process. See KAFKA-4942 for more information.
     @Test
-    public void testLongRunningCommitWithoutTimeout() throws InterruptedException {
+    public void testLongRunningCommitWithoutTimeout() {
         createTask(initialState);
 
         workerTask.initialize(TASK_CONFIG);
@@ -1225,7 +1217,6 @@ public class WorkerSinkTaskMockitoTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testTaskCancelPreventsFinalOffsetCommit() {
         createTask(initialState);
@@ -1286,10 +1277,6 @@ public class WorkerSinkTaskMockitoTest {
         // iter 2
         expectTaskGetTopic();
         expectConversionAndTransformation(null, new RecordHeaders());
-
-        final Map<TopicPartition, OffsetAndMetadata> workerStartingOffsets = new HashMap<>();
-        workerStartingOffsets.put(TOPIC_PARTITION, new OffsetAndMetadata(FIRST_OFFSET));
-        workerStartingOffsets.put(TOPIC_PARTITION2, new OffsetAndMetadata(FIRST_OFFSET));
 
         final Map<TopicPartition, OffsetAndMetadata> workerCurrentOffsets = new HashMap<>();
         workerCurrentOffsets.put(TOPIC_PARTITION, new OffsetAndMetadata(FIRST_OFFSET + 1));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -547,7 +547,7 @@ public class WorkerSinkTaskTest {
         workerTask.iteration();
         verifyPollInitialAssignment();
 
-        Throwable thrownException = assertThrows(RuntimeException.class, () -> workerTask.iteration());
+        RuntimeException thrownException = assertThrows(RuntimeException.class, () -> workerTask.iteration());
         assertEquals(exception, thrownException);
     }
 
@@ -571,7 +571,7 @@ public class WorkerSinkTaskTest {
         workerTask.iteration();
         verifyPollInitialAssignment();
 
-        Throwable thrownException = assertThrows(RuntimeException.class, () -> workerTask.iteration());
+        RuntimeException thrownException = assertThrows(RuntimeException.class, () -> workerTask.iteration());
         assertEquals(exception, thrownException);
     }
 
@@ -597,7 +597,7 @@ public class WorkerSinkTaskTest {
         expectRebalanceAssignmentError(exception);
 
         try {
-            Throwable thrownException = assertThrows(RuntimeException.class, () -> workerTask.iteration());
+            RuntimeException thrownException = assertThrows(RuntimeException.class, () -> workerTask.iteration());
             assertEquals(exception, thrownException);
         } finally {
             verify(sinkTask).close(INITIAL_ASSIGNMENT);
@@ -1156,7 +1156,7 @@ public class WorkerSinkTaskTest {
         // Throw another exception while closing the task's assignment
         doThrow(closeException).when(sinkTask).close(any(Collection.class));
 
-        Throwable thrownException = assertThrows(RuntimeException.class, () -> workerTask.execute());
+        RuntimeException thrownException = assertThrows(RuntimeException.class, () -> workerTask.execute());
         assertEquals(closeException, thrownException);
 
         verify(consumer).wakeup();
@@ -1196,10 +1196,10 @@ public class WorkerSinkTaskTest {
         workerTask.initialize(TASK_CONFIG);
         workerTask.initializeAndStart();
 
-        Throwable thrownException = assertThrows(ConnectException.class, () -> workerTask.execute());
-        assertSame("Exception from put should be the cause", putException, thrownException.getCause());
+        RuntimeException thrownException = assertThrows(ConnectException.class, () -> workerTask.execute());
+        assertEquals("Exception from put should be the cause", putException, thrownException.getCause());
         assertTrue("Exception from close should be suppressed", thrownException.getSuppressed().length > 0);
-        assertSame(closeException, thrownException.getSuppressed()[0]);
+        assertEquals(closeException, thrownException.getSuppressed()[0]);
     }
 
     @Test


### PR DESCRIPTION
Follow up of https://github.com/apache/kafka/pull/15316

* Rename `WorkerSinkTaskMockitoTest` back to `WorkerSinkTaskTest`
* Tidy up the code a bit

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
