### PR TITLE
MINOR: Update javadocs and exception string in "deprecated" ProcessorRecordContext#hashcode

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
@@ -192,14 +192,15 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
             Objects.equals(headers, that.headers);
     }
 
+    /**
+     * Equality is implemented in support of tests, *not* for use in Hash collections, since this class is mutable
+     * due to the {@link Headers} field it contains.
+     */
+    @Deprecated
     @Override
     public int hashCode() {
-        int result = (int) (timestamp ^ (timestamp >>> 32));
-        result = 31 * result + (int) (offset ^ (offset >>> 32));
-        result = 31 * result + (topic != null ? topic.hashCode() : 0);
-        result = 31 * result + partition;
-        result = 31 * result + (headers != null ? headers.hashCode() : 0);
-        return result;
+        throw new UnsupportedOperationException("ProcessorRecordContext is unsafe for use in Hash collections "
+                                                    + "due to the mutable Headers field");
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
@@ -192,13 +192,14 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
             Objects.equals(headers, that.headers);
     }
 
-    /**
-     * Equality is implemented in support of tests, *not* for use in Hash collections, since this class is mutable.
-     */
-    @Deprecated
     @Override
     public int hashCode() {
-        throw new UnsupportedOperationException("ProcessorRecordContext is unsafe for use in Hash collections");
+        int result = (int) (timestamp ^ (timestamp >>> 32));
+        result = 31 * result + (int) (offset ^ (offset >>> 32));
+        result = 31 * result + (topic != null ? topic.hashCode() : 0);
+        result = 31 * result + partition;
+        result = 31 * result + (headers != null ? headers.hashCode() : 0);
+        return result;
     }
 
     @Override


### PR DESCRIPTION
~~Something I noticed while working on a new feature -- this class has deprecated its hashcode and actually goes so far as to throw an exception if/when it's invoked. The deprecation note claims this is because the class is mutable, but I don't actually see this happening anywhere in the code. The _reference_ to this object is modified during processing (by the ProcessorContext), but the object itself has no setters and all fields are private.~~

~~Given the deprecation was years ago, I'm guessing we simply changed from mutating the actual record context object to mutating the reference stored by the ProcessorContext sometime in the past few years, and forgot to remove this deprecation/exception~~ 

update: turns out the existing javadocs were accurate/up-to-date after all, and the class actually isn't technically safe for use in hash collections. Given the lack of explanation or detail in the javadocs was what lead to my misunderstanding (in addition to my own foolishness, of course) I figure it makes sense to convert this PR into a docs improvement instead of simply closing it.

This PR updates the javadocs for the "deprecated" hashCode() method of ProcessorRecordContext, as well as the UnsupportedOperationException thrown in its implementation, to actually explain why the class is mutable and therefore unsafe for use in hash collections. They now point out the mutable field in the class (namely the Headers)