### PR TITLE
KAFKA-16312, KAFKA-16185: Local epochs in reconciliation 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -567,7 +567,7 @@ public class HeartbeatRequestManager implements RequestManager {
             // reconciled. This is ensured by resending the topic partitions whenever the local assignment,
             // including its local epoch is changed (although the local epoch is not sent in the heartbeat).
             LocalAssignment local = membershipManager.currentAssignment();
-            if (!local.equals(sentFields.localAssignment)) {
+            if (sendAllFields || !local.equals(sentFields.localAssignment)) {
                 List<ConsumerGroupHeartbeatRequestData.TopicPartitions> topicPartitions =
                     buildTopicPartitionsList(local.partitions);
                 data.setTopicPartitions(topicPartitions);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -535,7 +535,7 @@ public class HeartbeatRequestManager implements RequestManager {
 
             boolean sendAllFields = membershipManager.state() == MemberState.JOINING;
 
-            // RebalanceTimeoutMs - only sent if has changed since the last heartbeat
+            // RebalanceTimeoutMs - only sent when joining or if it has changed since the last heartbeat
             if (sendAllFields || sentFields.rebalanceTimeoutMs != rebalanceTimeoutMs) {
                 data.setRebalanceTimeoutMs(rebalanceTimeoutMs);
                 sentFields.rebalanceTimeoutMs = rebalanceTimeoutMs;
@@ -549,11 +549,11 @@ public class HeartbeatRequestManager implements RequestManager {
                     sentFields.subscribedTopicNames = subscribedTopicNames;
                 }
             } else {
-                // SubscribedTopicRegex - only sent if has changed since the last heartbeat
+                // SubscribedTopicRegex - only sent if it has changed since the last heartbeat
                 //                      - not supported yet
             }
 
-            // ServerAssignor - only sent if has changed since the last heartbeat
+            // ServerAssignor - sent when joining or if it has changed since the last heartbeat
             this.membershipManager.serverAssignor().ifPresent(serverAssignor -> {
                 if (sendAllFields || !serverAssignor.equals(sentFields.serverAssignor)) {
                     data.setServerAssignor(serverAssignor);
@@ -563,9 +563,10 @@ public class HeartbeatRequestManager implements RequestManager {
 
             // ClientAssignors - not supported yet
 
-            // TopicPartitions - sent with the first heartbeat after a new assignment from the server was
-            // reconciled. This is ensured by resending the topic partitions whenever the local assignment,
-            // including its local epoch is changed (although the local epoch is not sent in the heartbeat).
+            // TopicPartitions - sent when joining or with the first heartbeat after a new assignment from
+            // the server was reconciled. This is ensured by resending the topic partitions whenever the
+            // local assignment, including its local epoch is changed (although the local epoch is not sent
+            // in the heartbeat).
             LocalAssignment local = membershipManager.currentAssignment();
             if (sendAllFields || !local.equals(sentFields.localAssignment)) {
                 List<ConsumerGroupHeartbeatRequestData.TopicPartitions> topicPartitions =

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
@@ -18,12 +18,17 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.internals.events.ConsumerRebalanceListenerCallbackCompletedEvent;
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -192,11 +197,82 @@ public interface MembershipManager extends RequestManager {
      * Besides the assigned partitions, it contains a local epoch that is bumped whenever the assignment changes, to ensure
      * that two assignments with the same partitions but different local epochs are not considered equal.
      */
-    interface LocalAssignment {
+    final class LocalAssignment {
 
-        Map<Uuid, SortedSet<Integer>> getPartitions();
+        public static final long NONE_EPOCH = -1;
 
-        boolean isNone();
+        public static final LocalAssignment NONE = new LocalAssignment(NONE_EPOCH, Collections.emptyMap());
 
+        public final long localEpoch;
+
+        public final Map<Uuid, SortedSet<Integer>> partitions;
+
+        public LocalAssignment(long localEpoch, Map<Uuid, SortedSet<Integer>> partitions) {
+            this.localEpoch = localEpoch;
+            this.partitions = partitions;
+            if (localEpoch == NONE_EPOCH && !partitions.isEmpty()) {
+                throw new IllegalArgumentException("Local epoch must be set if there are partitions");
+            }
+        }
+
+        public LocalAssignment(long localEpoch, SortedSet<TopicIdPartition> topicIdPartitions) {
+            this.localEpoch = localEpoch;
+            this.partitions = new HashMap<>();
+            if (localEpoch == NONE_EPOCH && !topicIdPartitions.isEmpty()) {
+                throw new IllegalArgumentException("Local epoch must be set if there are partitions");
+            }
+            topicIdPartitions.forEach(topicIdPartition -> {
+                Uuid topicId = topicIdPartition.topicId();
+                partitions.computeIfAbsent(topicId, k -> new TreeSet<>()).add(topicIdPartition.partition());
+            });
+        }
+
+        public String toString() {
+            return "LocalAssignment{" +
+                "localEpoch=" + localEpoch +
+                ", partitions=" + partitions +
+                '}';
+        }
+
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final LocalAssignment that = (LocalAssignment) o;
+            return localEpoch == that.localEpoch && Objects.equals(partitions, that.partitions);
+        }
+
+        public int hashCode() {
+            return Objects.hash(localEpoch, partitions);
+        }
+
+        public boolean isNone() {
+            return localEpoch == NONE_EPOCH;
+        }
+
+        Optional<LocalAssignment> updateWith(ConsumerGroupHeartbeatResponseData.Assignment assignment) {
+
+            // Return if we have an assignment, and it is the same as current assignment; comparison without creating a new collection
+            if (localEpoch != NONE_EPOCH) {
+                if (partitions.size() == assignment.topicPartitions().size() &&
+                    assignment.topicPartitions().stream().allMatch(
+                        tp -> partitions.containsKey(tp.topicId()) &&
+                            partitions.get(tp.topicId()).size() == tp.partitions().size() &&
+                            partitions.get(tp.topicId()).containsAll(tp.partitions()))) {
+                    return Optional.empty();
+                }
+            }
+
+            // Bump local epoch and replace assignment
+            long nextLocalEpoch = localEpoch + 1;
+            HashMap<Uuid, SortedSet<Integer>> partitions = new HashMap<>();
+            assignment.topicPartitions().forEach(topicPartitions ->
+                partitions.put(topicPartitions.topicId(), new TreeSet<>(topicPartitions.partitions())));
+            return Optional.of(new LocalAssignment(nextLocalEpoch, partitions));
+
+        }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
@@ -254,7 +254,6 @@ public interface MembershipManager extends RequestManager {
         }
 
         Optional<LocalAssignment> updateWith(ConsumerGroupHeartbeatResponseData.Assignment assignment) {
-
             // Return if we have an assignment, and it is the same as current assignment; comparison without creating a new collection
             if (localEpoch != NONE_EPOCH) {
                 if (partitions.size() == assignment.topicPartitions().size() &&

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
@@ -18,16 +18,12 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.internals.events.ConsumerRebalanceListenerCallbackCompletedEvent;
-import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -196,49 +192,11 @@ public interface MembershipManager extends RequestManager {
      * Besides the assigned partitions, it contains a local epoch that is bumped whenever the assignment changes, to ensure
      * that two assignments with the same partitions but different local epochs are not considered equal.
      */
-    final class LocalAssignment {
+    interface LocalAssignment {
 
-        public final long localEpoch;
+        Map<Uuid, SortedSet<Integer>> getPartitions();
 
-        public final Map<Uuid, SortedSet<Integer>> partitions;
+        boolean isNone();
 
-        public LocalAssignment(long localEpoch, Map<Uuid, SortedSet<Integer>> partitions) {
-            this.localEpoch = localEpoch;
-            this.partitions = partitions;
-        }
-
-        public LocalAssignment(long localEpoch, SortedSet<TopicIdPartition> topicIdPartitions) {
-            this.localEpoch = localEpoch;
-            this.partitions = new HashMap<>();
-            topicIdPartitions.forEach(topicIdPartition -> {
-                Uuid topicId = topicIdPartition.topicId();
-                partitions.computeIfAbsent(topicId, k -> new TreeSet<>()).add(topicIdPartition.partition());
-            });
-        }
-
-        @Override
-        public String toString() {
-            return "{" +
-                "localEpoch=" + localEpoch +
-                ", partitions=" + partitions +
-                '}';
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            final LocalAssignment that = (LocalAssignment) o;
-            return localEpoch == that.localEpoch && Objects.equals(partitions, that.partitions);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(localEpoch, partitions);
-        }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManager.java
@@ -18,12 +18,16 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.internals.events.ConsumerRebalanceListenerCallbackCompletedEvent;
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -99,7 +103,7 @@ public interface MembershipManager extends RequestManager {
      * @return Current assignment for the member as received from the broker (topic IDs and
      * partitions). This is the last assignment that the member has successfully reconciled.
      */
-    Map<Uuid, SortedSet<Integer>> currentAssignment();
+    LocalAssignment currentAssignment();
 
     /**
      * Transition the member to the FENCED state, where the member will release the assignment by
@@ -185,4 +189,56 @@ public interface MembershipManager extends RequestManager {
      * releasing its assignment. This is expected to be used when the poll timer is reset.
      */
     void maybeRejoinStaleMember();
+
+    /**
+     * A data structure to represent the current assignment, and current target assignment of a member in a consumer group.
+     *
+     * Besides the assigned partitions, it contains a local epoch that is bumped whenever the assignment changes, to ensure
+     * that two assignments with the same partitions but different local epochs are not considered equal.
+     */
+    final class LocalAssignment {
+
+        public final long localEpoch;
+
+        public final Map<Uuid, SortedSet<Integer>> partitions;
+
+        public LocalAssignment(long localEpoch, Map<Uuid, SortedSet<Integer>> partitions) {
+            this.localEpoch = localEpoch;
+            this.partitions = partitions;
+        }
+
+        public LocalAssignment(long localEpoch, SortedSet<TopicIdPartition> topicIdPartitions) {
+            this.localEpoch = localEpoch;
+            this.partitions = new HashMap<>();
+            topicIdPartitions.forEach(topicIdPartition -> {
+                Uuid topicId = topicIdPartition.topicId();
+                partitions.computeIfAbsent(topicId, k -> new TreeSet<>()).add(topicIdPartition.partition());
+            });
+        }
+
+        @Override
+        public String toString() {
+            return "{" +
+                "localEpoch=" + localEpoch +
+                ", partitions=" + partitions +
+                '}';
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final LocalAssignment that = (LocalAssignment) o;
+            return localEpoch == that.localEpoch && Objects.equals(partitions, that.partitions);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(localEpoch, partitions);
+        }
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -909,9 +909,8 @@ public class MembershipManagerImpl implements MembershipManager {
         SortedSet<TopicIdPartition> assignedTopicIdPartitions = findResolvableAssignmentAndTriggerMetadataUpdate();
         final LocalAssignment resolvedAssignment = new LocalAssignment(currentTargetAssignment.localEpoch, assignedTopicIdPartitions);
 
-        if (!currentAssignment.isNone() &&
-            resolvedAssignment.partitions.equals(currentAssignment.partitions)) {
-            log.debug("There are unresolved partitions, and the resolvable fragment of the  target assignment {} is equal to the current "
+        if (!currentAssignment.isNone() && resolvedAssignment.partitions.equals(currentAssignment.partitions)) {
+            log.debug("There are unresolved partitions, and the resolvable fragment of the target assignment {} is equal to the current "
                 + "assignment. Bumping the local epoch of the assignment and acknowledging the partially resolved assignment",
                 resolvedAssignment.partitions);
             currentAssignment = resolvedAssignment;
@@ -974,10 +973,11 @@ public class MembershipManagerImpl implements MembershipManager {
             }
 
             revokeAndAssign(resolvedAssignment, assignedTopicIdPartitions, revokedPartitions, addedPartitions);
-        }).whenComplete((__, error) -> {
+        }).exceptionally(error -> {
             if (error != null) {
                 log.error("Reconciliation failed.", error);
             }
+            return null;
         });
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -172,9 +172,12 @@ public class MembershipManagerImpl implements MembershipManager {
     private final Optional<String> serverAssignor;
 
     /**
-     * Assignment that the member received from the server and successfully processed.
+     * Assignment that the member received from the server and successfully processed, together with
+     * its local epoch.
+     *
+     * This is null when we are not in a group, or we haven't reconciled any assignment yet.
      */
-    private Map<Uuid, SortedSet<Integer>> currentAssignment;
+    private LocalAssignment currentAssignment;
 
     /**
      * Subscription state object holding the current assignment the member has for the topics it
@@ -210,12 +213,12 @@ public class MembershipManagerImpl implements MembershipManager {
     private final Map<Uuid, String> assignedTopicNamesCache;
 
     /**
-     * Topic IDs and partitions received in the last target assignment. Items are added to this set
-     * every time a target assignment is received. This is where the member collects the assignment
-     * received from the broker, even though it may not be ready to fully reconcile due to missing
-     * metadata.
+     * Topic IDs and partitions received in the last target assignment, together with its local epoch.
+     *
+     * This member reassigned every time a new assignment is received.
+     * It is null whenever we are not in a group.
      */
-    private final Map<Uuid, SortedSet<Integer>> currentTargetAssignment;
+    private LocalAssignment currentTargetAssignment;
 
     /**     
      * If there is a reconciliation running (triggering commit, callbacks) for the
@@ -329,8 +332,8 @@ public class MembershipManagerImpl implements MembershipManager {
         this.commitRequestManager = commitRequestManager;
         this.metadata = metadata;
         this.assignedTopicNamesCache = new HashMap<>();
-        this.currentTargetAssignment = new HashMap<>();
-        this.currentAssignment = new HashMap<>();
+        this.currentTargetAssignment = null;
+        this.currentAssignment = null;
         this.log = logContext.logger(MembershipManagerImpl.class);
         this.stateUpdatesListeners = new ArrayList<>();
         this.clientTelemetryReporter = clientTelemetryReporter;
@@ -451,9 +454,6 @@ public class MembershipManagerImpl implements MembershipManager {
                 return;
             }
             processAssignmentReceived(assignment);
-
-        } else if (targetAssignmentReconciled()) {
-            transitionTo(MemberState.STABLE);
         }
     }
 
@@ -508,9 +508,30 @@ public class MembershipManagerImpl implements MembershipManager {
      */
     private void replaceTargetAssignmentWithNewAssignment(
             ConsumerGroupHeartbeatResponseData.Assignment assignment) {
-        currentTargetAssignment.clear();
+
+        // Return if the same as current assignment; comparison without creating a new collection
+        if (currentTargetAssignment != null) {
+            // check if the new assignment is different from the current target assignment
+            if (currentTargetAssignment.partitions.size() == assignment.topicPartitions().size() &&
+                assignment.topicPartitions().stream().allMatch(
+                    tp -> currentTargetAssignment.partitions.containsKey(tp.topicId()) &&
+                        currentTargetAssignment.partitions.get(tp.topicId()).size() == tp.partitions().size() &&
+                        currentTargetAssignment.partitions.get(tp.topicId()).containsAll(tp.partitions()))) {
+                return;
+            }
+        }
+
+        // Bump local epoch and replace assignment
+        long nextLocalEpoch;
+        if (currentTargetAssignment == null) {
+            nextLocalEpoch = 0;
+        } else {
+            nextLocalEpoch = currentTargetAssignment.localEpoch + 1;
+        }
+        HashMap<Uuid, SortedSet<Integer>> partitions = new HashMap<>();
         assignment.topicPartitions().forEach(topicPartitions ->
-            currentTargetAssignment.put(topicPartitions.topicId(), new TreeSet<>(topicPartitions.partitions())));
+            partitions.put(topicPartitions.topicId(), new TreeSet<>(topicPartitions.partitions())));
+        currentTargetAssignment = new LocalAssignment(nextLocalEpoch, partitions);
     }
 
     /**
@@ -568,7 +589,11 @@ public class MembershipManagerImpl implements MembershipManager {
     public void transitionToFatal() {
         MemberState previousState = state;
         transitionTo(MemberState.FATAL);
-        log.error("Member {} with epoch {} transitioned to {} state", memberId, memberEpoch, MemberState.FATAL);
+        if (memberId.isEmpty()) {
+            log.error("Member {} with epoch {} transitioned to {} state", memberId, memberEpoch, MemberState.FATAL);
+        } else {
+            log.error("Non-member transitioned to {} state", MemberState.FATAL);
+        }
         notifyEpochChange(Optional.empty(), Optional.empty());
 
         if (previousState == MemberState.UNSUBSCRIBED) {
@@ -604,7 +629,8 @@ public class MembershipManagerImpl implements MembershipManager {
         if (subscriptions.hasAutoAssignedPartitions()) {
             subscriptions.assignFromSubscribed(Collections.emptySet());
         }
-        updateCurrentAssignment(Collections.emptySet());
+        currentTargetAssignment = null;
+        currentAssignment = null;
         clearPendingAssignmentsAndLocalNamesCache();
     }
 
@@ -620,7 +646,6 @@ public class MembershipManagerImpl implements MembershipManager {
                                                     SortedSet<TopicPartition> addedPartitions) {
         Collection<TopicPartition> assignedTopicPartitions = toTopicPartitionSet(assignedPartitions);
         subscriptions.assignFromSubscribedAwaitingCallback(assignedTopicPartitions, addedPartitions);
-        updateCurrentAssignment(assignedPartitions);
     }
 
     /**
@@ -748,7 +773,7 @@ public class MembershipManagerImpl implements MembershipManager {
                 ConsumerGroupHeartbeatRequest.LEAVE_GROUP_STATIC_MEMBER_EPOCH :
                 ConsumerGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH;
         updateMemberEpoch(leaveEpoch);
-        currentAssignment = new HashMap<>();
+        currentAssignment = null;
         transitionTo(MemberState.LEAVING);
     }
 
@@ -816,7 +841,7 @@ public class MembershipManagerImpl implements MembershipManager {
      * @return True if there are no assignments waiting to be resolved from metadata or reconciled.
      */
     private boolean targetAssignmentReconciled() {
-        return currentAssignment.equals(currentTargetAssignment);
+        return currentAssignment != null && currentAssignment.equals(currentTargetAssignment);
     }
 
     /**
@@ -889,12 +914,12 @@ public class MembershipManagerImpl implements MembershipManager {
      */
     void maybeReconcile() {
         if (targetAssignmentReconciled()) {
-            log.debug("Ignoring reconciliation attempt. Target assignment is equal to the " +
+            log.trace("Ignoring reconciliation attempt. Target assignment is equal to the " +
                     "current assignment.");
             return;
         }
         if (reconciliationInProgress) {
-            log.debug("Ignoring reconciliation attempt. Another reconciliation is already in progress. Assignment " +
+            log.trace("Ignoring reconciliation attempt. Another reconciliation is already in progress. Assignment " +
                 currentTargetAssignment + " will be handled in the next reconciliation loop.");
             return;
         }
@@ -902,29 +927,22 @@ public class MembershipManagerImpl implements MembershipManager {
         // Find the subset of the target assignment that can be resolved to topic names, and trigger a metadata update
         // if some topic IDs are not resolvable.
         SortedSet<TopicIdPartition> assignedTopicIdPartitions = findResolvableAssignmentAndTriggerMetadataUpdate();
+        final LocalAssignment resolvedAssignment = new LocalAssignment(currentTargetAssignment.localEpoch, assignedTopicIdPartitions);
 
-        SortedSet<TopicPartition> ownedPartitions = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
-        ownedPartitions.addAll(subscriptions.assignedPartitions());
+        if (resolvedAssignment.equals(currentAssignment)) {
+            log.debug("Ignoring reconciliation attempt. Target assignment ready to reconcile {} " +
+                    "is equal to the member current assignment.", resolvedAssignment);
+            return;
+        }
+
+        markReconciliationInProgress();
 
         // Keep copy of assigned TopicPartitions created from the TopicIdPartitions that are
         // being reconciled. Needed for interactions with the centralized subscription state that
         // does not support topic IDs yet, and for the callbacks.
         SortedSet<TopicPartition> assignedTopicPartitions = toTopicPartitionSet(assignedTopicIdPartitions);
-
-        // Check same assignment. Based on topic names for now, until topic IDs are properly
-        // supported in the centralized subscription state object. Note that this check is
-        // required to make sure that reconciliation is not triggered if the assignment ready to
-        // be reconciled is the same as the current one (even though the member may remain
-        // in RECONCILING state if it has some unresolved assignments).
-        boolean sameAssignmentReceived = assignedTopicPartitions.equals(ownedPartitions);
-
-        if (sameAssignmentReceived) {
-            log.debug("Ignoring reconciliation attempt. Target assignment ready to reconcile {} " +
-                    "is equal to the member current assignment {}.", assignedTopicPartitions, ownedPartitions);
-            return;
-        }
-
-        markReconciliationInProgress();
+        SortedSet<TopicPartition> ownedPartitions = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
+        ownedPartitions.addAll(subscriptions.assignedPartitions());
 
         // Partitions to assign (not previously owned)
         SortedSet<TopicPartition> addedPartitions = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
@@ -936,12 +954,13 @@ public class MembershipManagerImpl implements MembershipManager {
         revokedPartitions.addAll(ownedPartitions);
         revokedPartitions.removeAll(assignedTopicPartitions);
 
-        log.info("Updating assignment with\n" +
+        log.info("Updating assignment with local epoch {}\n" +
                         "\tAssigned partitions:                       {}\n" +
                         "\tCurrent owned partitions:                  {}\n" +
                         "\tAdded partitions (assigned - owned):       {}\n" +
                         "\tRevoked partitions (owned - assigned):     {}\n",
-                assignedTopicIdPartitions,
+                resolvedAssignment.localEpoch,
+                assignedTopicPartitions,
                 ownedPartitions,
                 addedPartitions,
                 revokedPartitions
@@ -970,7 +989,7 @@ public class MembershipManagerImpl implements MembershipManager {
                 log.debug("Auto-commit before reconciling new assignment completed successfully.");
             }
 
-            revokeAndAssign(assignedTopicIdPartitions, revokedPartitions, addedPartitions);
+            revokeAndAssign(resolvedAssignment, assignedTopicIdPartitions, revokedPartitions, addedPartitions);
         });
     }
 
@@ -988,7 +1007,8 @@ public class MembershipManagerImpl implements MembershipManager {
      * then complete the reconciliation by updating the assignment and making the appropriate state
      * transition. Note that if any of the 2 callbacks fails, the reconciliation should fail.
      */
-    private void revokeAndAssign(SortedSet<TopicIdPartition> assignedTopicIdPartitions,
+    private void revokeAndAssign(LocalAssignment resolvedAssignment,
+                                 SortedSet<TopicIdPartition> assignedTopicIdPartitions,
                                  SortedSet<TopicPartition> revokedPartitions,
                                  SortedSet<TopicPartition> addedPartitions) {
         CompletableFuture<Void> revocationResult;
@@ -1028,8 +1048,9 @@ public class MembershipManagerImpl implements MembershipManager {
                 // RECONCILING -> FENCED transition.
                 log.error("Reconciliation failed.", error);
             } else {
-                boolean memberHasRejoined = memberEpochOnReconciliationStart != memberEpoch;
-                if (state == MemberState.RECONCILING && !memberHasRejoined) {
+                if (state == MemberState.RECONCILING) {
+                    updateCurrentAssignment(resolvedAssignment);
+
                     // Reschedule the auto commit starting from now that the member has a new assignment.
                     commitRequestManager.resetAutoCommitTimer();
 
@@ -1045,12 +1066,8 @@ public class MembershipManagerImpl implements MembershipManager {
     }
 
     // Visible for testing.
-    void updateCurrentAssignment(Set<TopicIdPartition> assignedTopicIdPartitions) {
-        currentAssignment.clear();
-        assignedTopicIdPartitions.forEach(topicIdPartition -> {
-            Uuid topicId = topicIdPartition.topicId();
-            currentAssignment.computeIfAbsent(topicId, k -> new TreeSet<>()).add(topicIdPartition.partition());
-        });
+    void updateCurrentAssignment(LocalAssignment resolvedAssignment) {
+        currentAssignment = resolvedAssignment;
     }
 
     /**
@@ -1109,7 +1126,7 @@ public class MembershipManagerImpl implements MembershipManager {
      */
     private SortedSet<TopicIdPartition> findResolvableAssignmentAndTriggerMetadataUpdate() {
         final SortedSet<TopicIdPartition> assignmentReadyToReconcile = new TreeSet<>(TOPIC_ID_PARTITION_COMPARATOR);
-        final HashMap<Uuid, SortedSet<Integer>> unresolved = new HashMap<>(currentTargetAssignment);
+        final HashMap<Uuid, SortedSet<Integer>> unresolved = new HashMap<>(currentTargetAssignment.partitions);
 
         // Try to resolve topic names from metadata cache or subscription cache, and move
         // assignments from the "unresolved" collection, to the "assignmentReadyToReconcile" one.
@@ -1382,7 +1399,7 @@ public class MembershipManagerImpl implements MembershipManager {
      * or the next reconciliation loop). Remove all elements from the topic names cache.
      */
     private void clearPendingAssignmentsAndLocalNamesCache() {
-        currentTargetAssignment.clear();
+        currentTargetAssignment = null;
         assignedTopicNamesCache.clear();
     }
 
@@ -1424,7 +1441,7 @@ public class MembershipManagerImpl implements MembershipManager {
      * {@inheritDoc}
      */
     @Override
-    public Map<Uuid, SortedSet<Integer>> currentAssignment() {
+    public LocalAssignment currentAssignment() {
         return this.currentAssignment;
     }
 
@@ -1449,9 +1466,15 @@ public class MembershipManagerImpl implements MembershipManager {
      * Visible for testing.
      */
     Map<Uuid, SortedSet<Integer>> topicPartitionsAwaitingReconciliation() {
+        if (currentTargetAssignment == null) {
+            return Collections.emptyMap();
+        }
+        if (currentAssignment == null) {
+            return currentTargetAssignment.partitions;
+        }
         final Map<Uuid, SortedSet<Integer>> topicPartitionMap = new HashMap<>();
-        currentTargetAssignment.forEach((topicId, targetPartitions) -> {
-            final SortedSet<Integer> reconciledPartitions = currentAssignment.get(topicId);
+        currentTargetAssignment.partitions.forEach((topicId, targetPartitions) -> {
+            final SortedSet<Integer> reconciledPartitions = currentAssignment.partitions.get(topicId);
             if (!targetPartitions.equals(reconciledPartitions)) {
                 final TreeSet<Integer> missingPartitions = new TreeSet<>(targetPartitions);
                 if (reconciledPartitions != null) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -911,9 +911,13 @@ public class MembershipManagerImpl implements MembershipManager {
         SortedSet<TopicIdPartition> assignedTopicIdPartitions = findResolvableAssignmentAndTriggerMetadataUpdate();
         final LocalAssignmentImpl resolvedAssignment = new LocalAssignmentImpl(currentTargetAssignment.localEpoch, assignedTopicIdPartitions);
 
-        if (resolvedAssignment.equals(currentAssignment)) {
-            log.debug("Ignoring reconciliation attempt. Target assignment ready to reconcile {} " +
-                    "is equal to the member current assignment.", resolvedAssignment);
+        if (currentAssignment != LocalAssignmentImpl.NONE &&
+            resolvedAssignment.localEpoch <= currentAssignment.localEpoch + 1 &&
+            resolvedAssignment.partitions.equals(currentAssignment.partitions)) {
+            log.debug("Ignoring reconciliation attempt. The resolvable fragment of the target assignment {} " +
+                "is equal to the current assignment, and no intermediate assignments were received.", resolvedAssignment);
+            // May bump the local epoch
+            currentAssignment = resolvedAssignment;
             return;
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -913,7 +913,7 @@ public class MembershipManagerImpl implements MembershipManager {
             resolvedAssignment.localEpoch <= currentAssignment.localEpoch + 1 &&
             resolvedAssignment.partitions.equals(currentAssignment.partitions)) {
             log.debug("Ignoring reconciliation attempt. The resolvable fragment of the target assignment {} " +
-                "is equal to the current assignment, and no intermediate assignments were received.", resolvedAssignment);
+                "is equal to the current assignment, and no intermediate assignments were received.", resolvedAssignment.partitions);
             // May bump the local epoch
             currentAssignment = resolvedAssignment;
             return;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -909,13 +909,13 @@ public class MembershipManagerImpl implements MembershipManager {
         SortedSet<TopicIdPartition> assignedTopicIdPartitions = findResolvableAssignmentAndTriggerMetadataUpdate();
         final LocalAssignment resolvedAssignment = new LocalAssignment(currentTargetAssignment.localEpoch, assignedTopicIdPartitions);
 
-        if (currentAssignment != LocalAssignment.NONE &&
-            resolvedAssignment.localEpoch <= currentAssignment.localEpoch + 1 &&
+        if (!currentAssignment.isNone() &&
             resolvedAssignment.partitions.equals(currentAssignment.partitions)) {
-            log.debug("Ignoring reconciliation attempt. The resolvable fragment of the target assignment {} " +
-                "is equal to the current assignment, and no intermediate assignments were received.", resolvedAssignment.partitions);
-            // May bump the local epoch
+            log.debug("There are unresolved partitions, and the resolvable fragment of the  target assignment {} is equal to the current "
+                + "assignment. Bumping the local epoch of the assignment and acknowledging the partially resolved assignment",
+                resolvedAssignment.partitions);
             currentAssignment = resolvedAssignment;
+            transitionTo(MemberState.ACKNOWLEDGING);
             return;
         }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
@@ -185,7 +185,7 @@ public class HeartbeatRequestManagerTest {
         assertTrue(heartbeatRequest.data().memberId().isEmpty());
         assertEquals(0, heartbeatRequest.data().memberEpoch());
 
-        // Should include subscription and group basic info to start getting assignments.
+        // Should include subscription and group basic info to start getting assignments, as well as rebalanceTimeoutMs
         assertEquals(Collections.singletonList(topic), heartbeatRequest.data().subscribedTopicNames());
         assertEquals(DEFAULT_MAX_POLL_INTERVAL_MS, heartbeatRequest.data().rebalanceTimeoutMs());
         assertEquals(DEFAULT_GROUP_ID, heartbeatRequest.data().groupId());
@@ -318,7 +318,8 @@ public class HeartbeatRequestManagerTest {
         assertEquals(DEFAULT_GROUP_ID, heartbeatRequest.data().groupId());
         assertEquals(memberId, heartbeatRequest.data().memberId());
         assertEquals(memberEpoch, heartbeatRequest.data().memberEpoch());
-        assertEquals(DEFAULT_MAX_POLL_INTERVAL_MS, heartbeatRequest.data().rebalanceTimeoutMs());
+        // RebalanceTimeoutMs only included in first heartbeat (epoch = 0)
+        assertEquals(-1, heartbeatRequest.data().rebalanceTimeoutMs());
         assertEquals(subscribedTopics, heartbeatRequest.data().subscribedTopicNames());
         assertEquals(DEFAULT_GROUP_INSTANCE_ID, heartbeatRequest.data().instanceId());
         assertEquals(DEFAULT_REMOTE_ASSIGNOR, heartbeatRequest.data().serverAssignor());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
@@ -488,7 +488,7 @@ public class HeartbeatRequestManagerTest {
         assertEquals(DEFAULT_MAX_POLL_INTERVAL_MS, data.rebalanceTimeoutMs());
         assertEquals(Collections.singletonList(topic), data.subscribedTopicNames());
         assertEquals(ConsumerTestBuilder.DEFAULT_REMOTE_ASSIGNOR, data.serverAssignor());
-        assertNull(data.topicPartitions());
+        assertEquals(Collections.emptyList(), data.topicPartitions());
         membershipManager.onHeartbeatRequestSent();
         assertEquals(MemberState.JOINING, membershipManager.state());
 
@@ -501,7 +501,7 @@ public class HeartbeatRequestManagerTest {
         assertEquals(DEFAULT_MAX_POLL_INTERVAL_MS, data.rebalanceTimeoutMs());
         assertEquals(Collections.singletonList(topic), data.subscribedTopicNames());
         assertEquals(ConsumerTestBuilder.DEFAULT_REMOTE_ASSIGNOR, data.serverAssignor());
-        assertNull(data.topicPartitions());
+        assertEquals(Collections.emptyList(), data.topicPartitions());
         membershipManager.onHeartbeatRequestSent();
         assertEquals(MemberState.JOINING, membershipManager.state());
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
@@ -1080,7 +1080,11 @@ public class MembershipManagerImplTest {
         receiveEmptyAssignment(membershipManager);
 
         verifyReconciliationNotTriggered(membershipManager);
+
         membershipManager.poll(time.milliseconds());
+
+        verifyReconciliationTriggeredAndCompleted(membershipManager, Collections.emptyList());
+
         membershipManager.onHeartbeatRequestSent();
 
         assertEquals(MemberState.STABLE, membershipManager.state());
@@ -2354,8 +2358,8 @@ public class MembershipManagerImplTest {
         when(subscriptionState.hasAutoAssignedPartitions()).thenReturn(true);
     }
 
-    private MembershipManagerImpl mockJoinAndReceiveAssignment(boolean expectSubscriptionUpdated) {
-        return mockJoinAndReceiveAssignment(expectSubscriptionUpdated, createAssignment(expectSubscriptionUpdated));
+    private MembershipManagerImpl mockJoinAndReceiveAssignment(boolean triggerReconciliation) {
+        return mockJoinAndReceiveAssignment(triggerReconciliation, createAssignment(triggerReconciliation));
     }
 
     private MembershipManagerImpl mockJoinAndReceiveAssignment(boolean triggerReconciliation,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -681,10 +682,7 @@ public class MembershipManagerImplTest {
         receiveAssignment(newAssignment, membershipManager);
         membershipManager.poll(time.milliseconds());
 
-        // We bumped the local epoch, so new reconciliation is triggered
-        assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
-        membershipManager.onHeartbeatRequestSent();
-
+        verifyReconciliationNotTriggered(membershipManager);
         assertEquals(MemberState.RECONCILING, membershipManager.state());
         assertEquals(Collections.singleton(topicId2), membershipManager.topicsAwaitingReconciliation());
         verify(metadata).requestUpdate(anyBoolean());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
@@ -739,6 +739,12 @@ public class MembershipManagerImplTest {
         receiveAssignment(newAssignment, membershipManager);
         membershipManager.poll(time.milliseconds());
 
+        // No full reconciliation triggered, but assignment needs to be acknowledged.
+        assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
+        assertTrue(membershipManager.shouldHeartbeatNow());
+
+        membershipManager.onHeartbeatRequestSent();
+
         verifyReconciliationNotTriggered(membershipManager);
         assertEquals(MemberState.RECONCILING, membershipManager.state());
         assertEquals(Collections.singleton(topicId2), membershipManager.topicsAwaitingReconciliation());


### PR DESCRIPTION
The goal of this PR is to change the following internals of the reconciliation:

 - Introduce a "local epoch" to the local target assignment. When a new target is received by the server, we compare it with the current value. If it is the same, no change. Otherwise, we bump the local epoch and store the new target assignment. Then, on the reconciliation, we also store the epoch in the reconciled assignment and keep using target != current to trigger the reconciliation. 
 - When we are not in a group (we have not received an assignment), we use null to represent the local target assignment instead of an empty list, to avoid confusions with an empty assignment received by the server. Similarly, we use null to represent the current assignment, when we haven't reconciled the assignment yet.
 - We also carry the new epoch into the request builder to ensure that we report the owned partitions for the last local epoch.
 - To address [KAFKA-16312](https://issues.apache.org/jira/browse/KAFKA-16312) (call onPartitionsAssigned on empty assignments after joining), we apply the initial assignment returned by the group coordinator (whether empty or not) as a normal reconciliation. This avoids introducing another code path to trigger rebalance listeners - reconciliation is the only way to transition to STABLE. The unneeded parts of reconciliation (autocommit, revocation) will be skipped in the existing. Since a lot of unit tests assumed that not reconciliation behavior is invoked when joining the group with an empty assignment, this required a lot of the changes in the unit tests.

## Testing

These changes allow the new consumer to pass the first 10 system tests. We piggy-back a minor change to the `HeartbeatManager` that are required for those system tests as well: always send `rebalanceTimoutMs`, `subscriptions` when (re-)joining.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
