### PR TITLE
KAFKA-16365: AssignmentsManager callback handling issues

### DIFF
--- a/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
@@ -197,21 +197,19 @@ public class AssignmentsManager {
             if (existing != null) {
                 if (existing.dirId.equals(dirId)) {
                     existing.merge(this);
-                    if (log.isDebugEnabled()) log.debug("Ignoring duplicate assignment {}", this);
+                    log.debug("Ignoring duplicate assignment {}", this);
                     return;
                 }
                 if (existing.timestampNs > timestampNs) {
                     existing.merge(this);
-                    if (log.isDebugEnabled()) log.debug("Dropping assignment {} because it's older than existing {}", this, existing);
+                    log.debug("Dropping assignment {} because it's older than existing {}", this, existing);
                     return;
                 } else if (!existingIsInFlight) {
                     this.merge(existing);
-                    if (log.isDebugEnabled()) log.debug("Dropping existing assignment {} because it's older than {}", existing, this);
+                    log.debug("Dropping existing assignment {} because it's older than {}", existing, this);
                 }
             }
-            if (log.isDebugEnabled()) {
-                log.debug("Received new assignment {}", this);
-            }
+            log.debug("Received new assignment {}", this);
             pending.put(partition, this);
 
             if (inflight == null || inflight.isEmpty()) {
@@ -272,9 +270,7 @@ public class AssignmentsManager {
             }
             Map<TopicIdPartition, Uuid> assignment = inflight.entrySet().stream()
                     .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().dirId));
-            if (log.isDebugEnabled()) {
-                log.debug("Dispatching {} assignments:  {}", assignment.size(), assignment);
-            }
+            log.debug("Dispatching {} assignments:  {}", assignment.size(), assignment);
             channelManager.sendRequest(new AssignReplicasToDirsRequest.Builder(
                     buildRequestData(brokerId, brokerEpochSupplier.get(), assignment)),
                     new AssignReplicasToDirsRequestCompletionHandler());
@@ -331,9 +327,7 @@ public class AssignmentsManager {
         }
         @Override
         public void onComplete(ClientResponse response) {
-            if (log.isDebugEnabled()) {
-                log.debug("Received controller response: {}", response);
-            }
+            log.debug("Received controller response: {}", response);
             appendResponseEvent(response);
         }
         void appendResponseEvent(ClientResponse response) {
@@ -352,9 +346,7 @@ public class AssignmentsManager {
     }
 
     private void scheduleDispatch(long delayNs) {
-        if (log.isDebugEnabled()) {
-            log.debug("Scheduling dispatch in {}ns", delayNs);
-        }
+        log.debug("Scheduling dispatch in {}ns", delayNs);
         eventQueue.enqueue(EventQueue.EventInsertionType.DEFERRED, DispatchEvent.TAG,
                 new EventQueue.LatestDeadlineFunction(time.nanoseconds() + delayNs), new DispatchEvent());
     }

--- a/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
@@ -189,8 +189,10 @@ public class AssignmentsManager {
         @Override
         public void run() throws Exception {
             AssignmentEvent existing = pending.getOrDefault(partition, null);
+            boolean existingIsInFlight = false;
             if (existing == null && inflight != null) {
                 existing = inflight.getOrDefault(partition, null);
+                existingIsInFlight = true;
             }
             if (existing != null) {
                 if (existing.dirId.equals(dirId)) {
@@ -202,7 +204,7 @@ public class AssignmentsManager {
                     existing.merge(this);
                     if (log.isDebugEnabled()) log.debug("Dropping assignment {} because it's older than existing {}", this, existing);
                     return;
-                } else {
+                } else if (!existingIsInFlight) {
                     this.merge(existing);
                     if (log.isDebugEnabled()) log.debug("Dropping existing assignment {} because it's older than {}", existing, this);
                 }

--- a/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
@@ -179,9 +179,6 @@ public class AssignmentsManager {
             if (!partition.equals(other.partition)) {
                 throw new IllegalArgumentException("Cannot merge events for different partitions");
             }
-            if (!dirId.equals(other.dirId)) {
-                throw new IllegalArgumentException("Cannot merge events for different directories");
-            }
             completionHandlers.addAll(other.completionHandlers);
         }
         void onComplete() {
@@ -202,9 +199,12 @@ public class AssignmentsManager {
                     return;
                 }
                 if (existing.timestampNs > timestampNs) {
-                    existing.onComplete();
-                    if (log.isDebugEnabled()) log.debug("Dropping assignment {} because it's older than {}", this, existing);
+                    existing.merge(this);
+                    if (log.isDebugEnabled()) log.debug("Dropping assignment {} because it's older than existing {}", this, existing);
                     return;
+                } else {
+                    this.merge(existing);
+                    if (log.isDebugEnabled()) log.debug("Dropping existing assignment {} because it's older than {}", existing, this);
                 }
             }
             if (log.isDebugEnabled()) {

--- a/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/AssignmentsManager.java
@@ -188,6 +188,7 @@ public class AssignmentsManager {
         }
         @Override
         public void run() throws Exception {
+            log.trace("Received assignment {}", this);
             AssignmentEvent existing = pending.getOrDefault(partition, null);
             boolean existingIsInFlight = false;
             if (existing == null && inflight != null) {
@@ -209,7 +210,7 @@ public class AssignmentsManager {
                     log.debug("Dropping existing assignment {} because it's older than {}", existing, this);
                 }
             }
-            log.debug("Received new assignment {}", this);
+            log.debug("Queueing new assignment {}", this);
             pending.put(partition, this);
 
             if (inflight == null || inflight.isEmpty()) {

--- a/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
@@ -349,12 +349,15 @@ public class AssignmentsManagerTest {
         activeWait(() -> remainingInvocations.getCount() == 0);
     }
 
-    void activeWait(Supplier<Boolean> predicate) {
-        while (!predicate.get()) {
-            time.sleep(100);
-            manager.wakeup();
-            Thread.yield();
-        }
+    void activeWait(Supplier<Boolean> predicate) throws InterruptedException {
+        TestUtils.waitForCondition(() -> {
+            boolean conditionSatisfied = predicate.get();
+            if (!conditionSatisfied) {
+                time.sleep(100);
+                manager.wakeup();
+            }
+            return conditionSatisfied;
+        }, TestUtils.DEFAULT_MAX_WAIT_MS, 0, null);
     }
 
     static Metric findMetric(String name) {

--- a/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
@@ -357,7 +357,7 @@ public class AssignmentsManagerTest {
                 manager.wakeup();
             }
             return conditionSatisfied;
-        }, TestUtils.DEFAULT_MAX_WAIT_MS, 0, null);
+        }, TestUtils.DEFAULT_MAX_WAIT_MS, 50, null);
     }
 
     static Metric findMetric(String name) {


### PR DESCRIPTION
When moving replicas between directories in the same broker, future replica promotion hinges on acknowledgment from the controller of a change in the directory assignment.

ReplicaAlterLogDirsThread relies on AssignmentsManager for a completion notification of the directory assignment change.

In its current form, under certain assignment scheduling, AssignmentsManager both miss completion notifications, or prematurely trigger them.

