### PR TITLE
MINOR: Improve logging in AssignmentsManager

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -283,6 +283,8 @@ class LogManager(logDirs: Seq[File],
    */
   def directoryId(dir: String): Option[Uuid] = directoryIds.get(dir)
 
+  def directoryPath(uuid: Uuid): Option[String] = directoryIds.find(_._2 == uuid).map(_._1)
+
   /**
    * Determine directory ID for each directory with a meta.properties.
    * If meta.properties does not include a directory ID, one is generated and persisted back to meta.properties.

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -296,11 +296,13 @@ class BrokerServer(
         time,
         assignmentsChannelManager,
         config.brokerId,
-        () => lifecycleManager.brokerEpoch
+        () => lifecycleManager.brokerEpoch,
+        (directoryId: Uuid) => logManager.directoryPath(directoryId).asJava,
+        (topicId: Uuid) => Optional.ofNullable(metadataCache.topicIdsToNames().get(topicId))
       )
       val directoryEventHandler = new DirectoryEventHandler {
-        override def handleAssignment(partition: TopicIdPartition, directoryId: Uuid, callback: Runnable): Unit =
-          assignmentsManager.onAssignment(partition, directoryId, callback)
+        override def handleAssignment(partition: TopicIdPartition, directoryId: Uuid, reason: String, callback: Runnable): Unit =
+          assignmentsManager.onAssignment(partition, directoryId, reason, callback)
 
         override def handleFailure(directoryId: Uuid): Unit =
           lifecycleManager.propagateDirectoryFailure(directoryId)

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -102,7 +102,8 @@ class ReplicaAlterLogDirsThread(name: String,
         val PromotionState(reassignmentState, topicId, originalDir) = this.promotionStates.get(topicPartition)
         // Revert any reassignments for partitions that did not complete the future replica promotion
         if (originalDir.isDefined && topicId.isDefined && reassignmentState.maybeInconsistentMetadata) {
-          directoryEventHandler.handleAssignment(new TopicIdPartition(topicId.get, topicPartition.partition()), originalDir.get, () => ())
+          directoryEventHandler.handleAssignment(new TopicIdPartition(topicId.get, topicPartition.partition()), originalDir.get,
+            "Reverting reassignment for canceled future replica", () => ())
         }
         this.promotionStates.remove(topicPartition)
       }
@@ -130,7 +131,7 @@ class ReplicaAlterLogDirsThread(name: String,
         partition.runCallbackIfFutureReplicaCaughtUp(_ => {
           val targetDir = partition.futureReplicaDirectoryId().get
           val topicIdPartition = new TopicIdPartition(topicId.get, topicPartition.partition())
-          directoryEventHandler.handleAssignment(topicIdPartition, targetDir, () => updateReassignmentState(topicPartition, ReassignmentState.Accepted))
+          directoryEventHandler.handleAssignment(topicIdPartition, targetDir, "Future replica promotion", () => updateReassignmentState(topicPartition, ReassignmentState.Accepted))
           updateReassignmentState(topicPartition, ReassignmentState.Queued)
         })
       case ReassignmentState.Accepted =>

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2886,6 +2886,11 @@ class ReplicaManager(val config: KafkaConfig,
       topicPartitionActualLog <- logManager.getLog(partition.topicPartition(), false)
       topicPartitionActualDirectoryId <- logManager.directoryId(topicPartitionActualLog.dir.getParent)
       if partitionDirectoryId != topicPartitionActualDirectoryId
-    } directoryEventHandler.handleAssignment(new common.TopicIdPartition(partition.topicId, partition.partition()), topicPartitionActualDirectoryId, () => ())
+    } directoryEventHandler.handleAssignment(
+      new common.TopicIdPartition(partition.topicId, partition.partition()),
+      topicPartitionActualDirectoryId,
+      "Applying metadata delta",
+      () => ()
+    )
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
@@ -501,9 +501,9 @@ class ReplicaAlterLogDirsThreadTest {
     thread.removePartitions(tp.toSet)
 
     verify(directoryEventHandler).handleAssignment(ArgumentMatchers.eq(tips(1)), ArgumentMatchers.eq(dirIds(1)),
-      "shouldRevertReassignmentsForIncompleteFutureReplicaPromotions[Queued]", any())
+      ArgumentMatchers.eq("Reverting reassignment for canceled future replica"), any())
     verify(directoryEventHandler).handleAssignment(ArgumentMatchers.eq(tips(2)), ArgumentMatchers.eq(dirIds(2)),
-      "shouldRevertReassignmentsForIncompleteFutureReplicaPromotions[Accepted]", any())
+      ArgumentMatchers.eq("Reverting reassignment for canceled future replica"), any())
     verifyNoMoreInteractions(directoryEventHandler)
   }
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
@@ -464,7 +464,8 @@ class ReplicaAlterLogDirsThreadTest {
       ArgumentCaptor.forClass(classOf[org.apache.kafka.server.common.TopicIdPartition])
     val logIdCaptureT1p0: ArgumentCaptor[Uuid] = ArgumentCaptor.forClass(classOf[Uuid])
 
-    verify(directoryEventHandler).handleAssignment(topicIdPartitionCaptureT1p0.capture(), logIdCaptureT1p0.capture(), any())
+    verify(directoryEventHandler).handleAssignment(topicIdPartitionCaptureT1p0.capture(), logIdCaptureT1p0.capture(),
+      ArgumentMatchers.eq("Reverting reassignment for canceled future replica"), any())
 
     assertEquals(new org.apache.kafka.server.common.TopicIdPartition(topicId, t1p0.partition()), topicIdPartitionCaptureT1p0.getValue)
     assertEquals(partition.logDirectoryId().get, logIdCaptureT1p0.getValue)
@@ -499,8 +500,10 @@ class ReplicaAlterLogDirsThreadTest {
 
     thread.removePartitions(tp.toSet)
 
-    verify(directoryEventHandler).handleAssignment(ArgumentMatchers.eq(tips(1)), ArgumentMatchers.eq(dirIds(1)), any())
-    verify(directoryEventHandler).handleAssignment(ArgumentMatchers.eq(tips(2)), ArgumentMatchers.eq(dirIds(2)), any())
+    verify(directoryEventHandler).handleAssignment(ArgumentMatchers.eq(tips(1)), ArgumentMatchers.eq(dirIds(1)),
+      "shouldRevertReassignmentsForIncompleteFutureReplicaPromotions[Queued]", any())
+    verify(directoryEventHandler).handleAssignment(ArgumentMatchers.eq(tips(2)), ArgumentMatchers.eq(dirIds(2)),
+      "shouldRevertReassignmentsForIncompleteFutureReplicaPromotions[Accepted]", any())
     verifyNoMoreInteractions(directoryEventHandler)
   }
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -5050,7 +5050,8 @@ class ReplicaManagerTest {
       val topicIdPartitionCapture: ArgumentCaptor[org.apache.kafka.server.common.TopicIdPartition] =
         ArgumentCaptor.forClass(classOf[org.apache.kafka.server.common.TopicIdPartition])
       val logIdCaptureForPartition: ArgumentCaptor[Uuid] = ArgumentCaptor.forClass(classOf[Uuid])
-      verify(replicaManager.directoryEventHandler, atLeastOnce()).handleAssignment(topicIdPartitionCapture.capture(), logIdCaptureForPartition.capture(), any())
+      verify(replicaManager.directoryEventHandler, atLeastOnce()).handleAssignment(topicIdPartitionCapture.capture(), logIdCaptureForPartition.capture(),
+        ArgumentMatchers.eq("Applying metadata delta"), any())
 
       assertEquals(topicIdPartitionCapture.getAllValues.asScala,
         List(
@@ -5095,7 +5096,8 @@ class ReplicaManagerTest {
       val topicIdPartitionCapture: ArgumentCaptor[org.apache.kafka.server.common.TopicIdPartition] =
         ArgumentCaptor.forClass(classOf[org.apache.kafka.server.common.TopicIdPartition])
       val logIdCaptureForPartition: ArgumentCaptor[Uuid] = ArgumentCaptor.forClass(classOf[Uuid])
-      verify(replicaManager.directoryEventHandler, atLeastOnce()).handleAssignment(topicIdPartitionCapture.capture(), logIdCaptureForPartition.capture(), any())
+      verify(replicaManager.directoryEventHandler, atLeastOnce()).handleAssignment(topicIdPartitionCapture.capture(), logIdCaptureForPartition.capture(),
+        ArgumentMatchers.eq("Applying metadata delta"), any())
 
       assertEquals(topicIdPartitionCapture.getAllValues.asScala,
         List(

--- a/server-common/src/main/java/org/apache/kafka/server/common/DirectoryEventHandler.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/DirectoryEventHandler.java
@@ -25,7 +25,7 @@ public interface DirectoryEventHandler {
      * A no-op implementation of {@link DirectoryEventHandler}.
      */
     DirectoryEventHandler NOOP = new DirectoryEventHandler() {
-        @Override public void handleAssignment(TopicIdPartition partition, Uuid directoryId, Runnable callback) {}
+        @Override public void handleAssignment(TopicIdPartition partition, Uuid directoryId, String reason, Runnable callback) {}
         @Override public void handleFailure(Uuid directoryId) {}
     };
 
@@ -35,7 +35,7 @@ public interface DirectoryEventHandler {
      * @param partition    The topic partition
      * @param callback     Callback to apply when the request is completed.
      */
-    void handleAssignment(TopicIdPartition partition, Uuid directoryId, Runnable callback);
+    void handleAssignment(TopicIdPartition partition, Uuid directoryId, String reason, Runnable callback);
 
     /**
      * Handle the transition of an online log directory to the offline state.

--- a/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/AssignmentsManagerTest.java
@@ -46,6 +46,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -77,7 +78,15 @@ public class AssignmentsManagerTest {
     public void setup() {
         time = new MockTime();
         channelManager = mock(NodeToControllerChannelManager.class);
-        manager = new AssignmentsManager(time, channelManager, 8, () -> 100L);
+        Map<Uuid, String> topicNames = new HashMap<>();
+        topicNames.put(TOPIC_1, "TOPIC_1");
+        topicNames.put(TOPIC_2, "TOPIC_2");
+        Map<Uuid, String> dirPaths = new HashMap<>();
+        dirPaths.put(DIR_1, "DIR_1");
+        dirPaths.put(DIR_2, "DIR_2");
+        dirPaths.put(DIR_3, "DIR_3");
+        manager = new AssignmentsManager(time, channelManager, 8, () -> 100L,
+                id -> Optional.ofNullable(dirPaths.get(id)), id -> Optional.ofNullable(topicNames.get(id)));
     }
 
     @AfterEach
@@ -167,11 +176,11 @@ public class AssignmentsManagerTest {
         }).when(channelManager).sendRequest(any(AssignReplicasToDirsRequest.Builder.class),
             any(ControllerRequestCompletionHandler.class));
 
-        manager.onAssignment(new TopicIdPartition(TOPIC_1, 1), DIR_1, () -> { });
-        manager.onAssignment(new TopicIdPartition(TOPIC_1, 2), DIR_2, () -> { });
-        manager.onAssignment(new TopicIdPartition(TOPIC_1, 3), DIR_3, () -> { });
-        manager.onAssignment(new TopicIdPartition(TOPIC_1, 4), DIR_1, () -> { });
-        manager.onAssignment(new TopicIdPartition(TOPIC_2, 5), DIR_2, () -> { });
+        manager.onAssignment(new TopicIdPartition(TOPIC_1, 1), DIR_1, "testAssignmentAggregation", () -> { });
+        manager.onAssignment(new TopicIdPartition(TOPIC_1, 2), DIR_2, "testAssignmentAggregation", () -> { });
+        manager.onAssignment(new TopicIdPartition(TOPIC_1, 3), DIR_3, "testAssignmentAggregation", () -> { });
+        manager.onAssignment(new TopicIdPartition(TOPIC_1, 4), DIR_1, "testAssignmentAggregation", () -> { });
+        manager.onAssignment(new TopicIdPartition(TOPIC_2, 5), DIR_2, "testAssignmentAggregation", () -> { });
         while (!readyToAssert.await(1, TimeUnit.MILLISECONDS)) {
             time.sleep(100);
             manager.wakeup();
@@ -206,7 +215,7 @@ public class AssignmentsManagerTest {
             }
             if (readyToAssert.getCount() == 4) {
                 invocation.getArgument(1, ControllerRequestCompletionHandler.class).onTimeout();
-                manager.onAssignment(new TopicIdPartition(TOPIC_1, 2), DIR_3, () -> { });
+                manager.onAssignment(new TopicIdPartition(TOPIC_1, 2), DIR_3, "testRequeuesFailedAssignmentPropagations", () -> { });
             }
             if (readyToAssert.getCount() == 3) {
                 invocation.getArgument(1, ControllerRequestCompletionHandler.class).onComplete(
@@ -214,10 +223,10 @@ public class AssignmentsManagerTest {
                         new UnsupportedVersionException("test unsupported version exception"), null, null));
 
                 // duplicate should be ignored
-                manager.onAssignment(new TopicIdPartition(TOPIC_1, 2), DIR_3, () -> { });
+                manager.onAssignment(new TopicIdPartition(TOPIC_1, 2), DIR_3, "testRequeuesFailedAssignmentPropagations", () -> { });
 
                 manager.onAssignment(new TopicIdPartition(TOPIC_1, 3),
-                     Uuid.fromString("xHLCnG54R9W3lZxTPnpk1Q"), () -> { });
+                     Uuid.fromString("xHLCnG54R9W3lZxTPnpk1Q"), "testRequeuesFailedAssignmentPropagations", () -> { });
             }
             if (readyToAssert.getCount() == 2) {
                 invocation.getArgument(1, ControllerRequestCompletionHandler.class).onComplete(
@@ -227,10 +236,10 @@ public class AssignmentsManagerTest {
 
                 // duplicate should be ignored
                 manager.onAssignment(new TopicIdPartition(TOPIC_1, 3),
-                     Uuid.fromString("xHLCnG54R9W3lZxTPnpk1Q"), () -> { }); 
+                     Uuid.fromString("xHLCnG54R9W3lZxTPnpk1Q"), "testRequeuesFailedAssignmentPropagations", () -> { });
 
                 manager.onAssignment(new TopicIdPartition(TOPIC_1, 4),
-                     Uuid.fromString("RCYu1A0CTa6eEIpuKDOfxw"), () -> { });
+                     Uuid.fromString("RCYu1A0CTa6eEIpuKDOfxw"), "testRequeuesFailedAssignmentPropagations", () -> { });
             }
             if (readyToAssert.getCount() == 1) {
                 invocation.getArgument(1, ControllerRequestCompletionHandler.class).onComplete(
@@ -243,7 +252,7 @@ public class AssignmentsManagerTest {
         }).when(channelManager).sendRequest(any(AssignReplicasToDirsRequest.Builder.class),
             any(ControllerRequestCompletionHandler.class));
 
-        manager.onAssignment(new TopicIdPartition(TOPIC_1, 1), DIR_1, () -> { });
+        manager.onAssignment(new TopicIdPartition(TOPIC_1, 1), DIR_1, "testRequeuesFailedAssignmentPropagations", () -> { });
         while (!readyToAssert.await(1, TimeUnit.MILLISECONDS)) {
             time.sleep(TimeUnit.SECONDS.toMillis(1));
             manager.wakeup();
@@ -292,7 +301,7 @@ public class AssignmentsManagerTest {
                 any(ControllerRequestCompletionHandler.class));
 
         for (int i = 0; i < 300; i++) {
-            manager.onAssignment(new TopicIdPartition(TOPIC_1, i % 5), DIR_1, readyToAssert::countDown);
+            manager.onAssignment(new TopicIdPartition(TOPIC_1, i % 5), DIR_1, "testOnCompletion", readyToAssert::countDown);
         }
 
         while (!readyToAssert.await(1, TimeUnit.MILLISECONDS)) {
@@ -342,7 +351,7 @@ public class AssignmentsManagerTest {
         Uuid[] dirs = {DIR_1, DIR_2, DIR_3};
         for (int i = 0; i < remainingInvocations.getCount(); i++) {
             time.sleep(100);
-            manager.onAssignment(new TopicIdPartition(TOPIC_1, 0), dirs[i % 3], onComplete);
+            manager.onAssignment(new TopicIdPartition(TOPIC_1, 0), dirs[i % 3], "testAssignmentCompaction", onComplete);
         }
         activeWait(completionFuture::isDone);
         completionFuture.get().run();
@@ -383,7 +392,7 @@ public class AssignmentsManagerTest {
         assertEquals(0, queuedReplicaToDirAssignments.value());
 
         for (int i = 0; i < 4; i++) {
-            manager.onAssignment(new TopicIdPartition(TOPIC_1, i), DIR_1, () -> { });
+            manager.onAssignment(new TopicIdPartition(TOPIC_1, i), DIR_1, "testQueuedReplicaToDirAssignmentsMetric", () -> { });
         }
         while (!readyToAssert.await(1, TimeUnit.MILLISECONDS)) {
             time.sleep(100);
@@ -391,7 +400,7 @@ public class AssignmentsManagerTest {
         assertEquals(4, queuedReplicaToDirAssignments.value());
 
         for (int i = 4; i < 8; i++) {
-            manager.onAssignment(new TopicIdPartition(TOPIC_1, i), DIR_1, () -> { });
+            manager.onAssignment(new TopicIdPartition(TOPIC_1, i), DIR_1, "testQueuedReplicaToDirAssignmentsMetric", () -> { });
         }
         TestUtils.retryOnExceptionWithTimeout(5_000, () -> assertEquals(8, queuedReplicaToDirAssignments.value()));
     }


### PR DESCRIPTION
At the moment it can be a bit difficult to troubleshoot issues related to the AssignmentsManager. Mainly because:

1. Topic partitions are logged with topic ID and partition index but without the topic name.
2. Directory IDs are logged without the directory path.
3. Assignment reasons aren't tracked.

This patch addresses the three issues.
