### PR TITLE
MINOR; Make string from array

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -1564,7 +1564,7 @@ object LogManager {
       Option(newTopicsImage.getPartition(topicId, partitionId)) match {
         case Some(partition) =>
           if (!partition.replicas.contains(brokerId)) {
-            info(s"Found stray log dir $log: the current replica assignment ${partition.replicas} " +
+            info(s"Found stray log dir $log: the current replica assignment ${partition.replicas.mkString("[", ", ", "]")} " +
               s"does not contain the local brokerId $brokerId.")
             Some(log.topicPartition)
           } else {


### PR DESCRIPTION
If toString is called on an array it returns the string representing the object reference.  Use mkString instead to print the content of the array.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
