### PR TITLE
MINOR: fix javadoc warnings

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/FinalizedVersionRange.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/FinalizedVersionRange.java
@@ -28,7 +28,7 @@ public class FinalizedVersionRange {
 
     /**
      * Raises an exception unless the following condition is met:
-     * minVersionLevel >= 1 and maxVersionLevel >= 1 and maxVersionLevel >= minVersionLevel.
+     * {@code minVersionLevel >= 1} and {@code maxVersionLevel >= 1} and {@code maxVersionLevel >= minVersionLevel}.
      *
      * @param minVersionLevel   The minimum version level value.
      * @param maxVersionLevel   The maximum version level value.

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1278,7 +1278,8 @@ public class RemoteLogManager implements Closeable {
      *
      * For ex:
      * <pre>
-     *  &lt;epoch - start offset&gt;
+     * {@code
+     *  <epoch - start offset>
      *  0 - 0
      *  1 - 10
      *  2 - 20
@@ -1287,11 +1288,13 @@ public class RemoteLogManager implements Closeable {
      *  5 - 60  // epoch 5 does not have records or messages associated with it
      *  6 - 60
      *  7 - 70
+     * }
      * </pre>
      *
      *  When the above leaderEpochMap is passed to this method, it returns the following map:
      * <pre>
-     *  &lt;epoch - start offset&gt;
+     * {@code
+     *  <epoch - start offset>
      *  0 - 0
      *  1 - 10
      *  2 - 20
@@ -1299,6 +1302,7 @@ public class RemoteLogManager implements Closeable {
      *  4 - 40
      *  6 - 60
      *  7 - 70
+     * }
      * </pre>
      *
      * @param leaderEpochs The leader epoch map to be refined.

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1277,7 +1277,8 @@ public class RemoteLogManager implements Closeable {
      * does not contain any messages/records associated with them.
      *
      * For ex:
-     *  <epoch - start offset>
+     * <pre>
+     *  &lt;epoch - start offset&gt;
      *  0 - 0
      *  1 - 10
      *  2 - 20
@@ -1286,9 +1287,11 @@ public class RemoteLogManager implements Closeable {
      *  5 - 60  // epoch 5 does not have records or messages associated with it
      *  6 - 60
      *  7 - 70
+     * </pre>
      *
      *  When the above leaderEpochMap is passed to this method, it returns the following map:
-     *  <epoch - start offset>
+     * <pre>
+     *  &lt;epoch - start offset&gt;
      *  0 - 0
      *  1 - 10
      *  2 - 20
@@ -1296,6 +1299,7 @@ public class RemoteLogManager implements Closeable {
      *  4 - 40
      *  6 - 60
      *  7 - 70
+     * </pre>
      *
      * @param leaderEpochs The leader epoch map to be refined.
      */

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteStorageMetrics.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteStorageMetrics.java
@@ -27,8 +27,6 @@ import java.util.Set;
 /**
  * This class contains the metrics related to tiered storage feature, which is to have a centralized
  * place to store them, so that we can verify all of them easily.
- *
- * @see kafka.api.MetricsTest
  */
 public class RemoteStorageMetrics {
     private static final String REMOTE_LOG_READER_METRICS_NAME_PREFIX = "RemoteLogReader";

--- a/streams/src/main/java/org/apache/kafka/streams/query/RangeQuery.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/RangeQuery.java
@@ -90,7 +90,7 @@ public final class RangeQuery<K, V> implements Query<KeyValueIterator<K, V>> {
 
     /**
      * Interactive range query using an upper bound to filter the keys returned.
-     * If both <K,V> are null, RangQuery returns a full range scan.
+     * If both {@code <K,V>} are null, RangQuery returns a full range scan.
      * @param upper The key that specifies the upper bound of the range
      * @param <K> The key type
      * @param <V> The value type

--- a/streams/src/main/java/org/apache/kafka/streams/query/TimestampedRangeQuery.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/TimestampedRangeQuery.java
@@ -65,7 +65,7 @@ public final class TimestampedRangeQuery<K, V> implements Query<KeyValueIterator
 
     /**
      * Interactive range query using an upper bound to filter the keys returned.
-     * If both <K,V> are null, RangQuery returns a full range scan.
+     * If both {@code <K,V>} are null, RangQuery returns a full range scan.
      * @param upper The key that specifies the upper bound of the range
      * @param <K> The key type
      * @param <V> The value type

--- a/streams/src/main/java/org/apache/kafka/streams/state/QueryableStoreTypes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/QueryableStoreTypes.java
@@ -49,7 +49,7 @@ public final class QueryableStoreTypes {
     }
 
     /**
-     * A {@link QueryableStoreType} that accepts {@link ReadOnlyKeyValueStore ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>>}.
+     * A {@link QueryableStoreType} that accepts {@link ReadOnlyKeyValueStore ReadOnlyKeyValueStore&lt;K, ValueAndTimestamp&lt;V&gt;&gt;}.
      *
      * @param <K> key type of the store
      * @param <V> value type of the store
@@ -71,7 +71,7 @@ public final class QueryableStoreTypes {
     }
 
     /**
-     * A {@link QueryableStoreType} that accepts {@link ReadOnlyWindowStore ReadOnlyWindowStore<K, ValueAndTimestamp<V>>}.
+     * A {@link QueryableStoreType} that accepts {@link ReadOnlyWindowStore ReadOnlyWindowStore&lt;K, ValueAndTimestamp&lt;V&gt;&gt;}.
      *
      * @param <K> key type of the store
      * @param <V> value type of the store


### PR DESCRIPTION
Fixes javadoc warning for unescaped `<` and `>` chars.
