### PR TITLE
KAFKA-16369: Broker may not shut down when SocketServer fails to bind as Address already in use

### DIFF
--- a/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
@@ -53,7 +53,7 @@ class KafkaServerTest extends QuorumTestHarness {
       // start a server with listener on the port already bound
       assertThrows(classOf[RuntimeException],
         () => kafkaServer = Option(createServerWithListenerOnPort(serverSocket.getLocalPort)),
-        "Exepected RuntimeException because of KafkaServer startup failure due do address already in use"
+        "Expected RuntimeException due to address already in use during KafkaServer startup"
       )
     } finally {
       CoreUtils.swallow(serverSocket.close(), this);


### PR DESCRIPTION
Add a Wait for all the SocketServer ports to be open, and the Acceptors to be started

The BrokerServer (KRaft mode) had such a wait, which was missing from the KafkaServer (ZK mode).