### PR TITLE
KAFKA-16359: Corrected manifest file for kafka-clients

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -305,6 +305,24 @@ subprojects {
           } else {
             apply plugin: 'com.github.johnrengelman.shadow'
             project.shadow.component(mavenJava)
+
+            // Fix for avoiding inclusion of runtime dependencies marked as 'shadow' in MANIFEST Class-Path.
+            // https://github.com/johnrengelman/shadow/issues/324
+            afterEvaluate {
+              pom.withXml { xml ->
+                if (xml.asNode().get('dependencies') == null) {
+                  xml.asNode().appendNode('dependencies')
+                }
+                def dependenciesNode = xml.asNode().get('dependencies').get(0)
+                project.configurations.shadowed.allDependencies.each {
+                  def dependencyNode = dependenciesNode.appendNode('dependency')
+                  dependencyNode.appendNode('groupId', it.group)
+                  dependencyNode.appendNode('artifactId', it.name)
+                  dependencyNode.appendNode('version', it.version)
+                  dependencyNode.appendNode('scope', 'runtime')
+                }
+              }
+            }
           }
 
           afterEvaluate {
@@ -1425,6 +1443,7 @@ project(':clients') {
 
   configurations {
     generator
+    shadowed
   }
 
   dependencies {
@@ -1435,10 +1454,10 @@ project(':clients') {
     implementation libs.opentelemetryProto
 
     // libraries which should be added as runtime dependencies in generated pom.xml should be defined here:
-    shadow libs.zstd
-    shadow libs.lz4
-    shadow libs.snappy
-    shadow libs.slf4jApi
+    shadowed libs.zstd
+    shadowed libs.lz4
+    shadowed libs.snappy
+    shadowed libs.slf4jApi
 
     compileOnly libs.jacksonDatabind // for SASL/OAUTHBEARER bearer token parsing
     compileOnly libs.jacksonJDK8Datatypes

--- a/build.gradle
+++ b/build.gradle
@@ -1510,10 +1510,9 @@ project(':clients') {
 
     // dependencies excluded from the final jar, since they are declared as runtime dependencies
     dependencies {
-      exclude(dependency(libs.snappy))
-      exclude(dependency(libs.zstd))
-      exclude(dependency(libs.lz4))
-      exclude(dependency(libs.slf4jApi))
+      project.configurations.shadowed.allDependencies.each {
+        exclude(dependency(it.group + ':' + it.name + ':' + it.version))
+      }
       // exclude proto files from the jar
       exclude "**/opentelemetry/proto/**/*.proto"
       exclude "**/google/protobuf/*.proto"


### PR DESCRIPTION
The issue [KAFKA-16359](https://issues.apache.org/jira/browse/KAFKA-16359) reported inclusion of `kafka-clients` runtime dependencies in MANIFEST.MF `Class-Path`.

The root cause is the issue defined [here](https://github.com/johnrengelman/shadow/issues/324) with the usage of `shadow` plugin.

Looking into the specifics of plugin and [documentation](https://imperceptiblethoughts.com/shadow/configuration/#configuring-the-runtime-classpath), specifies that any dependency marked as `shadow` will be treated as following by the shadow plugin:

1. Adds the dependency as runtime dependency in resultant pom.xml - [code here](https://github.com/johnrengelman/shadow/blob/1d647471b9130d35b17771a50be382f6cb442d71/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.groovy#L32)
2. Adds the dependency as `Class-Path` in `MANIFEST.MF` as well - [code here](https://github.com/johnrengelman/shadow/blob/1d647471b9130d35b17771a50be382f6cb442d71/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy#L71)

### Resolution
We do need the runtime dependencies available in the pom (1 above) but not on manifest (2 above). Also there is no clear way to separate the behaviour as both above tasks relies on `shadow` configuration. 

To fix, I have defined another custom configuration named `shadowed` which is later used to populate the correct pom (the [code is similar to what shadow plugin does](https://github.com/johnrengelman/shadow/blob/1d647471b9130d35b17771a50be382f6cb442d71/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.groovy#L32) to populate pom for runtime dependencies).

Though this might seem like a workaround, but I think that's the only way to fix the issue. I have checked other SDKs which suffered with same issue and went with similar route to populate pom.

### Verification

1. Exploded jar by `jar -xvf kafka-clients....jar` and compared pre and post manifest contents.
![Screenshot 2024-03-13 at 9 37 16 PM](https://github.com/apache/kafka/assets/2861565/bffa07f1-f8a6-4c77-a4e0-3b38c0968fc7)

2. Verified pre and post resultant pom.
![Screenshot 2024-03-13 at 9 39 08 PM](https://github.com/apache/kafka/assets/2861565/edf7c936-eaab-4072-91dc-f0827cf1f5af)

3. Verified pre and post jar tf output `jar -tf kafka-clients-3.8.0-SNAPSHOT.jar  > jar_tf_output`  
![Screenshot 2024-03-13 at 9 38 48 PM](https://github.com/apache/kafka/assets/2861565/147a8570-0295-4edb-91a0-ddc7dab1e659)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
