### PR TITLE
KAFKA-16374; High watermark updates should have a higher priority

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorEventProcessor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorEventProcessor.java
@@ -24,10 +24,18 @@ import java.util.concurrent.RejectedExecutionException;
 public interface CoordinatorEventProcessor extends AutoCloseable {
 
     /**
-     * Enqueues a new {{@link CoordinatorEvent}}.
+     * Enqueues a new {{@link CoordinatorEvent}} at the end of the processor.
      *
      * @param event The event.
      * @throws RejectedExecutionException If the event processor is closed.
      */
-    void enqueue(CoordinatorEvent event) throws RejectedExecutionException;
+    void enqueueLast(CoordinatorEvent event) throws RejectedExecutionException;
+
+    /**
+     * Enqueues a new {{@link CoordinatorEvent}} at the front of the processor.
+     *
+     * @param event The event.
+     * @throws RejectedExecutionException If the event processor is closed.
+     */
+    void enqueueFirst(CoordinatorEvent event) throws RejectedExecutionException;
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -51,6 +51,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -356,7 +357,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
 
                     log.debug("Scheduling write event {} for timer {}.", event.name, key);
                     try {
-                        enqueue(event);
+                        enqueueLast(event);
                     } catch (NotCoordinatorException ex) {
                         log.info("Failed to enqueue write event {} for timer {} because the runtime is closed. Ignoring it.",
                             event.name, key);
@@ -439,6 +440,12 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         SnapshottableCoordinator<S, U> coordinator;
 
         /**
+         * The high watermark listener registered to all the partitions
+         * backing the coordinators.
+         */
+        HighWatermarkListener highWatermarklistener;
+
+        /**
          * Constructor.
          *
          * @param tp The topic partition of the coordinator.
@@ -495,6 +502,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
 
                 case ACTIVE:
                     state = CoordinatorState.ACTIVE;
+                    highWatermarklistener = new HighWatermarkListener();
                     partitionWriter.registerListener(tp, highWatermarklistener);
                     coordinator.onLoaded(metadataImage);
                     break;
@@ -520,7 +528,10 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
          * Unloads the coordinator.
          */
         private void unload() {
-            partitionWriter.deregisterListener(tp, highWatermarklistener);
+            if (highWatermarklistener != null) {
+                partitionWriter.deregisterListener(tp, highWatermarklistener);
+                highWatermarklistener = null;
+            }
             timer.cancelAll();
             deferredEventQueue.failAll(Errors.NOT_COORDINATOR.exception());
             if (coordinator != null) {
@@ -1179,6 +1190,16 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      * backing the coordinator are updated.
      */
     class HighWatermarkListener implements PartitionWriter.Listener {
+
+        private static final long NO_OFFSET = -1L;
+
+        /**
+         * The atomic long is used to store the last and unprocessed high watermark
+         * received from the partition. The atomic value is replaced by -1L when
+         * the high watermark is taken to update the context.
+         */
+        private final AtomicLong lastHighWatermark = new AtomicLong(NO_OFFSET);
+
         /**
          * Updates the high watermark of the corresponding coordinator.
          *
@@ -1191,30 +1212,37 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             long offset
         ) {
             log.debug("High watermark of {} incremented to {}.", tp, offset);
-            scheduleInternalOperation("HighWatermarkUpdated(tp=" + tp + ", offset=" + offset + ")", tp, () -> {
-                CoordinatorContext context = coordinators.get(tp);
-                if (context != null) {
-                    context.lock.lock();
-                    try {
-                        if (context.state == CoordinatorState.ACTIVE) {
-                            // The updated high watermark can be applied to the coordinator only if the coordinator
-                            // exists and is in the active state.
-                            log.debug("Updating high watermark of {} to {}.", tp, offset);
-                            context.coordinator.updateLastCommittedOffset(offset);
-                            context.deferredEventQueue.completeUpTo(offset);
-                            coordinatorMetrics.onUpdateLastCommittedOffset(tp, offset);
-                        } else {
-                            log.debug("Ignored high watermark updated for {} to {} because the coordinator is not active.",
-                                tp, offset);
+            if (lastHighWatermark.getAndSet(offset) == NO_OFFSET) {
+                // An event to apply the new high watermark is pushed to the front of the
+                // queue only if the previous value was -1L. If it was not, it means that
+                // there is already an event waiting to process the last value.
+                processor.enqueueFirst(new CoordinatorInternalEvent("HighWatermarkUpdate", tp, () -> {
+                    long newHighWatermark = lastHighWatermark.getAndSet(NO_OFFSET);
+
+                    CoordinatorContext context = coordinators.get(tp);
+                    if (context != null) {
+                        context.lock.lock();
+                        try {
+                            if (context.state == CoordinatorState.ACTIVE) {
+                                // The updated high watermark can be applied to the coordinator only if the coordinator
+                                // exists and is in the active state.
+                                log.debug("Updating high watermark of {} to {}.", tp, newHighWatermark);
+                                context.coordinator.updateLastCommittedOffset(newHighWatermark);
+                                context.deferredEventQueue.completeUpTo(newHighWatermark);
+                                coordinatorMetrics.onUpdateLastCommittedOffset(tp, newHighWatermark);
+                            } else {
+                                log.debug("Ignored high watermark updated for {} to {} because the coordinator is not active.",
+                                    tp, newHighWatermark);
+                            }
+                        } finally {
+                            context.lock.unlock();
                         }
-                    } finally {
-                        context.lock.unlock();
+                    } else {
+                        log.debug("Ignored high watermark updated for {} to {} because the coordinator does not exist.",
+                            tp, newHighWatermark);
                     }
-                } else {
-                    log.debug("Ignored high watermark updated for {} to {} because the coordinator does not exist.",
-                        tp, offset);
-                }
-            });
+                }));
+            }
         }
     }
 
@@ -1262,12 +1290,6 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
      * The partition writer used by the runtime to persist records.
      */
     private final PartitionWriter<U> partitionWriter;
-
-    /**
-     * The high watermark listener registered to all the partitions
-     * backing the coordinators.
-     */
-    private final HighWatermarkListener highWatermarklistener;
 
     /**
      * The coordinator loaded used by the runtime.
@@ -1335,7 +1357,6 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         this.coordinators = new ConcurrentHashMap<>();
         this.processor = processor;
         this.partitionWriter = partitionWriter;
-        this.highWatermarklistener = new HighWatermarkListener();
         this.loader = loader;
         this.coordinatorShardBuilderSupplier = coordinatorShardBuilderSupplier;
         this.runtimeMetrics = runtimeMetrics;
@@ -1353,14 +1374,28 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
     }
 
     /**
-     * Enqueues a new event.
+     * Enqueues a new event at the end of the processing queue.
      *
      * @param event The event.
      * @throws NotCoordinatorException If the event processor is closed.
      */
-    private void enqueue(CoordinatorEvent event) {
+    private void enqueueLast(CoordinatorEvent event) {
         try {
-            processor.enqueue(event);
+            processor.enqueueLast(event);
+        } catch (RejectedExecutionException ex) {
+            throw new NotCoordinatorException("Can't accept an event because the processor is closed", ex);
+        }
+    }
+
+    /**
+     * Enqueues a new event at the front of the processing queue.
+     *
+     * @param event The event.
+     * @throws NotCoordinatorException If the event processor is closed.
+     */
+    private void enqueueFirst(CoordinatorEvent event) {
+        try {
+            processor.enqueueFirst(event);
         } catch (RejectedExecutionException ex) {
             throw new NotCoordinatorException("Can't accept an event because the processor is closed", ex);
         }
@@ -1442,7 +1477,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         throwIfNotRunning();
         log.debug("Scheduled execution of write operation {}.", name);
         CoordinatorWriteEvent<T> event = new CoordinatorWriteEvent<>(name, tp, timeout, op);
-        enqueue(event);
+        enqueueLast(event);
         return event.future;
     }
 
@@ -1515,7 +1550,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 timeout,
                 op
             );
-            enqueue(event);
+            enqueueLast(event);
             return event.future;
         });
     }
@@ -1554,7 +1589,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             result,
             timeout
         );
-        enqueue(event);
+        enqueueLast(event);
         return event.future;
     }
 
@@ -1578,7 +1613,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         throwIfNotRunning();
         log.debug("Scheduled execution of read operation {}.", name);
         CoordinatorReadEvent<T> event = new CoordinatorReadEvent<>(name, tp, op);
-        enqueue(event);
+        enqueueLast(event);
         return event.future;
     }
 
@@ -1619,7 +1654,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         Runnable op
     ) {
         log.debug("Scheduled execution of internal operation {}.", name);
-        enqueue(new CoordinatorInternalEvent(name, tp, op));
+        enqueueLast(new CoordinatorInternalEvent(name, tp, op));
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -1216,7 +1216,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 // An event to apply the new high watermark is pushed to the front of the
                 // queue only if the previous value was -1L. If it was not, it means that
                 // there is already an event waiting to process the last value.
-                processor.enqueueFirst(new CoordinatorInternalEvent("HighWatermarkUpdate", tp, () -> {
+                enqueueFirst(new CoordinatorInternalEvent("HighWatermarkUpdate", tp, () -> {
                     long newHighWatermark = lastHighWatermark.getAndSet(NO_OFFSET);
 
                     CoordinatorContext context = coordinators.get(tp);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntime.java
@@ -1201,6 +1201,13 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         private final AtomicLong lastHighWatermark = new AtomicLong(NO_OFFSET);
 
         /**
+         * @return The last high watermark received or NO_OFFSET is none is pending.
+         */
+        public long lastHighWatermark() {
+            return lastHighWatermark.get();
+        }
+
+        /**
          * Updates the high watermark of the corresponding coordinator.
          *
          * @param tp        The topic partition.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessor.java
@@ -198,14 +198,25 @@ public class MultiThreadedEventProcessor implements CoordinatorEventProcessor {
     }
 
     /**
-     * Enqueues a new {{@link CoordinatorEvent}}.
+     * Enqueues a new {{@link CoordinatorEvent}} at the end of the processor.
      *
      * @param event The event.
      * @throws RejectedExecutionException If the event processor is closed.
      */
     @Override
-    public void enqueue(CoordinatorEvent event) throws RejectedExecutionException {
-        accumulator.add(event);
+    public void enqueueLast(CoordinatorEvent event) throws RejectedExecutionException {
+        accumulator.addLast(event);
+    }
+
+    /**
+     * Enqueues a new {{@link CoordinatorEvent}} at the front of the processor.
+     *
+     * @param event The event.
+     * @throws RejectedExecutionException If the event processor is closed.
+     */
+    @Override
+    public void enqueueFirst(CoordinatorEvent event) throws RejectedExecutionException {
+        accumulator.addFirst(event);
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntimeTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/CoordinatorRuntimeTest.java
@@ -2663,6 +2663,7 @@ public class CoordinatorRuntimeTest {
         processor.poll();
 
         assertEquals(-1, runtime.contextOrThrow(TP).highWatermarklistener.lastHighWatermark());
+        assertEquals(2, runtime.contextOrThrow(TP).coordinator.lastCommittedOffset());
         assertTrue(write1.isDone());
         assertTrue(write2.isDone());
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
@@ -186,7 +186,7 @@ public class MultiThreadedEventProcessorTest {
                 new FutureEvent<>(new TopicPartition("foo", 2), numEventsExecuted::incrementAndGet)
             );
 
-            events.forEach(eventProcessor::enqueue);
+            events.forEach(eventProcessor::enqueueLast);
 
             CompletableFuture.allOf(events
                 .stream()
@@ -223,7 +223,7 @@ public class MultiThreadedEventProcessorTest {
                 new FutureEvent<>(new TopicPartition("foo", 1), numEventsExecuted::incrementAndGet, true)  // Event 5
             );
 
-            events.forEach(eventProcessor::enqueue);
+            events.forEach(eventProcessor::enqueueLast);
 
             // Events 0 and 1 are executed.
             assertTrue(events.get(0).awaitExecution(5, TimeUnit.SECONDS));
@@ -301,7 +301,7 @@ public class MultiThreadedEventProcessorTest {
         eventProcessor.close();
 
         assertThrows(RejectedExecutionException.class,
-            () -> eventProcessor.enqueue(new FutureEvent<>(new TopicPartition("foo", 0), () -> 0)));
+            () -> eventProcessor.enqueueLast(new FutureEvent<>(new TopicPartition("foo", 0), () -> 0)));
     }
 
     @Test
@@ -332,14 +332,14 @@ public class MultiThreadedEventProcessorTest {
             );
 
             // Enqueue the blocking event.
-            eventProcessor.enqueue(blockingEvent);
+            eventProcessor.enqueueLast(blockingEvent);
 
             // Ensure that the blocking event is executed.
             waitForCondition(() -> numEventsExecuted.get() > 0,
                 "Blocking event not executed.");
 
             // Enqueue the other events.
-            events.forEach(eventProcessor::enqueue);
+            events.forEach(eventProcessor::enqueueLast);
 
             // Events should not be completed.
             events.forEach(event -> assertFalse(event.future.isDone()));
@@ -349,7 +349,7 @@ public class MultiThreadedEventProcessorTest {
 
             // Enqueuing a new event is rejected.
             assertThrows(RejectedExecutionException.class,
-                () -> eventProcessor.enqueue(blockingEvent));
+                () -> eventProcessor.enqueueLast(blockingEvent));
 
             // Release the blocking event to unblock the thread.
             blockingEvent.release();
@@ -398,7 +398,7 @@ public class MultiThreadedEventProcessorTest {
             new DelayEventAccumulator(mockTime, 500L)
         )) {
             // Enqueue the blocking event.
-            eventProcessor.enqueue(blockingEvent);
+            eventProcessor.enqueueLast(blockingEvent);
 
             // Ensure that the blocking event is executed.
             waitForCondition(() -> numEventsExecuted.get() > 0,
@@ -414,7 +414,7 @@ public class MultiThreadedEventProcessorTest {
                 mockTime.milliseconds()
             );
 
-            eventProcessor.enqueue(otherEvent);
+            eventProcessor.enqueueLast(otherEvent);
 
             // Pass the time.
             mockTime.sleep(3000L);
@@ -492,7 +492,7 @@ public class MultiThreadedEventProcessorTest {
                 new FutureEvent<>(new TopicPartition("foo", 2), numEventsExecuted::incrementAndGet)
             );
 
-            events.forEach(eventProcessor::enqueue);
+            events.forEach(eventProcessor::enqueueLast);
 
             CompletableFuture.allOf(events
                 .stream()


### PR DESCRIPTION
When the group coordinator is under heavy load, the current mechanism to release pending events based on updated high watermark, which consist in pushing an event at the end of the queue, is bad because pending events pay the cost of the queue twice. A first time for the handling of the first event and a second time for the handling of the hwm update. This patch changes this logic to push the hwm update event to the front of the queue in order to release pending events as soon as as possible.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
