### PR TITLE
KAFKA-16217: Stop the abort transaction try loop when closing producers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -270,14 +270,7 @@ public class Sender implements Runnable {
         while (!forceClose && transactionManager != null && transactionManager.hasOngoingTransaction()) {
             if (!transactionManager.isCompleting()) {
                 log.info("Aborting incomplete transaction due to shutdown");
-
-                try {
-                    // It is possible for the transaction manager to throw errors when aborting. Catch these
-                    // so as not to interfere with the rest of the shutdown logic.
-                    transactionManager.beginAbort();
-                } catch (Exception e) {
-                    log.error("Error in kafka producer I/O thread while aborting transaction: ", e);
-                }
+                transactionManager.beginAbort();
             }
             try {
                 runOnce();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -270,7 +270,15 @@ public class Sender implements Runnable {
         while (!forceClose && transactionManager != null && transactionManager.hasOngoingTransaction()) {
             if (!transactionManager.isCompleting()) {
                 log.info("Aborting incomplete transaction due to shutdown");
-                transactionManager.beginAbort();
+                try {
+                    // It is possible for the transaction manager to throw errors when aborting. Catch these
+                    // so as not to interfere with the rest of the shutdown logic.
+                    transactionManager.beginAbort();
+                } catch (Exception e) {
+                    log.error("Error in kafka producer I/O thread while aborting transaction when during closing: ", e);
+                    // Force close in case the transactionManager is in error states.
+                    forceClose = true;
+                }
             }
             try {
                 runOnce();

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -3255,12 +3255,9 @@ public class SenderTest {
         when(transactionManager.hasOngoingTransaction()).thenReturn(true);
         when(transactionManager.beginAbort()).thenThrow(new IllegalStateException());
         sender.initiateClose();
-        try {
-            // The sender should directly get closed.
-            sender.run();
-        } catch (Exception e) {
-            assertTrue(e instanceof IllegalStateException);
-        }
+
+        // The sender should directly get closed.
+        sender.run();
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -3258,6 +3258,7 @@ public class SenderTest {
 
         // The sender should directly get closed.
         sender.run();
+        verify(transactionManager, times(1)).close();
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -130,9 +130,11 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class SenderTest {
     private static final int MAX_REQUEST_SIZE = 1024 * 1024;
@@ -3236,6 +3238,28 @@ public class SenderTest {
             assertEquals(offset, futureIsProduced.get().offset());
         } finally {
             m.close();
+        }
+    }
+
+    // This test is expected to run fast. If timeout, the sender is not able to close properly.
+    @Timeout(5)
+    @Test
+    public void testSenderShouldCloseWhenTransactionManagerInErrorState() throws Exception {
+        metrics.close();
+        Map<String, String> clientTags = Collections.singletonMap("client-id", "clientA");
+        metrics = new Metrics(new MetricConfig().tags(clientTags));
+        TransactionManager transactionManager = mock(TransactionManager.class);
+        SenderMetricsRegistry metricsRegistry = new SenderMetricsRegistry(metrics);
+        Sender sender = new Sender(logContext, client, metadata, this.accumulator, false, MAX_REQUEST_SIZE, ACKS_ALL,
+                1, metricsRegistry, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
+        when(transactionManager.hasOngoingTransaction()).thenReturn(true);
+        when(transactionManager.beginAbort()).thenThrow(new IllegalStateException());
+        sender.initiateClose();
+        try {
+            // The sender should directly get closed.
+            sender.run();
+        } catch (Exception e) {
+            assertTrue(e instanceof IllegalStateException);
         }
     }
 


### PR DESCRIPTION
This is a mitigation fix for the https://issues.apache.org/jira/browse/KAFKA-16217. Exceptions should not block closing the producers.
This PR reverts a part of the change https://github.com/apache/kafka/pull/13591