### PR TITLE
MINOR:Add hint for `resumeDeletions` in `TopicDeletionManager`

### DIFF
--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -314,6 +314,15 @@ class TopicDeletionManager(config: KafkaConfig,
     }
   }
 
+  /**
+   * Here are the following cases that would be invoked for the resume of deletion:
+   * 1. Controller failover.
+   * 2. New topics to delete is enqueued by child change of `/admin/deleted_topics`.
+   * 3. New broker starts up. Any replicas belonging to topics queued up for deletion can be deleted since the broker is up.
+   * 4. Partition reassignment completes. Any partitions belonging to topics queued up for deletion finished reassignment.
+   * 5. When a broker that hosts replicas for topics to be deleted goes down.
+   * 6. Invoked by the StopReplicaResponse callback when it receives no error code for a replica of a topic to be deleted.
+   * */
   private def resumeDeletions(): Unit = {
     val topicsQueuedForDeletion = Set.empty[String] ++ controllerContext.topicsToBeDeleted
     val topicsEligibleForRetry = mutable.Set.empty[String]

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -182,7 +182,7 @@ class TopicDeletionManager(config: KafkaConfig,
       true
   }
 
-  private def isTopicDeletionInProgress(topic: String): Boolean = {
+  private def isTopicReplicaDeletionInProgress(topic: String): Boolean = {
     if (isDeleteTopicEnabled) {
       controllerContext.isAnyReplicaInState(topic, ReplicaDeletionStarted)
     } else
@@ -219,7 +219,7 @@ class TopicDeletionManager(config: KafkaConfig,
    */
   private def isTopicEligibleForDeletion(topic: String): Boolean = {
     controllerContext.isTopicQueuedUpForDeletion(topic) &&
-      !isTopicDeletionInProgress(topic) &&
+      !isTopicReplicaDeletionInProgress(topic) &&
       !isTopicIneligibleForDeletion(topic)
   }
 


### PR DESCRIPTION
1. The `resumeDeletions` method is called from multiple places and is the core logic responsible for executing the deletion. Therefore, adding comments to indicate where this method is being called can help better understand this part of the logic.
2. The `isTopicDeletionInProgress` method has the same name and parameters in both `TopicDeletionManager` and `ControllerContext`, but the meanings they express are entirely different. In the context of `TopicDeletionManager`, this method accurately indicates whether any replicas of the corresponding topic are currently in the process of being deleted on the broker. Topics in this state are not eligible for further deletion logic. On the other hand, in `ControllerContext`, the method simply indicates whether the topic has begun the deletion process, regardless of whether it is in the pre-deletion, mid-deletion, or post-deletion state on the broker. Therefore, the meanings and roles of the two methods are completely different, and having the same name can cause confusion when reading the code. To address this issue, it is recommended to rename the `isTopicDeletionInProgress` method in one or both classes to more accurately reflect their respective meanings. For example, in `TopicDeletionManager`, the method could be renamed to `isTopicReplicaDeletionInProgress` to emphasize that it checks for replicas of the topic that are currently being deleted. And in `ControllerContext`, the method `isTopicDeletionInProgress` could clarify that it only checks if the deletion process has begun for the topic. By doing so, code readability and maintainability will be improved, and confusion will be reduced.