### PR TITLE
MINOR: Fix wrong highWatermark assert equals condition in HighwatermarkPersistenceTest

### DIFF
--- a/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
@@ -94,12 +94,13 @@ class HighwatermarkPersistenceTest {
 
       replicaManager.checkpointHighWatermarks()
       fooPartition0Hw = hwmFor(replicaManager, topic, 0)
-      assertEquals(log0.highWatermark, fooPartition0Hw)
+      assertEquals(0L, fooPartition0Hw)
       // set the high watermark for local replica
+      append(partition0, count = 5)
       partition0.localLogOrException.updateHighWatermark(5L)
       replicaManager.checkpointHighWatermarks()
       fooPartition0Hw = hwmFor(replicaManager, topic, 0)
-      assertEquals(log0.highWatermark, fooPartition0Hw)
+      assertEquals(5L, fooPartition0Hw)
     } finally {
       // shutdown the replica manager upon test completion
       replicaManager.shutdown(false)


### PR DESCRIPTION
  This pr is aims to fix the wrong highWatermark assert equals condition in `HighwatermarkPersistenceTest`.  The highWatermark need lower than LEO, but in `HighwatermarkPersistenceTest#testHighWatermarkPersistenceSinglePartition`, the test not append only data to partition, so `updateHighWatermark()` cannot work, the `hw` are always 0.

However, the test don't failed before because of the assert equals condition is self judgement which will be always true (equals to 0).
 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
