### PR TITLE
KAFKA-16381 use volatile to guarantee KafkaMetric#config visibility across threads

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -26,7 +26,7 @@ public final class KafkaMetric implements Metric {
     private final Object lock;
     private final Time time;
     private final MetricValueProvider<?> metricValueProvider;
-    private MetricConfig config;
+    private volatile MetricConfig config;
 
     // public for testing
     public KafkaMetric(Object lock, MetricName metricName, MetricValueProvider<?> valueProvider,
@@ -41,9 +41,7 @@ public final class KafkaMetric implements Metric {
     }
 
     public MetricConfig config() {
-        synchronized (lock) {
-            return this.config;
-        }
+        return this.config;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -41,7 +41,9 @@ public final class KafkaMetric implements Metric {
     }
 
     public MetricConfig config() {
-        return this.config;
+        synchronized (lock) {
+            return this.config;
+        }
     }
 
     @Override


### PR DESCRIPTION
## Context
In KafkaMetirc.java, the config getter is 

```
@Override
public MetricName metricName()
{ return this.metricName; }
```

and there is a setter 

```
public void config(MetricConfig config) {
    synchronized (lock) {    
         this.config = config;  
     }
}
```

Since it's possible to set and get in the mean time, we should consider this case for getting.

Refer to [KAFKA-16381](https://issues.apache.org/jira/browse/KAFKA-16381).

## Solution
Set the config as volatile, which can avoid the case, and it's also lighter than adding a lock in getter.

## Test
```
./gradlew cleanTest core:test --tests ConnectionQuotasTest --tests ControllerMutationQuotaTest stream:test --tests StandbyTaskTest --tests StreamTaskTest
```
and it passed

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
