### PR TITLE
MINOR: unlock before closing queue

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/queue/KafkaEventQueue.java
+++ b/server-common/src/main/java/org/apache/kafka/queue/KafkaEventQueue.java
@@ -260,6 +260,7 @@ public final class KafkaEventQueue implements EventQueue {
                         if (deadlineMap.isEmpty() && (shuttingDown || interrupted)) {
                             // If there are no more entries to process, and the queue is
                             // closing, exit the thread.
+                            lock.unlock();
                             return;
                         }
                     } else {


### PR DESCRIPTION
The lock should be released before closing queue.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
