### PR TITLE
MINOR : Removed the depreciated information about Zk to Kraft migration.

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3797,14 +3797,6 @@ foo
     <li>Modifying certain dynamic configurations on the standalone KRaft controller</li>
   </ul>
 
-  <h4 class="anchor-heading"><a id="kraft_zk_migration" class="anchor-link"></a><a href="#kraft_zk_migration">ZooKeeper to KRaft Migration</a></h4>
-
-  <p>
-    <b>ZooKeeper to KRaft migration is ready for production clusters since version 3.6</b>
-    Please refer to
-    <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-833%3A+Mark+KRaft+as+Production+Ready#KIP833:MarkKRaftasProductionReady-Kafka3.5" target="_blank">KIP-833</a> for more information.
-  </p>
-
   <h3>Terminology</h3>
   <ul>
     <li>Brokers that are in <b>ZK mode</b> store their metadata in Apache ZooKepeer. This is the old mode of handling metadata.</li>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3802,7 +3802,7 @@ foo
   <p>
     <b>ZooKeeper to KRaft migration is ready for production clusters since version 3.6</b>
     Please refer to
-    <a href="https://issues.apache.org/jira/projects/KAFKA" target="_blank">KIP-866</a> for more information.
+    <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-833%3A+Mark+KRaft+as+Production+Ready#KIP833:MarkKRaftasProductionReady-Kafka3.5" target="_blank">KIP-833</a> for more information.
   </p>
 
   <h3>Terminology</h3>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3800,9 +3800,9 @@ foo
   <h4 class="anchor-heading"><a id="kraft_zk_migration" class="anchor-link"></a><a href="#kraft_zk_migration">ZooKeeper to KRaft Migration</a></h4>
 
   <p>
-    <b>ZooKeeper to KRaft migration is considered an Early Access feature and is not recommended for production clusters.</b>
-    Please report issues with ZooKeeper to KRaft migration using the
-    <a href="https://issues.apache.org/jira/projects/KAFKA" target="_blank">project JIRA</a> and the "kraft" component.
+    <b>ZooKeeper to KRaft migration is ready for production clusters since version 3.6</b>
+    Please refer to
+    <a href="https://issues.apache.org/jira/projects/KAFKA" target="_blank">KIP-866</a> for more information.
   </p>
 
   <h3>Terminology</h3>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -3797,6 +3797,8 @@ foo
     <li>Modifying certain dynamic configurations on the standalone KRaft controller</li>
   </ul>
 
+  <h4 class="anchor-heading"><a id="kraft_zk_migration" class="anchor-link"></a><a href="#kraft_zk_migration">ZooKeeper to KRaft Migration</a></h4>
+
   <h3>Terminology</h3>
   <ul>
     <li>Brokers that are in <b>ZK mode</b> store their metadata in Apache ZooKepeer. This is the old mode of handling metadata.</li>


### PR DESCRIPTION
The current document about Zookeeper to kraft migration is depreciated.
Accord to [KIP-833: Mark KRaft as Production Ready](https://cwiki.apache.org/confluence/display/KAFKA/KIP-833%3A+Mark+KRaft+as+Production+Ready), the migration from ZK mode supported as GA.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
