### PR TITLE
MINOR: Update upgrade docs to refer 3.6.2 version

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -106,9 +106,9 @@
         </li>
     </ul>
 
-<h4><a id="upgrade_3_6_1" href="#upgrade_3_6_1">Upgrading to 3.6.1 from any version 0.8.x through 3.5.x</a></h4>
+<h4><a id="upgrade_3_6_2" href="#upgrade_3_6_2">Upgrading to 3.6.2 from any version 0.8.x through 3.5.x</a></h4>
 
-    <h5><a id="upgrade_361_zk" href="#upgrade_361_zk">Upgrading ZooKeeper-based clusters</a></h5>
+    <h5><a id="upgrade_362_zk" href="#upgrade_362_zk">Upgrading ZooKeeper-based clusters</a></h5>
     <p><b>If you are upgrading from a version prior to 2.1.x, please see the note in step 5 below about the change to the schema used to store consumer offsets.
         Once you have changed the inter.broker.protocol.version to the latest version, it will not be possible to downgrade to a version prior to 2.1.</b></p>
 
@@ -149,7 +149,7 @@
         </li>
     </ol>
 
-    <h5><a id="upgrade_361_kraft" href="#upgrade_361_kraft">Upgrading KRaft-based clusters</a></h5>
+    <h5><a id="upgrade_362_kraft" href="#upgrade_362_kraft">Upgrading KRaft-based clusters</a></h5>
     <p><b>If you are upgrading from a version prior to 3.3.0, please see the note in step 3 below. Once you have changed the metadata.version to the latest version, it will not be possible to downgrade to a version prior to 3.3-IV0.</b></p>
 
     <p><b>For a rolling upgrade:</b></p>


### PR DESCRIPTION
Bump the version number in the "Upgrading to ..." header in docs/upgrade.html to upcoming release  version.