### PR TITLE
KAFKA-16386: Convert NETWORK_EXCEPTIONs from KIP-890 transaction verification

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -922,6 +922,12 @@ private[group] class GroupCoordinator(
           val (error, verificationGuard) = errorAndGuard
           if (error != Errors.NONE) {
             val finalError = error match {
+              // Transaction verification can fail with `NETWORK_EXCEPTION`, a retriable error which
+              // older clients may not expect and retry correctly. We have the option of translating
+              // `NETWORK_EXCEPTION` to either `COORDINATOR_LOAD_IN_PROGRESS` or
+              // `COORDINATOR_NOT_AVAILABLE`, which trigger the desired retry behavior in older
+              // clients. We use `COORDINATOR_LOAD_IN_PROGRESS` because `COORDINATOR_NOT_AVAILABLE`
+              // also triggers an unnecessary coordinator lookup.
               case Errors.NETWORK_EXCEPTION => Errors.COORDINATOR_LOAD_IN_PROGRESS
               case other => GroupMetadataManager.maybeConvertOffsetCommitError(other)
             }

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -921,16 +921,7 @@ private[group] class GroupCoordinator(
         ): Unit = {
           val (error, verificationGuard) = errorAndGuard
           if (error != Errors.NONE) {
-            val finalError = error match {
-              // Transaction verification can fail with `NETWORK_EXCEPTION`, a retriable error which
-              // older clients may not expect and retry correctly. We have the option of translating
-              // `NETWORK_EXCEPTION` to either `COORDINATOR_LOAD_IN_PROGRESS` or
-              // `COORDINATOR_NOT_AVAILABLE`, which trigger the desired retry behavior in older
-              // clients. We use `COORDINATOR_LOAD_IN_PROGRESS` because `COORDINATOR_NOT_AVAILABLE`
-              // also triggers an unnecessary coordinator lookup.
-              case Errors.NETWORK_EXCEPTION => Errors.COORDINATOR_LOAD_IN_PROGRESS
-              case other => GroupMetadataManager.maybeConvertOffsetCommitError(other)
-            }
+            val finalError = GroupMetadataManager.maybeConvertOffsetCommitError(error)
             responseCallback(offsetMetadata.map { case (k, _) => k -> finalError })
           } else {
             doTxnCommitOffsets(group, memberId, groupInstanceId, generationId, producerId, producerEpoch,

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -921,7 +921,10 @@ private[group] class GroupCoordinator(
         ): Unit = {
           val (error, verificationGuard) = errorAndGuard
           if (error != Errors.NONE) {
-            val finalError = GroupMetadataManager.maybeConvertOffsetCommitError(error)
+            val finalError = error match {
+              case Errors.NETWORK_EXCEPTION => Errors.COORDINATOR_LOAD_IN_PROGRESS
+              case other => GroupMetadataManager.maybeConvertOffsetCommitError(other)
+            }
             responseCallback(offsetMetadata.map { case (k, _) => k -> finalError })
           } else {
             doTxnCommitOffsets(group, memberId, groupInstanceId, generationId, producerId, producerEpoch,

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -1368,11 +1368,9 @@ object GroupMetadataManager {
       case Errors.NETWORK_EXCEPTION =>
         // When committing offsets transactionally, we now verify the transaction with the
         // transaction coordinator. Verification can fail with `NETWORK_EXCEPTION`, a retriable
-        // error which older clients may not expect and retry correctly. We have the option of
-        // translating `NETWORK_EXCEPTION` to either `COORDINATOR_LOAD_IN_PROGRESS` or
-        // `COORDINATOR_NOT_AVAILABLE`, which trigger the desired retry behavior in older clients.
-        // We use `COORDINATOR_LOAD_IN_PROGRESS` because `COORDINATOR_NOT_AVAILABLE` also triggers
-        // an unnecessary coordinator lookup.
+        // error which older clients may not expect and retry correctly. We translate the error to
+        // `COORDINATOR_LOAD_IN_PROGRESS` because it causes clients to retry the request without an
+        // unnecessary coordinator lookup.
         Errors.COORDINATOR_LOAD_IN_PROGRESS
 
       case Errors.UNKNOWN_TOPIC_OR_PARTITION

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -1365,6 +1365,16 @@ object GroupMetadataManager {
 
   def maybeConvertOffsetCommitError(error: Errors) : Errors = {
     error match {
+      case Errors.NETWORK_EXCEPTION =>
+        // When committing offsets transactionally, we now verify the transaction with the
+        // transaction coordinator. Verification can fail with `NETWORK_EXCEPTION`, a retriable
+        // error which older clients may not expect and retry correctly. We have the option of
+        // translating `NETWORK_EXCEPTION` to either `COORDINATOR_LOAD_IN_PROGRESS` or
+        // `COORDINATOR_NOT_AVAILABLE`, which trigger the desired retry behavior in older clients.
+        // We use `COORDINATOR_LOAD_IN_PROGRESS` because `COORDINATOR_NOT_AVAILABLE` also triggers
+        // an unnecessary coordinator lookup.
+        Errors.COORDINATOR_LOAD_IN_PROGRESS
+
       case Errors.UNKNOWN_TOPIC_OR_PARTITION
            | Errors.NOT_ENOUGH_REPLICAS
            | Errors.NOT_ENOUGH_REPLICAS_AFTER_APPEND =>

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -831,6 +831,7 @@ class ReplicaManager(val config: KafkaConfig,
             error match {
               case Errors.INVALID_TXN_STATE => Some(error.exception("Partition was not added to the transaction"))
               case Errors.CONCURRENT_TRANSACTIONS |
+                   Errors.NETWORK_EXCEPTION |
                    Errors.COORDINATOR_LOAD_IN_PROGRESS |
                    Errors.COORDINATOR_NOT_AVAILABLE |
                    Errors.NOT_COORDINATOR => Some(new NotEnoughReplicasException(

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -831,8 +831,9 @@ class ReplicaManager(val config: KafkaConfig,
             error match {
               case Errors.INVALID_TXN_STATE => Some(error.exception("Partition was not added to the transaction"))
               // Transaction verification can fail with a retriable error that older clients may not
-              // retry correctly. Translate these to `NOT_ENOUGH_REPLICAS`, which will cause such
-              // clients to retry the produce request.
+              // retry correctly. Translate these to an error which will cause such clients to retry
+              // the produce request. We use `NOT_ENOUGH_REPLICAS` because it does not trigger a
+              // metadata refresh.
               case Errors.CONCURRENT_TRANSACTIONS |
                    Errors.NETWORK_EXCEPTION |
                    Errors.COORDINATOR_LOAD_IN_PROGRESS |

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -830,6 +830,9 @@ class ReplicaManager(val config: KafkaConfig,
           val customException =
             error match {
               case Errors.INVALID_TXN_STATE => Some(error.exception("Partition was not added to the transaction"))
+              // Transaction verification can fail with a retriable error that older clients may not
+              // retry correctly. Translate these to `NOT_ENOUGH_REPLICAS`, which will cause such
+              // clients to retry the produce request.
               case Errors.CONCURRENT_TRANSACTIONS |
                    Errors.NETWORK_EXCEPTION |
                    Errors.COORDINATOR_LOAD_IN_PROGRESS |

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -832,7 +832,7 @@ class ReplicaManager(val config: KafkaConfig,
               case Errors.INVALID_TXN_STATE => Some(error.exception("Partition was not added to the transaction"))
               // Transaction verification can fail with a retriable error that older clients may not
               // retry correctly. Translate these to an error which will cause such clients to retry
-              // the produce request. We use `NOT_ENOUGH_REPLICAS` because it does not trigger a
+              // the produce request. We pick `NOT_ENOUGH_REPLICAS` because it does not trigger a
               // metadata refresh.
               case Errors.CONCURRENT_TRANSACTIONS |
                    Errors.NETWORK_EXCEPTION |

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -3844,6 +3844,7 @@ class GroupCoordinatorTest {
 
     verifyErrors(Errors.INVALID_PRODUCER_ID_MAPPING, Errors.INVALID_PRODUCER_ID_MAPPING)
     verifyErrors(Errors.INVALID_TXN_STATE, Errors.INVALID_TXN_STATE)
+    verifyErrors(Errors.NETWORK_EXCEPTION, Errors.COORDINATOR_LOAD_IN_PROGRESS)
     verifyErrors(Errors.NOT_ENOUGH_REPLICAS, Errors.COORDINATOR_NOT_AVAILABLE)
     verifyErrors(Errors.NOT_LEADER_OR_FOLLOWER, Errors.NOT_COORDINATOR)
     verifyErrors(Errors.KAFKA_STORAGE_ERROR, Errors.NOT_COORDINATOR)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -2526,7 +2526,16 @@ class ReplicaManagerTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = classOf[Errors], names = Array("NOT_COORDINATOR", "CONCURRENT_TRANSACTIONS", "COORDINATOR_LOAD_IN_PROGRESS", "COORDINATOR_NOT_AVAILABLE"))
+  @EnumSource(
+    value = classOf[Errors],
+    names = Array(
+      "NOT_COORDINATOR",
+      "CONCURRENT_TRANSACTIONS",
+      "NETWORK_EXCEPTION",
+      "COORDINATOR_LOAD_IN_PROGRESS",
+      "COORDINATOR_NOT_AVAILABLE"
+    )
+  )
   def testVerificationErrorConversions(error: Errors): Unit = {
     val tp0 = new TopicPartition(topic, 0)
     val producerId = 24L

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -863,7 +863,15 @@ public class GroupCoordinatorService implements GroupCoordinator {
             "txn-commit-offset",
             request,
             exception,
-            (error, __) -> TxnOffsetCommitRequest.getErrorResponse(request, error)
+            (error, __) -> TxnOffsetCommitRequest.getErrorResponse(
+                request,
+                // Transaction verification can throw `NETWORK_EXCEPTION`s, which older clients may
+                // not expect. Translate them to `COORDINATOR_LOAD_IN_PROGRESS` which triggers a
+                // retry without coordinator lookup.
+                error == Errors.NETWORK_EXCEPTION ?
+                    Errors.COORDINATOR_LOAD_IN_PROGRESS :
+                    error
+            )
         ));
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -1098,12 +1098,9 @@ public class GroupCoordinatorService implements GroupCoordinator {
             case NETWORK_EXCEPTION:
                 // When committing offsets transactionally, we now verify the transaction with the
                 // transaction coordinator. Verification can fail with `NETWORK_EXCEPTION`, a
-                // retriable error which older clients may not expect and retry correctly. We have
-                // the option of translating `NETWORK_EXCEPTION` to either
-                // `COORDINATOR_LOAD_IN_PROGRESS` or `COORDINATOR_NOT_AVAILABLE`, which trigger the
-                // desired retry behavior in older clients. We use `COORDINATOR_LOAD_IN_PROGRESS`
-                // because `COORDINATOR_NOT_AVAILABLE` also triggers an unnecessary coordinator
-                // lookup.
+                // retriable error which older clients may not expect and retry correctly. We
+                // translate the error to `COORDINATOR_LOAD_IN_PROGRESS` because it causes clients
+                // to retry the request without an unnecessary coordinator lookup.
                 return handler.apply(Errors.COORDINATOR_LOAD_IN_PROGRESS, null);
 
             case UNKNOWN_TOPIC_OR_PARTITION:

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -865,9 +865,12 @@ public class GroupCoordinatorService implements GroupCoordinator {
             exception,
             (error, __) -> TxnOffsetCommitRequest.getErrorResponse(
                 request,
-                // Transaction verification can throw `NETWORK_EXCEPTION`s, which older clients may
-                // not expect. Translate them to `COORDINATOR_LOAD_IN_PROGRESS` which triggers a
-                // retry without coordinator lookup.
+                // Transaction verification can fail with `NETWORK_EXCEPTION`, a retriable error
+                // which older clients may not expect and retry correctly. We have the option of
+                // translating `NETWORK_EXCEPTION` to either `COORDINATOR_LOAD_IN_PROGRESS` or
+                // `COORDINATOR_NOT_AVAILABLE`, which trigger the desired retry behavior in older
+                // clients. We use `COORDINATOR_LOAD_IN_PROGRESS` because
+                // `COORDINATOR_NOT_AVAILABLE` also triggers an unnecessary coordinator lookup.
                 error == Errors.NETWORK_EXCEPTION ?
                     Errors.COORDINATOR_LOAD_IN_PROGRESS :
                     error


### PR DESCRIPTION
KIP-890 Part 1 introduced verification of transactions with the transaction coordinator on the `Produce` and `TxnOffsetCommit` paths. This introduced the possibility of new errors when responding to those requests. For backwards compatibility with older clients, a choice was made to convert some of the new retriable errors to existing errors that are expected and retried correctly by older clients.

`NETWORK_EXCEPTION` was forgotten about and not converted, but can occur if, for example, the transaction coordinator is temporarily refusing connections. Now, we convert it to:
 * `NOT_ENOUGH_REPLICAS` on the `Produce` path, just like the other retriable errors that can arise from transaction verification.
 * `COORDINATOR_LOAD_IN_PROGRESS` on the `TxnOffsetCommit` path. This error does not force coordinator lookup on clients, unlike `COORDINATOR_NOT_AVAILABLE`. Note that this deviates from KIP-890, which says that retriable errors should be converted to `COORDINATOR_NOT_AVAILABLE`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
