### PR TITLE
MINOR: Add retry mechanism to EOS example

### DIFF
--- a/examples/src/main/java/kafka/examples/Consumer.java
+++ b/examples/src/main/java/kafka/examples/Consumer.java
@@ -109,7 +109,7 @@ public class Consumer extends Thread implements ConsumerRebalanceListener {
                 }
             }
         } catch (Throwable e) {
-            Utils.printOut("Unhandled exception");
+            Utils.printErr("Unhandled exception");
             e.printStackTrace();
         }
         Utils.printOut("Fetched %d records", numRecords - remainingRecords);
@@ -145,6 +145,7 @@ public class Consumer extends Thread implements ConsumerRebalanceListener {
         }
         // sets the reset offset policy in case of invalid or no offset
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1);
         return new KafkaConsumer<>(props);
     }
 

--- a/examples/src/main/java/kafka/examples/Consumer.java
+++ b/examples/src/main/java/kafka/examples/Consumer.java
@@ -145,7 +145,6 @@ public class Consumer extends Thread implements ConsumerRebalanceListener {
         }
         // sets the reset offset policy in case of invalid or no offset
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1);
         return new KafkaConsumer<>(props);
     }
 

--- a/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
+++ b/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
@@ -40,7 +40,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 
 import static java.time.Duration.ofMillis;

--- a/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
+++ b/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
@@ -226,7 +226,7 @@ public class ExactlyOnceMessageProcessor extends Thread implements ConsumerRebal
 
     /**
      * When we get a generic {@code KafkaException} while processing records, we retry up to {@code MAX_RETRIES} times.
-     * If we exceed this threshold, we log and error and move on to the next batch of records.
+     * If we exceed this threshold, we log an error and move on to the next batch of records.
      * In a real world application you may want to to send these records to a dead letter topic (DLT) for further processing.
      * 
      * @param retries Current number of retries

--- a/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
+++ b/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
@@ -248,6 +248,11 @@ public class ExactlyOnceMessageProcessor extends Thread implements ConsumerRebal
      * @return Updated number of retries
      */
     private int maybeRetry(int retries, KafkaConsumer<Integer, String> consumer) {
+        if (retries < 0) {
+            Utils.printErr("The number of retries must be greater than zero");
+            shutdown();
+        }
+        
         if (retries < MAX_RETRIES) {
             // retry: reset fetch offset
             // the consumer fetch position needs to be restored to the committed offset before the transaction started

--- a/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
+++ b/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
@@ -241,7 +241,7 @@ public class ExactlyOnceMessageProcessor extends Thread implements ConsumerRebal
     /**
      * When we get a generic {@code KafkaException} while processing records, we retry up to {@code MAX_RETRIES} times.
      * If we exceed this threshold, we log and error and move on to the next batch of records.
-     * In a real world application you may want to to send these records to a DLQ for further processing.
+     * In a real world application you may want to to send these records to a dead letter topic (DLT) for further processing.
      * 
      * @param retries Current number of retries
      * @param consumer Consumer instance
@@ -266,7 +266,7 @@ public class ExactlyOnceMessageProcessor extends Thread implements ConsumerRebal
                 }
             });
             retries++;
-        } else if (retries >= MAX_RETRIES) {
+        } else {
             // continue: skip records
             // the consumer fetch position needs to be committed as if records were processed successfully
             Utils.printErr("Skipping records after %d retries", MAX_RETRIES);

--- a/examples/src/main/java/kafka/examples/Producer.java
+++ b/examples/src/main/java/kafka/examples/Producer.java
@@ -89,7 +89,7 @@ public class Producer extends Thread {
                 sentRecords++;
             }
         } catch (Throwable e) {
-            Utils.printOut("Unhandled exception");
+            Utils.printErr("Unhandled exception");
             e.printStackTrace();
         }
         Utils.printOut("Sent %d records", sentRecords);


### PR DESCRIPTION
In the initial EOS example, a retry logic was implemented within the `resetToLastCommittedPositions` method. During refactoring, this logic was removed becasue a poison pill prevented the example from reaching the final phase of consuming from the output topic.

In this change, I suggest to add it back, but with a retry limit defined as `MAX_RETRIES`. Once this limit is reached, the problematic batch will be logged and skipped, allowing the processor to move on and process remaining records. If some records are skipped, the example will still hit the hard timeout (2 minutes), but after consuming all processed records.
