### PR TITLE
KAFKA-16392: Stop emitting warning log message when parsing source connector offsets with null partitions

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetUtils.java
@@ -115,8 +115,10 @@ public class OffsetUtils {
         }
 
         if (!(keyList.get(1) instanceof Map)) {
-            log.warn("Ignoring offset partition key with an unexpected format for the second element in the partition key list. " +
-                    "Expected type: {}, actual type: {}", Map.class.getName(), className(keyList.get(1)));
+            if (keyList.get(1) != null) {
+                log.warn("Ignoring offset partition key with an unexpected format for the second element in the partition key list. " +
+                        "Expected type: {}, actual type: {}", Map.class.getName(), className(keyList.get(1)));
+            }
             return;
         }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetUtilsTest.java
@@ -135,7 +135,7 @@ public class OffsetUtilsTest {
     }
 
     @Test
-    public void testProcessPartitionKeyNullOffset() {
+    public void testProcessPartitionKeyNullPartition() {
         try (LogCaptureAppender logCaptureAppender = LogCaptureAppender.createAndRegister(OffsetUtils.class)) {
             Map<String, Set<Map<String, Object>>> connectorPartitions = new HashMap<>();
             OffsetUtils.processPartitionKey(serializePartitionKey(Arrays.asList("connector-name", null)), new byte[0], CONVERTER, connectorPartitions);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetUtilsTest.java
@@ -134,6 +134,16 @@ public class OffsetUtilsTest {
         }
     }
 
+    @Test
+    public void testProcessPartitionKeyNullOffset() {
+        try (LogCaptureAppender logCaptureAppender = LogCaptureAppender.createAndRegister(OffsetUtils.class)) {
+            Map<String, Set<Map<String, Object>>> connectorPartitions = new HashMap<>();
+            OffsetUtils.processPartitionKey(serializePartitionKey(Arrays.asList("connector-name", null)), new byte[0], CONVERTER, connectorPartitions);
+            assertEquals(Collections.emptyMap(), connectorPartitions);
+            assertEquals(0, logCaptureAppender.getMessages().size());
+        }
+    }
+
     private byte[] serializePartitionKey(Object key) {
         return CONVERTER.fromConnectData("", null, key);
     }


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-16392)

This is a pretty lightweight change; we wrap the warning log message for unrecognized source partition types in a null guard.

One test is added to verify the fix that ensures no log messages are emitted in the affected scenario.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
