### PR TITLE
KAFKA-16388: add production-ready test of 2.7, 3.3 - 3.6 release to MetadataVersionTest.testFromVersionString

### DIFF
--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -132,6 +132,8 @@ class MetadataVersionTest {
         assertEquals(IBP_2_6_IV0, MetadataVersion.fromVersionString("2.6"));
         assertEquals(IBP_2_6_IV0, MetadataVersion.fromVersionString("2.6-IV0"));
 
+        // 2.7-IV2 is the latest production version in the 2.7 line
+        assertEquals(IBP_2_7_IV2, MetadataVersion.fromVersionString("2.7"));
         assertEquals(IBP_2_7_IV0, MetadataVersion.fromVersionString("2.7-IV0"));
         assertEquals(IBP_2_7_IV1, MetadataVersion.fromVersionString("2.7-IV1"));
         assertEquals(IBP_2_7_IV2, MetadataVersion.fromVersionString("2.7-IV2"));
@@ -150,24 +152,31 @@ class MetadataVersionTest {
         assertEquals(IBP_3_2_IV0, MetadataVersion.fromVersionString("3.2"));
         assertEquals(IBP_3_2_IV0, MetadataVersion.fromVersionString("3.2-IV0"));
 
+        // 3.3-IV3 is the latest production version in the 3.3 line
+        assertEquals(IBP_3_3_IV3, MetadataVersion.fromVersionString("3.3"));
         assertEquals(IBP_3_3_IV0, MetadataVersion.fromVersionString("3.3-IV0"));
         assertEquals(IBP_3_3_IV1, MetadataVersion.fromVersionString("3.3-IV1"));
         assertEquals(IBP_3_3_IV2, MetadataVersion.fromVersionString("3.3-IV2"));
         assertEquals(IBP_3_3_IV3, MetadataVersion.fromVersionString("3.3-IV3"));
 
+        // 3.4-IV0 is the latest production version in the 3.4 line
+        assertEquals(IBP_3_4_IV0, MetadataVersion.fromVersionString("3.4"));
         assertEquals(IBP_3_4_IV0, MetadataVersion.fromVersionString("3.4-IV0"));
 
+        // 3.5-IV2 is the latest production version in the 3.5 line
+        assertEquals(IBP_3_5_IV2, MetadataVersion.fromVersionString("3.5"));
         assertEquals(IBP_3_5_IV0, MetadataVersion.fromVersionString("3.5-IV0"));
         assertEquals(IBP_3_5_IV1, MetadataVersion.fromVersionString("3.5-IV1"));
         assertEquals(IBP_3_5_IV2, MetadataVersion.fromVersionString("3.5-IV2"));
 
+        // 3.6-IV2 is the latest production version in the 3.6 line
+        assertEquals(IBP_3_6_IV2, MetadataVersion.fromVersionString("3.6"));
         assertEquals(IBP_3_6_IV0, MetadataVersion.fromVersionString("3.6-IV0"));
         assertEquals(IBP_3_6_IV1, MetadataVersion.fromVersionString("3.6-IV1"));
         assertEquals(IBP_3_6_IV2, MetadataVersion.fromVersionString("3.6-IV2"));
 
         // 3.7-IV4 is the latest production version in the 3.7 line
         assertEquals(IBP_3_7_IV4, MetadataVersion.fromVersionString("3.7"));
-
         assertEquals(IBP_3_7_IV0, MetadataVersion.fromVersionString("3.7-IV0"));
         assertEquals(IBP_3_7_IV1, MetadataVersion.fromVersionString("3.7-IV1"));
         assertEquals(IBP_3_7_IV2, MetadataVersion.fromVersionString("3.7-IV2"));


### PR DESCRIPTION
Add 2.7, 3.3~3.6 release test to MetadataVersionTest.testFromVersionString

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
