### PR TITLE
KAFKA-16395: Producer should refresh metadata when a request is cancelled due to request timeout

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -585,6 +585,8 @@ public class Sender implements Runnable {
         if (response.wasTimedOut()) {
             log.trace("Cancelled request with header {} due to the last request to node {} timed out",
                 requestHeader, response.destination());
+            // we must use an exception that extends InvalidMetadataException to trigger a metadata refresh
+            // this is to handle the case where the current leader is unavailable and leadership has been moved away
             for (ProducerBatch batch : batches.values())
                 completeBatch(batch, new ProduceResponse.PartitionResponse(Errors.NETWORK_EXCEPTION, String.format("Disconnected from node %s due to request timeout", response.destination())),
                         correlationId, now, null);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -586,7 +586,7 @@ public class Sender implements Runnable {
             log.trace("Cancelled request with header {} due to the last request to node {} timed out",
                 requestHeader, response.destination());
             for (ProducerBatch batch : batches.values())
-                completeBatch(batch, new ProduceResponse.PartitionResponse(Errors.REQUEST_TIMED_OUT, String.format("Disconnected from node %s due to timeout", response.destination())),
+                completeBatch(batch, new ProduceResponse.PartitionResponse(Errors.NETWORK_EXCEPTION, String.format("Disconnected from node %s due to request timeout", response.destination())),
                         correlationId, now, null);
         } else if (response.wasDisconnected()) {
             log.trace("Cancelled request with header {} due to node {} being disconnected",

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -428,7 +428,7 @@ public class SenderTest {
         try {
             Sender sender = new Sender(logContext, client, metadata, this.accumulator, false, MAX_REQUEST_SIZE, ACKS_ALL,
                 5, senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, null, apiVersions);
-            Future<RecordMetadata> future = appendToAccumulator(tp0, 0L, "key", "value");
+            appendToAccumulator(tp0, 0L, "key", "value");
             sender.runOnce(); // connect
             sender.runOnce(); // send produce request
             assertFalse(metadata.updateRequested());


### PR DESCRIPTION
### What
On a client-side triggered request timeout (the client did not receive a response from the server in a timely manner), the client needs to refresh metadata. This requires the partition response passed to `completeBatch` to be an `instanceof InvalidMetadataException`.
This is slightly different than Errors.REQUEST_TIMED_OUT, since the latter is returned when the HWM fails to advance within the configured request timeout threshold, so we do not want to make `REQUEST_TIMED_OUT` an invalid metadata exception.

I couldn't find a better fit than NETWORK_EXCEPTION, so hopefully the improved logging from KAFKA-14317 still reasonably distinguishes between request timeouts and sudden connection interrupts.

### Testing
Added a unit test in `SenderTest` using 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
