### PR TITLE
KRaft upgrade tests should only use latest stable mv

### DIFF
--- a/tests/kafkatest/tests/core/kraft_upgrade_test.py
+++ b/tests/kafkatest/tests/core/kraft_upgrade_test.py
@@ -23,7 +23,7 @@ from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.utils import is_int
 from kafkatest.version import LATEST_3_1, LATEST_3_2, LATEST_3_3, LATEST_3_4, LATEST_3_5, \
-    DEV_BRANCH, KafkaVersion, LATEST_METADATA_VERSION
+    DEV_BRANCH, KafkaVersion, LATEST_STABLE_METADATA_VERSION
 
 #
 # Test upgrading between different KRaft versions.
@@ -71,8 +71,8 @@ class TestKRaftUpgrade(ProduceConsumeValidateTest):
             self.kafka.start_node(node)
             self.wait_until_rejoin()
             self.logger.info("Successfully restarted broker node %s" % node.account.hostname)
-        self.logger.info("Changing metadata.version to %s" % LATEST_METADATA_VERSION)
-        self.kafka.upgrade_metadata_version(LATEST_METADATA_VERSION)
+        self.logger.info("Changing metadata.version to %s" % LATEST_STABLE_METADATA_VERSION)
+        self.kafka.upgrade_metadata_version(LATEST_STABLE_METADATA_VERSION)
 
     def run_upgrade(self, from_kafka_version):
         """Test upgrade of Kafka broker cluster from various versions to the current version

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -124,7 +124,8 @@ def get_version(node=None):
 DEV_BRANCH = KafkaVersion("dev")
 DEV_VERSION = KafkaVersion("3.8.0-SNAPSHOT")
 
-LATEST_METADATA_VERSION = "3.8"
+# This should match the LATEST_PRODUCTION version defined in MetadataVersion.java
+LATEST_STABLE_METADATA_VERSION = "3.7"
 
 # 0.8.2.x versions
 V_0_8_2_1 = KafkaVersion("0.8.2.1")


### PR DESCRIPTION
This should help us avoid testing MVs before they are usable (stable).
We revert back from testing 3.8 in this case since 3.7 is the current stable version.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
