### PR TITLE
KAFKA-15951: MissingSourceTopicException should include topic names

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/errors/MissingSourceTopicException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/MissingSourceTopicException.java
@@ -16,11 +16,25 @@
  */
 package org.apache.kafka.streams.errors;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class MissingSourceTopicException extends StreamsException {
 
     private final static long serialVersionUID = 1L;
+    private final Set<String> missingTopics;
 
     public MissingSourceTopicException(final String message) {
         super(message);
+        this.missingTopics = new HashSet<>();
+    }
+
+    public MissingSourceTopicException(final String message, final Set<String> missingTopics) {
+        super(message);
+        this.missingTopics = missingTopics;
+    }
+
+    public Set<String> getMissingTopics() {
+        return this.missingTopics;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/errors/MissingSourceTopicException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/MissingSourceTopicException.java
@@ -16,25 +16,11 @@
  */
 package org.apache.kafka.streams.errors;
 
-import java.util.HashSet;
-import java.util.Set;
-
 public class MissingSourceTopicException extends StreamsException {
 
     private final static long serialVersionUID = 1L;
-    private final Set<String> missingTopics;
 
     public MissingSourceTopicException(final String message) {
         super(message);
-        this.missingTopics = new HashSet<>();
-    }
-
-    public MissingSourceTopicException(final String message, final Set<String> missingTopics) {
-        super(message);
-        this.missingTopics = missingTopics;
-    }
-
-    public Set<String> getMissingTopics() {
-        return this.missingTopics;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RepartitionTopics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RepartitionTopics.java
@@ -119,7 +119,8 @@ public class RepartitionTopics {
             return new StreamsException(
                 new MissingSourceTopicException(String.format(
                     "Missing source topics %s for subtopology %d of topology %s",
-                    missingSourceTopics, subtopologyId, topologyName)),
+                    missingSourceTopics, subtopologyId, topologyName),
+                    missingSourceTopics),
                 new TaskId(subtopologyId, 0, topologyName));
         }).collect(Collectors.toCollection(LinkedList::new));
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RepartitionTopics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RepartitionTopics.java
@@ -110,6 +110,13 @@ public class RepartitionTopics {
             .collect(Collectors.toSet());
     }
 
+    public Set<String> missingSourceTopics(){
+        return missingInputTopicsBySubtopology.entrySet().stream()
+                .map(entry -> entry.getValue())
+                .flatMap(missingTopicSet -> missingTopicSet.stream())
+                .collect(Collectors.toSet());
+    }
+
     public Queue<StreamsException> missingSourceTopicExceptions() {
         return missingInputTopicsBySubtopology.entrySet().stream().map(entry -> {
             final Set<String> missingSourceTopics = entry.getValue();
@@ -119,8 +126,7 @@ public class RepartitionTopics {
             return new StreamsException(
                 new MissingSourceTopicException(String.format(
                     "Missing source topics %s for subtopology %d of topology %s",
-                    missingSourceTopics, subtopologyId, topologyName),
-                    missingSourceTopics),
+                    missingSourceTopics, subtopologyId, topologyName)),
                 new TaskId(subtopologyId, 0, topologyName));
         }).collect(Collectors.toCollection(LinkedList::new));
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RepartitionTopics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RepartitionTopics.java
@@ -110,7 +110,7 @@ public class RepartitionTopics {
             .collect(Collectors.toSet());
     }
 
-    public Set<String> missingSourceTopics(){
+    public Set<String> missingSourceTopics() {
         return missingInputTopicsBySubtopology.entrySet().stream()
                 .map(entry -> entry.getValue())
                 .flatMap(missingTopicSet -> missingTopicSet.stream())

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -523,17 +523,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         final boolean isMissingInputTopics = !repartitionTopics.missingSourceTopicExceptions().isEmpty();
         if (isMissingInputTopics) {
             if (!taskManager.topologyMetadata().hasNamedTopologies()) {
-                final Set<String> aggregatedMissingTopics = repartitionTopics.missingSourceTopicExceptions()
-                        .stream()
-                        .filter(e -> e.getCause() instanceof MissingSourceTopicException)
-                        .map(e -> (MissingSourceTopicException) e.getCause())
-                        .map(e -> e.getMissingTopics())
-                        .flatMap(Collection::stream)
-                        .collect(Collectors.toSet());
-
-                throw new MissingSourceTopicException(
-                        String.format("Missing source topics. %s", aggregatedMissingTopics),
-                        aggregatedMissingTopics);
+                final String errorMsg = String.format("Missing source topics. %s", repartitionTopics.missingSourceTopics());
+                throw new MissingSourceTopicException(errorMsg);
             } else {
                 nonFatalExceptionsToHandle.addAll(repartitionTopics.missingSourceTopicExceptions());
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -523,7 +523,17 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         final boolean isMissingInputTopics = !repartitionTopics.missingSourceTopicExceptions().isEmpty();
         if (isMissingInputTopics) {
             if (!taskManager.topologyMetadata().hasNamedTopologies()) {
-                throw new MissingSourceTopicException("Missing source topics.");
+                final Set<String> aggregatedMissingTopics = repartitionTopics.missingSourceTopicExceptions()
+                        .stream()
+                        .filter(e -> e.getCause() instanceof MissingSourceTopicException)
+                        .map(e -> (MissingSourceTopicException) e.getCause())
+                        .map(e -> e.getMissingTopics())
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toSet());
+
+                throw new MissingSourceTopicException(
+                        String.format("Missing source topics. %s", aggregatedMissingTopics),
+                        aggregatedMissingTopics);
             } else {
                 nonFatalExceptionsToHandle.addAll(repartitionTopics.missingSourceTopicExceptions());
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -524,6 +524,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         if (isMissingInputTopics) {
             if (!taskManager.topologyMetadata().hasNamedTopologies()) {
                 final String errorMsg = String.format("Missing source topics. %s", repartitionTopics.missingSourceTopics());
+                log.error(errorMsg);
                 throw new MissingSourceTopicException(errorMsg);
             } else {
                 nonFatalExceptionsToHandle.addAll(repartitionTopics.missingSourceTopicExceptions());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
@@ -53,7 +53,9 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
         // NB: all task management is already handled by:
         // org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor.onAssignment
         if (assignmentErrorCode.get() == AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA.code()) {
-            log.error("Received error code {}", AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA);
+            log.error("Received error code {}. {}",
+                    AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA.codeName(),
+                    AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA.description());
             taskManager.handleRebalanceComplete();
             throw new MissingSourceTopicException("One or more source topics were missing during rebalance");
         } else if (assignmentErrorCode.get() == AssignorError.VERSION_PROBING.code()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorError.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorError.java
@@ -23,7 +23,7 @@ public enum AssignorError {
     INCOMPLETE_SOURCE_TOPIC_METADATA(1, "INCOMPLETE_SOURCE_TOPIC_METADATA","Missing source topics are existed. To check which topics are missing, please look into the logs of the consumer group leader. Only the leaders knows and logs the name of the missing topics."),
     VERSION_PROBING(2, "VERSION_PROBING", "VERSION_PROBING"), // not actually used anymore, but we may hit it during a rolling upgrade from earlier versions
     ASSIGNMENT_ERROR(3, "ASSIGNMENT_ERROR", "Hit an unexpected exception during task assignment phase of rebalance."),
-    SHUTDOWN_REQUESTED(4, "SHUTDOWN_REQUESTED","Encountered fatal error, and should send shutdown request for the entire application.");
+    SHUTDOWN_REQUESTED(4, "SHUTDOWN_REQUESTED", "A KafkaStreams instance encountered a fatal error and requested a shutdown for the entire application.");
 
     private final int code;
     private final String codeName;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorError.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorError.java
@@ -19,20 +19,31 @@ package org.apache.kafka.streams.processor.internals.assignment;
 public enum AssignorError {
     // Note: this error code should be reserved for fatal errors, as the receiving clients are future-proofed
     // to throw an exception upon an unrecognized error code.
-    NONE(0),
-    INCOMPLETE_SOURCE_TOPIC_METADATA(1),
-    VERSION_PROBING(2), // not actually used anymore, but we may hit it during a rolling upgrade from earlier versions
-    ASSIGNMENT_ERROR(3),
-    SHUTDOWN_REQUESTED(4);
+    NONE(0, "NONE", "NONE"),
+    INCOMPLETE_SOURCE_TOPIC_METADATA(1, "INCOMPLETE_SOURCE_TOPIC_METADATA","Missing source topics are existed. To check which topics are missing, please look into the logs of the consumer group leader. Only the leaders knows and logs the name of the missing topics."),
+    VERSION_PROBING(2, "VERSION_PROBING", "VERSION_PROBING"), // not actually used anymore, but we may hit it during a rolling upgrade from earlier versions
+    ASSIGNMENT_ERROR(3, "ASSIGNMENT_ERROR", "Hit an unexpected exception during task assignment phase of rebalance."),
+    SHUTDOWN_REQUESTED(4, "SHUTDOWN_REQUESTED","Encountered fatal error, and should send shutdown request for the entire application.");
 
     private final int code;
+    private final String codeName;
+    private final String description;
 
-    AssignorError(final int code) {
+    AssignorError(final int code, final String codeName, final String description) {
         this.code = code;
+        this.codeName = codeName;
+        this.description = description;
     }
 
     public int code() {
         return code;
+    }
+
+    public String codeName() {
+        return codeName;
+    }
+    public String description() {
+        return description;
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorError.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorError.java
@@ -21,7 +21,7 @@ public enum AssignorError {
     // to throw an exception upon an unrecognized error code.
     NONE(0, "NONE", "NONE"),
     INCOMPLETE_SOURCE_TOPIC_METADATA(1, "INCOMPLETE_SOURCE_TOPIC_METADATA","Missing source topics are existed. To check which topics are missing, please look into the logs of the consumer group leader. Only the leaders knows and logs the name of the missing topics."),
-    VERSION_PROBING(2, "VERSION_PROBING", "VERSION_PROBING"), // not actually used anymore, but we may hit it during a rolling upgrade from earlier versions
+    VERSION_PROBING(2, "VERSION_PROBING", "Could not read internal rebalance metadata due to unknown encoding version."), // not actually used anymore, but we may hit it during a rolling upgrade from earlier versions
     ASSIGNMENT_ERROR(3, "ASSIGNMENT_ERROR", "Hit an unexpected exception during task assignment phase of rebalance."),
     SHUTDOWN_REQUESTED(4, "SHUTDOWN_REQUESTED", "A KafkaStreams instance encountered a fatal error and requested a shutdown for the entire application.");
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorError.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorError.java
@@ -20,7 +20,7 @@ public enum AssignorError {
     // Note: this error code should be reserved for fatal errors, as the receiving clients are future-proofed
     // to throw an exception upon an unrecognized error code.
     NONE(0, "NONE", "NONE"),
-    INCOMPLETE_SOURCE_TOPIC_METADATA(1, "INCOMPLETE_SOURCE_TOPIC_METADATA","Missing source topics are existed. To check which topics are missing, please look into the logs of the consumer group leader. Only the leaders knows and logs the name of the missing topics."),
+    INCOMPLETE_SOURCE_TOPIC_METADATA(1, "INCOMPLETE_SOURCE_TOPIC_METADATA", "Missing metadata for source topics. Check the group leader logs for details."),
     VERSION_PROBING(2, "VERSION_PROBING", "Could not read internal rebalance metadata due to unknown encoding version."), // not actually used anymore, but we may hit it during a rolling upgrade from earlier versions
     ASSIGNMENT_ERROR(3, "ASSIGNMENT_ERROR", "Hit an unexpected exception during task assignment phase of rebalance."),
     SHUTDOWN_REQUESTED(4, "SHUTDOWN_REQUESTED", "A KafkaStreams instance encountered a fatal error and requested a shutdown for the entire application.");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorError.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorError.java
@@ -22,7 +22,7 @@ public enum AssignorError {
     NONE(0, "NONE", "NONE"),
     INCOMPLETE_SOURCE_TOPIC_METADATA(1, "INCOMPLETE_SOURCE_TOPIC_METADATA", "Missing metadata for source topics. Check the group leader logs for details."),
     VERSION_PROBING(2, "VERSION_PROBING", "Could not read internal rebalance metadata due to unknown encoding version."), // not actually used anymore, but we may hit it during a rolling upgrade from earlier versions
-    ASSIGNMENT_ERROR(3, "ASSIGNMENT_ERROR", "Hit an unexpected exception during task assignment phase of rebalance."),
+    ASSIGNMENT_ERROR(3, "ASSIGNMENT_ERROR", "Internal task assignment error. Check the group leader logs for details."),
     SHUTDOWN_REQUESTED(4, "SHUTDOWN_REQUESTED", "A KafkaStreams instance encountered a fatal error and requested a shutdown for the entire application.");
 
     private final int code;


### PR DESCRIPTION
This is minor changes!

- Jira : https://issues.apache.org/jira/browse/KAFKA-15951
- `MissingSourceTopicException` has field `missingTopics` to store missing topics. 
- The `StreamsPartitionAssignor` throws a `MissingSourceTopicException`. and it depends on result of `repartitionTopics.missingSourceTopicExceptions().isEmpty()`. thus, `missingSourceTopicExceptions()` must always contain an iterable `MissingSourceTopicException`, allowing for the aggregation and throwing of `MissingSourceTopics`.
- Idea for improving more
  -  `StreamsRebalanceListener` can throw `MissingSourceTopicException` as well. however, `StreamsRebalanceListener` cannot get missing topic List because `StreamsRebalanceListener` depends on ErrorCode `AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA.code()`
  - If `StreamsRebalanceListener` should include missing topic list when it throws `MissingSourceTopicException` as well, we can consider `ThreadLocal` to reach the target. 
  - Skeleton
    -  Set `ThreadLocal` to `StreamThread` as member field.
    -  Put missing topics to `ThreadLocal`. 
    - `StreamsRebalanceListener` can get missing topics through `ThreadLocal`..

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
