### PR TITLE
KAFKA-16271: Upgrade consumer_rolling_upgrade_test.py

### DIFF
--- a/tests/kafkatest/tests/client/consumer_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/client/consumer_rolling_upgrade_test.py
@@ -18,7 +18,7 @@ from ducktape.mark.resource import cluster
 
 
 from kafkatest.tests.verifiable_consumer_test import VerifiableConsumerTest
-from kafkatest.services.kafka import TopicPartition, quorum
+from kafkatest.services.kafka import TopicPartition, quorum, consumer_group
 
 class ConsumerRollingUpgradeTest(VerifiableConsumerTest):
     TOPIC = "test_topic"
@@ -56,7 +56,12 @@ class ConsumerRollingUpgradeTest(VerifiableConsumerTest):
         metadata_quorum=[quorum.isolated_kraft],
         use_new_coordinator=[True, False]
     )
-    def rolling_update_test(self, metadata_quorum=quorum.zk, use_new_coordinator=False):
+    @matrix(
+        metadata_quorum=quorum.all_kraft,
+        use_new_coordinator=[True],
+        group_protocol=consumer_group.all_group_protocols
+    )
+    def rolling_update_test(self, metadata_quorum=quorum.zk, use_new_coordinator=False, group_protocol=None):
         """
         Verify rolling updates of partition assignment strategies works correctly. In this
         test, we use a rolling restart to change the group's assignment strategy from "range" 
@@ -65,7 +70,7 @@ class ConsumerRollingUpgradeTest(VerifiableConsumerTest):
         """
 
         # initialize the consumer using range assignment
-        consumer = self.setup_consumer(self.TOPIC, assignment_strategy=self.RANGE)
+        consumer = self.setup_consumer(self.TOPIC, assignment_strategy=self.RANGE, group_protocol=group_protocol)
 
         consumer.start()
         self.await_all_members(consumer)


### PR DESCRIPTION
Upgrading the test to use the consumer group protocol.  The two tests are failing due to `Mismatch Assignment`

```
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.11.4
session_id:       2024-03-21--001
run time:         3 minutes 24.632 seconds
tests run:        7
passed:           5
flaky:            0
failed:           2
ignored:          0
================================================================================
test_id:    kafkatest.tests.client.consumer_rolling_upgrade_test.ConsumerRollingUpgradeTest.rolling_update_test.metadata_quorum=COMBINED_KRAFT.use_new_coordinator=True.group_protocol=classic
status:     PASS
run time:   24.599 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.consumer_rolling_upgrade_test.ConsumerRollingUpgradeTest.rolling_update_test.metadata_quorum=COMBINED_KRAFT.use_new_coordinator=True.group_protocol=consumer
status:     FAIL
run time:   26.638 seconds


    AssertionError("Mismatched assignment: {frozenset(), frozenset({TopicPartition(topic='test_topic', partition=3), TopicPartition(topic='test_topic', partition=0), TopicPartition(topic='test_topic', partition=1), TopicPartition(topic='test_topic', partition=2)})}")
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 186, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 246, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.9/dist-packages/ducktape/mark/_mark.py", line 433, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/client/consumer_rolling_upgrade_test.py", line 77, in rolling_update_test
    self._verify_range_assignment(consumer)
  File "/opt/kafka-dev/tests/kafkatest/tests/client/consumer_rolling_upgrade_test.py", line 38, in _verify_range_assignment
    assert assignment == set([
AssertionError: Mismatched assignment: {frozenset(), frozenset({TopicPartition(topic='test_topic', partition=3), TopicPartition(topic='test_topic', partition=0), TopicPartition(topic='test_topic', partition=1), TopicPartition(topic='test_topic', partition=2)})}

--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.consumer_rolling_upgrade_test.ConsumerRollingUpgradeTest.rolling_update_test.metadata_quorum=ISOLATED_KRAFT.use_new_coordinator=False
status:     PASS
run time:   29.815 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.consumer_rolling_upgrade_test.ConsumerRollingUpgradeTest.rolling_update_test.metadata_quorum=ISOLATED_KRAFT.use_new_coordinator=True
status:     PASS
run time:   29.766 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.consumer_rolling_upgrade_test.ConsumerRollingUpgradeTest.rolling_update_test.metadata_quorum=ISOLATED_KRAFT.use_new_coordinator=True.group_protocol=classic
status:     PASS
run time:   30.086 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.consumer_rolling_upgrade_test.ConsumerRollingUpgradeTest.rolling_update_test.metadata_quorum=ISOLATED_KRAFT.use_new_coordinator=True.group_protocol=consumer
status:     FAIL
run time:   35.965 seconds


    AssertionError("Mismatched assignment: {frozenset(), frozenset({TopicPartition(topic='test_topic', partition=3), TopicPartition(topic='test_topic', partition=0), TopicPartition(topic='test_topic', partition=1), TopicPartition(topic='test_topic', partition=2)})}")
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 186, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 246, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.9/dist-packages/ducktape/mark/_mark.py", line 433, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/opt/kafka-dev/tests/kafkatest/tests/client/consumer_rolling_upgrade_test.py", line 77, in rolling_update_test
    self._verify_range_assignment(consumer)
  File "/opt/kafka-dev/tests/kafkatest/tests/client/consumer_rolling_upgrade_test.py", line 38, in _verify_range_assignment
    assert assignment == set([
AssertionError: Mismatched assignment: {frozenset(), frozenset({TopicPartition(topic='test_topic', partition=3), TopicPartition(topic='test_topic', partition=0), TopicPartition(topic='test_topic', partition=1), TopicPartition(topic='test_topic', partition=2)})}

--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.consumer_rolling_upgrade_test.ConsumerRollingUpgradeTest.rolling_update_test.metadata_quorum=ZK.use_new_coordinator=False
status:     PASS
run time:   27.644 seconds
--------------------------------------------------------------------------------
```