### PR TITLE
KAFKA-16375: Fix for rejoin while reconciling

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -228,8 +228,9 @@ public class MembershipManagerImpl implements MembershipManager {
     private boolean reconciliationInProgress;
 
     /**
-     * True if a reconciliation is in progress and the member rejoined the group. Used to know
-     * that the reconciliation in progress should be interrupted and not be applied.
+     * True if a reconciliation is in progress and the member rejoined the group since the start
+     * of the reconciliation. Used to know that the reconciliation in progress should be
+     * interrupted and not be applied.
      */
     private boolean rejoinedWhileReconciliationInProgress;
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -228,7 +228,7 @@ public class MembershipManagerImpl implements MembershipManager {
     private boolean reconciliationInProgress;
 
     /**
-     * True if a reconciliation is in progress and the member rejoins the group. Used to know
+     * True if a reconciliation is in progress and the member rejoined the group. Used to know
      * that the reconciliation in progress should be interrupted and not be applied.
      */
     private boolean rejoinedWhileReconciliationInProgress;
@@ -1058,7 +1058,7 @@ public class MembershipManagerImpl implements MembershipManager {
         boolean shouldAbort = state != MemberState.RECONCILING || rejoinedWhileReconciliationInProgress;
         if (shouldAbort) {
             String reason = interruptedReconciliationReason();
-            log.error("Interrupting reconciliation because " + reason);
+            log.info("Interrupting reconciliation that is not relevant anymore because " + reason);
             markReconciliationCompleted();
         }
         return shouldAbort;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImpl.java
@@ -228,11 +228,10 @@ public class MembershipManagerImpl implements MembershipManager {
     private boolean reconciliationInProgress;
 
     /**
-     * Epoch the member had when the reconciliation in progress started. This is used to identify if
-     * the member has rejoined while it was reconciling an assignment (in which case the result
-     * of the reconciliation is not applied.)
+     * True if a reconciliation is in progress and the member rejoins the group. Used to know
+     * that the reconciliation in progress should be interrupted and not be applied.
      */
-    private int memberEpochOnReconciliationStart;
+    private boolean rejoinedWhileReconciliationInProgress;
 
     /**
      * If the member is currently leaving the group after a call to {@link #leaveGroup()}}, this
@@ -641,6 +640,9 @@ public class MembershipManagerImpl implements MembershipManager {
                     "the member is in FATAL state");
             return;
         }
+        if (reconciliationInProgress) {
+            rejoinedWhileReconciliationInProgress = true;
+        }
         resetEpoch();
         transitionTo(MemberState.JOINING);
         clearPendingAssignmentsAndLocalNamesCache();
@@ -972,7 +974,10 @@ public class MembershipManagerImpl implements MembershipManager {
                 log.debug("Auto-commit before reconciling new assignment completed successfully.");
             }
 
-            revokeAndAssign(resolvedAssignment, assignedTopicIdPartitions, revokedPartitions, addedPartitions);
+            if (!maybeAbortReconciliation()) {
+                revokeAndAssign(resolvedAssignment, assignedTopicIdPartitions, revokedPartitions, addedPartitions);
+            }
+
         }).exceptionally(error -> {
             if (error != null) {
                 log.error("Reconciliation failed.", error);
@@ -1010,25 +1015,18 @@ public class MembershipManagerImpl implements MembershipManager {
         // and assignment, executed sequentially).
         CompletableFuture<Void> reconciliationResult =
             revocationResult.thenCompose(__ -> {
-                boolean memberHasRejoined = memberEpochOnReconciliationStart != memberEpoch;
-                if (state == MemberState.RECONCILING && !memberHasRejoined) {
+                if (!maybeAbortReconciliation()) {
                     // Apply assignment
                     return assignPartitions(assignedTopicIdPartitions, addedPartitions);
                 } else {
-                    log.debug("Revocation callback completed but the member already " +
-                        "transitioned out of the reconciling state for epoch {} into " +
-                        "{} state with epoch {}. Interrupting reconciliation as it's " +
-                        "not relevant anymore,", memberEpochOnReconciliationStart, state, memberEpoch);
-                    String reason = interruptedReconciliationErrorMessage();
                     CompletableFuture<Void> res = new CompletableFuture<>();
                     res.completeExceptionally(new KafkaException("Interrupting reconciliation" +
-                        " after revocation. " + reason));
+                        " after revocation. " + interruptedReconciliationReason()));
                     return res;
                 }
             });
 
         reconciliationResult.whenComplete((result, error) -> {
-            markReconciliationCompleted();
             if (error != null) {
                 // Leaving member in RECONCILING state after callbacks fail. The member
                 // won't send the ack, and the expectation is that the broker will kick the
@@ -1036,7 +1034,7 @@ public class MembershipManagerImpl implements MembershipManager {
                 // RECONCILING -> FENCED transition.
                 log.error("Reconciliation failed.", error);
             } else {
-                if (state == MemberState.RECONCILING) {
+                if (!maybeAbortReconciliation()) {
                     currentAssignment = resolvedAssignment;
 
                     // Reschedule the auto commit starting from now that the member has a new assignment.
@@ -1044,13 +1042,26 @@ public class MembershipManagerImpl implements MembershipManager {
 
                     // Make assignment effective on the broker by transitioning to send acknowledge.
                     transitionTo(MemberState.ACKNOWLEDGING);
-                } else {
-                    String reason = interruptedReconciliationErrorMessage();
-                    log.error("Interrupting reconciliation after partitions assigned callback " +
-                        "completed. " + reason);
                 }
             }
+            markReconciliationCompleted();
         });
+    }
+
+    /**
+     * @return True if the reconciliation in progress should not continue. This could be because
+     * the member is not in RECONCILING state anymore (member failed or is leaving the group), or
+     * if it has rejoined the group (note that after rejoining the member could be RECONCILING
+     * again, so checking the state is not enough)
+     */
+    boolean maybeAbortReconciliation() {
+        boolean shouldAbort = state != MemberState.RECONCILING || rejoinedWhileReconciliationInProgress;
+        if (shouldAbort) {
+            String reason = interruptedReconciliationReason();
+            log.error("Interrupting reconciliation because " + reason);
+            markReconciliationCompleted();
+        }
+        return shouldAbort;
     }
 
     // Visible for testing.
@@ -1070,14 +1081,11 @@ public class MembershipManagerImpl implements MembershipManager {
     /**
      * @return Reason for interrupting a reconciliation progress when callbacks complete.
      */
-    private String interruptedReconciliationErrorMessage() {
-        String reason;
-        if (state != MemberState.RECONCILING) {
-            reason = "The member already transitioned out of the reconciling state into " + state;
-        } else {
-            reason = "The member has re-joined the group.";
+    private String interruptedReconciliationReason() {
+        if (rejoinedWhileReconciliationInProgress) {
+            return "the member has re-joined the group";
         }
-        return reason;
+        return "the member already transitioned out of the reconciling state into " + state;
     }
 
     /**
@@ -1085,7 +1093,7 @@ public class MembershipManagerImpl implements MembershipManager {
      */
     void markReconciliationInProgress() {
         reconciliationInProgress = true;
-        memberEpochOnReconciliationStart = memberEpoch;
+        rejoinedWhileReconciliationInProgress = false;
     }
 
     /**
@@ -1093,6 +1101,7 @@ public class MembershipManagerImpl implements MembershipManager {
      */
     void markReconciliationCompleted() {
         reconciliationInProgress = false;
+        rejoinedWhileReconciliationInProgress = false;
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
@@ -2624,8 +2624,7 @@ public class MembershipManagerImplTest {
         // reconciliation loop.
         assertEquals(assignmentAfterRejoin, membershipManager.topicPartitionsAwaitingReconciliation());
 
-        // Stale reconciliation should have been aborted and a new one should be triggered on the
-        // next poll
+        // Stale reconciliation should have been aborted and a new one should be triggered on the next poll.
         assertFalse(membershipManager.reconciliationInProgress());
         clearInvocations(membershipManager);
         membershipManager.poll(time.milliseconds());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
@@ -470,13 +470,13 @@ public class MembershipManagerImplTest {
     }
 
     /**
-     * This is the case where a member is stuck reconciling an assignment A (waiting on
-     * metadata, commit or callbacks), and it rejoins (due to fence or unsubscribe/subscribe). If
-     * the reconciliation of A completes it should not be applied (it should not update the
-     * assignment on the member or send ack).
+     * This is the case where a member is stuck reconciling an assignment A (waiting for commit
+     * to complete), and it rejoins (due to fence or unsubscribe/subscribe). If the
+     * reconciliation of A completes it should be interrupted, and it should not update the
+     * assignment on the member or send ack.
      */
     @Test
-    public void testDelayedReconciliationResultDiscardedIfMemberRejoins() {
+    public void testDelayedReconciliationResultDiscardedAfterCommitIfMemberRejoins() {
         MembershipManagerImpl membershipManager = createMemberInStableState();
         Uuid topicId1 = Uuid.randomUuid();
         String topic1 = "topic1";
@@ -496,25 +496,83 @@ public class MembershipManagerImplTest {
         testFencedMemberReleasesAssignmentAndTransitionsToJoining(membershipManager);
         clearInvocations(subscriptionState);
 
-        // Get new assignment A2 after rejoining. This should not trigger a reconciliation just
-        // yet because there is another on in progress, but should keep the new assignment ready
-        // to be reconciled next.
-        Uuid topicId3 = Uuid.randomUuid();
-        mockOwnedPartitionAndAssignmentReceived(membershipManager, topicId3, "topic3", owned);
-        receiveAssignmentAfterRejoin(topicId3, Collections.singletonList(5), membershipManager);
-        verifyReconciliationNotTriggered(membershipManager);
-        Map<Uuid, SortedSet<Integer>> assignmentAfterRejoin = topicIdPartitionsMap(topicId3, 5);
-        assertEquals(assignmentAfterRejoin, membershipManager.topicPartitionsAwaitingReconciliation());
+        Map<Uuid, SortedSet<Integer>> assignmentAfterRejoin = receiveAssignmentAfterRejoin(
+            Collections.singletonList(5), membershipManager, owned);
 
         // Reconciliation completes when the member has already re-joined the group. Should not
-        // update the subscription state or send ack.
+        // proceed with the revocation, update the subscription state or send ack.
         commitResult.complete(null);
-        verify(subscriptionState, never()).assignFromSubscribed(anyCollection());
-        assertNotEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
+        assertInitialReconciliationDiscardedAfterRejoin(membershipManager, assignmentAfterRejoin);
+    }
 
-        // Assignment received after rejoining should be ready to reconcile on the next
-        // reconciliation loop.
-        assertEquals(assignmentAfterRejoin, membershipManager.topicPartitionsAwaitingReconciliation());
+    /**
+     * This is the case where a member is stuck reconciling an assignment A (waiting for
+     * onPartitionsRevoked callback to complete), and it rejoins (due to fence or
+     * unsubscribe/subscribe). When the reconciliation of A completes it should be interrupted,
+     * and it should not update the assignment on the member or send ack.
+     */
+    @Test
+    public void testDelayedReconciliationResultDiscardedAfterPartitionsRevokedCallbackIfMemberRejoins() {
+        MembershipManagerImpl membershipManager = createMemberInStableState();
+        Uuid topicId1 = Uuid.randomUuid();
+        String topic1 = "topic1";
+        List<TopicIdPartition> owned = Collections.singletonList(new TopicIdPartition(topicId1,
+            new TopicPartition(topic1, 0)));
+        mockOwnedPartitionAndAssignmentReceived(membershipManager, topicId1, topic1, owned);
+
+        // Reconciliation that does not complete stuck on onPartitionsRevoked callback
+        ConsumerRebalanceListenerInvoker invoker = consumerRebalanceListenerInvoker();
+        ConsumerRebalanceListenerCallbackCompletedEvent callbackCompletedEvent =
+            mockNewAssignmentStuckOnPartitionsRevokedCallback(membershipManager, topicId1, topic1,
+            Arrays.asList(1, 2), owned.get(0).topicPartition(), invoker);
+        Map<Uuid, SortedSet<Integer>> assignment1 = topicIdPartitionsMap(topicId1,  1, 2);
+        assertEquals(assignment1, membershipManager.topicPartitionsAwaitingReconciliation());
+
+        // Get fenced and rejoin while still reconciling. Get new assignment to reconcile after rejoining.
+        testFencedMemberReleasesAssignmentAndTransitionsToJoining(membershipManager);
+        clearInvocations(subscriptionState);
+
+        Map<Uuid, SortedSet<Integer>> assignmentAfterRejoin = receiveAssignmentAfterRejoin(
+            Collections.singletonList(5), membershipManager, owned);
+
+        // onPartitionsRevoked callback completes when the member has already re-joined the group.
+        // Should not proceed with the assignment, update the subscription state or send ack.
+        completeCallback(callbackCompletedEvent, membershipManager);
+        assertInitialReconciliationDiscardedAfterRejoin(membershipManager, assignmentAfterRejoin);
+    }
+
+    /**
+     * This is the case where a member is stuck reconciling an assignment A (waiting for
+     * onPartitionsAssigned callback to complete), and it rejoins (due to fence or
+     * unsubscribe/subscribe). If the reconciliation of A completes it should be interrupted, and it
+     * should not update the assignment on the member or send ack.
+     */
+    @Test
+    public void testDelayedReconciliationResultDiscardedAfterPartitionsAssignedCallbackIfMemberRejoins() {
+        MembershipManagerImpl membershipManager = createMemberInStableState();
+        Uuid topicId1 = Uuid.randomUuid();
+        String topic1 = "topic1";
+
+        // Reconciliation that does not complete stuck on onPartitionsAssigned callback
+        ConsumerRebalanceListenerInvoker invoker = consumerRebalanceListenerInvoker();
+        int newPartition = 1;
+        ConsumerRebalanceListenerCallbackCompletedEvent callbackCompletedEvent =
+            mockNewAssignmentStuckOnPartitionsAssignedCallback(membershipManager, topicId1,
+                topic1, newPartition, invoker);
+        Map<Uuid, SortedSet<Integer>> assignment1 = topicIdPartitionsMap(topicId1,  newPartition);
+        assertEquals(assignment1, membershipManager.topicPartitionsAwaitingReconciliation());
+
+        // Get fenced and rejoin while still reconciling. Get new assignment to reconcile after rejoining.
+        testFencedMemberReleasesAssignmentAndTransitionsToJoining(membershipManager);
+        clearInvocations(subscriptionState);
+
+        Map<Uuid, SortedSet<Integer>> assignmentAfterRejoin = receiveAssignmentAfterRejoin(
+            Collections.singletonList(5), membershipManager, Collections.emptyList());
+
+        // onPartitionsAssigned callback completes when the member has already re-joined the group.
+        // Should not update the subscription state or send ack.
+        completeCallback(callbackCompletedEvent, membershipManager);
+        assertInitialReconciliationDiscardedAfterRejoin(membershipManager, assignmentAfterRejoin);
     }
 
     /**
@@ -2147,7 +2205,7 @@ public class MembershipManagerImplTest {
     }
 
     @Test
-    public void testRebalanceMetricsForMultipleReconcilations() {
+    public void testRebalanceMetricsForMultipleReconciliations() {
         MembershipManagerImpl membershipManager = createMemberInStableState();
         ConsumerRebalanceListenerInvoker invoker = consumerRebalanceListenerInvoker();
 
@@ -2297,6 +2355,57 @@ public class MembershipManagerImplTest {
         assertEquals(MemberState.RECONCILING, membershipManager.state());
 
         return commitResult;
+    }
+
+    private ConsumerRebalanceListenerCallbackCompletedEvent mockNewAssignmentStuckOnPartitionsRevokedCallback(
+        MembershipManagerImpl membershipManager, Uuid topicId, String topicName,
+        List<Integer> partitions, TopicPartition ownedPartition, ConsumerRebalanceListenerInvoker invoker) {
+        doNothing().when(subscriptionState).markPendingRevocation(anySet());
+        CounterConsumerRebalanceListener listener = new CounterConsumerRebalanceListener();
+        when(subscriptionState.assignedPartitions()).thenReturn(Collections.singleton(ownedPartition));
+        when(subscriptionState.hasAutoAssignedPartitions()).thenReturn(true);
+        when(subscriptionState.rebalanceListener()).thenReturn(Optional.of(listener));
+        when(commitRequestManager.autoCommitEnabled()).thenReturn(false);
+
+        when(metadata.topicNames()).thenReturn(Collections.singletonMap(topicId, topicName));
+        receiveAssignment(topicId, partitions, membershipManager);
+        membershipManager.poll(time.milliseconds());
+        verifyReconciliationTriggered(membershipManager);
+        clearInvocations(membershipManager);
+        assertEquals(MemberState.RECONCILING, membershipManager.state());
+
+        return performCallback(
+            membershipManager,
+            invoker,
+            ConsumerRebalanceListenerMethodName.ON_PARTITIONS_REVOKED,
+            topicPartitions(ownedPartition.topic(), ownedPartition.partition()),
+            false
+        );
+    }
+
+    private ConsumerRebalanceListenerCallbackCompletedEvent mockNewAssignmentStuckOnPartitionsAssignedCallback(
+        MembershipManagerImpl membershipManager, Uuid topicId, String topicName, int newPartition,
+        ConsumerRebalanceListenerInvoker invoker) {
+        CounterConsumerRebalanceListener listener = new CounterConsumerRebalanceListener();
+        when(subscriptionState.assignedPartitions()).thenReturn(Collections.emptySet());
+        when(subscriptionState.hasAutoAssignedPartitions()).thenReturn(true);
+        when(subscriptionState.rebalanceListener()).thenReturn(Optional.of(listener));
+        when(commitRequestManager.autoCommitEnabled()).thenReturn(false);
+
+        when(metadata.topicNames()).thenReturn(Collections.singletonMap(topicId, topicName));
+        receiveAssignment(topicId, Collections.singletonList(newPartition), membershipManager);
+        membershipManager.poll(time.milliseconds());
+        verifyReconciliationTriggered(membershipManager);
+        clearInvocations(membershipManager);
+        assertEquals(MemberState.RECONCILING, membershipManager.state());
+
+        return performCallback(
+            membershipManager,
+            invoker,
+            ConsumerRebalanceListenerMethodName.ON_PARTITIONS_ASSIGNED,
+            topicPartitions(topicName, newPartition),
+            false
+        );
     }
 
     private void verifyReconciliationTriggered(MembershipManagerImpl membershipManager) {
@@ -2480,7 +2589,15 @@ public class MembershipManagerImplTest {
         membershipManager.onHeartbeatSuccess(heartbeatResponse.data());
     }
 
-    private void receiveAssignmentAfterRejoin(Uuid topicId, List<Integer> partitions, MembershipManager membershipManager) {
+    private Map<Uuid, SortedSet<Integer>> receiveAssignmentAfterRejoin(List<Integer> partitions,
+                                                                       MembershipManagerImpl membershipManager,
+                                                                       Collection<TopicIdPartition> owned) {
+        // Get new assignment after rejoining. This should not trigger a reconciliation just
+        // yet because there is another one in progress, but should keep the new assignment ready
+        // to be reconciled next.
+        Uuid topicId = Uuid.randomUuid();
+        mockOwnedPartitionAndAssignmentReceived(membershipManager, topicId, "topic3", owned);
+
         ConsumerGroupHeartbeatResponseData.Assignment targetAssignment = new ConsumerGroupHeartbeatResponseData.Assignment()
                 .setTopicPartitions(Collections.singletonList(
                         new ConsumerGroupHeartbeatResponseData.TopicPartitions()
@@ -2489,6 +2606,23 @@ public class MembershipManagerImplTest {
         ConsumerGroupHeartbeatResponse heartbeatResponse =
                 createConsumerGroupHeartbeatResponseWithBumpedEpoch(targetAssignment);
         membershipManager.onHeartbeatSuccess(heartbeatResponse.data());
+
+        verifyReconciliationNotTriggered(membershipManager);
+        Map<Uuid, SortedSet<Integer>> assignmentAfterRejoin = topicIdPartitionsMap(topicId, 5);
+        assertEquals(assignmentAfterRejoin, membershipManager.topicPartitionsAwaitingReconciliation());
+        return assignmentAfterRejoin;
+    }
+
+    private void assertInitialReconciliationDiscardedAfterRejoin(
+        MembershipManagerImpl membershipManager,
+        Map<Uuid, SortedSet<Integer>> assignmentAfterRejoin) {
+        verify(subscriptionState, never()).markPendingRevocation(any());
+        verify(subscriptionState, never()).assignFromSubscribed(anyCollection());
+        assertNotEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
+
+        // Assignment received after rejoining should be ready to reconcile on the next
+        // reconciliation loop.
+        assertEquals(assignmentAfterRejoin, membershipManager.topicPartitionsAwaitingReconciliation());
     }
 
     private void receiveEmptyAssignment(MembershipManager membershipManager) {
@@ -2578,7 +2712,6 @@ public class MembershipManagerImplTest {
         when(subscriptionState.assignedPartitions()).thenReturn(Collections.singleton(ownedPartition));
         when(subscriptionState.hasAutoAssignedPartitions()).thenReturn(true);
         when(subscriptionState.rebalanceListener()).thenReturn(Optional.of(listener));
-        // doNothing().when(subscriptionState).markPendingRevocation(anySet());
         when(commitRequestManager.autoCommitEnabled()).thenReturn(false);
         membershipManager.transitionToFenced();
         return performCallback(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MembershipManagerImplTest.java
@@ -2623,6 +2623,13 @@ public class MembershipManagerImplTest {
         // Assignment received after rejoining should be ready to reconcile on the next
         // reconciliation loop.
         assertEquals(assignmentAfterRejoin, membershipManager.topicPartitionsAwaitingReconciliation());
+
+        // Stale reconciliation should have been aborted and a new one should be triggered on the
+        // next poll
+        assertFalse(membershipManager.reconciliationInProgress());
+        clearInvocations(membershipManager);
+        membershipManager.poll(time.milliseconds());
+        verify(membershipManager).markReconciliationInProgress();
     }
 
     private void receiveEmptyAssignment(MembershipManager membershipManager) {


### PR DESCRIPTION
This PR includes a fix to properly identify a reconciliation that should be interrupted and not applied because the member has rejoined. It does so simply based on a flag (not epochs, server or local). If the member has rejoined while reconciling, the reconciliation will be interrupted. 

This also ensures that the check to abort the reconciliation is performed on all the 3 stages of the reconciliation that could be delayed: commit, onPartitionsRevoked, onPartitionsAssigned. 
