### PR TITLE
MINOR: Preventing running the :core tests twice when testing with coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -748,7 +748,7 @@ subprojects {
   }
 
   if (userEnableTestCoverage) {
-    def coverageGen = it.path == ':core' ? 'reportScoverage' : 'jacocoTestReport'
+    def coverageGen = it.path == ':core' ? 'reportTestScoverage' : 'jacocoTestReport'
     tasks.register('reportCoverage').configure { dependsOn(coverageGen) }
   }
 


### PR DESCRIPTION
reportScoverage task (which was used previously as dependency of the registered coverage task) creates a task for each Test task and executes them. There's unitTest, integrationTest and the test tasks (which is just for executing both unit and integration), so reportScoverage executes all three with their corresponding scoverage task, hence running all tests twice. Solution is just to use the reportTestScoverage task as dependency.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
