### PR TITLE
KAFKA-16408: Fix handling of '--version' or '--help' for GetOffsetShell

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
+++ b/tools/src/main/java/org/apache/kafka/tools/GetOffsetShell.java
@@ -59,6 +59,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class GetOffsetShell {
+    static final String USAGE_TEXT = "An interactive shell for getting topic-partition offsets.";
     private static final Pattern TOPIC_PARTITION_PATTERN = Pattern.compile("([^:,]*)(?::(?:([0-9]*)|(?:([0-9]*)-([0-9]*))))?");
 
     public static void main(String... args) {
@@ -142,7 +143,7 @@ public class GetOffsetShell {
             excludeInternalTopicsOpt = parser.accepts("exclude-internal-topics", "By default, internal topics are included. If specified, internal topics are excluded.");
 
             if (args.length == 0) {
-                CommandLineUtils.printUsageAndExit(parser, "An interactive shell for getting topic-partition offsets.");
+                CommandLineUtils.printUsageAndExit(parser, USAGE_TEXT);
             }
 
             try {
@@ -156,6 +157,8 @@ public class GetOffsetShell {
             } else {
                 effectiveBrokerListOpt = brokerListOpt;
             }
+
+            CommandLineUtils.maybePrintHelpOrVersion(this, USAGE_TEXT);
 
             CommandLineUtils.checkRequiredArgs(parser, options, effectiveBrokerListOpt);
 

--- a/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.Exit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -315,6 +316,18 @@ public class GetOffsetShellTest {
     @ClusterTest
     public void testTopicPartitionsFlagWithPartitionsFlagCauseExit() {
         assertExitCodeIsOne("--topic-partitions", "__consumer_offsets", "--partitions", "0");
+    }
+
+    @ClusterTest
+    public void testPrintHelp() {
+        String out = ToolsTestUtils.captureStandardErr(() -> GetOffsetShell.mainNoExit("--help"));
+        assertTrue(out.startsWith(GetOffsetShell.USAGE_TEXT));
+    }
+
+    @ClusterTest
+    public void testPrintVersion() {
+        String out = ToolsTestUtils.captureStandardOut(() -> GetOffsetShell.mainNoExit("--version"));
+        assertEquals(AppInfoParser.getVersion(), out);
     }
 
     private void assertExitCodeIsOne(String... args) {


### PR DESCRIPTION
Added call CommandLineUtils#maybePrintHelpOrVersion before check required args.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
