### PR TITLE
KAFKA-16409: DeleteRecordsCommand should use standard exception handling

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/DeleteRecordsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/DeleteRecordsCommand.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DeleteRecordsResult;
 import org.apache.kafka.clients.admin.RecordsToDelete;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.common.AdminCommandFailedException;
 import org.apache.kafka.server.common.AdminOperationException;
@@ -61,7 +62,18 @@ public class DeleteRecordsCommand {
     private static final DecodeJson.DecodeString STRING = new DecodeJson.DecodeString();
 
     public static void main(String[] args) throws Exception {
-        execute(args, System.out);
+        Exit.exit(mainNoExit(args));
+    }
+
+    static int mainNoExit(String... args) {
+        try {
+            execute(args, System.out);
+            return 0;
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+            System.err.println(Utils.stackTrace(e));
+            return 1;
+        }
     }
 
     static Map<TopicPartition, List<Long>> parseOffsetJsonStringWithoutDedup(String jsonData) throws JsonProcessingException {

--- a/tools/src/test/java/org/apache/kafka/tools/DeleteRecordsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/DeleteRecordsCommandTest.java
@@ -120,7 +120,11 @@ public class DeleteRecordsCommandTest {
 class DeleteRecordsCommandUnitTest {
     @Test
     public void testOffsetFileNotExists() {
-        assertThrows(IOException.class, () -> DeleteRecordsCommand.main(new String[]{
+        assertThrows(IOException.class, () -> DeleteRecordsCommand.execute(new String[]{
+            "--bootstrap-server", "localhost:9092",
+            "--offset-json-file", "/not/existing/file"
+        }, System.out));
+        assertEquals(1, DeleteRecordsCommand.mainNoExit(new String[]{
             "--bootstrap-server", "localhost:9092",
             "--offset-json-file", "/not/existing/file"
         }));
@@ -128,7 +132,12 @@ class DeleteRecordsCommandUnitTest {
 
     @Test
     public void testCommandConfigNotExists() {
-        assertThrows(NoSuchFileException.class, () -> DeleteRecordsCommand.main(new String[] {
+        assertThrows(NoSuchFileException.class, () -> DeleteRecordsCommand.execute(new String[] {
+            "--bootstrap-server", "localhost:9092",
+            "--offset-json-file", "/not/existing/file",
+            "--command-config", "/another/not/existing/file"
+        }, System.out));
+        assertEquals(1, DeleteRecordsCommand.mainNoExit(new String[] {
             "--bootstrap-server", "localhost:9092",
             "--offset-json-file", "/not/existing/file",
             "--command-config", "/another/not/existing/file"


### PR DESCRIPTION
When an exception is thrown in kafka-delete-records, it propagates through `main` to the JVM, producing the following message:
```
bin/kafka-delete-records.sh --bootstrap-server localhost:9092 --offset-json-file /tmp/does-not-exist
Exception in thread "main" java.io.IOException: Unable to read file /tmp/does-not-exist
	at org.apache.kafka.common.utils.Utils.readFileAsString(Utils.java:787)
	at org.apache.kafka.tools.DeleteRecordsCommand.execute(DeleteRecordsCommand.java:105)
	at org.apache.kafka.tools.DeleteRecordsCommand.main(DeleteRecordsCommand.java:64)
Caused by: java.nio.file.NoSuchFileException: /tmp/does-not-exist
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:218)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:380)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:432)
	at java.base/java.nio.file.Files.readAllBytes(Files.java:3288)
	at org.apache.kafka.common.utils.Utils.readFileAsString(Utils.java:784)
	... 2 more
```

This is in contrast to the error handling used in other tools, such as the kafka-log-dirs:

```
bin/kafka-log-dirs.sh --bootstrap-server localhost:9092 --describe --command-config /tmp/does-not-exist
/tmp/does-not-exist
java.nio.file.NoSuchFileException: /tmp/does-not-exist
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:218)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:380)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:432)
	at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:422)
	at java.base/java.nio.file.Files.newInputStream(Files.java:160)
	at org.apache.kafka.common.utils.Utils.loadProps(Utils.java:686)
	at org.apache.kafka.common.utils.Utils.loadProps(Utils.java:673)
	at org.apache.kafka.tools.LogDirsCommand.createAdminClient(LogDirsCommand.java:149)
	at org.apache.kafka.tools.LogDirsCommand.execute(LogDirsCommand.java:68)
	at org.apache.kafka.tools.LogDirsCommand.mainNoExit(LogDirsCommand.java:54)
	at org.apache.kafka.tools.LogDirsCommand.main(LogDirsCommand.java:49)
```

After the fix, the error from kafka-delete-records will be like:

```
Unable to read file /tmp/does-not-exist
java.io.IOException: Unable to read file /tmp/does-not-exist
	at org.apache.kafka.common.utils.Utils.readFileAsString(Utils.java:787)
	at org.apache.kafka.tools.DeleteRecordsCommand.execute(DeleteRecordsCommand.java:117)
	at org.apache.kafka.tools.DeleteRecordsCommand.mainNoExit(DeleteRecordsCommand.java:70)
	at org.apache.kafka.tools.DeleteRecordsCommand.main(DeleteRecordsCommand.java:65)
Caused by: java.nio.file.NoSuchFileException: /tmp/does-not-exist
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:218)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:380)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:432)
	at java.base/java.nio.file.Files.readAllBytes(Files.java:3288)
	at org.apache.kafka.common.utils.Utils.readFileAsString(Utils.java:784)
	... 3 more
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
