### PR TITLE
MINOR: Add type check to classic group timeout operations

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2425,7 +2425,7 @@ public class GroupMetadataManager {
         try {
             group = getOrMaybeCreateClassicGroup(groupId, false);
         } catch (UnknownMemberIdException | GroupIdNotFoundException exception) {
-            log.debug(exception.getMessage() + " " + "Skipping rebalance stage.");
+            log.debug("Cannot find the group, skipping rebalance stage.", exception);
             return EMPTY_RESULT;
         }
         return completeClassicGroupJoin(group);
@@ -2843,7 +2843,7 @@ public class GroupMetadataManager {
         try {
             group = getOrMaybeCreateClassicGroup(groupId, false);
         } catch (UnknownMemberIdException | GroupIdNotFoundException exception) {
-            log.debug(exception.getMessage() + " " + "Skipping the initial rebalance stage.", groupId);
+            log.debug("Cannot find the group, skipping the initial rebalance stage.", exception);
             return EMPTY_RESULT;
         }
 


### PR DESCRIPTION
When implementing the group type conversion from a classic group to a consumer group, if the replay of conversion records fails, the group should be reverted back including its timeouts. 

A possible solution is to keep all the classic group timeouts and add a type check to the timeout operations. If the group is successfully upgraded, it won't be able to pass the type check and its operations will be executed without actually doing anything; if the group upgrade fails, the group map will be reverted and the timeout operations will be executed as is.

We've already have group type check in consumer group timeout operations. This pr adds similar type check to those classic group timeout operations.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
