### PR TITLE
KAFKA-16397 - Use ByteBufferOutputStream to avoid array copy

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
@@ -29,8 +29,6 @@ import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -203,10 +201,10 @@ public class ClientTelemetryUtils {
 
     public static ByteBuffer decompress(byte[] metrics, CompressionType compressionType) {
         ByteBuffer data = ByteBuffer.wrap(metrics);
-        try (InputStream in = compressionType.wrapForInput(data, RecordBatch.CURRENT_MAGIC_VALUE, BufferSupplier.create())){
+        try (InputStream in = compressionType.wrapForInput(data, RecordBatch.CURRENT_MAGIC_VALUE, BufferSupplier.create())) {
             byte[] bytes = new byte[data.capacity() * 2];
             int nRead = in.read(bytes, 0, bytes.length);
-            try(ByteBufferOutputStream out = new ByteBufferOutputStream(nRead)) {
+            try (ByteBufferOutputStream out = new ByteBufferOutputStream(nRead)) {
                 out.write(bytes, 0, nRead);
                 return out.buffer();
             }

--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
@@ -202,7 +202,7 @@ public class ClientTelemetryUtils {
     public static ByteBuffer decompress(byte[] metrics, CompressionType compressionType) {
         ByteBuffer data = ByteBuffer.wrap(metrics);
         try (InputStream in = compressionType.wrapForInput(data, RecordBatch.CURRENT_MAGIC_VALUE, BufferSupplier.create());
-             ByteBufferOutputStream out = new ByteBufferOutputStream(1)) {
+             ByteBufferOutputStream out = new ByteBufferOutputStream(512)) {
             byte[] bytes = new byte[data.capacity() * 2];
             int nRead;
             while ((nRead = in.read(bytes, 0, bytes.length)) != -1) {

--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
@@ -203,14 +203,17 @@ public class ClientTelemetryUtils {
         ByteBuffer data = ByteBuffer.wrap(metrics);
         try (InputStream in = compressionType.wrapForInput(data, RecordBatch.CURRENT_MAGIC_VALUE, BufferSupplier.create())) {
             byte[] bytes = new byte[data.capacity() * 2];
-            int nRead = in.read(bytes, 0, bytes.length);
-            try (ByteBufferOutputStream out = new ByteBufferOutputStream(nRead)) {
-                out.write(bytes, 0, nRead);
-                return out.buffer();
+            int nRead;
+            while ((nRead = in.read(bytes, 0, bytes.length)) != -1) {
+                try (ByteBufferOutputStream out = new ByteBufferOutputStream(nRead)) {
+                    out.write(bytes, 0, nRead);
+                    return out.buffer();
+                }
             }
         } catch (IOException e) {
             throw new KafkaException("Failed to decompress metrics data", e);
         }
+        return null;
     }
 
     public static MetricsData deserializeMetricsData(ByteBuffer serializedMetricsData) {

--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
@@ -203,15 +203,14 @@ public class ClientTelemetryUtils {
         ByteBuffer data = ByteBuffer.wrap(metrics);
         try (InputStream in = compressionType.wrapForInput(data, RecordBatch.CURRENT_MAGIC_VALUE, BufferSupplier.create());
              ByteBufferOutputStream out = new ByteBufferOutputStream(1)) {
-                byte[] bytes = new byte[data.capacity() * 2];
-                int nRead;
-                while ((nRead = in.read(bytes, 0, bytes.length)) != -1) {
-                    out.write(bytes, 0, nRead);
-                }
-                out.buffer().flip();
-                return out.buffer();
-        }
-         catch (IOException e) {
+            byte[] bytes = new byte[data.capacity() * 2];
+            int nRead;
+            while ((nRead = in.read(bytes, 0, bytes.length)) != -1) {
+                out.write(bytes, 0, nRead);
+            }
+            out.buffer().flip();
+            return out.buffer();
+        } catch (IOException e) {
             throw new KafkaException("Failed to decompress metrics data", e);
         }
     }

--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
@@ -204,16 +204,17 @@ public class ClientTelemetryUtils {
         try (InputStream in = compressionType.wrapForInput(data, RecordBatch.CURRENT_MAGIC_VALUE, BufferSupplier.create())) {
             byte[] bytes = new byte[data.capacity() * 2];
             int nRead;
+            int totalReads = 0;
             while ((nRead = in.read(bytes, 0, bytes.length)) != -1) {
-                try (ByteBufferOutputStream out = new ByteBufferOutputStream(nRead)) {
-                    out.write(bytes, 0, nRead);
-                    return out.buffer();
-                }
+                totalReads+=nRead;
+            }
+            try (ByteBufferOutputStream out = new ByteBufferOutputStream(totalReads)) {
+                out.write(bytes, 0, totalReads);
+                return out.buffer();
             }
         } catch (IOException e) {
             throw new KafkaException("Failed to decompress metrics data", e);
         }
-        return null;
     }
 
     public static MetricsData deserializeMetricsData(ByteBuffer serializedMetricsData) {

--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtils.java
@@ -202,7 +202,7 @@ public class ClientTelemetryUtils {
     public static ByteBuffer decompress(byte[] metrics, CompressionType compressionType) {
         ByteBuffer data = ByteBuffer.wrap(metrics);
         try (InputStream in = compressionType.wrapForInput(data, RecordBatch.CURRENT_MAGIC_VALUE, BufferSupplier.create());
-             ByteBufferOutputStream out = new ByteBufferOutputStream(512)) {
+            ByteBufferOutputStream out = new ByteBufferOutputStream(512)) {
             byte[] bytes = new byte[data.capacity() * 2];
             int nRead;
             while ((nRead = in.read(bytes, 0, bytes.length)) != -1) {

--- a/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtilsTest.java
@@ -134,7 +134,7 @@ public class ClientTelemetryUtilsTest {
             assertArrayEquals(testString, compressed);
         }
         ByteBuffer decompressed = ClientTelemetryUtils.decompress(compressed, compressionType);
-        byte[] actualResult = Utils.toArray(decompressed, testString.length);
+        byte[] actualResult = Utils.toArray(decompressed);
         assertNotNull(decompressed);
         assertArrayEquals(testString, actualResult);
     }

--- a/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtilsTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.telemetry.internals;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.utils.Utils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -133,7 +134,7 @@ public class ClientTelemetryUtilsTest {
             assertArrayEquals(testString, compressed);
         }
         ByteBuffer decompressed = ClientTelemetryUtils.decompress(compressed, compressionType);
-        byte[] actualResult = Arrays.copyOfRange(decompressed.array(), 0, testString.length);
+        byte[] actualResult = Utils.toArray(decompressed, testString.length);
         assertNotNull(decompressed);
         assertArrayEquals(testString, actualResult);
     }

--- a/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtilsTest.java
@@ -132,9 +132,9 @@ public class ClientTelemetryUtilsTest {
         } else {
             assertArrayEquals(testString, compressed);
         }
-
         ByteBuffer decompressed = ClientTelemetryUtils.decompress(compressed, compressionType);
+        byte[] actualResult = Arrays.copyOfRange(decompressed.array(), 0, testString.length);
         assertNotNull(decompressed);
-        assertArrayEquals(testString, decompressed.array());
+        assertArrayEquals(testString, actualResult);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/telemetry/internals/ClientTelemetryUtilsTest.java
@@ -134,8 +134,8 @@ public class ClientTelemetryUtilsTest {
             assertArrayEquals(testString, compressed);
         }
         ByteBuffer decompressed = ClientTelemetryUtils.decompress(compressed, compressionType);
-        byte[] actualResult = Utils.toArray(decompressed);
         assertNotNull(decompressed);
+        byte[] actualResult = Utils.toArray(decompressed);
         assertArrayEquals(testString, actualResult);
     }
 }


### PR DESCRIPTION
Hi all,
This PR is based on [KAFKA-16397](https://issues.apache.org/jira/browse/KAFKA-16397). 
I replaced the ByteArrayOutputStream with ByteBufferOutputStream to avoid array copy. 
Also remove the while loop since the input size of bytes is deterministic.
Thanks!

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
