### PR TITLE
KAFKA-16417:When initializeResources throws an exception in TopicBasedRemoteLogMetadataManager.scala, initializationFailed needs to be set to true

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
@@ -436,6 +436,7 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
                     log.info("Initialized topic-based RLMM resources successfully");
                 } catch (Exception e) {
                     log.error("Encountered error while initializing producer/consumer", e);
+                    initializationFailed = true;
                     return;
                 } finally {
                     lock.writeLock().unlock();
@@ -463,7 +464,7 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
             }
             return description != null;
         } catch (ExecutionException | InterruptedException ex) {
-            log.info("Topic {} does not exist. Error: {}", topic, ex.getCause().getMessage());
+            log.info("Encountered error while describe topic {}. Error: {}", topic, ex.getCause().getMessage());
             return false;
         }
     }


### PR DESCRIPTION
If the initializing producer/consumer fails, the broker cannot actually read and write the remote storage system normally. We need to mark initializationFailed= true to sense this event.

