### PR TITLE
KAFKA-16416: Use NetworkClientTest to replace RequestResponseTest to be the example of log4j output

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,14 @@ Follow instructions in https://kafka.apache.org/quickstart
     ./gradlew clients:test --tests org.apache.kafka.clients.MetadataTest.testTimeToNextUpdate
 
 ### Running a particular unit/integration test with log4j output ###
-Change the log4j setting in either `clients/src/test/resources/log4j.properties` or `core/src/test/resources/log4j.properties`
+By default, there will be only small number of logs output while testing. You can adjust it by changing the `log4j.properties` in the test project directory.
 
-For example, you can modify the line in `clients/src/test/resources/log4j.properties` to `log4j.logger.org.apache.kafka=INFO` and then run:
+For example, if you want to see more logs for clients project tests, you can modify the line in `clients/src/test/resources/log4j.properties` 
+to `log4j.logger.org.apache.kafka=INFO` and then run:
     
     ./gradlew cleanTest clients:test --tests NetworkClientTest   
 
-And you should see INFO level logs in the file under the `./clients/build/test-results/test` directory.
+And you should see `INFO` level logs in the file under the `./clients/build/test-results/test` directory.
 
 ### Specifying test retries ###
 By default, each failed test is retried once up to a maximum of five retries per test run. Tests are retried at the end of the test task. Adjust these parameters in the following way:

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Change the log4j setting in either `clients/src/test/resources/log4j.properties`
 
 For example, you can modify the line in `clients/src/test/resources/log4j.properties` to `log4j.logger.org.apache.kafka=INFO` and then run:
     
-    ./gradlew cleanTest clients:test --tests NetworkClientTest --info   
+    ./gradlew cleanTest clients:test --tests NetworkClientTest   
 
-And you should see INFO level logs in the console and also find them under the build/test-results directory.
+And you should see INFO level logs in the file under the build/test-results directory.
 
 ### Specifying test retries ###
 By default, each failed test is retried once up to a maximum of five retries per test run. Tests are retried at the end of the test task. Adjust these parameters in the following way:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For example, you can modify the line in `clients/src/test/resources/log4j.proper
     
     ./gradlew cleanTest clients:test --tests NetworkClientTest   
 
-And you should see INFO level logs in the file under the build/test-results directory.
+And you should see INFO level logs in the file under the `./clients/build/test-results/test` directory.
 
 ### Specifying test retries ###
 By default, each failed test is retried once up to a maximum of five retries per test run. Tests are retried at the end of the test task. Adjust these parameters in the following way:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ Follow instructions in https://kafka.apache.org/quickstart
 ### Running a particular unit/integration test with log4j output ###
 Change the log4j setting in either `clients/src/test/resources/log4j.properties` or `core/src/test/resources/log4j.properties`
 
-    ./gradlew clients:test --tests RequestResponseTest
+For example, you can modify the line in `clients/src/test/resources/log4j.properties` to `log4j.logger.org.apache.kafka=INFO` and then run:
+    
+    ./gradlew cleanTest clients:test --tests NetworkClientTest --info   
+
+And you should see INFO level logs in the console and also find them under the build/test-results directory.
 
 ### Specifying test retries ###
 By default, each failed test is retried once up to a maximum of five retries per test run. Tests are retried at the end of the test task. Adjust these parameters in the following way:

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ Follow instructions in https://kafka.apache.org/quickstart
     ./gradlew clients:test --tests org.apache.kafka.clients.MetadataTest.testTimeToNextUpdate
 
 ### Running a particular unit/integration test with log4j output ###
-By default, there will be only small number of logs output while testing. You can adjust it by changing the `log4j.properties` in the test project directory.
+By default, there will be only small number of logs output while testing. You can adjust it by changing the `log4j.properties` file in the module's `src/test/resources` directory.
 
-For example, if you want to see more logs for clients project tests, you can modify the line in `clients/src/test/resources/log4j.properties` 
+For example, if you want to see more logs for clients project tests, you can modify [the line](https://github.com/apache/kafka/blob/trunk/clients/src/test/resources/log4j.properties#L21) in `clients/src/test/resources/log4j.properties` 
 to `log4j.logger.org.apache.kafka=INFO` and then run:
     
     ./gradlew cleanTest clients:test --tests NetworkClientTest   
 
-And you should see `INFO` level logs in the file under the `./clients/build/test-results/test` directory.
+And you should see `INFO` level logs in the file under the `clients/build/test-results/test` directory.
 
 ### Specifying test retries ###
 By default, each failed test is retried once up to a maximum of five retries per test run. Tests are retried at the end of the test task. Adjust these parameters in the following way:


### PR DESCRIPTION
jira url: https://issues.apache.org/jira/browse/KAFKA-16416

For the part to introduce how to show log4j's info when executing unit test in README, it seems that current example 
`RequestResponseTest` only have `WARN` and `TRACE` level info.

I switch to another test case, which has `INFO`, `DEBUG`, `TRACE` and `WARN` so it's easier to observe the log level changes.  Also add `cleanTest` and `--info` to ensure the unit test do execute each time and the info directly shows on the console


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
