### PR TITLE
MINOR: add docker usage documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ Using compiled files:
 Using docker image:
 
     docker run -p 9092:9092 apache/kafka:3.7.0
-    
 
 ### Running a Kafka broker in ZooKeeper mode
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Using compiled files:
     ./bin/zookeeper-server-start.sh config/zookeeper.properties
     ./bin/kafka-server-start.sh config/server.properties
 
->Since ZooKeeper is planned to be removed in Apache Kafka 4.0, the docker image only support running in KRaft mode
+>Since ZooKeeper mode is already deprecated and planned to be removed in Apache Kafka 4.0, the docker image only supports running in KRaft mode
 
 ### Cleaning the build ###
     ./gradlew clean
@@ -294,7 +294,6 @@ See [tests/README.md](tests/README.md).
 ### Running in Vagrant ###
 
 See [vagrant/README.md](vagrant/README.md).
-
 
 ### Contribution ###
 

--- a/README.md
+++ b/README.md
@@ -87,14 +87,25 @@ fail due to code changes. You can just run:
 
 ### Running a Kafka broker in KRaft mode
 
+Using compiled files:
+
     KAFKA_CLUSTER_ID="$(./bin/kafka-storage.sh random-uuid)"
     ./bin/kafka-storage.sh format -t $KAFKA_CLUSTER_ID -c config/kraft/server.properties
     ./bin/kafka-server-start.sh config/kraft/server.properties
 
+Using docker image:
+
+    docker run -p 9092:9092 apache/kafka:3.7.0
+    
+
 ### Running a Kafka broker in ZooKeeper mode
+
+Using compiled files:
 
     ./bin/zookeeper-server-start.sh config/zookeeper.properties
     ./bin/kafka-server-start.sh config/server.properties
+
+>Since ZooKeeper is planned to be removed in Apache Kafka 4.0, the docker image only support running in KRaft mode
 
 ### Cleaning the build ###
     ./gradlew clean
@@ -285,15 +296,6 @@ See [tests/README.md](tests/README.md).
 
 See [vagrant/README.md](vagrant/README.md).
 
-### Running in Docker ###
-You could use the official docker image to run Kafka in Docker. It is available at [Docker Hub](https://hub.docker.com/r/apache/kafka).
-
-For example, to start a single-node Kafka, you can run the following command: 
-
-     docker compose -f docker/examples/jvm/single-node/plaintext/docker-compose.yml up
-
-
-For the detail, see [docker/examples/README.md](docker/examples/README.md).
 
 ### Contribution ###
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,16 @@ See [tests/README.md](tests/README.md).
 
 See [vagrant/README.md](vagrant/README.md).
 
+### Running in Docker ###
+You could use the official docker image to run Kafka in Docker. It is available at [Docker Hub](https://hub.docker.com/r/apache/kafka).
+
+For example, to start a single-node Kafka, you can run the following command: 
+
+     docker compose -f docker/examples/jvm/single-node/plaintext/docker-compose.yml up
+
+
+For the detail, see [docker/examples/README.md](docker/examples/README.md).
+
 ### Contribution ###
 
 Apache Kafka is interested in building the community; we would welcome any thoughts or [patches](https://issues.apache.org/jira/browse/KAFKA). You can reach us [on the Apache mailing lists](http://kafka.apache.org/contact.html).


### PR DESCRIPTION
We have a detail usage guide for running Kafka in docker. However, it might be easy for people to miss it if they only scan through the README.

This PR add a basic example command for quick start and  link directing users to the detailed usage guide

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
