### PR TITLE
KAFKA-16423: Stop emitting warning log message when parsing source connector with null connector name

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetUtils.java
@@ -109,8 +109,10 @@ public class OffsetUtils {
         }
 
         if (!(keyList.get(0) instanceof String)) {
-            log.warn("Ignoring offset partition key with an unexpected format for the first element in the partition key list. " +
-                    "Expected type: {}, actual type: {}", String.class.getName(), className(keyList.get(0)));
+            if (keyList.get(0) != null) {
+                log.warn("Ignoring offset partition key with an unexpected format for the first element in the partition key list. " +
+                        "Expected type: {}, actual type: {}", String.class.getName(), className(keyList.get(0)));
+            }
             return;
         }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetUtilsTest.java
@@ -144,6 +144,16 @@ public class OffsetUtilsTest {
         }
     }
 
+    @Test
+    public void testProcessPartitionKeyNullConnectorName() {
+        try (LogCaptureAppender logCaptureAppender = LogCaptureAppender.createAndRegister(OffsetUtils.class)) {
+            Map<String, Set<Map<String, Object>>> connectorPartitions = new HashMap<>();
+            OffsetUtils.processPartitionKey(serializePartitionKey(Arrays.asList(null, new HashMap<>())), new byte[0], CONVERTER, connectorPartitions);
+            assertEquals(Collections.emptyMap(), connectorPartitions);
+            assertEquals(0, logCaptureAppender.getMessages().size());
+        }
+    }
+
     private byte[] serializePartitionKey(Object key) {
         return CONVERTER.fromConnectData("", null, key);
     }


### PR DESCRIPTION
This is a pretty lightweight change; we wrap the warning log message for unrecognized source partition types in a null guard.

One test is added to verify the fix that ensures no log messages are emitted in the affected scenario.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
