### PR TITLE
KAFKA-15915: Flaky ProducerIdManagerTest error injection fix

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
@@ -211,8 +211,7 @@ class RPCProducerIdManager(brokerId: Int,
   }
 
 
-  // Visible for testing
-  private[transaction] def maybeRequestNextBlock(): Unit = {
+  private def maybeRequestNextBlock(): Unit = {
     val retryTimestamp = backoffDeadlineMs.get()
     if (retryTimestamp == NoRetry || time.milliseconds() >= retryTimestamp) {
       // Send a request only if we reached the retry deadline, or if no deadline was set.

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -214,7 +214,6 @@ class ProducerIdManagerTest {
 
     verifyNewBlockAndProducerId(manager, new ProducerIdsBlock(0, 0, 1), 0)
 
-    time.sleep(RetryBackoffMs)
     verifyFailure(manager)
 
     time.sleep(RetryBackoffMs)


### PR DESCRIPTION
testUnrecoverableErrors was flaky as the wanted error either affected the next block request (prefecthing) or just missed that.


First I tried to wait for the background thread to be finished before setting the Errors.X. But then it consistently failed, because the generateProducerId call does prefetching too and after a successful producer id generation we set the error and expected that it will fail again with coordinator-load-in-progress exception but since the block was prefetched, it was able to serve us with a proper producer id. 

1) calling generateProducerId --> no current block exists, so requesting block --> CoordinatorLoadInProgressException
asserting exception
2) calling generateProducerId again --> prefetching, requesting the next block --> giving back the producer id from the first block
asserting received producer id
setting error -- waiting for the background callback(s) to be finished first
3) calling generateProducerId, expecting CoordinatorLoadInProgressException, but --> works like 2), just the prefetching callback is failing due to the error we set before

Note: without the waiting for the background thread completions the error setting could happened before the 2) step's callback or after that, the test was written in a way that it expected to happen before the cb. 

This was the point I realised that we need to have a queue to control the responses rather than trying to do it in the middle of the test method.

Errors can be passed in a queue at creation of the mock id manager instead modifying on-the-fly.
In the queue we're specifying Errors, how the background thread (which imitates the controllerChannel) should behave, return an error or a proper response and call the callback accordingly with that.


I was able to simplify the mock manager id class as well, no need for the maybeRequestNextBlock overriding if the errors are handled this way via a queue.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
