### PR TITLE
[MINOR] Renaming the `Abortable_Transaction` error to `Transaction_Abortable`

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1330,7 +1330,7 @@ public class TransactionManager {
                 // We could still receive INVALID_PRODUCER_EPOCH from old versioned transaction coordinator,
                 // just treat it the same as PRODUCE_FENCED.
                 fatalError(Errors.PRODUCER_FENCED.exception());
-            } else if (error == Errors.ABORTABLE_TRANSACTION) {
+            } else if (error == Errors.TRANSACTION_ABORTABLE) {
                 abortableError(error.exception());
             } else {
                 fatalError(new KafkaException("Unexpected error in InitProducerIdResponse; " + error.message()));
@@ -1401,7 +1401,7 @@ public class TransactionManager {
                 } else if (error == Errors.UNKNOWN_PRODUCER_ID || error == Errors.INVALID_PRODUCER_ID_MAPPING) {
                     abortableErrorIfPossible(error.exception());
                     return;
-                } else if (error == Errors.ABORTABLE_TRANSACTION) {
+                } else if (error == Errors.TRANSACTION_ABORTABLE) {
                     abortableError(error.exception());
                     return;
                 } else {
@@ -1507,7 +1507,7 @@ public class TransactionManager {
                 fatalError(error.exception());
             } else if (error == Errors.GROUP_AUTHORIZATION_FAILED) {
                 abortableError(GroupAuthorizationException.forGroupId(key));
-            } else if (error == Errors.ABORTABLE_TRANSACTION) {
+            } else if (error == Errors.TRANSACTION_ABORTABLE) {
                 abortableError(error.exception());
             } else {
                 fatalError(new KafkaException(String.format("Could not find a coordinator with type %s with key %s due to " +
@@ -1562,7 +1562,7 @@ public class TransactionManager {
                 fatalError(error.exception());
             } else if (error == Errors.UNKNOWN_PRODUCER_ID || error == Errors.INVALID_PRODUCER_ID_MAPPING) {
                 abortableErrorIfPossible(error.exception());
-            } else if (error == Errors.ABORTABLE_TRANSACTION) {
+            } else if (error == Errors.TRANSACTION_ABORTABLE) {
                 abortableError(error.exception());
             } else {
                 fatalError(new KafkaException("Unhandled error in EndTxnResponse: " + error.message()));
@@ -1622,7 +1622,7 @@ public class TransactionManager {
                 fatalError(error.exception());
             } else if (error == Errors.GROUP_AUTHORIZATION_FAILED) {
                 abortableError(GroupAuthorizationException.forGroupId(builder.data.groupId()));
-            } else if (error == Errors.ABORTABLE_TRANSACTION) {
+            } else if (error == Errors.TRANSACTION_ABORTABLE) {
                 abortableError(error.exception());
             } else {
                 fatalError(new KafkaException("Unexpected error in AddOffsetsToTxnResponse: " + error.message()));
@@ -1687,7 +1687,7 @@ public class TransactionManager {
                     abortableError(GroupAuthorizationException.forGroupId(builder.data.groupId()));
                     break;
                 } else if (error == Errors.FENCED_INSTANCE_ID ||
-                        error == Errors.ABORTABLE_TRANSACTION) {
+                        error == Errors.TRANSACTION_ABORTABLE) {
                     abortableError(error.exception());
                     break;
                 } else if (error == Errors.UNKNOWN_MEMBER_ID

--- a/clients/src/main/java/org/apache/kafka/common/errors/TransactionAbortableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/TransactionAbortableException.java
@@ -16,8 +16,8 @@
  */
 package org.apache.kafka.common.errors;
 
-public class AbortableTransactionException extends ApiException {
-    public AbortableTransactionException(String message) {
+public class TransactionAbortableException extends ApiException {
+    public TransactionAbortableException(String message) {
         super(message);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -138,7 +138,7 @@ import org.apache.kafka.common.errors.UnsupportedEndpointTypeException;
 import org.apache.kafka.common.errors.UnsupportedForMessageFormatException;
 import org.apache.kafka.common.errors.UnsupportedSaslMechanismException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
-import org.apache.kafka.common.errors.AbortableTransactionException;
+import org.apache.kafka.common.errors.TransactionAbortableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -394,7 +394,7 @@ public enum Errors {
     UNKNOWN_SUBSCRIPTION_ID(117, "Client sent a push telemetry request with an invalid or outdated subscription ID.", UnknownSubscriptionIdException::new),
     TELEMETRY_TOO_LARGE(118, "Client sent a push telemetry request larger than the maximum size the broker will accept.", TelemetryTooLargeException::new),
     INVALID_REGISTRATION(119, "The controller has considered the broker registration to be invalid.", InvalidRegistrationException::new),
-    ABORTABLE_TRANSACTION(120, "The server encountered an error with the transaction. The client can abort the transaction to continue using this transactional ID.", AbortableTransactionException::new);
+    TRANSACTION_ABORTABLE(120, "The server encountered an error with the transaction. The client can abort the transaction to continue using this transactional ID.", TransactionAbortableException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/resources/common/message/AddOffsetsToTxnRequest.json
+++ b/clients/src/main/resources/common/message/AddOffsetsToTxnRequest.json
@@ -24,7 +24,7 @@
   //
   // Version 3 enables flexible versions.
   //
-  // Version 4 adds support for new error code ABORTABLE_TRANSACTION (KIP-890).
+  // Version 4 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [

--- a/clients/src/main/resources/common/message/AddOffsetsToTxnResponse.json
+++ b/clients/src/main/resources/common/message/AddOffsetsToTxnResponse.json
@@ -23,7 +23,7 @@
   //
   // Version 3 enables flexible versions.
   //
-  // Version 4 adds support for new error code ABORTABLE_TRANSACTION (KIP-890).
+  // Version 4 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [

--- a/clients/src/main/resources/common/message/AddPartitionsToTxnRequest.json
+++ b/clients/src/main/resources/common/message/AddPartitionsToTxnRequest.json
@@ -26,7 +26,7 @@
   //
   // Version 4 adds VerifyOnly field to check if partitions are already in transaction and adds support to batch multiple transactions.
   //
-  // Version 5 adds support for new error code ABORTABLE_TRANSACTION (KIP-890).
+  // Version 5 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   // Versions 3 and below will be exclusively used by clients and versions 4 and above will be used by brokers.
   "latestVersionUnstable": false,
   "validVersions": "0-5",

--- a/clients/src/main/resources/common/message/AddPartitionsToTxnResponse.json
+++ b/clients/src/main/resources/common/message/AddPartitionsToTxnResponse.json
@@ -25,7 +25,7 @@
   //
   // Version 4 adds support to batch multiple transactions and a top level error code.
   //
-  // Version 5 adds support for new error code ABORTABLE_TRANSACTION (KIP-890).
+  // Version 5 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   "validVersions": "0-5",
   "flexibleVersions": "3+",
   "fields": [

--- a/clients/src/main/resources/common/message/EndTxnRequest.json
+++ b/clients/src/main/resources/common/message/EndTxnRequest.json
@@ -24,7 +24,7 @@
   //
   // Version 3 enables flexible versions.
   //
-  // Version 4 adds support for new error code ABORTABLE_TRANSACTION (KIP-890).
+  // Version 4 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [

--- a/clients/src/main/resources/common/message/EndTxnResponse.json
+++ b/clients/src/main/resources/common/message/EndTxnResponse.json
@@ -23,7 +23,7 @@
   //
   // Version 3 enables flexible versions.
   //
-  // Version 4 adds support for new error code ABORTABLE_TRANSACTION (KIP-890).
+  // Version 4 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [

--- a/clients/src/main/resources/common/message/FindCoordinatorRequest.json
+++ b/clients/src/main/resources/common/message/FindCoordinatorRequest.json
@@ -26,7 +26,7 @@
   //
   // Version 4 adds support for batching via CoordinatorKeys (KIP-699)
   //
-  // Version 5 adds support for new error code ABORTABLE_TRANSACTION (KIP-890).
+  // Version 5 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   "validVersions": "0-5",
   "deprecatedVersions": "0",
   "flexibleVersions": "3+",

--- a/clients/src/main/resources/common/message/FindCoordinatorResponse.json
+++ b/clients/src/main/resources/common/message/FindCoordinatorResponse.json
@@ -25,7 +25,7 @@
   //
   // Version 4 adds support for batching via Coordinators (KIP-699)
   //
-  // Version 5 adds support for new error code ABORTABLE_TRANSACTION (KIP-890).
+  // Version 5 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   "validVersions": "0-5",
   "flexibleVersions": "3+",
   "fields": [

--- a/clients/src/main/resources/common/message/InitProducerIdRequest.json
+++ b/clients/src/main/resources/common/message/InitProducerIdRequest.json
@@ -26,7 +26,7 @@
   //
   // Version 4 adds the support for new error code PRODUCER_FENCED.
   //
-  // Verison 5 adds support for new error code ABORTABLE_TRANSACTION (KIP-890).
+  // Verison 5 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   "validVersions": "0-5",
   "flexibleVersions": "2+",
   "fields": [

--- a/clients/src/main/resources/common/message/InitProducerIdResponse.json
+++ b/clients/src/main/resources/common/message/InitProducerIdResponse.json
@@ -25,7 +25,7 @@
   //
   // Version 4 adds the support for new error code PRODUCER_FENCED.
   //
-  // Version 5 adds support for new error code ABORTABLE_TRANSACTION (KIP-890).
+  // Version 5 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   "validVersions": "0-5",
   "flexibleVersions": "2+",
   "fields": [

--- a/clients/src/main/resources/common/message/ProduceRequest.json
+++ b/clients/src/main/resources/common/message/ProduceRequest.json
@@ -36,7 +36,7 @@
   //
   // Version 10 is the same as version 9 (KIP-951).
   //
-  // Version 11 adds support for new error code ABORTABLE_TRANSACTION (KIP-890).
+  // Version 11 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   "validVersions": "0-11",
   "deprecatedVersions": "0-6",
   "flexibleVersions": "9+",

--- a/clients/src/main/resources/common/message/ProduceResponse.json
+++ b/clients/src/main/resources/common/message/ProduceResponse.json
@@ -35,7 +35,7 @@
   //
   // Version 10 adds 'CurrentLeader' and 'NodeEndpoints' as tagged fields (KIP-951)
   //
-  // Version 11 adds support for new error code ABORTABLE_TRANSACTION (KIP-890).
+  // Version 11 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   "validVersions": "0-11",
   "flexibleVersions": "9+",
   "fields": [

--- a/clients/src/main/resources/common/message/TxnOffsetCommitRequest.json
+++ b/clients/src/main/resources/common/message/TxnOffsetCommitRequest.json
@@ -24,7 +24,7 @@
   //
   // Version 3 adds the member.id, group.instance.id and generation.id.
   //
-  // Version 4 adds support for new error code ABORTABLE_TRANSACTION (KIP-890).
+  // Version 4 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [

--- a/clients/src/main/resources/common/message/TxnOffsetCommitResponse.json
+++ b/clients/src/main/resources/common/message/TxnOffsetCommitResponse.json
@@ -23,7 +23,7 @@
   //
   // Version 3 adds illegal generation, fenced instance id, and unknown member id errors.
   //
-  // Version 4 adds support for new error code ABORTABLE_TRANSACTION (KIP-890).
+  // Version 4 adds support for new error code TRANSACTION_ABORTABLE (KIP-890).
   "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -42,7 +42,7 @@ import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.TransactionAbortedException;
 import org.apache.kafka.common.errors.UnsupportedForMessageFormatException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
-import org.apache.kafka.common.errors.AbortableTransactionException;
+import org.apache.kafka.common.errors.TransactionAbortableException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.message.AddPartitionsToTxnResponseData;
 import org.apache.kafka.common.message.ApiMessageType;
@@ -3149,10 +3149,10 @@ public class SenderTest {
     }
 
     @Test
-    public void testAbortableTxnExceptionIsAnAbortableError() throws Exception {
+    public void testTransactionAbortablenExceptionIsAnAbortableError() throws Exception {
         ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(123456L, (short) 0);
         apiVersions.update("0", NodeApiVersions.create(ApiKeys.INIT_PRODUCER_ID.id, (short) 0, (short) 3));
-        TransactionManager txnManager = new TransactionManager(logContext, "textAbortableTxnException", 60000, 100, apiVersions);
+        TransactionManager txnManager = new TransactionManager(logContext, "textTransactionAbortableException", 60000, 100, apiVersions);
 
         setupWithTransactionState(txnManager);
         doInitTransactions(txnManager, producerIdAndEpoch);
@@ -3164,11 +3164,11 @@ public class SenderTest {
 
         Future<RecordMetadata> request = appendToAccumulator(tp0);
         sender.runOnce();  // send request
-        sendIdempotentProducerResponse(0, tp0, Errors.ABORTABLE_TRANSACTION, -1);
+        sendIdempotentProducerResponse(0, tp0, Errors.TRANSACTION_ABORTABLE, -1);
 
-        // Return AbortableTransactionException error. It should be abortable.
+        // Return TransactionAbortableException error. It should be abortable.
         sender.runOnce();
-        assertFutureFailure(request, AbortableTransactionException.class);
+        assertFutureFailure(request, TransactionAbortableException.class);
         assertTrue(txnManager.hasAbortableError());
         TransactionalRequestResult result = txnManager.beginAbort();
         sender.runOnce();

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -369,7 +369,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                   if (txnMetadata.topicPartitions.contains(part))
                     (part, Errors.NONE)
                   else
-                    (part, Errors.ABORTABLE_TRANSACTION)
+                    (part, Errors.TRANSACTION_ABORTABLE)
                 }.toMap)
               }
             }

--- a/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
+++ b/core/src/main/scala/kafka/server/AddPartitionsToTxnManager.scala
@@ -45,7 +45,7 @@ object AddPartitionsToTxnManager {
 /**
  * This is an enum which handles the Partition Response based on the Request Version and the exact operation
  *    defaultError:       This is the default workflow which maps to cases when the Produce Request Version or the Txn_offset_commit request was lower than the first version supporting the new Error Class
- *    genericError:       This maps to the case when the clients are updated to handle the AbortableTxnException
+ *    genericError:       This maps to the case when the clients are updated to handle the TransactionAbortableException
  *    addPartition:       This is a WIP. To be updated as a part of KIP-890 Part 2
  */
 sealed trait SupportedOperation
@@ -226,7 +226,7 @@ class AddPartitionsToTxnManager(
                   val code =
                     if (partitionResult.partitionErrorCode == Errors.PRODUCER_FENCED.code)
                       Errors.INVALID_PRODUCER_EPOCH.code
-                    else if (partitionResult.partitionErrorCode() == Errors.ABORTABLE_TRANSACTION.code && transactionDataAndCallbacks.supportedOperation != genericError) // For backward compatibility with clients.
+                    else if (partitionResult.partitionErrorCode() == Errors.TRANSACTION_ABORTABLE.code && transactionDataAndCallbacks.supportedOperation != genericError) // For backward compatibility with clients.
                       Errors.INVALID_TXN_STATE.code
                     else
                       partitionResult.partitionErrorCode

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -283,7 +283,7 @@ class TransactionCoordinatorTest {
 
     coordinator.handleVerifyPartitionsInTransaction(transactionalId, 0L, 0, partitions, verifyPartitionsInTxnCallback)
     errors.foreach { case (_, error) =>
-      assertEquals(Errors.ABORTABLE_TRANSACTION, error)
+      assertEquals(Errors.TRANSACTION_ABORTABLE, error)
     }
   }
 
@@ -399,7 +399,7 @@ class TransactionCoordinatorTest {
     val extraPartitions = partitions ++ Set(new TopicPartition("topic2", 0))
     
     coordinator.handleVerifyPartitionsInTransaction(transactionalId, 0L, 0, extraPartitions, verifyPartitionsInTxnCallback)
-    assertEquals(Errors.ABORTABLE_TRANSACTION, errors(new TopicPartition("topic2", 0)))
+    assertEquals(Errors.TRANSACTION_ABORTABLE, errors(new TopicPartition("topic2", 0)))
     assertEquals(Errors.NONE, errors(new TopicPartition("topic1", 0)))
     verify(transactionManager).getTransactionState(ArgumentMatchers.eq(transactionalId))
   }

--- a/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnManagerTest.scala
@@ -299,31 +299,31 @@ class AddPartitionsToTxnManagerTest {
     assertEquals(expectedTransaction1Errors, transaction1Errors)
     assertEquals(expectedTransaction2Errors, transaction2Errors)
 
-    val preConvertedAbortableTransaction1Errors = topicPartitions.map(_ -> Errors.TRANSACTION_ABORTABLE).toMap
-    val preConvertedAbortableTransaction2Errors = Map(new TopicPartition("foo", 1) -> Errors.NONE,
+    val preConvertedTransactionAbortableErrorsTxn1 = topicPartitions.map(_ -> Errors.TRANSACTION_ABORTABLE).toMap
+    val preConvertedTransactionAbortableErrorsTxn2 = Map(new TopicPartition("foo", 1) -> Errors.NONE,
       new TopicPartition("foo", 2) -> Errors.TRANSACTION_ABORTABLE,
       new TopicPartition("foo", 3) -> Errors.NONE)
-    val abortableTransaction1ErrorResponse = AddPartitionsToTxnResponse.resultForTransaction(transactionalId1, preConvertedAbortableTransaction1Errors.asJava)
-    val abortableTransaction2ErrorResponse = AddPartitionsToTxnResponse.resultForTransaction(transactionalId2, preConvertedAbortableTransaction2Errors.asJava)
+    val transactionAbortableErrorResponseTxn1 = AddPartitionsToTxnResponse.resultForTransaction(transactionalId1, preConvertedTransactionAbortableErrorsTxn1.asJava)
+    val transactionAbortableErrorResponseTxn2 = AddPartitionsToTxnResponse.resultForTransaction(transactionalId2, preConvertedTransactionAbortableErrorsTxn2.asJava)
     val mixedErrorsAddPartitionsResponseAbortableError = new AddPartitionsToTxnResponse(new AddPartitionsToTxnResponseData()
-      .setResultsByTransaction(new AddPartitionsToTxnResultCollection(Seq(abortableTransaction1ErrorResponse, abortableTransaction2ErrorResponse).iterator.asJava)))
+      .setResultsByTransaction(new AddPartitionsToTxnResultCollection(Seq(transactionAbortableErrorResponseTxn1, transactionAbortableErrorResponseTxn2).iterator.asJava)))
     val mixedAbortableErrorsResponse = clientResponse(mixedErrorsAddPartitionsResponseAbortableError)
 
-    val expectedAbortableTransaction1ErrorsLowerVersion = topicPartitions.map(_ -> Errors.INVALID_TXN_STATE).toMap
-    val expectedAbortableTransaction2ErrorsLowerVersion = Map(new TopicPartition("foo", 2) -> Errors.INVALID_TXN_STATE)
+    val expectedTransactionAbortableErrorsTxn1LowerVersion = topicPartitions.map(_ -> Errors.INVALID_TXN_STATE).toMap
+    val expectedTransactionAbortableErrorsTxn2LowerVersion = Map(new TopicPartition("foo", 2) -> Errors.INVALID_TXN_STATE)
 
-    val expectedAbortableTransaction1ErrorsHigherVersion = topicPartitions.map(_ -> Errors.TRANSACTION_ABORTABLE).toMap
-    val expectedAbortableTransaction2ErrorsHigherVersion = Map(new TopicPartition("foo", 2) -> Errors.TRANSACTION_ABORTABLE)
+    val expectedTransactionAbortableErrorsTxn1HigherVersion = topicPartitions.map(_ -> Errors.TRANSACTION_ABORTABLE).toMap
+    val expectedTransactionAbortableErrorsTxn2HigherVersion = Map(new TopicPartition("foo", 2) -> Errors.TRANSACTION_ABORTABLE)
 
     addTransactionsToVerifyRequestVersion(defaultError)
     receiveResponse(mixedAbortableErrorsResponse)
-    assertEquals(expectedAbortableTransaction1ErrorsLowerVersion, transaction1Errors)
-    assertEquals(expectedAbortableTransaction2ErrorsLowerVersion, transaction2Errors)
+    assertEquals(expectedTransactionAbortableErrorsTxn1LowerVersion, transaction1Errors)
+    assertEquals(expectedTransactionAbortableErrorsTxn2LowerVersion, transaction2Errors)
 
     addTransactionsToVerifyRequestVersion(genericError)
     receiveResponse(mixedAbortableErrorsResponse)
-    assertEquals(expectedAbortableTransaction1ErrorsHigherVersion, transaction1Errors)
-    assertEquals(expectedAbortableTransaction2ErrorsHigherVersion, transaction2Errors)
+    assertEquals(expectedTransactionAbortableErrorsTxn1HigherVersion, transaction1Errors)
+    assertEquals(expectedTransactionAbortableErrorsTxn2HigherVersion, transaction2Errors)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnManagerTest.scala
@@ -299,9 +299,9 @@ class AddPartitionsToTxnManagerTest {
     assertEquals(expectedTransaction1Errors, transaction1Errors)
     assertEquals(expectedTransaction2Errors, transaction2Errors)
 
-    val preConvertedAbortableTransaction1Errors = topicPartitions.map(_ -> Errors.ABORTABLE_TRANSACTION).toMap
+    val preConvertedAbortableTransaction1Errors = topicPartitions.map(_ -> Errors.TRANSACTION_ABORTABLE).toMap
     val preConvertedAbortableTransaction2Errors = Map(new TopicPartition("foo", 1) -> Errors.NONE,
-      new TopicPartition("foo", 2) -> Errors.ABORTABLE_TRANSACTION,
+      new TopicPartition("foo", 2) -> Errors.TRANSACTION_ABORTABLE,
       new TopicPartition("foo", 3) -> Errors.NONE)
     val abortableTransaction1ErrorResponse = AddPartitionsToTxnResponse.resultForTransaction(transactionalId1, preConvertedAbortableTransaction1Errors.asJava)
     val abortableTransaction2ErrorResponse = AddPartitionsToTxnResponse.resultForTransaction(transactionalId2, preConvertedAbortableTransaction2Errors.asJava)
@@ -312,8 +312,8 @@ class AddPartitionsToTxnManagerTest {
     val expectedAbortableTransaction1ErrorsLowerVersion = topicPartitions.map(_ -> Errors.INVALID_TXN_STATE).toMap
     val expectedAbortableTransaction2ErrorsLowerVersion = Map(new TopicPartition("foo", 2) -> Errors.INVALID_TXN_STATE)
 
-    val expectedAbortableTransaction1ErrorsHigherVersion = topicPartitions.map(_ -> Errors.ABORTABLE_TRANSACTION).toMap
-    val expectedAbortableTransaction2ErrorsHigherVersion = Map(new TopicPartition("foo", 2) -> Errors.ABORTABLE_TRANSACTION)
+    val expectedAbortableTransaction1ErrorsHigherVersion = topicPartitions.map(_ -> Errors.TRANSACTION_ABORTABLE).toMap
+    val expectedAbortableTransaction2ErrorsHigherVersion = Map(new TopicPartition("foo", 2) -> Errors.TRANSACTION_ABORTABLE)
 
     addTransactionsToVerifyRequestVersion(defaultError)
     receiveResponse(mixedAbortableErrorsResponse)

--- a/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnRequestServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnRequestServerTest.scala
@@ -163,7 +163,7 @@ class AddPartitionsToTxnRequestServerTest extends BaseRequestTest {
 
     val verifyErrors = verifyResponse.errors()
 
-    assertEquals(Collections.singletonMap(transactionalId, Collections.singletonMap(tp0, Errors.ABORTABLE_TRANSACTION)), verifyErrors)
+    assertEquals(Collections.singletonMap(transactionalId, Collections.singletonMap(tp0, Errors.TRANSACTION_ABORTABLE)), verifyErrors)
   }
   
   private def setUpTransactions(transactionalId: String, verifyOnly: Boolean, partitions: Set[TopicPartition]): (Int, AddPartitionsToTxnTransaction) = {


### PR DESCRIPTION
This is a follow-up to [this](https://github.com/apache/kafka/pull/15486) PR which introduced the new `ABORTABLE_TRANSACTION` error as a part of KIP-890 efforts. However on further discussion, we seem to gain consensus that the error should be rather named as `TRANSACTION_ABORTABLE`. 
This PR aims to address the same. There are no changes in the code apart from that.

### References
JIRA: https://issues.apache.org/jira/browse/KAFKA-16314
Original PR: https://github.com/apache/kafka/pull/15486

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
