### PR TITLE
MINOR: enhance kafka-reassign-partitions command output

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
@@ -807,7 +807,7 @@ public class ReassignPartitionsCommand {
             Set<TopicPartitionReplica> completed = alterReplicaLogDirs(adminClient, pendingReplicas);
             if (!completed.isEmpty()) {
                 completed.stream().sorted(ReassignPartitionsCommand::compareTopicPartitionReplicas).forEach(replica -> {
-                    System.out.printf("Successfully started moving log directory to %s for replica %s-%s with broker id: %s %n",
+                    System.out.printf("Successfully started moving log directory to %s for replica %s-%s with broker %s %n",
                         pendingReplicas.get(replica), replica.topic(), replica.partition(), replica.brokerId());
                 });
             }
@@ -1483,7 +1483,6 @@ public class ReassignPartitionsCommand {
         for (Entry<TopicPartitionReplica, KafkaFuture<Void>> e : values.entrySet()) {
             TopicPartitionReplica replica = e.getKey();
             KafkaFuture<Void> future = e.getValue();
-
             try {
                 future.get();
                 results.add(replica);

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
@@ -806,12 +806,8 @@ public class ReassignPartitionsCommand {
         do {
             Set<TopicPartitionReplica> completed = alterReplicaLogDirs(adminClient, pendingReplicas);
             if (!completed.isEmpty()) {
-                System.out.printf("Successfully started log directory move%s for: %s%n",
-                    completed.size() == 1 ? "" : "s",
-                    completed.stream()
-                        .sorted(ReassignPartitionsCommand::compareTopicPartitionReplicas)
-                        .map(Object::toString)
-                        .collect(Collectors.joining(",")));
+                completed.forEach(replica -> System.out.printf("Successfully started moving log directory to %s for replica %s-%s with broker id: %s %n",
+                         pendingReplicas.get(replica), replica.topic(), replica.partition(), replica.brokerId()));
             }
             completed.forEach(pendingReplicas::remove);
             if (pendingReplicas.isEmpty()) {
@@ -1485,6 +1481,7 @@ public class ReassignPartitionsCommand {
         for (Entry<TopicPartitionReplica, KafkaFuture<Void>> e : values.entrySet()) {
             TopicPartitionReplica replica = e.getKey();
             KafkaFuture<Void> future = e.getValue();
+
             try {
                 future.get();
                 results.add(replica);

--- a/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/reassign/ReassignPartitionsCommand.java
@@ -806,8 +806,10 @@ public class ReassignPartitionsCommand {
         do {
             Set<TopicPartitionReplica> completed = alterReplicaLogDirs(adminClient, pendingReplicas);
             if (!completed.isEmpty()) {
-                completed.forEach(replica -> System.out.printf("Successfully started moving log directory to %s for replica %s-%s with broker id: %s %n",
-                         pendingReplicas.get(replica), replica.topic(), replica.partition(), replica.brokerId()));
+                completed.stream().sorted(ReassignPartitionsCommand::compareTopicPartitionReplicas).forEach(replica -> {
+                    System.out.printf("Successfully started moving log directory to %s for replica %s-%s with broker id: %s %n",
+                        pendingReplicas.get(replica), replica.topic(), replica.partition(), replica.brokerId());
+                });
             }
             completed.forEach(pendingReplicas::remove);
             if (pendingReplicas.isEmpty()) {


### PR DESCRIPTION
Currently, when we using `kafka-reassign-partitions` to move the log directory, the output only indicates which replica's movement has successfully started. 

This PR propose to show more detailed information, helping end users understand that the operation is proceeding as expected.

For example, if I have a mv.json as below, which move `t3-0`, `t3-1` to different log directory

```json
{
    "version":1,
    "partitions":[
        { "topic":"t3","partition":0,"replicas":[1],"log_dirs":["/var/lib/kafka/data/logs"] },
        { "topic":"t3","partition":1,"replicas":[1, 2, 3],"log_dirs":["/var/lib/kafka/data/logs", "/var/lib/kafka/data/logs2", "/var/lib/kafka/data/logs2"] }
    ]
}

```

- origin output
```
Successfully started partition reassignments for t3-0,t3-1
Successfully started log directory moves for: t3-0-1,t3-1-1,t3-1-2,t3-1-3
```
- proposed output
```
Successfully started partition reassignments for t3-0,t3-1
Successfully started moving log directory to /var/lib/kafka/data/logs for replica t3-0 with broker id: 1
Successfully started moving log directory to /var/lib/kafka/data/logs for replica t3-1 with broker id: 1
Successfully started moving log directory to /var/lib/kafka/data/logs2 for replica t3-1 with broker id: 2
Successfully started moving log directory to /var/lib/kafka/data/logs2 for replica t3-1 with broker id: 3
```


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
