### PR TITLE
MINOR: Remove redundant ApiVersionsResponse#filterApis

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -168,13 +168,6 @@ public class ApiVersionsResponse extends AbstractResponse {
 
     public static ApiVersionCollection filterApis(
         RecordVersion minRecordVersion,
-        ApiMessageType.ListenerType listenerType
-    ) {
-        return filterApis(minRecordVersion, listenerType, false, false);
-    }
-
-    public static ApiVersionCollection filterApis(
-        RecordVersion minRecordVersion,
         ApiMessageType.ListenerType listenerType,
         boolean enableUnstableLastVersion,
         boolean clientTelemetryEnabled

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -712,7 +712,7 @@ public class KafkaAdminClientTest {
         if (error == Errors.NONE) {
             return ApiVersionsResponse.createApiVersionsResponse(
                 0,
-                ApiVersionsResponse.filterApis(RecordVersion.current(), ApiMessageType.ListenerType.ZK_BROKER),
+                ApiVersionsResponse.filterApis(RecordVersion.current(), ApiMessageType.ListenerType.ZK_BROKER, false, false),
                 convertSupportedFeaturesMap(defaultFeatureMetadata().supportedFeatures()),
                 Collections.singletonMap("test_feature_1", (short) 2),
                 defaultFeatureMetadata().finalizedFeaturesEpoch().get(),


### PR DESCRIPTION
The method `ApiVersionsResponse#filterApis(RecordVersion, ApiMessageType.ListenerType)` is only used in test, we can remove it and invoke the other one.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
