### PR TITLE
KAFKA-16424: remove truncated logs after alter dir

### DIFF
--- a/core/src/test/scala/unit/kafka/server/AlterReplicaLogDirsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterReplicaLogDirsRequestTest.scala
@@ -18,15 +18,18 @@
 package kafka.server
 
 import java.io.File
-
 import kafka.utils._
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.message.AlterReplicaLogDirsRequestData
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AlterReplicaLogDirsRequest, AlterReplicaLogDirsResponse}
+import org.apache.kafka.server.config.ServerLogConfigs
+import org.apache.kafka.storage.internals.log.LogFileUtils
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
+import java.util.Properties
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.util.Random
@@ -36,6 +39,11 @@ class AlterReplicaLogDirsRequestTest extends BaseRequestTest {
   override val brokerCount = 1
 
   val topic = "topic"
+
+  override def brokerPropertyOverrides(properties: Properties): Unit = {
+    properties.put(ServerLogConfigs.LOG_INITIAL_TASK_DELAY_MS_CONFIG, "0")
+    properties.put(ServerLogConfigs.LOG_CLEANUP_INTERVAL_MS_CONFIG, "1000")
+  }
 
   private def findErrorForPartition(response: AlterReplicaLogDirsResponse, tp: TopicPartition): Errors = {
     Errors.forCode(response.data.results.asScala
@@ -114,6 +122,58 @@ class AlterReplicaLogDirsRequestTest extends BaseRequestTest {
     assertEquals(Errors.LOG_DIR_NOT_FOUND, findErrorForPartition(alterReplicaDirResponse3, new TopicPartition(topic, 0)))
     assertEquals(Errors.KAFKA_STORAGE_ERROR, findErrorForPartition(alterReplicaDirResponse3, new TopicPartition(topic, 1)))
     assertEquals(Errors.KAFKA_STORAGE_ERROR, findErrorForPartition(alterReplicaDirResponse3, new TopicPartition(topic, 2)))
+  }
+
+  @Test
+  def testAlterReplicaLogDirsRequestWithRetention(): Unit = {
+    val partitionNum = 1
+
+    // Alter replica dir before topic creation
+    val logDir1 = new File(servers.head.config.logDirs(1)).getAbsolutePath
+    val partitionDirs1 = (0 until partitionNum).map(partition => new TopicPartition(topic, partition) -> logDir1).toMap
+    val alterReplicaLogDirsResponse1 = sendAlterReplicaLogDirsRequest(partitionDirs1)
+
+    // The response should show error UNKNOWN_TOPIC_OR_PARTITION for all partitions
+    val tp = new TopicPartition(topic, 0)
+    assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, findErrorForPartition(alterReplicaLogDirsResponse1, tp))
+    assertTrue(servers.head.logManager.getLog(tp).isEmpty)
+
+    val topicProperties = new Properties()
+    topicProperties.put(TopicConfig.RETENTION_BYTES_CONFIG, "1024")
+    // This test needs enough time to wait for dir movement happened.
+    // We don't want files with `.deleted` suffix are removed too fast,
+    // so we can validate there will be orphan files and orphan files will be removed eventually.
+    topicProperties.put(TopicConfig.FILE_DELETE_DELAY_MS_CONFIG, "10000")
+    topicProperties.put(TopicConfig.SEGMENT_BYTES_CONFIG, "1024")
+
+    createTopic(topic, partitionNum, 1, topicProperties)
+    assertEquals(logDir1, servers.head.logManager.getLog(tp).get.dir.getParent)
+
+    // send enough records to trigger log rolling
+    (0 until 20).foreach { _ =>
+      TestUtils.generateAndProduceMessages(servers, topic, 10, 1)
+    }
+    TestUtils.waitUntilTrue(() => servers.head.logManager.getLog(new TopicPartition(topic, 0)).get.numberOfSegments > 1,
+      "timed out waiting for log segment to roll")
+
+    // Wait for log segment retention in original dir.
+    TestUtils.waitUntilTrue(() => {
+      new File(logDir1, tp.toString).listFiles().count(_.getName.endsWith(LogFileUtils.DELETED_FILE_SUFFIX)) > 0
+    }, "timed out waiting for log segment to retention")
+
+    // Alter replica dir again after topic creation
+    val logDir2 = new File(servers.head.config.logDirs(2)).getAbsolutePath
+    val alterReplicaLogDirsResponse2 = sendAlterReplicaLogDirsRequest(Map(tp -> logDir2))
+    // The response should succeed for all partitions
+    assertEquals(Errors.NONE, findErrorForPartition(alterReplicaLogDirsResponse2, tp))
+    TestUtils.waitUntilTrue(() => {
+      logDir2 == servers.head.logManager.getLog(tp).get.dir.getParent
+    }, "timed out waiting for replica movement")
+
+    // Make sure the deleted log segment is removed
+    TestUtils.waitUntilTrue(() => {
+      new File(logDir2, tp.toString).listFiles().count(_.getName.endsWith(LogFileUtils.DELETED_FILE_SUFFIX)) == 0
+    }, "timed out waiting for removing deleted log segment")
   }
 
   private def sendAlterReplicaLogDirsRequest(partitionDirs: Map[TopicPartition, String]): AlterReplicaLogDirsResponse = {


### PR DESCRIPTION
If there are some logs to be deleted during the log dir movement, we'll send for a scheduler to do the deletion later.
However, when the log dir movement completed, the future log is renamed, the async log deletion will fail with no file existed error.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
