### PR TITLE
MINOR: remove redundant check in appendLegacyRecord

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
@@ -717,8 +717,6 @@ public class MemoryRecordsBuilder implements AutoCloseable {
 
     private long appendLegacyRecord(long offset, long timestamp, ByteBuffer key, ByteBuffer value, byte magic) throws IOException {
         ensureOpenForRecordAppend();
-        if (compressionType == CompressionType.NONE && timestampType == TimestampType.LOG_APPEND_TIME)
-            timestamp = logAppendTime;
 
         int size = LegacyRecord.recordSize(magic, key, value);
         AbstractLegacyRecordBatch.writeHeader(appendStream, toInnerOffset(offset), size);


### PR DESCRIPTION
## Context
In `MemoeyRecordsBuilder.appendLegacyRecord`, there are two similar checks currently

1.  
```
if (compressionType == CompressionType.NONE && timestampType == TimestampType.LOG_APPEND_TIME)
```

2. 
```
if (timestampType == TimestampType.LOG_APPEND_TIME)
```

The first check verify the timestamp type and compression type, the second check verify the timestamp type again.
However, if it's LOG_APPEND_TIME, we should choose the `logAppendTime` no matter whether it's compressed or not.
The `logAppendTime` is init in LogValidator 203L. 

## Solution 
Remove the redundant check.

## Test
run 
` ./gradlew clean client:test --tests org.apache.kafka.common.record.MemoryRecordsBuilderTest
`
and it passed

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
