### PR TITLE
KAFKA-16068: Use TestPlugins in ConnectorValidationIntegrationTest to silence plugin scanning errors

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
@@ -69,9 +69,6 @@ public class ConnectorValidationIntegrationTest {
         Map<String, String> workerProps = new HashMap<>();
         workerProps.put(GROUP_ID_CONFIG, WORKER_GROUP_ID);
 
-        // Work around a circular-dependency in TestPlugins.
-        TestPlugins.pluginPath();
-
         // build a Connect cluster backed by Kafka and Zk
         connect = new EmbeddedConnectCluster.Builder()
                 .name("connector-validation-connect-cluster")

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
@@ -334,7 +334,7 @@ public class ConnectorValidationIntegrationTest {
     @Test
     public void testConnectorHasConverterWithNoSuitableConstructor() throws InterruptedException {
         Map<String, String> config = defaultSinkConnectorProps();
-        config.put(KEY_CONVERTER_CLASS_CONFIG, TestPlugins.TestPlugin.ALWAYS_THROW_EXCEPTION.className());
+        config.put(KEY_CONVERTER_CLASS_CONFIG, TestPlugins.TestPlugin.BAD_PACKAGING_DEFAULT_CONSTRUCTOR_PRIVATE_CONNECTOR.className());
         connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
                 config.get(CONNECTOR_CLASS_CONFIG),
                 config,
@@ -346,7 +346,7 @@ public class ConnectorValidationIntegrationTest {
     @Test
     public void testConnectorHasConverterThatThrowsExceptionOnInstantiation() throws InterruptedException {
         Map<String, String> config = defaultSinkConnectorProps();
-        config.put(KEY_CONVERTER_CLASS_CONFIG, TestPlugins.TestPlugin.ALWAYS_THROW_EXCEPTION.className());
+        config.put(KEY_CONVERTER_CLASS_CONFIG, TestPlugins.TestPlugin.BAD_PACKAGING_DEFAULT_CONSTRUCTOR_THROWS_CONNECTOR.className());
         connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
                 config.get(CONNECTOR_CLASS_CONFIG),
                 config,
@@ -407,7 +407,7 @@ public class ConnectorValidationIntegrationTest {
     @Test
     public void testConnectorHasHeaderConverterThatThrowsExceptionOnInstantiation() throws InterruptedException {
         Map<String, String> config = defaultSinkConnectorProps();
-        config.put(HEADER_CONVERTER_CLASS_CONFIG, TestPlugins.TestPlugin.ALWAYS_THROW_EXCEPTION.className());
+        config.put(HEADER_CONVERTER_CLASS_CONFIG, TestPlugins.TestPlugin.BAD_PACKAGING_DEFAULT_CONSTRUCTOR_THROWS_CONNECTOR.className());
         connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(
                 config.get(CONNECTOR_CLASS_CONFIG),
                 config,


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-16068)

The ConnectorValidationIntegrationTest creates test plugins, some with erroneous behavior. In particular:
```
[2023-12-29 10:28:06,548] ERROR Failed to discover Converter in classpath: Unable to instantiate TestConverterWithPrivateConstructor: Plugin class default constructor must be public (org.apache.kafka.connect.runtime.isolation.ReflectionScanner:138) [2023-12-29 10:28:06,550]
ERROR Failed to discover Converter in classpath: Unable to instantiate TestConverterWithConstructorThatThrowsException: Failed to invoke plugin constructor (org.apache.kafka.connect.runtime.isolation.ReflectionScanner:138)
java.lang.reflect.InvocationTargetException
```
I found 4 methods with erroneous behavior:
- testConnectorHasConverterWithNoSuitableConstructor()
- testConnectorHasConverterThatThrowsExceptionOnInstantiation()
- testConnectorHasHeaderConverterWithNoSuitableConstructor()
- testConnectorHasHeaderConverterThatThrowsExceptionOnInstantiation()

These plugins should be eliminated from the classpath, so that the errors do not appear in unrelated tests. Instead, plugins with erroneous behavior should only be present in the TestPlugins, so that tests can opt-in to loading them.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
