### PR TITLE
Add s390x support to CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -174,6 +174,26 @@ pipeline {
             echo 'Skipping Kafka Streams archetype test for Java 21'
           }
         }
+
+        stage('s390x') {
+          agent { label 's390x' }
+          tools {
+            jdk 'jdk_21_latest'
+          }
+          options {
+            timeout(time: 8, unit: 'HOURS')
+            timestamps()
+          }
+          environment {
+            SCALA_VERSION=2.13
+          }
+          steps {
+            doValidation()
+            doTest(env)
+            echo 'Skipping Kafka Streams archetype test for s390x'
+          }
+        }
+
       }
     }
   }


### PR DESCRIPTION
We would like to add support for s390x to existing CI. Adding s390x build stage which uses Jdk21 and Scala 2.13.
Verified the build and tests locally.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
