### PR TITLE
KAFKA-16471: invoke SSLEngine::closeInbound on SslTransportLayer close

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -202,9 +202,9 @@ public class SslTransportLayer implements TransportLayer {
             try {
                 sslEngine.closeInbound();
             } catch (SSLException e) {
-                // This is a debug log because an exception may be raised here frequently due to peers which do not
-                // follow the TLS spec and fail to send a close_notify alert. Even if they do, we currently don't read
-                // data from the socket after close() is invoked.
+                // This log is for debugging purposes as an exception might occur frequently
+                // at this point due to peers not following the TLS specs and failing to send a close_notify alert. 
+                // Even if they do, currently, we do not read data from the socket after invoking close().
                 log.debug("SSLEngine.closeInBound() raised an exception.", e);
             }
             socketChannel.socket().close();

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -199,6 +199,14 @@ public class SslTransportLayer implements TransportLayer {
         } catch (IOException ie) {
             log.debug("Failed to send SSL Close message", ie);
         } finally {
+            try {
+                sslEngine.closeInbound();
+            } catch (SSLException e) {
+                // This is a debug log because an exception may be raised here frequently due to peers which do not
+                // follow the TLS spec and fail to send a close_notify alert. Even if they do, we currently don't read
+                // data from the socket after close() is invoked.
+                log.debug("SSLEngine.closeInBound() raised an exception.", e);
+            }
             socketChannel.socket().close();
             socketChannel.close();
             netReadBuffer = null;

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -69,6 +69,7 @@ import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
 
@@ -79,6 +80,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -1540,6 +1542,7 @@ public class SslTransportLayerTest {
         SelectionKey selectionKey = mock(SelectionKey.class);
         when(socketChannel.socket()).thenReturn(socket);
         when(selectionKey.channel()).thenReturn(socketChannel);
+        doThrow(new SSLException("Mock exception")).when(sslEngine).closeInbound();
         SslTransportLayer sslTransportLayer = new SslTransportLayer(
                 "test-channel",
                 selectionKey,


### PR DESCRIPTION
Invokes `SSLEngine::closeInbound` after we flush close_notify alert to the socket. This fixes memory leak in Netty/OpenSSL based SSLEngine which only free native resources once closeInbound has been invoked.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
