### PR TITLE
KAFKA-16473: Use correct cluster ID when formatting log dir.

### DIFF
--- a/core/src/main/scala/kafka/docker/KafkaDockerWrapper.scala
+++ b/core/src/main/scala/kafka/docker/KafkaDockerWrapper.scala
@@ -87,8 +87,12 @@ object KafkaDockerWrapper {
     parser.parseArgsOrFail(args)
   }
 
-  private def formatStorageCmd(configsPath: Path, env: Map[String, String]): Array[String] = {
-    Array("format", "--cluster-id=" + env.get("CLUSTER_ID"), "-c", s"${configsPath.toString}/server.properties")
+  private[docker] def formatStorageCmd(configsPath: Path, env: Map[String, String]): Array[String] = {
+    val clusterId = env.get("CLUSTER_ID") match {
+      case Some(str) => str
+      case None => throw new RuntimeException("CLUSTER_ID environment variable is not set.")
+    }
+    Array("format", "--cluster-id=" + clusterId, "-c", s"${configsPath.toString}/server.properties")
   }
 
   private def prepareConfigs(defaultConfigsPath: Path, mountedConfigsPath: Path, finalConfigsPath: Path): Unit = {

--- a/core/src/test/scala/unit/kafka/docker/KafkaDockerWrapperTest.scala
+++ b/core/src/test/scala/unit/kafka/docker/KafkaDockerWrapperTest.scala
@@ -16,11 +16,11 @@
  */
 package kafka.docker
 
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.{assertArrayEquals, assertEquals, assertThrows}
 import org.junit.jupiter.api.Test
 
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path}
+import java.nio.file.{Files, Path, Paths}
 
 class KafkaDockerWrapperTest {
   @Test
@@ -125,6 +125,21 @@ class KafkaDockerWrapperTest {
     val expected = "default.config=default value"
 
     assertEquals(expected, actual)
+  }
+
+  @Test
+  def testFormatStorageCmd(): Unit = {
+    val configsPath = Paths.get("/path/to/configs")
+    val envVars = Map("CLUSTER_ID" -> "MYwKGPhXQZidgd0qMv8Mkw")
+
+    val expected = Array("format", "--cluster-id=MYwKGPhXQZidgd0qMv8Mkw", "-c", "/path/to/configs/server.properties")
+    val actual = KafkaDockerWrapper.formatStorageCmd(configsPath, envVars)
+
+    assertArrayEquals(expected.toArray[Object], actual.toArray[Object])
+
+    assertThrows(classOf[RuntimeException], () => {
+      KafkaDockerWrapper.formatStorageCmd(configsPath, Map())
+    })
   }
 
   @Test


### PR DESCRIPTION
This fixes an issue that when starting a Docker container for the first time, the cluster ID used when formatting the log dir would not be `$CLUSTER_ID` but `Some($CLUSTER_ID)` (KAFKA-16473).

In order to be able to test the `formatStorageCmd` method which contained the bug, the method has been made package private.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
