### PR TITLE
KAFKA-16472: Fix integration tests in Java with parameter name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -280,6 +280,10 @@ subprojects {
       options.compilerArgs << "-Xlint:-options"
   }
 
+  // -parameters generates arguments with parameter names in TestInfo#getDisplayName.
+  // ref: https://github.com/junit-team/junit5/blob/4c0dddad1b96d4a20e92a2cd583954643ac56ac0/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java#L161-L164
+  compileTestJava.options.compilerArgs.add "-parameters"
+
   // We should only set this if Java version is < 9 (--release is recommended for >= 9), but the Scala plugin for IntelliJ sets
   // `-target` incorrectly if this is unset
   sourceCompatibility = minJavaVersion

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/DeleteOffsetsConsumerGroupCommandIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/DeleteOffsetsConsumerGroupCommandIntegrationTest.java
@@ -55,7 +55,7 @@ public class DeleteOffsetsConsumerGroupCommandIntegrationTest extends ConsumerGr
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"zk", "kraft"})
-    public void testDeleteOffsetsNonExistingGroup() {
+    public void testDeleteOffsetsNonExistingGroup(String quorum) {
         String group = "missing.group";
         String topic = "foo:1";
         ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(getArgs(group, topic));
@@ -66,49 +66,49 @@ public class DeleteOffsetsConsumerGroupCommandIntegrationTest extends ConsumerGr
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"zk", "kraft"})
-    public void testDeleteOffsetsOfStableConsumerGroupWithTopicPartition() {
+    public void testDeleteOffsetsOfStableConsumerGroupWithTopicPartition(String quorum) {
         testWithStableConsumerGroup(TOPIC, 0, 0, Errors.GROUP_SUBSCRIBED_TO_TOPIC);
     }
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"zk", "kraft"})
-    public void testDeleteOffsetsOfStableConsumerGroupWithTopicOnly() {
+    public void testDeleteOffsetsOfStableConsumerGroupWithTopicOnly(String quorum) {
         testWithStableConsumerGroup(TOPIC, -1, 0, Errors.GROUP_SUBSCRIBED_TO_TOPIC);
     }
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"zk", "kraft"})
-    public void testDeleteOffsetsOfStableConsumerGroupWithUnknownTopicPartition() {
+    public void testDeleteOffsetsOfStableConsumerGroupWithUnknownTopicPartition(String quorum) {
         testWithStableConsumerGroup("foobar", 0, 0, Errors.UNKNOWN_TOPIC_OR_PARTITION);
     }
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"zk", "kraft"})
-    public void testDeleteOffsetsOfStableConsumerGroupWithUnknownTopicOnly() {
+    public void testDeleteOffsetsOfStableConsumerGroupWithUnknownTopicOnly(String quorum) {
         testWithStableConsumerGroup("foobar", -1, -1, Errors.UNKNOWN_TOPIC_OR_PARTITION);
     }
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"zk", "kraft"})
-    public void testDeleteOffsetsOfEmptyConsumerGroupWithTopicPartition() {
+    public void testDeleteOffsetsOfEmptyConsumerGroupWithTopicPartition(String quorum) {
         testWithEmptyConsumerGroup(TOPIC, 0, 0, Errors.NONE);
     }
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"zk", "kraft"})
-    public void testDeleteOffsetsOfEmptyConsumerGroupWithTopicOnly() {
+    public void testDeleteOffsetsOfEmptyConsumerGroupWithTopicOnly(String quorum) {
         testWithEmptyConsumerGroup(TOPIC, -1, 0, Errors.NONE);
     }
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"zk", "kraft"})
-    public void testDeleteOffsetsOfEmptyConsumerGroupWithUnknownTopicPartition() {
+    public void testDeleteOffsetsOfEmptyConsumerGroupWithUnknownTopicPartition(String quorum) {
         testWithEmptyConsumerGroup("foobar", 0, 0, Errors.UNKNOWN_TOPIC_OR_PARTITION);
     }
 
     @ParameterizedTest(name = TEST_WITH_PARAMETERIZED_QUORUM_NAME)
     @ValueSource(strings = {"zk", "kraft"})
-    public void testDeleteOffsetsOfEmptyConsumerGroupWithUnknownTopicOnly() {
+    public void testDeleteOffsetsOfEmptyConsumerGroupWithUnknownTopicOnly(String quorum) {
         testWithEmptyConsumerGroup("foobar", -1, -1, Errors.UNKNOWN_TOPIC_OR_PARTITION);
     }
 


### PR DESCRIPTION
Following test cases don't really run kraft case. The reason is that the test info doesn't contain parameter name, so it always returns false in TestInfoUtils#isKRaft.

- TopicCommandIntegrationTest
- DeleteConsumerGroupsTest
- AuthorizerIntegrationTest
- DeleteOffsetsConsumerGroupCommandIntegrationTest

We can fix it by adding `options.compilerArgs << '-parameters'` after https://github.com/apache/kafka/blob/376e9e20dbf7c7aeb6f6f666d47932c445eb6bd1/build.gradle#L264-L273

Also, we have to add `String quorum` to cases in DeleteOffsetsConsumerGroupCommandIntegrationTest.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
