### PR TITLE
KAFKA-16477: Detect thread leaked client-metrics-reaper in tests

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -708,6 +708,7 @@ class BrokerServer(
 
       CoreUtils.swallow(lifecycleManager.close(), this)
       CoreUtils.swallow(config.dynamicConfig.clear(), this)
+      CoreUtils.swallow(clientMetricsManager.close(), this)
       sharedServer.stopForBroker()
       info("shut down completed")
     } catch {

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -71,7 +71,7 @@ import org.apache.kafka.common.utils.Utils.formatAddress
 import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.controller.QuorumController
 import org.apache.kafka.metadata.properties.MetaProperties
-import org.apache.kafka.server.ControllerRequestCompletionHandler
+import org.apache.kafka.server.{ClientMetricsManager, ControllerRequestCompletionHandler}
 import org.apache.kafka.server.authorizer.{AuthorizableRequestContext, Authorizer => JAuthorizer}
 import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
 import org.apache.kafka.server.config.{Defaults, ZkConfigs}
@@ -2490,7 +2490,8 @@ object TestUtils extends Logging {
       AdminClientUnitTestEnv.kafkaAdminClientNetworkThreadPrefix(),
       AbstractCoordinator.HEARTBEAT_THREAD_PREFIX,
       QuorumTestHarness.ZkClientEventThreadSuffix,
-      QuorumController.CONTROLLER_THREAD_SUFFIX
+      QuorumController.CONTROLLER_THREAD_SUFFIX,
+      ClientMetricsManager.CLIENT_METRICS_REAPER_THREAD_NAME,
     )
 
     def unexpectedThreads: Set[String] = {

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -77,6 +77,7 @@ import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
 import org.apache.kafka.server.config.{Defaults, ZkConfigs}
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.util.MockTime
+import org.apache.kafka.server.util.timer.SystemTimer
 import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig, LogDirFailureChannel, ProducerStateManagerConfig}
 import org.apache.kafka.test.{TestSslUtils, TestUtils => JTestUtils}
 import org.apache.zookeeper.KeeperException.SessionExpiredException
@@ -2492,6 +2493,7 @@ object TestUtils extends Logging {
       QuorumTestHarness.ZkClientEventThreadSuffix,
       QuorumController.CONTROLLER_THREAD_SUFFIX,
       ClientMetricsManager.CLIENT_METRICS_REAPER_THREAD_NAME,
+      SystemTimer.SYSTEM_TIMER_THREAD_PREFIX,
     )
 
     def unexpectedThreads: Set[String] = {

--- a/server-common/src/main/java/org/apache/kafka/server/util/timer/SystemTimer.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/timer/SystemTimer.java
@@ -110,4 +110,9 @@ public class SystemTimer implements Timer {
     public void close() {
         taskExecutor.shutdown();
     }
+
+    // visible for testing
+    boolean isExecutorTerminated() {
+        return taskExecutor.isTerminated();
+    }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/util/timer/SystemTimer.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/timer/SystemTimer.java
@@ -27,6 +27,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class SystemTimer implements Timer {
+    public static final String SYSTEM_TIMER_THREAD_PREFIX = "executor-";
+
     // timeout timer
     private final ExecutorService taskExecutor;
     private final DelayQueue<TimerTaskList> delayQueue;
@@ -49,7 +51,7 @@ public class SystemTimer implements Timer {
         long startMs
     ) {
         this.taskExecutor = Executors.newFixedThreadPool(1,
-            runnable -> KafkaThread.nonDaemon("executor-" + executorName, runnable));
+            runnable -> KafkaThread.nonDaemon(SYSTEM_TIMER_THREAD_PREFIX + executorName, runnable));
         this.delayQueue = new DelayQueue<>();
         this.taskCounter = new AtomicInteger(0);
         this.timingWheel = new TimingWheel(

--- a/server-common/src/main/java/org/apache/kafka/server/util/timer/SystemTimer.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/timer/SystemTimer.java
@@ -112,7 +112,7 @@ public class SystemTimer implements Timer {
     }
 
     // visible for testing
-    boolean isExecutorTerminated() {
+    boolean isTerminated() {
         return taskExecutor.isTerminated();
     }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/util/timer/SystemTimerReaper.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/timer/SystemTimerReaper.java
@@ -76,4 +76,17 @@ public class SystemTimerReaper implements Timer {
         reaper.awaitShutdown();
         timer.close();
     }
+
+    // visible for testing
+    boolean isReaperShutdown() {
+        return reaper.isShutdownComplete();
+    }
+
+    // visible for testing
+    boolean isTimerShutdown() {
+        if (timer instanceof SystemTimer) {
+            return ((SystemTimer) timer).isExecutorTerminated();
+        }
+        return true;
+    }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/util/timer/SystemTimerReaper.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/timer/SystemTimerReaper.java
@@ -78,15 +78,7 @@ public class SystemTimerReaper implements Timer {
     }
 
     // visible for testing
-    boolean isReaperShutdown() {
+    boolean isShutdown() {
         return reaper.isShutdownComplete();
-    }
-
-    // visible for testing
-    boolean isTimerShutdown() {
-        if (timer instanceof SystemTimer) {
-            return ((SystemTimer) timer).isExecutorTerminated();
-        }
-        return true;
     }
 }

--- a/server-common/src/test/java/org/apache/kafka/server/util/timer/SystemTimerReaperTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/timer/SystemTimerReaperTest.java
@@ -64,12 +64,9 @@ public class SystemTimerReaperTest {
     @Test
     public void testReaperClose() throws Exception {
         Timer timer = Mockito.mock(Timer.class);
-        SystemTimerReaper timerReaper2 = new SystemTimerReaper("reaper", timer);
-        timerReaper2.close();
-        Mockito.verify(timer, Mockito.times(1)).close();
-
-        SystemTimerReaper timerReaper = new SystemTimerReaper("reaper", new SystemTimer("timer"));
+        SystemTimerReaper timerReaper = new SystemTimerReaper("reaper", timer);
         timerReaper.close();
+        Mockito.verify(timer, Mockito.times(1)).close();
         TestUtils.waitForCondition(() -> timerReaper.isShutdown(), "reaper not shutdown");
     }
 }

--- a/server-common/src/test/java/org/apache/kafka/server/util/timer/SystemTimerReaperTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/timer/SystemTimerReaperTest.java
@@ -59,4 +59,11 @@ public class SystemTimerReaperTest {
             timer.close();
         }
     }
+
+    @Test
+    public void testReaperClose() throws Exception {
+        SystemTimerReaper timer = new SystemTimerReaper("reaper", new SystemTimer("timer"));
+        timer.close();
+        TestUtils.waitForCondition(() -> timer.isReaperShutdown() && timer.isTimerShutdown(), "reaper or timer not shutdown");
+    }
 }

--- a/server-common/src/test/java/org/apache/kafka/server/util/timer/SystemTimerReaperTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/timer/SystemTimerReaperTest.java
@@ -67,6 +67,6 @@ public class SystemTimerReaperTest {
         SystemTimerReaper timerReaper = new SystemTimerReaper("reaper", timer);
         timerReaper.close();
         Mockito.verify(timer, Mockito.times(1)).close();
-        TestUtils.waitForCondition(() -> timerReaper.isShutdown(), "reaper not shutdown");
+        TestUtils.waitForCondition(timerReaper::isShutdown, "reaper not shutdown");
     }
 }

--- a/server-common/src/test/java/org/apache/kafka/server/util/timer/SystemTimerReaperTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/timer/SystemTimerReaperTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.server.util.timer;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -62,8 +63,13 @@ public class SystemTimerReaperTest {
 
     @Test
     public void testReaperClose() throws Exception {
-        SystemTimerReaper timer = new SystemTimerReaper("reaper", new SystemTimer("timer"));
-        timer.close();
-        TestUtils.waitForCondition(() -> timer.isReaperShutdown() && timer.isTimerShutdown(), "reaper or timer not shutdown");
+        Timer timer = Mockito.mock(Timer.class);
+        SystemTimerReaper timerReaper2 = new SystemTimerReaper("reaper", timer);
+        timerReaper2.close();
+        Mockito.verify(timer, Mockito.times(1)).close();
+
+        SystemTimerReaper timerReaper = new SystemTimerReaper("reaper", new SystemTimer("timer"));
+        timerReaper.close();
+        TestUtils.waitForCondition(() -> timerReaper.isShutdown(), "reaper not shutdown");
     }
 }

--- a/server-common/src/test/java/org/apache/kafka/server/util/timer/TimerTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/timer/TimerTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.server.util.timer;
 
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -66,7 +67,7 @@ public class TimerTest {
         }
     }
 
-    private Timer timer = null;
+    private SystemTimer timer = null;
 
     @BeforeEach
     public void setup() {
@@ -76,6 +77,7 @@ public class TimerTest {
     @AfterEach
     public void teardown() throws Exception {
         timer.close();
+        TestUtils.waitForCondition(() -> timer.isExecutorTerminated(), "timer excutor not terminated");
     }
 
     @Test

--- a/server-common/src/test/java/org/apache/kafka/server/util/timer/TimerTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/timer/TimerTest.java
@@ -77,7 +77,7 @@ public class TimerTest {
     @AfterEach
     public void teardown() throws Exception {
         timer.close();
-        TestUtils.waitForCondition(() -> timer.isTerminated(), "timer executor not terminated");
+        TestUtils.waitForCondition(timer::isTerminated, "timer executor not terminated");
     }
 
     @Test

--- a/server-common/src/test/java/org/apache/kafka/server/util/timer/TimerTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/util/timer/TimerTest.java
@@ -77,7 +77,7 @@ public class TimerTest {
     @AfterEach
     public void teardown() throws Exception {
         timer.close();
-        TestUtils.waitForCondition(() -> timer.isExecutorTerminated(), "timer excutor not terminated");
+        TestUtils.waitForCondition(() -> timer.isTerminated(), "timer executor not terminated");
     }
 
     @Test

--- a/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
@@ -79,6 +79,7 @@ import java.util.stream.Stream;
  * Handles client telemetry metrics requests/responses, subscriptions and instance information.
  */
 public class ClientMetricsManager implements AutoCloseable {
+    public static final String CLIENT_METRICS_REAPER_THREAD_NAME = "client-metrics-reaper";
 
     private static final Logger log = LoggerFactory.getLogger(ClientMetricsManager.class);
     private static final List<Byte> SUPPORTED_COMPRESSION_TYPES = Collections.unmodifiableList(
@@ -112,7 +113,7 @@ public class ClientMetricsManager implements AutoCloseable {
         this.subscriptionMap = new ConcurrentHashMap<>();
         this.subscriptionUpdateVersion = new AtomicInteger(0);
         this.clientInstanceCache = new SynchronizedCache<>(new LRUCache<>(CACHE_MAX_SIZE));
-        this.expirationTimer = new SystemTimerReaper("client-metrics-reaper", new SystemTimer("client-metrics"));
+        this.expirationTimer = new SystemTimerReaper(CLIENT_METRICS_REAPER_THREAD_NAME, new SystemTimer("client-metrics"));
         this.clientTelemetryMaxBytes = clientTelemetryMaxBytes;
         this.time = time;
         this.cacheExpiryMs = cacheExpiryMs;


### PR DESCRIPTION
related to KAFKA-16477, 

After profiling the kafka tests, tons of `client-metrics-reaper` thread not cleanup after BrokerServer shutdown.
The thread `client-metrics-reaper` comes from [ClientMetricsManager#expirationTimer](https://github.com/apache/kafka/blob/a2ee0855ee5e73f3a74555d52294bb4acfd28945/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java#L115), and BrokerServer#shudown doesn't close ClientMetricsManager which let the thread still runs in background.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
