### PR TITLE
KAFKA-16482: Eliminate the IDE warnings of accepting ClusterConfig in BeforeEach

### DIFF
--- a/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
@@ -20,7 +20,7 @@ package kafka.coordinator.transaction
 import kafka.network.SocketServer
 import kafka.server.{IntegrationTestUtils, KafkaConfig}
 import kafka.test.ClusterInstance
-import kafka.test.annotation.{AutoStart, ClusterTest, ClusterTests, Type}
+import kafka.test.annotation.{AutoStart, ClusterConfigProperty, ClusterTest, ClusterTestDefaults, ClusterTests, Type}
 import kafka.test.junit.ClusterTestExtensions
 import org.apache.kafka.common.message.InitProducerIdRequestData
 import org.apache.kafka.common.network.ListenerName
@@ -30,20 +30,19 @@ import org.apache.kafka.common.requests.{InitProducerIdRequest, InitProducerIdRe
 import org.apache.kafka.server.common.MetadataVersion
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.extension.ExtendWith
-import org.junit.jupiter.api.{BeforeEach, Disabled, Timeout}
+import org.junit.jupiter.api.{Disabled, Timeout}
 
 import java.util.stream.{Collectors, IntStream}
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
 
+
+@ClusterTestDefaults(serverProperties = Array(
+  new ClusterConfigProperty(key = "transaction.state.log.num.partitions", value = "1"),
+  new ClusterConfigProperty(key = "transaction.state.log.replication.factor", value = "3")
+))
 @ExtendWith(value = Array(classOf[ClusterTestExtensions]))
 class ProducerIdsIntegrationTest(private val cluster: ClusterInstance) {
-
-  @BeforeEach
-  def setUp(): Unit = {
-    cluster.config().serverProperties().put(KafkaConfig.TransactionsTopicPartitionsProp, "1")
-    cluster.config().serverProperties().put(KafkaConfig.TransactionsTopicReplicationFactorProp, "3")
-  }
 
   @ClusterTests(Array(
     new ClusterTest(clusterType = Type.ZK, brokers = 3, metadataVersion = MetadataVersion.IBP_2_8_IV1),

--- a/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
@@ -42,7 +42,7 @@ import scala.jdk.CollectionConverters._
   new ClusterConfigProperty(key = "transaction.state.log.replication.factor", value = "3")
 ))
 @ExtendWith(value = Array(classOf[ClusterTestExtensions]))
-class ProducerIdsIntegrationTest(private val cluster: ClusterInstance) {
+class ProducerIdsIntegrationTest {
 
   @ClusterTests(Array(
     new ClusterTest(clusterType = Type.ZK, brokers = 3, metadataVersion = MetadataVersion.IBP_2_8_IV1),

--- a/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
@@ -19,9 +19,9 @@ package kafka.coordinator.transaction
 
 import kafka.network.SocketServer
 import kafka.server.{IntegrationTestUtils, KafkaConfig}
+import kafka.test.ClusterInstance
 import kafka.test.annotation.{AutoStart, ClusterTest, ClusterTests, Type}
 import kafka.test.junit.ClusterTestExtensions
-import kafka.test.{ClusterConfig, ClusterInstance}
 import org.apache.kafka.common.message.InitProducerIdRequestData
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
@@ -29,20 +29,20 @@ import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.requests.{InitProducerIdRequest, InitProducerIdResponse}
 import org.apache.kafka.server.common.MetadataVersion
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.junit.jupiter.api.{BeforeEach, Disabled, Timeout}
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.{BeforeEach, Disabled, Timeout}
 
 import java.util.stream.{Collectors, IntStream}
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
 
 @ExtendWith(value = Array(classOf[ClusterTestExtensions]))
-class ProducerIdsIntegrationTest {
+class ProducerIdsIntegrationTest(private val cluster: ClusterInstance) {
 
   @BeforeEach
-  def setup(clusterConfig: ClusterConfig): Unit = {
-    clusterConfig.serverProperties().put(KafkaConfig.TransactionsTopicPartitionsProp, "1")
-    clusterConfig.serverProperties().put(KafkaConfig.TransactionsTopicReplicationFactorProp, "3")
+  def setUp(): Unit = {
+    cluster.config().serverProperties().put(KafkaConfig.TransactionsTopicPartitionsProp, "1")
+    cluster.config().serverProperties().put(KafkaConfig.TransactionsTopicReplicationFactorProp, "3")
   }
 
   @ClusterTests(Array(

--- a/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
@@ -38,8 +38,7 @@ import scala.jdk.CollectionConverters._
 
 
 @ClusterTestDefaults(serverProperties = Array(
-  new ClusterConfigProperty(key = "transaction.state.log.num.partitions", value = "1"),
-  new ClusterConfigProperty(key = "transaction.state.log.replication.factor", value = "3")
+  new ClusterConfigProperty(key = "transaction.state.log.num.partitions", value = "1")
 ))
 @ExtendWith(value = Array(classOf[ClusterTestExtensions]))
 class ProducerIdsIntegrationTest {

--- a/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.tools;
 
 import kafka.test.ClusterInstance;
+import kafka.test.annotation.ClusterConfigProperty;
 import kafka.test.annotation.ClusterTest;
 import kafka.test.annotation.ClusterTestDefaults;
 import kafka.test.annotation.Type;
@@ -29,7 +30,6 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.server.common.AdminCommandFailedException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import scala.collection.JavaConverters;
@@ -59,7 +59,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("deprecation")
 @ExtendWith(value = ClusterTestExtensions.class)
-@ClusterTestDefaults(clusterType = Type.ALL, brokers = 3)
+@ClusterTestDefaults(clusterType = Type.ALL, brokers = 3, serverProperties = {
+    @ClusterConfigProperty(key = "auto.create.topics.enable", value = "false"),
+    @ClusterConfigProperty(key = "auto.leader.rebalance.enable", value = "false"),
+    @ClusterConfigProperty(key = "controlled.shutdown.enable", value = "true"),
+    @ClusterConfigProperty(key = "controlled.shutdown.max.retries", value = "1"),
+    @ClusterConfigProperty(key = "controlled.shutdown.retry.backoff.ms", value = "1000"),
+    @ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "2")
+})
 @Tag("integration")
 public class LeaderElectionCommandTest {
     private final ClusterInstance cluster;
@@ -68,16 +75,6 @@ public class LeaderElectionCommandTest {
 
     public LeaderElectionCommandTest(ClusterInstance cluster) {
         this.cluster = cluster;
-    }
-
-    @BeforeEach
-    void setup() {
-        TestUtils.verifyNoUnexpectedThreads("@BeforeEach");
-        cluster.config().serverProperties().put("auto.leader.rebalance.enable", "false");
-        cluster.config().serverProperties().put("controlled.shutdown.enable", "true");
-        cluster.config().serverProperties().put("controlled.shutdown.max.retries", "1");
-        cluster.config().serverProperties().put("controlled.shutdown.retry.backoff.ms", "1000");
-        cluster.config().serverProperties().put("offsets.topic.replication.factor", "2");
     }
 
     @ClusterTest

--- a/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.tools;
 
-import kafka.test.ClusterConfig;
 import kafka.test.ClusterInstance;
 import kafka.test.annotation.ClusterTest;
 import kafka.test.annotation.ClusterTestDefaults;
@@ -72,13 +71,13 @@ public class LeaderElectionCommandTest {
     }
 
     @BeforeEach
-    void setup(ClusterConfig clusterConfig) {
+    void setup() {
         TestUtils.verifyNoUnexpectedThreads("@BeforeEach");
-        clusterConfig.serverProperties().put("auto.leader.rebalance.enable", "false");
-        clusterConfig.serverProperties().put("controlled.shutdown.enable", "true");
-        clusterConfig.serverProperties().put("controlled.shutdown.max.retries", "1");
-        clusterConfig.serverProperties().put("controlled.shutdown.retry.backoff.ms", "1000");
-        clusterConfig.serverProperties().put("offsets.topic.replication.factor", "2");
+        cluster.config().serverProperties().put("auto.leader.rebalance.enable", "false");
+        cluster.config().serverProperties().put("controlled.shutdown.enable", "true");
+        cluster.config().serverProperties().put("controlled.shutdown.max.retries", "1");
+        cluster.config().serverProperties().put("controlled.shutdown.retry.backoff.ms", "1000");
+        cluster.config().serverProperties().put("offsets.topic.replication.factor", "2");
     }
 
     @ClusterTest
@@ -244,7 +243,7 @@ public class LeaderElectionCommandTest {
 
     @ClusterTest
     public void testTopicDoesNotExist() {
-        Throwable e =  assertThrows(AdminCommandFailedException.class, () -> LeaderElectionCommand.run(
+        Throwable e = assertThrows(AdminCommandFailedException.class, () -> LeaderElectionCommand.run(
             Duration.ofSeconds(30),
             "--bootstrap-server", cluster.bootstrapServers(),
             "--election-type", "preferred",
@@ -326,6 +325,7 @@ public class LeaderElectionCommandTest {
 
         return file.toPath();
     }
+
     private static Path tempAdminConfig(String defaultApiTimeoutMs, String requestTimeoutMs) throws Exception {
         String content = "default.api.timeout.ms=" + defaultApiTimeoutMs + "\nrequest.timeout.ms=" + requestTimeoutMs;
         java.io.File file = TestUtils.tempFile("admin-config", ".properties");


### PR DESCRIPTION
Tuning the way to setup config in test to eliminate the IDE warnings

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
