### PR TITLE
KAFKA-16481: Fixing flaky test kafka.server.ReplicaManagerTest#testRemoteLogReaderMetrics

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1336,7 +1336,7 @@ public class RemoteLogManager implements Closeable {
 
         if (logOptional.isPresent()) {
             Option<LeaderEpochFileCache> leaderEpochCache = logOptional.get().leaderEpochCache();
-            if (leaderEpochCache.isDefined()) {
+            if (leaderEpochCache != null && leaderEpochCache.isDefined()) {
                 epoch = leaderEpochCache.get().epochForOffset(offset);
             }
         }


### PR DESCRIPTION
Noticed in the build: https://ci-builds.apache.org/blue/organizations/jenkins/Kafka%2Fkafka-pr/detail/PR-15621/32/tests/

There are a lot of NPEs of the form:

```
[2024-04-05 21:08:58,617] WARN [RemoteLogManager=0 partition=C_F_5O-eSYWmgQoron0dOQ:test-topic-0] Current task for topic-partition C_F_5O-eSYWmgQoron0dOQ:test-topic-0 received error but it will be scheduled. Reason: Cannot invoke "org.apache.kafka.common.TopicPartition.topic()" because the return value of "kafka.log.UnifiedLog.topicPartition()" is null (kafka.log.remote.RemoteLogManager$RLMTask:829)
[2024-04-05 21:08:58,622] ERROR Error occurred while reading the remote data for test-topic-0 (kafka.log.remote.RemoteLogReader:71)
java.lang.NullPointerException: Cannot invoke "scala.Option.isDefined()" because "leaderEpochCache" is null
	at kafka.log.remote.RemoteLogManager.read(RemoteLogManager.java:1339)
	at kafka.log.remote.RemoteLogManager.read(RemoteLogManager.java:1325)
	at kafka.log.remote.RemoteLogReader.call(RemoteLogReader.java:62)
	at kafka.log.remote.RemoteLogReader.call(RemoteLogReader.java:31)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
[2024-04-05 21:08:58,623] ERROR Error occurred while reading the remote data for test-topic-0 (kafka.log.remote.RemoteLogReader:71)
java.lang.NullPointerException: Cannot invoke "scala.Option.isDefined()" because "leaderEpochCache" is null
	at kafka.log.remote.RemoteLogManager.read(RemoteLogManager.java:1339)
	at kafka.log.remote.RemoteLogManager.read(RemoteLogManager.java:1325)
	at kafka.log.remote.RemoteLogReader.call(RemoteLogReader.java:62)
	at kafka.log.remote.RemoteLogReader.call(RemoteLogReader.java:31)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
[2024-04-05 21:08:58,623] ERROR Error occurred while reading the remote data for test-topic-0 (kafka.log.remote.RemoteLogReader:71)
java.lang.NullPointerException: Cannot invoke "scala.Option.isDefined()" because "leaderEpochCache" is null
	at kafka.log.remote.RemoteLogManager.read(RemoteLogManager.java:1339)
	at kafka.log.remote.RemoteLogManager.read(RemoteLogManager.java:1325)
	at kafka.log.remote.RemoteLogReader.call(RemoteLogReader.java:62)
	at kafka.log.remote.RemoteLogReader.call(RemoteLogReader.java:31)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
[2024-04-05 21:08:58,624] ERROR Error occurred while reading the remote data for test-topic-0 (kafka.log.remote.RemoteLogReader:71)
java.lang.NullPointerException: Cannot invoke "scala.Option.isDefined()" because "leaderEpochCache" is null
	at kafka.log.remote.RemoteLogManager.read(RemoteLogManager.java:1339)
	at kafka.log.remote.RemoteLogManager.read(RemoteLogManager.java:1325)
	at kafka.log.remote.RemoteLogReader.call(RemoteLogReader.java:62)
	at kafka.log.remote.RemoteLogReader.call(RemoteLogReader.java:31)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
[2024-04-05 21:08:58,625] ERROR Error occurred while reading the remote data for test-topic-0 (kafka.log.remote.RemoteLogReader:71)
java.lang.NullPointerException: Cannot invoke "scala.Option.isDefined()" because "leaderEpochCache" is null
	at kafka.log.remote.RemoteLogManager.read(RemoteLogManager.java:1339)
	at kafka.log.remote.RemoteLogManager.read(RemoteLogManager.java:1325)
	at kafka.log.remote.RemoteLogReader.call(RemoteLogReader.java:62)
	at kafka.log.remote.RemoteLogReader.call(RemoteLogReader.java:31)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
[2024-04-05 21:09:03,690] ERROR Error building remote log auxiliary state for test-topic-0 (kafka.server.ReplicaFetcherThread:76)
org.apache.kafka.server.log.remote.storage.RemoteStorageException: Failed to build remote log aux
	at kafka.log.remote.RemoteLogManager.fetchRemoteLogSegmentMetadata(RemoteLogManager.java:443)
	at kafka.server.ReplicaFetcherTierStateMachine.buildRemoteLogAuxState(ReplicaFetcherTierStateMachine.java:229)
	at kafka.server.ReplicaFetcherTierStateMachine.start(ReplicaFetcherTierStateMachine.java:107)
	at kafka.server.AbstractFetcherThread.handleOffsetsMovedToTieredStorage(AbstractFetcherThread.scala:763)
	at kafka.server.AbstractFetcherThread.$anonfun$processFetchRequest$7(AbstractFetcherThread.scala:414)
	at scala.Option.foreach(Option.scala:437)
	at kafka.server.AbstractFetcherThread.$anonfun$processFetchRequest$6(AbstractFetcherThread.scala:333)
	at kafka.server.AbstractFetcherThread.$anonfun$processFetchRequest$6$adapted(AbstractFetcherThread.scala:332)
	at kafka.utils.Implicits$MapExtensionMethods$.$anonfun$forKeyValue$1(Implicits.scala:62)
	at scala.collection.MapOps.foreachEntry(Map.scala:244)
	at scala.collection.MapOps.foreachEntry$(Map.scala:240)
	at scala.collection.AbstractMap.foreachEntry(Map.scala:405)
	at kafka.server.AbstractFetcherThread.processFetchRequest(AbstractFetcherThread.scala:332)
	at kafka.server.AbstractFetcherThread.$anonfun$maybeFetch$3(AbstractFetcherThread.scala:131)
	at kafka.server.AbstractFetcherThread.$anonfun$maybeFetch$3$adapted(AbstractFetcherThread.scala:130)
	at scala.Option.foreach(Option.scala:437)
	at kafka.server.AbstractFetcherThread.maybeFetch(AbstractFetcherThread.scala:130)
	at kafka.server.AbstractFetcherThread.doWork(AbstractFetcherThread.scala:113)
	at kafka.server.ReplicaFetcherThread.doWork(ReplicaFetcherThread.scala:98)
	at org.apache.kafka.server.util.ShutdownableThread.run(ShutdownableThread.java:135)
```

When I ran the test locally as well, the NPEs were found once when the test had failed. I think adding the null check should fix the issue in this case.