### PR TITLE
KAFKA-16280: Expose method to determine metric measurability (KIP-1019)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -75,7 +75,7 @@ public final class KafkaMetric implements Metric {
     public Object metricValue() {
         long now = time.milliseconds();
         synchronized (this.lock) {
-            if (this.metricValueProvider instanceof Measurable)
+            if (isMeasurable())
                 return ((Measurable) metricValueProvider).measure(config, now);
             else if (this.metricValueProvider instanceof Gauge)
                 return ((Gauge<?>) metricValueProvider).value(config, now);
@@ -85,12 +85,21 @@ public final class KafkaMetric implements Metric {
     }
 
     /**
+     * The method determines if the metric value provider is of type Measurable.
+     *
+     * @return true if the metric value provider is of type Measurable, false otherwise.
+     */
+    public boolean isMeasurable() {
+        return this.metricValueProvider instanceof Measurable;
+    }
+
+    /**
      * Get the underlying metric provider, which should be a {@link Measurable}
      * @return Return the metric provider
      * @throws IllegalStateException if the underlying metric is not a {@link Measurable}.
      */
     public Measurable measurable() {
-        if (this.metricValueProvider instanceof Measurable)
+        if (isMeasurable())
             return (Measurable) metricValueProvider;
         else
             throw new IllegalStateException("Not a measurable: " + this.metricValueProvider.getClass());
@@ -103,7 +112,7 @@ public final class KafkaMetric implements Metric {
      */
     double measurableValue(long timeMs) {
         synchronized (this.lock) {
-            if (this.metricValueProvider instanceof Measurable)
+            if (isMeasurable())
                 return ((Measurable) metricValueProvider).measure(config, timeMs);
             else
                 return 0;

--- a/clients/src/test/java/org/apache/kafka/common/metrics/KafkaMetricTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/KafkaMetricTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.metrics;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.utils.MockTime;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class KafkaMetricTest {
+
+    private static final MetricName METRIC_NAME = new MetricName("name", "group", "description", Collections.emptyMap());
+
+    @Test
+    public void testIsMeasurable() {
+        Measurable metricValueProvider = (config, now) -> 0;
+        KafkaMetric metric = new KafkaMetric(new Object(), METRIC_NAME, metricValueProvider, new MetricConfig(), new MockTime());
+        assertTrue(metric.isMeasurable());
+        assertEquals(metricValueProvider, metric.measurable());
+    }
+
+    @Test
+    public void testIsMeasurableWithGaugeProvider() {
+        Gauge<Double> metricValueProvider = (config, now) -> 0.0;
+        KafkaMetric metric = new KafkaMetric(new Object(), METRIC_NAME, metricValueProvider, new MetricConfig(), new MockTime());
+        assertFalse(metric.isMeasurable());
+        assertThrows(IllegalStateException.class, metric::measurable);
+    }
+
+}


### PR DESCRIPTION
The PR implements the changes defined in [KIP-1019](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1019%3A+Expose+method+to+determine+Metric+Measurability) which exposes method to check if metric is of type Measurable.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
