### PR TITLE
KAFKA-16599: LegacyConsumer should always await pending async commits on commitSync and close

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -229,7 +229,11 @@ public abstract class ConsumerCoordinatorTest {
     @AfterEach
     public void teardown() {
         this.metrics.close();
-        this.coordinator.close(time.timer(0));
+        try {
+            this.coordinator.close(time.timer(0));
+        } catch (Exception e) {
+            // ignore
+        }
     }
 
     @Test

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerCommitTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerCommitTest.scala
@@ -304,13 +304,12 @@ class PlaintextConsumerCommitTest extends AbstractConsumerTest {
     consumeAndVerifyRecords(consumer = otherConsumer, numRecords = 1, startingOffset = 5, startingTimestamp = startingTimestamp)
   }
 
-  // TODO: This only works in the new consumer, but should be fixed for the old consumer as well
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
-  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersConsumerGroupProtocolOnly"))
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
   def testCommitAsyncCompletedBeforeConsumerCloses(quorum: String, groupProtocol: String): Unit = {
     // This is testing the contract that asynchronous offset commit are completed before the consumer
     // is closed, even when no commit sync is performed as part of the close (due to auto-commit
-    // disabled, or simply because there are no consumed offsets).
+    // disabled, or simply because there no consumed offsets).
     val producer = createProducer()
     sendRecords(producer, numRecords = 3, tp)
     sendRecords(producer, numRecords = 3, tp2)
@@ -326,9 +325,8 @@ class PlaintextConsumerCommitTest extends AbstractConsumerTest {
     assertEquals(2, cb.successCount)
   }
 
-  // TODO: This only works in the new consumer, but should be fixed for the old consumer as well
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
-  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersConsumerGroupProtocolOnly"))
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
   def testCommitAsyncCompletedBeforeCommitSyncReturns(quorum: String, groupProtocol: String): Unit = {
     // This is testing the contract that asynchronous offset commits sent previously with the
     // `commitAsync` are guaranteed to have their callbacks invoked prior to completion of


### PR DESCRIPTION
The javadoc for `KafkaConsumer.commitSync` says:

> Note that asynchronous offset commits sent previously with the {https://github.com/link #commitAsync(OffsetCommitCallback)}
> (or similar) are guaranteed to have their callbacks invoked prior to completion of this method.

This is not always true in the legacy consumer, when the set of offsets is empty, the execution of the commit callback is not always awaited. There are also various races possible that can avoid callback handler execution. 

Similarly, there is code in the legacy consumer to await the completion of the commit callback before closing, however, the code doesn't cover all cases and the behavior is therefore inconsistent. While the javadoc doesn't explicitly promise callback execution, it promises "completing commits", which one would reasonably expect to include callback execution. Either way, the current behavior of the legacy consumer is inconsistent. 

This change proposed a number of fixes to clean up the callback execution guarantees:

 - We also need to await async commits that are "pending" instead of "in-flight", because we do not know the coordinator yet.
 - In close, we need do not only execute the commit listeners of "pending" commits, but also those of "in-flight" commits.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
