### PR TITLE
MINOR: Kafka streams docs fixes

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -790,7 +790,7 @@ public interface KTable<K, V> {
      * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
      * Setting a new value preserves data co-location with respect to the key.
      *
-     * @param transformerSupplier a instance of {@link ValueTransformerWithKeySupplier} that generates a
+     * @param transformerSupplier an instance of {@link ValueTransformerWithKeySupplier} that generates a
      *                            {@link ValueTransformerWithKey}.
      *                            At least one transformer instance will be created per streaming task.
      *                            Transformers do not need to be thread-safe.
@@ -863,7 +863,7 @@ public interface KTable<K, V> {
      * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
      * Setting a new value preserves data co-location with respect to the key.
      *
-     * @param transformerSupplier a instance of {@link ValueTransformerWithKeySupplier} that generates a
+     * @param transformerSupplier an instance of {@link ValueTransformerWithKeySupplier} that generates a
      *                            {@link ValueTransformerWithKey}.
      *                            At least one transformer instance will be created per streaming task.
      *                            Transformers do not need to be thread-safe.
@@ -940,7 +940,7 @@ public interface KTable<K, V> {
      * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
      * Setting a new value preserves data co-location with respect to the key.
      *
-     * @param transformerSupplier a instance of {@link ValueTransformerWithKeySupplier} that generates a
+     * @param transformerSupplier an instance of {@link ValueTransformerWithKeySupplier} that generates a
      *                            {@link ValueTransformerWithKey}.
      *                            At least one transformer instance will be created per streaming task.
      *                            Transformers do not need to be thread-safe.
@@ -1019,7 +1019,7 @@ public interface KTable<K, V> {
      * Note that the key is read-only and should not be modified, as this can lead to corrupt partitioning.
      * Setting a new value preserves data co-location with respect to the key.
      *
-     * @param transformerSupplier a instance of {@link ValueTransformerWithKeySupplier} that generates a
+     * @param transformerSupplier an instance of {@link ValueTransformerWithKeySupplier} that generates a
      *                            {@link ValueTransformerWithKey}.
      *                            At least one transformer instance will be created per streaming task.
      *                            Transformers do not need to be thread-safe.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Suppressed.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Suppressed.java
@@ -124,7 +124,7 @@ public interface Suppressed<K> extends NamedOperation<Suppressed<K>> {
         /**
          * Disable the changelog for this suppression's internal buffer.
          * This will turn off fault-tolerance for the suppression, and will result in data loss in the event of a rebalance.
-         * By default the changelog is enabled.
+         * By default, the changelog is enabled.
          * @return this
          */
         BC withLoggingDisabled();
@@ -144,7 +144,7 @@ public interface Suppressed<K> extends NamedOperation<Suppressed<K>> {
     /**
      * Configure the suppression to emit only the "final results" from the window.
      *
-     * By default all Streams operators emit results whenever new results are available.
+     * By default, all Streams operators emit results whenever new results are available.
      * This includes windowed operations.
      *
      * This configuration will instead emit just one result per key for each window, guaranteeing
@@ -167,7 +167,7 @@ public interface Suppressed<K> extends NamedOperation<Suppressed<K>> {
 
     /**
      * Configure the suppression to wait {@code timeToWaitForMoreEvents} amount of time after receiving a record
-     * before emitting it further downstream. If another record for the same key arrives in the mean time, it replaces
+     * before emitting it further downstream. If another record for the same key arrives in the meantime, it replaces
      * the first record in the buffer but does <em>not</em> re-start the timer.
      *
      * @param timeToWaitForMoreEvents The amount of time to wait, per record, for new events.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedCogroupedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedCogroupedKStream.java
@@ -181,7 +181,7 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * name of the store defined in {@link Materialized}, and "-changelog" is a fixed suffix.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
@@ -239,7 +239,7 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * name of the store defined in {@link Materialized}, and "-changelog" is a fixed suffix.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedKStream.java
@@ -151,7 +151,7 @@ public interface TimeWindowedKStream<K, V> {
      * contain characters other than ASCII alphanumerics, '.', '_' and '-'.
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the provide store name defined
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the name of the store defined
      * in {@code Materialized}, and "-changelog" is a fixed suffix.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
@@ -201,7 +201,7 @@ public interface TimeWindowedKStream<K, V> {
      * contain characters other than ASCII alphanumerics, '.', '_' and '-'.
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the provide store name defined
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the name of the store defined
      * in {@code Materialized}, and "-changelog" is a fixed suffix.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
@@ -354,7 +354,7 @@ public interface TimeWindowedKStream<K, V> {
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * name of the store defined in {@link Materialized}, and "-changelog" is a fixed suffix.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
@@ -416,7 +416,7 @@ public interface TimeWindowedKStream<K, V> {
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
-     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * name of the store defined in {@link Materialized}, and "-changelog" is a fixed suffix.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
      *
@@ -576,7 +576,7 @@ public interface TimeWindowedKStream<K, V> {
      * contain characters other than ASCII alphanumerics, '.', '_' and '-'.
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the provide store name defined
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the name of the store defined
      * in {@code Materialized}, and "-changelog" is a fixed suffix.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.
@@ -640,7 +640,7 @@ public interface TimeWindowedKStream<K, V> {
      * contain characters other than ASCII alphanumerics, '.', '_' and '-'.
      * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
      * user-specified in {@link StreamsConfig} via parameter
-     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the provide store name defined
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the name of the store defined
      * in {@link Materialized}, and "-changelog" is a fixed suffix.
      * <p>
      * You can retrieve all generated internal topic names via {@link Topology#describe()}.


### PR DESCRIPTION
- Incorrect use of verb "provide" in : _"storeName" is the provide store name defined in Materialized_.
Changed to _"storeName" is the name of the store defined in Materialized_

- fix _a_ vs _an_
