### PR TITLE
KAFKA-16211: Inconsistent config values in CreateTopicsResult and DescribeConfigsResult

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2530,8 +2530,10 @@ public class KafkaAdminClient extends AdminClient {
         final Map<Integer, Map<ConfigResource, KafkaFutureImpl<Config>>> nodeFutures = new HashMap<>(configResources.size());
 
         for (ConfigResource resource : configResources) {
+            // nodeFor will return null if the resource is not of type BROKER
             Integer broker = nodeFor(resource);
             nodeFutures.compute(broker, (key, value) -> {
+                // since the resource is of type TOPIC, key will be null
                 if (value == null) {
                     value = new HashMap<>();
                 }
@@ -2542,11 +2544,13 @@ public class KafkaAdminClient extends AdminClient {
 
         final long now = time.milliseconds();
         for (Map.Entry<Integer, Map<ConfigResource, KafkaFutureImpl<Config>>> entry : nodeFutures.entrySet()) {
+            // This node will be null if the resource is of type TOPIC
             final Integer node = entry.getKey();
             Map<ConfigResource, KafkaFutureImpl<Config>> unified = entry.getValue();
 
             runnable.call(new Call("describeConfigs", calcDeadlineMs(now, options.timeoutMs()),
-                node != null ? new ConstantNodeIdProvider(node, true) : new LeastLoadedBrokerOrActiveKController()) {
+                    // if node is null, new LeastLoadedBrokerOrActiveKController is passed here
+                    node != null ? new ConstantNodeIdProvider(node, true) : new LeastLoadedBrokerOrActiveKController()) {
 
                 @Override
                 DescribeConfigsRequest.Builder createRequest(int timeoutMs) {


### PR DESCRIPTION
*When creating a topic in KRaft cluster, a config value returned by createTopics() is different than what you get from describeConfigs().​*

*My guess from reading the code is that describeTopics() will send the request to a specified broker if the config resource is broker (ConfigResouce.Type.BROKER). In the case that the config resource is topic (ConfigResouce.Type.TOPIC), then a broker will be assigned using LeastLoadBrokerOrActiveKController() (in KafkaAdminClient), which in this situation will assign the "least loaded" broker. I have tested this and, indeed, each time I use describeConfigs() with the ConfigResource's type being "TOPIC", a different broker's static configuration may be returned. My question is: Is it supposed to be the way describeConfigs() should be used with the configResource's type being ConfigResouce.Type.TOPIC? Or even, are we supposed to use describeConfig() with configResource's type being ConfigResouce.Type.TOPIC instead of strictly with ConfigResouce.Type.BROKER?

I have also added some comments in the code for my understanding of the logic of describeConfigs() *

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
