### PR TITLE
KAFKA-16466: add details of an internal exception to the failure message

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/errors/EventHandlerExceptionInfo.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/errors/EventHandlerExceptionInfo.java
@@ -192,7 +192,7 @@ public final class EventHandlerExceptionInfo {
         }
         bld.append(".");
         if (!isFault && internalException.getMessage() != null) {
-            bld.append(" Detailed exception message: ");
+            bld.append(" Exception message: ");
             bld.append(internalException.getMessage());
         }
         return bld.toString();

--- a/metadata/src/main/java/org/apache/kafka/controller/errors/EventHandlerExceptionInfo.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/errors/EventHandlerExceptionInfo.java
@@ -191,6 +191,10 @@ public final class EventHandlerExceptionInfo {
             }
         }
         bld.append(".");
+        if (!isFault) {
+            bld.append(" Detailed exception message: ");
+            bld.append(internalException.getMessage());
+        }
         return bld.toString();
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/errors/EventHandlerExceptionInfo.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/errors/EventHandlerExceptionInfo.java
@@ -191,7 +191,7 @@ public final class EventHandlerExceptionInfo {
             }
         }
         bld.append(".");
-        if (!isFault) {
+        if (!isFault && internalException.getMessage() != null) {
             bld.append(" Detailed exception message: ");
             bld.append(internalException.getMessage());
         }


### PR DESCRIPTION
EventHandlerExceptionInfo#failureMessage() didn't include a message of the propagated exception. But it would be helpful to have them for non-fault exceptions. This PR adds it, so it can be helpful to debug errors

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
