### PR TITLE
MINOR: Add test for PartitionMetadataFile

### DIFF
--- a/checkstyle/import-control-storage.xml
+++ b/checkstyle/import-control-storage.xml
@@ -73,9 +73,10 @@
     <subpackage name="storage.internals">
         <allow pkg="com.fasterxml.jackson" />
         <allow pkg="com.yammer.metrics.core" />
+        <allow pkg="org.apache.kafka.common" />
         <allow pkg="org.apache.kafka.server"/>
         <allow pkg="org.apache.kafka.storage.internals"/>
-        <allow pkg="org.apache.kafka.common" />
+        <allow pkg="org.apache.kafka.test" />
         <allow pkg="com.github.benmanes.caffeine.cache" />
     </subpackage>
 

--- a/storage/src/test/java/org/apache/kafka/storage/internals/checkpoint/PartitionMetadataFileTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/checkpoint/PartitionMetadataFileTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.storage.internals.checkpoint;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.InconsistentTopicIdException;
+import org.apache.kafka.common.utils.Utils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PartitionMetadataFileTest  {
+    private final File dir = assertDoesNotThrow(() -> Files.createTempDirectory("tmp")).toFile();
+
+    @AfterEach
+    public void tearDown() {
+        assertDoesNotThrow(() -> Utils.delete(dir));
+    }
+
+    @Test
+    public void testSetRecordWithDifferentTopicId() {
+        File partitionMetadata = PartitionMetadataFile.newFile(dir);
+        PartitionMetadataFile partitionMetadataFile = new PartitionMetadataFile(partitionMetadata, null);
+        Uuid topicId = Uuid.randomUuid();
+        assertDoesNotThrow(() -> partitionMetadataFile.record(topicId));
+        Uuid differentTopicId = Uuid.randomUuid();
+        assertThrows(InconsistentTopicIdException.class, () -> partitionMetadataFile.record(differentTopicId));
+    }
+
+    @Test
+    public void testSetRecordWithSameTopicId() {
+        File partitionMetadata = PartitionMetadataFile.newFile(dir);
+        PartitionMetadataFile partitionMetadataFile = new PartitionMetadataFile(partitionMetadata, null);
+        Uuid topicId = Uuid.randomUuid();
+        assertDoesNotThrow(() -> partitionMetadataFile.record(topicId));
+        assertDoesNotThrow(() -> partitionMetadataFile.record(topicId));
+    }
+}

--- a/storage/src/test/java/org/apache/kafka/storage/internals/checkpoint/PartitionMetadataFileTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/checkpoint/PartitionMetadataFileTest.java
@@ -42,7 +42,7 @@ class PartitionMetadataFileTest  {
     public void testSetRecordWithDifferentTopicId() {
         PartitionMetadataFile partitionMetadataFile = new PartitionMetadataFile(file, null);
         Uuid topicId = Uuid.randomUuid();
-        assertDoesNotThrow(() -> partitionMetadataFile.record(topicId));
+        partitionMetadataFile.record(topicId);
         Uuid differentTopicId = Uuid.randomUuid();
         assertThrows(InconsistentTopicIdException.class, () -> partitionMetadataFile.record(differentTopicId));
     }
@@ -51,7 +51,7 @@ class PartitionMetadataFileTest  {
     public void testSetRecordWithSameTopicId() {
         PartitionMetadataFile partitionMetadataFile = new PartitionMetadataFile(file, null);
         Uuid topicId = Uuid.randomUuid();
-        assertDoesNotThrow(() -> partitionMetadataFile.record(topicId));
+        partitionMetadataFile.record(topicId);
         assertDoesNotThrow(() -> partitionMetadataFile.record(topicId));
     }
 
@@ -60,8 +60,8 @@ class PartitionMetadataFileTest  {
         PartitionMetadataFile partitionMetadataFile = new PartitionMetadataFile(file, null);
 
         Uuid topicId = Uuid.randomUuid();
-        assertDoesNotThrow(() -> partitionMetadataFile.record(topicId));
-        assertDoesNotThrow(partitionMetadataFile::maybeFlush);
+        partitionMetadataFile.record(topicId);
+        partitionMetadataFile.maybeFlush();
 
         // The following content is encoded by PartitionMetadata#encode, which is invoked during the flush
         List<String> lines = Files.readAllLines(file.toPath());
@@ -73,8 +73,8 @@ class PartitionMetadataFileTest  {
     @Test
     public void testMaybeFlushWithNoTopicIdPresent() {
         PartitionMetadataFile partitionMetadataFile = new PartitionMetadataFile(file, null);
+        partitionMetadataFile.maybeFlush();
 
-        assertDoesNotThrow(partitionMetadataFile::maybeFlush);
         assertEquals(0, file.length());
     }
 
@@ -84,8 +84,8 @@ class PartitionMetadataFileTest  {
         PartitionMetadataFile partitionMetadataFile = new PartitionMetadataFile(file, channel);
 
         Uuid topicId = Uuid.randomUuid();
-        assertDoesNotThrow(() -> partitionMetadataFile.record(topicId));
-        assertDoesNotThrow(partitionMetadataFile::maybeFlush);
+        partitionMetadataFile.record(topicId);
+        partitionMetadataFile.maybeFlush();
 
         PartitionMetadata metadata = partitionMetadataFile.read();
         assertEquals(0, metadata.version());

--- a/storage/src/test/java/org/apache/kafka/storage/internals/checkpoint/PartitionMetadataFileTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/checkpoint/PartitionMetadataFileTest.java
@@ -53,6 +53,10 @@ class PartitionMetadataFileTest  {
         Uuid topicId = Uuid.randomUuid();
         partitionMetadataFile.record(topicId);
         assertDoesNotThrow(() -> partitionMetadataFile.record(topicId));
+
+        Uuid sameTopicId = Uuid.fromString(topicId.toString());
+        partitionMetadataFile.record(sameTopicId);
+        assertDoesNotThrow(() -> partitionMetadataFile.record(topicId));
     }
 
     @Test


### PR DESCRIPTION
In PartitionMetadataFile.java, there is a defensive early-fail design when setting a different topicId, but there are no corresponding test cases. Hence, this PR adds two tests for setting the same and different topicId.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
