### PR TITLE
MINOR: Fix io-[wait-]ratio metrics description

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -1281,14 +1281,14 @@ public class Selector implements Selectable, AutoCloseable {
 
         /**
          * This method generates `time-total` metrics but has a couple of deficiencies: no `-ns` suffix and no dash between basename
-         * and `time-toal` suffix.
+         * and `time-total` suffix.
          * @deprecated use {{@link #createIOThreadRatioMeter(Metrics, String, Map, String, String)}} for new metrics instead
          */
         @Deprecated
         private Meter createIOThreadRatioMeterLegacy(Metrics metrics, String groupName,  Map<String, String> metricTags,
                 String baseName, String action) {
             MetricName rateMetricName = metrics.metricName(baseName + "-ratio", groupName,
-                    String.format("*Deprecated* The fraction of time the I/O thread spent %s", action), metricTags);
+                    String.format("The fraction of time the I/O thread spent %s", action), metricTags);
             MetricName totalMetricName = metrics.metricName(baseName + "time-total", groupName,
                     String.format("*Deprecated* The total time the I/O thread spent %s", action), metricTags);
             return new Meter(TimeUnit.NANOSECONDS, rateMetricName, totalMetricName);

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -1287,8 +1287,10 @@ public class Selector implements Selectable, AutoCloseable {
         @Deprecated
         private Meter createIOThreadRatioMeterLegacy(Metrics metrics, String groupName,  Map<String, String> metricTags,
                 String baseName, String action) {
+            // this name remains relevant, non-deprecated descendant method uses the same 
             MetricName rateMetricName = metrics.metricName(baseName + "-ratio", groupName,
                     String.format("The fraction of time the I/O thread spent %s", action), metricTags);
+            // this name is deprecated
             MetricName totalMetricName = metrics.metricName(baseName + "time-total", groupName,
                     String.format("*Deprecated* The total time the I/O thread spent %s", action), metricTags);
             return new Meter(TimeUnit.NANOSECONDS, rateMetricName, totalMetricName);

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -1280,8 +1280,11 @@ public class Selector implements Selectable, AutoCloseable {
         }
 
         /**
-         * This method generates `time-total` metrics but has a couple of deficiencies: no `-ns` suffix and no dash between basename
-         * and `time-total` suffix.
+         * <p>This method generates `time-total` metrics but has a couple of deficiencies: no `-ns` suffix and no dash between basename
+         * and `time-total` suffix.</p>
+         * <p>"-ratio"-suffixed name is relevant and the same as used in 
+         * {{@link #createIOThreadRatioMeter(Metrics, String, Map, String, String)}}.</p>
+         * <p>"time-total"-suffixed name is deprecated.</p>
          * @deprecated use {{@link #createIOThreadRatioMeter(Metrics, String, Map, String, String)}} for new metrics instead
          */
         @Deprecated

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -1280,11 +1280,8 @@ public class Selector implements Selectable, AutoCloseable {
         }
 
         /**
-         * <p>This method generates `time-total` metrics but has a couple of deficiencies: no `-ns` suffix and no dash between basename
-         * and `time-total` suffix.</p>
-         * <p>"-ratio"-suffixed name is relevant and the same as used in 
-         * {{@link #createIOThreadRatioMeter(Metrics, String, Map, String, String)}}.</p>
-         * <p>"time-total"-suffixed name is deprecated.</p>
+         * This method generates `time-total` metrics but has a couple of deficiencies: no `-ns` suffix and no dash between basename
+         * and `time-total` suffix.
          * @deprecated use {{@link #createIOThreadRatioMeter(Metrics, String, Map, String, String)}} for new metrics instead
          */
         @Deprecated

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -1025,8 +1025,8 @@ public class SelectorTest {
         // knowing metric group and tag set, which are not trivial dependencies
         for (MetricName metricName : metrics.metrics().keySet()) {
             String name = metricName.name();
-            String description = metricName.description().toLowerCase(Locale.ROOT);
-            boolean markedDeprecated = description.contains("deprecated");
+            String description = metricName.description();
+            boolean markedDeprecated = description.toLowerCase(Locale.ROOT).contains("deprecated");
             if (actual.contains(name)) {
                 assertFalse(markedDeprecated, name + " shouldn't be deprecated");
             }

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
@@ -1012,6 +1013,28 @@ public class SelectorTest {
         assertEquals(0, selector.completedReceives().size());
     }
 
+    /**
+     * Validate that correct subset of io metrics marked deprecated in docs
+     */
+    @Test
+    public void testIoMetricsHaveCorrectDoc() {
+        List<String> actual = asList("io-ratio", "io-wait-ratio");
+        List<String> deprecated = asList("iotime-total", "io-waittime-total");
+
+        // iterate through all metrics, since metrics.metric(metricName) requires 
+        // knowing metric group and tag set, which are not trivial dependencies
+        for (MetricName metricName : metrics.metrics().keySet()) {
+            String name = metricName.name();
+            String description = metricName.description().toLowerCase(Locale.ROOT);
+            boolean markedDeprecated = description.contains("deprecated");
+            if (actual.contains(name)) {
+                assertFalse(markedDeprecated, name + " shouldn't be deprecated");
+            }
+            if (deprecated.contains(name)) {
+                assertTrue(markedDeprecated, name + " should be deprecated");
+            }
+        }
+    }
 
     private String blockingRequest(String node, String s) throws IOException {
         selector.send(createSend(node, s));

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -1019,11 +1019,10 @@ public class SelectorTest {
      */
     @Test
     public void testIoMetricsHaveCorrectDoc() {
-        List<String> actual = asList("io-ratio", "io-wait-ratio");
-        List<String> deprecated = asList("iotime-total", "io-waittime-total");
         Predicate<MetricName> docDeprecated =
                 mName -> mName.description().toLowerCase(Locale.ROOT).contains("deprecated");
 
+        List<String> actual = asList("io-ratio", "io-wait-ratio");
         assertEquals(
                 actual.size(),
                 metrics.metrics().keySet().stream()
@@ -1033,6 +1032,7 @@ public class SelectorTest {
                 "Metrics " + actual + " should be registered as non-deprecated"
         );
 
+        List<String> deprecated = asList("iotime-total", "io-waittime-total");
         assertEquals(
                 deprecated.size(),
                 metrics.metrics().keySet().stream()


### PR DESCRIPTION
[Implementation of KIP-773](https://github.com/apache/kafka/pull/11302) deprecated `iotime-total`  and `io-waittime-total` metrics. It wasn't expected to mark `io-ratio` and `io-wait-ratio` deprecated. However, now they have `*Deprecated* ` in their description. Here is the reason:
1. register `io-ratio` (desc: `*Deprecated* The fraction of time ...`) -> registered
2. register `iotime-total` (desc: `*Deprecated* The total time ...`) -> registered 
3. register `io-ratio` (desc: `The fraction of time ...`) -> **skipped, the same name already exists in registry**
4. register `io-time-ns-total` (desc: `The total time ...`) -> registered 

As a result, `io-ratio` has incorrect description. The same for `io-wait-ratio`. This PR fixes these descriptions..

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)