### PR TITLE
KAFKA-16556: SubscriptionState should not prematurely reset 'pending' partitions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1623,6 +1623,11 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
             // If there are partitions still needing a position and a reset policy is defined,
             // request reset using the default policy. If no reset strategy is defined and there
             // are partitions with a missing position, then we will raise a NoOffsetForPartitionException exception.
+            //
+            // Note: this will *not* initialize the position for any partitions that are in the process
+            // of being assigned and awaiting ConsumerRebalanceListener callbacks. We don't  want to reset
+            // positions until the partition has been fully assigned *and* not until
+            // initWithCommittedOffsetsIfNeeded has had its chance to look up its committed offset.
             subscriptions.resetInitializingPositions();
 
             // Reset positions using partition offsets retrieved from the leader, for any partitions

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1625,9 +1625,10 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
             // are partitions with a missing position, then we will raise a NoOffsetForPartitionException exception.
             //
             // Note: this will *not* initialize the position for any partitions that are in the process
-            // of being assigned and awaiting ConsumerRebalanceListener callbacks. We don't  want to reset
-            // positions until the partition has been fully assigned *and* not until
-            // initWithCommittedOffsetsIfNeeded has had its chance to look up its committed offset.
+            // of being assigned and awaiting ConsumerRebalanceListener callbacks. We don't want to reset
+            // positions until the partition has been fully assigned *and* we want to wait until
+            // initWithCommittedOffsetsIfNeeded has had a chance to look up the partition's committed
+            // offset, if applicable.
             subscriptions.resetInitializingPositions();
 
             // Reset positions using partition offsets retrieved from the leader, for any partitions

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -967,4 +967,39 @@ public class SubscriptionStateTest {
 
         assertThrows(IllegalStateException.class, () -> state.isOffsetResetNeeded(unassignedPartition));
     }
+
+    /**
+     * This test checks that we will not attempt to prematurely reset position of partitions that are pending.
+     *
+     * See KAFKA-16556.
+     */
+    @Test
+    public void testPendingPartitionsDoNotResetPositions() {
+        Optional<ConsumerRebalanceListener> listener = Optional.of(new CounterConsumerRebalanceListener());
+        Set<String> topics = Collections.singleton(topic);
+        Collection<TopicPartition> assignedPartitions = Collections.singleton(tp0);
+
+        // User subscribes to a topic and the group coordinator assigns a partitions to our consumer.
+        state.subscribe(topics, listener);
+        state.assignFromSubscribedAwaitingCallback(assignedPartitions, assignedPartitions);
+
+        // The logic in initializingPartitions will filter out the pending partition and it will
+        // not be considered fetchable.
+        assertFalse(state.initializingPartitions().contains(tp0));
+        assertFalse(state.isFetchable(tp0));
+        assertFalse(state.hasAllFetchPositions());
+
+        // Let's pretend this code is being executed by the Consumer.poll() code on the application thread.
+        assertFalse(state.isOffsetResetNeeded(tp0));
+        state.resetInitializingPositions();
+        assertFalse(state.isOffsetResetNeeded(tp0));
+
+        // Shortly after, on the next loop of the poll() method, we complete the callback.
+        state.enablePartitionsAwaitingCallback(Collections.singleton(tp0));
+
+        // THEN, we can reset the partition (if needed).
+        assertFalse(state.isOffsetResetNeeded(tp0));
+        state.resetInitializingPositions();
+        assertTrue(state.isOffsetResetNeeded(tp0));
+    }
 }


### PR DESCRIPTION
Partitions that are marked as `pendingOnAssignedCallback` should not be reset in `resetInitializingPositions()`. Pending partitions are omitted from the set returned by `initializingPartitions()`. As a result, the Consumer does not include them in the set of partitions for which it attempts to load committed offsets. The code used by the Consumer to reset positions  (`resetInitializingPositions()`) should likewise skip partitions marked as pending.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
