### PR TITLE
MINOR adds '-parameters' compiler option for :core tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -703,6 +703,11 @@ subprojects {
     if (versions.baseScala == "2.13" || JavaVersion.current().isJava9Compatible())
       scalaCompileOptions.additionalParameters += ["-release", String.valueOf(minJavaVersion)]
 
+    // -parameters generates arguments with parameter names in TestInfo#getDisplayName.
+    // ref: https://github.com/junit-team/junit5/blob/4c0dddad1b96d4a20e92a2cd583954643ac56ac0/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java#L161-L164
+    if (name == "compileTestScala")
+      options.compilerArgs << "-parameters"
+
     configure(scalaCompileOptions.forkOptions) {
       memoryMaximumSize = defaultMaxHeapSize
       jvmArgs = defaultJvmArgs
@@ -1239,9 +1244,6 @@ project(':core') {
       }
     }
   }
-  // -parameters generates arguments with parameter names in TestInfo#getDisplayName.
-  // ref: https://github.com/junit-team/junit5/blob/4c0dddad1b96d4a20e92a2cd583954643ac56ac0/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java#L161-L164
-  compileTestScala.options.compilerArgs.add "-parameters"
 }
 
 project(':metadata') {

--- a/build.gradle
+++ b/build.gradle
@@ -1241,7 +1241,7 @@ project(':core') {
   }
   // -parameters generates arguments with parameter names in TestInfo#getDisplayName.
   // ref: https://github.com/junit-team/junit5/blob/4c0dddad1b96d4a20e92a2cd583954643ac56ac0/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java#L161-L164
-  //compileTestScala.options.compilerArgs.add "-parameters"
+  compileTestScala.options.compilerArgs.add "-parameters"
 }
 
 project(':metadata') {

--- a/build.gradle
+++ b/build.gradle
@@ -1239,7 +1239,9 @@ project(':core') {
       }
     }
   }
-  compileTestScala.options.compilerArgs.add "-parameters"
+  // -parameters generates arguments with parameter names in TestInfo#getDisplayName.
+  // ref: https://github.com/junit-team/junit5/blob/4c0dddad1b96d4a20e92a2cd583954643ac56ac0/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java#L161-L164
+  //compileTestScala.options.compilerArgs.add "-parameters"
 }
 
 project(':metadata') {

--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,13 @@ ext {
   repo = file("$rootDir/.git").isDirectory() ? Grgit.open(currentDir: project.getRootDir()) : null
 
   commitId = determineCommitId()
+
+  addParametersForTests = { name, options ->
+    // -parameters generates arguments with parameter names in TestInfo#getDisplayName.
+    // ref: https://github.com/junit-team/junit5/blob/4c0dddad1b96d4a20e92a2cd583954643ac56ac0/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java#L161-L164
+    if (name == "compileTestJava" || name == "compileTestScala")
+      options.compilerArgs << "-parameters"
+  }
 }
 
 allprojects {
@@ -278,11 +285,9 @@ subprojects {
     // --source/--target 8 is deprecated in Java 20, suppress warning until Java 8 support is dropped in Kafka 4.0
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_20))
       options.compilerArgs << "-Xlint:-options"
-  }
 
-  // -parameters generates arguments with parameter names in TestInfo#getDisplayName.
-  // ref: https://github.com/junit-team/junit5/blob/4c0dddad1b96d4a20e92a2cd583954643ac56ac0/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java#L161-L164
-  compileTestJava.options.compilerArgs.add "-parameters"
+    addParametersForTests(name, options)
+  }
 
   // We should only set this if Java version is < 9 (--release is recommended for >= 9), but the Scala plugin for IntelliJ sets
   // `-target` incorrectly if this is unset
@@ -703,10 +708,7 @@ subprojects {
     if (versions.baseScala == "2.13" || JavaVersion.current().isJava9Compatible())
       scalaCompileOptions.additionalParameters += ["-release", String.valueOf(minJavaVersion)]
 
-    // -parameters generates arguments with parameter names in TestInfo#getDisplayName.
-    // ref: https://github.com/junit-team/junit5/blob/4c0dddad1b96d4a20e92a2cd583954643ac56ac0/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java#L161-L164
-    if (name == "compileTestScala")
-      options.compilerArgs << "-parameters"
+    addParametersForTests(name, options)
 
     configure(scalaCompileOptions.forkOptions) {
       memoryMaximumSize = defaultMaxHeapSize

--- a/build.gradle
+++ b/build.gradle
@@ -1239,6 +1239,7 @@ project(':core') {
       }
     }
   }
+  compileTestScala.options.compilerArgs.add "-parameters"
 }
 
 project(':metadata') {


### PR DESCRIPTION
All `core` module tests compiled as scala tests, but `-parameters` compiler option required for junit added only to javatest compiler option. This PR fixes it.

Before fix:
```
❯ ./gradlew cleanTest :core:test --tests BootstrapControllersIntegrationTest.testDescribeCluster

> Configure project :
Starting build with version 3.8.0-SNAPSHOT (commit id e5a85607) using Gradle 8.7, Java 21 and Scala 2.13.12
Build properties: maxParallelForks=10, maxScalacThreads=8, maxTestRetries=0

> Task :core:test

Gradle Test Run :core:test > Gradle Test Executor 105 > BootstrapControllersIntegrationTest > testDescribeCluster(boolean) > 
    "testDescribeCluster(boolean).false" PASSED

Gradle Test Run :core:test > Gradle Test Executor 105 > BootstrapControllersIntegrationTest > testDescribeCluster(boolean) > 
    "testDescribeCluster(boolean).true" PASSED
```

After fix (Please, note difference in test names):
```
❯ ./gradlew cleanTest :core:test --tests BootstrapControllersIntegrationTest.testDescribeCluster

> Configure project :
Starting build with version 3.8.0-SNAPSHOT (commit id e5a85607) using Gradle 8.7, Java 21 and Scala 2.13.12
Build properties: maxParallelForks=10, maxScalacThreads=8, maxTestRetries=0

> Task :core:compileTestScala
...
> Task :core:test

Gradle Test Run :core:test > Gradle Test Executor 107 > BootstrapControllersIntegrationTest > testDescribeCluster(boolean) > 
    "testDescribeCluster(boolean).usingBootstrapControllers=false" PASSED

Gradle Test Run :core:test > Gradle Test Executor 107 > BootstrapControllersIntegrationTest > testDescribeCluster(boolean) > 
    "testDescribeCluster(boolean).usingBootstrapControllers=true" PASSED

```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
