### PR TITLE
KAFKA-16363: Storage tool crashes if dir is unavailable

### DIFF
--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -440,8 +440,12 @@ object StorageTool extends Logging {
         "Use --ignore-formatted to ignore this directory and format the others.")
     }
     if (!copier.errorLogDirs().isEmpty) {
-      val firstLogDir = copier.errorLogDirs().iterator().next()
-      throw new TerseFailure(s"I/O error trying to read log directory $firstLogDir.")
+      copier.errorLogDirs().forEach(errorLogDir => {
+        stream.println(s"I/O error trying to read log directory $errorLogDir. Ignoring...")
+      })
+      if(metaPropertiesEnsemble.emptyLogDirs().isEmpty) {
+        throw new TerseFailure("No available log directories to format.")
+      }
     }
     if (metaPropertiesEnsemble.emptyLogDirs().isEmpty) {
       stream.println("All of the log directories are already formatted.")

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -443,7 +443,7 @@ object StorageTool extends Logging {
       copier.errorLogDirs().forEach(errorLogDir => {
         stream.println(s"I/O error trying to read log directory $errorLogDir. Ignoring...")
       })
-      if(metaPropertiesEnsemble.emptyLogDirs().isEmpty) {
+      if (metaPropertiesEnsemble.emptyLogDirs().isEmpty && copier.logDirProps().isEmpty) {
         throw new TerseFailure("No available log directories to format.")
       }
     }

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -192,64 +192,57 @@ Found problem:
     } finally Utils.delete(tempDir)
   }
 
-  private def runFormatCommand(stream: ByteArrayOutputStream, directories: Seq[String]): Int = {
+  private def runFormatCommand(stream: ByteArrayOutputStream, directories: Seq[String], ignoreFormatted: Boolean = false): Int = {
     val metaProperties = new MetaProperties.Builder().
       setVersion(MetaPropertiesVersion.V1).
       setClusterId("XcZZOzUqS4yHOjhMQB6JLQ").
       setNodeId(2).
       build()
     val bootstrapMetadata = StorageTool.buildBootstrapMetadata(MetadataVersion.latestTesting(), None, "test format command")
-    StorageTool.formatCommand(new PrintStream(stream), directories, metaProperties, bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false)
+    StorageTool.formatCommand(new PrintStream(stream), directories, metaProperties, bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted)
   }
 
   @Test
   def testFormatSucceedsIfAllDirectoriesAreAvailable(): Unit = {
     val availableDir1 = TestUtils.tempDir()
     val availableDir2 = TestUtils.tempDir()
-    try {
-      val stream = new ByteArrayOutputStream()
-      assertEquals(0, runFormatCommand(stream, Seq(availableDir1.toString, availableDir2.toString)))
-      assertTrue(stream.toString().contains("Formatting %s".format(availableDir1)))
-      assertTrue(stream.toString().contains("Formatting %s".format(availableDir2)))
-    } finally {
-      Utils.delete(availableDir1)
-      Utils.delete(availableDir2)
-    }
+    val stream = new ByteArrayOutputStream()
+    assertEquals(0, runFormatCommand(stream, Seq(availableDir1.toString, availableDir2.toString)))
+    assertTrue(stream.toString().contains("Formatting %s".format(availableDir1)))
+    assertTrue(stream.toString().contains("Formatting %s".format(availableDir2)))
   }
 
   @Test
   def testFormatSucceedsIfAtLeastOneDirectoryIsAvailable(): Unit = {
     val availableDir1 = TestUtils.tempDir()
     val unavailableDir1 = TestUtils.tempFile()
-    try {
-      val stream = new ByteArrayOutputStream()
-      assertEquals(0, runFormatCommand(stream, Seq(availableDir1.toString, unavailableDir1.toString)))
-      assertTrue(stream.toString().contains("I/O error trying to read log directory %s. Ignoring...".format(unavailableDir1)))
-      assertTrue(stream.toString().contains("Formatting %s".format(availableDir1)))
-      assertFalse(stream.toString().contains("Formatting %s".format(unavailableDir1)))
-    } finally {
-      Utils.delete(availableDir1)
-      Utils.delete(unavailableDir1)
-    }
+    val stream = new ByteArrayOutputStream()
+    assertEquals(0, runFormatCommand(stream, Seq(availableDir1.toString, unavailableDir1.toString)))
+    assertTrue(stream.toString().contains("I/O error trying to read log directory %s. Ignoring...".format(unavailableDir1)))
+    assertTrue(stream.toString().contains("Formatting %s".format(availableDir1)))
+    assertFalse(stream.toString().contains("Formatting %s".format(unavailableDir1)))
   }
 
   @Test
   def testFormatFailsIfAllDirectoriesAreUnavailable(): Unit = {
     val unavailableDir1 = TestUtils.tempFile()
     val unavailableDir2 = TestUtils.tempFile()
-    try {
-      val stream = new ByteArrayOutputStream()
-      try {
-        assertEquals(1, runFormatCommand(stream, Seq(unavailableDir1.toString, unavailableDir2.toString)))
-      } catch {
-        case e: TerseFailure => assertEquals("No available log directories to format.", e.getMessage)
-      }
-      assertTrue(stream.toString().contains("I/O error trying to read log directory %s. Ignoring...".format(unavailableDir1)))
-      assertTrue(stream.toString().contains("I/O error trying to read log directory %s. Ignoring...".format(unavailableDir2)))
-    } finally {
-      Utils.delete(unavailableDir1)
-      Utils.delete(unavailableDir2)
-    }
+    val stream = new ByteArrayOutputStream()
+    assertEquals("No available log directories to format.", assertThrows(classOf[TerseFailure],
+      () => runFormatCommand(stream, Seq(unavailableDir1.toString, unavailableDir2.toString))).getMessage)
+    assertTrue(stream.toString().contains("I/O error trying to read log directory %s. Ignoring...".format(unavailableDir1)))
+    assertTrue(stream.toString().contains("I/O error trying to read log directory %s. Ignoring...".format(unavailableDir2)))
+  }
+
+  @Test
+  def testFormatSucceedsIfAtLeastOneFormattedDirectoryIsAvailable(): Unit = {
+    val availableDir1 = TestUtils.tempDir()
+    val stream = new ByteArrayOutputStream()
+    assertEquals(0, runFormatCommand(stream, Seq(availableDir1.toString)))
+
+    val stream2 = new ByteArrayOutputStream()
+    val unavailableDir1 = TestUtils.tempFile()
+    assertEquals(0, runFormatCommand(stream2, Seq(availableDir1.toString, unavailableDir1.toString), ignoreFormatted = true))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -192,25 +192,25 @@ Found problem:
     } finally Utils.delete(tempDir)
   }
 
+  private def runFormatCommand(stream: ByteArrayOutputStream, directories: Seq[String]): Int = {
+    val metaProperties = new MetaProperties.Builder().
+      setVersion(MetaPropertiesVersion.V1).
+      setClusterId("XcZZOzUqS4yHOjhMQB6JLQ").
+      setNodeId(2).
+      build()
+    val bootstrapMetadata = StorageTool.buildBootstrapMetadata(MetadataVersion.latestTesting(), None, "test format command")
+    StorageTool.formatCommand(new PrintStream(stream), directories, metaProperties, bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false)
+  }
+
   @Test
   def testFormatSucceedsIfAllDirectoriesAreAvailable(): Unit = {
     val availableDir1 = TestUtils.tempDir()
     val availableDir2 = TestUtils.tempDir()
-
     try {
-      val metaProperties = new MetaProperties.Builder().
-        setVersion(MetaPropertiesVersion.V1).
-        setClusterId("XcZZOzUqS4yHOjhMQB6JLQ").
-        setNodeId(2).
-        build()
       val stream = new ByteArrayOutputStream()
-      val bootstrapMetadata = StorageTool.buildBootstrapMetadata(MetadataVersion.latestTesting(), None, "test format command")
-
-      assertEquals(0,
-        StorageTool.formatCommand(new PrintStream(stream), Seq(availableDir1.toString, availableDir2.toString), metaProperties, bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false))
+      assertEquals(0, runFormatCommand(stream, Seq(availableDir1.toString, availableDir2.toString)))
       assertTrue(stream.toString().contains("Formatting %s".format(availableDir1)))
       assertTrue(stream.toString().contains("Formatting %s".format(availableDir2)))
-
     } finally {
       Utils.delete(availableDir1)
       Utils.delete(availableDir2)
@@ -221,22 +221,12 @@ Found problem:
   def testFormatSucceedsIfAtLeastOneDirectoryIsAvailable(): Unit = {
     val availableDir1 = TestUtils.tempDir()
     val unavailableDir1 = TestUtils.tempFile()
-
     try {
-      val metaProperties = new MetaProperties.Builder().
-        setVersion(MetaPropertiesVersion.V1).
-        setClusterId("XcZZOzUqS4yHOjhMQB6JLQ").
-        setNodeId(2).
-        build()
       val stream = new ByteArrayOutputStream()
-      val bootstrapMetadata = StorageTool.buildBootstrapMetadata(MetadataVersion.latestTesting(), None, "test format command")
-
-      assertEquals(0,
-        StorageTool.formatCommand(new PrintStream(stream), Seq(availableDir1.toString, unavailableDir1.toString), metaProperties, bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false))
+      assertEquals(0, runFormatCommand(stream, Seq(availableDir1.toString, unavailableDir1.toString)))
       assertTrue(stream.toString().contains("I/O error trying to read log directory %s. Ignoring...".format(unavailableDir1)))
       assertTrue(stream.toString().contains("Formatting %s".format(availableDir1)))
       assertFalse(stream.toString().contains("Formatting %s".format(unavailableDir1)))
-
     } finally {
       Utils.delete(availableDir1)
       Utils.delete(unavailableDir1)
@@ -247,25 +237,15 @@ Found problem:
   def testFormatFailsIfAllDirectoriesAreUnavailable(): Unit = {
     val unavailableDir1 = TestUtils.tempFile()
     val unavailableDir2 = TestUtils.tempFile()
-
     try {
-      val metaProperties = new MetaProperties.Builder().
-        setVersion(MetaPropertiesVersion.V1).
-        setClusterId("XcZZOzUqS4yHOjhMQB6JLQ").
-        setNodeId(2).
-        build()
       val stream = new ByteArrayOutputStream()
-      val bootstrapMetadata = StorageTool.buildBootstrapMetadata(MetadataVersion.latestTesting(), None, "test format command")
-
       try {
-        assertEquals(1,
-          StorageTool.formatCommand(new PrintStream(stream), Seq(unavailableDir1.toString, unavailableDir2.toString), metaProperties, bootstrapMetadata, MetadataVersion.latestTesting(), ignoreFormatted = false))
+        assertEquals(1, runFormatCommand(stream, Seq(unavailableDir1.toString, unavailableDir2.toString)))
       } catch {
         case e: TerseFailure => assertEquals("No available log directories to format.", e.getMessage)
       }
       assertTrue(stream.toString().contains("I/O error trying to read log directory %s. Ignoring...".format(unavailableDir1)))
       assertTrue(stream.toString().contains("I/O error trying to read log directory %s. Ignoring...".format(unavailableDir2)))
-
     } finally {
       Utils.delete(unavailableDir1)
       Utils.delete(unavailableDir2)


### PR DESCRIPTION
Prevents the storage tool from crashing when some of the directories are unavailable, but others are still available and have not yet been formatted.

Should all directories be unavailable however, and no existing directories have been formatted, then the tool will fail.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
