### PR TITLE
KAFKA-16571: reassign_partitions_test.bounce_brokers should wait for messages to be sent to every partition

### DIFF
--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -97,7 +97,7 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
         def check_all_partitions():
             acked_partitions = self.producer.acked_by_partition
             for i in range(self.num_partitions):
-                if f"{self.topic}-{i}" not in acked_partitions:
+                if TopicPartition(self.topic, i) not in acked_partitions:
                     return False
             return True
 

--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -103,7 +103,7 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
 
         # ensure all partitions have data so we don't hit OutOfOrderExceptions due to broker restarts
         wait_until(check_all_partitions,
-                   timeout_sec=30,
+                   timeout_sec=60,
                    err_msg="Failed to produce to all partitions in 30s")
 
         # send reassign partitions command

--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -19,7 +19,7 @@ from ducktape.utils.util import wait_until
 
 from kafkatest.services.kafka import config_property
 from kafkatest.services.zookeeper import ZookeeperService
-from kafkatest.services.kafka import KafkaService, quorum, consumer_group
+from kafkatest.services.kafka import KafkaService, quorum, consumer_group, TopicPartition
 from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest


### PR DESCRIPTION
Added the check before the reassignment occurs and we start bouncing brokers.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
