### PR TITLE
KAFKA-16461: New consumer fails to consume records in security_test.py system test

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -645,7 +645,10 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
         // command line arguments are passed in by the system test framework.
         if (groupProtocol.equalsIgnoreCase(GroupProtocol.CONSUMER.name())) {
             consumerProps.put(ConsumerConfig.GROUP_PROTOCOL_CONFIG, groupProtocol);
-            consumerProps.put(ConsumerConfig.GROUP_REMOTE_ASSIGNOR_CONFIG, res.getString("groupRemoteAssignor"));
+            String groupRemoteAssignor = res.getString("groupRemoteAssignor");
+
+            if (groupRemoteAssignor != null)
+                consumerProps.put(ConsumerConfig.GROUP_REMOTE_ASSIGNOR_CONFIG, groupRemoteAssignor);
         } else {
             // This means we're using the old consumer group protocol.
             consumerProps.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, res.getString("assignmentStrategy"));


### PR DESCRIPTION
The system test was failing because the `VerifiableConsumer` failed with a `NullPointerException` during startup. The reason for the NPE was an attempt to put a `null` as the value of `--group-remote-assignor` in the `Consumer`'s configuration.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
