### PR TITLE
KAFKA-16579: Revert Consumer Rolling Upgrade

### DIFF
--- a/tests/kafkatest/tests/client/consumer_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/client/consumer_rolling_upgrade_test.py
@@ -18,7 +18,7 @@ from ducktape.mark.resource import cluster
 
 
 from kafkatest.tests.verifiable_consumer_test import VerifiableConsumerTest
-from kafkatest.services.kafka import TopicPartition, quorum, consumer_group
+from kafkatest.services.kafka import TopicPartition, quorum
 
 class ConsumerRollingUpgradeTest(VerifiableConsumerTest):
     TOPIC = "test_topic"
@@ -56,12 +56,7 @@ class ConsumerRollingUpgradeTest(VerifiableConsumerTest):
         metadata_quorum=[quorum.isolated_kraft],
         use_new_coordinator=[True, False]
     )
-    @matrix(
-        metadata_quorum=quorum.all_kraft,
-        use_new_coordinator=[True],
-        group_protocol=consumer_group.all_group_protocols
-    )
-    def rolling_update_test(self, metadata_quorum=quorum.zk, use_new_coordinator=False, group_protocol=None):
+    def rolling_update_test(self, metadata_quorum=quorum.zk, use_new_coordinator=False):
         """
         Verify rolling updates of partition assignment strategies works correctly. In this
         test, we use a rolling restart to change the group's assignment strategy from "range" 
@@ -70,7 +65,7 @@ class ConsumerRollingUpgradeTest(VerifiableConsumerTest):
         """
 
         # initialize the consumer using range assignment
-        consumer = self.setup_consumer(self.TOPIC, assignment_strategy=self.RANGE, group_protocol=group_protocol)
+        consumer = self.setup_consumer(self.TOPIC, assignment_strategy=self.RANGE)
 
         consumer.start()
         self.await_all_members(consumer)


### PR DESCRIPTION
Consumer Rolling Upgrade is meant to test the protocol upgrade for the old protocol.  Therefore, I am removing old changes.

```
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.11.4
session_id:       2024-04-18--004
run time:         1 minute 38.006 seconds
tests run:        3
passed:           3
flaky:            0
failed:           0
ignored:          0
================================================================================
test_id:    kafkatest.tests.client.consumer_rolling_upgrade_test.ConsumerRollingUpgradeTest.rolling_update_test.metadata_quorum=ISOLATED_KRAFT.use_new_coordinator=False
status:     PASS
run time:   33.562 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.consumer_rolling_upgrade_test.ConsumerRollingUpgradeTest.rolling_update_test.metadata_quorum=ISOLATED_KRAFT.use_new_coordinator=True
status:     PASS
run time:   34.902 seconds
--------------------------------------------------------------------------------
test_id:    kafkatest.tests.client.consumer_rolling_upgrade_test.ConsumerRollingUpgradeTest.rolling_update_test.metadata_quorum=ZK.use_new_coordinator=False
status:     PASS
run time:   29.447 seconds
--------------------------------------------------------------------------------
```