### PR TITLE
KAFKA-15838: KIP-1040: Add replace.null.with.default to InsertField, ExtractField, HeaderFrom, Cast, SetSchemaMetadata, TimestampConverter, MaskField transforms

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -67,7 +67,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
                     + "or value (<code>" + Value.class.getName() + "</code>).";
 
     public static final String SPEC_CONFIG = "spec";
-    public static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
+    public static final String REPLACE_NULL_WITH_DEFAULT = "replace.null.with.default";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(SPEC_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new ConfigDef.Validator() {
@@ -90,7 +90,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
             "List of fields and the type to cast them to of the form field1:type,field2:type to cast fields of "
                     + "Maps or Structs. A single type to cast the entire value. Valid types are int8, int16, int32, "
                     + "int64, float32, float64, boolean, and string. Note that binary fields can only be cast to string.")
-            .define(REPLACE_NULL_WITH_DEFAULT_CONFIG,
+            .define(REPLACE_NULL_WITH_DEFAULT,
                     ConfigDef.Type.BOOLEAN,
                     true,
                     ConfigDef.Importance.MEDIUM,
@@ -117,7 +117,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
     private Map<String, Schema.Type> casts;
     private Schema.Type wholeValueCastType;
     private Cache<Schema, Schema> schemaUpdateCache;
-    private Boolean replaceNullWithDefault;
+    private boolean replaceNullWithDefault;
 
     @Override
     public String version() {
@@ -130,7 +130,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         casts = parseFieldTypes(config.getList(SPEC_CONFIG));
         wholeValueCastType = casts.get(WHOLE_VALUE_CAST);
         schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
-        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
+        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT);
     }
 
     @Override
@@ -193,7 +193,6 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
     }
 
     private Object getFieldValue(Struct value, Field field) {
-
         if (replaceNullWithDefault) {
             return value.get(field);
         }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -67,7 +67,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
                     + "or value (<code>" + Value.class.getName() + "</code>).";
 
     public static final String SPEC_CONFIG = "spec";
-    public static final String REPLACE_NULL_WITH_DEFAULT = "replace.null.with.default";
+    public static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(SPEC_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new ConfigDef.Validator() {
@@ -90,7 +90,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
             "List of fields and the type to cast them to of the form field1:type,field2:type to cast fields of "
                     + "Maps or Structs. A single type to cast the entire value. Valid types are int8, int16, int32, "
                     + "int64, float32, float64, boolean, and string. Note that binary fields can only be cast to string.")
-            .define(REPLACE_NULL_WITH_DEFAULT,
+            .define(REPLACE_NULL_WITH_DEFAULT_CONFIG,
                     ConfigDef.Type.BOOLEAN,
                     true,
                     ConfigDef.Importance.MEDIUM,
@@ -130,7 +130,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         casts = parseFieldTypes(config.getList(SPEC_CONFIG));
         wholeValueCastType = casts.get(WHOLE_VALUE_CAST);
         schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
-        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT);
+        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
     }
 
     @Override

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -67,6 +67,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
                     + "or value (<code>" + Value.class.getName() + "</code>).";
 
     public static final String SPEC_CONFIG = "spec";
+    public static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(SPEC_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new ConfigDef.Validator() {
@@ -88,7 +89,12 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
             ConfigDef.Importance.HIGH,
             "List of fields and the type to cast them to of the form field1:type,field2:type to cast fields of "
                     + "Maps or Structs. A single type to cast the entire value. Valid types are int8, int16, int32, "
-                    + "int64, float32, float64, boolean, and string. Note that binary fields can only be cast to string.");
+                    + "int64, float32, float64, boolean, and string. Note that binary fields can only be cast to string.")
+            .define(REPLACE_NULL_WITH_DEFAULT_CONFIG,
+                    ConfigDef.Type.BOOLEAN,
+                    true,
+                    ConfigDef.Importance.MEDIUM,
+                    "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
 
     private static final String PURPOSE = "cast types";
 
@@ -111,6 +117,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
     private Map<String, Schema.Type> casts;
     private Schema.Type wholeValueCastType;
     private Cache<Schema, Schema> schemaUpdateCache;
+    private Boolean replaceNullWithDefault;
 
     @Override
     public String version() {
@@ -123,6 +130,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         casts = parseFieldTypes(config.getList(SPEC_CONFIG));
         wholeValueCastType = casts.get(WHOLE_VALUE_CAST);
         schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
+        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
     }
 
     @Override
@@ -175,13 +183,21 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
 
         final Struct updatedValue = new Struct(updatedSchema);
         for (Field field : value.schema().fields()) {
-            final Object origFieldValue = value.get(field);
+            final Object origFieldValue = getFieldValue(value, field);
             final Schema.Type targetType = casts.get(field.name());
             final Object newFieldValue = targetType != null ? castValueToType(field.schema(), origFieldValue, targetType) : origFieldValue;
             log.trace("Cast field '{}' from '{}' to '{}'", field.name(), origFieldValue, newFieldValue);
             updatedValue.put(updatedSchema.field(field.name()), newFieldValue);
         }
         return newRecord(record, updatedSchema, updatedValue);
+    }
+
+    private Object getFieldValue(Struct value, Field field) {
+
+        if (replaceNullWithDefault) {
+            return value.get(field);
+        }
+        return value.getWithoutDefault(field.name());
     }
 
     private Schema getOrBuildSchema(Schema valueSchema) {

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ExtractField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ExtractField.java
@@ -54,9 +54,9 @@ public abstract class ExtractField<R extends ConnectRecord<R>> implements Transf
                     )
                     .define(REPLACE_NULL_WITH_DEFAULT_CONFIG,
                             ConfigDef.Type.BOOLEAN,
-                            Boolean.TRUE,
+                            true,
                             ConfigDef.Importance.MEDIUM,
-                            "Determine if null field value must be replaced with its default value or not."));
+                            "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used."));
 
     private static final String PURPOSE = "field extraction";
 

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ExtractField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ExtractField.java
@@ -41,7 +41,7 @@ public abstract class ExtractField<R extends ConnectRecord<R>> implements Transf
                     + "or value (<code>" + Value.class.getName() + "</code>).";
 
     private static final String FIELD_CONFIG = "field";
-    private static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
+    private static final String REPLACE_NULL_WITH_DEFAULT = "replace.null.with.default";
 
     public static final ConfigDef CONFIG_DEF = FieldSyntaxVersion.appendConfigTo(
             new ConfigDef()
@@ -52,7 +52,7 @@ public abstract class ExtractField<R extends ConnectRecord<R>> implements Transf
                             ConfigDef.Importance.MEDIUM,
                             "Field name to extract."
                     )
-                    .define(REPLACE_NULL_WITH_DEFAULT_CONFIG,
+                    .define(REPLACE_NULL_WITH_DEFAULT,
                             ConfigDef.Type.BOOLEAN,
                             true,
                             ConfigDef.Importance.MEDIUM,
@@ -74,7 +74,7 @@ public abstract class ExtractField<R extends ConnectRecord<R>> implements Transf
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
         originalPath = config.getString(FIELD_CONFIG);
         fieldPath = new SingleFieldPath(originalPath, FieldSyntaxVersion.fromConfig(config));
-        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
+        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT);
     }
 
     @Override

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ExtractField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ExtractField.java
@@ -41,7 +41,7 @@ public abstract class ExtractField<R extends ConnectRecord<R>> implements Transf
                     + "or value (<code>" + Value.class.getName() + "</code>).";
 
     private static final String FIELD_CONFIG = "field";
-    private static final String REPLACE_NULL_WITH_DEFAULT = "replace.null.with.default";
+    private static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
 
     public static final ConfigDef CONFIG_DEF = FieldSyntaxVersion.appendConfigTo(
             new ConfigDef()
@@ -52,7 +52,7 @@ public abstract class ExtractField<R extends ConnectRecord<R>> implements Transf
                             ConfigDef.Importance.MEDIUM,
                             "Field name to extract."
                     )
-                    .define(REPLACE_NULL_WITH_DEFAULT,
+                    .define(REPLACE_NULL_WITH_DEFAULT_CONFIG,
                             ConfigDef.Type.BOOLEAN,
                             true,
                             ConfigDef.Importance.MEDIUM,
@@ -74,7 +74,7 @@ public abstract class ExtractField<R extends ConnectRecord<R>> implements Transf
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
         originalPath = config.getString(FIELD_CONFIG);
         fieldPath = new SingleFieldPath(originalPath, FieldSyntaxVersion.fromConfig(config));
-        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT);
+        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
     }
 
     @Override

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ExtractField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ExtractField.java
@@ -71,8 +71,8 @@ public abstract class ExtractField<R extends ConnectRecord<R>> implements Transf
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
         originalPath = config.getString(FIELD_CONFIG);
         fieldPath = new SingleFieldPath(originalPath, FieldSyntaxVersion.fromConfig(config));
-        keyConverterReplaceNullWithDefault = props.get(KEY_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG) == null || (boolean) props.get(KEY_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG);
-        valueConverterReplaceNullWithDefault = props.get(VALUE_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG) == null || (boolean) props.get(VALUE_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG);
+        keyConverterReplaceNullWithDefault = props.get(KEY_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG) == null || (Boolean) props.get(KEY_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG);
+        valueConverterReplaceNullWithDefault = props.get(VALUE_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG) == null || (Boolean) props.get(VALUE_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG);
     }
 
     @Override

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ExtractField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ExtractField.java
@@ -44,14 +44,19 @@ public abstract class ExtractField<R extends ConnectRecord<R>> implements Transf
     private static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
 
     public static final ConfigDef CONFIG_DEF = FieldSyntaxVersion.appendConfigTo(
-        new ConfigDef()
-            .define(
-                FIELD_CONFIG,
-                ConfigDef.Type.STRING,
-                ConfigDef.NO_DEFAULT_VALUE,
-                ConfigDef.Importance.MEDIUM,
-                "Field name to extract."
-            ).define(REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, Boolean.TRUE, ConfigDef.Importance.MEDIUM, "Determine if null field value must be replaced with its default value or not."));
+            new ConfigDef()
+                    .define(
+                            FIELD_CONFIG,
+                            ConfigDef.Type.STRING,
+                            ConfigDef.NO_DEFAULT_VALUE,
+                            ConfigDef.Importance.MEDIUM,
+                            "Field name to extract."
+                    )
+                    .define(REPLACE_NULL_WITH_DEFAULT_CONFIG,
+                            ConfigDef.Type.BOOLEAN,
+                            Boolean.TRUE,
+                            ConfigDef.Importance.MEDIUM,
+                            "Determine if null field value must be replaced with its default value or not."));
 
     private static final String PURPOSE = "field extraction";
 
@@ -86,11 +91,7 @@ public abstract class ExtractField<R extends ConnectRecord<R>> implements Transf
                 throw new IllegalArgumentException("Unknown field: " + originalPath);
             }
 
-            if (replaceNullWithDefault) {
-                return newRecord(record, field.schema(), value == null ? null : fieldPath.valueFrom(value));
-            }
-
-            return newRecord(record, field.schema(), value == null ? null : value.getWithoutDefault(fieldName));
+            return newRecord(record, field.schema(), value == null ? null : fieldPath.valueFrom(value, replaceNullWithDefault));
         }
     }
 

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
@@ -49,6 +49,7 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
     public static final String OPERATION_FIELD = "operation";
     private static final String MOVE_OPERATION = "move";
     private static final String COPY_OPERATION = "copy";
+    public static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
 
     public static final String OVERVIEW_DOC =
             "Moves or copies fields in the key/value of a record into that record's headers. " +
@@ -70,15 +71,17 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
             .define(OPERATION_FIELD, ConfigDef.Type.STRING, NO_DEFAULT_VALUE,
                     ConfigDef.ValidString.in(MOVE_OPERATION, COPY_OPERATION), ConfigDef.Importance.HIGH,
                     "Either <code>move</code> if the fields are to be moved to the headers (removed from the key/value), " +
-                            "or <code>copy</code> if the fields are to be copied to the headers (retained in the key/value).");
+                            "or <code>copy</code> if the fields are to be copied to the headers (retained in the key/value).")
+            .define(REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+                    "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
 
     private final Cache<Schema, Schema> moveSchemaCache = new SynchronizedCache<>(new LRUCache<>(16));
     enum Operation {
         MOVE(MOVE_OPERATION),
         COPY(COPY_OPERATION);
 
-        private final String name;
 
+        private final String name;
         Operation(String name) {
             this.name = name;
         }
@@ -97,6 +100,7 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
         public String toString() {
             return name;
         }
+
     }
 
     private List<String> fields;
@@ -104,6 +108,8 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
     private List<String> headers;
 
     private Operation operation;
+
+    private Boolean replaceNullWithDefault;
 
     @Override
     public R apply(R record) {
@@ -131,7 +137,7 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
             updatedSchema = moveSchema(operatingSchema);
             updatedValue = new Struct(updatedSchema);
             for (Field field : updatedSchema.fields()) {
-                updatedValue.put(field, value.get(field.name()));
+                updatedValue.put(field, getFieldValue(value, field));
             }
         } else {
             updatedSchema = operatingSchema;
@@ -140,7 +146,7 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
         for (int i = 0; i < fields.size(); i++) {
             String fieldName = fields.get(i);
             String headerName = headers.get(i);
-            Object fieldValue = value.schema().field(fieldName) != null ? value.get(fieldName) : null;
+            Object fieldValue = value.schema().field(fieldName) != null ? getFieldValue(value, value.schema().field(fieldName)) : null;
             Schema fieldSchema = operatingSchema.field(fieldName).schema();
             updatedHeaders.add(headerName, fieldValue, fieldSchema);
         }
@@ -176,6 +182,14 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
             updatedHeaders.add(headerName, fieldValue, null);
         }
         return newRecord(record, null, updatedValue, updatedHeaders);
+    }
+
+    private Object getFieldValue(Struct value, Field field) {
+
+        if (replaceNullWithDefault) {
+            return value.get(field.name());
+        }
+        return value.getWithoutDefault(field.name());
     }
 
     protected abstract Object operatingValue(R record);
@@ -240,5 +254,6 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
                     FIELDS_FIELD, HEADERS_FIELD));
         }
         operation = Operation.fromName(config.getString(OPERATION_FIELD));
+        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
     }
 }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
@@ -49,7 +49,7 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
     public static final String OPERATION_FIELD = "operation";
     private static final String MOVE_OPERATION = "move";
     private static final String COPY_OPERATION = "copy";
-    public static final String REPLACE_NULL_WITH_DEFAULT = "replace.null.with.default";
+    public static final String REPLACE_NULL_WITH_DEFAULT_FIELD = "replace.null.with.default";
 
     public static final String OVERVIEW_DOC =
             "Moves or copies fields in the key/value of a record into that record's headers. " +
@@ -72,7 +72,7 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
                     ConfigDef.ValidString.in(MOVE_OPERATION, COPY_OPERATION), ConfigDef.Importance.HIGH,
                     "Either <code>move</code> if the fields are to be moved to the headers (removed from the key/value), " +
                             "or <code>copy</code> if the fields are to be copied to the headers (retained in the key/value).")
-            .define(REPLACE_NULL_WITH_DEFAULT, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+            .define(REPLACE_NULL_WITH_DEFAULT_FIELD, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
                     "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
 
     private final Cache<Schema, Schema> moveSchemaCache = new SynchronizedCache<>(new LRUCache<>(16));
@@ -100,7 +100,6 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
         public String toString() {
             return name;
         }
-
     }
 
     private List<String> fields;
@@ -253,6 +252,6 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
                     FIELDS_FIELD, HEADERS_FIELD));
         }
         operation = Operation.fromName(config.getString(OPERATION_FIELD));
-        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT);
+        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT_FIELD);
     }
 }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
@@ -49,7 +49,7 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
     public static final String OPERATION_FIELD = "operation";
     private static final String MOVE_OPERATION = "move";
     private static final String COPY_OPERATION = "copy";
-    public static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
+    public static final String REPLACE_NULL_WITH_DEFAULT = "replace.null.with.default";
 
     public static final String OVERVIEW_DOC =
             "Moves or copies fields in the key/value of a record into that record's headers. " +
@@ -72,7 +72,7 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
                     ConfigDef.ValidString.in(MOVE_OPERATION, COPY_OPERATION), ConfigDef.Importance.HIGH,
                     "Either <code>move</code> if the fields are to be moved to the headers (removed from the key/value), " +
                             "or <code>copy</code> if the fields are to be copied to the headers (retained in the key/value).")
-            .define(REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+            .define(REPLACE_NULL_WITH_DEFAULT, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
                     "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
 
     private final Cache<Schema, Schema> moveSchemaCache = new SynchronizedCache<>(new LRUCache<>(16));
@@ -80,8 +80,8 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
         MOVE(MOVE_OPERATION),
         COPY(COPY_OPERATION);
 
-
         private final String name;
+
         Operation(String name) {
             this.name = name;
         }
@@ -109,7 +109,7 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
 
     private Operation operation;
 
-    private Boolean replaceNullWithDefault;
+    private boolean replaceNullWithDefault;
 
     @Override
     public R apply(R record) {
@@ -185,7 +185,6 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
     }
 
     private Object getFieldValue(Struct value, Field field) {
-
         if (replaceNullWithDefault) {
             return value.get(field.name());
         }
@@ -254,6 +253,6 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
                     FIELDS_FIELD, HEADERS_FIELD));
         }
         operation = Operation.fromName(config.getString(OPERATION_FIELD));
-        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
+        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT);
     }
 }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
@@ -126,8 +126,8 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
         timestampField = InsertionSpec.parse(config.getString(ConfigName.TIMESTAMP_FIELD));
         staticField = InsertionSpec.parse(config.getString(ConfigName.STATIC_FIELD));
         staticValue = config.getString(ConfigName.STATIC_VALUE);
-        keyConverterReplaceNullWithDefault = props.get(KEY_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG) == null || (boolean) props.get(KEY_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG);
-        valueConverterReplaceNullWithDefault = props.get(VALUE_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG) == null || (boolean) props.get(VALUE_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG);
+        keyConverterReplaceNullWithDefault = props.get(KEY_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG) == null || (Boolean) props.get(KEY_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG);
+        valueConverterReplaceNullWithDefault = props.get(VALUE_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG) == null || (Boolean) props.get(VALUE_CONVERTER_REPLACE_NULL_WITH_DEFAULT_CONFIG);
 
         if (topicField == null && partitionField == null && offsetField == null && timestampField == null && staticField == null) {
             throw new ConfigException("No field insertion configured");

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
@@ -54,7 +54,7 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
         String TIMESTAMP_FIELD = "timestamp.field";
         String STATIC_FIELD = "static.field";
         String STATIC_VALUE = "static.value";
-        String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
+        String REPLACE_NULL_WITH_DEFAULT = "replace.null.with.default";
     }
 
     private static final String OPTIONALITY_DOC = "Suffix with <code>!</code> to make this a required field, or <code>?</code> to keep it optional (the default).";
@@ -72,7 +72,7 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
                     "Field name for static data field. " + OPTIONALITY_DOC)
             .define(ConfigName.STATIC_VALUE, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM,
                     "Static field value, if field name configured.")
-            .define(ConfigName.REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+            .define(ConfigName.REPLACE_NULL_WITH_DEFAULT, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
                     "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
 
     private static final String PURPOSE = "field insertion";
@@ -106,8 +106,7 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
     private InsertionSpec timestampField;
     private InsertionSpec staticField;
     private String staticValue;
-
-    protected boolean replaceNullWithDefault;
+    private boolean replaceNullWithDefault;
 
     private Cache<Schema, Schema> schemaUpdateCache;
 
@@ -125,7 +124,7 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
         timestampField = InsertionSpec.parse(config.getString(ConfigName.TIMESTAMP_FIELD));
         staticField = InsertionSpec.parse(config.getString(ConfigName.STATIC_FIELD));
         staticValue = config.getString(ConfigName.STATIC_VALUE);
-        replaceNullWithDefault = config.getBoolean(ConfigName.REPLACE_NULL_WITH_DEFAULT_CONFIG);
+        replaceNullWithDefault = config.getBoolean(ConfigName.REPLACE_NULL_WITH_DEFAULT);
 
         if (topicField == null && partitionField == null && offsetField == null && timestampField == null && staticField == null) {
             throw new ConfigException("No field insertion configured");
@@ -234,7 +233,6 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
     }
 
     private Object getFieldValue(Struct value, Field field) {
-
         if (replaceNullWithDefault) {
             return value.get(field);
         }
@@ -257,7 +255,6 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
 
     protected abstract R newRecord(R record, Schema updatedSchema, Object updatedValue);
 
-
     public static class Key<R extends ConnectRecord<R>> extends InsertField<R> {
 
         @Override
@@ -274,6 +271,7 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
         protected R newRecord(R record, Schema updatedSchema, Object updatedValue) {
             return record.newRecord(record.topic(), record.kafkaPartition(), updatedSchema, updatedValue, record.valueSchema(), record.value(), record.timestamp());
         }
+
     }
 
     public static class Value<R extends ConnectRecord<R>> extends InsertField<R> {
@@ -292,6 +290,7 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
         protected R newRecord(R record, Schema updatedSchema, Object updatedValue) {
             return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(), updatedSchema, updatedValue, record.timestamp());
         }
+
     }
 
 }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertField.java
@@ -72,8 +72,8 @@ public abstract class InsertField<R extends ConnectRecord<R>> implements Transfo
                     "Field name for static data field. " + OPTIONALITY_DOC)
             .define(ConfigName.STATIC_VALUE, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM,
                     "Static field value, if field name configured.")
-            .define(ConfigName.REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, Boolean.TRUE, ConfigDef.Importance.MEDIUM,
-                    "Determine if null field value must be replaced with its default value or not.");
+            .define(ConfigName.REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+                    "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
 
     private static final String PURPOSE = "field insertion";
 

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/MaskField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/MaskField.java
@@ -52,7 +52,7 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
 
     private static final String FIELDS_CONFIG = "fields";
     private static final String REPLACEMENT_CONFIG = "replacement";
-    private static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
+    private static final String REPLACE_NULL_WITH_DEFAULT = "replace.null.with.default";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(FIELDS_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new NonEmptyListValidator(),
@@ -60,7 +60,7 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
             .define(REPLACEMENT_CONFIG, ConfigDef.Type.STRING, null, new ConfigDef.NonEmptyString(),
                     ConfigDef.Importance.LOW, "Custom value replacement, that will be applied to all"
                             + " 'fields' values (numeric or non-empty string values only).")
-            .define(REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+            .define(REPLACE_NULL_WITH_DEFAULT, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
                     "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
 
     private static final String PURPOSE = "mask fields";
@@ -94,7 +94,7 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
 
     private Set<String> maskedFields;
     private String replacement;
-    private Boolean replaceNullWithDefault;
+    private boolean replaceNullWithDefault;
 
     @Override
     public String version() {
@@ -106,7 +106,7 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
         maskedFields = new HashSet<>(config.getList(FIELDS_CONFIG));
         replacement = config.getString(REPLACEMENT_CONFIG);
-        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
+        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT);
     }
 
     @Override
@@ -138,7 +138,6 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
     }
 
     private Object getFieldValue(Struct value, Field field) {
-
         if (replaceNullWithDefault) {
             return value.get(field);
         }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/MaskField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/MaskField.java
@@ -52,7 +52,7 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
 
     private static final String FIELDS_CONFIG = "fields";
     private static final String REPLACEMENT_CONFIG = "replacement";
-    private static final String REPLACE_NULL_WITH_DEFAULT = "replace.null.with.default";
+    private static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(FIELDS_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new NonEmptyListValidator(),
@@ -60,7 +60,7 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
             .define(REPLACEMENT_CONFIG, ConfigDef.Type.STRING, null, new ConfigDef.NonEmptyString(),
                     ConfigDef.Importance.LOW, "Custom value replacement, that will be applied to all"
                             + " 'fields' values (numeric or non-empty string values only).")
-            .define(REPLACE_NULL_WITH_DEFAULT, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+            .define(REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
                     "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
 
     private static final String PURPOSE = "mask fields";
@@ -106,7 +106,7 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
         maskedFields = new HashSet<>(config.getList(FIELDS_CONFIG));
         replacement = config.getString(REPLACEMENT_CONFIG);
-        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT);
+        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
     }
 
     @Override

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/MaskField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/MaskField.java
@@ -52,13 +52,16 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
 
     private static final String FIELDS_CONFIG = "fields";
     private static final String REPLACEMENT_CONFIG = "replacement";
+    private static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(FIELDS_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new NonEmptyListValidator(),
                     ConfigDef.Importance.HIGH, "Names of fields to mask.")
             .define(REPLACEMENT_CONFIG, ConfigDef.Type.STRING, null, new ConfigDef.NonEmptyString(),
                     ConfigDef.Importance.LOW, "Custom value replacement, that will be applied to all"
-                            + " 'fields' values (numeric or non-empty string values only).");
+                            + " 'fields' values (numeric or non-empty string values only).")
+            .define(REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+                    "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
 
     private static final String PURPOSE = "mask fields";
 
@@ -91,6 +94,7 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
 
     private Set<String> maskedFields;
     private String replacement;
+    private Boolean replaceNullWithDefault;
 
     @Override
     public String version() {
@@ -102,6 +106,7 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
         maskedFields = new HashSet<>(config.getList(FIELDS_CONFIG));
         replacement = config.getString(REPLACEMENT_CONFIG);
+        replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
     }
 
     @Override
@@ -126,10 +131,18 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
         final Struct value = requireStruct(operatingValue(record), PURPOSE);
         final Struct updatedValue = new Struct(value.schema());
         for (Field field : value.schema().fields()) {
-            final Object origFieldValue = value.get(field);
+            final Object origFieldValue = getFieldValue(value, field);
             updatedValue.put(field, maskedFields.contains(field.name()) ? masked(origFieldValue) : origFieldValue);
         }
         return newRecord(record, updatedValue);
+    }
+
+    private Object getFieldValue(Struct value, Field field) {
+
+        if (replaceNullWithDefault) {
+            return value.get(field);
+        }
+        return value.getWithoutDefault(field.name());
     }
 
     private Object masked(Object value) {

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/SetSchemaMetadata.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/SetSchemaMetadata.java
@@ -39,17 +39,17 @@ public abstract class SetSchemaMetadata<R extends ConnectRecord<R>> implements T
     public static final String OVERVIEW_DOC =
             "Set the schema name, version or both on the record's key (<code>" + Key.class.getName() + "</code>)"
                     + " or value (<code>" + Value.class.getName() + "</code>) schema.";
-    private interface ConfigName {
 
+    private interface ConfigName {
         String SCHEMA_NAME = "schema.name";
         String SCHEMA_VERSION = "schema.version";
-        String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
+        String REPLACE_NULL_WITH_DEFAULT = "replace.null.with.default";
     }
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(ConfigName.SCHEMA_NAME, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, "Schema name to set.")
             .define(ConfigName.SCHEMA_VERSION, ConfigDef.Type.INT, null, ConfigDef.Importance.HIGH, "Schema version to set.")
-            .define(ConfigName.REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+            .define(ConfigName.REPLACE_NULL_WITH_DEFAULT, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
                     "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
 
     private String schemaName;
@@ -66,7 +66,7 @@ public abstract class SetSchemaMetadata<R extends ConnectRecord<R>> implements T
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, configs);
         schemaName = config.getString(ConfigName.SCHEMA_NAME);
         schemaVersion = config.getInt(ConfigName.SCHEMA_VERSION);
-        replaceNullWithDefault = config.getBoolean(ConfigName.REPLACE_NULL_WITH_DEFAULT_CONFIG);
+        replaceNullWithDefault = config.getBoolean(ConfigName.REPLACE_NULL_WITH_DEFAULT);
 
         if (schemaName == null && schemaVersion == null) {
             throw new ConfigException("Neither schema name nor version configured");
@@ -101,7 +101,6 @@ public abstract class SetSchemaMetadata<R extends ConnectRecord<R>> implements T
     }
 
     private Object getFieldValue(Struct value, Field field) {
-
         if (replaceNullWithDefault) {
             return value.get(field);
         }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/TimestampConverter.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/TimestampConverter.java
@@ -68,7 +68,7 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
     public static final String UNIX_PRECISION_CONFIG = "unix.precision";
     private static final String UNIX_PRECISION_DEFAULT = "milliseconds";
 
-    public static final String REPLACE_NULL_WITH_DEFAULT = "replace.null.with.default";
+    public static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
 
     private static final String PURPOSE = "converting timestamp formats";
 
@@ -107,7 +107,7 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
                     "The desired Unix precision for the timestamp: seconds, milliseconds, microseconds, or nanoseconds. " +
                             "Used to generate the output when type=unix or used to parse the input if the input is a Long." +
                             "Note: This SMT will cause precision loss during conversions from, and to, values with sub-millisecond components.")
-            .define(REPLACE_NULL_WITH_DEFAULT, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+            .define(REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
                     "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
 
 
@@ -302,7 +302,7 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
         String formatPattern = simpleConfig.getString(FORMAT_CONFIG);
         final String unixPrecision = simpleConfig.getString(UNIX_PRECISION_CONFIG);
         schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
-        replaceNullWithDefault = simpleConfig.getBoolean(REPLACE_NULL_WITH_DEFAULT);
+        replaceNullWithDefault = simpleConfig.getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
 
         if (type.equals(TYPE_STRING) && Utils.isBlank(formatPattern)) {
             throw new ConfigException("TimestampConverter requires format option to be specified when using string timestamps");

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/TimestampConverter.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/TimestampConverter.java
@@ -68,6 +68,8 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
     public static final String UNIX_PRECISION_CONFIG = "unix.precision";
     private static final String UNIX_PRECISION_DEFAULT = "milliseconds";
 
+    public static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
+
     private static final String PURPOSE = "converting timestamp formats";
 
     private static final String TYPE_STRING = "string";
@@ -104,7 +106,10 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
                     ConfigDef.Importance.LOW,
                     "The desired Unix precision for the timestamp: seconds, milliseconds, microseconds, or nanoseconds. " +
                             "Used to generate the output when type=unix or used to parse the input if the input is a Long." +
-                            "Note: This SMT will cause precision loss during conversions from, and to, values with sub-millisecond components.");
+                            "Note: This SMT will cause precision loss during conversions from, and to, values with sub-millisecond components.")
+            .define(REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+                    "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
+
 
     private interface TimestampTranslator {
         /**
@@ -287,7 +292,7 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
     }
     private Config config;
     private Cache<Schema, Schema> schemaUpdateCache;
-
+    private Boolean replaceNullWithDefault;
 
     @Override
     public void configure(Map<String, ?> configs) {
@@ -297,6 +302,7 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
         String formatPattern = simpleConfig.getString(FORMAT_CONFIG);
         final String unixPrecision = simpleConfig.getString(UNIX_PRECISION_CONFIG);
         schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
+        replaceNullWithDefault = simpleConfig.getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
 
         if (type.equals(TYPE_STRING) && Utils.isBlank(formatPattern)) {
             throw new ConfigException("TimestampConverter requires format option to be specified when using string timestamps");
@@ -415,13 +421,21 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
         for (Field field : value.schema().fields()) {
             final Object updatedFieldValue;
             if (field.name().equals(config.field)) {
-                updatedFieldValue = convertTimestamp(value.get(field), timestampTypeFromSchema(field.schema()));
+                updatedFieldValue = convertTimestamp(getFieldValue(value, field), timestampTypeFromSchema(field.schema()));
             } else {
-                updatedFieldValue = value.get(field);
+                updatedFieldValue = getFieldValue(value, field);
             }
             updatedValue.put(field.name(), updatedFieldValue);
         }
         return updatedValue;
+    }
+
+    private Object getFieldValue(Struct value, Field field) {
+
+        if (replaceNullWithDefault) {
+            return value.get(field);
+        }
+        return value.getWithoutDefault(field.name());
     }
 
     private R applySchemaless(R record) {

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/TimestampConverter.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/TimestampConverter.java
@@ -68,7 +68,7 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
     public static final String UNIX_PRECISION_CONFIG = "unix.precision";
     private static final String UNIX_PRECISION_DEFAULT = "milliseconds";
 
-    public static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
+    public static final String REPLACE_NULL_WITH_DEFAULT = "replace.null.with.default";
 
     private static final String PURPOSE = "converting timestamp formats";
 
@@ -107,7 +107,7 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
                     "The desired Unix precision for the timestamp: seconds, milliseconds, microseconds, or nanoseconds. " +
                             "Used to generate the output when type=unix or used to parse the input if the input is a Long." +
                             "Note: This SMT will cause precision loss during conversions from, and to, values with sub-millisecond components.")
-            .define(REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+            .define(REPLACE_NULL_WITH_DEFAULT, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
                     "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
 
 
@@ -292,7 +292,7 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
     }
     private Config config;
     private Cache<Schema, Schema> schemaUpdateCache;
-    private Boolean replaceNullWithDefault;
+    private boolean replaceNullWithDefault;
 
     @Override
     public void configure(Map<String, ?> configs) {
@@ -302,7 +302,7 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
         String formatPattern = simpleConfig.getString(FORMAT_CONFIG);
         final String unixPrecision = simpleConfig.getString(UNIX_PRECISION_CONFIG);
         schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
-        replaceNullWithDefault = simpleConfig.getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
+        replaceNullWithDefault = simpleConfig.getBoolean(REPLACE_NULL_WITH_DEFAULT);
 
         if (type.equals(TYPE_STRING) && Utils.isBlank(formatPattern)) {
             throw new ConfigException("TimestampConverter requires format option to be specified when using string timestamps");
@@ -431,7 +431,6 @@ public abstract class TimestampConverter<R extends ConnectRecord<R>> implements 
     }
 
     private Object getFieldValue(Struct value, Field field) {
-
         if (replaceNullWithDefault) {
             return value.get(field);
         }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -185,8 +185,9 @@ public class SingleFieldPath {
             if (current == null) return null;
         }
 
-        if (current.schema().field(lastStep()) != null) {
-            return withDefault ? current.get(lastStep()) : current.getWithoutDefault(lastStep());
+        String lastStep = lastStep();
+        if (current.schema().field(lastStep) != null) {
+            return withDefault ? current.get(lastStep) : current.getWithoutDefault(lastStep);
         } else {
             return null;
         }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -167,6 +167,11 @@ public class SingleFieldPath {
      * If object is not found, then {@code null} is returned.
      */
     public Object valueFrom(Struct struct) {
+
+        return valueFrom(struct, true);
+    }
+
+    public Object valueFrom(Struct struct, boolean withDefault) {
         if (struct == null) return null;
 
         Struct current = struct;
@@ -181,7 +186,7 @@ public class SingleFieldPath {
         }
 
         if (current.schema().field(lastStep()) != null) {
-            return current.get(lastStep());
+            return withDefault ? current.get(lastStep()) : current.getWithoutDefault(lastStep());
         } else {
             return null;
         }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -31,6 +31,9 @@ import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -41,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -53,6 +57,12 @@ public class CastTest {
     private static final long MILLIS_PER_HOUR = TimeUnit.HOURS.toMillis(1);
     private static final long MILLIS_PER_DAY = TimeUnit.DAYS.toMillis(1);
 
+    public static Stream<Arguments> data() {
+        return Stream.of(
+                Arguments.of(false, null),
+                Arguments.of(true, "10")
+        );
+    }
     @AfterEach
     public void teardown() {
         xformKey.close();
@@ -97,6 +107,23 @@ public class CastTest {
             Schema.STRING_SCHEMA, "key", Schema.STRING_SCHEMA, null);
         SourceRecord transformed = xformValue.apply(original);
         assertEquals(original, transformed);
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void castFieldWithDefaultValueRecordWithSchema(boolean replaceNullWithDefault, Object expectedValue) {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(Cast.SPEC_CONFIG, "magic:string");
+        configs.put(Cast.REPLACE_NULL_WITH_DEFAULT_CONFIG, replaceNullWithDefault);
+        xformValue.configure(configs);
+        Schema structSchema = SchemaBuilder.struct()
+                .field("magic", SchemaBuilder.int32().optional().defaultValue(10).build()).build();
+        SourceRecord original = new SourceRecord(null, null, "topic", 0,
+                Schema.STRING_SCHEMA, "key", structSchema, new Struct(structSchema).put("magic", null));
+        SourceRecord transformed = xformValue.apply(original);
+
+        assertEquals(Type.STRING, transformed.valueSchema().field("magic").schema().type());
+        assertEquals(expectedValue, ((Struct) transformed.value()).getWithoutDefault("magic"));
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -114,7 +114,7 @@ public class CastTest {
     public void castFieldWithDefaultValueRecordWithSchema(boolean replaceNullWithDefault, Object expectedValue) {
         Map<String, Object> configs = new HashMap<>();
         configs.put(Cast.SPEC_CONFIG, "magic:string");
-        configs.put(Cast.REPLACE_NULL_WITH_DEFAULT_CONFIG, replaceNullWithDefault);
+        configs.put(Cast.REPLACE_NULL_WITH_DEFAULT, replaceNullWithDefault);
         xformValue.configure(configs);
         Schema structSchema = SchemaBuilder.struct()
                 .field("magic", SchemaBuilder.int32().optional().defaultValue(10).build()).build();

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -114,7 +114,7 @@ public class CastTest {
     public void castFieldWithDefaultValueRecordWithSchema(boolean replaceNullWithDefault, Object expectedValue) {
         Map<String, Object> configs = new HashMap<>();
         configs.put(Cast.SPEC_CONFIG, "magic:string");
-        configs.put(Cast.REPLACE_NULL_WITH_DEFAULT, replaceNullWithDefault);
+        configs.put(Cast.REPLACE_NULL_WITH_DEFAULT_CONFIG, replaceNullWithDefault);
         xformValue.configure(configs);
         Schema structSchema = SchemaBuilder.struct()
                 .field("magic", SchemaBuilder.int32().optional().defaultValue(10).build()).build();

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
@@ -193,8 +193,7 @@ public class ExtractFieldTest {
     }
 
     @Test
-    @DisplayName("Null key value instead of default must be used")
-    public void whenKeyConverterReplaceNullWithDefaultIsFalseExtractFieldWithNullValueMustReturnNull() {
+    public void testUnsetOptionalFieldIsNull() {
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "optional_with_default");
@@ -216,8 +215,7 @@ public class ExtractFieldTest {
     }
 
     @Test
-    @DisplayName("Default key value must be used")
-    public void whenKeyConverterReplaceNullWithDefaultIsTrueExtractFieldWithNullValueMustReturnDefaultValueWhenPresent() {
+    public void testUnsetOptionalFieldReplacedWithDefault() {
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "optional_with_default");
@@ -239,8 +237,7 @@ public class ExtractFieldTest {
 
 
     @Test
-    @DisplayName("Null value instead of default must be used")
-    public void whenValueConverterReplaceNullWithDefaultIsFalseExtractFieldWithNullValueMustReturnNull() {
+    public void testUnsetOptionalFieldValueIsNull() {
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "optional_with_default");
@@ -262,8 +259,7 @@ public class ExtractFieldTest {
     }
 
     @Test
-    @DisplayName("Default key value must be used")
-    public void whenValueConverterReplaceNullWithDefaultIsTrueExtractFieldWithNullValueMustReturnDefaultValueWhenPresent() {
+    public void testUnsetOptionalFieldValueReplacedWithDefault() {
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "optional_with_default");

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.transforms.field.FieldSyntaxVersion;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.connect.transforms;
 
-import java.util.HashMap;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -27,6 +26,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,19 +34,21 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class ExtractFieldTest {
-    private final ExtractField<SinkRecord> xform = new ExtractField.Key<>();
+    private final ExtractField<SinkRecord> xformKey = new ExtractField.Key<>();
+    private final ExtractField<SinkRecord> xformValue = new ExtractField.Value<>();
 
     @AfterEach
     public void teardown() {
-        xform.close();
+        xformKey.close();
+        xformValue.close();
     }
 
     @Test
     public void schemaless() {
-        xform.configure(Collections.singletonMap("field", "magic"));
+        xformKey.configure(Collections.singletonMap("field", "magic"));
 
         final SinkRecord record = new SinkRecord("test", 0, null, Collections.singletonMap("magic", 42), null, null, 0);
-        final SinkRecord transformedRecord = xform.apply(record);
+        final SinkRecord transformedRecord = xformKey.apply(record);
 
         assertNull(transformedRecord.keySchema());
         assertEquals(42, transformedRecord.key());
@@ -69,11 +71,11 @@ public class ExtractFieldTest {
 
     @Test
     public void nullSchemaless() {
-        xform.configure(Collections.singletonMap("field", "magic"));
+        xformKey.configure(Collections.singletonMap("field", "magic"));
 
         final Map<String, Object> key = null;
         final SinkRecord record = new SinkRecord("test", 0, null, key, null, null, 0);
-        final SinkRecord transformedRecord = xform.apply(record);
+        final SinkRecord transformedRecord = xformKey.apply(record);
 
         assertNull(transformedRecord.keySchema());
         assertNull(transformedRecord.key());
@@ -81,12 +83,12 @@ public class ExtractFieldTest {
 
     @Test
     public void withSchema() {
-        xform.configure(Collections.singletonMap("field", "magic"));
+        xformKey.configure(Collections.singletonMap("field", "magic"));
 
         final Schema keySchema = SchemaBuilder.struct().field("magic", Schema.INT32_SCHEMA).build();
         final Struct key = new Struct(keySchema).put("magic", 42);
         final SinkRecord record = new SinkRecord("test", 0, keySchema, key, null, null, 0);
-        final SinkRecord transformedRecord = xform.apply(record);
+        final SinkRecord transformedRecord = xformKey.apply(record);
 
         assertEquals(Schema.INT32_SCHEMA, transformedRecord.keySchema());
         assertEquals(42, transformedRecord.key());
@@ -111,12 +113,12 @@ public class ExtractFieldTest {
 
     @Test
     public void testNullWithSchema() {
-        xform.configure(Collections.singletonMap("field", "magic"));
+        xformKey.configure(Collections.singletonMap("field", "magic"));
 
         final Schema keySchema = SchemaBuilder.struct().field("magic", Schema.INT32_SCHEMA).optional().build();
         final Struct key = null;
         final SinkRecord record = new SinkRecord("test", 0, keySchema, key, null, null, 0);
-        final SinkRecord transformedRecord = xform.apply(record);
+        final SinkRecord transformedRecord = xformKey.apply(record);
 
         assertEquals(Schema.INT32_SCHEMA, transformedRecord.keySchema());
         assertNull(transformedRecord.key());
@@ -124,10 +126,10 @@ public class ExtractFieldTest {
 
     @Test
     public void nonExistentFieldSchemalessShouldReturnNull() {
-        xform.configure(Collections.singletonMap("field", "nonexistent"));
+        xformKey.configure(Collections.singletonMap("field", "nonexistent"));
 
         final SinkRecord record = new SinkRecord("test", 0, null, Collections.singletonMap("magic", 42), null, null, 0);
-        final SinkRecord transformedRecord = xform.apply(record);
+        final SinkRecord transformedRecord = xformKey.apply(record);
 
         assertNull(transformedRecord.keySchema());
         assertNull(transformedRecord.key());
@@ -150,14 +152,14 @@ public class ExtractFieldTest {
 
     @Test
     public void nonExistentFieldWithSchemaShouldFail() {
-        xform.configure(Collections.singletonMap("field", "nonexistent"));
+        xformKey.configure(Collections.singletonMap("field", "nonexistent"));
 
         final Schema keySchema = SchemaBuilder.struct().field("magic", Schema.INT32_SCHEMA).build();
         final Struct key = new Struct(keySchema).put("magic", 42);
         final SinkRecord record = new SinkRecord("test", 0, keySchema, key, null, null, 0);
 
         try {
-            xform.apply(record);
+            xformKey.apply(record);
             fail("Expected exception wasn't raised");
         } catch (IllegalArgumentException iae) {
             assertEquals("Unknown field: nonexistent", iae.getMessage());
@@ -186,7 +188,96 @@ public class ExtractFieldTest {
 
     @Test
     public void testExtractFieldVersionRetrievedFromAppInfoParser() {
-        assertEquals(AppInfoParser.getVersion(), xform.version());
+        assertEquals(AppInfoParser.getVersion(), xformKey.version());
+    }
+
+    @Test
+    public void whenKeyConverterReplaceNullWithDefaultIsFalseExtractFieldWithNullValueMustReturnNull() {
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "optional_with_default");
+        config.put("key.converter.replace.null.with.default", false);
+
+        xformKey.configure(config);
+
+        final Schema keySchema = SchemaBuilder.struct()
+                .field("optional_with_default", SchemaBuilder.int32().optional().defaultValue(42).build())
+                .build();
+        final Struct key = new Struct(keySchema).put("optional_with_default", null);
+
+        final SinkRecord record = new SinkRecord("test", 0, keySchema, key, null, null, 0);
+
+        final SinkRecord transformedRecord = xformKey.apply(record);
+        Integer extractedValue = (Integer) transformedRecord.key();
+
+        assertNull(extractedValue);
+    }
+
+    @Test
+    public void whenKeyConverterReplaceNullWithDefaultIsTrueExtractFieldWithNullValueMustReturnDefaultValueWhenPresent() {
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "optional_with_default");
+        config.put("key.converter.replace.null.with.default", true);
+
+        xformKey.configure(config);
+
+        final Schema keySchema = SchemaBuilder.struct()
+                .field("optional_with_default", SchemaBuilder.int32().optional().defaultValue(42).build())
+                .build();
+        final Struct key = new Struct(keySchema).put("optional_with_default", null);
+
+        final SinkRecord record = new SinkRecord("test", 0, keySchema, key, null, null, 0);
+
+        final SinkRecord transformedRecord = xformKey.apply(record);
+        Integer extractedValue = (Integer) transformedRecord.key();
+
+        assertEquals(42, extractedValue);
+    }
+
+
+    @Test
+    public void whenValueConverterReplaceNullWithDefaultIsFalseExtractFieldWithNullValueMustReturnNull() {
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "optional_with_default");
+        config.put("value.converter.replace.null.with.default", false);
+
+        xformValue.configure(config);
+
+        final Schema valueSchema = SchemaBuilder.struct()
+                .field("optional_with_default", SchemaBuilder.int32().optional().defaultValue(42).build())
+                .build();
+        final Struct value = new Struct(valueSchema).put("optional_with_default", null);
+
+        final SinkRecord record = new SinkRecord("test", 0, null, null, valueSchema, value, 0);
+
+        final SinkRecord transformedRecord = xformValue.apply(record);
+        Integer extractedValue = (Integer) transformedRecord.value();
+
+        assertNull(extractedValue);
+    }
+
+    @Test
+    public void whenValueConverterReplaceNullWithDefaultIsTrueExtractFieldWithNullValueMustReturnDefaultValueWhenPresent() {
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "optional_with_default");
+        config.put("value.converter.replace.null.with.default", true);
+
+        xformValue.configure(config);
+
+        final Schema valueSchema = SchemaBuilder.struct()
+                .field("optional_with_default", SchemaBuilder.int32().optional().defaultValue(42).build())
+                .build();
+        final Struct value = new Struct(valueSchema).put("optional_with_default", null);
+
+        final SinkRecord record = new SinkRecord("test", 0, null, null, valueSchema, value,  0);
+
+        final SinkRecord transformedRecord = xformValue.apply(record);
+        Integer extractedValue = (Integer) transformedRecord.value();
+
+        assertEquals(42, extractedValue);
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.transforms.field.FieldSyntaxVersion;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -192,11 +193,12 @@ public class ExtractFieldTest {
     }
 
     @Test
+    @DisplayName("Null key value instead of default must be used")
     public void whenKeyConverterReplaceNullWithDefaultIsFalseExtractFieldWithNullValueMustReturnNull() {
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "optional_with_default");
-        config.put("key.converter.replace.null.with.default", false);
+        config.put("replace.null.with.default", false);
 
         xformKey.configure(config);
 
@@ -214,11 +216,11 @@ public class ExtractFieldTest {
     }
 
     @Test
+    @DisplayName("Default key value must be used")
     public void whenKeyConverterReplaceNullWithDefaultIsTrueExtractFieldWithNullValueMustReturnDefaultValueWhenPresent() {
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "optional_with_default");
-        config.put("key.converter.replace.null.with.default", true);
 
         xformKey.configure(config);
 
@@ -237,11 +239,12 @@ public class ExtractFieldTest {
 
 
     @Test
+    @DisplayName("Null value instead of default must be used")
     public void whenValueConverterReplaceNullWithDefaultIsFalseExtractFieldWithNullValueMustReturnNull() {
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "optional_with_default");
-        config.put("value.converter.replace.null.with.default", false);
+        config.put("replace.null.with.default", false);
 
         xformValue.configure(config);
 
@@ -259,11 +262,11 @@ public class ExtractFieldTest {
     }
 
     @Test
+    @DisplayName("Default key value must be used")
     public void whenValueConverterReplaceNullWithDefaultIsTrueExtractFieldWithNullValueMustReturnDefaultValueWhenPresent() {
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "optional_with_default");
-        config.put("value.converter.replace.null.with.default", true);
 
         xformValue.configure(config);
 

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
@@ -60,11 +60,11 @@ public class ExtractFieldTest {
         Map<String, String> configs = new HashMap<>();
         configs.put(FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG, FieldSyntaxVersion.V2.name());
         configs.put("field", "magic.foo");
-        xform.configure(configs);
+        xformKey.configure(configs);
 
         final Map<String, Object> key = Collections.singletonMap("magic", Collections.singletonMap("foo", 42));
         final SinkRecord record = new SinkRecord("test", 0, null, key, null, null, 0);
-        final SinkRecord transformedRecord = xform.apply(record);
+        final SinkRecord transformedRecord = xformKey.apply(record);
 
         assertNull(transformedRecord.keySchema());
         assertEquals(42, transformedRecord.key());
@@ -100,13 +100,13 @@ public class ExtractFieldTest {
         Map<String, String> configs = new HashMap<>();
         configs.put(FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG, FieldSyntaxVersion.V2.name());
         configs.put("field", "magic.foo");
-        xform.configure(configs);
+        xformKey.configure(configs);
 
         final Schema fooSchema = SchemaBuilder.struct().field("foo", Schema.INT32_SCHEMA).build();
         final Schema keySchema = SchemaBuilder.struct().field("magic", fooSchema).build();
         final Struct key = new Struct(keySchema).put("magic", new Struct(fooSchema).put("foo", 42));
         final SinkRecord record = new SinkRecord("test", 0, keySchema, key, null, null, 0);
-        final SinkRecord transformedRecord = xform.apply(record);
+        final SinkRecord transformedRecord = xformKey.apply(record);
 
         assertEquals(Schema.INT32_SCHEMA, transformedRecord.keySchema());
         assertEquals(42, transformedRecord.key());
@@ -141,11 +141,11 @@ public class ExtractFieldTest {
         Map<String, String> configs = new HashMap<>();
         configs.put(FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG, FieldSyntaxVersion.V2.name());
         configs.put("field", "magic.nonexistent");
-        xform.configure(configs);
+        xformKey.configure(configs);
 
         final Map<String, Object> key = Collections.singletonMap("magic", Collections.singletonMap("foo", 42));
         final SinkRecord record = new SinkRecord("test", 0, null, key, null, null, 0);
-        final SinkRecord transformedRecord = xform.apply(record);
+        final SinkRecord transformedRecord = xformKey.apply(record);
 
         assertNull(transformedRecord.keySchema());
         assertNull(transformedRecord.key());
@@ -172,7 +172,7 @@ public class ExtractFieldTest {
         Map<String, String> configs = new HashMap<>();
         configs.put(FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG, FieldSyntaxVersion.V2.name());
         configs.put("field", "magic.nonexistent");
-        xform.configure(configs);
+        xformKey.configure(configs);
 
         final Schema fooSchema = SchemaBuilder.struct().field("foo", Schema.INT32_SCHEMA).build();
         final Schema keySchema = SchemaBuilder.struct().field("magic", fooSchema).build();
@@ -180,7 +180,7 @@ public class ExtractFieldTest {
         final SinkRecord record = new SinkRecord("test", 0, keySchema, key, null, null, 0);
 
         try {
-            xform.apply(record);
+            xformKey.apply(record);
             fail("Expected exception wasn't raised");
         } catch (IllegalArgumentException iae) {
             assertEquals("Unknown field: magic.nonexistent", iae.getMessage());

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderFromTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderFromTest.java
@@ -148,7 +148,7 @@ public class HeaderFromTest {
                         .withField("field1", STRING_SCHEMA, "field1-value")
                         .withField("field2", STRING_SCHEMA, "field2-value")
                         .addHeader("header1", STRING_SCHEMA, "existing-value"),
-                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.COPY,
+                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.COPY, true,
                     new RecordBuilder()
                         .withField("field1", STRING_SCHEMA, "field1-value")
                         .withField("field2", STRING_SCHEMA, "field2-value")
@@ -163,7 +163,7 @@ public class HeaderFromTest {
                         .withField("field1", STRING_SCHEMA, "field1-value")
                         .withField("field2", STRING_SCHEMA, "field2-value")
                         .addHeader("header1", STRING_SCHEMA, "existing-value"),
-                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.MOVE,
+                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.MOVE, true,
                     new RecordBuilder()
                         // field1 got moved
                         .withField("field2", STRING_SCHEMA, "field2-value")
@@ -178,7 +178,7 @@ public class HeaderFromTest {
                         .withField("field1", STRING_SCHEMA, "field1-value")
                         .withField("field2", STRING_SCHEMA, "field2-value")
                         .addHeader("inserted1", STRING_SCHEMA, "existing-value"),
-                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.COPY,
+                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.COPY, true,
                     new RecordBuilder()
                         .withField("field1", STRING_SCHEMA, "field1-value")
                         .withField("field2", STRING_SCHEMA, "field2-value")
@@ -193,7 +193,7 @@ public class HeaderFromTest {
                         .withField("field1", STRING_SCHEMA, "field1-value")
                         .withField("field2", STRING_SCHEMA, "field2-value")
                         .addHeader("inserted1", STRING_SCHEMA, "existing-value"),
-                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.MOVE,
+                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.MOVE, true,
                     new RecordBuilder()
                         // field1 got moved
                         .withField("field2", STRING_SCHEMA, "field2-value")
@@ -210,7 +210,7 @@ public class HeaderFromTest {
                         .withField("field1", schema, struct)
                         .withField("field2", STRING_SCHEMA, "field2-value")
                         .addHeader("header1", STRING_SCHEMA, "existing-value"),
-                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.COPY,
+                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.COPY, true,
                     new RecordBuilder()
                         .withField("field1", schema, struct)
                         .withField("field2", STRING_SCHEMA, "field2-value")
@@ -225,7 +225,7 @@ public class HeaderFromTest {
                         .withField("field1", schema, struct)
                         .withField("field2", STRING_SCHEMA, "field2-value")
                         .addHeader("header1", STRING_SCHEMA, "existing-value"),
-                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.MOVE,
+                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.MOVE, true,
                     new RecordBuilder()
                         // field1 got moved
                         .withField("field2", STRING_SCHEMA, "field2-value")
@@ -241,7 +241,7 @@ public class HeaderFromTest {
                         .withField("field2", STRING_SCHEMA, "field2-value")
                         .addHeader("header1", STRING_SCHEMA, "existing-value"),
                     // two headers from the same field
-                    asList("field1", "field1"), asList("inserted1", "inserted2"), HeaderFrom.Operation.MOVE,
+                    asList("field1", "field1"), asList("inserted1", "inserted2"), HeaderFrom.Operation.MOVE, true,
                     new RecordBuilder()
                         // field1 got moved
                         .withField("field2", STRING_SCHEMA, "field2-value")
@@ -258,22 +258,53 @@ public class HeaderFromTest {
                         .withField("field2", STRING_SCHEMA, "field2-value")
                         .addHeader("header1", STRING_SCHEMA, "existing-value"),
                     // two headers from the same field
-                    asList("field1", "field2"), asList("inserted1", "inserted1"), HeaderFrom.Operation.MOVE,
+                    asList("field1", "field2"), asList("inserted1", "inserted1"), HeaderFrom.Operation.MOVE, true,
                     new RecordBuilder()
                         // field1 and field2 got moved
                         .addHeader("header1", STRING_SCHEMA, "existing-value")
                         .addHeader("inserted1", STRING_SCHEMA, "field1-value")
                         .addHeader("inserted1", STRING_SCHEMA, "field2-value")
                 ));
+            result.add(
+                    Arguments.of(
+                            "Copy null field without default",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", SchemaBuilder.string().defaultValue("default").optional().build(), "field1-value")
+                                    .withField("field2", SchemaBuilder.string().defaultValue("default").optional().build(), null)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            asList("field1", "field2"), asList("inserted1", "inserted2"), HeaderFrom.Operation.COPY, false,
+                            new RecordBuilder()
+                                    .withField("field1", SchemaBuilder.string().defaultValue("default").optional().build(), "field1-value")
+                                    .withField("field2", SchemaBuilder.string().defaultValue("default").optional().build(), null)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", SchemaBuilder.string().defaultValue("default").optional().build(), "field1-value")
+                                    .addHeader("inserted2", SchemaBuilder.string().defaultValue("default").optional().build(), null)
+                    ));
+            result.add(
+                    Arguments.of(
+                            "Move null field without default",
+                            testKeyTransform,
+                            new RecordBuilder()
+                                    .withField("field1", SchemaBuilder.string().defaultValue("default").optional().build(), "field1-value")
+                                    .withField("field2", SchemaBuilder.string().defaultValue("default").optional().build(), null)
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                            asList("field1", "field2"), asList("inserted1", "inserted2"), HeaderFrom.Operation.MOVE, false,
+                            new RecordBuilder()
+                                    .addHeader("header1", STRING_SCHEMA, "existing-value")
+                                    .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                                    .addHeader("inserted2", SchemaBuilder.string().defaultValue("default").optional().build(), null)
+                    ));
         }
         return result;
     }
 
-    private Map<String, Object> config(List<String> headers, List<String> transformFields, HeaderFrom.Operation operation) {
+    private Map<String, Object> config(List<String> headers, List<String> transformFields, HeaderFrom.Operation operation, boolean useFieldDefault) {
         Map<String, Object> result = new HashMap<>();
         result.put(HeaderFrom.HEADERS_FIELD, headers);
         result.put(HeaderFrom.FIELDS_FIELD, transformFields);
         result.put(HeaderFrom.OPERATION_FIELD, operation.toString());
+        result.put(HeaderFrom.REPLACE_NULL_WITH_DEFAULT_CONFIG, useFieldDefault);
         return result;
     }
 
@@ -282,11 +313,11 @@ public class HeaderFromTest {
     public void schemaless(String description,
                            boolean keyTransform,
                            RecordBuilder originalBuilder,
-                           List<String> transformFields, List<String> headers1, HeaderFrom.Operation operation,
+                           List<String> transformFields, List<String> headers1, HeaderFrom.Operation operation, boolean replaceNullWithDefault,
                            RecordBuilder expectedBuilder) {
         HeaderFrom<SourceRecord> xform = keyTransform ? new HeaderFrom.Key<>() : new HeaderFrom.Value<>();
 
-        xform.configure(config(headers1, transformFields, operation));
+        xform.configure(config(headers1, transformFields, operation, replaceNullWithDefault));
         ConnectHeaders headers = new ConnectHeaders();
         headers.addString("existing", "existing-value");
 
@@ -301,10 +332,10 @@ public class HeaderFromTest {
     public void withSchema(String description,
                            boolean keyTransform,
                            RecordBuilder originalBuilder,
-                           List<String> transformFields, List<String> headers1, HeaderFrom.Operation operation,
+                           List<String> transformFields, List<String> headers1, HeaderFrom.Operation operation, boolean replaceNullWithDefault,
                            RecordBuilder expectedBuilder) {
         HeaderFrom<SourceRecord> xform = keyTransform ? new HeaderFrom.Key<>() : new HeaderFrom.Value<>();
-        xform.configure(config(headers1, transformFields, operation));
+        xform.configure(config(headers1, transformFields, operation, replaceNullWithDefault));
         ConnectHeaders headers = new ConnectHeaders();
         headers.addString("existing", "existing-value");
         Headers expect = headers.duplicate();
@@ -321,7 +352,7 @@ public class HeaderFromTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void invalidConfigExtraHeaderConfig(boolean keyTransform) {
-        Map<String, Object> config = config(singletonList("foo"), asList("foo", "bar"), HeaderFrom.Operation.COPY);
+        Map<String, Object> config = config(singletonList("foo"), asList("foo", "bar"), HeaderFrom.Operation.COPY, true);
         HeaderFrom<?> xform = keyTransform ? new HeaderFrom.Key<>() : new HeaderFrom.Value<>();
         assertThrows(ConfigException.class, () -> xform.configure(config));
     }
@@ -329,7 +360,7 @@ public class HeaderFromTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void invalidConfigExtraFieldConfig(boolean keyTransform) {
-        Map<String, Object> config = config(asList("foo", "bar"), singletonList("foo"), HeaderFrom.Operation.COPY);
+        Map<String, Object> config = config(asList("foo", "bar"), singletonList("foo"), HeaderFrom.Operation.COPY, true);
         HeaderFrom<?> xform = keyTransform ? new HeaderFrom.Key<>() : new HeaderFrom.Value<>();
         assertThrows(ConfigException.class, () -> xform.configure(config));
     }
@@ -337,7 +368,7 @@ public class HeaderFromTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void invalidConfigEmptyHeadersAndFieldsConfig(boolean keyTransform) {
-        Map<String, Object> config = config(emptyList(), emptyList(), HeaderFrom.Operation.COPY);
+        Map<String, Object> config = config(emptyList(), emptyList(), HeaderFrom.Operation.COPY, true);
         HeaderFrom<?> xform = keyTransform ? new HeaderFrom.Key<>() : new HeaderFrom.Value<>();
         assertThrows(ConfigException.class, () -> xform.configure(config));
     }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderFromTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderFromTest.java
@@ -292,7 +292,7 @@ public class HeaderFromTest {
                             asList("field1", "field2"), asList("inserted1", "inserted2"), HeaderFrom.Operation.MOVE, false,
                             new RecordBuilder()
                                     .addHeader("header1", STRING_SCHEMA, "existing-value")
-                                    .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                                    .addHeader("inserted1", SchemaBuilder.string().defaultValue("default").optional().build(), "field1-value")
                                     .addHeader("inserted2", SchemaBuilder.string().defaultValue("default").optional().build(), null)
                     ));
         }
@@ -304,7 +304,7 @@ public class HeaderFromTest {
         result.put(HeaderFrom.HEADERS_FIELD, headers);
         result.put(HeaderFrom.FIELDS_FIELD, transformFields);
         result.put(HeaderFrom.OPERATION_FIELD, operation.toString());
-        result.put(HeaderFrom.REPLACE_NULL_WITH_DEFAULT_CONFIG, useFieldDefault);
+        result.put(HeaderFrom.REPLACE_NULL_WITH_DEFAULT, useFieldDefault);
         return result;
     }
 

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderFromTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderFromTest.java
@@ -304,7 +304,7 @@ public class HeaderFromTest {
         result.put(HeaderFrom.HEADERS_FIELD, headers);
         result.put(HeaderFrom.FIELDS_FIELD, transformFields);
         result.put(HeaderFrom.OPERATION_FIELD, operation.toString());
-        result.put(HeaderFrom.REPLACE_NULL_WITH_DEFAULT, useFieldDefault);
+        result.put(HeaderFrom.REPLACE_NULL_WITH_DEFAULT_FIELD, useFieldDefault);
         return result;
     }
 

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -211,6 +212,7 @@ public class InsertFieldTest {
     }
 
     @Test
+    @DisplayName("Null value fields copied as null instead of default")
     public void whenValueConverterReplaceNullWithDefaultIsFalseNullCopiedFieldsWithNullValueMustRemainNull() {
 
         final Map<String, Object> props = new HashMap<>();
@@ -219,7 +221,7 @@ public class InsertFieldTest {
         props.put("timestamp.field", "timestamp_field?");
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
-        props.put("value.converter.replace.null.with.default", false);
+        props.put("replace.null.with.default", false);
 
         xformValue.configure(props);
 
@@ -240,6 +242,7 @@ public class InsertFieldTest {
     }
 
     @Test
+    @DisplayName("Use default value when coping fields with null value")
     public void whenValueConverterReplaceNullWithDefaultIsTrueCopiedFieldsWithNullValueMustUseDefault() {
 
         final Map<String, Object> props = new HashMap<>();
@@ -248,7 +251,6 @@ public class InsertFieldTest {
         props.put("timestamp.field", "timestamp_field?");
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
-        props.put("value.converter.replace.null.with.default", true);
 
         xformValue.configure(props);
 

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -25,11 +25,15 @@ import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -39,6 +43,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class InsertFieldTest {
     private final InsertField<SourceRecord> xformKey = new InsertField.Key<>();
     private final InsertField<SourceRecord> xformValue = new InsertField.Value<>();
+
+    public static Stream<Arguments> data() {
+        return Stream.of(
+                Arguments.of(false, null),
+                Arguments.of(true, 42L)
+        );
+    }
 
     @AfterEach
     public void teardown() {
@@ -210,8 +221,9 @@ public class InsertFieldTest {
         assertEquals(xformKey.version(), xformValue.version());
     }
 
-    @Test
-    public void testUnsetOptionalFieldIsNull() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUnsetOptionalField(boolean replaceNullWithDefault, Object expectedValue) {
 
         final Map<String, Object> props = new HashMap<>();
         props.put("topic.field", "topic_field!");
@@ -219,7 +231,7 @@ public class InsertFieldTest {
         props.put("timestamp.field", "timestamp_field?");
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
-        props.put("replace.null.with.default", false);
+        props.put("replace.null.with.default", replaceNullWithDefault);
 
         xformValue.configure(props);
 
@@ -235,35 +247,8 @@ public class InsertFieldTest {
         assertEquals(simpleStructSchema.doc(), transformedRecord.valueSchema().doc());
 
         assertEquals(magicFieldSchema, transformedRecord.valueSchema().field("magic_with_default").schema());
-        assertNull(((Struct) transformedRecord.value()).getInt64("magic_with_default"));
+        assertEquals(expectedValue, ((Struct) transformedRecord.value()).getInt64("magic_with_default"));
 
     }
 
-    @Test
-    public void testUnsetOptionalFieldReplacedWithDefault() {
-
-        final Map<String, Object> props = new HashMap<>();
-        props.put("topic.field", "topic_field!");
-        props.put("partition.field", "partition_field");
-        props.put("timestamp.field", "timestamp_field?");
-        props.put("static.field", "instance_id");
-        props.put("static.value", "my-instance-id");
-
-        xformValue.configure(props);
-
-        Schema magicFieldSchema = SchemaBuilder.int64().optional().defaultValue(42L).build();
-        final Schema simpleStructSchema = SchemaBuilder.struct().name("name").version(1).doc("doc").field("magic_with_default", magicFieldSchema).build();
-        final Struct simpleStruct = new Struct(simpleStructSchema).put("magic_with_default", null);
-
-        final SourceRecord record = new SourceRecord(null, null, "test", 0, null, null, simpleStructSchema, simpleStruct, 789L);
-        final SourceRecord transformedRecord = xformValue.apply(record);
-
-        assertEquals(simpleStructSchema.name(), transformedRecord.valueSchema().name());
-        assertEquals(simpleStructSchema.version(), transformedRecord.valueSchema().version());
-        assertEquals(simpleStructSchema.doc(), transformedRecord.valueSchema().doc());
-
-        assertEquals(magicFieldSchema, transformedRecord.valueSchema().field("magic_with_default").schema());
-        assertEquals(42L, ((Struct) transformedRecord.value()).getInt64("magic_with_default").longValue());
-
-    }
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -212,8 +212,7 @@ public class InsertFieldTest {
     }
 
     @Test
-    @DisplayName("Null value fields copied as null instead of default")
-    public void whenValueConverterReplaceNullWithDefaultIsFalseNullCopiedFieldsWithNullValueMustRemainNull() {
+    public void testUnsetOptionalFieldIsNull() {
 
         final Map<String, Object> props = new HashMap<>();
         props.put("topic.field", "topic_field!");
@@ -242,8 +241,7 @@ public class InsertFieldTest {
     }
 
     @Test
-    @DisplayName("Use default value when coping fields with null value")
-    public void whenValueConverterReplaceNullWithDefaultIsTrueCopiedFieldsWithNullValueMustUseDefault() {
+    public void testUnsetOptionalFieldReplacedWithDefault() {
 
         final Map<String, Object> props = new HashMap<>();
         props.put("topic.field", "topic_field!");

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/MaskFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/MaskFieldTest.java
@@ -61,6 +61,7 @@ public class MaskFieldTest {
             .field("decimal", Decimal.schema(0))
             .field("array", SchemaBuilder.array(Schema.INT32_SCHEMA))
             .field("map", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA))
+            .field("withDefault", SchemaBuilder.string().optional().defaultValue("default").build())
             .build();
     private static final Map<String, Object> VALUES = new HashMap<>();
     private static final Struct VALUES_WITH_SCHEMA = new Struct(SCHEMA);
@@ -96,6 +97,7 @@ public class MaskFieldTest {
         VALUES_WITH_SCHEMA.put("decimal", new BigDecimal(42));
         VALUES_WITH_SCHEMA.put("array", Arrays.asList(1, 2, 3));
         VALUES_WITH_SCHEMA.put("map", Collections.singletonMap("what", "what"));
+        VALUES_WITH_SCHEMA.put("withDefault", null);
     }
 
     private static MaskField<SinkRecord> transform(List<String> fields, String replacement) {
@@ -103,6 +105,7 @@ public class MaskFieldTest {
         Map<String, Object> props = new HashMap<>();
         props.put("fields", fields);
         props.put("replacement", replacement);
+        props.put("replace.null.with.default", false);
         xform.configure(props);
         return xform;
     }
@@ -180,6 +183,7 @@ public class MaskFieldTest {
         assertEquals(BigDecimal.ZERO, updatedValue.get("decimal"));
         assertEquals(Collections.emptyList(), updatedValue.get("array"));
         assertEquals(Collections.emptyMap(), updatedValue.get("map"));
+        assertEquals(null, updatedValue.getWithoutDefault("withDefault"));
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/SetSchemaMetadataTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/SetSchemaMetadataTest.java
@@ -67,7 +67,7 @@ public class SetSchemaMetadataTest {
         xform.configure(Collections.singletonMap("schema.version", 42));
         final SinkRecord record = new SinkRecord("", 0, null, null, SchemaBuilder.struct().build(), null, 0);
         final SinkRecord updatedRecord = xform.apply(record);
-        assertEquals(Integer.valueOf(42), updatedRecord.valueSchema().version());
+        assertEquals(42, updatedRecord.valueSchema().version());
     }
 
     @Test
@@ -83,7 +83,7 @@ public class SetSchemaMetadataTest {
         final SinkRecord updatedRecord = xform.apply(record);
 
         assertEquals("foo", updatedRecord.valueSchema().name());
-        assertEquals(Integer.valueOf(42), updatedRecord.valueSchema().version());
+        assertEquals(42, updatedRecord.valueSchema().version());
     }
 
     @Test
@@ -109,7 +109,7 @@ public class SetSchemaMetadataTest {
         final SinkRecord updatedRecord = xform.apply(record);
 
         assertEquals("foo", updatedRecord.valueSchema().name());
-        assertEquals(Integer.valueOf(42), updatedRecord.valueSchema().version());
+        assertEquals(42, updatedRecord.valueSchema().version());
 
         // Make sure the struct's schema and fields all point to the new schema
         assertMatchingSchema((Struct) updatedRecord.value(), updatedRecord.valueSchema());
@@ -139,7 +139,7 @@ public class SetSchemaMetadataTest {
         final SinkRecord updatedRecord = xform.apply(record);
 
         assertEquals("foo", updatedRecord.valueSchema().name());
-        assertEquals(Integer.valueOf(42), updatedRecord.valueSchema().version());
+        assertEquals(42, updatedRecord.valueSchema().version());
 
         // Make sure the struct's schema and fields all point to the new schema
         assertMatchingSchema((Struct) updatedRecord.value(), updatedRecord.valueSchema());

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
@@ -28,6 +28,9 @@ import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Calendar;
 import java.util.Collections;
@@ -35,6 +38,7 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -86,6 +90,12 @@ public class TimestampConverterTest {
         DATE_PLUS_TIME_STRING = "1970 01 02 00 00 01 234 UTC";
     }
 
+    public static Stream<Arguments> data() {
+        return Stream.of(
+                Arguments.of(false, null),
+                Arguments.of(true, EPOCH.getTime())
+        );
+    }
 
     // Configuration
 
@@ -550,6 +560,36 @@ public class TimestampConverterTest {
                 .build();
         assertEquals(expectedSchema, transformed.valueSchema());
         assertEquals(DATE_PLUS_TIME.getTime(), ((Struct) transformed.value()).get("ts"));
+        assertEquals("test", ((Struct) transformed.value()).get("other"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testWithSchemaNullFieldWithDefaultConversion(boolean replaceNullWithDefault, Object expectedValue) {
+        Map<String, Object> config = new HashMap<>();
+        config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
+        config.put(TimestampConverter.FIELD_CONFIG, "ts");
+        config.put(TimestampConverter.REPLACE_NULL_WITH_DEFAULT_CONFIG, false);
+        xformValue.configure(config);
+
+        // ts field is a unix timestamp
+        Schema structWithTimestampFieldSchema = SchemaBuilder.struct()
+                .field("ts", SchemaBuilder.int64().optional().defaultValue(0L).build())
+                .field("other", Schema.STRING_SCHEMA)
+                .build();
+        Struct original = new Struct(structWithTimestampFieldSchema);
+        original.put("ts", null);
+        original.put("other", "test");
+
+        SourceRecord transformed = xformValue.apply(createRecordWithSchema(structWithTimestampFieldSchema, original));
+
+        Schema expectedSchema = SchemaBuilder.struct()
+                .field("ts", Timestamp.builder().optional().build())
+                .field("other", Schema.STRING_SCHEMA)
+                .build();
+
+        assertEquals(expectedSchema, transformed.valueSchema());
+        assertEquals(null, ((Struct) transformed.value()).get("ts"));
         assertEquals("test", ((Struct) transformed.value()).get("other"));
     }
 

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
@@ -569,7 +569,7 @@ public class TimestampConverterTest {
         Map<String, Object> config = new HashMap<>();
         config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
         config.put(TimestampConverter.FIELD_CONFIG, "ts");
-        config.put(TimestampConverter.REPLACE_NULL_WITH_DEFAULT, false);
+        config.put(TimestampConverter.REPLACE_NULL_WITH_DEFAULT_CONFIG, false);
         xformValue.configure(config);
 
         // ts field is a unix timestamp

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
@@ -569,7 +569,7 @@ public class TimestampConverterTest {
         Map<String, Object> config = new HashMap<>();
         config.put(TimestampConverter.TARGET_TYPE_CONFIG, "Timestamp");
         config.put(TimestampConverter.FIELD_CONFIG, "ts");
-        config.put(TimestampConverter.REPLACE_NULL_WITH_DEFAULT_CONFIG, false);
+        config.put(TimestampConverter.REPLACE_NULL_WITH_DEFAULT, false);
         xformValue.configure(config);
 
         // ts field is a unix timestamp


### PR DESCRIPTION
*Value `null` is valid for an optional filed, even though the field has a default value.
Only when field is required, the class return default value fallback when value is `null`*


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
