### PR TITLE
KAFKA-16591: Clear all admins after close all of them.

### DIFF
--- a/core/src/test/java/kafka/test/junit/RaftClusterInvocationContext.java
+++ b/core/src/test/java/kafka/test/junit/RaftClusterInvocationContext.java
@@ -263,6 +263,7 @@ public class RaftClusterInvocationContext implements TestTemplateInvocationConte
         public void stop() {
             if (stopped.compareAndSet(false, true)) {
                 admins.forEach(admin -> Utils.closeQuietly(admin, "admin"));
+                admins.clear();
                 Utils.closeQuietly(clusterReference.get(), "cluster");
                 if (zkReference.get() != null) {
                     Utils.closeQuietly(zkReference.get(), "zk");


### PR DESCRIPTION
[KAFKA-16591](https://issues.apache.org/jira/browse/KAFKA-16591)
After closing all admins, we should also clear the queue of admins.

