### PR TITLE
MINOR: fix javadoc argument name in KRaftMetadataCache#getTopicMetadataForDescribeTopicResponse

### DIFF
--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -267,7 +267,7 @@ class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging w
    *
    * @param topics                        The iterator of topics and their corresponding first partition id to fetch.
    * @param listenerName                  The listener name.
-   * @param firstTopicPartitionStartIndex The start partition index for the first topic
+   * @param topicPartitionStartIndex      The start partition index for the first topic
    * @param maximumNumberOfPartitions     The max number of partitions to return.
    * @param ignoreTopicsWithExceptions    Whether ignore the topics with exception.
    */


### PR DESCRIPTION
Minor javadoc argument rename to match the actual argument name in the method.