### PR TITLE
KAFKA-16548: Change to use `streamingIterator` 

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -38,6 +38,7 @@ import org.apache.kafka.common.record.RemoteLogInputStream;
 import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.ChildFirstClassLoader;
+import org.apache.kafka.common.utils.CloseableIterator;
 import org.apache.kafka.common.utils.KafkaThread;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
@@ -464,11 +465,12 @@ public class RemoteLogManager implements Closeable {
                 RecordBatch batch = remoteLogInputStream.nextBatch();
                 if (batch == null) break;
                 if (batch.maxTimestamp() >= timestamp && batch.lastOffset() >= startingOffset) {
-                    Iterator<Record> recordStreamingIterator = batch.streamingIterator(BufferSupplier.NO_CACHING);
-                    while (recordStreamingIterator.hasNext()) {
-                        Record record = recordStreamingIterator.next();
-                        if (record.timestamp() >= timestamp && record.offset() >= startingOffset)
-                            return Optional.of(new FileRecords.TimestampAndOffset(record.timestamp(), record.offset(), maybeLeaderEpoch(batch.partitionLeaderEpoch())));
+                    try (CloseableIterator<Record> recordStreamingIterator = batch.streamingIterator(BufferSupplier.NO_CACHING)) {
+                        while (recordStreamingIterator.hasNext()) {
+                            Record record = recordStreamingIterator.next();
+                            if (record.timestamp() >= timestamp && record.offset() >= startingOffset)
+                                return Optional.of(new FileRecords.TimestampAndOffset(record.timestamp(), record.offset(), maybeLeaderEpoch(batch.partitionLeaderEpoch())));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
change to use `streamingIterator` because we don't show all record, and we need early return
