### PR TITLE
Minor: Fix CDS in docker image

### DIFF
--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -28,7 +28,7 @@ COPY jsa_launch /etc/kafka/docker/jsa_launch
 RUN set -eux ; \
     apk update ; \
     apk upgrade ; \
-    apk add --no-cache wget gcompat gpg gpg-agent procps netcat-openbsd bash; \
+    apk add --no-cache wget gcompat gpg gpg-agent procps bash; \
     mkdir opt/kafka; \
     wget -nv -O kafka.tgz "$kafka_url"; \
     wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \
@@ -62,7 +62,7 @@ LABEL org.label-schema.name="kafka" \
 RUN set -eux ; \
     apk update ; \
     apk upgrade ; \
-    apk add --no-cache wget gpg gpg-agent gcompat bash; \
+    apk add --no-cache wget gcompat gpg gpg-agent procps bash; \
     mkdir opt/kafka; \
     wget -nv -O kafka.tgz "$kafka_url"; \
     wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \


### PR DESCRIPTION
Fix CDS in docker image.

Due to difference in packages present when jsa files were generated and when docker image is generated, there is a log on starting docker image.

`[0.001s][warning][cds] The shared archive file has a bad magic number: 0`

There is no functionality impact, only startup time is higher because of this issue.

This PR fixes the warning and improves startup performance of the docker image