### PR TITLE
KAFKA-16588: broker shutdown hangs when log.segment.delete.delay.ms is zero

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerLogConfigs.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerLogConfigs.java
@@ -86,7 +86,7 @@ public class ServerLogConfigs {
 
     public static final String LOG_DELETE_DELAY_MS_CONFIG = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.FILE_DELETE_DELAY_MS_CONFIG);
     public static final long LOG_DELETE_DELAY_MS_DEFAULT = 60000L;
-    public static final String LOG_DELETE_DELAY_MS_DOC = "The amount of time to wait before deleting a file from the filesystem";
+    public static final String LOG_DELETE_DELAY_MS_DOC = "The amount of time to wait before deleting a file from the filesystem. If the value is 0 and there is no file to delete, the system will wait 1 millisecond. Low value will cause busy waiting";
 
     public static final String LOG_FLUSH_SCHEDULER_INTERVAL_MS_CONFIG = LOG_PREFIX + "flush.scheduler.interval.ms";
     public static final long LOG_FLUSH_SCHEDULER_INTERVAL_MS_DEFAULT = Long.MAX_VALUE;


### PR DESCRIPTION
If `log.segment.delete.delay.ms` is zero, We call `take` even though the `logsToBeDeleted` is empty, and `KafkaScheduler#shutdown` call `shutdown` rather than `shudownNow` (https://github.com/apache/kafka/blob/trunk/server-common/src/main/java/org/apache/kafka/server/util/KafkaScheduler.java#L134)

Hence, the thread won't be completed forever, and it blocks the shutdown of broker.

We should replace the `take` by `poll` since we have checked the element before.

The zero is a valid value: https://github.com/apache/kafka/blob/f22ad6645bfec0b38e820e0090261c9f6b421a74/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java#L258
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
