### PR TITLE
KAFKA-16598 Mirgrate `ResetConsumerGroupOffsetTest` to new test infra

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ResetConsumerGroupOffsetTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ResetConsumerGroupOffsetTest.java
@@ -17,16 +17,12 @@
 package org.apache.kafka.tools.consumer.group;
 
 import joptsimple.OptionException;
+import kafka.test.ClusterGenerator;
 import kafka.test.ClusterInstance;
-import kafka.test.annotation.ClusterConfigProperty;
-import kafka.test.annotation.ClusterTest;
-import kafka.test.annotation.ClusterTestDefaults;
-import kafka.test.annotation.Type;
+import kafka.test.annotation.ClusterTemplate;
 import kafka.test.junit.ClusterTestExtensions;
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.GroupProtocol;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -39,8 +35,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.test.TestUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.BufferedWriter;
@@ -51,14 +45,11 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -71,7 +62,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG;
+import static org.apache.kafka.clients.admin.AdminClientConfig.RETRIES_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_PROTOCOL_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
@@ -80,8 +71,6 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZE
 import static org.apache.kafka.clients.producer.ProducerConfig.ACKS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG;
-import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG;
 import static org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -98,33 +87,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * - export/import
  */
 @ExtendWith(value = ClusterTestExtensions.class)
-@ClusterTestDefaults(clusterType = Type.ALL, serverProperties = {
-        @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
-        @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")})
-@Tag("integration")
 public class ResetConsumerGroupOffsetTest {
 
-    private static final String TOPIC = "foo";
-    private static final String GROUP = "test.group";
-    private final ClusterInstance cluster;
+    private static final String TOPIC_PREFIX = "foo-";
+    private static final String GROUP_PREFIX = "test.group-";
 
-    public ResetConsumerGroupOffsetTest(ClusterInstance cluster) {
-        this.cluster = cluster;
+    private static void generator(ClusterGenerator clusterGenerator) {
+        ConsumerGroupCommandTestUtils.generator(clusterGenerator);
     }
 
-    @AfterEach
-    public void stopCluster() {
-        cluster.stop();
-    }
-
-    private String[] basicArgs() {
+    private String[] basicArgs(ClusterInstance cluster) {
         return new String[]{"--reset-offsets",
             "--bootstrap-server", cluster.bootstrapServers(),
             "--timeout", Long.toString(DEFAULT_MAX_WAIT_MS)};
     }
 
-    private String[] buildArgsForGroups(List<String> groups, String... args) {
-        List<String> res = new ArrayList<>(asList(basicArgs()));
+    private String[] buildArgsForGroups(ClusterInstance cluster, List<String> groups, String... args) {
+        List<String> res = new ArrayList<>(asList(basicArgs(cluster)));
         for (String group : groups) {
             res.add("--group");
             res.add(group);
@@ -133,458 +112,586 @@ public class ResetConsumerGroupOffsetTest {
         return res.toArray(new String[0]);
     }
 
-    private String[] buildArgsForGroup(String group, String... args) {
-        return buildArgsForGroups(singletonList(group), args);
+    private String[] buildArgsForGroup(ClusterInstance cluster, String group, String... args) {
+        return buildArgsForGroups(cluster, singletonList(group), args);
     }
 
-    private String[] buildArgsForAllGroups(String... args) {
-        List<String> res = new ArrayList<>(asList(basicArgs()));
+    private String[] buildArgsForAllGroups(ClusterInstance cluster, String... args) {
+        List<String> res = new ArrayList<>(asList(basicArgs(cluster)));
         res.add("--all-groups");
         res.addAll(asList(args));
         return res.toArray(new String[0]);
     }
 
-    @ClusterTest
-    public void testResetOffsetsNotExistingGroup() throws Exception {
+    @ClusterTemplate("generator")
+    public void testResetOffsetsNotExistingGroup(ClusterInstance cluster) throws Exception {
+        String topic = generateRandomTopic();
         String group = "missing.group";
-        String[] args = buildArgsForGroup(group, "--all-topics", "--to-current", "--execute");
-        ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(args);
-        // Make sure we got a coordinator
-        TestUtils.waitForCondition(
-                () -> "localhost".equals(consumerGroupCommand.collectGroupState(group).coordinator.host()),
-                "Can't find a coordinator");
-        Map<TopicPartition, OffsetAndMetadata> resetOffsets = consumerGroupCommand.resetOffsets().get(group);
-        assertTrue(resetOffsets.isEmpty());
-        assertTrue(committedOffsets(TOPIC, group).isEmpty());
+        String[] args = buildArgsForGroup(cluster, group, "--all-topics", "--to-current", "--execute");
+
+        try (ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(args)) {
+            // Make sure we got a coordinator
+            TestUtils.waitForCondition(
+                    () -> "localhost".equals(service.collectGroupState(group).coordinator.host()),
+                    "Can't find a coordinator");
+            Map<TopicPartition, OffsetAndMetadata> resetOffsets = service.resetOffsets().get(group);
+            assertTrue(resetOffsets.isEmpty());
+            assertTrue(committedOffsets(cluster, topic, group).isEmpty());
+        }
     }
 
-    @ClusterTest
-    public void testResetOffsetsExistingTopic() {
+    @ClusterTemplate("generator")
+    public void testResetOffsetsExistingTopic(ClusterInstance cluster) {
+        String topic = generateRandomTopic();
         String group = "new.group";
-        String[] args = buildArgsForGroup(group, "--topic", TOPIC, "--to-offset", "50");
-        produceMessages(TOPIC, 100);
-        resetAndAssertOffsets(args, 50, true, singletonList(TOPIC));
-        resetAndAssertOffsets(addTo(args, "--dry-run"), 50, true, singletonList(TOPIC));
-        resetAndAssertOffsets(addTo(args, "--execute"), 50, false, singletonList(TOPIC));
+        String[] args = buildArgsForGroup(cluster, group, "--topic", topic, "--to-offset", "50");
+
+        produceMessages(cluster, topic, 100);
+        resetAndAssertOffsets(cluster, args, 50, true, singletonList(topic));
+        resetAndAssertOffsets(cluster, addTo(args, "--dry-run"),
+                50, true, singletonList(topic));
+        resetAndAssertOffsets(cluster, addTo(args, "--execute"),
+                50, false, singletonList(topic));
     }
 
-    @ClusterTest
-    public void testResetOffsetsExistingTopicSelectedGroups() throws Exception {
-        produceMessages(TOPIC, 100);
-        List<String> groups = generateIds(GROUP);
-        for (String group : groups) {
-            try (AutoCloseable ignored =
-                         addConsumerGroupExecutor(1, TOPIC, group, GroupProtocol.CLASSIC.name)) {
-                awaitConsumerProgress(TOPIC, group, 100L);
-            }
-        }
-        String[] args = buildArgsForGroups(groups, "--topic", TOPIC, "--to-offset", "50");
-        resetAndAssertOffsets(args, 50, true, singletonList(TOPIC));
-        resetAndAssertOffsets(addTo(args, "--dry-run"), 50, true, singletonList(TOPIC));
-        resetAndAssertOffsets(addTo(args, "--execute"), 50, false, singletonList(TOPIC));
-    }
+    @ClusterTemplate("generator")
+    public void testResetOffsetsExistingTopicSelectedGroups(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String topic = generateRandomTopic();
 
-    @ClusterTest
-    public void testResetOffsetsExistingTopicAllGroups() throws Exception {
-        String[] args = buildArgsForAllGroups("--topic", TOPIC, "--to-offset", "50");
-        produceMessages(TOPIC, 100);
-        for (int i = 1; i <= 3; i++) {
-            String group = GROUP + i;
-            try (AutoCloseable ignored =
-                         addConsumerGroupExecutor(1, TOPIC, group, GroupProtocol.CLASSIC.name)) {
-                awaitConsumerProgress(TOPIC, group, 100L);
-            }
-        }
-        resetAndAssertOffsets(args, 50, true, singletonList(TOPIC));
-        resetAndAssertOffsets(addTo(args, "--dry-run"), 50, true, singletonList(TOPIC));
-        resetAndAssertOffsets(addTo(args, "--execute"), 50, false, singletonList(TOPIC));
-    }
-
-    @ClusterTest
-    public void testResetOffsetsAllTopicsAllGroups() throws Exception {
-        String[] args = buildArgsForAllGroups("--all-topics", "--to-offset", "50");
-        List<String> topics = generateIds(TOPIC);
-        List<String> groups = generateIds(GROUP);
-        topics.forEach(topic -> produceMessages(topic, 100));
-
-        for (String topic : topics) {
+            produceMessages(cluster, topic, 100);
+            List<String> groups = generateIds(topic);
             for (String group : groups) {
-                try (AutoCloseable ignored =
-                             addConsumerGroupExecutor(3, topic, group, GroupProtocol.CLASSIC.name)) {
-                    awaitConsumerProgress(topic, group, 100);
+                try (AutoCloseable consumerGroupCloseable =
+                             consumerGroupClosable(cluster, 1, topic, group, groupProtocol)) {
+                    awaitConsumerProgress(cluster, topic, group, 100L);
                 }
             }
+
+            String[] args = buildArgsForGroups(cluster, groups, "--topic", topic, "--to-offset", "50");
+            resetAndAssertOffsets(cluster, args, 50, true, singletonList(topic));
+            resetAndAssertOffsets(cluster, addTo(args, "--dry-run"),
+                    50, true, singletonList(topic));
+            resetAndAssertOffsets(cluster, addTo(args, "--execute"),
+                    50, false, singletonList(topic));
         }
-        resetAndAssertOffsets(args, 50, true, topics);
-        resetAndAssertOffsets(addTo(args, "--dry-run"), 50, true, topics);
-        resetAndAssertOffsets(addTo(args, "--execute"), 50, false, topics);
     }
 
-    @ClusterTest
-    public void testResetOffsetsToLocalDateTime() throws Exception {
-        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
-        LocalDateTime dateTime = now().minusDays(1);
+    @ClusterTemplate("generator")
+    public void testResetOffsetsExistingTopicAllGroups(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String topic = generateRandomTopic();
+            String[] args = buildArgsForAllGroups(cluster, "--topic", topic, "--to-offset", "50");
 
-        produceMessages(TOPIC, 100);
-
-        try (AutoCloseable ignored = addConsumerGroupExecutor(1, TOPIC, GROUP, GroupProtocol.CLASSIC.name)) {
-            awaitConsumerProgress(TOPIC, GROUP, 100L);
+            produceMessages(cluster, topic, 100);
+            for (int i = 1; i <= 3; i++) {
+                String group = generateRandomGroupId();
+                try (AutoCloseable consumerGroupCloseable =
+                             consumerGroupClosable(cluster, 1, topic, group, groupProtocol)) {
+                    awaitConsumerProgress(cluster, topic, group, 100L);
+                }
+            }
+            resetAndAssertOffsets(cluster, args, 50, true, singletonList(topic));
+            resetAndAssertOffsets(cluster, addTo(args, "--dry-run"),
+                    50, true, singletonList(topic));
+            resetAndAssertOffsets(cluster, addTo(args, "--execute"),
+                    50, false, singletonList(topic));
         }
-
-        String[] args = buildArgsForGroup(GROUP, "--all-topics", "--to-datetime", format.format(dateTime), "--execute");
-        resetAndAssertOffsets(args, 0);
     }
 
-    @ClusterTest
-    public void testResetOffsetsToZonedDateTime() throws Exception {
-        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+    @ClusterTemplate("generator")
+    public void testResetOffsetsAllTopicsAllGroups(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String groupId = generateRandomGroupId();
+            String topicId = generateRandomTopic();
 
-        produceMessages(TOPIC, 50);
-        ZonedDateTime checkpoint = now().atZone(ZoneId.systemDefault());
-        produceMessages(TOPIC, 50);
-        try (AutoCloseable ignored = addConsumerGroupExecutor(1, TOPIC, GROUP, GroupProtocol.CLASSIC.name)) {
-            awaitConsumerProgress(TOPIC, GROUP, 100L);
+            String[] args = buildArgsForAllGroups(cluster, "--all-topics", "--to-offset", "50");
+            List<String> topics = generateIds(groupId);
+            List<String> groups = generateIds(topicId);
+            topics.forEach(topic -> produceMessages(cluster, topic, 100));
+
+            for (String topic : topics) {
+                for (String group : groups) {
+                    try (AutoCloseable consumerGroupCloseable =
+                                 consumerGroupClosable(cluster, 3, topic, group, groupProtocol)) {
+                        awaitConsumerProgress(cluster, topic, group, 100);
+                    }
+                }
+            }
+
+            resetAndAssertOffsets(cluster, args, 50, true, topics);
+            resetAndAssertOffsets(cluster, addTo(args, "--dry-run"),
+                    50, true, topics);
+            resetAndAssertOffsets(cluster, addTo(args, "--execute"),
+                    50, false, topics);
+
+            try (Admin admin = cluster.createAdminClient()) {
+                admin.deleteConsumerGroups(groups).all().get();
+            }
         }
-        String[] args = buildArgsForGroup(GROUP,
-                "--all-topics", "--to-datetime", format.format(checkpoint),
-                "--execute");
-        resetAndAssertOffsets(args, 50);
     }
 
-    @ClusterTest
-    public void testResetOffsetsByDuration() throws Exception {
-        String[] args = buildArgsForGroup(GROUP, "--all-topics", "--by-duration", "PT1M", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 1);
-        resetAndAssertOffsets(args, 0);
+    @ClusterTemplate("generator")
+    public void testResetOffsetsToLocalDateTime(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
+
+            DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+            LocalDateTime dateTime = now().minusDays(1);
+            String[] args = buildArgsForGroup(cluster, group,
+                "--all-topics", "--to-datetime",
+                format.format(dateTime), "--execute");
+
+            produceMessages(cluster, topic, 100);
+
+            try (AutoCloseable consumerGroupCloseable =
+                         consumerGroupClosable(cluster, 1, topic, group, groupProtocol)) {
+                awaitConsumerProgress(cluster, topic, group, 100L);
+            }
+
+            resetAndAssertOffsets(cluster, topic, args, 0);
+        }
     }
 
-    @ClusterTest
-    public void testResetOffsetsByDurationToEarliest() throws Exception {
-        String[] args = buildArgsForGroup(GROUP, "--all-topics", "--by-duration", "PT0.1S", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 1);
-        resetAndAssertOffsets(args, 100);
+    @ClusterTemplate("generator")
+    public void testResetOffsetsToZonedDateTime(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
+            DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+
+            produceMessages(cluster, topic, 50);
+            ZonedDateTime checkpoint = now().atZone(ZoneId.systemDefault());
+            produceMessages(cluster, topic, 50);
+
+            String[] args = buildArgsForGroup(cluster, group,
+                    "--all-topics", "--to-datetime", format.format(checkpoint),
+                    "--execute");
+
+            try (AutoCloseable consumerGroupCloseable =
+                         consumerGroupClosable(cluster, 1, topic, group, groupProtocol)) {
+                awaitConsumerProgress(cluster, topic, group, 100L);
+            }
+
+            resetAndAssertOffsets(cluster, topic, args, 50);
+        }
     }
 
-    @ClusterTest
-    public void testResetOffsetsByDurationFallbackToLatestWhenNoRecords() throws ExecutionException, InterruptedException {
-        String topic = "foo2";
-        String[] args = buildArgsForGroup(GROUP, "--topic", topic, "--by-duration", "PT1M", "--execute");
+    @ClusterTemplate("generator")
+    public void testResetOffsetsByDuration(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
+
+            String[] args = buildArgsForGroup(cluster, group, "--all-topics", "--by-duration", "PT1M", "--execute");
+            produceConsumeAndShutdown(cluster, topic, group, 1, groupProtocol);
+            resetAndAssertOffsets(cluster, topic, args, 0);
+        }
+    }
+
+    @ClusterTemplate("generator")
+    public void testResetOffsetsByDurationToEarliest(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
+
+            String[] args = buildArgsForGroup(cluster, group, "--all-topics", "--by-duration", "PT0.1S", "--execute");
+            produceConsumeAndShutdown(cluster, topic, group, 1, groupProtocol);
+            resetAndAssertOffsets(cluster, topic, args, 100);
+        }
+    }
+
+    @ClusterTemplate("generator")
+    public void testResetOffsetsByDurationFallbackToLatestWhenNoRecords(ClusterInstance cluster) throws ExecutionException, InterruptedException {
+        String group = generateRandomGroupId();
+        String topic = generateRandomTopic();
+
+        String[] args = buildArgsForGroup(cluster, group, "--topic", topic, "--by-duration", "PT1M", "--execute");
 
         try (Admin admin = cluster.createAdminClient()) {
             admin.createTopics(singleton(new NewTopic(topic, 1, (short) 1))).all().get();
-            resetAndAssertOffsets(args, 0, false, singletonList("foo2"));
+            resetAndAssertOffsets(cluster, args, 0, false, singletonList(topic));
             admin.deleteTopics(singleton(topic)).all().get();
         }
     }
 
-    @ClusterTest
-    public void testResetOffsetsToEarliest() throws Exception {
-        String[] args = buildArgsForGroup(GROUP, "--all-topics", "--to-earliest", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 1);
-        resetAndAssertOffsets(args, 0);
+    @ClusterTemplate("generator")
+    public void testResetOffsetsToEarliest(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
+
+            String[] args = buildArgsForGroup(cluster, group, "--all-topics", "--to-earliest", "--execute");
+            produceConsumeAndShutdown(cluster, topic, group, 1, groupProtocol);
+            resetAndAssertOffsets(cluster, topic, args, 0);
+        }
     }
 
-    @ClusterTest
-    public void testResetOffsetsToLatest() throws Exception {
-        String[] args = buildArgsForGroup(GROUP, "--all-topics", "--to-latest", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 1);
-        produceMessages(TOPIC, 100);
-        resetAndAssertOffsets(args, 200);
+    @ClusterTemplate("generator")
+    public void testResetOffsetsToLatest(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
+
+            String[] args = buildArgsForGroup(cluster, group, "--all-topics", "--to-latest", "--execute");
+            produceConsumeAndShutdown(cluster, topic, group, 1, groupProtocol);
+            produceMessages(cluster, topic, 100);
+            resetAndAssertOffsets(cluster, topic, args, 200);
+        }
     }
 
-    @ClusterTest
-    public void testResetOffsetsToCurrentOffset() throws Exception {
-        String[] args = buildArgsForGroup(GROUP, "--all-topics", "--to-current", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 1);
-        produceMessages(TOPIC, 100);
-        resetAndAssertOffsets(args, 100);
+    @ClusterTemplate("generator")
+    public void testResetOffsetsToCurrentOffset(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
+
+            String[] args = buildArgsForGroup(cluster, group, "--all-topics", "--to-current", "--execute");
+            produceConsumeAndShutdown(cluster, topic, group, 1, groupProtocol);
+            produceMessages(cluster, topic, 100);
+            resetAndAssertOffsets(cluster, topic, args, 100);
+        }
     }
 
-    @ClusterTest
-    public void testResetOffsetsToSpecificOffset() throws Exception {
-        String[] args = buildArgsForGroup(GROUP, "--all-topics", "--to-offset", "1", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 1);
-        resetAndAssertOffsets(args, 1);
+    @ClusterTemplate("generator")
+    public void testResetOffsetsToSpecificOffset(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
+
+            String[] args = buildArgsForGroup(cluster, group, "--all-topics", "--to-offset", "1", "--execute");
+            produceConsumeAndShutdown(cluster, topic, group, 1, groupProtocol);
+            resetAndAssertOffsets(cluster, topic, args, 1);
+        }
     }
 
-    @ClusterTest
-    public void testResetOffsetsShiftPlus() throws Exception {
-        String[] args = buildArgsForGroup(GROUP, "--all-topics", "--shift-by", "50", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 1);
-        produceMessages(TOPIC, 100);
-        resetAndAssertOffsets(args, 150);
+    @ClusterTemplate("generator")
+    public void testResetOffsetsShiftPlus(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
+
+            String[] args = buildArgsForGroup(cluster, group, "--all-topics", "--shift-by", "50", "--execute");
+            produceConsumeAndShutdown(cluster, topic, group, 1, groupProtocol);
+            produceMessages(cluster, topic, 100);
+            resetAndAssertOffsets(cluster, topic, args, 150);
+        }
     }
 
-    @ClusterTest
-    public void testResetOffsetsShiftMinus() throws Exception {
-        String[] args = buildArgsForGroup(GROUP, "--all-topics", "--shift-by", "-50", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 1);
-        produceMessages(TOPIC, 100);
-        resetAndAssertOffsets(args, 50);
+    @ClusterTemplate("generator")
+    public void testResetOffsetsShiftMinus(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
+
+            String[] args = buildArgsForGroup(cluster, group, "--all-topics", "--shift-by", "-50", "--execute");
+            produceConsumeAndShutdown(cluster, topic, group, 1, groupProtocol);
+            produceMessages(cluster, topic, 100);
+            resetAndAssertOffsets(cluster, topic, args, 50);
+        }
     }
 
-    @ClusterTest
-    public void testResetOffsetsShiftByLowerThanEarliest() throws Exception {
-        String[] args = buildArgsForGroup(GROUP, "--all-topics", "--shift-by", "-150", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 1);
-        produceMessages(TOPIC, 100);
-        resetAndAssertOffsets(args, 0);
+    @ClusterTemplate("generator")
+    public void testResetOffsetsShiftByLowerThanEarliest(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
+
+            String[] args = buildArgsForGroup(cluster, group, "--all-topics", "--shift-by", "-150", "--execute");
+            produceConsumeAndShutdown(cluster, topic, group, 1, groupProtocol);
+            produceMessages(cluster, topic, 100);
+            resetAndAssertOffsets(cluster, topic, args, 0);
+        }
     }
 
-    @ClusterTest
-    public void testResetOffsetsShiftByHigherThanLatest() throws Exception {
-        String[] args = buildArgsForGroup(GROUP, "--all-topics", "--shift-by", "150", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 1);
-        produceMessages(TOPIC, 100);
-        resetAndAssertOffsets(args, 200);
+    @ClusterTemplate("generator")
+    public void testResetOffsetsShiftByHigherThanLatest(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
+
+            String[] args = buildArgsForGroup(cluster, group, "--all-topics", "--shift-by", "150", "--execute");
+            produceConsumeAndShutdown(cluster, topic, group, 1, groupProtocol);
+            produceMessages(cluster, topic, 100);
+            resetAndAssertOffsets(cluster, topic, args, 200);
+        }
     }
 
-    @ClusterTest
-    public void testResetOffsetsToEarliestOnOneTopic() throws Exception {
-        String[] args = buildArgsForGroup(GROUP, "--topic", TOPIC, "--to-earliest", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 1);
-        resetAndAssertOffsets(args, 0);
+    @ClusterTemplate("generator")
+    public void testResetOffsetsToEarliestOnOneTopic(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
+
+            String[] args = buildArgsForGroup(cluster, group, "--topic", topic, "--to-earliest", "--execute");
+            produceConsumeAndShutdown(cluster, topic, group, 1, groupProtocol);
+            resetAndAssertOffsets(cluster, topic, args, 0);
+        }
     }
 
-    @ClusterTest
-    public void testResetOffsetsToEarliestOnOneTopicAndPartition() throws Exception {
-        String topic = "bar";
-        try (Admin admin = cluster.createAdminClient()) {
-            admin.createTopics(singleton(new NewTopic(topic, 2, (short) 1))).all().get();
+    @ClusterTemplate("generator")
+    public void testResetOffsetsToEarliestOnOneTopicAndPartition(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
+            String[] args = buildArgsForGroup(cluster, group, "--topic", topic + ":1",
+                "--to-earliest", "--execute");
 
-            String[] args = buildArgsForGroup(GROUP, "--topic", topic + ":1", "--to-earliest", "--execute");
-            ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(args);
+            try (Admin admin = cluster.createAdminClient();
+                 ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(args)) {
+                admin.createTopics(singleton(new NewTopic(topic, 2, (short) 1))).all().get();
 
-            produceConsumeAndShutdown(topic, GROUP, 2);
-            Map<TopicPartition, Long> priorCommittedOffsets = committedOffsets(topic, GROUP);
+                produceConsumeAndShutdown(cluster, topic, group, 2, groupProtocol);
+                Map<TopicPartition, Long> priorCommittedOffsets = committedOffsets(cluster, topic, group);
+                TopicPartition tp0 = new TopicPartition(topic, 0);
+                TopicPartition tp1 = new TopicPartition(topic, 1);
+                Map<TopicPartition, Long> expectedOffsets = new HashMap<>();
+                expectedOffsets.put(tp0, priorCommittedOffsets.get(tp0));
+                expectedOffsets.put(tp1, 0L);
+                resetAndAssertOffsetsCommitted(cluster, service, expectedOffsets, topic);
+
+                admin.deleteTopics(singleton(topic)).all().get();
+            }
+        }
+    }
+
+    @ClusterTemplate("generator")
+    public void testResetOffsetsToEarliestOnTopics(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic1 = generateRandomTopic();
+            String topic2 = generateRandomTopic();
+            String[] args = buildArgsForGroup(cluster, group,
+                "--topic", topic1,
+                "--topic", topic2,
+                "--to-earliest", "--execute");
+
+            try (Admin admin = cluster.createAdminClient();
+                 ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(args)) {
+                admin.createTopics(asList(new NewTopic(topic1, 1, (short) 1),
+                        new NewTopic(topic2, 1, (short) 1))).all().get();
+
+                produceConsumeAndShutdown(cluster, topic1, group, 1, groupProtocol);
+                produceConsumeAndShutdown(cluster, topic2, group, 1, groupProtocol);
+
+                TopicPartition tp1 = new TopicPartition(topic1, 0);
+                TopicPartition tp2 = new TopicPartition(topic2, 0);
+
+                Map<TopicPartition, Long> allResetOffsets = toOffsetMap(resetOffsets(service).get(group));
+                Map<TopicPartition, Long> expMap = new HashMap<>();
+                expMap.put(tp1, 0L);
+                expMap.put(tp2, 0L);
+                assertEquals(expMap, allResetOffsets);
+                assertEquals(singletonMap(tp1, 0L), committedOffsets(cluster, topic1, group));
+                assertEquals(singletonMap(tp2, 0L), committedOffsets(cluster, topic2, group));
+
+                admin.deleteTopics(asList(topic1, topic2)).all().get();
+            }
+        }
+    }
+
+    @ClusterTemplate("generator")
+    public void testResetOffsetsToEarliestOnTopicsAndPartitions(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic1 = generateRandomTopic();
+            String topic2 = generateRandomTopic();
+            String[] args = buildArgsForGroup(cluster, group,
+                "--topic", topic1 + ":1",
+                "--topic", topic2 + ":1",
+                "--to-earliest", "--execute");
+
+            try (Admin admin = cluster.createAdminClient();
+                 ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(args)) {
+                admin.createTopics(asList(new NewTopic(topic1, 2, (short) 1),
+                        new NewTopic(topic2, 2, (short) 1))).all().get();
+
+                produceConsumeAndShutdown(cluster, topic1, group, 2, groupProtocol);
+                produceConsumeAndShutdown(cluster, topic2, group, 2, groupProtocol);
+
+                Map<TopicPartition, Long> priorCommittedOffsets1 =
+                        committedOffsets(cluster, topic1, group);
+                Map<TopicPartition, Long> priorCommittedOffsets2 =
+                        committedOffsets(cluster, topic2, group);
+
+                TopicPartition tp1 = new TopicPartition(topic1, 1);
+                TopicPartition tp2 = new TopicPartition(topic2, 1);
+                Map<TopicPartition, Long> allResetOffsets = toOffsetMap(resetOffsets(service).get(group));
+                Map<TopicPartition, Long> expMap = new HashMap<>();
+                expMap.put(tp1, 0L);
+                expMap.put(tp2, 0L);
+                assertEquals(expMap, allResetOffsets);
+                priorCommittedOffsets1.put(tp1, 0L);
+                assertEquals(priorCommittedOffsets1, committedOffsets(cluster, topic1, group));
+                priorCommittedOffsets2.put(tp2, 0L);
+                assertEquals(priorCommittedOffsets2, committedOffsets(cluster, topic2, group));
+
+                admin.deleteTopics(asList(topic1, topic2)).all().get();
+            }
+        }
+    }
+
+    @ClusterTemplate("generator")
+    // This one deals with old CSV export/import format for a single --group arg:
+    // "topic,partition,offset" to support old behavior
+    public void testResetOffsetsExportImportPlanSingleGroupArg(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group = generateRandomGroupId();
+            String topic = generateRandomTopic();
 
             TopicPartition tp0 = new TopicPartition(topic, 0);
             TopicPartition tp1 = new TopicPartition(topic, 1);
-            Map<TopicPartition, Long> expectedOffsets = new HashMap<>();
-            expectedOffsets.put(tp0, priorCommittedOffsets.get(tp0));
-            expectedOffsets.put(tp1, 0L);
-            resetAndAssertOffsetsCommitted(consumerGroupCommand, expectedOffsets, topic);
-
-            admin.deleteTopics(singleton(topic)).all().get();
-        }
-    }
-
-    @ClusterTest
-    public void testResetOffsetsToEarliestOnTopics() throws Exception {
-        String topic1 = "topic1";
-        String topic2 = "topic2";
-        try (Admin admin = cluster.createAdminClient()) {
-            admin.createTopics(asList(new NewTopic(topic1, 1, (short) 1),
-                    new NewTopic(topic2, 1, (short) 1))).all().get();
-
-            String[] args = buildArgsForGroup(GROUP, "--topic", topic1,
-                    "--topic", topic2,
-                    "--to-earliest", "--execute");
-            ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(args);
-
-            produceConsumeAndShutdown(topic1, GROUP, 1);
-            produceConsumeAndShutdown(topic2, GROUP, 1);
-
-            TopicPartition tp1 = new TopicPartition(topic1, 0);
-            TopicPartition tp2 = new TopicPartition(topic2, 0);
-
-            Map<TopicPartition, Long> allResetOffsets = toOffsetMap(resetOffsets(consumerGroupCommand).get(GROUP));
-            Map<TopicPartition, Long> expMap = new HashMap<>();
-            expMap.put(tp1, 0L);
-            expMap.put(tp2, 0L);
-            assertEquals(expMap, allResetOffsets);
-            assertEquals(singletonMap(tp1, 0L), committedOffsets(topic1, GROUP));
-            assertEquals(singletonMap(tp2, 0L), committedOffsets(topic2, GROUP));
-
-            admin.deleteTopics(asList(topic1, topic2)).all().get();
-        }
-    }
-
-    @ClusterTest
-    public void testResetOffsetsToEarliestOnTopicsAndPartitions() throws Exception {
-        String topic1 = "topic1";
-        String topic2 = "topic2";
-        try (Admin admin = cluster.createAdminClient()) {
-            admin.createTopics(asList(new NewTopic(topic1, 2, (short) 1),
-                    new NewTopic(topic2, 2, (short) 1))).all().get();
-
-            String[] args = buildArgsForGroup(GROUP,
-                    "--topic", topic1 + ":1",
-                    "--topic", topic2 + ":1",
-                    "--to-earliest", "--execute");
-            ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(args);
-
-            produceConsumeAndShutdown(topic1, GROUP, 2);
-            produceConsumeAndShutdown(topic2, GROUP, 2);
-
-            Map<TopicPartition, Long> priorCommittedOffsets1 = committedOffsets(topic1, GROUP);
-            Map<TopicPartition, Long> priorCommittedOffsets2 = committedOffsets(topic2, GROUP);
-
-            TopicPartition tp1 = new TopicPartition(topic1, 1);
-            TopicPartition tp2 = new TopicPartition(topic2, 1);
-            Map<TopicPartition, Long> allResetOffsets = toOffsetMap(resetOffsets(consumerGroupCommand).get(GROUP));
-            Map<TopicPartition, Long> expMap = new HashMap<>();
-            expMap.put(tp1, 0L);
-            expMap.put(tp2, 0L);
-            assertEquals(expMap, allResetOffsets);
-            priorCommittedOffsets1.put(tp1, 0L);
-            assertEquals(priorCommittedOffsets1, committedOffsets(topic1, GROUP));
-            priorCommittedOffsets2.put(tp2, 0L);
-            assertEquals(priorCommittedOffsets2, committedOffsets(topic2, GROUP));
-
-            admin.deleteTopics(asList(topic1, topic2)).all().get();
-        }
-    }
-
-    @ClusterTest
-    // This one deals with old CSV export/import format for a single --group arg:
-    // "topic,partition,offset" to support old behavior
-    public void testResetOffsetsExportImportPlanSingleGroupArg() throws Exception {
-        String topic = "bar";
-        TopicPartition tp0 = new TopicPartition(topic, 0);
-        TopicPartition tp1 = new TopicPartition(topic, 1);
-        Admin admin = cluster.createAdminClient();
-        admin.createTopics(singleton(new NewTopic(topic, 2, (short) 1))).all().get();
-
-        String[] cgcArgs = buildArgsForGroup(GROUP, "--all-topics", "--to-offset", "2", "--export");
-        ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(cgcArgs);
-
-        produceConsumeAndShutdown(topic, GROUP, 2);
-
-        File file = TestUtils.tempFile("reset", ".csv");
-
-        Map<String, Map<TopicPartition, OffsetAndMetadata>> exportedOffsets = consumerGroupCommand.resetOffsets();
-        BufferedWriter bw = new BufferedWriter(new FileWriter(file));
-        bw.write(consumerGroupCommand.exportOffsetsToCsv(exportedOffsets));
-        bw.close();
-
-        Map<TopicPartition, Long> exp1 = new HashMap<>();
-        exp1.put(tp0, 2L);
-        exp1.put(tp1, 2L);
-        assertEquals(exp1, toOffsetMap(exportedOffsets.get(GROUP)));
-
-        String[] cgcArgsExec = buildArgsForGroup(GROUP, "--all-topics",
+            String[] cgcArgs = buildArgsForGroup(cluster, group, "--all-topics", "--to-offset", "2", "--export");
+            File file = TestUtils.tempFile("reset", ".csv");
+            String[] cgcArgsExec = buildArgsForGroup(cluster, group, "--all-topics",
                 "--from-file", file.getCanonicalPath(), "--dry-run");
-        ConsumerGroupCommand.ConsumerGroupService consumerGroupCommandExec = getConsumerGroupService(cgcArgsExec);
-        Map<String, Map<TopicPartition, OffsetAndMetadata>> importedOffsets = consumerGroupCommandExec.resetOffsets();
-        assertEquals(exp1, toOffsetMap(importedOffsets.get(GROUP)));
 
-        admin.deleteTopics(singleton(topic));
+            try (Admin admin = cluster.createAdminClient();
+                 ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(cgcArgs);
+                 BufferedWriter bw = new BufferedWriter(new FileWriter(file));
+                 ConsumerGroupCommand.ConsumerGroupService serviceExec = getConsumerGroupService(cgcArgsExec)) {
+
+                admin.createTopics(singleton(new NewTopic(topic, 2, (short) 1))).all().get();
+                produceConsumeAndShutdown(cluster, topic, group, 2, groupProtocol);
+
+                Map<String, Map<TopicPartition, OffsetAndMetadata>> exportedOffsets = service.resetOffsets();
+
+                bw.write(service.exportOffsetsToCsv(exportedOffsets));
+                bw.close();
+
+                Map<TopicPartition, Long> exp1 = new HashMap<>();
+                exp1.put(tp0, 2L);
+                exp1.put(tp1, 2L);
+                assertEquals(exp1, toOffsetMap(exportedOffsets.get(group)));
+
+                Map<String, Map<TopicPartition, OffsetAndMetadata>> importedOffsets = serviceExec.resetOffsets();
+                assertEquals(exp1, toOffsetMap(importedOffsets.get(group)));
+
+                admin.deleteTopics(singleton(topic));
+            }
+        }
     }
 
-    @ClusterTest
+    @ClusterTemplate("generator")
     // This one deals with universal CSV export/import file format "group,topic,partition,offset",
     // supporting multiple --group args or --all-groups arg
-    public void testResetOffsetsExportImportPlan() throws Exception {
-        String group1 = GROUP + "1";
-        String group2 = GROUP + "2";
-        String topic1 = "bar1";
-        String topic2 = "bar2";
-        TopicPartition t1p0 = new TopicPartition(topic1, 0);
-        TopicPartition t1p1 = new TopicPartition(topic1, 1);
-        TopicPartition t2p0 = new TopicPartition(topic2, 0);
-        TopicPartition t2p1 = new TopicPartition(topic2, 1);
-        Admin admin = cluster.createAdminClient();
-        admin.createTopics(asList(new NewTopic(topic1, 2, (short) 1),
-                new NewTopic(topic2, 2, (short) 1))).all().get();
+    public void testResetOffsetsExportImportPlan(ClusterInstance cluster) throws Exception {
+        for (GroupProtocol groupProtocol : cluster.supportedGroupProtocols()) {
+            String group1 = generateRandomGroupId();
+            String group2 = generateRandomGroupId();
+            String topic1 = generateRandomTopic();
+            String topic2 = generateRandomTopic();
 
-
-        String[] cgcArgs = buildArgsForGroups(asList(group1, group2),
+            TopicPartition t1p0 = new TopicPartition(topic1, 0);
+            TopicPartition t1p1 = new TopicPartition(topic1, 1);
+            TopicPartition t2p0 = new TopicPartition(topic2, 0);
+            TopicPartition t2p1 = new TopicPartition(topic2, 1);
+            String[] cgcArgs = buildArgsForGroups(cluster, asList(group1, group2),
                 "--all-topics", "--to-offset", "2", "--export");
-        ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(cgcArgs);
-
-        produceConsumeAndShutdown(topic1, group1, 1);
-        produceConsumeAndShutdown(topic2, group2, 1);
-
-        awaitConsumerGroupInactive(consumerGroupCommand, group1);
-        awaitConsumerGroupInactive(consumerGroupCommand, group2);
-
-        File file = TestUtils.tempFile("reset", ".csv");
-
-        Map<String, Map<TopicPartition, OffsetAndMetadata>> exportedOffsets = consumerGroupCommand.resetOffsets();
-        BufferedWriter bw = new BufferedWriter(new FileWriter(file));
-        bw.write(consumerGroupCommand.exportOffsetsToCsv(exportedOffsets));
-        bw.close();
-        Map<TopicPartition, Long> exp1 = new HashMap<>();
-        exp1.put(t1p0, 2L);
-        exp1.put(t1p1, 2L);
-        Map<TopicPartition, Long> exp2 = new HashMap<>();
-        exp2.put(t2p0, 2L);
-        exp2.put(t2p1, 2L);
-
-        assertEquals(exp1, toOffsetMap(exportedOffsets.get(group1)));
-        assertEquals(exp2, toOffsetMap(exportedOffsets.get(group2)));
-
-        // Multiple --group's offset import
-        String[] cgcArgsExec = buildArgsForGroups(asList(group1, group2), "--all-topics",
+            File file = TestUtils.tempFile("reset", ".csv");
+            // Multiple --group's offset import
+            String[] cgcArgsExec = buildArgsForGroups(cluster, asList(group1, group2),
+                "--all-topics",
                 "--from-file", file.getCanonicalPath(), "--dry-run");
-        ConsumerGroupCommand.ConsumerGroupService consumerGroupCommandExec = getConsumerGroupService(cgcArgsExec);
-        Map<String, Map<TopicPartition, OffsetAndMetadata>> importedOffsets = consumerGroupCommandExec.resetOffsets();
-        assertEquals(exp1, toOffsetMap(importedOffsets.get(group1)));
-        assertEquals(exp2, toOffsetMap(importedOffsets.get(group2)));
-
-        // Single --group offset import using "group,topic,partition,offset" csv format
-        String[] cgcArgsExec2 = buildArgsForGroup(group1, "--all-topics",
+            // Single --group offset import using "group,topic,partition,offset" csv format
+            String[] cgcArgsExec2 = buildArgsForGroup(cluster, group1, "--all-topics",
                 "--from-file", file.getCanonicalPath(), "--dry-run");
-        ConsumerGroupCommand.ConsumerGroupService consumerGroupCommandExec2 = getConsumerGroupService(cgcArgsExec2);
-        Map<String, Map<TopicPartition, OffsetAndMetadata>> importedOffsets2 = consumerGroupCommandExec2.resetOffsets();
-        assertEquals(exp1, toOffsetMap(importedOffsets2.get(group1)));
 
-        admin.deleteTopics(asList(topic1, topic2));
+            try (Admin admin = cluster.createAdminClient();
+                 ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(cgcArgs);
+                 BufferedWriter bw = new BufferedWriter(new FileWriter(file));
+                 ConsumerGroupCommand.ConsumerGroupService serviceExec = getConsumerGroupService(cgcArgsExec);
+                 ConsumerGroupCommand.ConsumerGroupService serviceExec2 = getConsumerGroupService(cgcArgsExec2)) {
+
+                admin.createTopics(asList(new NewTopic(topic1, 2, (short) 1),
+                        new NewTopic(topic2, 2, (short) 1))).all().get();
+
+                produceConsumeAndShutdown(cluster, topic1, group1, 1, groupProtocol);
+                produceConsumeAndShutdown(cluster, topic2, group2, 1, groupProtocol);
+
+                awaitConsumerGroupInactive(service, group1);
+                awaitConsumerGroupInactive(service, group2);
+
+                Map<String, Map<TopicPartition, OffsetAndMetadata>> exportedOffsets = service.resetOffsets();
+                bw.write(service.exportOffsetsToCsv(exportedOffsets));
+                bw.close();
+
+                Map<TopicPartition, Long> exp1 = new HashMap<>();
+                exp1.put(t1p0, 2L);
+                exp1.put(t1p1, 2L);
+                Map<TopicPartition, Long> exp2 = new HashMap<>();
+                exp2.put(t2p0, 2L);
+                exp2.put(t2p1, 2L);
+
+                assertEquals(exp1, toOffsetMap(exportedOffsets.get(group1)));
+                assertEquals(exp2, toOffsetMap(exportedOffsets.get(group2)));
+
+                Map<String, Map<TopicPartition, OffsetAndMetadata>> importedOffsets = serviceExec.resetOffsets();
+                assertEquals(exp1, toOffsetMap(importedOffsets.get(group1)));
+                assertEquals(exp2, toOffsetMap(importedOffsets.get(group2)));
+
+                Map<String, Map<TopicPartition, OffsetAndMetadata>> importedOffsets2 = serviceExec2.resetOffsets();
+                assertEquals(exp1, toOffsetMap(importedOffsets2.get(group1)));
+
+                admin.deleteTopics(asList(topic1, topic2));
+            }
+        }
     }
 
-    @ClusterTest
-    public void testResetWithUnrecognizedNewConsumerOption() {
+    @ClusterTemplate("generator")
+    public void testResetWithUnrecognizedNewConsumerOption(ClusterInstance cluster) {
+        String group = generateRandomGroupId();
         String[] cgcArgs = new String[]{"--new-consumer",
             "--bootstrap-server", cluster.bootstrapServers(),
-            "--reset-offsets", "--group", GROUP, "--all-topics",
+            "--reset-offsets", "--group", group, "--all-topics",
             "--to-offset", "2", "--export"};
         assertThrows(OptionException.class, () -> getConsumerGroupService(cgcArgs));
     }
 
-    private Map<TopicPartition, Long> committedOffsets(String topic, String group) {
-        try (Consumer<String, String> consumer = createNoAutoCommitConsumer(group)) {
-            Set<TopicPartition> partitions = consumer.partitionsFor(topic)
-                    .stream()
-                    .map(partitionInfo -> new TopicPartition(partitionInfo.topic(), partitionInfo.partition()))
-                    .collect(Collectors.toSet());
-            return consumer.committed(partitions)
-                    .entrySet()
-                    .stream()
-                    .filter(e -> e.getValue() != null)
-                    .collect(toMap(Map.Entry::getKey, e -> e.getValue().offset()));
-        }
+    private String generateRandomTopic() {
+        return TOPIC_PREFIX + TestUtils.randomString(10);
     }
 
-    private Consumer<String, String> createNoAutoCommitConsumer(String group) {
-        Properties props = new Properties();
-        props.put(BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
-        props.put(GROUP_ID_CONFIG, group);
-        props.put(ENABLE_AUTO_COMMIT_CONFIG, "false");
-        return new KafkaConsumer<>(props, new StringDeserializer(), new StringDeserializer());
+    private String generateRandomGroupId() {
+        return GROUP_PREFIX + TestUtils.randomString(10);
+    }
+
+    private Map<TopicPartition, Long> committedOffsets(ClusterInstance cluster,
+                                                       String topic,
+                                                       String group) {
+        try (Admin admin = Admin.create(singletonMap(BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers()))) {
+            return admin.listConsumerGroupOffsets(group)
+                    .all().get()
+                    .get(group).entrySet()
+                    .stream()
+                    .filter(e -> e.getKey().topic().equals(topic))
+                    .collect(toMap(Map.Entry::getKey, e -> e.getValue().offset()));
+        } catch (ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private ConsumerGroupCommand.ConsumerGroupService getConsumerGroupService(String[] args) {
         return new ConsumerGroupCommand.ConsumerGroupService(
                 ConsumerGroupCommandOptions.fromArgs(args),
-                singletonMap(AdminClientConfig.RETRIES_CONFIG,
-                        Integer.toString(Integer.MAX_VALUE)));
+                singletonMap(RETRIES_CONFIG, Integer.toString(Integer.MAX_VALUE)));
     }
 
-    private void produceMessages(String topic, int numMessages) {
+    private void produceMessages(ClusterInstance cluster, String topic, int numMessages) {
         List<ProducerRecord<byte[], byte[]>> records = IntStream.range(0, numMessages)
                 .mapToObj(i -> new ProducerRecord<byte[], byte[]>(topic, new byte[100 * 1000]))
                 .collect(Collectors.toList());
-        produceMessages(records);
+        produceMessages(cluster, records);
     }
 
-    private void produceMessages(List<ProducerRecord<byte[], byte[]>> records) {
-        try (Producer<byte[], byte[]> producer = createProducer()) {
+    private void produceMessages(ClusterInstance cluster, List<ProducerRecord<byte[], byte[]>> records) {
+        try (Producer<byte[], byte[]> producer = createProducer(cluster)) {
             records.forEach(producer::send);
         }
     }
 
-    private Producer<byte[], byte[]> createProducer() {
+    private Producer<byte[], byte[]> createProducer(ClusterInstance cluster) {
         Properties props = new Properties();
         props.put(BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
         props.put(ACKS_CONFIG, "1");
@@ -593,20 +700,28 @@ public class ResetConsumerGroupOffsetTest {
         return new KafkaProducer<>(props);
     }
 
-    private void resetAndAssertOffsets(String[] args, long expectedOffset) {
-        resetAndAssertOffsets(args, expectedOffset, false, singletonList(TOPIC));
+    private void resetAndAssertOffsets(ClusterInstance cluster,
+                                       String topic,
+                                       String[] args,
+                                       long expectedOffset) {
+        resetAndAssertOffsets(cluster, args, expectedOffset, false, singletonList(topic));
     }
 
-    private void resetAndAssertOffsets(String[] args, long expectedOffset, boolean dryRun, List<String> topics) {
-        try (ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(args)) {
+    private void resetAndAssertOffsets(ClusterInstance cluster,
+                                       String[] args,
+                                       long expectedOffset,
+                                       boolean dryRun,
+                                       List<String> topics) {
+        try (ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(args)) {
             Map<String, Map<TopicPartition, Long>> topicToExpectedOffsets = getTopicExceptOffsets(topics, expectedOffset);
             Map<String, Map<TopicPartition, OffsetAndMetadata>> resetOffsetsResultByGroup =
-                    resetOffsets(consumerGroupCommand);
+                    resetOffsets(service);
             for (final String topic : topics) {
                 resetOffsetsResultByGroup.forEach((group, partitionInfo) -> {
-                    Map<TopicPartition, Long> priorOffsets = committedOffsets(topic, group);
+                    Map<TopicPartition, Long> priorOffsets = committedOffsets(cluster, topic, group);
                     assertEquals(topicToExpectedOffsets.get(topic), partitionToOffsets(topic, partitionInfo));
-                    assertEquals(dryRun ? priorOffsets : topicToExpectedOffsets.get(topic), committedOffsets(topic, group));
+                    assertEquals(dryRun ? priorOffsets : topicToExpectedOffsets.get(topic),
+                            committedOffsets(cluster, topic, group));
                 });
             }
         }
@@ -634,23 +749,29 @@ public class ResetConsumerGroupOffsetTest {
     }
 
     private static List<String> generateIds(String name) {
-        return IntStream.rangeClosed(1, 3)
+        return IntStream.rangeClosed(1, 2)
                 .mapToObj(id -> name + id)
                 .collect(Collectors.toList());
     }
 
-    private void produceConsumeAndShutdown(String topic, String group, int numConsumers) throws Exception {
-        produceMessages(topic, 100);
-        try (AutoCloseable ignored = addConsumerGroupExecutor(numConsumers, topic, group, GroupProtocol.CLASSIC.name)) {
-            awaitConsumerProgress(topic, group, 100);
+    private void produceConsumeAndShutdown(ClusterInstance cluster,
+                                           String topic,
+                                           String group,
+                                           int numConsumers,
+                                           GroupProtocol groupProtocol) throws Exception {
+        produceMessages(cluster, topic, 100);
+        try (AutoCloseable consumerGroupCloseable =
+                     consumerGroupClosable(cluster, numConsumers, topic, group, groupProtocol)) {
+            awaitConsumerProgress(cluster, topic, group, 100);
         }
     }
 
-    private AutoCloseable addConsumerGroupExecutor(int numConsumers,
-                                                   String topic,
-                                                   String group,
-                                                   String groupProtocol) {
-        Map<String, Object> configs = composeConsumerConfigs(group, groupProtocol);
+    private AutoCloseable consumerGroupClosable(ClusterInstance cluster,
+                                                int numConsumers,
+                                                String topic,
+                                                String group,
+                                                GroupProtocol groupProtocol) {
+        Map<String, Object> configs = composeConsumerConfigs(cluster, group, groupProtocol);
         return ConsumerGroupCommandTestUtils.buildConsumers(
                 numConsumers,
                 false,
@@ -658,59 +779,55 @@ public class ResetConsumerGroupOffsetTest {
                 () -> new KafkaConsumer<String, String>(configs));
     }
 
-    private Map<String, Object> composeConsumerConfigs(String group, String groupProtocol) {
+    private Map<String, Object> composeConsumerConfigs(ClusterInstance cluster,
+                                                       String group,
+                                                       GroupProtocol groupProtocol) {
         HashMap<String, Object> configs = new HashMap<>();
         configs.put(BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
         configs.put(GROUP_ID_CONFIG, group);
-        configs.put(GROUP_PROTOCOL_CONFIG, groupProtocol);
+        configs.put(GROUP_PROTOCOL_CONFIG, groupProtocol.name);
         configs.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         configs.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         configs.put(PARTITION_ASSIGNMENT_STRATEGY_CONFIG, RangeAssignor.class.getName());
         return configs;
     }
 
-    private void awaitConsumerProgress(String topic, String group, long count) throws Exception {
-        try (Consumer<String, String> consumer = createNoAutoCommitConsumer(group)) {
-            Set<TopicPartition> partitions = consumer.partitionsFor(topic)
-                    .stream()
-                    .map(partitionInfo -> new TopicPartition(partitionInfo.topic(), partitionInfo.partition()))
-                    .collect(Collectors.toSet());
-
-            TestUtils.waitForCondition(() -> {
-                Collection<OffsetAndMetadata> committed = consumer.committed(partitions).values();
-                long total = committed.stream()
-                        .mapToLong(offsetAndMetadata -> Optional.ofNullable(offsetAndMetadata)
-                                .map(OffsetAndMetadata::offset)
-                                .orElse(0L)).sum();
-                return total == count;
-            }, "Expected that consumer group has consumed all messages from topic/partition. " +
-                    "Expected offset: " + count +
-                    ". Actual offset: " +
-                    committedOffsets(topic, group).values().stream().mapToLong(Long::longValue).sum());
-        }
+    private void awaitConsumerProgress(ClusterInstance cluster,
+                                       String topic,
+                                       String group,
+                                       long count) throws Exception {
+        TestUtils.waitForCondition(() -> committedOffsets(cluster, topic, group)
+                        .values()
+                        .stream()
+                        .mapToLong(l -> l).sum() == count,
+                "Expected that consumer group has consumed all messages from topic/partition. " +
+                        "Expected offset: " + count +
+                        ". Actual offset: " + committedOffsets(cluster, topic, group).values()
+                        .stream().mapToLong(l -> l).sum());
     }
 
-    private void awaitConsumerGroupInactive(ConsumerGroupCommand.ConsumerGroupService consumerGroupService,
+    private void awaitConsumerGroupInactive(ConsumerGroupCommand.ConsumerGroupService service,
                                             String group) throws Exception {
         TestUtils.waitForCondition(() -> {
-            ConsumerGroupState state = consumerGroupService.collectGroupState(group).state;
+            ConsumerGroupState state = service.collectGroupState(group).state;
             return Objects.equals(state, ConsumerGroupState.EMPTY) || Objects.equals(state, ConsumerGroupState.DEAD);
         }, "Expected that consumer group is inactive. Actual state: " +
-                consumerGroupService.collectGroupState(group).state);
+                service.collectGroupState(group).state);
     }
 
-    private void resetAndAssertOffsetsCommitted(ConsumerGroupCommand.ConsumerGroupService consumerGroupService,
+    private void resetAndAssertOffsetsCommitted(ClusterInstance cluster,
+                                                ConsumerGroupCommand.ConsumerGroupService service,
                                                 Map<TopicPartition, Long> expectedOffsets,
                                                 String topic) {
-        Map<String, Map<TopicPartition, OffsetAndMetadata>> allResetOffsets = resetOffsets(consumerGroupService);
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> allResetOffsets = resetOffsets(service);
 
         allResetOffsets.forEach((group, offsetsInfo) -> offsetsInfo.forEach((tp, offsetMetadata) -> {
             assertEquals(offsetMetadata.offset(), expectedOffsets.get(tp));
-            assertEquals(expectedOffsets, committedOffsets(topic, group));
+            assertEquals(expectedOffsets, committedOffsets(cluster, topic, group));
         }));
     }
 
-    Map<TopicPartition, Long> toOffsetMap(Map<TopicPartition, OffsetAndMetadata> map) {
+    private Map<TopicPartition, Long> toOffsetMap(Map<TopicPartition, OffsetAndMetadata> map) {
         return map.entrySet()
                 .stream()
                 .collect(toMap(Map.Entry::getKey, e -> e.getValue().offset()));

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ResetConsumerGroupOffsetTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ResetConsumerGroupOffsetTest.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.tools.consumer.group;
 
 import joptsimple.OptionException;
-import kafka.test.ClusterGenerator;
+import kafka.test.ClusterConfig;
 import kafka.test.ClusterInstance;
 import kafka.test.annotation.ClusterTemplate;
 import kafka.test.junit.ClusterTestExtensions;
@@ -92,8 +92,8 @@ public class ResetConsumerGroupOffsetTest {
     private static final String TOPIC_PREFIX = "foo-";
     private static final String GROUP_PREFIX = "test.group-";
 
-    private static void generator(ClusterGenerator clusterGenerator) {
-        ConsumerGroupCommandTestUtils.generator(clusterGenerator);
+    private static List<ClusterConfig> generator() {
+        return ConsumerGroupCommandTestUtils.generator();
     }
 
     private String[] basicArgs(ClusterInstance cluster) {

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ResetConsumerGroupOffsetTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ResetConsumerGroupOffsetTest.java
@@ -23,6 +23,7 @@ import kafka.test.annotation.ClusterTemplate;
 import kafka.test.junit.ClusterTestExtensions;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.GroupProtocol;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -63,6 +64,7 @@ import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.admin.AdminClientConfig.RETRIES_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_PROTOCOL_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
@@ -71,6 +73,7 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZE
 import static org.apache.kafka.clients.producer.ProducerConfig.ACKS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG;
 import static org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -789,6 +792,8 @@ public class ResetConsumerGroupOffsetTest {
         configs.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         configs.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         configs.put(PARTITION_ASSIGNMENT_STRATEGY_CONFIG, RangeAssignor.class.getName());
+        configs.put(AUTO_COMMIT_INTERVAL_MS_CONFIG, 1000);
+        configs.put(GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, 1000);
         return configs;
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ResetConsumerGroupOffsetTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ResetConsumerGroupOffsetTest.java
@@ -17,25 +17,41 @@
 package org.apache.kafka.tools.consumer.group;
 
 import joptsimple.OptionException;
+import kafka.test.ClusterInstance;
+import kafka.test.annotation.ClusterConfigProperty;
+import kafka.test.annotation.ClusterTest;
+import kafka.test.annotation.ClusterTestDefaults;
+import kafka.test.annotation.Type;
+import kafka.test.junit.ClusterTestExtensions;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.GroupProtocol;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.RangeAssignor;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.ConsumerGroupState;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.test.TestUtils;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,10 +59,29 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static java.time.LocalDateTime.now;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toMap;
+import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_PROTOCOL_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.ACKS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG;
+import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG;
 import static org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -62,100 +97,122 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * - scope=topics+partitions, scenario=to-earliest
  * - export/import
  */
-public class ResetConsumerGroupOffsetTest extends ConsumerGroupCommandTest {
+@ExtendWith(value = ClusterTestExtensions.class)
+@ClusterTestDefaults(clusterType = Type.ALL, serverProperties = {
+        @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+        @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1")})
+@Tag("integration")
+public class ResetConsumerGroupOffsetTest {
+
+    private static final String TOPIC = "foo";
+    private static final String GROUP = "test.group";
+    private final ClusterInstance cluster;
+
+    public ResetConsumerGroupOffsetTest(ClusterInstance cluster) {
+        this.cluster = cluster;
+    }
+
+    @AfterEach
+    public void stopCluster() {
+        cluster.stop();
+    }
+
     private String[] basicArgs() {
         return new String[]{"--reset-offsets",
-            "--bootstrap-server", bootstrapServers(listenerName()),
+            "--bootstrap-server", cluster.bootstrapServers(),
             "--timeout", Long.toString(DEFAULT_MAX_WAIT_MS)};
     }
 
-    private String[] buildArgsForGroups(List<String> groups, String...args) {
-        List<String> res = new ArrayList<>(Arrays.asList(basicArgs()));
+    private String[] buildArgsForGroups(List<String> groups, String... args) {
+        List<String> res = new ArrayList<>(asList(basicArgs()));
         for (String group : groups) {
             res.add("--group");
             res.add(group);
         }
-        res.addAll(Arrays.asList(args));
+        res.addAll(asList(args));
         return res.toArray(new String[0]);
     }
 
-    private String[] buildArgsForGroup(String group, String...args) {
-        return buildArgsForGroups(Collections.singletonList(group), args);
+    private String[] buildArgsForGroup(String group, String... args) {
+        return buildArgsForGroups(singletonList(group), args);
     }
 
-    private String[] buildArgsForAllGroups(String...args) {
-        List<String> res = new ArrayList<>(Arrays.asList(basicArgs()));
+    private String[] buildArgsForAllGroups(String... args) {
+        List<String> res = new ArrayList<>(asList(basicArgs()));
         res.add("--all-groups");
-        res.addAll(Arrays.asList(args));
+        res.addAll(asList(args));
         return res.toArray(new String[0]);
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsNotExistingGroup() throws Exception {
         String group = "missing.group";
         String[] args = buildArgsForGroup(group, "--all-topics", "--to-current", "--execute");
         ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(args);
         // Make sure we got a coordinator
         TestUtils.waitForCondition(
-            () -> Objects.equals(consumerGroupCommand.collectGroupState(group).coordinator.host(), "localhost"),
-            "Can't find a coordinator");
+                () -> "localhost".equals(consumerGroupCommand.collectGroupState(group).coordinator.host()),
+                "Can't find a coordinator");
         Map<TopicPartition, OffsetAndMetadata> resetOffsets = consumerGroupCommand.resetOffsets().get(group);
         assertTrue(resetOffsets.isEmpty());
         assertTrue(committedOffsets(TOPIC, group).isEmpty());
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsExistingTopic() {
         String group = "new.group";
         String[] args = buildArgsForGroup(group, "--topic", TOPIC, "--to-offset", "50");
         produceMessages(TOPIC, 100);
-        resetAndAssertOffsets(args, 50, true, Collections.singletonList(TOPIC));
-        resetAndAssertOffsets(addTo(args, "--dry-run"), 50, true, Collections.singletonList(TOPIC));
-        resetAndAssertOffsets(addTo(args, "--execute"), 50, false, Collections.singletonList(TOPIC));
+        resetAndAssertOffsets(args, 50, true, singletonList(TOPIC));
+        resetAndAssertOffsets(addTo(args, "--dry-run"), 50, true, singletonList(TOPIC));
+        resetAndAssertOffsets(addTo(args, "--execute"), 50, false, singletonList(TOPIC));
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsExistingTopicSelectedGroups() throws Exception {
         produceMessages(TOPIC, 100);
-        List<String> groups = IntStream.rangeClosed(1, 3).mapToObj(id -> GROUP + id).collect(Collectors.toList());
+        List<String> groups = generateIds(GROUP);
         for (String group : groups) {
-            ConsumerGroupExecutor executor = addConsumerGroupExecutor(1, TOPIC, group, GroupProtocol.CLASSIC.name);
-            awaitConsumerProgress(TOPIC, group, 100L);
-            executor.shutdown();
+            try (AutoCloseable ignored =
+                         addConsumerGroupExecutor(1, TOPIC, group, GroupProtocol.CLASSIC.name)) {
+                awaitConsumerProgress(TOPIC, group, 100L);
+            }
         }
         String[] args = buildArgsForGroups(groups, "--topic", TOPIC, "--to-offset", "50");
-        resetAndAssertOffsets(args, 50, true, Collections.singletonList(TOPIC));
-        resetAndAssertOffsets(addTo(args, "--dry-run"), 50, true, Collections.singletonList(TOPIC));
-        resetAndAssertOffsets(addTo(args, "--execute"), 50, false, Collections.singletonList(TOPIC));
+        resetAndAssertOffsets(args, 50, true, singletonList(TOPIC));
+        resetAndAssertOffsets(addTo(args, "--dry-run"), 50, true, singletonList(TOPIC));
+        resetAndAssertOffsets(addTo(args, "--execute"), 50, false, singletonList(TOPIC));
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsExistingTopicAllGroups() throws Exception {
         String[] args = buildArgsForAllGroups("--topic", TOPIC, "--to-offset", "50");
         produceMessages(TOPIC, 100);
         for (int i = 1; i <= 3; i++) {
             String group = GROUP + i;
-            ConsumerGroupExecutor executor = addConsumerGroupExecutor(1, TOPIC, group, GroupProtocol.CLASSIC.name);
-            awaitConsumerProgress(TOPIC, group, 100L);
-            executor.shutdown();
+            try (AutoCloseable ignored =
+                         addConsumerGroupExecutor(1, TOPIC, group, GroupProtocol.CLASSIC.name)) {
+                awaitConsumerProgress(TOPIC, group, 100L);
+            }
         }
-        resetAndAssertOffsets(args, 50, true, Collections.singletonList(TOPIC));
-        resetAndAssertOffsets(addTo(args, "--dry-run"), 50, true, Collections.singletonList(TOPIC));
-        resetAndAssertOffsets(addTo(args, "--execute"), 50, false, Collections.singletonList(TOPIC));
+        resetAndAssertOffsets(args, 50, true, singletonList(TOPIC));
+        resetAndAssertOffsets(addTo(args, "--dry-run"), 50, true, singletonList(TOPIC));
+        resetAndAssertOffsets(addTo(args, "--execute"), 50, false, singletonList(TOPIC));
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsAllTopicsAllGroups() throws Exception {
         String[] args = buildArgsForAllGroups("--all-topics", "--to-offset", "50");
-        List<String> topics = IntStream.rangeClosed(1, 3).mapToObj(i -> TOPIC + i).collect(Collectors.toList());
-        List<String> groups = IntStream.rangeClosed(1, 3).mapToObj(i -> GROUP + i).collect(Collectors.toList());
+        List<String> topics = generateIds(TOPIC);
+        List<String> groups = generateIds(GROUP);
         topics.forEach(topic -> produceMessages(topic, 100));
 
         for (String topic : topics) {
             for (String group : groups) {
-                ConsumerGroupExecutor executor = addConsumerGroupExecutor(3, topic, group, GroupProtocol.CLASSIC.name);
-                awaitConsumerProgress(topic, group, 100);
-                executor.shutdown();
+                try (AutoCloseable ignored =
+                             addConsumerGroupExecutor(3, topic, group, GroupProtocol.CLASSIC.name)) {
+                    awaitConsumerProgress(topic, group, 100);
+                }
             }
         }
         resetAndAssertOffsets(args, 50, true, topics);
@@ -163,225 +220,236 @@ public class ResetConsumerGroupOffsetTest extends ConsumerGroupCommandTest {
         resetAndAssertOffsets(addTo(args, "--execute"), 50, false, topics);
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsToLocalDateTime() throws Exception {
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
-        Calendar calendar = Calendar.getInstance();
-        calendar.add(Calendar.DATE, -1);
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+        LocalDateTime dateTime = now().minusDays(1);
 
         produceMessages(TOPIC, 100);
 
-        ConsumerGroupExecutor executor = addConsumerGroupExecutor(1, TOPIC, GROUP, GroupProtocol.CLASSIC.name);
-        awaitConsumerProgress(TOPIC, GROUP, 100L);
-        executor.shutdown();
+        try (AutoCloseable ignored = addConsumerGroupExecutor(1, TOPIC, GROUP, GroupProtocol.CLASSIC.name)) {
+            awaitConsumerProgress(TOPIC, GROUP, 100L);
+        }
 
-        String[] args = buildArgsForGroup(GROUP, "--all-topics", "--to-datetime", format.format(calendar.getTime()), "--execute");
+        String[] args = buildArgsForGroup(GROUP, "--all-topics", "--to-datetime", format.format(dateTime), "--execute");
         resetAndAssertOffsets(args, 0);
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsToZonedDateTime() throws Exception {
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 
         produceMessages(TOPIC, 50);
-        Date checkpoint = new Date();
+        ZonedDateTime checkpoint = now().atZone(ZoneId.systemDefault());
         produceMessages(TOPIC, 50);
-
-        ConsumerGroupExecutor executor = addConsumerGroupExecutor(1, TOPIC, GROUP, GroupProtocol.CLASSIC.name);
-        awaitConsumerProgress(TOPIC, GROUP, 100L);
-        executor.shutdown();
-
-        String[] args = buildArgsForGroup(GROUP, "--all-topics", "--to-datetime", format.format(checkpoint), "--execute");
+        try (AutoCloseable ignored = addConsumerGroupExecutor(1, TOPIC, GROUP, GroupProtocol.CLASSIC.name)) {
+            awaitConsumerProgress(TOPIC, GROUP, 100L);
+        }
+        String[] args = buildArgsForGroup(GROUP,
+                "--all-topics", "--to-datetime", format.format(checkpoint),
+                "--execute");
         resetAndAssertOffsets(args, 50);
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsByDuration() throws Exception {
         String[] args = buildArgsForGroup(GROUP, "--all-topics", "--by-duration", "PT1M", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 100, 1);
+        produceConsumeAndShutdown(TOPIC, GROUP, 1);
         resetAndAssertOffsets(args, 0);
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsByDurationToEarliest() throws Exception {
         String[] args = buildArgsForGroup(GROUP, "--all-topics", "--by-duration", "PT0.1S", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 100, 1);
+        produceConsumeAndShutdown(TOPIC, GROUP, 1);
         resetAndAssertOffsets(args, 100);
     }
 
-    @Test
-    public void testResetOffsetsByDurationFallbackToLatestWhenNoRecords() {
+    @ClusterTest
+    public void testResetOffsetsByDurationFallbackToLatestWhenNoRecords() throws ExecutionException, InterruptedException {
         String topic = "foo2";
         String[] args = buildArgsForGroup(GROUP, "--topic", topic, "--by-duration", "PT1M", "--execute");
-        createTopic(topic, 1, 1, new Properties(), listenerName(), new Properties());
-        resetAndAssertOffsets(args, 0, false, Collections.singletonList("foo2"));
 
-        adminZkClient().deleteTopic(topic);
+        try (Admin admin = cluster.createAdminClient()) {
+            admin.createTopics(singleton(new NewTopic(topic, 1, (short) 1))).all().get();
+            resetAndAssertOffsets(args, 0, false, singletonList("foo2"));
+            admin.deleteTopics(singleton(topic)).all().get();
+        }
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsToEarliest() throws Exception {
         String[] args = buildArgsForGroup(GROUP, "--all-topics", "--to-earliest", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 100, 1);
+        produceConsumeAndShutdown(TOPIC, GROUP, 1);
         resetAndAssertOffsets(args, 0);
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsToLatest() throws Exception {
         String[] args = buildArgsForGroup(GROUP, "--all-topics", "--to-latest", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 100, 1);
+        produceConsumeAndShutdown(TOPIC, GROUP, 1);
         produceMessages(TOPIC, 100);
         resetAndAssertOffsets(args, 200);
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsToCurrentOffset() throws Exception {
         String[] args = buildArgsForGroup(GROUP, "--all-topics", "--to-current", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 100, 1);
+        produceConsumeAndShutdown(TOPIC, GROUP, 1);
         produceMessages(TOPIC, 100);
         resetAndAssertOffsets(args, 100);
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsToSpecificOffset() throws Exception {
         String[] args = buildArgsForGroup(GROUP, "--all-topics", "--to-offset", "1", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 100, 1);
+        produceConsumeAndShutdown(TOPIC, GROUP, 1);
         resetAndAssertOffsets(args, 1);
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsShiftPlus() throws Exception {
         String[] args = buildArgsForGroup(GROUP, "--all-topics", "--shift-by", "50", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 100, 1);
+        produceConsumeAndShutdown(TOPIC, GROUP, 1);
         produceMessages(TOPIC, 100);
         resetAndAssertOffsets(args, 150);
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsShiftMinus() throws Exception {
         String[] args = buildArgsForGroup(GROUP, "--all-topics", "--shift-by", "-50", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 100, 1);
+        produceConsumeAndShutdown(TOPIC, GROUP, 1);
         produceMessages(TOPIC, 100);
         resetAndAssertOffsets(args, 50);
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsShiftByLowerThanEarliest() throws Exception {
         String[] args = buildArgsForGroup(GROUP, "--all-topics", "--shift-by", "-150", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 100, 1);
+        produceConsumeAndShutdown(TOPIC, GROUP, 1);
         produceMessages(TOPIC, 100);
         resetAndAssertOffsets(args, 0);
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsShiftByHigherThanLatest() throws Exception {
         String[] args = buildArgsForGroup(GROUP, "--all-topics", "--shift-by", "150", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 100, 1);
+        produceConsumeAndShutdown(TOPIC, GROUP, 1);
         produceMessages(TOPIC, 100);
         resetAndAssertOffsets(args, 200);
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsToEarliestOnOneTopic() throws Exception {
         String[] args = buildArgsForGroup(GROUP, "--topic", TOPIC, "--to-earliest", "--execute");
-        produceConsumeAndShutdown(TOPIC, GROUP, 100, 1);
+        produceConsumeAndShutdown(TOPIC, GROUP, 1);
         resetAndAssertOffsets(args, 0);
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsToEarliestOnOneTopicAndPartition() throws Exception {
         String topic = "bar";
-        createTopic(topic, 2, 1, new Properties(), listenerName(), new Properties());
+        try (Admin admin = cluster.createAdminClient()) {
+            admin.createTopics(singleton(new NewTopic(topic, 2, (short) 1))).all().get();
 
-        String[] args = buildArgsForGroup(GROUP, "--topic", topic + ":1", "--to-earliest", "--execute");
-        ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(args);
+            String[] args = buildArgsForGroup(GROUP, "--topic", topic + ":1", "--to-earliest", "--execute");
+            ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(args);
 
-        produceConsumeAndShutdown(topic, GROUP, 100, 2);
-        Map<TopicPartition, Long> priorCommittedOffsets = committedOffsets(topic, GROUP);
+            produceConsumeAndShutdown(topic, GROUP, 2);
+            Map<TopicPartition, Long> priorCommittedOffsets = committedOffsets(topic, GROUP);
 
-        TopicPartition tp0 = new TopicPartition(topic, 0);
-        TopicPartition tp1 = new TopicPartition(topic, 1);
-        Map<TopicPartition, Long> expectedOffsets = new HashMap<>();
-        expectedOffsets.put(tp0, priorCommittedOffsets.get(tp0));
-        expectedOffsets.put(tp1, 0L);
-        resetAndAssertOffsetsCommitted(consumerGroupCommand, expectedOffsets, topic);
+            TopicPartition tp0 = new TopicPartition(topic, 0);
+            TopicPartition tp1 = new TopicPartition(topic, 1);
+            Map<TopicPartition, Long> expectedOffsets = new HashMap<>();
+            expectedOffsets.put(tp0, priorCommittedOffsets.get(tp0));
+            expectedOffsets.put(tp1, 0L);
+            resetAndAssertOffsetsCommitted(consumerGroupCommand, expectedOffsets, topic);
 
-        adminZkClient().deleteTopic(topic);
+            admin.deleteTopics(singleton(topic)).all().get();
+        }
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsToEarliestOnTopics() throws Exception {
         String topic1 = "topic1";
         String topic2 = "topic2";
-        createTopic(topic1, 1, 1, new Properties(), listenerName(), new Properties());
-        createTopic(topic2, 1, 1, new Properties(), listenerName(), new Properties());
+        try (Admin admin = cluster.createAdminClient()) {
+            admin.createTopics(asList(new NewTopic(topic1, 1, (short) 1),
+                    new NewTopic(topic2, 1, (short) 1))).all().get();
 
-        String[] args = buildArgsForGroup(GROUP, "--topic", topic1, "--topic", topic2, "--to-earliest", "--execute");
-        ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(args);
+            String[] args = buildArgsForGroup(GROUP, "--topic", topic1,
+                    "--topic", topic2,
+                    "--to-earliest", "--execute");
+            ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(args);
 
-        produceConsumeAndShutdown(topic1, GROUP, 100, 1);
-        produceConsumeAndShutdown(topic2, GROUP, 100, 1);
+            produceConsumeAndShutdown(topic1, GROUP, 1);
+            produceConsumeAndShutdown(topic2, GROUP, 1);
 
-        TopicPartition tp1 = new TopicPartition(topic1, 0);
-        TopicPartition tp2 = new TopicPartition(topic2, 0);
+            TopicPartition tp1 = new TopicPartition(topic1, 0);
+            TopicPartition tp2 = new TopicPartition(topic2, 0);
 
-        Map<TopicPartition, Long> allResetOffsets = toOffsetMap(resetOffsets(consumerGroupCommand).get(GROUP));
-        Map<TopicPartition, Long> expMap = new HashMap<>();
-        expMap.put(tp1, 0L);
-        expMap.put(tp2, 0L);
-        assertEquals(expMap, allResetOffsets);
-        assertEquals(Collections.singletonMap(tp1, 0L), committedOffsets(topic1, GROUP));
-        assertEquals(Collections.singletonMap(tp2, 0L), committedOffsets(topic2, GROUP));
+            Map<TopicPartition, Long> allResetOffsets = toOffsetMap(resetOffsets(consumerGroupCommand).get(GROUP));
+            Map<TopicPartition, Long> expMap = new HashMap<>();
+            expMap.put(tp1, 0L);
+            expMap.put(tp2, 0L);
+            assertEquals(expMap, allResetOffsets);
+            assertEquals(singletonMap(tp1, 0L), committedOffsets(topic1, GROUP));
+            assertEquals(singletonMap(tp2, 0L), committedOffsets(topic2, GROUP));
 
-        adminZkClient().deleteTopic(topic1);
-        adminZkClient().deleteTopic(topic2);
+            admin.deleteTopics(asList(topic1, topic2)).all().get();
+        }
     }
 
-    @Test
+    @ClusterTest
     public void testResetOffsetsToEarliestOnTopicsAndPartitions() throws Exception {
         String topic1 = "topic1";
         String topic2 = "topic2";
+        try (Admin admin = cluster.createAdminClient()) {
+            admin.createTopics(asList(new NewTopic(topic1, 2, (short) 1),
+                    new NewTopic(topic2, 2, (short) 1))).all().get();
 
-        createTopic(topic1, 2, 1, new Properties(), listenerName(), new Properties());
-        createTopic(topic2, 2, 1, new Properties(), listenerName(), new Properties());
+            String[] args = buildArgsForGroup(GROUP,
+                    "--topic", topic1 + ":1",
+                    "--topic", topic2 + ":1",
+                    "--to-earliest", "--execute");
+            ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(args);
 
-        String[] args = buildArgsForGroup(GROUP, "--topic", topic1 + ":1", "--topic", topic2 + ":1", "--to-earliest", "--execute");
-        ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(args);
+            produceConsumeAndShutdown(topic1, GROUP, 2);
+            produceConsumeAndShutdown(topic2, GROUP, 2);
 
-        produceConsumeAndShutdown(topic1, GROUP, 100, 2);
-        produceConsumeAndShutdown(topic2, GROUP, 100, 2);
+            Map<TopicPartition, Long> priorCommittedOffsets1 = committedOffsets(topic1, GROUP);
+            Map<TopicPartition, Long> priorCommittedOffsets2 = committedOffsets(topic2, GROUP);
 
-        Map<TopicPartition, Long> priorCommittedOffsets1 = committedOffsets(topic1, GROUP);
-        Map<TopicPartition, Long> priorCommittedOffsets2 = committedOffsets(topic2, GROUP);
+            TopicPartition tp1 = new TopicPartition(topic1, 1);
+            TopicPartition tp2 = new TopicPartition(topic2, 1);
+            Map<TopicPartition, Long> allResetOffsets = toOffsetMap(resetOffsets(consumerGroupCommand).get(GROUP));
+            Map<TopicPartition, Long> expMap = new HashMap<>();
+            expMap.put(tp1, 0L);
+            expMap.put(tp2, 0L);
+            assertEquals(expMap, allResetOffsets);
+            priorCommittedOffsets1.put(tp1, 0L);
+            assertEquals(priorCommittedOffsets1, committedOffsets(topic1, GROUP));
+            priorCommittedOffsets2.put(tp2, 0L);
+            assertEquals(priorCommittedOffsets2, committedOffsets(topic2, GROUP));
 
-        TopicPartition tp1 = new TopicPartition(topic1, 1);
-        TopicPartition tp2 = new TopicPartition(topic2, 1);
-        Map<TopicPartition, Long> allResetOffsets = toOffsetMap(resetOffsets(consumerGroupCommand).get(GROUP));
-        Map<TopicPartition, Long> expMap = new HashMap<>();
-        expMap.put(tp1, 0L);
-        expMap.put(tp2, 0L);
-        assertEquals(expMap, allResetOffsets);
-        priorCommittedOffsets1.put(tp1, 0L);
-        assertEquals(priorCommittedOffsets1, committedOffsets(topic1, GROUP));
-        priorCommittedOffsets2.put(tp2, 0L);
-        assertEquals(priorCommittedOffsets2, committedOffsets(topic2, GROUP));
-
-        adminZkClient().deleteTopic(topic1);
-        adminZkClient().deleteTopic(topic2);
+            admin.deleteTopics(asList(topic1, topic2)).all().get();
+        }
     }
 
-    @Test
-    // This one deals with old CSV export/import format for a single --group arg: "topic,partition,offset" to support old behavior
+    @ClusterTest
+    // This one deals with old CSV export/import format for a single --group arg:
+    // "topic,partition,offset" to support old behavior
     public void testResetOffsetsExportImportPlanSingleGroupArg() throws Exception {
         String topic = "bar";
         TopicPartition tp0 = new TopicPartition(topic, 0);
         TopicPartition tp1 = new TopicPartition(topic, 1);
-        createTopic(topic, 2, 1, new Properties(), listenerName(), new Properties());
+        Admin admin = cluster.createAdminClient();
+        admin.createTopics(singleton(new NewTopic(topic, 2, (short) 1))).all().get();
 
         String[] cgcArgs = buildArgsForGroup(GROUP, "--all-topics", "--to-offset", "2", "--export");
         ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(cgcArgs);
 
-        produceConsumeAndShutdown(topic, GROUP, 100, 2);
+        produceConsumeAndShutdown(topic, GROUP, 2);
 
         File file = TestUtils.tempFile("reset", ".csv");
 
@@ -395,15 +463,16 @@ public class ResetConsumerGroupOffsetTest extends ConsumerGroupCommandTest {
         exp1.put(tp1, 2L);
         assertEquals(exp1, toOffsetMap(exportedOffsets.get(GROUP)));
 
-        String[] cgcArgsExec = buildArgsForGroup(GROUP, "--all-topics", "--from-file", file.getCanonicalPath(), "--dry-run");
+        String[] cgcArgsExec = buildArgsForGroup(GROUP, "--all-topics",
+                "--from-file", file.getCanonicalPath(), "--dry-run");
         ConsumerGroupCommand.ConsumerGroupService consumerGroupCommandExec = getConsumerGroupService(cgcArgsExec);
         Map<String, Map<TopicPartition, OffsetAndMetadata>> importedOffsets = consumerGroupCommandExec.resetOffsets();
         assertEquals(exp1, toOffsetMap(importedOffsets.get(GROUP)));
 
-        adminZkClient().deleteTopic(topic);
+        admin.deleteTopics(singleton(topic));
     }
 
-    @Test
+    @ClusterTest
     // This one deals with universal CSV export/import file format "group,topic,partition,offset",
     // supporting multiple --group args or --all-groups arg
     public void testResetOffsetsExportImportPlan() throws Exception {
@@ -415,14 +484,17 @@ public class ResetConsumerGroupOffsetTest extends ConsumerGroupCommandTest {
         TopicPartition t1p1 = new TopicPartition(topic1, 1);
         TopicPartition t2p0 = new TopicPartition(topic2, 0);
         TopicPartition t2p1 = new TopicPartition(topic2, 1);
-        createTopic(topic1, 2, 1, new Properties(), listenerName(), new Properties());
-        createTopic(topic2, 2, 1, new Properties(), listenerName(), new Properties());
+        Admin admin = cluster.createAdminClient();
+        admin.createTopics(asList(new NewTopic(topic1, 2, (short) 1),
+                new NewTopic(topic2, 2, (short) 1))).all().get();
 
-        String[] cgcArgs = buildArgsForGroups(Arrays.asList(group1, group2), "--all-topics", "--to-offset", "2", "--export");
+
+        String[] cgcArgs = buildArgsForGroups(asList(group1, group2),
+                "--all-topics", "--to-offset", "2", "--export");
         ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(cgcArgs);
 
-        produceConsumeAndShutdown(topic1, group1, 100, 1);
-        produceConsumeAndShutdown(topic2, group2, 100, 1);
+        produceConsumeAndShutdown(topic1, group1, 1);
+        produceConsumeAndShutdown(topic2, group2, 1);
 
         awaitConsumerGroupInactive(consumerGroupCommand, group1);
         awaitConsumerGroupInactive(consumerGroupCommand, group2);
@@ -444,98 +516,187 @@ public class ResetConsumerGroupOffsetTest extends ConsumerGroupCommandTest {
         assertEquals(exp2, toOffsetMap(exportedOffsets.get(group2)));
 
         // Multiple --group's offset import
-        String[] cgcArgsExec = buildArgsForGroups(Arrays.asList(group1, group2), "--all-topics", "--from-file", file.getCanonicalPath(), "--dry-run");
+        String[] cgcArgsExec = buildArgsForGroups(asList(group1, group2), "--all-topics",
+                "--from-file", file.getCanonicalPath(), "--dry-run");
         ConsumerGroupCommand.ConsumerGroupService consumerGroupCommandExec = getConsumerGroupService(cgcArgsExec);
         Map<String, Map<TopicPartition, OffsetAndMetadata>> importedOffsets = consumerGroupCommandExec.resetOffsets();
         assertEquals(exp1, toOffsetMap(importedOffsets.get(group1)));
         assertEquals(exp2, toOffsetMap(importedOffsets.get(group2)));
 
         // Single --group offset import using "group,topic,partition,offset" csv format
-        String[] cgcArgsExec2 = buildArgsForGroup(group1, "--all-topics", "--from-file", file.getCanonicalPath(), "--dry-run");
+        String[] cgcArgsExec2 = buildArgsForGroup(group1, "--all-topics",
+                "--from-file", file.getCanonicalPath(), "--dry-run");
         ConsumerGroupCommand.ConsumerGroupService consumerGroupCommandExec2 = getConsumerGroupService(cgcArgsExec2);
         Map<String, Map<TopicPartition, OffsetAndMetadata>> importedOffsets2 = consumerGroupCommandExec2.resetOffsets();
         assertEquals(exp1, toOffsetMap(importedOffsets2.get(group1)));
 
-        adminZkClient().deleteTopic(TOPIC);
+        admin.deleteTopics(asList(topic1, topic2));
     }
 
-    @Test
+    @ClusterTest
     public void testResetWithUnrecognizedNewConsumerOption() {
-        String[] cgcArgs = new String[]{"--new-consumer", "--bootstrap-server", bootstrapServers(listenerName()), "--reset-offsets",
-            "--group", GROUP, "--all-topics", "--to-offset", "2", "--export"};
+        String[] cgcArgs = new String[]{"--new-consumer",
+            "--bootstrap-server", cluster.bootstrapServers(),
+            "--reset-offsets", "--group", GROUP, "--all-topics",
+            "--to-offset", "2", "--export"};
         assertThrows(OptionException.class, () -> getConsumerGroupService(cgcArgs));
+    }
+
+    private Map<TopicPartition, Long> committedOffsets(String topic, String group) {
+        try (Consumer<String, String> consumer = createNoAutoCommitConsumer(group)) {
+            Set<TopicPartition> partitions = consumer.partitionsFor(topic)
+                    .stream()
+                    .map(partitionInfo -> new TopicPartition(partitionInfo.topic(), partitionInfo.partition()))
+                    .collect(Collectors.toSet());
+            return consumer.committed(partitions)
+                    .entrySet()
+                    .stream()
+                    .filter(e -> e.getValue() != null)
+                    .collect(toMap(Map.Entry::getKey, e -> e.getValue().offset()));
+        }
+    }
+
+    private Consumer<String, String> createNoAutoCommitConsumer(String group) {
+        Properties props = new Properties();
+        props.put(BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+        props.put(GROUP_ID_CONFIG, group);
+        props.put(ENABLE_AUTO_COMMIT_CONFIG, "false");
+        return new KafkaConsumer<>(props, new StringDeserializer(), new StringDeserializer());
+    }
+
+    private ConsumerGroupCommand.ConsumerGroupService getConsumerGroupService(String[] args) {
+        return new ConsumerGroupCommand.ConsumerGroupService(
+                ConsumerGroupCommandOptions.fromArgs(args),
+                singletonMap(AdminClientConfig.RETRIES_CONFIG,
+                        Integer.toString(Integer.MAX_VALUE)));
     }
 
     private void produceMessages(String topic, int numMessages) {
         List<ProducerRecord<byte[], byte[]>> records = IntStream.range(0, numMessages)
-            .mapToObj(i -> new ProducerRecord<byte[], byte[]>(topic, new byte[100 * 1000]))
-            .collect(Collectors.toList());
-        kafka.utils.TestUtils.produceMessages(servers(), seq(records), 1);
+                .mapToObj(i -> new ProducerRecord<byte[], byte[]>(topic, new byte[100 * 1000]))
+                .collect(Collectors.toList());
+        produceMessages(records);
     }
 
-    private void produceConsumeAndShutdown(String topic, String group, int totalMessages, int numConsumers) throws Exception {
-        produceMessages(topic, totalMessages);
-        ConsumerGroupExecutor executor = addConsumerGroupExecutor(numConsumers, topic, group, GroupProtocol.CLASSIC.name);
-        awaitConsumerProgress(topic, group, totalMessages);
-        executor.shutdown();
+    private void produceMessages(List<ProducerRecord<byte[], byte[]>> records) {
+        try (Producer<byte[], byte[]> producer = createProducer()) {
+            records.forEach(producer::send);
+        }
     }
 
-    private void awaitConsumerProgress(String topic,
-                                       String group,
-                                       long count) throws Exception {
+    private Producer<byte[], byte[]> createProducer() {
+        Properties props = new Properties();
+        props.put(BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+        props.put(ACKS_CONFIG, "1");
+        props.put(KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        props.put(VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        return new KafkaProducer<>(props);
+    }
+
+    private void resetAndAssertOffsets(String[] args, long expectedOffset) {
+        resetAndAssertOffsets(args, expectedOffset, false, singletonList(TOPIC));
+    }
+
+    private void resetAndAssertOffsets(String[] args, long expectedOffset, boolean dryRun, List<String> topics) {
+        try (ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(args)) {
+            Map<String, Map<TopicPartition, Long>> topicToExpectedOffsets = getTopicExceptOffsets(topics, expectedOffset);
+            Map<String, Map<TopicPartition, OffsetAndMetadata>> resetOffsetsResultByGroup =
+                    resetOffsets(consumerGroupCommand);
+            for (final String topic : topics) {
+                resetOffsetsResultByGroup.forEach((group, partitionInfo) -> {
+                    Map<TopicPartition, Long> priorOffsets = committedOffsets(topic, group);
+                    assertEquals(topicToExpectedOffsets.get(topic), partitionToOffsets(topic, partitionInfo));
+                    assertEquals(dryRun ? priorOffsets : topicToExpectedOffsets.get(topic), committedOffsets(topic, group));
+                });
+            }
+        }
+    }
+
+    private Map<String, Map<TopicPartition, Long>> getTopicExceptOffsets(List<String> topics,
+                                                                         long expectedOffset) {
+        return topics.stream()
+                .collect(toMap(Function.identity(),
+                        topic -> singletonMap(new TopicPartition(topic, 0),
+                                expectedOffset)));
+    }
+
+    private Map<String, Map<TopicPartition, OffsetAndMetadata>> resetOffsets(
+            ConsumerGroupCommand.ConsumerGroupService consumerGroupService) {
+        return consumerGroupService.resetOffsets();
+    }
+
+    private Map<TopicPartition, Long> partitionToOffsets(String topic,
+                                                         Map<TopicPartition, OffsetAndMetadata> partitionInfo) {
+        return partitionInfo.entrySet()
+                .stream()
+                .filter(entry -> Objects.equals(entry.getKey().topic(), topic))
+                .collect(toMap(Map.Entry::getKey, e -> e.getValue().offset()));
+    }
+
+    private static List<String> generateIds(String name) {
+        return IntStream.rangeClosed(1, 3)
+                .mapToObj(id -> name + id)
+                .collect(Collectors.toList());
+    }
+
+    private void produceConsumeAndShutdown(String topic, String group, int numConsumers) throws Exception {
+        produceMessages(topic, 100);
+        try (AutoCloseable ignored = addConsumerGroupExecutor(numConsumers, topic, group, GroupProtocol.CLASSIC.name)) {
+            awaitConsumerProgress(topic, group, 100);
+        }
+    }
+
+    private AutoCloseable addConsumerGroupExecutor(int numConsumers,
+                                                   String topic,
+                                                   String group,
+                                                   String groupProtocol) {
+        Map<String, Object> configs = composeConsumerConfigs(group, groupProtocol);
+        return ConsumerGroupCommandTestUtils.buildConsumers(
+                numConsumers,
+                false,
+                topic,
+                () -> new KafkaConsumer<String, String>(configs));
+    }
+
+    private Map<String, Object> composeConsumerConfigs(String group, String groupProtocol) {
+        HashMap<String, Object> configs = new HashMap<>();
+        configs.put(BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+        configs.put(GROUP_ID_CONFIG, group);
+        configs.put(GROUP_PROTOCOL_CONFIG, groupProtocol);
+        configs.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        configs.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        configs.put(PARTITION_ASSIGNMENT_STRATEGY_CONFIG, RangeAssignor.class.getName());
+        return configs;
+    }
+
+    private void awaitConsumerProgress(String topic, String group, long count) throws Exception {
         try (Consumer<String, String> consumer = createNoAutoCommitConsumer(group)) {
-            Set<TopicPartition> partitions = consumer.partitionsFor(topic).stream()
-                .map(partitionInfo -> new TopicPartition(partitionInfo.topic(), partitionInfo.partition()))
-                .collect(Collectors.toSet());
+            Set<TopicPartition> partitions = consumer.partitionsFor(topic)
+                    .stream()
+                    .map(partitionInfo -> new TopicPartition(partitionInfo.topic(), partitionInfo.partition()))
+                    .collect(Collectors.toSet());
 
             TestUtils.waitForCondition(() -> {
                 Collection<OffsetAndMetadata> committed = consumer.committed(partitions).values();
                 long total = committed.stream()
-                    .mapToLong(offsetAndMetadata -> Optional.ofNullable(offsetAndMetadata).map(OffsetAndMetadata::offset).orElse(0L))
-                    .sum();
-
+                        .mapToLong(offsetAndMetadata -> Optional.ofNullable(offsetAndMetadata)
+                                .map(OffsetAndMetadata::offset)
+                                .orElse(0L)).sum();
                 return total == count;
             }, "Expected that consumer group has consumed all messages from topic/partition. " +
-                "Expected offset: " + count + ". Actual offset: " + committedOffsets(topic, group).values().stream().mapToLong(Long::longValue).sum());
+                    "Expected offset: " + count +
+                    ". Actual offset: " +
+                    committedOffsets(topic, group).values().stream().mapToLong(Long::longValue).sum());
         }
     }
 
-    private void awaitConsumerGroupInactive(ConsumerGroupCommand.ConsumerGroupService consumerGroupService, String group) throws Exception {
+    private void awaitConsumerGroupInactive(ConsumerGroupCommand.ConsumerGroupService consumerGroupService,
+                                            String group) throws Exception {
         TestUtils.waitForCondition(() -> {
             ConsumerGroupState state = consumerGroupService.collectGroupState(group).state;
             return Objects.equals(state, ConsumerGroupState.EMPTY) || Objects.equals(state, ConsumerGroupState.DEAD);
-        }, "Expected that consumer group is inactive. Actual state: " + consumerGroupService.collectGroupState(group).state);
-    }
-
-    private void resetAndAssertOffsets(String[] args,
-                                       long expectedOffset) {
-        resetAndAssertOffsets(args, expectedOffset, false, Collections.singletonList(TOPIC));
-    }
-
-    private void resetAndAssertOffsets(String[] args,
-                                      long expectedOffset,
-                                      boolean dryRun,
-                                      List<String> topics) {
-        ConsumerGroupCommand.ConsumerGroupService consumerGroupCommand = getConsumerGroupService(args);
-        Map<String, Map<TopicPartition, Long>> expectedOffsets = topics.stream().collect(Collectors.toMap(
-            Function.identity(),
-            topic -> Collections.singletonMap(new TopicPartition(topic, 0), expectedOffset)));
-        Map<String, Map<TopicPartition, OffsetAndMetadata>> resetOffsetsResultByGroup = resetOffsets(consumerGroupCommand);
-
-        try {
-            for (final String topic : topics) {
-                resetOffsetsResultByGroup.forEach((group, partitionInfo) -> {
-                    Map<TopicPartition, Long> priorOffsets = committedOffsets(topic, group);
-                    assertEquals(expectedOffsets.get(topic),
-                        partitionInfo.entrySet().stream()
-                            .filter(entry -> Objects.equals(entry.getKey().topic(), topic))
-                            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().offset())));
-                    assertEquals(dryRun ? priorOffsets : expectedOffsets.get(topic), committedOffsets(topic, group));
-                });
-            }
-        } finally {
-            consumerGroupCommand.close();
-        }
+        }, "Expected that consumer group is inactive. Actual state: " +
+                consumerGroupService.collectGroupState(group).state);
     }
 
     private void resetAndAssertOffsetsCommitted(ConsumerGroupCommand.ConsumerGroupService consumerGroupService,
@@ -543,25 +704,21 @@ public class ResetConsumerGroupOffsetTest extends ConsumerGroupCommandTest {
                                                 String topic) {
         Map<String, Map<TopicPartition, OffsetAndMetadata>> allResetOffsets = resetOffsets(consumerGroupService);
 
-        allResetOffsets.forEach((group, offsetsInfo) -> {
-            offsetsInfo.forEach((tp, offsetMetadata) -> {
-                assertEquals(offsetMetadata.offset(), expectedOffsets.get(tp));
-                assertEquals(expectedOffsets, committedOffsets(topic, group));
-            });
-        });
-    }
-
-    private Map<String, Map<TopicPartition, OffsetAndMetadata>> resetOffsets(ConsumerGroupCommand.ConsumerGroupService consumerGroupService) {
-        return consumerGroupService.resetOffsets();
+        allResetOffsets.forEach((group, offsetsInfo) -> offsetsInfo.forEach((tp, offsetMetadata) -> {
+            assertEquals(offsetMetadata.offset(), expectedOffsets.get(tp));
+            assertEquals(expectedOffsets, committedOffsets(topic, group));
+        }));
     }
 
     Map<TopicPartition, Long> toOffsetMap(Map<TopicPartition, OffsetAndMetadata> map) {
-        return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().offset()));
+        return map.entrySet()
+                .stream()
+                .collect(toMap(Map.Entry::getKey, e -> e.getValue().offset()));
     }
 
-    private String[] addTo(String[] args, String...extra) {
-        List<String> res = new ArrayList<>(Arrays.asList(args));
-        res.addAll(Arrays.asList(extra));
+    private String[] addTo(String[] args, String... extra) {
+        List<String> res = new ArrayList<>(asList(args));
+        res.addAll(asList(extra));
         return res.toArray(new String[0]);
     }
 }


### PR DESCRIPTION
Currently, I'm working on the ResetConsumerGroupOffsetTest. I'm a bit puzzled about the parameter `bootstrapServers(listenerName())` in the old code. It seems to return localhost:+random port number. My understanding is that in the Scala part of the code, it first creates a broker and then returns the IP and port number of that broker. However, I'm not sure which part of the new testing framework corresponds to this parameter. Currently, I'm using `ClusterInstance`, but in the subsequent segment `consumerGroupCommand.collectGroupState(group).coordinator.host()`, it times out.