### PR TITLE
KAFKA-16573: Specify node and store where serdes are needed

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1856,12 +1856,12 @@ public class StreamsConfig extends AbstractConfig {
      * Return an {@link Serde#configure(Map, boolean) configured} instance of {@link #DEFAULT_KEY_SERDE_CLASS_CONFIG key Serde
      * class}.
      *
-     * @return an configured instance of key Serde class
+     * @return a configured instance of key Serde class
      */
     @SuppressWarnings("WeakerAccess")
     public Serde<?> defaultKeySerde() {
         final Object keySerdeConfigSetting = get(DEFAULT_KEY_SERDE_CLASS_CONFIG);
-        if (keySerdeConfigSetting ==  null) {
+        if (keySerdeConfigSetting == null) {
             throw new ConfigException("Please specify a key serde or set one through StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG");
         }
         try {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WrappingNullableUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WrappingNullableUtils.java
@@ -42,6 +42,7 @@ public class WrappingNullableUtils {
         }
         return deserializerToUse;
     }
+
     @SuppressWarnings("unchecked")
     private static <T> Serializer<T> prepareSerializer(final Serializer<T> specificSerializer, final ProcessorContext context, final boolean isKey, final String name) {
         final Serializer<T> serializerToUse;
@@ -60,7 +61,7 @@ public class WrappingNullableUtils {
     private static <T> Serde<T> prepareSerde(final Serde<T> specificSerde, final SerdeGetter getter, final boolean isKey) {
         final Serde<T> serdeToUse;
         if (specificSerde == null) {
-            serdeToUse = (Serde<T>) (isKey ?  getter.keySerde() : getter.valueSerde());
+            serdeToUse = (Serde<T>) (isKey ? getter.keySerde() : getter.valueSerde());
         } else {
             serdeToUse = specificSerde;
         }
@@ -93,12 +94,14 @@ public class WrappingNullableUtils {
     public static <V> Serde<V> prepareValueSerde(final Serde<V> specificSerde, final SerdeGetter getter) {
         return prepareSerde(specificSerde, getter, false);
     }
+
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static <T> void initNullableSerializer(final Serializer<T> specificSerializer, final SerdeGetter getter) {
         if (specificSerializer instanceof WrappingNullableSerializer) {
             ((WrappingNullableSerializer) specificSerializer).setIfUnset(getter);
         }
     }
+
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static <T> void initNullableDeserializer(final Deserializer<T> specificDeserializer, final SerdeGetter getter) {
         if (specificDeserializer instanceof WrappingNullableDeserializer) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WrappingNullableUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WrappingNullableUtils.java
@@ -33,9 +33,7 @@ public class WrappingNullableUtils {
         final Deserializer<T> deserializerToUse;
 
         if (specificDeserializer == null) {
-            final Deserializer<?> contextKeyDeserializer = context.keySerde().deserializer();
-            final Deserializer<?> contextValueDeserializer = context.valueSerde().deserializer();
-            deserializerToUse = (Deserializer<T>) (isKey ? contextKeyDeserializer : contextValueDeserializer);
+            deserializerToUse = (Deserializer<T>) (isKey ? context.keySerde().deserializer() : context.valueSerde().deserializer());
         } else {
             deserializerToUse = specificDeserializer;
             initNullableDeserializer(deserializerToUse, new SerdeGetter(context));
@@ -47,9 +45,7 @@ public class WrappingNullableUtils {
     private static <T> Serializer<T> prepareSerializer(final Serializer<T> specificSerializer, final ProcessorContext context, final boolean isKey, final String name) {
         final Serializer<T> serializerToUse;
         if (specificSerializer == null) {
-            final Serializer<?> contextKeySerializer = context.keySerde().serializer();
-            final Serializer<?> contextValueSerializer = context.valueSerde().serializer();
-            serializerToUse = (Serializer<T>) (isKey ? contextKeySerializer : contextValueSerializer);
+            serializerToUse = (Serializer<T>) (isKey ? context.keySerde().serializer() : context.valueSerde().serializer());
         } else {
             serializerToUse = specificSerializer;
             initNullableSerializer(serializerToUse, new SerdeGetter(context));

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
@@ -16,7 +16,9 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.TopicNameExtractor;
 import org.apache.kafka.streams.processor.api.Record;
@@ -58,8 +60,14 @@ public class SinkNode<KIn, VIn> extends ProcessorNode<KIn, VIn, Void, Void> {
     public void init(final InternalProcessorContext<Void, Void> context) {
         super.init(context);
         this.context = context;
-        keySerializer = prepareKeySerializer(keySerializer, context, this.name());
-        valSerializer = prepareValueSerializer(valSerializer, context, this.name());
+        try {
+            keySerializer = prepareKeySerializer(keySerializer, context, this.name());
+            valSerializer = prepareValueSerializer(valSerializer, context, this.name());
+        } catch (final ConfigException e) {
+            throw new ConfigException(String.format("Failed to initialize serdes for sink node %s", name()), e);
+        } catch (final StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize serdes for sink node %s", name()), e);
+        }
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
@@ -63,7 +63,7 @@ public class SinkNode<KIn, VIn> extends ProcessorNode<KIn, VIn, Void, Void> {
         try {
             keySerializer = prepareKeySerializer(keySerializer, context, this.name());
         } catch (final ConfigException e) {
-            throw new ConfigException(String.format("Failed to initialize key serdes for sink node %s", name()));
+            throw new ConfigException(String.format("Failed to initialize key serdes for sink node %s. %s", name(), e.getMessage()));
         } catch (final StreamsException e) {
             throw new StreamsException(String.format("Failed to initialize key serdes for sink node %s", name()), e);
         }
@@ -71,7 +71,7 @@ public class SinkNode<KIn, VIn> extends ProcessorNode<KIn, VIn, Void, Void> {
         try {
             valSerializer = prepareValueSerializer(valSerializer, context, this.name());
         } catch (final ConfigException e) {
-            throw new ConfigException(String.format("Failed to initialize value serdes for sink node %s", name()));
+            throw new ConfigException(String.format("Failed to initialize value serdes for sink node %s. %s", name(), e.getMessage()));
         } catch (final StreamsException e) {
             throw new StreamsException(String.format("Failed to initialize value serdes for sink node %s", name()), e);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
@@ -62,18 +62,14 @@ public class SinkNode<KIn, VIn> extends ProcessorNode<KIn, VIn, Void, Void> {
         this.context = context;
         try {
             keySerializer = prepareKeySerializer(keySerializer, context, this.name());
-        } catch (final ConfigException e) {
-            throw new ConfigException(String.format("Failed to initialize key serdes for sink node %s. %s", name(), e.getMessage()));
-        } catch (final StreamsException e) {
-            throw new StreamsException(String.format("Failed to initialize key serdes for sink node %s", name()), e);
+        } catch (ConfigException | StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize key serdes for sink node %s", name()), e, context.taskId());
         }
 
         try {
             valSerializer = prepareValueSerializer(valSerializer, context, this.name());
-        } catch (final ConfigException e) {
-            throw new ConfigException(String.format("Failed to initialize value serdes for sink node %s. %s", name(), e.getMessage()));
-        } catch (final StreamsException e) {
-            throw new StreamsException(String.format("Failed to initialize value serdes for sink node %s", name()), e);
+        } catch (final ConfigException | StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize value serdes for sink node %s", name()), e, context.taskId());
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
@@ -62,11 +62,18 @@ public class SinkNode<KIn, VIn> extends ProcessorNode<KIn, VIn, Void, Void> {
         this.context = context;
         try {
             keySerializer = prepareKeySerializer(keySerializer, context, this.name());
+        } catch (final ConfigException e) {
+            throw new ConfigException(String.format("Failed to initialize key serdes for sink node %s", name()));
+        } catch (final StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize key serdes for sink node %s", name()), e);
+        }
+
+        try {
             valSerializer = prepareValueSerializer(valSerializer, context, this.name());
         } catch (final ConfigException e) {
-            throw new ConfigException(String.format("Failed to initialize serdes for sink node %s", name()), e);
+            throw new ConfigException(String.format("Failed to initialize value serdes for sink node %s", name()));
         } catch (final StreamsException e) {
-            throw new StreamsException(String.format("Failed to initialize serdes for sink node %s", name()), e);
+            throw new StreamsException(String.format("Failed to initialize value serdes for sink node %s", name()), e);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
@@ -16,9 +16,11 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.metrics.ProcessorNodeMetrics;
@@ -74,8 +76,14 @@ public class SourceNode<KIn, VIn> extends ProcessorNode<KIn, VIn, KIn, VIn> {
         super.init(context);
         this.context = context;
 
-        keyDeserializer = prepareKeyDeserializer(keyDeserializer, context, name());
-        valDeserializer = prepareValueDeserializer(valDeserializer, context, name());
+        try {
+            keyDeserializer = prepareKeyDeserializer(keyDeserializer, context, name());
+            valDeserializer = prepareValueDeserializer(valDeserializer, context, name());
+        } catch (final ConfigException e) {
+            throw new ConfigException(String.format("Failed to initialize serdes for source node %s", name()), e);
+        } catch (final StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize serdes for source node %s", name()), e);
+        }
     }
 
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
@@ -78,11 +78,18 @@ public class SourceNode<KIn, VIn> extends ProcessorNode<KIn, VIn, KIn, VIn> {
 
         try {
             keyDeserializer = prepareKeyDeserializer(keyDeserializer, context, name());
+        } catch (final ConfigException e) {
+            throw new ConfigException(String.format("Failed to initialize key serdes for source node %s", name()));
+        } catch (final StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize key serdes for source node %s", name()), e);
+        }
+
+        try {
             valDeserializer = prepareValueDeserializer(valDeserializer, context, name());
         } catch (final ConfigException e) {
-            throw new ConfigException(String.format("Failed to initialize serdes for source node %s", name()), e);
+            throw new ConfigException(String.format("Failed to initialize value serdes for source node %s", name()));
         } catch (final StreamsException e) {
-            throw new StreamsException(String.format("Failed to initialize serdes for source node %s", name()), e);
+            throw new StreamsException(String.format("Failed to initialize value serdes for source node %s", name()), e);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
@@ -79,7 +79,7 @@ public class SourceNode<KIn, VIn> extends ProcessorNode<KIn, VIn, KIn, VIn> {
         try {
             keyDeserializer = prepareKeyDeserializer(keyDeserializer, context, name());
         } catch (final ConfigException e) {
-            throw new ConfigException(String.format("Failed to initialize key serdes for source node %s", name()));
+            throw new ConfigException(String.format("Failed to initialize key serdes for source node %s. %s", name(), e.getMessage()));
         } catch (final StreamsException e) {
             throw new StreamsException(String.format("Failed to initialize key serdes for source node %s", name()), e);
         }
@@ -87,7 +87,7 @@ public class SourceNode<KIn, VIn> extends ProcessorNode<KIn, VIn, KIn, VIn> {
         try {
             valDeserializer = prepareValueDeserializer(valDeserializer, context, name());
         } catch (final ConfigException e) {
-            throw new ConfigException(String.format("Failed to initialize value serdes for source node %s", name()));
+            throw new ConfigException(String.format("Failed to initialize value serdes for source node %s. %s", name(), e.getMessage()));
         } catch (final StreamsException e) {
             throw new StreamsException(String.format("Failed to initialize value serdes for source node %s", name()), e);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
@@ -78,18 +78,14 @@ public class SourceNode<KIn, VIn> extends ProcessorNode<KIn, VIn, KIn, VIn> {
 
         try {
             keyDeserializer = prepareKeyDeserializer(keyDeserializer, context, name());
-        } catch (final ConfigException e) {
-            throw new ConfigException(String.format("Failed to initialize key serdes for source node %s. %s", name(), e.getMessage()));
-        } catch (final StreamsException e) {
-            throw new StreamsException(String.format("Failed to initialize key serdes for source node %s", name()), e);
+        } catch (final ConfigException | StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize key serdes for source node %s", name()), e, context.taskId());
         }
 
         try {
             valDeserializer = prepareValueDeserializer(valDeserializer, context, name());
-        } catch (final ConfigException e) {
-            throw new ConfigException(String.format("Failed to initialize value serdes for source node %s. %s", name(), e.getMessage()));
-        } catch (final StreamsException e) {
-            throw new StreamsException(String.format("Failed to initialize value serdes for source node %s", name()), e);
+        } catch (final ConfigException | StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize value serdes for source node %s", name()), e, context.taskId());
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
@@ -23,6 +24,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -173,21 +175,33 @@ public class MeteredKeyValueStore<K, V>
     protected void initStoreSerde(final ProcessorContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        serdes = new StateSerdes<>(
-            changelogTopic,
-            prepareKeySerde(keySerde, new SerdeGetter(context)),
-            prepareValueSerdeForStore(valueSerde, new SerdeGetter(context))
-        );
+        try {
+            serdes = new StateSerdes<>(
+                changelogTopic,
+                prepareKeySerde(keySerde, new SerdeGetter(context)),
+                prepareValueSerdeForStore(valueSerde, new SerdeGetter(context))
+            );
+        } catch (final ConfigException e) {
+            throw new ConfigException(String.format("Failed to initialize serdes for store %s", storeName), e);
+        } catch (final StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize serdes for store %s", storeName), e);
+        }
     }
 
     protected void initStoreSerde(final StateStoreContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        serdes = new StateSerdes<>(
-            changelogTopic,
-            prepareKeySerde(keySerde, new SerdeGetter(context)),
-            prepareValueSerdeForStore(valueSerde, new SerdeGetter(context))
-        );
+        try {
+            serdes = new StateSerdes<>(
+                changelogTopic,
+                prepareKeySerde(keySerde, new SerdeGetter(context)),
+                prepareValueSerdeForStore(valueSerde, new SerdeGetter(context))
+            );
+        } catch (final ConfigException e) {
+            throw new ConfigException(String.format("Failed to initialize serdes for store %s", storeName), e);
+        } catch (final StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize serdes for store %s", storeName), e);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -172,13 +172,15 @@ public class MeteredKeyValueStore<K, V>
     protected void initStoreSerde(final ProcessorContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        serdes = StoreSerdeInitializer.prepareStoreSerde(context, storeName, changelogTopic, keySerde, valueSerde);
+        serdes = StoreSerdeInitializer.prepareStoreSerde(
+            context, storeName, changelogTopic, keySerde, valueSerde, this::prepareValueSerdeForStore);
     }
 
     protected void initStoreSerde(final StateStoreContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        serdes = StoreSerdeInitializer.prepareStoreSerde(context, storeName, changelogTopic, keySerde, valueSerde);
+        serdes = StoreSerdeInitializer.prepareStoreSerde(
+            context, storeName, changelogTopic, keySerde, valueSerde, this::prepareValueSerdeForStore);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -16,14 +16,15 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.Change;
-import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -50,6 +51,8 @@ import java.util.Objects;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareKeySerde;
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareValueSerde;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 
 public class MeteredSessionStore<K, V>
@@ -137,21 +140,33 @@ public class MeteredSessionStore<K, V>
     private void initStoreSerde(final ProcessorContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        serdes = new StateSerdes<>(
-            changelogTopic,
-            WrappingNullableUtils.prepareKeySerde(keySerde, new SerdeGetter(context)),
-            WrappingNullableUtils.prepareValueSerde(valueSerde, new SerdeGetter(context))
-        );
+        try {
+            serdes = new StateSerdes<>(
+                changelogTopic,
+                prepareKeySerde(keySerde, new SerdeGetter(context)),
+                prepareValueSerde(valueSerde, new SerdeGetter(context))
+            );
+        } catch (final ConfigException e) {
+            throw new ConfigException(String.format("Failed to initialize serdes for store %s", storeName), e);
+        } catch (final StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize serdes for store %s", storeName), e);
+        }
     }
 
     private void initStoreSerde(final StateStoreContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        serdes = new StateSerdes<>(
-            changelogTopic,
-            WrappingNullableUtils.prepareKeySerde(keySerde, new SerdeGetter(context)),
-            WrappingNullableUtils.prepareValueSerde(valueSerde, new SerdeGetter(context))
-        );
+        try {
+            serdes = new StateSerdes<>(
+                changelogTopic,
+                prepareKeySerde(keySerde, new SerdeGetter(context)),
+                prepareValueSerde(valueSerde, new SerdeGetter(context))
+            );
+        } catch (final ConfigException e) {
+            throw new ConfigException(String.format("Failed to initialize serdes for store %s", storeName), e);
+        } catch (final StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize serdes for store %s", storeName), e);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -16,13 +16,11 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.ProcessorStateException;
-import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -31,7 +29,6 @@ import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.ProcessorContextUtils;
-import org.apache.kafka.streams.processor.internals.SerdeGetter;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.query.FailureReason;
 import org.apache.kafka.streams.query.PositionBound;
@@ -51,8 +48,6 @@ import java.util.Objects;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareKeySerde;
-import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareValueSerde;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 
 public class MeteredSessionStore<K, V>
@@ -140,33 +135,13 @@ public class MeteredSessionStore<K, V>
     private void initStoreSerde(final ProcessorContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        try {
-            serdes = new StateSerdes<>(
-                changelogTopic,
-                prepareKeySerde(keySerde, new SerdeGetter(context)),
-                prepareValueSerde(valueSerde, new SerdeGetter(context))
-            );
-        } catch (final ConfigException e) {
-            throw new ConfigException(String.format("Failed to initialize serdes for store %s", storeName), e);
-        } catch (final StreamsException e) {
-            throw new StreamsException(String.format("Failed to initialize serdes for store %s", storeName), e);
-        }
+        serdes = StoreSerdeInitializer.prepareStoreSerde(context, storeName, changelogTopic, keySerde, valueSerde);
     }
 
     private void initStoreSerde(final StateStoreContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        try {
-            serdes = new StateSerdes<>(
-                changelogTopic,
-                prepareKeySerde(keySerde, new SerdeGetter(context)),
-                prepareValueSerde(valueSerde, new SerdeGetter(context))
-            );
-        } catch (final ConfigException e) {
-            throw new ConfigException(String.format("Failed to initialize serdes for store %s", storeName), e);
-        } catch (final StreamsException e) {
-            throw new StreamsException(String.format("Failed to initialize serdes for store %s", storeName), e);
-        }
+        serdes = StoreSerdeInitializer.prepareStoreSerde(context, storeName, changelogTopic, keySerde, valueSerde);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.Change;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -135,13 +136,15 @@ public class MeteredSessionStore<K, V>
     private void initStoreSerde(final ProcessorContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        serdes = StoreSerdeInitializer.prepareStoreSerde(context, storeName, changelogTopic, keySerde, valueSerde);
+        serdes = StoreSerdeInitializer.prepareStoreSerde(
+            context, storeName, changelogTopic, keySerde, valueSerde, WrappingNullableUtils::prepareValueSerde);
     }
 
     private void initStoreSerde(final StateStoreContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        serdes = StoreSerdeInitializer.prepareStoreSerde(context, storeName, changelogTopic, keySerde, valueSerde);
+        serdes = StoreSerdeInitializer.prepareStoreSerde(
+            context, storeName, changelogTopic, keySerde, valueSerde, WrappingNullableUtils::prepareValueSerde);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
@@ -86,6 +86,7 @@ public class MeteredTimestampedKeyValueStore<K, V>
                             (query, positionBound, config, store) -> runTimestampedKeyQuery(query, positionBound, config)
                     )
             );
+
     @SuppressWarnings("unchecked")
     @Override
     protected Serde<ValueAndTimestamp<V>> prepareValueSerdeForStore(final Serde<ValueAndTimestamp<V>> valueSerde, final SerdeGetter getter) {
@@ -95,7 +96,6 @@ public class MeteredTimestampedKeyValueStore<K, V>
             return super.prepareValueSerdeForStore(valueSerde, getter);
         }
     }
-
 
     public RawAndDeserializedValue<V> getWithBinary(final K key) {
         try {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
@@ -26,10 +26,13 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
 import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
+
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -296,11 +299,17 @@ public class MeteredVersionedKeyValueStore<K, V>
             // additionally init raw value serde
             final String storeName = super.name();
             final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-            plainValueSerdes = new StateSerdes<>(
-                changelogTopic,
-                prepareKeySerde(keySerde, new SerdeGetter(context)),
-                prepareValueSerde(plainValueSerde, new SerdeGetter(context))
-            );
+            try {
+                plainValueSerdes = new StateSerdes<>(
+                    changelogTopic,
+                    prepareKeySerde(keySerde, new SerdeGetter(context)),
+                    prepareValueSerde(plainValueSerde, new SerdeGetter(context))
+                );
+            } catch (final ConfigException e) {
+                throw new ConfigException(String.format("Failed to initialize serdes for store %s", storeName), e);
+            } catch (final StreamsException e) {
+                throw new StreamsException(String.format("Failed to initialize serdes for store %s", storeName), e);
+            }
         }
 
         @Override
@@ -310,11 +319,17 @@ public class MeteredVersionedKeyValueStore<K, V>
             // additionally init raw value serde
             final String storeName = super.name();
             final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-            plainValueSerdes = new StateSerdes<>(
-                changelogTopic,
-                prepareKeySerde(keySerde, new SerdeGetter(context)),
-                prepareValueSerde(plainValueSerde, new SerdeGetter(context))
-            );
+            try {
+                plainValueSerdes = new StateSerdes<>(
+                    changelogTopic,
+                    prepareKeySerde(keySerde, new SerdeGetter(context)),
+                    prepareValueSerde(plainValueSerde, new SerdeGetter(context))
+                );
+            } catch (final ConfigException e) {
+                throw new ConfigException(String.format("Failed to initialize serdes for store %s", storeName), e);
+            } catch (final StreamsException e) {
+                throw new StreamsException(String.format("Failed to initialize serdes for store %s", storeName), e);
+            }
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
@@ -18,8 +18,6 @@ package org.apache.kafka.streams.state.internals;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareKeySerde;
-import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareValueSerde;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 
 
@@ -27,12 +25,10 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.ProcessorStateException;
-import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -299,17 +295,7 @@ public class MeteredVersionedKeyValueStore<K, V>
             // additionally init raw value serde
             final String storeName = super.name();
             final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-            try {
-                plainValueSerdes = new StateSerdes<>(
-                    changelogTopic,
-                    prepareKeySerde(keySerde, new SerdeGetter(context)),
-                    prepareValueSerde(plainValueSerde, new SerdeGetter(context))
-                );
-            } catch (final ConfigException e) {
-                throw new ConfigException(String.format("Failed to initialize serdes for store %s", storeName), e);
-            } catch (final StreamsException e) {
-                throw new StreamsException(String.format("Failed to initialize serdes for store %s", storeName), e);
-            }
+            plainValueSerdes = StoreSerdeInitializer.prepareStoreSerde(context, storeName, changelogTopic, keySerde, plainValueSerde);
         }
 
         @Override
@@ -319,17 +305,7 @@ public class MeteredVersionedKeyValueStore<K, V>
             // additionally init raw value serde
             final String storeName = super.name();
             final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-            try {
-                plainValueSerdes = new StateSerdes<>(
-                    changelogTopic,
-                    prepareKeySerde(keySerde, new SerdeGetter(context)),
-                    prepareValueSerde(plainValueSerde, new SerdeGetter(context))
-                );
-            } catch (final ConfigException e) {
-                throw new ConfigException(String.format("Failed to initialize serdes for store %s", storeName), e);
-            } catch (final StreamsException e) {
-                throw new StreamsException(String.format("Failed to initialize serdes for store %s", storeName), e);
-            }
+            plainValueSerdes = StoreSerdeInitializer.prepareStoreSerde(context, storeName, changelogTopic, keySerde, plainValueSerde);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -295,7 +296,8 @@ public class MeteredVersionedKeyValueStore<K, V>
             // additionally init raw value serde
             final String storeName = super.name();
             final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-            plainValueSerdes = StoreSerdeInitializer.prepareStoreSerde(context, storeName, changelogTopic, keySerde, plainValueSerde);
+            plainValueSerdes = StoreSerdeInitializer.prepareStoreSerde(
+                context, storeName, changelogTopic, keySerde, plainValueSerde, WrappingNullableUtils::prepareValueSerde);
         }
 
         @Override
@@ -305,7 +307,8 @@ public class MeteredVersionedKeyValueStore<K, V>
             // additionally init raw value serde
             final String storeName = super.name();
             final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-            plainValueSerdes = StoreSerdeInitializer.prepareStoreSerde(context, storeName, changelogTopic, keySerde, plainValueSerde);
+            plainValueSerdes = StoreSerdeInitializer.prepareStoreSerde(
+                context, storeName, changelogTopic, keySerde, plainValueSerde, WrappingNullableUtils::prepareValueSerde);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -16,11 +16,13 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
@@ -156,19 +158,31 @@ public class MeteredWindowStore<K, V>
     private void initStoreSerde(final ProcessorContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        serdes = new StateSerdes<>(
-            changelogTopic,
-            prepareKeySerde(keySerde, new SerdeGetter(context)),
-            prepareValueSerde(valueSerde, new SerdeGetter(context)));
+        try {
+            serdes = new StateSerdes<>(
+                changelogTopic,
+                prepareKeySerde(keySerde, new SerdeGetter(context)),
+                prepareValueSerde(valueSerde, new SerdeGetter(context)));
+        } catch (final ConfigException e) {
+            throw new ConfigException(String.format("Failed to initialize serdes for store %s", storeName), e);
+        } catch (final StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize serdes for store %s", storeName), e);
+        }
     }
 
     private void initStoreSerde(final StateStoreContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        serdes = new StateSerdes<>(
-            changelogTopic,
-            prepareKeySerde(keySerde, new SerdeGetter(context)),
-            prepareValueSerde(valueSerde, new SerdeGetter(context)));
+        try {
+            serdes = new StateSerdes<>(
+                changelogTopic,
+                prepareKeySerde(keySerde, new SerdeGetter(context)),
+                prepareValueSerde(valueSerde, new SerdeGetter(context)));
+        } catch (final ConfigException e) {
+            throw new ConfigException(String.format("Failed to initialize serdes for store %s", storeName), e);
+        } catch (final StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize serdes for store %s", storeName), e);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -16,13 +16,11 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.ProcessorStateException;
-import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
@@ -54,7 +52,6 @@ import java.util.Objects;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareKeySerde;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 import static org.apache.kafka.streams.state.internals.StoreQueryUtils.getDeserializeValue;
 
@@ -158,31 +155,13 @@ public class MeteredWindowStore<K, V>
     private void initStoreSerde(final ProcessorContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        try {
-            serdes = new StateSerdes<>(
-                changelogTopic,
-                prepareKeySerde(keySerde, new SerdeGetter(context)),
-                prepareValueSerde(valueSerde, new SerdeGetter(context)));
-        } catch (final ConfigException e) {
-            throw new ConfigException(String.format("Failed to initialize serdes for store %s", storeName), e);
-        } catch (final StreamsException e) {
-            throw new StreamsException(String.format("Failed to initialize serdes for store %s", storeName), e);
-        }
+        serdes = StoreSerdeInitializer.prepareStoreSerde(context, storeName, changelogTopic, keySerde, valueSerde);
     }
 
     private void initStoreSerde(final StateStoreContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        try {
-            serdes = new StateSerdes<>(
-                changelogTopic,
-                prepareKeySerde(keySerde, new SerdeGetter(context)),
-                prepareValueSerde(valueSerde, new SerdeGetter(context)));
-        } catch (final ConfigException e) {
-            throw new ConfigException(String.format("Failed to initialize serdes for store %s", storeName), e);
-        } catch (final StreamsException e) {
-            throw new StreamsException(String.format("Failed to initialize serdes for store %s", storeName), e);
-        }
+        serdes = StoreSerdeInitializer.prepareStoreSerde(context, storeName, changelogTopic, keySerde, valueSerde);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -155,13 +155,15 @@ public class MeteredWindowStore<K, V>
     private void initStoreSerde(final ProcessorContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        serdes = StoreSerdeInitializer.prepareStoreSerde(context, storeName, changelogTopic, keySerde, valueSerde);
+        serdes = StoreSerdeInitializer.prepareStoreSerde(
+            context, storeName, changelogTopic, keySerde, valueSerde, this::prepareValueSerde);
     }
 
     private void initStoreSerde(final StateStoreContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName, Boolean.FALSE);
-        serdes = StoreSerdeInitializer.prepareStoreSerde(context, storeName, changelogTopic, keySerde, valueSerde);
+        serdes = StoreSerdeInitializer.prepareStoreSerde(
+            context, storeName, changelogTopic, keySerde, valueSerde, this::prepareValueSerde);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreSerdeInitializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreSerdeInitializer.java
@@ -27,8 +27,10 @@ import org.apache.kafka.streams.state.StateSerdes;
 
 
 public class StoreSerdeInitializer {
-    static <K, V> StateSerdes<K, V> prepareStoreSerde(final StateStoreContext context, final String storeName,
-                                                      final String changelogTopic, final Serde<K> keySerde,
+    static <K, V> StateSerdes<K, V> prepareStoreSerde(final StateStoreContext context,
+                                                      final String storeName,
+                                                      final String changelogTopic,
+                                                      final Serde<K> keySerde,
                                                       final Serde<V> valueSerde,
                                                       final PrepareFunc<V> prepareValueSerdeFunc) {
         return new StateSerdes<>(
@@ -38,8 +40,10 @@ public class StoreSerdeInitializer {
         );
     }
 
-    static <K, V> StateSerdes<K, V> prepareStoreSerde(final ProcessorContext context, final String storeName,
-                                                      final String changelogTopic, final Serde<K> keySerde,
+    static <K, V> StateSerdes<K, V> prepareStoreSerde(final ProcessorContext context,
+                                                      final String storeName,
+                                                      final String changelogTopic,
+                                                      final Serde<K> keySerde,
                                                       final Serde<V> valueSerde,
                                                       final PrepareFunc<V> prepareValueSerdeFunc) {
         return new StateSerdes<>(
@@ -49,8 +53,11 @@ public class StoreSerdeInitializer {
         );
     }
 
-    private static <T> Serde<T> prepareSerde(final PrepareFunc<T> prepare, final String storeName, final Serde<T> serde,
-                                             final SerdeGetter getter, final Boolean isKey) {
+    private static <T> Serde<T> prepareSerde(final PrepareFunc<T> prepare,
+                                             final String storeName,
+                                             final Serde<T> serde,
+                                             final SerdeGetter getter,
+                                             final Boolean isKey) {
 
         final String serdeType = isKey ? "key" : "value";
         try {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreSerdeInitializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreSerdeInitializer.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.internals.SerdeGetter;
+import org.apache.kafka.streams.state.StateSerdes;
+
+
+public class StoreSerdeInitializer {
+    static <K, V> StateSerdes<K, V> prepareStoreSerde(final StateStoreContext context, final String storeName,
+                                                      final String changelogTopic, final Serde<K> keySerde,
+                                                      final Serde<V> valueSerde) {
+        return new StateSerdes<>(
+            changelogTopic,
+            prepareSerde(WrappingNullableUtils::prepareKeySerde, storeName, keySerde, new SerdeGetter(context), true),
+            prepareSerde(WrappingNullableUtils::prepareValueSerde, storeName, valueSerde, new SerdeGetter(context), false)
+        );
+    }
+
+    static <K, V> StateSerdes<K, V> prepareStoreSerde(final ProcessorContext context, final String storeName,
+                                                      final String changelogTopic, final Serde<K> keySerde,
+                                                      final Serde<V> valueSerde) {
+        return new StateSerdes<>(
+            changelogTopic,
+            prepareSerde(WrappingNullableUtils::prepareKeySerde, storeName, keySerde, new SerdeGetter(context), true),
+            prepareSerde(WrappingNullableUtils::prepareValueSerde, storeName, valueSerde, new SerdeGetter(context), false)
+        );
+    }
+
+    private static <T> Serde<T> prepareSerde(final PrepareFunc<T> prepare, final String storeName, final Serde<T> serde,
+                                             final SerdeGetter getter, final Boolean isKey) {
+
+        final String serdeType = isKey ? "key" : "value";
+        try {
+            return prepare.prepareSerde(serde, getter);
+        } catch (final ConfigException e) {
+            throw new ConfigException(String.format("Failed to initialize %s serdes for store %s", serdeType, storeName));
+        } catch (final StreamsException e) {
+            throw new StreamsException(String.format("Failed to initialize %s serdes for store %s", serdeType, storeName), e);
+        }
+    }
+}
+
+interface PrepareFunc<T> {
+    Serde<T> prepareSerde(Serde<T> serde, SerdeGetter getter);
+}
+

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreSerdeInitializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreSerdeInitializer.java
@@ -29,21 +29,23 @@ import org.apache.kafka.streams.state.StateSerdes;
 public class StoreSerdeInitializer {
     static <K, V> StateSerdes<K, V> prepareStoreSerde(final StateStoreContext context, final String storeName,
                                                       final String changelogTopic, final Serde<K> keySerde,
-                                                      final Serde<V> valueSerde) {
+                                                      final Serde<V> valueSerde,
+                                                      final PrepareFunc<V> prepareValueSerdeFunc) {
         return new StateSerdes<>(
             changelogTopic,
             prepareSerde(WrappingNullableUtils::prepareKeySerde, storeName, keySerde, new SerdeGetter(context), true),
-            prepareSerde(WrappingNullableUtils::prepareValueSerde, storeName, valueSerde, new SerdeGetter(context), false)
+            prepareSerde(prepareValueSerdeFunc, storeName, valueSerde, new SerdeGetter(context), false)
         );
     }
 
     static <K, V> StateSerdes<K, V> prepareStoreSerde(final ProcessorContext context, final String storeName,
                                                       final String changelogTopic, final Serde<K> keySerde,
-                                                      final Serde<V> valueSerde) {
+                                                      final Serde<V> valueSerde,
+                                                      final PrepareFunc<V> prepareValueSerdeFunc) {
         return new StateSerdes<>(
             changelogTopic,
             prepareSerde(WrappingNullableUtils::prepareKeySerde, storeName, keySerde, new SerdeGetter(context), true),
-            prepareSerde(WrappingNullableUtils::prepareValueSerde, storeName, valueSerde, new SerdeGetter(context), false)
+            prepareSerde(prepareValueSerdeFunc, storeName, valueSerde, new SerdeGetter(context), false)
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -154,10 +153,9 @@ public class ProcessorNodeTest {
             .flatMapValues(value -> Collections.singletonList(""));
         final Topology topology = builder.build();
 
-        final ConfigException se = assertThrows(ConfigException.class, () -> new TopologyTestDriver(topology));
-        final String msg = se.getMessage();
-        assertThat(msg, containsString("Failed to initialize key serdes for source node"));
-        assertThat(msg, containsString("Please specify a key serde or set one through StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG"));
+        final StreamsException se = assertThrows(StreamsException.class, () -> new TopologyTestDriver(topology));
+        assertThat(se.getMessage(), containsString("Failed to initialize key serdes for source node"));
+        assertThat(se.getCause().getMessage(), containsString("Please specify a key serde or set one through StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG"));
     }
 
     private static class ClassCastProcessor extends ExceptionalProcessor {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -156,8 +156,7 @@ public class ProcessorNodeTest {
 
         final ConfigException se = assertThrows(ConfigException.class, () -> new TopologyTestDriver(topology));
         final String msg = se.getMessage();
-        assertTrue("Error about class cast with serdes", msg.contains("StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG"));
-        assertTrue("Error about class cast with serdes", msg.contains("specify a key serde"));
+        assertTrue("Error about class cast with serdes", msg.contains("Failed to initialize key serdes for source node"));
     }
 
     private static class ClassCastProcessor extends ExceptionalProcessor {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -156,7 +156,8 @@ public class ProcessorNodeTest {
 
         final ConfigException se = assertThrows(ConfigException.class, () -> new TopologyTestDriver(topology));
         final String msg = se.getMessage();
-        assertTrue("Error about class cast with serdes", msg.contains("Failed to initialize key serdes for source node"));
+        assertThat(msg, containsString("Failed to initialize key serdes for source node"));
+        assertThat(msg, containsString("Please specify a key serde or set one through StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG"));
     }
 
     private static class ClassCastProcessor extends ExceptionalProcessor {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SinkNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SinkNodeTest.java
@@ -75,33 +75,41 @@ public class SinkNodeTest {
     }
 
     @Test
-    public void shouldThrowConfigExceptionOnUndefinedKeySerde() {
+    public void shouldThrowStreamsExceptionOnUndefinedKeySerde() {
         utilsMock.when(() -> WrappingNullableUtils.prepareKeySerializer(any(), any(), any()))
             .thenThrow(new ConfigException("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG"));
 
-        final Throwable exception = assertThrows(ConfigException.class, () -> sink.init(context));
+        final Throwable exception = assertThrows(StreamsException.class, () -> sink.init(context));
 
         assertThat(
             exception.getMessage(),
-            equalTo("Failed to initialize key serdes for sink node anyNodeName. Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG")
+            equalTo("Failed to initialize key serdes for sink node anyNodeName")
+        );
+        assertThat(
+            exception.getCause().getMessage(),
+            equalTo("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG")
         );
     }
 
     @Test
-    public void shouldThrowConfigExceptionOnUndefinedValueSerde() {
+    public void shouldThrowStreamsExceptionOnUndefinedValueSerde() {
         utilsMock.when(() -> WrappingNullableUtils.prepareValueSerializer(any(), any(), any()))
             .thenThrow(new ConfigException("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG"));
 
-        final Throwable exception = assertThrows(ConfigException.class, () -> sink.init(context));
+        final Throwable exception = assertThrows(StreamsException.class, () -> sink.init(context));
 
         assertThat(
             exception.getMessage(),
-            equalTo("Failed to initialize value serdes for sink node anyNodeName. Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG")
+            equalTo("Failed to initialize value serdes for sink node anyNodeName")
+        );
+        assertThat(
+            exception.getCause().getMessage(),
+            equalTo("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG")
         );
     }
 
     @Test
-    public void shouldThrowStreamsExceptionOnUndefinedSerde() {
+    public void shouldThrowStreamsExceptionWithExplicitErrorMessage() {
         utilsMock.when(() -> WrappingNullableUtils.prepareKeySerializer(any(), any(), any())).thenThrow(new StreamsException(""));
 
         final Throwable exception = assertThrows(StreamsException.class, () -> sink.init(context));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SinkNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SinkNodeTest.java
@@ -16,18 +16,27 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockRecordCollector;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 
 public class SinkNodeTest {
     private final StateSerdes<Bytes, Bytes> anyStateSerde = StateSerdes.withBuiltinTypes("anyName", Bytes.class, Bytes.class);
@@ -40,14 +49,21 @@ public class SinkNodeTest {
     // Used to verify that the correct exceptions are thrown if the compiler checks are bypassed
     @SuppressWarnings({"unchecked", "rawtypes"})
     private final SinkNode<Object, Object> illTypedSink = (SinkNode) sink;
+    private MockedStatic<WrappingNullableUtils> utilsMock;
 
-    @Before
-    public void before() {
-        sink.init(context);
+    @BeforeEach
+    public void setup() {
+        utilsMock = Mockito.mockStatic(WrappingNullableUtils.class);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        utilsMock.close();
     }
 
     @Test
     public void shouldThrowStreamsExceptionOnInputRecordWithInvalidTimestamp() {
+        sink.init(context);
         // When/Then
         context.setTime(-1); // ensures a negative timestamp is set for the record we send next
         try {
@@ -58,4 +74,30 @@ public class SinkNodeTest {
         }
     }
 
+    @Test
+    public void shouldThrowConfigExceptionOnUndefinedKeySerde() {
+        utilsMock.when(() -> WrappingNullableUtils.prepareKeySerializer(any(), any(), any())).thenThrow(new ConfigException(""));
+
+        final Throwable exception = assertThrows(ConfigException.class, () -> sink.init(context));
+
+        assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for sink node anyNodeName"));
+    }
+
+    @Test
+    public void shouldThrowConfigExceptionOnUndefinedValueSerde() {
+        utilsMock.when(() -> WrappingNullableUtils.prepareValueSerializer(any(), any(), any())).thenThrow(new ConfigException(""));
+
+        final Throwable exception = assertThrows(ConfigException.class, () -> sink.init(context));
+
+        assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for sink node anyNodeName"));
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnUndefinedSerde() {
+        utilsMock.when(() -> WrappingNullableUtils.prepareKeySerializer(any(), any(), any())).thenThrow(new StreamsException(""));
+
+        final Throwable exception = assertThrows(StreamsException.class, () -> sink.init(context));
+
+        assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for sink node anyNodeName"));
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SinkNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SinkNodeTest.java
@@ -76,20 +76,28 @@ public class SinkNodeTest {
 
     @Test
     public void shouldThrowConfigExceptionOnUndefinedKeySerde() {
-        utilsMock.when(() -> WrappingNullableUtils.prepareKeySerializer(any(), any(), any())).thenThrow(new ConfigException(""));
+        utilsMock.when(() -> WrappingNullableUtils.prepareKeySerializer(any(), any(), any()))
+            .thenThrow(new ConfigException("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG"));
 
         final Throwable exception = assertThrows(ConfigException.class, () -> sink.init(context));
 
-        assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for sink node anyNodeName"));
+        assertThat(
+            exception.getMessage(),
+            equalTo("Failed to initialize key serdes for sink node anyNodeName. Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG")
+        );
     }
 
     @Test
     public void shouldThrowConfigExceptionOnUndefinedValueSerde() {
-        utilsMock.when(() -> WrappingNullableUtils.prepareValueSerializer(any(), any(), any())).thenThrow(new ConfigException(""));
+        utilsMock.when(() -> WrappingNullableUtils.prepareValueSerializer(any(), any(), any()))
+            .thenThrow(new ConfigException("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG"));
 
         final Throwable exception = assertThrows(ConfigException.class, () -> sink.init(context));
 
-        assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for sink node anyNodeName"));
+        assertThat(
+            exception.getMessage(),
+            equalTo("Failed to initialize value serdes for sink node anyNodeName. Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG")
+        );
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
@@ -131,7 +131,7 @@ public class SourceNodeTest {
     }
 
     @Test
-    public void shouldThrowConfigExceptionOnUndefinedKeySerde() {
+    public void shouldThrowStreamsExceptionOnUndefinedKeySerde() {
         final InternalMockProcessorContext<String, String> context = new InternalMockProcessorContext<>();
 
         final SourceNode<String, String> node =
@@ -140,16 +140,20 @@ public class SourceNodeTest {
         utilsMock.when(() -> WrappingNullableUtils.prepareKeyDeserializer(any(), any(), any()))
             .thenThrow(new ConfigException("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG"));
 
-        final Throwable exception = assertThrows(ConfigException.class, () -> node.init(context));
+        final Throwable exception = assertThrows(StreamsException.class, () -> node.init(context));
 
         assertThat(
             exception.getMessage(),
-            equalTo("Failed to initialize key serdes for source node TESTING_NODE. Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG")
+            equalTo("Failed to initialize key serdes for source node TESTING_NODE")
+        );
+        assertThat(
+            exception.getCause().getMessage(),
+            equalTo("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG")
         );
     }
 
     @Test
-    public void shouldThrowConfigExceptionOnUndefinedValueSerde() {
+    public void shouldThrowStreamsExceptionOnUndefinedValueSerde() {
         final InternalMockProcessorContext<String, String> context = new InternalMockProcessorContext<>();
 
         final SourceNode<String, String> node =
@@ -158,16 +162,20 @@ public class SourceNodeTest {
         utilsMock.when(() -> WrappingNullableUtils.prepareValueDeserializer(any(), any(), any()))
             .thenThrow(new ConfigException("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG"));
 
-        final Throwable exception = assertThrows(ConfigException.class, () -> node.init(context));
+        final Throwable exception = assertThrows(StreamsException.class, () -> node.init(context));
 
         assertThat(
             exception.getMessage(),
-            equalTo("Failed to initialize value serdes for source node TESTING_NODE. Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG")
+            equalTo("Failed to initialize value serdes for source node TESTING_NODE")
+        );
+        assertThat(
+            exception.getCause().getMessage(),
+            equalTo("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG")
         );
     }
 
     @Test
-    public void shouldThrowStreamsExceptionOnUndefinedSerde() {
+    public void shouldThrowStreamsExceptionWithExplicitErrorMessage() {
         final InternalMockProcessorContext<String, String> context = new InternalMockProcessorContext<>();
 
         final SourceNode<String, String> node =

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
@@ -137,11 +137,15 @@ public class SourceNodeTest {
         final SourceNode<String, String> node =
             new SourceNode<>(context.currentNode().name(), new TheDeserializer(), new TheDeserializer());
 
-        utilsMock.when(() -> WrappingNullableUtils.prepareKeyDeserializer(any(), any(), any())).thenThrow(new ConfigException(""));
+        utilsMock.when(() -> WrappingNullableUtils.prepareKeyDeserializer(any(), any(), any()))
+            .thenThrow(new ConfigException("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG"));
 
         final Throwable exception = assertThrows(ConfigException.class, () -> node.init(context));
 
-        assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for source node TESTING_NODE"));
+        assertThat(
+            exception.getMessage(),
+            equalTo("Failed to initialize key serdes for source node TESTING_NODE. Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG")
+        );
     }
 
     @Test
@@ -151,11 +155,15 @@ public class SourceNodeTest {
         final SourceNode<String, String> node =
             new SourceNode<>(context.currentNode().name(), new TheDeserializer(), new TheDeserializer());
 
-        utilsMock.when(() -> WrappingNullableUtils.prepareValueDeserializer(any(), any(), any())).thenThrow(new ConfigException(""));
+        utilsMock.when(() -> WrappingNullableUtils.prepareValueDeserializer(any(), any(), any()))
+            .thenThrow(new ConfigException("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG"));
 
         final Throwable exception = assertThrows(ConfigException.class, () -> node.init(context));
 
-        assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for source node TESTING_NODE"));
+        assertThat(
+            exception.getMessage(),
+            equalTo("Failed to initialize value serdes for source node TESTING_NODE. Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG")
+        );
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
@@ -24,11 +25,17 @@ import org.apache.kafka.common.metrics.SensorAccessor;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockSourceNode;
 import org.apache.kafka.test.StreamsTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -39,9 +46,25 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 
 public class SourceNodeTest {
+    private MockedStatic<WrappingNullableUtils> utilsMock;
+
+    @BeforeEach
+    public void setup() {
+        utilsMock = Mockito.mockStatic(WrappingNullableUtils.class);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        utilsMock.close();
+    }
+
+
     @Test
     public void shouldProvideTopicHeadersAndDataToKeyDeserializer() {
         final SourceNode<String, String> sourceNode = new MockSourceNode<>(new TheDeserializer(), new TheDeserializer());
@@ -105,5 +128,47 @@ public class SourceNodeTest {
             sensorAccessor.parents().stream().map(Sensor::name).collect(Collectors.toList()),
             contains(sensorNamePrefix + ".s.process")
         );
+    }
+
+    @Test
+    public void shouldThrowConfigExceptionOnUndefinedKeySerde() {
+        final InternalMockProcessorContext<String, String> context = new InternalMockProcessorContext<>();
+
+        final SourceNode<String, String> node =
+            new SourceNode<>(context.currentNode().name(), new TheDeserializer(), new TheDeserializer());
+
+        utilsMock.when(() -> WrappingNullableUtils.prepareKeyDeserializer(any(), any(), any())).thenThrow(new ConfigException(""));
+
+        final Throwable exception = assertThrows(ConfigException.class, () -> node.init(context));
+
+        assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for source node TESTING_NODE"));
+    }
+
+    @Test
+    public void shouldThrowConfigExceptionOnUndefinedValueSerde() {
+        final InternalMockProcessorContext<String, String> context = new InternalMockProcessorContext<>();
+
+        final SourceNode<String, String> node =
+            new SourceNode<>(context.currentNode().name(), new TheDeserializer(), new TheDeserializer());
+
+        utilsMock.when(() -> WrappingNullableUtils.prepareValueDeserializer(any(), any(), any())).thenThrow(new ConfigException(""));
+
+        final Throwable exception = assertThrows(ConfigException.class, () -> node.init(context));
+
+        assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for source node TESTING_NODE"));
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnUndefinedSerde() {
+        final InternalMockProcessorContext<String, String> context = new InternalMockProcessorContext<>();
+
+        final SourceNode<String, String> node =
+            new SourceNode<>(context.currentNode().name(), new TheDeserializer(), new TheDeserializer());
+
+        utilsMock.when(() -> WrappingNullableUtils.prepareKeyDeserializer(any(), any(), any())).thenThrow(new StreamsException(""));
+
+        final Throwable exception = assertThrows(StreamsException.class, () -> node.init(context));
+
+        assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for source node TESTING_NODE"));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreSerdeInitializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreSerdeInitializerTest.java
@@ -31,10 +31,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 
 public class StoreSerdeInitializerTest {
@@ -62,7 +62,7 @@ public class StoreSerdeInitializerTest {
         utilsMock.when(() -> WrappingNullableUtils.prepareValueSerde(any(), any())).thenReturn(valueSerde);
 
         final StateSerdes<String, String> result = StoreSerdeInitializer.prepareStoreSerde(
-            (ProcessorContext) context, "myStore", "topic", keySerde, valueSerde);
+            (ProcessorContext) context, "myStore", "topic", keySerde, valueSerde, WrappingNullableUtils::prepareValueSerde);
 
         assertThat(result.keySerde(), equalTo(keySerde));
         assertThat(result.valueSerde(), equalTo(valueSerde));
@@ -75,8 +75,9 @@ public class StoreSerdeInitializerTest {
 
         utilsMock.when(() -> WrappingNullableUtils.prepareKeySerde(any(), any())).thenThrow(new ConfigException(""));
 
-        final Throwable exception = assertThrows(ConfigException.class, () -> StoreSerdeInitializer.prepareStoreSerde(
-            (ProcessorContext) context, "myStore", "topic", new Serdes.StringSerde(), new Serdes.StringSerde()));
+        final Throwable exception = assertThrows(ConfigException.class,
+            () -> StoreSerdeInitializer.prepareStoreSerde((ProcessorContext) context, "myStore", "topic",
+                new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
         assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for store myStore"));
     }
@@ -88,8 +89,9 @@ public class StoreSerdeInitializerTest {
         utilsMock.when(() -> WrappingNullableUtils.prepareValueSerde(any(), any()))
             .thenThrow(new ConfigException(""));
 
-        final Throwable exception = assertThrows(ConfigException.class, () -> StoreSerdeInitializer.prepareStoreSerde(
-            (ProcessorContext) context, "myStore", "topic", new Serdes.StringSerde(), new Serdes.StringSerde()));
+        final Throwable exception = assertThrows(ConfigException.class,
+            () -> StoreSerdeInitializer.prepareStoreSerde((ProcessorContext) context, "myStore", "topic",
+                new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
         assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for store myStore"));
     }
@@ -100,8 +102,9 @@ public class StoreSerdeInitializerTest {
 
         utilsMock.when(() -> WrappingNullableUtils.prepareKeySerde(any(), any())).thenThrow(new ConfigException(""));
 
-        final Throwable exception = assertThrows(ConfigException.class, () -> StoreSerdeInitializer.prepareStoreSerde(
-            (StateStoreContext) context, "myStore", "topic", new Serdes.StringSerde(), new Serdes.StringSerde()));
+        final Throwable exception = assertThrows(ConfigException.class,
+            () -> StoreSerdeInitializer.prepareStoreSerde((StateStoreContext) context, "myStore", "topic",
+                new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
         assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for store myStore"));
     }
@@ -112,8 +115,9 @@ public class StoreSerdeInitializerTest {
 
         utilsMock.when(() -> WrappingNullableUtils.prepareValueSerde(any(), any())).thenThrow(new ConfigException(""));
 
-        final Throwable exception = assertThrows(ConfigException.class, () -> StoreSerdeInitializer.prepareStoreSerde(
-            (StateStoreContext) context, "myStore", "topic", new Serdes.StringSerde(), new Serdes.StringSerde()));
+        final Throwable exception = assertThrows(ConfigException.class,
+            () -> StoreSerdeInitializer.prepareStoreSerde((StateStoreContext) context, "myStore", "topic",
+                new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
         assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for store myStore"));
     }
@@ -124,8 +128,9 @@ public class StoreSerdeInitializerTest {
 
         utilsMock.when(() -> WrappingNullableUtils.prepareKeySerde(any(), any())).thenThrow(new StreamsException(""));
 
-        final Throwable exception = assertThrows(StreamsException.class, () -> StoreSerdeInitializer.prepareStoreSerde(
-            (ProcessorContext) context, "myStore", "topic", new Serdes.StringSerde(), new Serdes.StringSerde()));
+        final Throwable exception = assertThrows(StreamsException.class,
+            () -> StoreSerdeInitializer.prepareStoreSerde((ProcessorContext) context, "myStore", "topic",
+                new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
         assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for store myStore"));
     }
@@ -136,8 +141,9 @@ public class StoreSerdeInitializerTest {
 
         utilsMock.when(() -> WrappingNullableUtils.prepareValueSerde(any(), any())).thenThrow(new StreamsException(""));
 
-        final Throwable exception = assertThrows(StreamsException.class, () -> StoreSerdeInitializer.prepareStoreSerde(
-            (StateStoreContext) context, "myStore", "topic", new Serdes.StringSerde(), new Serdes.StringSerde()));
+        final Throwable exception = assertThrows(StreamsException.class,
+            () -> StoreSerdeInitializer.prepareStoreSerde((StateStoreContext) context, "myStore", "topic",
+                new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
         assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for store myStore"));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreSerdeInitializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreSerdeInitializerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.state.StateSerdes;
+import org.apache.kafka.test.MockInternalNewProcessorContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+
+public class StoreSerdeInitializerTest {
+
+    private MockedStatic<WrappingNullableUtils> utilsMock;
+
+    @BeforeEach
+    public void setup() {
+        utilsMock = Mockito.mockStatic(WrappingNullableUtils.class);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        utilsMock.close();
+    }
+
+    @Test
+    public void shouldPrepareStoreSerdeForProcessorContext() {
+        final Serde<String> keySerde = new Serdes.StringSerde();
+        final Serde<String> valueSerde = new Serdes.StringSerde();
+
+        final MockInternalNewProcessorContext<String, String> context = new MockInternalNewProcessorContext<>();
+
+        utilsMock.when(() -> WrappingNullableUtils.prepareKeySerde(any(), any())).thenReturn(keySerde);
+        utilsMock.when(() -> WrappingNullableUtils.prepareValueSerde(any(), any())).thenReturn(valueSerde);
+
+        final StateSerdes<String, String> result = StoreSerdeInitializer.prepareStoreSerde(
+            (ProcessorContext) context, "myStore", "topic", keySerde, valueSerde);
+
+        assertThat(result.keySerde(), equalTo(keySerde));
+        assertThat(result.valueSerde(), equalTo(valueSerde));
+        assertThat(result.topic(), equalTo("topic"));
+    }
+
+    @Test
+    public void shouldThrowConfigExceptionOnUndefinedKeySerdeForProcessorContext() {
+        final MockInternalNewProcessorContext<String, String> context = new MockInternalNewProcessorContext<>();
+
+        utilsMock.when(() -> WrappingNullableUtils.prepareKeySerde(any(), any())).thenThrow(new ConfigException(""));
+
+        final Throwable exception = assertThrows(ConfigException.class, () -> StoreSerdeInitializer.prepareStoreSerde(
+            (ProcessorContext) context, "myStore", "topic", new Serdes.StringSerde(), new Serdes.StringSerde()));
+
+        assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for store myStore"));
+    }
+
+    @Test
+    public void shouldThrowConfigExceptionOnUndefinedValueSerdeForProcessorContext() {
+        final MockInternalNewProcessorContext<String, String> context = new MockInternalNewProcessorContext<>();
+
+        utilsMock.when(() -> WrappingNullableUtils.prepareValueSerde(any(), any()))
+            .thenThrow(new ConfigException(""));
+
+        final Throwable exception = assertThrows(ConfigException.class, () -> StoreSerdeInitializer.prepareStoreSerde(
+            (ProcessorContext) context, "myStore", "topic", new Serdes.StringSerde(), new Serdes.StringSerde()));
+
+        assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for store myStore"));
+    }
+
+    @Test
+    public void shouldThrowConfigExceptionOnUndefinedKeySerdeForStateStoreContext() {
+        final MockInternalNewProcessorContext<String, String> context = new MockInternalNewProcessorContext<>();
+
+        utilsMock.when(() -> WrappingNullableUtils.prepareKeySerde(any(), any())).thenThrow(new ConfigException(""));
+
+        final Throwable exception = assertThrows(ConfigException.class, () -> StoreSerdeInitializer.prepareStoreSerde(
+            (StateStoreContext) context, "myStore", "topic", new Serdes.StringSerde(), new Serdes.StringSerde()));
+
+        assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for store myStore"));
+    }
+
+    @Test
+    public void shouldThrowConfigExceptionOnUndefinedValueSerdeForStateStoreContext() {
+        final MockInternalNewProcessorContext<String, String> context = new MockInternalNewProcessorContext<>();
+
+        utilsMock.when(() -> WrappingNullableUtils.prepareValueSerde(any(), any())).thenThrow(new ConfigException(""));
+
+        final Throwable exception = assertThrows(ConfigException.class, () -> StoreSerdeInitializer.prepareStoreSerde(
+            (StateStoreContext) context, "myStore", "topic", new Serdes.StringSerde(), new Serdes.StringSerde()));
+
+        assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for store myStore"));
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnUndefinedKeySerdeForProcessorContext() {
+        final MockInternalNewProcessorContext<String, String> context = new MockInternalNewProcessorContext<>();
+
+        utilsMock.when(() -> WrappingNullableUtils.prepareKeySerde(any(), any())).thenThrow(new StreamsException(""));
+
+        final Throwable exception = assertThrows(StreamsException.class, () -> StoreSerdeInitializer.prepareStoreSerde(
+            (ProcessorContext) context, "myStore", "topic", new Serdes.StringSerde(), new Serdes.StringSerde()));
+
+        assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for store myStore"));
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionOnUndefinedValueSerdeForStateStoreContext() {
+        final MockInternalNewProcessorContext<String, String> context = new MockInternalNewProcessorContext<>();
+
+        utilsMock.when(() -> WrappingNullableUtils.prepareValueSerde(any(), any())).thenThrow(new StreamsException(""));
+
+        final Throwable exception = assertThrows(StreamsException.class, () -> StoreSerdeInitializer.prepareStoreSerde(
+            (StateStoreContext) context, "myStore", "topic", new Serdes.StringSerde(), new Serdes.StringSerde()));
+
+        assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for store myStore"));
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreSerdeInitializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreSerdeInitializerTest.java
@@ -70,60 +70,67 @@ public class StoreSerdeInitializerTest {
     }
 
     @Test
-    public void shouldThrowConfigExceptionOnUndefinedKeySerdeForProcessorContext() {
+    public void shouldThrowStreamsExceptionOnUndefinedKeySerdeForProcessorContext() {
         final MockInternalNewProcessorContext<String, String> context = new MockInternalNewProcessorContext<>();
 
-        utilsMock.when(() -> WrappingNullableUtils.prepareKeySerde(any(), any())).thenThrow(new ConfigException(""));
+        utilsMock.when(() -> WrappingNullableUtils.prepareKeySerde(any(), any()))
+            .thenThrow(new ConfigException("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG"));
 
-        final Throwable exception = assertThrows(ConfigException.class,
+        final Throwable exception = assertThrows(StreamsException.class,
             () -> StoreSerdeInitializer.prepareStoreSerde((ProcessorContext) context, "myStore", "topic",
                 new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
         assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for store myStore"));
+        assertThat(exception.getCause().getMessage(), equalTo("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG"));
     }
 
     @Test
-    public void shouldThrowConfigExceptionOnUndefinedValueSerdeForProcessorContext() {
+    public void shouldThrowStreamsExceptionOnUndefinedValueSerdeForProcessorContext() {
         final MockInternalNewProcessorContext<String, String> context = new MockInternalNewProcessorContext<>();
 
         utilsMock.when(() -> WrappingNullableUtils.prepareValueSerde(any(), any()))
-            .thenThrow(new ConfigException(""));
+            .thenThrow(new ConfigException("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG"));
 
-        final Throwable exception = assertThrows(ConfigException.class,
+        final Throwable exception = assertThrows(StreamsException.class,
             () -> StoreSerdeInitializer.prepareStoreSerde((ProcessorContext) context, "myStore", "topic",
                 new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
         assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for store myStore"));
+        assertThat(exception.getCause().getMessage(), equalTo("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG"));
     }
 
     @Test
-    public void shouldThrowConfigExceptionOnUndefinedKeySerdeForStateStoreContext() {
+    public void shouldThrowStreamsExceptionOnUndefinedKeySerdeForStateStoreContext() {
         final MockInternalNewProcessorContext<String, String> context = new MockInternalNewProcessorContext<>();
 
-        utilsMock.when(() -> WrappingNullableUtils.prepareKeySerde(any(), any())).thenThrow(new ConfigException(""));
+        utilsMock.when(() -> WrappingNullableUtils.prepareKeySerde(any(), any()))
+            .thenThrow(new ConfigException("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG"));
 
-        final Throwable exception = assertThrows(ConfigException.class,
+        final Throwable exception = assertThrows(StreamsException.class,
             () -> StoreSerdeInitializer.prepareStoreSerde((StateStoreContext) context, "myStore", "topic",
                 new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
         assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for store myStore"));
+        assertThat(exception.getCause().getMessage(), equalTo("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG"));
     }
 
     @Test
-    public void shouldThrowConfigExceptionOnUndefinedValueSerdeForStateStoreContext() {
+    public void shouldThrowStreamsExceptionOnUndefinedValueSerdeForStateStoreContext() {
         final MockInternalNewProcessorContext<String, String> context = new MockInternalNewProcessorContext<>();
 
-        utilsMock.when(() -> WrappingNullableUtils.prepareValueSerde(any(), any())).thenThrow(new ConfigException(""));
+        utilsMock.when(() -> WrappingNullableUtils.prepareValueSerde(any(), any()))
+            .thenThrow(new ConfigException("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG"));
 
-        final Throwable exception = assertThrows(ConfigException.class,
+        final Throwable exception = assertThrows(StreamsException.class,
             () -> StoreSerdeInitializer.prepareStoreSerde((StateStoreContext) context, "myStore", "topic",
                 new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
         assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for store myStore"));
+        assertThat(exception.getCause().getMessage(), equalTo("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG"));
     }
 
     @Test
-    public void shouldThrowStreamsExceptionOnUndefinedKeySerdeForProcessorContext() {
+    public void shouldThrowStreamsExceptionWithExplicitErrorMessageForProcessorContext() {
         final MockInternalNewProcessorContext<String, String> context = new MockInternalNewProcessorContext<>();
 
         utilsMock.when(() -> WrappingNullableUtils.prepareKeySerde(any(), any())).thenThrow(new StreamsException(""));
@@ -136,7 +143,7 @@ public class StoreSerdeInitializerTest {
     }
 
     @Test
-    public void shouldThrowStreamsExceptionOnUndefinedValueSerdeForStateStoreContext() {
+    public void shouldThrowStreamsExceptionWithExplicitErrorMessageForStateStoreContext() {
         final MockInternalNewProcessorContext<String, String> context = new MockInternalNewProcessorContext<>();
 
         utilsMock.when(() -> WrappingNullableUtils.prepareValueSerde(any(), any())).thenThrow(new StreamsException(""));


### PR DESCRIPTION
As described in KAFKA-16573, this PR is to add more information in the error message where serdes are not initialized.

It specifies whether it is a source / sink node whose serdes are needed and the node name. For stores, it provides the name of the store.