### PR TITLE
KAFKA-16609: Update parse_describe_topic to support new topic describe output

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -1396,6 +1396,12 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 continue
 
             fields = line.split("\t")
+
+            # There are additional fields on the end of the 'describe topic' output related to eligible leader
+            # replicas. We don't want or need those, so drop them before we attempt to parse.
+            assert len(fields) >= 4, "Not enough fields in describe topic output line: %s" % line
+            fields = fields[:4]
+
             # ["Partition: 4", "Leader: 0"] -> ["4", "0"]
             fields = list(map(lambda x: x.split(" ")[1], fields))
             partitions.append(


### PR DESCRIPTION
The format of the 'describe topic' output was changed as part of KAFKA-15585 which required an update in the parsing logic used by system tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
