### PR TITLE
MINOR: Clean up TestUtils.scala

### DIFF
--- a/core/src/test/scala/integration/kafka/api/SaslPlainPlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainPlaintextConsumerTest.scala
@@ -14,7 +14,6 @@ package kafka.api
 
 import kafka.utils.TestUtils.{isAclUnsecure, secureZkPaths}
 import kafka.utils.{JaasTestUtils, TestUtils}
-import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.server.config.ZkConfigs
@@ -56,14 +55,6 @@ class SaslPlainPlaintextConsumerTest extends BaseConsumerTest with SaslSetup {
    */
   @Test
   def testZkAclsDisabled(): Unit = {
-    verifyUnsecureZkAcls(zkClient)
-  }
-
-  /**
-   * Verifies that secure paths in ZK have no access control. This is
-   * the case when zookeeper.set.acl=false and no ACLs have been configured.
-   */
-  private def verifyUnsecureZkAcls(zkClient: KafkaZkClient): Unit = {
     secureZkPaths(zkClient).foreach(path => {
       if (zkClient.pathExists(path)) {
         val acls = zkClient.getAcl(path)

--- a/core/src/test/scala/integration/kafka/api/SaslPlainPlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainPlaintextConsumerTest.scala
@@ -12,12 +12,16 @@
   */
 package kafka.api
 
-import java.util.Locale
+import kafka.utils.TestUtils.{isAclUnsecure, secureZkPaths}
 import kafka.utils.{JaasTestUtils, TestUtils}
+import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.server.config.ZkConfigs
-import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo, Timeout}
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api._
+
+import java.util.Locale
 
 @Timeout(600)
 class SaslPlainPlaintextConsumerTest extends BaseConsumerTest with SaslSetup {
@@ -52,6 +56,20 @@ class SaslPlainPlaintextConsumerTest extends BaseConsumerTest with SaslSetup {
    */
   @Test
   def testZkAclsDisabled(): Unit = {
-    TestUtils.verifyUnsecureZkAcls(zkClient)
+    verifyUnsecureZkAcls(zkClient)
+  }
+
+  /**
+   * Verifies that secure paths in ZK have no access control. This is
+   * the case when zookeeper.set.acl=false and no ACLs have been configured.
+   */
+  private def verifyUnsecureZkAcls(zkClient: KafkaZkClient): Unit = {
+    secureZkPaths(zkClient).foreach(path => {
+      if (zkClient.pathExists(path)) {
+        val acls = zkClient.getAcl(path)
+        assertEquals(1, acls.size, s"Invalid ACLs for $path $acls")
+        acls.foreach(isAclUnsecure)
+      }
+    })
   }
 }

--- a/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
@@ -16,16 +16,10 @@
   */
 package kafka.api
 
-import java.security.AccessController
-import java.util.Properties
-
-import javax.security.auth.callback._
-import javax.security.auth.Subject
-import javax.security.auth.login.AppConfigurationEntry
-
-import scala.collection.Seq
-import kafka.utils.TestUtils
 import kafka.utils.JaasTestUtils._
+import kafka.utils.TestUtils
+import kafka.utils.TestUtils.isAclSecure
+import kafka.zk.{KafkaZkClient, ZkData}
 import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs
 import org.apache.kafka.common.network.Mode
@@ -33,8 +27,15 @@ import org.apache.kafka.common.security.auth._
 import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder
 import org.apache.kafka.common.security.plain.PlainAuthenticateCallback
 import org.apache.kafka.server.config.KafkaSecurityConfigs
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.Test
+
+import java.security.AccessController
+import java.util.Properties
+import javax.security.auth.Subject
+import javax.security.auth.callback._
+import javax.security.auth.login.AppConfigurationEntry
+import scala.collection.Seq
 
 object SaslPlainSslEndToEndAuthorizationTest {
 
@@ -149,6 +150,23 @@ class SaslPlainSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTes
    */
   @Test
   def testAcls(): Unit = {
-    TestUtils.verifySecureZkAcls(zkClient, 1)
+    verifySecureZkAcls(zkClient, 1)
+  }
+
+  /**
+   * Verifies that all secure paths in ZK are created with the expected ACL.
+   */
+  private def verifySecureZkAcls(zkClient: KafkaZkClient, usersWithAccess: Int): Unit = {
+    TestUtils.secureZkPaths(zkClient).foreach(path => {
+      if (zkClient.pathExists(path)) {
+        val sensitive = ZkData.sensitivePath(path)
+        // usersWithAccess have ALL access to path. For paths that are
+        // not sensitive, world has READ access.
+        val aclCount = if (sensitive) usersWithAccess else usersWithAccess + 1
+        val acls = zkClient.getAcl(path)
+        assertEquals(aclCount, acls.size, s"Invalid ACLs for $path $acls")
+        acls.foreach(acl => isAclSecure(acl, sensitive))
+      }
+    })
   }
 }

--- a/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
@@ -19,7 +19,7 @@ package kafka.api
 import kafka.utils.JaasTestUtils._
 import kafka.utils.TestUtils
 import kafka.utils.TestUtils.isAclSecure
-import kafka.zk.{KafkaZkClient, ZkData}
+import kafka.zk.ZkData
 import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs
 import org.apache.kafka.common.network.Mode
@@ -150,19 +150,12 @@ class SaslPlainSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTes
    */
   @Test
   def testAcls(): Unit = {
-    verifySecureZkAcls(zkClient, 1)
-  }
-
-  /**
-   * Verifies that all secure paths in ZK are created with the expected ACL.
-   */
-  private def verifySecureZkAcls(zkClient: KafkaZkClient, usersWithAccess: Int): Unit = {
     TestUtils.secureZkPaths(zkClient).foreach(path => {
       if (zkClient.pathExists(path)) {
         val sensitive = ZkData.sensitivePath(path)
         // usersWithAccess have ALL access to path. For paths that are
         // not sensitive, world has READ access.
-        val aclCount = if (sensitive) usersWithAccess else usersWithAccess + 1
+        val aclCount = if (sensitive) 1 else 1 + 1
         val acls = zkClient.getAcl(path)
         assertEquals(aclCount, acls.size, s"Invalid ACLs for $path $acls")
         acls.foreach(acl => isAclSecure(acl, sensitive))

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -17,32 +17,32 @@
 
 package kafka.api
 
-import java.lang.{Long => JLong}
-import java.nio.charset.StandardCharsets
-import java.time.Duration
-import java.util.concurrent.TimeUnit
-import java.util.{Optional, Properties}
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
 import kafka.utils.TestUtils.{consumeRecords, waitUntilTrue}
-import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig, ConsumerGroupMetadata, OffsetAndMetadata}
+import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
-import org.apache.kafka.common.errors.{InvalidProducerEpochException, ProducerFencedException, TimeoutException}
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.coordinator.transaction.{TransactionLogConfigs, TransactionStateManagerConfigs}
+import org.apache.kafka.common.errors.{InvalidProducerEpochException, ProducerFencedException, TimeoutException}
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
+import org.apache.kafka.coordinator.transaction.{TransactionLogConfigs, TransactionStateManagerConfigs}
 import org.apache.kafka.server.config.{ReplicationConfigs, ServerLogConfigs}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
+import java.lang.{Long => JLong}
+import java.nio.charset.StandardCharsets
+import java.time.Duration
 import java.util
+import java.util.concurrent.TimeUnit
+import java.util.{Optional, Properties}
 import scala.annotation.nowarn
 import scala.collection.{Seq, mutable}
-import scala.jdk.CollectionConverters._
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.concurrent.ExecutionException
+import scala.jdk.CollectionConverters._
 
 class TransactionsTest extends IntegrationTestHarness {
   override def brokerCount = 3
@@ -652,7 +652,7 @@ class TransactionsTest extends IntegrationTestHarness {
     val transactionalConsumer = transactionalConsumers.head
     transactionalConsumer.subscribe(List(topic1).asJava)
 
-    val transactionalRecords = TestUtils.consumeRecordsFor(transactionalConsumer, 1000)
+    val transactionalRecords = consumeRecordsFor(transactionalConsumer)
     assertTrue(transactionalRecords.isEmpty)
   }
 
@@ -889,6 +889,25 @@ class TransactionsTest extends IntegrationTestHarness {
         }
       })
     }, s"log start offset doesn't change to the expected position: $partitionStartOffsets, current position: $offsets")
+  }
+
+  /**
+   * Will consume all the records for the given consumer for the specified duration. If you want to drain all the
+   * remaining messages in the partitions the consumer is subscribed to, the duration should be set high enough so
+   * that the consumer has enough time to poll everything. This would be based on the number of expected messages left
+   * in the topic, and should not be too large (ie. more than a second) in our tests.
+   *
+   * @return All the records consumed by the consumer within the specified duration.
+   */
+  private def consumeRecordsFor[K, V](consumer: Consumer[K, V]): Seq[ConsumerRecord[K, V]] = {
+    val duration = 1000
+    val startTime = System.currentTimeMillis()
+    val records = new ArrayBuffer[ConsumerRecord[K, V]]()
+    waitUntilTrue(() => {
+      records ++= consumer.poll(Duration.ofMillis(50)).asScala
+      System.currentTimeMillis() - startTime > duration
+    }, s"The timeout $duration was greater than the maximum wait time.")
+    records
   }
 
   @throws(classOf[InterruptedException])

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -20,7 +20,7 @@ package kafka.api
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
 import kafka.utils.TestUtils.{consumeRecords, waitUntilTrue}
-import org.apache.kafka.clients.consumer._
+import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig, ConsumerGroupMetadata, ConsumerRecord, OffsetAndMetadata}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.{InvalidProducerEpochException, ProducerFencedException, TimeoutException}

--- a/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
@@ -38,7 +38,7 @@ import org.junit.jupiter.params.provider.ValueSource
 
 import java.io.IOException
 import java.net.{InetAddress, Socket}
-import java.util.concurrent._
+import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
 import java.util.{Collections, Properties}
 import scala.collection.Map
 import scala.jdk.CollectionConverters._

--- a/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
@@ -18,17 +18,13 @@
 
 package kafka.network
 
-import java.io.IOException
-import java.net.{InetAddress, Socket}
-import java.util.concurrent._
-import java.util.{Collections, Properties}
 import kafka.server.BaseRequestTest
 import kafka.utils.TestUtils
-import org.apache.kafka.clients.admin.Admin
+import org.apache.kafka.clients.admin.{Admin, AlterClientQuotasResult}
 import org.apache.kafka.common.message.ProduceRequestData
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.quota.ClientQuotaEntity
+import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity}
 import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRecord}
 import org.apache.kafka.common.requests.{ProduceRequest, ProduceResponse}
 import org.apache.kafka.common.security.auth.SecurityProtocol
@@ -40,6 +36,11 @@ import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
+import java.io.IOException
+import java.net.{InetAddress, Socket}
+import java.util.concurrent._
+import java.util.{Collections, Properties}
+import scala.collection.Map
 import scala.jdk.CollectionConverters._
 
 class DynamicConnectionQuotaTest extends BaseRequestTest {
@@ -273,7 +274,7 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     val initialConnectionCount = connectionCount
     val entity = new ClientQuotaEntity(Map(ClientQuotaEntity.IP -> ip.orNull).asJava)
     val request = Map(entity -> Map(QuotaConfigs.IP_CONNECTION_RATE_OVERRIDE_CONFIG -> Some(updatedRate.toDouble)))
-    TestUtils.alterClientQuotas(admin, request).all.get()
+    alterClientQuotas(admin, request).all.get()
     // use a random throwaway address if ip isn't specified to get the default value
     TestUtils.waitUntilTrue(() => brokers.head.socketServer.connectionQuotas.
       connectionRateForIp(InetAddress.getByName(ip.getOrElse(unknownHost))) == updatedRate,
@@ -406,5 +407,15 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     val rateCap = if (maxConnectionRate < Int.MaxValue) 1.2 * maxConnectionRate.toDouble else Int.MaxValue.toDouble
     assertTrue(actualRate <= rateCap, s"Listener $listener connection rate $actualRate must be below $rateCap")
     assertTrue(actualRate >= minConnectionRate, s"Listener $listener connection rate $actualRate must be above $minConnectionRate")
+  }
+
+  private def alterClientQuotas(adminClient: Admin, request: Map[ClientQuotaEntity, Map[String, Option[Double]]]): AlterClientQuotasResult = {
+    val entries = request.map { case (entity, alter) =>
+      val ops = alter.map { case (key, value) =>
+        new ClientQuotaAlteration.Op(key, value.map(Double.box).orNull)
+      }.asJavaCollection
+      new ClientQuotaAlteration(entity, ops)
+    }.asJavaCollection
+    adminClient.alterClientQuotas(entries)
   }
 }

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -1754,7 +1754,7 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
   }
 
   private def alterConfigsUsingConfigCommand(props: Properties): Unit = {
-    val propsFile = TestUtils.tempPropertiesFile(clientProps(SecurityProtocol.SSL))
+    val propsFile = tempPropertiesFile(clientProps(SecurityProtocol.SSL))
 
     servers.foreach { server =>
       val args = Array("--bootstrap-server", TestUtils.bootstrapServers(servers, new ListenerName(SecureInternal)),
@@ -1765,6 +1765,8 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
       ConfigCommand.main(args)
     }
   }
+
+  private def tempPropertiesFile(properties: Properties): File = TestUtils.tempPropertiesFile(properties.asScala)
 
   private abstract class ClientBuilder[T]() {
     protected var _bootstrapServers: Option[String] = None

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -16,26 +16,27 @@
  */
 package kafka.admin
 
-import java.util
-import java.util.concurrent.ExecutionException
-import java.util.{Collections, Optional, Properties}
-import scala.collection.Seq
+import kafka.controller.{OfflineReplica, PartitionAndReplica, ReplicaAssignment, ReplicaDeletionSuccessful}
 import kafka.log.UnifiedLog
-import kafka.zk.TopicPartitionZNode
-import kafka.utils._
 import kafka.server.{KafkaBroker, KafkaConfig, KafkaServer, QuorumTestHarness}
+import kafka.utils.TestUtils.waitForAllPartitionsMetadata
+import kafka.utils._
+import kafka.zk.TopicPartitionZNode
+import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, NewPartitionReassignment, NewPartitions}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.{TopicDeletionDisabledException, UnknownTopicOrPartitionException}
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.apache.kafka.metadata.BrokerState
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import kafka.controller.{OfflineReplica, PartitionAndReplica, ReplicaAssignment, ReplicaDeletionSuccessful}
-import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, NewPartitionReassignment, NewPartitions}
-import org.apache.kafka.common.network.ListenerName
-import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.{TopicDeletionDisabledException, UnknownTopicOrPartitionException}
-import org.apache.kafka.metadata.BrokerState
 
+import java.util
+import java.util.concurrent.ExecutionException
+import java.util.{Collections, Optional, Properties}
+import scala.collection.{Map, Seq}
 import scala.jdk.CollectionConverters._
 
 class DeleteTopicTest extends QuorumTestHarness {
@@ -294,7 +295,7 @@ class DeleteTopicTest extends QuorumTestHarness {
       TestUtils.waitUntilTrue(() => follower.brokerState == BrokerState.SHUTTING_DOWN,
         s"Follower ${follower.config.brokerId} was not shut down")
 
-      TestUtils.increasePartitions(admin, topic, 3, brokers.filter(_.config.brokerId != follower.config.brokerId))
+      increasePartitions(admin, topic, 3, brokers.filter(_.config.brokerId != follower.config.brokerId))
     } else {
       // capture the brokers before we shutdown so that we don't fail validation in `addPartitions`
       val brokersMetadata = adminZkClient.getBrokerMetadatas()
@@ -330,7 +331,7 @@ class DeleteTopicTest extends QuorumTestHarness {
     if (isKRaftTest()) {
       admin.deleteTopics(Collections.singletonList(topic)).all().get()
       // pass empty list of brokers to avoid validating metadata since the topic is being deleted.
-      TestUtils.increasePartitions(admin, topic, 3, Seq.empty)
+      increasePartitions(admin, topic, 3, Seq.empty)
     } else {
       zkClient.createTopLevelPaths()
       val brokersMetadata = adminZkClient.getBrokerMetadatas()
@@ -547,5 +548,32 @@ class DeleteTopicTest extends QuorumTestHarness {
     brokers.foreach(_.startup())
     TestUtils.waitUntilTrue(() => brokers.exists(_.asInstanceOf[KafkaServer].kafkaController.isActive), "No controller is elected")
     TestUtils.verifyTopicDeletion(zkClient, topic, 2, brokers)
+  }
+
+  private def increasePartitions[B <: KafkaBroker](admin: Admin,
+                                           topic: String,
+                                           totalPartitionCount: Int,
+                                           brokersToValidate: Seq[B]
+                                          ): Unit = {
+
+    try {
+      val newPartitionSet: Map[String, NewPartitions] = Map.apply(topic -> NewPartitions.increaseTo(totalPartitionCount))
+      admin.createPartitions(newPartitionSet.asJava)
+    } catch {
+      case e: ExecutionException =>
+        throw e
+    }
+
+    if (brokersToValidate.nonEmpty) {
+      // wait until we've propagated all partitions metadata to all brokers
+      val allPartitionsMetadata = waitForAllPartitionsMetadata(brokersToValidate, topic, totalPartitionCount)
+
+      (0 until totalPartitionCount - 1).map { i =>
+        i -> allPartitionsMetadata.get(new TopicPartition(topic, i)).map(_.leader()).getOrElse(
+          throw new IllegalStateException(s"Cannot get the partition leader for topic: $topic, partition: $i in server metadata cache"))
+      }.toMap
+    } else {
+      Map.empty
+    }
   }
 }

--- a/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
@@ -21,7 +21,7 @@ import kafka.server.MetadataCache
 import kafka.server.checkpoints.OffsetCheckpoints
 import kafka.server.metadata.MockConfigRepository
 import kafka.utils.TestUtils
-import kafka.utils.TestUtils.{MockAlterPartitionListener, MockAlterPartitionManager}
+import kafka.utils.TestUtils.MockAlterPartitionManager
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
@@ -37,6 +37,7 @@ import org.mockito.Mockito.{mock, when}
 
 import java.io.File
 import java.util.Properties
+import java.util.concurrent.atomic.AtomicInteger
 import scala.jdk.CollectionConverters._
 
 object AbstractPartitionTest {
@@ -155,5 +156,24 @@ class AbstractPartitionTest {
 
   private def createIsrChangeListener(): MockAlterPartitionListener = {
     new MockAlterPartitionListener()
+  }
+
+  class MockAlterPartitionListener extends AlterPartitionListener {
+    val expands: AtomicInteger = new AtomicInteger(0)
+    val shrinks: AtomicInteger = new AtomicInteger(0)
+    val failures: AtomicInteger = new AtomicInteger(0)
+
+    override def markIsrExpand(): Unit = expands.incrementAndGet()
+
+    override def markIsrShrink(): Unit = shrinks.incrementAndGet()
+
+    override def markFailed(): Unit = failures.incrementAndGet()
+
+
+    def reset(): Unit = {
+      expands.set(0)
+      shrinks.set(0)
+      failures.set(0)
+    }
   }
 }

--- a/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
@@ -20,12 +20,16 @@ import kafka.log.LogManager
 import kafka.server.MetadataCache
 import kafka.server.checkpoints.OffsetCheckpoints
 import kafka.server.metadata.MockConfigRepository
-import kafka.utils.TestUtils.{MockAlterPartitionListener, MockAlterPartitionManager}
 import kafka.utils.TestUtils
+import kafka.utils.TestUtils.{MockAlterPartitionListener, MockAlterPartitionManager}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.server.common.MetadataVersion
+import org.apache.kafka.server.config.ReplicationConfigs
+import org.apache.kafka.server.util.MockTime
+import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach}
 import org.mockito.ArgumentMatchers
@@ -33,11 +37,6 @@ import org.mockito.Mockito.{mock, when}
 
 import java.io.File
 import java.util.Properties
-import org.apache.kafka.server.common.MetadataVersion
-import org.apache.kafka.server.config.ReplicationConfigs
-import org.apache.kafka.server.util.MockTime
-import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig}
-
 import scala.jdk.CollectionConverters._
 
 object AbstractPartitionTest {
@@ -79,7 +78,7 @@ class AbstractPartitionTest {
     logManager.startup(Set.empty)
 
     alterPartitionManager = TestUtils.createAlterIsrManager()
-    alterPartitionListener = TestUtils.createIsrChangeListener()
+    alterPartitionListener = createIsrChangeListener()
     partition = new Partition(topicPartition,
       replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
       interBrokerProtocolVersion = interBrokerProtocolVersion,
@@ -152,5 +151,9 @@ class AbstractPartitionTest {
 
   def defaultBrokerEpoch(brokerId: Int): Long = {
     brokerId + 1000L
+  }
+
+  private def createIsrChangeListener(): MockAlterPartitionListener = {
+    new MockAlterPartitionListener()
   }
 }

--- a/core/src/test/scala/unit/kafka/controller/PartitionStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/PartitionStateMachineTest.scala
@@ -17,12 +17,15 @@
 package kafka.controller
 
 import kafka.api.LeaderAndIsr
+import kafka.cluster.Broker
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
 import kafka.zk.KafkaZkClient.UpdateLeaderAndIsrResult
 import kafka.zk.{KafkaZkClient, TopicPartitionStateZNode}
 import kafka.zookeeper._
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.server.common.MetadataVersion.{IBP_3_1_IV0, IBP_3_2_IV0}
 import org.apache.kafka.server.config.ReplicationConfigs
 import org.apache.kafka.storage.internals.log.LogConfig
@@ -87,7 +90,7 @@ class PartitionStateMachineTest {
 
   @Test
   def testNewPartitionToOnlinePartitionTransition(): Unit = {
-    controllerContext.setLiveBrokers(Map(TestUtils.createBrokerAndEpoch(brokerId, "host", 0)))
+    controllerContext.setLiveBrokers(Map(createBrokerAndEpoch(brokerId, "host", 0)))
     controllerContext.updatePartitionFullReplicaAssignment(partition, ReplicaAssignment(Seq(brokerId)))
     controllerContext.putPartitionState(partition, NewPartition)
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(LeaderAndIsr(brokerId, List(brokerId)), controllerEpoch)
@@ -108,7 +111,7 @@ class PartitionStateMachineTest {
 
   @Test
   def testNewPartitionToOnlinePartitionTransitionZooKeeperClientExceptionFromCreateStates(): Unit = {
-    controllerContext.setLiveBrokers(Map(TestUtils.createBrokerAndEpoch(brokerId, "host", 0)))
+    controllerContext.setLiveBrokers(Map(createBrokerAndEpoch(brokerId, "host", 0)))
     controllerContext.updatePartitionFullReplicaAssignment(partition, ReplicaAssignment(Seq(brokerId)))
     controllerContext.putPartitionState(partition, NewPartition)
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(LeaderAndIsr(brokerId, List(brokerId)), controllerEpoch)
@@ -127,7 +130,7 @@ class PartitionStateMachineTest {
 
   @Test
   def testNewPartitionToOnlinePartitionTransitionErrorCodeFromCreateStates(): Unit = {
-    controllerContext.setLiveBrokers(Map(TestUtils.createBrokerAndEpoch(brokerId, "host", 0)))
+    controllerContext.setLiveBrokers(Map(createBrokerAndEpoch(brokerId, "host", 0)))
     controllerContext.updatePartitionFullReplicaAssignment(partition, ReplicaAssignment(Seq(brokerId)))
     controllerContext.putPartitionState(partition, NewPartition)
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(LeaderAndIsr(brokerId, List(brokerId)), controllerEpoch)
@@ -160,7 +163,7 @@ class PartitionStateMachineTest {
 
   @Test
   def testOnlinePartitionToOnlineTransition(): Unit = {
-    controllerContext.setLiveBrokers(Map(TestUtils.createBrokerAndEpoch(brokerId, "host", 0)))
+    controllerContext.setLiveBrokers(Map(createBrokerAndEpoch(brokerId, "host", 0)))
     controllerContext.updatePartitionFullReplicaAssignment(partition, ReplicaAssignment(Seq(brokerId)))
     controllerContext.putPartitionState(partition, OnlinePartition)
     val leaderAndIsr = LeaderAndIsr(brokerId, List(brokerId))
@@ -191,8 +194,8 @@ class PartitionStateMachineTest {
   def testOnlinePartitionToOnlineTransitionForControlledShutdown(): Unit = {
     val otherBrokerId = brokerId + 1
     controllerContext.setLiveBrokers(Map(
-      TestUtils.createBrokerAndEpoch(brokerId, "host", 0),
-      TestUtils.createBrokerAndEpoch(otherBrokerId, "host", 0)))
+      createBrokerAndEpoch(brokerId, "host", 0),
+      createBrokerAndEpoch(otherBrokerId, "host", 0)))
     controllerContext.shuttingDownBrokerIds.add(brokerId)
     controllerContext.updatePartitionFullReplicaAssignment(
       partition,
@@ -247,7 +250,7 @@ class PartitionStateMachineTest {
 
   @Test
   def testOfflinePartitionToOnlinePartitionTransition(): Unit = {
-    controllerContext.setLiveBrokers(Map(TestUtils.createBrokerAndEpoch(brokerId, "host", 0)))
+    controllerContext.setLiveBrokers(Map(createBrokerAndEpoch(brokerId, "host", 0)))
     controllerContext.updatePartitionFullReplicaAssignment(partition, ReplicaAssignment(Seq(brokerId)))
     controllerContext.putPartitionState(partition, OfflinePartition)
     val leaderAndIsr = LeaderAndIsr(LeaderAndIsr.NoLeader, List(brokerId))
@@ -310,7 +313,7 @@ class PartitionStateMachineTest {
       )
     }
     val leaderBrokerId = brokerId + 1
-    controllerContext.setLiveBrokers(Map(TestUtils.createBrokerAndEpoch(brokerId, "host", 0)))
+    controllerContext.setLiveBrokers(Map(createBrokerAndEpoch(brokerId, "host", 0)))
     controllerContext.updatePartitionFullReplicaAssignment(
       partition,
       ReplicaAssignment(Seq(leaderBrokerId, brokerId))
@@ -353,8 +356,7 @@ class PartitionStateMachineTest {
       Seq(brokerId),
       partition,
       LeaderIsrAndControllerEpoch(updatedLeaderAndIsr, controllerEpoch),
-      replicaAssignment(Seq(leaderBrokerId, brokerId)),
-      isNew = false)
+      replicaAssignment(Seq(leaderBrokerId, brokerId)), isNew = false)
     verify(mockControllerBrokerRequestBatch).sendRequestsToBrokers(controllerEpoch)
     verify(mockZkClient).getTopicPartitionStatesRaw(any())
     verify(mockZkClient).updateLeaderAndIsr(any(), anyInt(), anyInt())
@@ -363,7 +365,7 @@ class PartitionStateMachineTest {
 
   @Test
   def testOfflinePartitionToOnlinePartitionTransitionZooKeeperClientExceptionFromStateLookup(): Unit = {
-    controllerContext.setLiveBrokers(Map(TestUtils.createBrokerAndEpoch(brokerId, "host", 0)))
+    controllerContext.setLiveBrokers(Map(createBrokerAndEpoch(brokerId, "host", 0)))
     controllerContext.updatePartitionFullReplicaAssignment(partition, ReplicaAssignment(Seq(brokerId)))
     controllerContext.putPartitionState(partition, OfflinePartition)
     val leaderAndIsr = LeaderAndIsr(LeaderAndIsr.NoLeader, List(brokerId))
@@ -386,7 +388,7 @@ class PartitionStateMachineTest {
 
   @Test
   def testOfflinePartitionToOnlinePartitionTransitionErrorCodeFromStateLookup(): Unit = {
-    controllerContext.setLiveBrokers(Map(TestUtils.createBrokerAndEpoch(brokerId, "host", 0)))
+    controllerContext.setLiveBrokers(Map(createBrokerAndEpoch(brokerId, "host", 0)))
     controllerContext.updatePartitionFullReplicaAssignment(partition, ReplicaAssignment(Seq(brokerId)))
     controllerContext.putPartitionState(partition, OfflinePartition)
     val leaderAndIsr = LeaderAndIsr(LeaderAndIsr.NoLeader, List(brokerId))
@@ -455,7 +457,7 @@ class PartitionStateMachineTest {
     */
   @Test
   def testUpdatingOfflinePartitionsCount(): Unit = {
-    controllerContext.setLiveBrokers(Map(TestUtils.createBrokerAndEpoch(brokerId, "host", 0)))
+    controllerContext.setLiveBrokers(Map(createBrokerAndEpoch(brokerId, "host", 0)))
 
     val partitionIds = Seq(0, 1, 2, 3)
     val topic = "test"
@@ -538,5 +540,10 @@ class PartitionStateMachineTest {
   }
 
   private def replicaAssignment(replicas: Seq[Int]): ReplicaAssignment = ReplicaAssignment(replicas, Seq(), Seq())
+
+  private def createBrokerAndEpoch(id: Int, host: String, port: Int, securityProtocol: SecurityProtocol = SecurityProtocol.PLAINTEXT,
+                           epoch: Long = 0): (Broker, Long) = {
+    (new Broker(id, host, port, ListenerName.forSecurityProtocol(securityProtocol), securityProtocol), epoch)
+  }
 
 }

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -622,10 +622,13 @@ class LogSegmentTest {
 
   private def writeNonsenseToFile(fileName: File, position: Long, size: Int): Unit = {
     val file = new RandomAccessFile(fileName, "rw")
-    file.seek(position)
-    for (_ <- 0 until size)
-      file.writeByte(random.nextInt(255))
-    file.close()
+    try {
+      file.seek(position)
+      for (_ <- 0 until size)
+        file.writeByte(random.nextInt(255))
+    } finally {
+      file.close()
+    }
   }
 
 }

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -17,7 +17,7 @@
 package kafka.log
 
 import kafka.utils.TestUtils
-import kafka.utils.TestUtils.checkEquals
+import kafka.utils.TestUtils.random
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.record._
@@ -25,13 +25,13 @@ import org.apache.kafka.common.utils.{MockTime, Time, Utils}
 import org.apache.kafka.coordinator.transaction.TransactionLogConfigs
 import org.apache.kafka.storage.internals.checkpoint.LeaderEpochCheckpoint
 import org.apache.kafka.storage.internals.epoch.LeaderEpochFileCache
-import org.apache.kafka.storage.internals.log.{BatchMetadata, EpochEntry, LogConfig, LogFileUtils, LogSegment, LogSegmentOffsetOverflowException, ProducerStateEntry, ProducerStateManager, ProducerStateManagerConfig, RollParams}
+import org.apache.kafka.storage.internals.log._
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
-import java.io.File
+import java.io.{File, RandomAccessFile}
 import java.util
 import java.util.{Optional, OptionalLong}
 import scala.collection._
@@ -327,7 +327,7 @@ class LogSegmentTest {
     for (i <- 0 until 100)
       seg.append(i, RecordBatch.NO_TIMESTAMP, -1L, records(i, i.toString))
     val indexFile = seg.offsetIndexFile
-    TestUtils.writeNonsenseToFile(indexFile, 5, indexFile.length.toInt)
+    writeNonsenseToFile(indexFile, 5, indexFile.length.toInt)
     seg.recover(newProducerStateManager(), Optional.empty())
     for (i <- 0 until 100) {
       val records = seg.read(i, 1, seg.size(), true).records.records
@@ -453,7 +453,7 @@ class LogSegmentTest {
     for (i <- 0 until 100)
       seg.append(i, i * 10, i, records(i, i.toString))
     val timeIndexFile = seg.timeIndexFile
-    TestUtils.writeNonsenseToFile(timeIndexFile, 5, timeIndexFile.length.toInt)
+    writeNonsenseToFile(timeIndexFile, 5, timeIndexFile.length.toInt)
     seg.recover(newProducerStateManager(), Optional.empty())
     for (i <- 0 until 100) {
       assertEquals(i, seg.findOffsetByTimestamp(i * 10, 0L).get.offset)
@@ -477,7 +477,7 @@ class LogSegmentTest {
 
       val recordPosition = seg.log.searchForOffsetWithSize(offsetToBeginCorruption, 0)
       val position = recordPosition.position + TestUtils.random.nextInt(15)
-      TestUtils.writeNonsenseToFile(seg.log.file, position, (seg.log.file.length - position).toInt)
+      writeNonsenseToFile(seg.log.file, position, (seg.log.file.length - position).toInt)
       seg.recover(newProducerStateManager(), Optional.empty())
       assertEquals((0 until offsetToBeginCorruption).toList, seg.log.batches.asScala.map(_.lastOffset).toList,
         "Should have truncated off bad messages.")
@@ -611,6 +611,21 @@ class LogSegmentTest {
       new ProducerStateManagerConfig(TransactionLogConfigs.PRODUCER_ID_EXPIRATION_MS_DEFAULT, false),
       new MockTime()
     )
+  }
+
+  private def checkEquals[T](s1: java.util.Iterator[T], s2: java.util.Iterator[T]): Unit = {
+    while (s1.hasNext && s2.hasNext)
+      assertEquals(s1.next, s2.next)
+    assertFalse(s1.hasNext, "Iterators have uneven length--first has more")
+    assertFalse(s2.hasNext, "Iterators have uneven length--second has more")
+  }
+
+  private def writeNonsenseToFile(fileName: File, position: Long, size: Int): Unit = {
+    val file = new RandomAccessFile(fileName, "rw")
+    file.seek(position)
+    for (_ <- 0 until size)
+      file.writeByte(random.nextInt(255))
+    file.close()
   }
 
 }

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -324,14 +324,14 @@ class RemoteIndexCacheTest {
     // Verify that Cleaner thread is still running even when exception is thrown in doWork()
     var threads = getRunningCleanerThread
     assertEquals(1, threads.size,
-      s"Found unexpected ${threads.size} threads=${threads.stream().map(t => t.getName).collect(Collectors.joining(", "))}")
+      s"Found unexpected ${threads.size} threads=${threads.stream().map[String](t => t.getName).collect(Collectors.joining(", "))}")
 
     // close the cache properly
     cache.close()
 
     // verify that the thread is closed properly
     threads = getRunningCleanerThread
-    assertTrue(threads.isEmpty, s"Found unexpected ${threads.size} threads=${threads.stream().map(t => t.getName).collect(Collectors.joining(", "))}")
+    assertTrue(threads.isEmpty, s"Found unexpected ${threads.size} threads=${threads.stream().map[String](t => t.getName).collect(Collectors.joining(", "))}")
     // if the thread is correctly being shutdown it will not be running
     assertFalse(cache.cleanerThread.isRunning, "Unexpected thread state=running. Check error logs.")
   }

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -17,23 +17,16 @@
 package kafka.server
 
 import kafka.cluster.Partition
-
-import java.net.InetAddress
-import java.nio.charset.StandardCharsets
-import java.util
-import java.util.Collections.{singletonList, singletonMap}
-import java.util.{Collections, Properties}
-import java.util.concurrent.ExecutionException
 import kafka.integration.KafkaServerTestHarness
 import kafka.log.UnifiedLog
 import kafka.log.remote.RemoteLogManager
-import kafka.utils._
 import kafka.server.Constants._
+import kafka.utils.TestUtils.random
+import kafka.utils._
 import kafka.zk.ConfigEntityChangeNotificationZNode
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET
 import org.apache.kafka.clients.admin.{Admin, AlterConfigOp, Config, ConfigEntry}
-import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.errors.{InvalidRequestException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.metrics.Quota
@@ -42,16 +35,23 @@ import org.apache.kafka.common.quota.ClientQuotaEntity.{CLIENT_ID, IP, USER}
 import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity}
 import org.apache.kafka.common.record.{CompressionType, RecordVersion}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
+import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.server.common.MetadataVersion.IBP_3_0_IV1
-import org.apache.kafka.server.config.{ConfigType, ServerLogConfigs, QuotaConfigs, ZooKeeperInternals}
+import org.apache.kafka.server.config.{ConfigType, QuotaConfigs, ServerLogConfigs, ZooKeeperInternals}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{Test, Timeout}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, anyString}
-import org.mockito.Mockito.{doNothing, mock, never, verify, when}
+import org.mockito.Mockito._
 
+import java.net.InetAddress
+import java.nio.charset.StandardCharsets
+import java.util
+import java.util.Collections.{singletonList, singletonMap}
+import java.util.concurrent.ExecutionException
+import java.util.{Collections, Properties}
 import scala.annotation.nowarn
 import scala.collection.{Map, Seq}
 import scala.jdk.CollectionConverters._
@@ -383,16 +383,18 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
   @ParameterizedTest
   @ValueSource(strings = Array("zk"))
   def testConfigChangeOnNonExistingTopic(quorum: String): Unit = {
-    val topic = TestUtils.tempTopic()
+    val topic = tempTopic()
     val logProps = new Properties()
     logProps.put(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG, 10000: java.lang.Integer)
     assertThrows(classOf[UnknownTopicOrPartitionException], () => adminZkClient.changeTopicConfig(topic, logProps))
   }
 
+  private def tempTopic() : String = "testTopic" + random.nextInt(1000000)
+
   @ParameterizedTest
   @ValueSource(strings = Array("zk", "kraft"))
   def testConfigChangeOnNonExistingTopicWithAdminClient(quorum: String): Unit = {
-    val topic = TestUtils.tempTopic()
+    val topic = tempTopic()
     val admin = createAdminClient()
     try {
       val resource = new ConfigResource(ConfigResource.Type.TOPIC, topic)

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -85,7 +85,7 @@ class LogOffsetTest extends BaseRequestTest {
     val offsets = log.legacyFetchOffsetsBefore(ListOffsetsRequest.LATEST_TIMESTAMP, 15)
     assertEquals(Seq(20L, 18L, 16L, 14L, 12L, 10L, 8L, 6L, 4L, 3L), offsets)
 
-    TestUtils.waitUntilTrue(() => TestUtils.isLeaderLocalOnBroker(topic, topicPartition.partition, broker),
+    TestUtils.waitUntilTrue(() => isLeaderLocalOnBroker(topic, topicPartition.partition, broker),
       "Leader should be elected")
     val request = ListOffsetsRequest.Builder.forReplica(0, 0)
       .setTargetTimes(buildTargetTimes(topicPartition, ListOffsetsRequest.LATEST_TIMESTAMP, 15).asJava).build()
@@ -152,7 +152,7 @@ class LogOffsetTest extends BaseRequestTest {
     val offsets = log.legacyFetchOffsetsBefore(ListOffsetsRequest.LATEST_TIMESTAMP, 15)
     assertEquals(Seq(20L, 18L, 16L, 14L, 12L, 10L, 8L, 6L, 4L, 2L, 0L), offsets)
 
-    TestUtils.waitUntilTrue(() => TestUtils.isLeaderLocalOnBroker(topic, 0, broker),
+    TestUtils.waitUntilTrue(() => isLeaderLocalOnBroker(topic, 0, broker),
       "Leader should be elected")
     val request = ListOffsetsRequest.Builder.forReplica(0, 0)
       .setTargetTimes(buildTargetTimes(topicPartition, ListOffsetsRequest.LATEST_TIMESTAMP, 15).asJava).build()
@@ -226,7 +226,7 @@ class LogOffsetTest extends BaseRequestTest {
     val offsets = log.legacyFetchOffsetsBefore(now, 15)
     assertEquals(Seq(20L, 18L, 16L, 14L, 12L, 10L, 8L, 6L, 4L, 2L, 0L), offsets)
 
-    TestUtils.waitUntilTrue(() => TestUtils.isLeaderLocalOnBroker(topic, topicPartition.partition, broker),
+    TestUtils.waitUntilTrue(() => isLeaderLocalOnBroker(topic, topicPartition.partition, broker),
       "Leader should be elected")
     val request = ListOffsetsRequest.Builder.forReplica(0, 0)
       .setTargetTimes(buildTargetTimes(topicPartition, now, 15).asJava).build()
@@ -254,7 +254,7 @@ class LogOffsetTest extends BaseRequestTest {
       val offsets = log.legacyFetchOffsetsBefore(timestamp, 10)
       assertEquals(Seq(0L), offsets)
 
-      TestUtils.waitUntilTrue(() => TestUtils.isLeaderLocalOnBroker(topic, topicPartition.partition, broker),
+      TestUtils.waitUntilTrue(() => isLeaderLocalOnBroker(topic, topicPartition.partition, broker),
         "Leader should be elected")
       val request = ListOffsetsRequest.Builder.forReplica(0, 0)
         .setTargetTimes(buildTargetTimes(topicPartition, timestamp, 10).asJava).build()
@@ -329,4 +329,7 @@ class LogOffsetTest extends BaseRequestTest {
     logManager.getLog(topicPartition).get
   }
 
+  private def isLeaderLocalOnBroker(topic: String, partitionId: Int, broker: KafkaBroker): Boolean = {
+    broker.replicaManager.onlinePartition(new TopicPartition(topic, partitionId)).exists(_.leaderLogIfLocal.isDefined)
+  }
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -60,7 +60,7 @@ import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.raft.QuorumConfig
 import org.apache.kafka.server.common.MetadataVersion.IBP_2_6_IV0
 import org.apache.kafka.server.common.{DirectoryEventHandler, MetadataVersion, OffsetAndEpoch}
-import org.apache.kafka.server.config.{ReplicationConfigs, ServerLogConfigs}
+import org.apache.kafka.server.config.{KRaftConfigs, ReplicationConfigs, ServerLogConfigs}
 import org.apache.kafka.server.log.remote.storage._
 import org.apache.kafka.server.metrics.{KafkaMetricsGroup, KafkaYammerMetrics}
 import org.apache.kafka.server.util.timer.MockTimer
@@ -73,17 +73,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{EnumSource, ValueSource}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import com.yammer.metrics.core.{Gauge, Meter}
-import kafka.log.remote.RemoteLogManager
-import kafka.zk.KafkaZkClient
-import org.apache.kafka.common.config.{AbstractConfig, TopicConfig}
-import org.apache.kafka.coordinator.transaction.TransactionLogConfigs
-import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, MetaPropertiesVersion, PropertiesUtils}
-import org.apache.kafka.network.SocketServerConfigs
-import org.apache.kafka.raft.QuorumConfig
-import org.apache.kafka.server.config.{KRaftConfigs, ReplicationConfigs, ServerLogConfigs}
-import org.apache.kafka.server.util.timer.MockTimer
-import org.apache.kafka.storage.internals.checkpoint.PartitionMetadataFile
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -26,6 +26,7 @@ import kafka.log.remote.RemoteLogManager
 import kafka.server.QuotaFactory.{QuotaManagers, UnboundedQuota}
 import kafka.server.checkpoints.{LazyOffsetCheckpoints, OffsetCheckpointFile}
 import kafka.server.epoch.util.MockBlockingSender
+import kafka.utils.TestUtils.waitUntilTrue
 import kafka.utils.{Exit, Pool, TestUtils}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.FetchSessionHandler
@@ -56,6 +57,7 @@ import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.metadata.migration.ZkMigrationState
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, MetaPropertiesVersion, PropertiesUtils}
 import org.apache.kafka.network.SocketServerConfigs
+import org.apache.kafka.raft.QuorumConfig
 import org.apache.kafka.server.common.MetadataVersion.IBP_2_6_IV0
 import org.apache.kafka.server.common.{DirectoryEventHandler, MetadataVersion, OffsetAndEpoch}
 import org.apache.kafka.server.config.{ReplicationConfigs, ServerLogConfigs}

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -17,24 +17,20 @@
 
 package kafka.server
 
-import java.io.File
-import java.io.ByteArrayInputStream
-import java.net.InetAddress
-import java.nio.file.{Files, Paths}
-import java.util
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
-import java.util.concurrent.{Callable, CountDownLatch, TimeUnit}
-import java.util.stream.IntStream
-import java.util.{Collections, Optional, OptionalLong, Properties}
+import com.yammer.metrics.core.{Gauge, Meter}
 import kafka.api._
 import kafka.cluster.PartitionTest.MockPartitionListener
 import kafka.cluster.{BrokerEndPoint, Partition}
 import kafka.log._
+import kafka.log.remote.RemoteLogManager
 import kafka.server.QuotaFactory.{QuotaManagers, UnboundedQuota}
 import kafka.server.checkpoints.{LazyOffsetCheckpoints, OffsetCheckpointFile}
 import kafka.server.epoch.util.MockBlockingSender
 import kafka.utils.{Exit, Pool, TestUtils}
+import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.FetchSessionHandler
+import org.apache.kafka.common._
+import org.apache.kafka.common.config.{AbstractConfig, TopicConfig}
 import org.apache.kafka.common.errors.{InvalidPidMappingException, KafkaStorageException}
 import org.apache.kafka.common.message.LeaderAndIsrRequestData
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
@@ -45,30 +41,36 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record._
-import org.apache.kafka.common.replica.{ClientMetadata, PartitionView, ReplicaSelector, ReplicaView}
 import org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata
 import org.apache.kafka.common.replica.ReplicaView.DefaultReplicaView
+import org.apache.kafka.common.replica.{ClientMetadata, PartitionView, ReplicaSelector, ReplicaView}
 import org.apache.kafka.common.requests.FetchRequest.PartitionData
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.utils.{LogContext, Time, Utils}
-import org.apache.kafka.common.{DirectoryId, IsolationLevel, Node, TopicIdPartition, TopicPartition, Uuid}
+import org.apache.kafka.coordinator.transaction.TransactionLogConfigs
 import org.apache.kafka.image._
 import org.apache.kafka.metadata.LeaderConstants.NO_LEADER
 import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.metadata.migration.ZkMigrationState
-import org.apache.kafka.server.common.{DirectoryEventHandler, OffsetAndEpoch}
-import org.apache.kafka.server.common.MetadataVersion
+import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, MetaPropertiesVersion, PropertiesUtils}
+import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.server.common.MetadataVersion.IBP_2_6_IV0
-import org.apache.kafka.server.log.remote.storage.{NoOpRemoteLogMetadataManager, NoOpRemoteStorageManager, RemoteLogManagerConfig, RemoteLogSegmentMetadata, RemoteStorageException, RemoteStorageManager}
+import org.apache.kafka.server.common.{DirectoryEventHandler, MetadataVersion, OffsetAndEpoch}
+import org.apache.kafka.server.config.{ReplicationConfigs, ServerLogConfigs}
+import org.apache.kafka.server.log.remote.storage._
 import org.apache.kafka.server.metrics.{KafkaMetricsGroup, KafkaYammerMetrics}
+import org.apache.kafka.server.util.timer.MockTimer
 import org.apache.kafka.server.util.{MockScheduler, MockTime}
-import org.apache.kafka.storage.internals.log.{AppendOrigin, FetchDataInfo, FetchIsolation, FetchParams, FetchPartitionData, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogOffsetSnapshot, LogSegments, LogStartOffsetIncrementReason, ProducerStateManager, ProducerStateManagerConfig, RemoteStorageFetchInfo, VerificationGuard}
+import org.apache.kafka.storage.internals.checkpoint.PartitionMetadataFile
+import org.apache.kafka.storage.internals.log._
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterAll, AfterEach, BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{EnumSource, ValueSource}
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
 import com.yammer.metrics.core.{Gauge, Meter}
 import kafka.log.remote.RemoteLogManager
 import kafka.zk.KafkaZkClient
@@ -83,9 +85,15 @@ import org.apache.kafka.storage.internals.checkpoint.PartitionMetadataFile
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
-import org.mockito.ArgumentMatchers.{any, anyBoolean, anyInt, anyLong, anyMap, anySet, anyString}
-import org.mockito.Mockito.{atLeastOnce, doAnswer, doReturn, mock, mockConstruction, never, reset, spy, times, verify, verifyNoInteractions, verifyNoMoreInteractions, when}
 
+import java.io.{ByteArrayInputStream, File}
+import java.net.InetAddress
+import java.nio.file.{Files, Paths}
+import java.util
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
+import java.util.concurrent.{Callable, CountDownLatch, TimeUnit}
+import java.util.stream.IntStream
+import java.util.{Collections, Optional, OptionalLong, Properties}
 import scala.collection.{Map, Seq, mutable}
 import scala.compat.java8.OptionConverters.RichOptionForJava8
 import scala.jdk.CollectionConverters._
@@ -144,12 +152,12 @@ class ReplicaManagerTest {
 
   @AfterEach
   def tearDown(): Unit = {
-    TestUtils.clearYammerMetricsExcept(metricsToBeDeletedInTheEnd)
+    clearYammerMetricsExcept(metricsToBeDeletedInTheEnd)
     Option(quotaManager).foreach(_.shutdown())
     metrics.close()
     // validate that the shutdown is working correctly by ensuring no lingering threads.
     // assert at the very end otherwise the other tear down steps will not be performed
-    TestUtils.assertNoNonDaemonThreadsWithWaiting(this.getClass.getName)
+    assertNoNonDaemonThreadsWithWaiting(this.getClass.getName)
   }
 
   @Test
@@ -644,7 +652,7 @@ class ReplicaManagerTest {
     val topicPartition = new TopicPartition(topic, 0)
 
     def assertLateTransactionCount(expectedCount: Option[Int]): Unit = {
-      assertEquals(expectedCount, TestUtils.yammerGaugeValue[Int]("PartitionsWithLateTransactionsCount"))
+      assertEquals(expectedCount, yammerGaugeValue[Int]("PartitionsWithLateTransactionsCount"))
     }
 
     try {
@@ -6593,6 +6601,33 @@ class ReplicaManagerTest {
           null
         }
       ))
+    }
+  }
+  // Some threads are closed, but the state didn't reflect in the JVM immediately, so add some wait time for it
+  private def assertNoNonDaemonThreadsWithWaiting(threadNamePrefix: String, waitTimeMs: Long = 500L): Unit = {
+    var nonDemonThreads: mutable.Set[Thread] = mutable.Set.empty[Thread]
+    waitUntilTrue(() => {
+      nonDemonThreads = Thread.getAllStackTraces.keySet.asScala.filter { t =>
+        !t.isDaemon && t.isAlive && t.getName.startsWith(threadNamePrefix)
+      }
+      0 == nonDemonThreads.size
+    }, s"Found unexpected ${nonDemonThreads.size} NonDaemon threads=${nonDemonThreads.map(t => t.getName).mkString(", ")}", waitTimeMs)
+  }
+
+  private def yammerGaugeValue[T](metricName: String): Option[T] = {
+    KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
+      .filter { case (k, _) => k.getMBeanName.endsWith(metricName) }
+      .values
+      .headOption
+      .map(_.asInstanceOf[Gauge[T]])
+      .map(_.value)
+  }
+
+  private def clearYammerMetricsExcept(names: Set[String]): Unit = {
+    for (metricName <- KafkaYammerMetrics.defaultRegistry.allMetrics.keySet.asScala) {
+      if (!names.contains(metricName.getMBeanName)) {
+        KafkaYammerMetrics.defaultRegistry.removeMetric(metricName)
+      }
     }
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ServerGenerateBrokerIdTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerGenerateBrokerIdTest.scala
@@ -16,16 +16,16 @@
   */
 package kafka.server
 
-import java.util.{OptionalInt, Properties}
-import scala.collection.Seq
 import kafka.utils.TestUtils
-import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, PropertiesUtils}
-import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
+import org.apache.zookeeper.KeeperException.NodeExistsException
 import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
 
 import java.io.File
-import org.apache.zookeeper.KeeperException.NodeExistsException
+import java.util.{OptionalInt, Properties}
+import scala.collection.Seq
 
 class ServerGenerateBrokerIdTest extends QuorumTestHarness {
   var props1: Properties = _
@@ -56,7 +56,7 @@ class ServerGenerateBrokerIdTest extends QuorumTestHarness {
     server1.shutdown()
     assertTrue(verifyBrokerMetadata(config1.logDirs, 1001))
     // restart the server check to see if it uses the brokerId generated previously
-    server1 = TestUtils.createServer(config1, threadNamePrefix = Option(this.getClass.getName))
+    server1 = createServer(config1, threadNamePrefix = Option(this.getClass.getName))
     servers = Seq(server1)
     assertEquals(server1.config.brokerId, 1001)
     server1.shutdown()
@@ -91,7 +91,7 @@ class ServerGenerateBrokerIdTest extends QuorumTestHarness {
     // Set reserve broker ids to cause collision and ensure disabling broker id generation ignores the setting
     props3.put(KafkaConfig.MaxReservedBrokerIdProp, "0")
     val config3 = KafkaConfig.fromProps(props3)
-    val server3 = TestUtils.createServer(config3, threadNamePrefix = Option(this.getClass.getName))
+    val server3 = createServer(config3, threadNamePrefix = Option(this.getClass.getName))
     servers = Seq(server3)
     assertEquals(server3.config.brokerId, 3)
     server3.shutdown()
@@ -141,7 +141,7 @@ class ServerGenerateBrokerIdTest extends QuorumTestHarness {
     // Start a good server
     val propsA = TestUtils.createBrokerConfig(1, zkConnect)
     val configA = KafkaConfig.fromProps(propsA)
-    val serverA = TestUtils.createServer(configA, threadNamePrefix = Option(this.getClass.getName))
+    val serverA = createServer(configA, threadNamePrefix = Option(this.getClass.getName))
 
     // Start a server that collides on the broker id
     val propsB = TestUtils.createBrokerConfig(1, zkConnect)
@@ -183,5 +183,9 @@ class ServerGenerateBrokerIdTest extends QuorumTestHarness {
       }
     }
     true
+  }
+
+  private def createServer(config: KafkaConfig, threadNamePrefix: Option[String]): KafkaServer = {
+    TestUtils.createServer(config, Time.SYSTEM, threadNamePrefix)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ServerGenerateClusterIdTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerGenerateClusterIdTest.scala
@@ -22,6 +22,7 @@ import scala.concurrent._
 import scala.concurrent.duration._
 import ExecutionContext.Implicits._
 import kafka.utils.TestUtils
+import org.apache.kafka.common.utils.Time
 import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, MetaPropertiesVersion, PropertiesUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
@@ -56,7 +57,7 @@ class ServerGenerateClusterIdTest extends QuorumTestHarness {
     // Make sure that the cluster id doesn't exist yet.
     assertFalse(zkClient.getClusterId.isDefined)
 
-    var server1 = TestUtils.createServer(config1, threadNamePrefix = Option(this.getClass.getName))
+    var server1 = createServer(config1, threadNamePrefix = Option(this.getClass.getName))
     servers = Seq(server1)
 
     // Validate the cluster id
@@ -70,7 +71,7 @@ class ServerGenerateClusterIdTest extends QuorumTestHarness {
     assertEquals(zkClient.getClusterId, Some(clusterIdOnFirstBoot))
 
     // Restart the server check to confirm that it uses the clusterId generated previously
-    server1 = TestUtils.createServer(config1, threadNamePrefix = Option(this.getClass.getName))
+    server1 = createServer(config1, threadNamePrefix = Option(this.getClass.getName))
     servers = Seq(server1)
 
     val clusterIdOnSecondBoot = server1.clusterId
@@ -87,13 +88,13 @@ class ServerGenerateClusterIdTest extends QuorumTestHarness {
 
   @Test
   def testAutoGenerateClusterIdForKafkaClusterSequential(): Unit = {
-    val server1 = TestUtils.createServer(config1, threadNamePrefix = Option(this.getClass.getName))
+    val server1 = createServer(config1, threadNamePrefix = Option(this.getClass.getName))
     val clusterIdFromServer1 = server1.clusterId
 
-    val server2 = TestUtils.createServer(config2, threadNamePrefix = Option(this.getClass.getName))
+    val server2 = createServer(config2, threadNamePrefix = Option(this.getClass.getName))
     val clusterIdFromServer2 = server2.clusterId
 
-    val server3 = TestUtils.createServer(config3, threadNamePrefix = Option(this.getClass.getName))
+    val server3 = createServer(config3, threadNamePrefix = Option(this.getClass.getName))
     val clusterIdFromServer3 = server3.clusterId
     servers = Seq(server1, server2, server3)
 
@@ -117,7 +118,7 @@ class ServerGenerateClusterIdTest extends QuorumTestHarness {
 
   @Test
   def testAutoGenerateClusterIdForKafkaClusterParallel(): Unit = {
-    val firstBoot = Future.traverse(Seq(config1, config2, config3))(config => Future(TestUtils.createServer(config, threadNamePrefix = Option(this.getClass.getName))))
+    val firstBoot = Future.traverse(Seq(config1, config2, config3))(config => Future(createServer(config, threadNamePrefix = Option(this.getClass.getName))))
     servers = Await.result(firstBoot, 100.second)
     val Seq(server1, server2, server3) = servers
 
@@ -145,7 +146,7 @@ class ServerGenerateClusterIdTest extends QuorumTestHarness {
   @Test
   def testConsistentClusterIdFromZookeeperAndFromMetaProps(): Unit = {
     // Check at the first boot
-    val server = TestUtils.createServer(config1, threadNamePrefix = Option(this.getClass.getName))
+    val server = createServer(config1, threadNamePrefix = Option(this.getClass.getName))
     val clusterId = server.clusterId
 
     assertTrue(verifyBrokerMetadata(server.config.logDirs, clusterId))
@@ -227,5 +228,9 @@ class ServerGenerateClusterIdTest extends QuorumTestHarness {
       }
     }
     true
+  }
+
+  def createServer(config: KafkaConfig, threadNamePrefix: Option[String]): KafkaServer = {
+    TestUtils.createServer(config, Time.SYSTEM, threadNamePrefix)
   }
 }

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -16,23 +16,9 @@
  */
 package kafka.utils
 
-import java.io._
-import java.net.InetAddress
-import java.nio._
-import java.nio.channels._
-import java.nio.charset.{Charset, StandardCharsets}
-import java.nio.file.{Files, StandardOpenOption}
-import java.security.cert.X509Certificate
-import java.time.Duration
-import java.util
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
-import java.util.concurrent.{Callable, CompletableFuture, ExecutionException, Executors, TimeUnit}
-import java.util.{Arrays, Collections, Optional, Properties}
-import com.yammer.metrics.core.{Gauge, Histogram, Meter}
-
-import javax.net.ssl.X509TrustManager
+import com.yammer.metrics.core.{Histogram, Meter}
 import kafka.api._
-import kafka.cluster.{AlterPartitionListener, Broker, EndPoint}
+import kafka.cluster.AlterPartitionListener
 import kafka.controller.{ControllerEventManager, LeaderIsrAndControllerEpoch}
 import kafka.log._
 import kafka.network.RequestChannel
@@ -42,17 +28,16 @@ import kafka.server.metadata.{ConfigRepository, MockConfigRepository}
 import kafka.tools.StorageTool
 import kafka.utils.Implicits._
 import kafka.zk._
-import org.apache.kafka.admin.BrokerMetadata
-import org.apache.kafka.clients.{ClientResponse, CommonClientConfigs}
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.clients.admin._
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.consumer.internals.AbstractCoordinator
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
-import org.apache.kafka.common.{KafkaFuture, Node, TopicIdPartition, TopicPartition, Uuid}
-import org.apache.kafka.common.acl.{AccessControlEntry, AccessControlEntryFilter, AclBinding, AclBindingFilter}
-import org.apache.kafka.common.config.{ConfigException, ConfigResource}
+import org.apache.kafka.clients.{ClientResponse, CommonClientConfigs}
+import org.apache.kafka.common._
+import org.apache.kafka.common.acl.{AccessControlEntry, AccessControlEntryFilter, AclBindingFilter}
 import org.apache.kafka.common.config.ConfigResource.Type.TOPIC
+import org.apache.kafka.common.config.{ConfigException, ConfigResource}
 import org.apache.kafka.common.errors.{KafkaStorageException, OperationNotAttemptedException, TopicExistsException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.header.Header
 import org.apache.kafka.common.internals.Topic
@@ -61,17 +46,16 @@ import org.apache.kafka.common.message.UpdateMetadataRequestData.UpdateMetadataP
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.{ClientInformation, ListenerName, Mode}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
-import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity}
 import org.apache.kafka.common.record._
-import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, EnvelopeRequest, FetchRequest, RequestContext, RequestHeader}
+import org.apache.kafka.common.requests._
 import org.apache.kafka.common.resource.ResourcePattern
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, KafkaPrincipalSerde, SecurityProtocol}
-import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer, Deserializer, IntegerSerializer, Serializer}
+import org.apache.kafka.common.serialization._
 import org.apache.kafka.common.utils.Utils.formatAddress
 import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.controller.QuorumController
-import org.apache.kafka.coordinator.transaction.TransactionLogConfigs
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
+import org.apache.kafka.coordinator.transaction.TransactionLogConfigs
 import org.apache.kafka.metadata.properties.MetaProperties
 import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.raft.QuorumConfig
@@ -79,9 +63,11 @@ import org.apache.kafka.server.{ClientMetricsManager, ControllerRequestCompletio
 import org.apache.kafka.server.authorizer.{AuthorizableRequestContext, Authorizer => JAuthorizer}
 import org.apache.kafka.server.config.{KRaftConfigs, ReplicationConfigs, ServerLogConfigs, QuotaConfigs, ZkConfigs}
 import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
+import org.apache.kafka.server.config.{QuotaConfigs, ReplicationConfigs, ServerLogConfigs, ZkConfigs}
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.util.MockTime
 import org.apache.kafka.server.util.timer.SystemTimer
+import org.apache.kafka.server.{ClientMetricsManager, ControllerRequestCompletionHandler}
 import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig, LogDirFailureChannel, ProducerStateManagerConfig}
 import org.apache.kafka.test.{TestSslUtils, TestUtils => JTestUtils}
 import org.apache.zookeeper.KeeperException.SessionExpiredException
@@ -91,6 +77,16 @@ import org.junit.jupiter.api.Assertions._
 import org.mockito.ArgumentMatchers.{any, anyBoolean}
 import org.mockito.Mockito
 
+import java.io._
+import java.net.InetAddress
+import java.nio._
+import java.nio.charset.{Charset, StandardCharsets}
+import java.nio.file.{Files, StandardOpenOption}
+import java.time.Duration
+import java.util
+import java.util.concurrent._
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.{Arrays, Collections, Optional, Properties}
 import scala.annotation.nowarn
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.collection.{Map, Seq, immutable, mutable}
@@ -133,8 +129,6 @@ object TestUtils extends Logging {
    */
   def tempDir(): File = JTestUtils.tempDirectory()
 
-  def tempTopic(): String = "testTopic" + random.nextInt(1000000)
-
   /**
    * Create a temporary relative directory
    */
@@ -169,20 +163,12 @@ object TestUtils extends Logging {
    */
   def tempFile(contents: String): File = JTestUtils.tempFile(contents)
 
-  def tempPropertiesFile(properties: Properties): File = {
-    return tempPropertiesFile(properties.asScala)
-  }
+  def tempPropertiesFile(properties: Properties): File = tempPropertiesFile(properties.asScala)
 
   def tempPropertiesFile(properties: Map[String, String]): File = {
     val content = properties.map{case (k, v) => k + "=" + v}.mkString(System.lineSeparator())
-    return tempFile(content)
+    tempFile(content)
   }
-
-  /**
-   * Create a temporary file and return an open file channel for this file
-   */
-  def tempChannel(): FileChannel =
-    FileChannel.open(tempFile().toPath, StandardOpenOption.READ, StandardOpenOption.WRITE)
 
   /**
    * Create a kafka server instance with appropriate test settings
@@ -192,10 +178,6 @@ object TestUtils extends Logging {
    */
   def createServer(config: KafkaConfig, time: Time = Time.SYSTEM): KafkaServer = {
     createServer(config, time, None)
-  }
-
-  def createServer(config: KafkaConfig, threadNamePrefix: Option[String]): KafkaServer = {
-    createServer(config, Time.SYSTEM, threadNamePrefix)
   }
 
   def createServer(config: KafkaConfig, time: Time, threadNamePrefix: Option[String]): KafkaServer = {
@@ -215,11 +197,6 @@ object TestUtils extends Logging {
 
   def boundPort(broker: KafkaBroker, securityProtocol: SecurityProtocol = SecurityProtocol.PLAINTEXT): Int =
     broker.boundPort(ListenerName.forSecurityProtocol(securityProtocol))
-
-  def createBrokerAndEpoch(id: Int, host: String, port: Int, securityProtocol: SecurityProtocol = SecurityProtocol.PLAINTEXT,
-                           epoch: Long = 0): (Broker, Long) = {
-    (new Broker(id, host, port, ListenerName.forSecurityProtocol(securityProtocol), securityProtocol), epoch)
-  }
 
   /**
    * Create a test config for the provided parameters.
@@ -476,7 +453,7 @@ object TestUtils extends Logging {
       cause != null &&
         cause.isInstanceOf[TopicExistsException] &&
         // wait until all partitions metadata are propagated before verifying partitions number and replication factor
-        !waitForAllPartitionsMetadata(brokers, topic, effectiveNumPartitions).isEmpty &&
+        waitForAllPartitionsMetadata(brokers, topic, effectiveNumPartitions).nonEmpty &&
         topicHasSameNumPartitionsAndReplicationFactor(admin, topic, effectiveNumPartitions, replicationFactor)
     }
 
@@ -504,33 +481,6 @@ object TestUtils extends Logging {
       i -> allPartitionsMetadata.get(new TopicPartition(topic, i)).map(_.leader()).getOrElse(
         throw new IllegalStateException(s"Cannot get the partition leader for topic: $topic, partition: $i in server metadata cache"))
     }.toMap
-  }
-
-  def increasePartitions[B <: KafkaBroker](admin: Admin,
-                                              topic: String,
-                                              totalPartitionCount: Int,
-                                              brokersToValidate: Seq[B]
-                                            ): Unit = {
-
-    try {
-      val newPartitionSet: Map[String, NewPartitions] = Map.apply(topic -> NewPartitions.increaseTo(totalPartitionCount))
-      admin.createPartitions(newPartitionSet.asJava)
-    } catch {
-      case e: ExecutionException =>
-        throw e
-    }
-
-    if (brokersToValidate.size > 0) {
-      // wait until we've propagated all partitions metadata to all brokers
-      val allPartitionsMetadata = waitForAllPartitionsMetadata(brokersToValidate, topic, totalPartitionCount)
-
-      (0 until totalPartitionCount - 1).map { i =>
-        i -> allPartitionsMetadata.get(new TopicPartition(topic, i)).map(_.leader()).getOrElse(
-          throw new IllegalStateException(s"Cannot get the partition leader for topic: $topic, partition: $i in server metadata cache"))
-      }.toMap
-    } else {
-      Map.empty
-    }
   }
 
   def describeTopic(
@@ -665,42 +615,6 @@ object TestUtils extends Logging {
   }
 
   /**
-   * Ensures that the consumer offsets/group metadata topic exists. If it does not, the topic is created and the method waits
-   * until the leader is elected and metadata is propagated to all brokers. If it does, the method verifies that it has
-   * the expected number of partition and replication factor however it does not guarantee that the topic is empty.
-   */
-  def createOffsetsTopic(zkClient: KafkaZkClient, servers: Seq[KafkaBroker]): Unit = {
-    val server = servers.head
-    val numPartitions = server.config.offsetsTopicPartitions
-    val replicationFactor = server.config.offsetsTopicReplicationFactor.toInt
-
-    try {
-      createTopic(
-        zkClient,
-        Topic.GROUP_METADATA_TOPIC_NAME,
-        numPartitions,
-        replicationFactor,
-        servers,
-        server.groupCoordinator.groupMetadataTopicConfigs
-      )
-    } catch {
-      case ex: TopicExistsException =>
-        val allPartitionsMetadata = waitForAllPartitionsMetadata(
-          servers,
-          Topic.GROUP_METADATA_TOPIC_NAME,
-          numPartitions
-        )
-
-        // If the topic already exists, we ensure that it has the required
-        // number of partitions and replication factor. If it has not, the
-        // exception is thrown further.
-        if (allPartitionsMetadata.size != numPartitions || allPartitionsMetadata.head._2.replicas.size != replicationFactor) {
-          throw ex
-        }
-    }
-  }
-
-  /**
    * Wrap a single record log buffer.
    */
   def singletonRecords(value: Array[Byte],
@@ -709,12 +623,6 @@ object TestUtils extends Logging {
                        timestamp: Long = RecordBatch.NO_TIMESTAMP,
                        magicValue: Byte = RecordBatch.CURRENT_MAGIC_VALUE): MemoryRecords = {
     records(Seq(new SimpleRecord(timestamp, key, value)), magicValue = magicValue, codec = codec)
-  }
-
-  def recordsWithValues(magicValue: Byte,
-                        codec: CompressionType,
-                        values: Array[Byte]*): MemoryRecords = {
-    records(values.map(value => new SimpleRecord(value)), magicValue, codec)
   }
 
   def records(records: Iterable[SimpleRecord],
@@ -738,87 +646,6 @@ object TestUtils extends Logging {
    * @param numBytes The size of the array
    */
   def randomBytes(numBytes: Int): Array[Byte] = JTestUtils.randomBytes(numBytes)
-
-  /**
-   * Generate a random string of letters and digits of the given length
-   *
-   * @param len The length of the string
-   * @return The random string
-   */
-  def randomString(len: Int): String = JTestUtils.randomString(len)
-
-  /**
-   * Check that the buffer content from buffer.position() to buffer.limit() is equal
-   */
-  def checkEquals(b1: ByteBuffer, b2: ByteBuffer): Unit = {
-    assertEquals(b1.limit() - b1.position(), b2.limit() - b2.position(), "Buffers should have equal length")
-    for (i <- 0 until b1.limit() - b1.position())
-      assertEquals(b1.get(b1.position() + i), b2.get(b1.position() + i), "byte " + i + " byte not equal.")
-  }
-
-  /**
-   *  Throw an exception if an iterable has different length than expected
-   *
-   */
-  def checkLength[T](s1: Iterator[T], expectedLength:Int): Unit = {
-    var n = 0
-    while (s1.hasNext) {
-      n += 1
-      s1.next()
-    }
-    assertEquals(expectedLength, n)
-  }
-
-  /**
-   * Throw an exception if the two iterators are of differing lengths or contain
-   * different messages on their Nth element
-   */
-  def checkEquals[T](s1: java.util.Iterator[T], s2: java.util.Iterator[T]): Unit = {
-    while (s1.hasNext && s2.hasNext)
-      assertEquals(s1.next, s2.next)
-    assertFalse(s1.hasNext, "Iterators have uneven length--first has more")
-    assertFalse(s2.hasNext, "Iterators have uneven length--second has more")
-  }
-
-  def stackedIterator[T](s: Iterator[T]*): Iterator[T] = {
-    new Iterator[T] {
-      var cur: Iterator[T] = _
-      val topIterator = s.iterator
-
-      def hasNext: Boolean = {
-        while (true) {
-          if (cur == null) {
-            if (topIterator.hasNext)
-              cur = topIterator.next()
-            else
-              return false
-          }
-          if (cur.hasNext)
-            return true
-          cur = null
-        }
-        // should never reach here
-        throw new RuntimeException("should not reach here")
-      }
-
-      def next() : T = cur.next()
-    }
-  }
-
-  /**
-   * Create a hexadecimal string for the given bytes
-   */
-  def hexString(bytes: Array[Byte]): String = hexString(ByteBuffer.wrap(bytes))
-
-  /**
-   * Create a hexadecimal string for the given bytes
-   */
-  def hexString(buffer: ByteBuffer): String = {
-    val builder = new StringBuilder("0x")
-    for (i <- 0 until buffer.limit())
-      builder.append(String.format("%x", Integer.valueOf(buffer.get(buffer.position() + i))))
-    builder.toString
-  }
 
   /**
    * Returns security configuration options for broker or clients
@@ -932,21 +759,6 @@ object TestUtils extends Logging {
     consumerProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, if (readCommitted) "read_committed" else "read_uncommitted")
     consumerProps ++= consumerSecurityConfigs(securityProtocol, trustStoreFile, saslProperties)
     new KafkaConsumer[K, V](consumerProps, keyDeserializer, valueDeserializer)
-  }
-
-  def createBrokersInZk(zkClient: KafkaZkClient, ids: Seq[Int]): Seq[Broker] =
-    createBrokersInZk(ids.map(new BrokerMetadata(_, Optional.empty())), zkClient)
-
-  def createBrokersInZk(brokerMetadatas: Seq[BrokerMetadata], zkClient: KafkaZkClient): Seq[Broker] = {
-    zkClient.makeSurePersistentPathExists(BrokerIdsZNode.path)
-    val brokers = brokerMetadatas.map { b =>
-      val protocol = SecurityProtocol.PLAINTEXT
-      val listenerName = ListenerName.forSecurityProtocol(protocol)
-      Broker(b.id, Seq(EndPoint("localhost", 6667, listenerName, protocol)), if (b.rack.isPresent) Some(b.rack.get()) else None)
-    }
-    brokers.foreach(b => zkClient.registerBroker(BrokerInfo(Broker(b.id, b.endPoints, rack = b.rack),
-      MetadataVersion.latestTesting, jmxPort = -1)))
-    brokers
   }
 
   def getMsgStrings(n: Int): Seq[String] = {
@@ -1124,24 +936,18 @@ object TestUtils extends Logging {
     }, msg = msg, pause = 0L, waitTimeMs = waitTimeMs)
   }
 
-  /**
-   * Wait for the presence of an optional value.
-   *
-   * @param func The function defining the optional value
-   * @param msg Error message in the case that the value never appears
-   * @param waitTimeMs Maximum time to wait
-   * @return The unwrapped value returned by the function
-   */
-  def awaitValue[T](func: () => Option[T], msg: => String, waitTimeMs: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): T = {
-    var value: Option[T] = None
-    waitUntilTrue(() => {
-      value = func()
-      value.isDefined
-    }, msg, waitTimeMs)
-    value.get
+  def subscribeAndWaitForRecords(topic: String,
+                                 consumer: Consumer[Array[Byte], Array[Byte]],
+                                 waitTimeMs: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Unit = {
+    consumer.subscribe(Collections.singletonList(topic))
+    pollRecordsUntilTrue(
+      consumer,
+      (records: ConsumerRecords[Array[Byte], Array[Byte]]) => !records.isEmpty,
+      "Expected records",
+      waitTimeMs)
   }
 
-  /**
+   /**
     * Wait until the given condition is true or throw an exception if the given wait time elapses.
     *
     * @param condition condition to check
@@ -1164,7 +970,7 @@ object TestUtils extends Logging {
     throw new RuntimeException("unexpected error")
   }
 
-  /**
+   /**
     * Invoke `compute` until `predicate` is true or `waitTime` elapses.
     *
     * Return the last `compute` result and a boolean indicating whether `predicate` succeeded for that value.
@@ -1209,10 +1015,6 @@ object TestUtils extends Logging {
     }
   }
 
-  def isLeaderLocalOnBroker(topic: String, partitionId: Int, broker: KafkaBroker): Boolean = {
-    broker.replicaManager.onlinePartition(new TopicPartition(topic, partitionId)).exists(_.leaderLogIfLocal.isDefined)
-  }
-
   def findLeaderEpoch(brokerId: Int,
                       topicPartition: TopicPartition,
                       brokers: Iterable[KafkaBroker]): Int = {
@@ -1235,7 +1037,7 @@ object TestUtils extends Logging {
       .getOrElse(throw new AssertionError(s"Unable to locate follower for $topicPartition"))
   }
 
-  /**
+   /**
     * Wait until all brokers know about each other.
     *
     * @param brokers The Kafka brokers.
@@ -1330,11 +1132,6 @@ object TestUtils extends Logging {
     controllerId.getOrElse(throw new AssertionError(s"Controller not elected after $timeout ms"))
   }
 
-  def waitUntilQuorumLeaderElected(controllerServer: ControllerServer, timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Int = {
-    val (leaderAndEpoch, _) = computeUntilTrue(controllerServer.raftManager.leaderAndEpoch, waitTime = timeout)(_.leaderId().isPresent)
-    leaderAndEpoch.leaderId().orElseThrow(() => new AssertionError(s"Quorum Controller leader not elected after $timeout ms"))
-  }
-
   def awaitLeaderChange[B <: KafkaBroker](
       brokers: Seq[B],
       tp: TopicPartition,
@@ -1353,22 +1150,6 @@ object TestUtils extends Logging {
     newLeaderExists.get
   }
 
-  def getLeaderIdForPartition[B <: KafkaBroker](
-      brokers: Seq[B],
-      tp: TopicPartition,
-      timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Int = {
-    def leaderExists: Option[Int] = {
-      brokers.find { broker =>
-          broker.replicaManager.onlinePartition(tp).exists(_.leaderLogIfLocal.isDefined)
-      }.map(_.config.brokerId)
-    }
-
-    waitUntilTrue(() => leaderExists.isDefined,
-      s"Did not find a leader for partition $tp after $timeout ms", waitTimeMs = timeout)
-
-    leaderExists.get
-  }
-
   def waitUntilLeaderIsKnown[B <: KafkaBroker](
       brokers: Seq[B],
       tp: TopicPartition,
@@ -1385,49 +1166,12 @@ object TestUtils extends Logging {
     leaderIfExists.get
   }
 
-  def writeNonsenseToFile(fileName: File, position: Long, size: Int): Unit = {
-    val file = new RandomAccessFile(fileName, "rw")
-    file.seek(position)
-    for (_ <- 0 until size)
-      file.writeByte(random.nextInt(255))
-    file.close()
-  }
-
   def appendNonsenseToFile(file: File, size: Int): Unit = {
     val outputStream = Files.newOutputStream(file.toPath(), StandardOpenOption.APPEND)
     try {
       for (_ <- 0 until size)
         outputStream.write(random.nextInt(255))
     } finally outputStream.close()
-  }
-
-  def checkForPhantomInSyncReplicas(zkClient: KafkaZkClient, topic: String, partitionToBeReassigned: Int, assignedReplicas: Seq[Int]): Unit = {
-    val inSyncReplicas = zkClient.getInSyncReplicasForPartition(new TopicPartition(topic, partitionToBeReassigned))
-    // in sync replicas should not have any replica that is not in the new assigned replicas
-    val phantomInSyncReplicas = inSyncReplicas.get.toSet -- assignedReplicas.toSet
-    assertTrue(phantomInSyncReplicas.isEmpty,
-      "All in sync replicas %s must be in the assigned replica list %s".format(inSyncReplicas, assignedReplicas))
-  }
-
-  def ensureNoUnderReplicatedPartitions(zkClient: KafkaZkClient, topic: String, partitionToBeReassigned: Int, assignedReplicas: Seq[Int],
-                                                servers: Seq[KafkaServer]): Unit = {
-    val topicPartition = new TopicPartition(topic, partitionToBeReassigned)
-    waitUntilTrue(() => {
-        val inSyncReplicas = zkClient.getInSyncReplicasForPartition(topicPartition)
-        inSyncReplicas.get.size == assignedReplicas.size
-      },
-      "Reassigned partition [%s,%d] is under replicated".format(topic, partitionToBeReassigned))
-    var leader: Option[Int] = None
-    waitUntilTrue(() => {
-        leader = zkClient.getLeaderForPartition(topicPartition)
-        leader.isDefined
-      },
-      "Reassigned partition [%s,%d] is unavailable".format(topic, partitionToBeReassigned))
-    waitUntilTrue(() => {
-        val leaderBroker = servers.filter(s => s.config.brokerId == leader.get).head
-        leaderBroker.replicaManager.underReplicatedPartitionCount == 0
-      },
-      "Reassigned partition [%s,%d] is under-replicated as reported by the leader %d".format(topic, partitionToBeReassigned, leader.get))
   }
 
   // Note: Call this method in the test itself, rather than the @AfterEach method.
@@ -1438,29 +1182,6 @@ object TestUtils extends Logging {
     }
     val threadCount = nonDaemonThreads.size
     assertEquals(0, threadCount, s"Found unexpected $threadCount NonDaemon threads=${nonDaemonThreads.map(t => t.getName).mkString(", ")}")
-  }
-
-  // Some threads are closed, but the state didn't reflect in the JVM immediately, so add some wait time for it
-  def assertNoNonDaemonThreadsWithWaiting(threadNamePrefix: String, waitTimeMs: Long = 500L): Unit = {
-    var nonDemonThreads: mutable.Set[Thread] = mutable.Set.empty[Thread]
-    waitUntilTrue(() => {
-      nonDemonThreads = Thread.getAllStackTraces.keySet.asScala.filter { t =>
-        !t.isDaemon && t.isAlive && t.getName.startsWith(threadNamePrefix)
-      }
-      0 == nonDemonThreads.size
-    }, s"Found unexpected ${nonDemonThreads.size} NonDaemon threads=${nonDemonThreads.map(t => t.getName).mkString(", ")}", waitTimeMs)
-  }
-
-  def numThreadsRunning(threadNamePrefix: String, isDaemon: Boolean): mutable.Set[Thread] = {
-    Thread.getAllStackTraces.keySet.asScala.filter { t =>
-      isDaemon && t.isAlive && t.getName.startsWith(threadNamePrefix)
-    }
-  }
-
-  def allThreadStackTraces(): String = {
-    Thread.getAllStackTraces.asScala.map { case (thread, stackTrace) =>
-      thread.getName + "\n\t" + stackTrace.toList.map(_.toString).mkString("\n\t")
-    }.mkString("\n")
   }
 
   def formatDirectories(
@@ -1595,10 +1316,6 @@ object TestUtils extends Logging {
     }
   }
 
-  def createIsrChangeListener(): MockAlterPartitionListener = {
-    new MockAlterPartitionListener()
-  }
-
   def produceMessages[B <: KafkaBroker](
       brokers: Seq[B],
       records: Seq[ProducerRecord[Array[Byte], Array[Byte]]],
@@ -1691,7 +1408,6 @@ object TestUtils extends Logging {
     ), "Failed to hard-delete the delete directory")
   }
 
-
   def causeLogDirFailure(failureType: LogDirFailureType, leaderBroker: KafkaBroker, partition: TopicPartition): File = {
     // Make log directory of the partition on the leader broker inaccessible by replacing it with a file
     val localLog = leaderBroker.replicaManager.localLogOrException(partition)
@@ -1724,12 +1440,6 @@ object TestUtils extends Logging {
     new String(bytes, encoding)
   }
 
-  def copyOf(props: Properties): Properties = {
-    val copy = new Properties()
-    copy ++= props
-    copy
-  }
-
   def sslConfigs(mode: Mode, clientCert: Boolean, trustStoreFile: Option[File], certAlias: String,
                  certCn: String = SslCertificateCn,
                  tlsProtocol: String = TestSslUtils.DEFAULT_TLS_PROTOCOL_FOR_TESTS): Properties = {
@@ -1748,20 +1458,6 @@ object TestUtils extends Logging {
     val sslProps = new Properties()
     sslConfigs.forEach { (k, v) => sslProps.put(k, v) }
     sslProps
-  }
-
-  // a X509TrustManager to trust self-signed certs for unit tests.
-  def trustAllCerts: X509TrustManager = {
-    val trustManager = new X509TrustManager() {
-      override def getAcceptedIssuers: Array[X509Certificate] = {
-        null
-      }
-      override def checkClientTrusted(certs: Array[X509Certificate], authType: String): Unit = {
-      }
-      override def checkServerTrusted(certs: Array[X509Certificate], authType: String): Unit = {
-      }
-    }
-    trustManager
   }
 
   def waitAndVerifyAcls(expected: Set[AccessControlEntry],
@@ -1801,7 +1497,7 @@ object TestUtils extends Logging {
     }
   }
 
-  private def secureZkPaths(zkClient: KafkaZkClient): Seq[String] = {
+  def secureZkPaths(zkClient: KafkaZkClient): Seq[String] = {
     def subPaths(path: String): Seq[String] = {
       if (zkClient.pathExists(path))
         path +: zkClient.getChildren(path).map(c => path + "/" + c).flatMap(subPaths)
@@ -1812,38 +1508,7 @@ object TestUtils extends Logging {
     topLevelPaths.flatMap(subPaths)
   }
 
-  /**
-   * Verifies that all secure paths in ZK are created with the expected ACL.
-   */
-  def verifySecureZkAcls(zkClient: KafkaZkClient, usersWithAccess: Int): Unit = {
-    secureZkPaths(zkClient).foreach(path => {
-      if (zkClient.pathExists(path)) {
-        val sensitive = ZkData.sensitivePath(path)
-        // usersWithAccess have ALL access to path. For paths that are
-        // not sensitive, world has READ access.
-        val aclCount = if (sensitive) usersWithAccess else usersWithAccess + 1
-        val acls = zkClient.getAcl(path)
-        assertEquals(aclCount, acls.size, s"Invalid ACLs for $path $acls")
-        acls.foreach(acl => isAclSecure(acl, sensitive))
-      }
-    })
-  }
-
-  /**
-   * Verifies that secure paths in ZK have no access control. This is
-   * the case when zookeeper.set.acl=false and no ACLs have been configured.
-   */
-  def verifyUnsecureZkAcls(zkClient: KafkaZkClient): Unit = {
-    secureZkPaths(zkClient).foreach(path => {
-      if (zkClient.pathExists(path)) {
-        val acls = zkClient.getAcl(path)
-        assertEquals(1, acls.size, s"Invalid ACLs for $path $acls")
-        acls.foreach(isAclUnsecure)
-      }
-    })
-  }
-
-  /**
+   /**
     * To use this you pass in a sequence of functions that are your arrange/act/assert test on the SUT.
     * They all run at the same time in the assertConcurrent method; the chances of triggering a multithreading code error,
     * and thereby failing some assertion are greatly increased.
@@ -1919,24 +1584,6 @@ object TestUtils extends Logging {
                            waitTimeMs: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Seq[ConsumerRecord[K, V]] = {
     val records = pollUntilAtLeastNumRecords(consumer, numRecords, waitTimeMs)
     assertEquals(numRecords, records.size, "Consumed more records than expected")
-    records
-  }
-
-  /**
-    * Will consume all the records for the given consumer for the specified duration. If you want to drain all the
-    * remaining messages in the partitions the consumer is subscribed to, the duration should be set high enough so
-    * that the consumer has enough time to poll everything. This would be based on the number of expected messages left
-    * in the topic, and should not be too large (ie. more than a second) in our tests.
-    *
-    * @return All the records consumed by the consumer within the specified duration.
-    */
-  def consumeRecordsFor[K, V](consumer: Consumer[K, V], duration: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Seq[ConsumerRecord[K, V]] = {
-    val startTime = System.currentTimeMillis()
-    val records = new ArrayBuffer[ConsumerRecord[K, V]]()
-    waitUntilTrue(() => {
-      records ++= consumer.poll(Duration.ofMillis(50)).asScala
-      System.currentTimeMillis() - startTime > duration
-    }, s"The timeout $duration was greater than the maximum wait time.")
     records
   }
 
@@ -2056,16 +1703,6 @@ object TestUtils extends Logging {
     adminClient.incrementalAlterConfigs(configs)
   }
 
-  def alterClientQuotas(adminClient: Admin, request: Map[ClientQuotaEntity, Map[String, Option[Double]]]): AlterClientQuotasResult = {
-    val entries = request.map { case (entity, alter) =>
-      val ops = alter.map { case (key, value) =>
-        new ClientQuotaAlteration.Op(key, value.map(Double.box).orNull)
-      }.asJavaCollection
-      new ClientQuotaAlteration(entity, ops)
-    }.asJavaCollection
-    adminClient.alterClientQuotas(entries)
-  }
-
   def assertLeader(client: Admin, topicPartition: TopicPartition, expectedLeader: Int): Unit = {
     waitForLeaderToBecome(client, topicPartition, Some(expectedLeader))
   }
@@ -2146,56 +1783,6 @@ object TestUtils extends Logging {
     )
   }
 
-  def waitForReplicasAssigned(client: Admin, partition: TopicPartition, brokerIds: Seq[Int]): Unit = {
-    waitUntilTrue(
-      () => {
-        val description = client.describeTopics(Set(partition.topic).asJava).allTopicNames.get.asScala
-        val replicas = description
-          .values
-          .flatMap(_.partitions.asScala.flatMap(_.replicas.asScala))
-          .map(_.id)
-          .toSeq
-
-        brokerIds == replicas
-      },
-      s"Expected brokers $brokerIds to be the replicas for $partition"
-    )
-  }
-
-  /**
-   * Capture the console output during the execution of the provided function.
-   */
-  def grabConsoleOutput(f: => Unit) : String = {
-    val out = new ByteArrayOutputStream
-    try scala.Console.withOut(out)(f)
-    finally scala.Console.out.flush()
-    out.toString
-  }
-
-  /**
-   * Capture the console error during the execution of the provided function.
-   */
-  def grabConsoleError(f: => Unit) : String = {
-    val err = new ByteArrayOutputStream
-    try scala.Console.withErr(err)(f)
-    finally scala.Console.err.flush()
-    err.toString
-  }
-
-  /**
-   * Capture both the console output and console error during the execution of the provided function.
-   */
-  def grabConsoleOutputAndError(f: => Unit) : (String, String) = {
-    val out = new ByteArrayOutputStream
-    val err = new ByteArrayOutputStream
-    try scala.Console.withOut(out)(scala.Console.withErr(err)(f))
-    finally {
-      scala.Console.out.flush()
-      scala.Console.err.flush()
-    }
-    (out.toString, err.toString)
-  }
-
   def assertFutureExceptionTypeEquals(future: KafkaFuture[_], clazz: Class[_ <: Throwable],
                                       expectedErrorMessage: Option[String] = None): Unit = {
     val cause = assertThrows(classOf[ExecutionException], () => future.get()).getCause
@@ -2229,15 +1816,6 @@ object TestUtils extends Logging {
     total.toLong
   }
 
-  def yammerGaugeValue[T](metricName: String): Option[T] = {
-    KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
-      .filter { case (k, _) => k.getMBeanName.endsWith(metricName) }
-      .values
-      .headOption
-      .map(_.asInstanceOf[Gauge[T]])
-      .map(_.value)
-  }
-
   def meterCount(metricName: String): Long = {
     meterCountOpt(metricName).getOrElse(fail(s"Unable to find metric $metricName"))
   }
@@ -2263,14 +1841,6 @@ object TestUtils extends Logging {
   def clearYammerMetrics(): Unit = {
     for (metricName <- KafkaYammerMetrics.defaultRegistry.allMetrics.keySet.asScala)
       KafkaYammerMetrics.defaultRegistry.removeMetric(metricName)
-  }
-
-  def clearYammerMetricsExcept(names: Set[String]): Unit = {
-    for (metricName <- KafkaYammerMetrics.defaultRegistry.allMetrics.keySet.asScala) {
-      if (!names.contains(metricName.getMBeanName)) {
-        KafkaYammerMetrics.defaultRegistry.removeMetric(metricName)
-      }
-    }
   }
 
   def stringifyTopicPartitions(partitions: Set[TopicPartition]): String = {
@@ -2309,7 +1879,7 @@ object TestUtils extends Logging {
     resetBrokersThrottle(admin, brokerIds)
   }
 
-  /**
+   /**
     * Throttles all replication across the cluster.
     * @param adminClient is the adminClient to use for making connection with the cluster
     * @param brokerIds all broker ids in the cluster
@@ -2391,48 +1961,6 @@ object TestUtils extends Logging {
     override def requestVersion(): Int = 0
     override def clientId(): String = ""
     override def correlationId(): Int = 0
-  }
-
-  def addAndVerifyAcls[B <: KafkaBroker](
-    brokers: Seq[B],
-    acls: Set[AccessControlEntry],
-    resource: ResourcePattern,
-    controllers: Seq[ControllerServer] = Seq(),
-  ): Unit = {
-    val authorizerForWrite = pickAuthorizerForWrite(brokers, controllers)
-    val aclBindings = acls.map { acl => new AclBinding(resource, acl) }
-    authorizerForWrite.createAcls(anonymousAuthorizableContext, aclBindings.toList.asJava).asScala
-      .map(_.toCompletableFuture.get)
-      .foreach { result =>
-        result.exception.ifPresent { e => throw e }
-      }
-    val aclFilter = new AclBindingFilter(resource.toFilter, AccessControlEntryFilter.ANY)
-    (brokers.map(_.authorizer.get) ++ controllers.map(_.authorizer.get)).foreach {
-      authorizer => waitAndVerifyAcls(
-        authorizer.acls(aclFilter).asScala.map(_.entry).toSet ++ acls,
-        authorizer, resource)
-    }
-  }
-
-  def removeAndVerifyAcls[B <: KafkaBroker](
-    brokers: Seq[B],
-    acls: Set[AccessControlEntry],
-    resource: ResourcePattern,
-    controllers: Seq[ControllerServer] = Seq(),
-  ): Unit = {
-    val authorizerForWrite = pickAuthorizerForWrite(brokers, controllers)
-    val aclBindingFilters = acls.map { acl => new AclBindingFilter(resource.toFilter, acl.toFilter) }
-    authorizerForWrite.deleteAcls(anonymousAuthorizableContext, aclBindingFilters.toList.asJava).asScala
-      .map(_.toCompletableFuture.get)
-      .foreach { result =>
-        result.exception.ifPresent { e => throw e }
-      }
-    val aclFilter = new AclBindingFilter(resource.toFilter, AccessControlEntryFilter.ANY)
-    (brokers.map(_.authorizer.get) ++ controllers.map(_.authorizer.get)).foreach {
-      authorizer => waitAndVerifyAcls(
-        authorizer.acls(aclFilter).asScala.map(_.entry).toSet -- acls,
-        authorizer, resource)
-    }
   }
 
   def buildEnvelopeRequest(

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -64,6 +64,7 @@ import org.apache.kafka.server.config._
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.util.MockTime
 import org.apache.kafka.server.util.timer.SystemTimer
+import org.apache.kafka.server.{ClientMetricsManager, ControllerRequestCompletionHandler}
 import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig, LogDirFailureChannel, ProducerStateManagerConfig}
 import org.apache.kafka.test.{TestSslUtils, TestUtils => JTestUtils}
 import org.apache.zookeeper.KeeperException.SessionExpiredException

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -58,15 +58,12 @@ import org.apache.kafka.coordinator.transaction.TransactionLogConfigs
 import org.apache.kafka.metadata.properties.MetaProperties
 import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.raft.QuorumConfig
-import org.apache.kafka.server.{ClientMetricsManager, ControllerRequestCompletionHandler}
 import org.apache.kafka.server.authorizer.{AuthorizableRequestContext, Authorizer => JAuthorizer}
-import org.apache.kafka.server.config.{KRaftConfigs, ReplicationConfigs, ServerLogConfigs, QuotaConfigs, ZkConfigs}
 import org.apache.kafka.server.common.{ApiMessageAndVersion, MetadataVersion}
-import org.apache.kafka.server.config.{QuotaConfigs, ReplicationConfigs, ServerLogConfigs, ZkConfigs}
+import org.apache.kafka.server.config._
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.util.MockTime
 import org.apache.kafka.server.util.timer.SystemTimer
-import org.apache.kafka.server.{ClientMetricsManager, ControllerRequestCompletionHandler}
 import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig, LogDirFailureChannel, ProducerStateManagerConfig}
 import org.apache.kafka.test.{TestSslUtils, TestUtils => JTestUtils}
 import org.apache.zookeeper.KeeperException.SessionExpiredException

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -159,8 +159,6 @@ object TestUtils extends Logging {
    */
   def tempFile(contents: String): File = JTestUtils.tempFile(contents)
 
-  def tempPropertiesFile(properties: Properties): File = tempPropertiesFile(properties.asScala)
-
   def tempPropertiesFile(properties: Map[String, String]): File = {
     val content = properties.map{case (k, v) => k + "=" + v}.mkString(System.lineSeparator())
     tempFile(content)
@@ -964,7 +962,7 @@ object TestUtils extends Logging {
    * easily wait on a condition before evaluating the assertions.
    */
   def tryUntilNoAssertionError[T](waitTime: Long = JTestUtils.DEFAULT_MAX_WAIT_MS, pause: Long = 100L)(assertions: => T): T = {
-    val (either, success) = TestUtils.computeUntilTrue({
+    val (either, _) = TestUtils.computeUntilTrue({
       try {
         val res = assertions
         Left(res)

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -18,7 +18,6 @@ package kafka.utils
 
 import com.yammer.metrics.core.{Histogram, Meter}
 import kafka.api._
-import kafka.cluster.AlterPartitionListener
 import kafka.controller.{ControllerEventManager, LeaderIsrAndControllerEpoch}
 import kafka.log._
 import kafka.network.RequestChannel
@@ -85,7 +84,7 @@ import java.nio.file.{Files, StandardOpenOption}
 import java.time.Duration
 import java.util
 import java.util.concurrent._
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.{Arrays, Collections, Optional, Properties}
 import scala.annotation.nowarn
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
@@ -1295,25 +1294,6 @@ object TestUtils extends Logging {
 
   def createAlterIsrManager(): MockAlterPartitionManager = {
     new MockAlterPartitionManager()
-  }
-
-  class MockAlterPartitionListener extends AlterPartitionListener {
-    val expands: AtomicInteger = new AtomicInteger(0)
-    val shrinks: AtomicInteger = new AtomicInteger(0)
-    val failures: AtomicInteger = new AtomicInteger(0)
-
-    override def markIsrExpand(): Unit = expands.incrementAndGet()
-
-    override def markIsrShrink(): Unit = shrinks.incrementAndGet()
-
-    override def markFailed(): Unit = failures.incrementAndGet()
-
-
-    def reset(): Unit = {
-      expands.set(0)
-      shrinks.set(0)
-      failures.set(0)
-    }
   }
 
   def produceMessages[B <: KafkaBroker](

--- a/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandTest.java
@@ -45,12 +45,16 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -81,7 +85,7 @@ public class LeaderElectionCommandTest {
     public void testAllTopicPartition() throws InterruptedException, ExecutionException {
         String topic = "unclean-topic";
         int partition = 0;
-        List<Integer> assignment = Arrays.asList(broker2, broker3);
+        List<Integer> assignment = asList(broker2, broker3);
 
         cluster.waitForReadyBrokers();
         Admin client = cluster.createAdminClient();
@@ -93,8 +97,8 @@ public class LeaderElectionCommandTest {
         TestUtils.assertLeader(client, topicPartition, broker2);
         cluster.shutdownBroker(broker3);
         TestUtils.waitForBrokersOutOfIsr(client,
-                JavaConverters.asScalaBuffer(Collections.singletonList(topicPartition)).toSet(),
-                JavaConverters.asScalaBuffer(Collections.singletonList(broker3)).toSet()
+                JavaConverters.asScalaBuffer(singletonList(topicPartition)).toSet(),
+                JavaConverters.asScalaBuffer(singletonList(broker3)).toSet()
         );
         cluster.shutdownBroker(broker2);
         TestUtils.assertNoLeader(client, topicPartition);
@@ -137,7 +141,7 @@ public class LeaderElectionCommandTest {
     public void testTopicPartition() throws InterruptedException, ExecutionException {
         String topic = "unclean-topic";
         int partition = 0;
-        List<Integer> assignment = Arrays.asList(broker2, broker3);
+        List<Integer> assignment = asList(broker2, broker3);
 
         cluster.waitForReadyBrokers();
         Admin client = cluster.createAdminClient();
@@ -149,8 +153,8 @@ public class LeaderElectionCommandTest {
 
         cluster.shutdownBroker(broker3);
         TestUtils.waitForBrokersOutOfIsr(client,
-            JavaConverters.asScalaBuffer(Collections.singletonList(topicPartition)).toSet(),
-            JavaConverters.asScalaBuffer(Collections.singletonList(broker3)).toSet()
+            JavaConverters.asScalaBuffer(singletonList(topicPartition)).toSet(),
+            JavaConverters.asScalaBuffer(singletonList(broker3)).toSet()
         );
         cluster.shutdownBroker(broker2);
         TestUtils.assertNoLeader(client, topicPartition);
@@ -171,7 +175,7 @@ public class LeaderElectionCommandTest {
     public void testPathToJsonFile() throws Exception {
         String topic = "unclean-topic";
         int partition = 0;
-        List<Integer> assignment = Arrays.asList(broker2, broker3);
+        List<Integer> assignment = asList(broker2, broker3);
 
         cluster.waitForReadyBrokers();
         Map<Integer, List<Integer>> partitionAssignment = new HashMap<>();
@@ -186,15 +190,15 @@ public class LeaderElectionCommandTest {
 
         cluster.shutdownBroker(broker3);
         TestUtils.waitForBrokersOutOfIsr(client,
-            JavaConverters.asScalaBuffer(Collections.singletonList(topicPartition)).toSet(),
-            JavaConverters.asScalaBuffer(Collections.singletonList(broker3)).toSet()
+            JavaConverters.asScalaBuffer(singletonList(topicPartition)).toSet(),
+            JavaConverters.asScalaBuffer(singletonList(broker3)).toSet()
         );
         cluster.shutdownBroker(broker2);
         TestUtils.assertNoLeader(client, topicPartition);
         cluster.startBroker(broker3);
         TestUtils.waitForOnlineBroker(client, broker3);
 
-        Path topicPartitionPath = tempTopicPartitionFile(Collections.singletonList(topicPartition));
+        Path topicPartitionPath = tempTopicPartitionFile(singletonList(topicPartition));
 
         assertEquals(0, LeaderElectionCommand.mainNoExit(
             "--bootstrap-server", cluster.bootstrapServers(),
@@ -209,7 +213,7 @@ public class LeaderElectionCommandTest {
     public void testPreferredReplicaElection() throws InterruptedException, ExecutionException {
         String topic = "preferred-topic";
         int partition = 0;
-        List<Integer> assignment = Arrays.asList(broker2, broker3);
+        List<Integer> assignment = asList(broker2, broker3);
 
         cluster.waitForReadyBrokers();
         Admin client = cluster.createAdminClient();
@@ -226,7 +230,7 @@ public class LeaderElectionCommandTest {
         TestUtils.assertLeader(client, topicPartition, broker3);
         cluster.startBroker(broker2);
         TestUtils.waitForBrokersInIsr(client, topicPartition,
-            JavaConverters.asScalaBuffer(Collections.singletonList(broker2)).toSet()
+            JavaConverters.asScalaBuffer(singletonList(broker2)).toSet()
         );
 
         assertEquals(0, LeaderElectionCommand.mainNoExit(
@@ -255,8 +259,8 @@ public class LeaderElectionCommandTest {
         String topic = "non-preferred-topic";
         int partition0 = 0;
         int partition1 = 1;
-        List<Integer> assignment0 = Arrays.asList(broker2, broker3);
-        List<Integer> assignment1 = Arrays.asList(broker3, broker2);
+        List<Integer> assignment0 = asList(broker2, broker3);
+        List<Integer> assignment1 = asList(broker3, broker2);
 
         cluster.waitForReadyBrokers();
         Admin client = cluster.createAdminClient();
@@ -276,13 +280,13 @@ public class LeaderElectionCommandTest {
         TestUtils.assertLeader(client, topicPartition0, broker3);
         cluster.startBroker(broker2);
         TestUtils.waitForBrokersInIsr(client, topicPartition0,
-            JavaConverters.asScalaBuffer(Collections.singletonList(broker2)).toSet()
+            JavaConverters.asScalaBuffer(singletonList(broker2)).toSet()
         );
         TestUtils.waitForBrokersInIsr(client, topicPartition1,
-            JavaConverters.asScalaBuffer(Collections.singletonList(broker2)).toSet()
+            JavaConverters.asScalaBuffer(singletonList(broker2)).toSet()
         );
 
-        Path topicPartitionPath = tempTopicPartitionFile(Arrays.asList(topicPartition0, topicPartition1));
+        Path topicPartitionPath = tempTopicPartitionFile(asList(topicPartition0, topicPartition1));
         String output = ToolsTestUtils.captureStandardOut(() ->
             LeaderElectionCommand.mainNoExit(
                 "--bootstrap-server", cluster.bootstrapServers(),
@@ -304,29 +308,45 @@ public class LeaderElectionCommandTest {
             String.format("Unexpected output: %s", secondLine));
     }
 
-    private static void createTopic(Admin admin, String topic, Map<Integer, List<Integer>> replicaAssignment) throws ExecutionException, InterruptedException {
+    private void createTopic(Admin admin, String topic, Map<Integer, List<Integer>> replicaAssignment) throws ExecutionException, InterruptedException {
         NewTopic newTopic = new NewTopic(topic, replicaAssignment);
-        List<NewTopic> newTopics = Collections.singletonList(newTopic);
+        List<NewTopic> newTopics = singletonList(newTopic);
         CreateTopicsResult createTopicResult = admin.createTopics(newTopics);
         createTopicResult.all().get();
     }
 
-    private static Path tempTopicPartitionFile(List<TopicPartition> partitions) throws Exception {
+    private Path tempTopicPartitionFile(List<TopicPartition> partitions) throws Exception {
         java.io.File file = TestUtils.tempFile("leader-election-command", ".json");
 
-        scala.collection.immutable.Set<TopicPartition> topicPartitionSet =
-            JavaConverters.asScalaBuffer(partitions).toSet();
-        String jsonString = TestUtils.stringifyTopicPartitions(topicPartitionSet);
+        String jsonString = stringifyTopicPartitions(new HashSet<>(partitions));
 
         Files.write(file.toPath(), jsonString.getBytes(StandardCharsets.UTF_8));
 
         return file.toPath();
     }
 
-    private static Path tempAdminConfig(String defaultApiTimeoutMs, String requestTimeoutMs) throws Exception {
+    private Path tempAdminConfig(String defaultApiTimeoutMs, String requestTimeoutMs) throws Exception {
         String content = "default.api.timeout.ms=" + defaultApiTimeoutMs + "\nrequest.timeout.ms=" + requestTimeoutMs;
         java.io.File file = TestUtils.tempFile("admin-config", ".properties");
         Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
         return file.toPath();
+    }
+
+    private String stringifyTopicPartitions(Set<TopicPartition> topicPartitions) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"partitions\":[");
+        Iterator<TopicPartition> iterator = topicPartitions.iterator();
+        while (iterator.hasNext()) {
+            TopicPartition topicPartition = iterator.next();
+            sb.append("{\"topic\":\"")
+                    .append(topicPartition.topic())
+                    .append("\",\"partition\":")
+                    .append(topicPartition.partition()).append("}");
+            if (iterator.hasNext()) {
+                sb.append(",");
+            }
+        }
+        sb.append("]}");
+        return sb.toString();
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/TopicCommandIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TopicCommandIntegrationTest.java
@@ -137,7 +137,7 @@ public class TopicCommandIntegrationTest extends kafka.integration.KafkaServerTe
         props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
         adminClient = Admin.create(props);
         topicService = new TopicCommand.TopicService(props, Optional.of(bootstrapServer));
-        testTopicName = String.format("%s-%s", info.getTestMethod().get().getName(), TestUtils.randomString(10));
+        testTopicName = String.format("%s-%s", info.getTestMethod().get().getName(), org.apache.kafka.test.TestUtils.randomString(10));
         scalaBrokers = brokers();
         scalaControllers = controllerServers();
     }

--- a/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/reassign/ReassignPartitionsIntegrationTest.java
@@ -54,6 +54,7 @@ import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
 import java.io.Closeable;
+import java.util.AbstractMap;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -74,12 +75,20 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_2_7_IV1;
+import static org.apache.kafka.server.config.QuotaConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG;
+import static org.apache.kafka.server.config.QuotaConfigs.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG;
 import static org.apache.kafka.server.config.ReplicationConfigs.AUTO_LEADER_REBALANCE_ENABLE_CONFIG;
 import static org.apache.kafka.server.config.ReplicationConfigs.INTER_BROKER_PROTOCOL_VERSION_CONFIG;
 import static org.apache.kafka.server.config.ReplicationConfigs.REPLICA_FETCH_BACKOFF_MS_CONFIG;
 import static org.apache.kafka.server.config.ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_CONFIG;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_2_7_IV1;
 import static org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS;
+import static org.apache.kafka.tools.ToolsTestUtils.assignThrottledPartitionReplicas;
+import static org.apache.kafka.tools.ToolsTestUtils.throttleAllBrokersReplication;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.BROKER_LEVEL_THROTTLES;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.cancelAssignment;
 import static org.apache.kafka.tools.reassign.ReassignPartitionsCommand.executeAssignment;
@@ -125,7 +134,7 @@ public class ReassignPartitionsIntegrationTest extends QuorumTestHarness {
         // the `AlterPartition` API. In this case, the controller will register individual
         // watches for each reassigning partition so that the reassignment can be
         // completed as soon as the ISR is expanded.
-        Map<String, String> configOverrides = Collections.singletonMap(INTER_BROKER_PROTOCOL_VERSION_CONFIG, IBP_2_7_IV1.version());
+        Map<String, String> configOverrides = singletonMap(INTER_BROKER_PROTOCOL_VERSION_CONFIG, IBP_2_7_IV1.version());
         cluster = new ReassignPartitionsTestCluster(configOverrides, Collections.emptyMap());
         cluster.setup();
         executeAndVerifyReassignment();
@@ -145,7 +154,7 @@ public class ReassignPartitionsIntegrationTest extends QuorumTestHarness {
         // change notification delay
         ZkAlterPartitionManager.DefaultIsrPropagationConfig_$eq(new IsrChangePropagationConfig(500, 100, 500));
 
-        Map<String, String> oldIbpConfig = Collections.singletonMap(INTER_BROKER_PROTOCOL_VERSION_CONFIG, IBP_2_7_IV1.version());
+        Map<String, String> oldIbpConfig = singletonMap(INTER_BROKER_PROTOCOL_VERSION_CONFIG, IBP_2_7_IV1.version());
         Map<Integer, Map<String, String>> brokerConfigOverrides = new HashMap<>();
         brokerConfigOverrides.put(1, oldIbpConfig);
         brokerConfigOverrides.put(2, oldIbpConfig);
@@ -212,7 +221,7 @@ public class ReassignPartitionsIntegrationTest extends QuorumTestHarness {
 
         // Execute the assignment
         runExecuteAssignment(cluster.adminClient, false, assignment, -1L, -1L);
-        Map<TopicPartition, PartitionReassignmentState> finalAssignment = Collections.singletonMap(part,
+        Map<TopicPartition, PartitionReassignmentState> finalAssignment = singletonMap(part,
             new PartitionReassignmentState(asList(3, 1, 2), asList(3, 1, 2), true));
 
         // Wait for the assignment to complete
@@ -352,13 +361,13 @@ public class ReassignPartitionsIntegrationTest extends QuorumTestHarness {
 
         TopicPartition part = new TopicPartition("baz", 2);
         try {
-            consumer.assign(Collections.singleton(part));
+            consumer.assign(singleton(part));
             TestUtils.pollUntilAtLeastNumRecords(consumer, 100, DEFAULT_MAX_WAIT_MS);
         } finally {
             consumer.close();
         }
-        TestUtils.removeReplicationThrottleForPartitions(cluster.adminClient, seq(asList(0, 1, 2, 3)), mutableSet(part).toSet());
-        Map<TopicPartition, PartitionReassignmentState> finalAssignment = Collections.singletonMap(part,
+        removeReplicationThrottleForPartitions(cluster.adminClient, part);
+        Map<TopicPartition, PartitionReassignmentState> finalAssignment = singletonMap(part,
             new PartitionReassignmentState(asList(3, 2, 1), asList(3, 2, 1), true));
         waitForVerifyAssignment(cluster.adminClient, assignment, false,
             new VerifyAssignmentResult(finalAssignment));
@@ -426,12 +435,7 @@ public class ReassignPartitionsIntegrationTest extends QuorumTestHarness {
             "]}";
 
         // We will throttle replica 4 so that only replica 3 joins the ISR
-        TestUtils.setReplicationThrottleForPartitions(
-            cluster.adminClient,
-            seq(asList(4)),
-            mutableSet(foo0).toSet(),
-            1
-        );
+        setReplicationThrottleForPartitions(cluster.adminClient, foo0);
 
         // Execute the assignment and wait for replica 3 (only) to join the ISR
         runExecuteAssignment(
@@ -448,7 +452,7 @@ public class ReassignPartitionsIntegrationTest extends QuorumTestHarness {
         );
 
         // Now cancel the assignment and verify that the partition is removed from cancelled replicas
-        assertEquals(new SimpleImmutableEntry<>(Collections.singleton(foo0), Collections.emptySet()), runCancelAssignment(cluster.adminClient, assignment, true));
+        assertEquals(new SimpleImmutableEntry<>(singleton(foo0), Collections.emptySet()), runCancelAssignment(cluster.adminClient, assignment, true));
         verifyReplicaDeleted(foo0, 3);
         verifyReplicaDeleted(foo0, 4);
     }
@@ -520,7 +524,7 @@ public class ReassignPartitionsIntegrationTest extends QuorumTestHarness {
         Map<Integer, Map<String, Long>> results = new HashMap<>();
         for (Integer brokerId : brokerIds) {
             ConfigResource brokerResource = new ConfigResource(ConfigResource.Type.BROKER, brokerId.toString());
-            Config brokerConfigs = cluster.adminClient.describeConfigs(Collections.singleton(brokerResource)).values()
+            Config brokerConfigs = cluster.adminClient.describeConfigs(singleton(brokerResource)).values()
                 .get(brokerResource)
                 .get();
 
@@ -558,27 +562,27 @@ public class ReassignPartitionsIntegrationTest extends QuorumTestHarness {
 
         // Check the output of --verify
         waitForVerifyAssignment(cluster.adminClient, reassignment.json, true,
-            new VerifyAssignmentResult(Collections.singletonMap(
+            new VerifyAssignmentResult(singletonMap(
                 topicPartition, new PartitionReassignmentState(asList(0, 1, 2), asList(0, 1, 2), true)
-            ), false, Collections.singletonMap(
+            ), false, singletonMap(
                 new TopicPartitionReplica(topicPartition.topic(), topicPartition.partition(), 0),
                 new ActiveMoveState(reassignment.currentDir, reassignment.targetDir, reassignment.targetDir)
             ), true));
-        waitForLogDirThrottle(Collections.singleton(0), logDirThrottle);
+        waitForLogDirThrottle(singleton(0), logDirThrottle);
 
         // Remove the throttle
-        cluster.adminClient.incrementalAlterConfigs(Collections.singletonMap(
+        cluster.adminClient.incrementalAlterConfigs(singletonMap(
                 new ConfigResource(ConfigResource.Type.BROKER, "0"),
-                Collections.singletonList(new AlterConfigOp(
+                singletonList(new AlterConfigOp(
                     new ConfigEntry(QuotaConfigs.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG, ""), AlterConfigOp.OpType.DELETE))))
             .all().get();
         waitForBrokerLevelThrottles(unthrottledBrokerConfigs);
 
         // Wait for the directory movement to complete.
         waitForVerifyAssignment(cluster.adminClient, reassignment.json, true,
-            new VerifyAssignmentResult(Collections.singletonMap(
+            new VerifyAssignmentResult(singletonMap(
                 topicPartition, new PartitionReassignmentState(asList(0, 1, 2), asList(0, 1, 2), true)
-            ), false, Collections.singletonMap(
+            ), false, singletonMap(
                 new TopicPartitionReplica(topicPartition.topic(), topicPartition.partition(), 0),
                 new CompletedMoveState(reassignment.targetDir)
             ), false));
@@ -604,18 +608,18 @@ public class ReassignPartitionsIntegrationTest extends QuorumTestHarness {
         long initialLogDirThrottle = 1L;
         runExecuteAssignment(cluster.adminClient, false, reassignment.json,
             -1L, initialLogDirThrottle);
-        waitForLogDirThrottle(new HashSet<>(Collections.singletonList(0)), initialLogDirThrottle);
+        waitForLogDirThrottle(new HashSet<>(singletonList(0)), initialLogDirThrottle);
 
         // Now increase the throttle and verify that the log dir movement completes
         long updatedLogDirThrottle = 3000000L;
         runExecuteAssignment(cluster.adminClient, true, reassignment.json,
             -1L, updatedLogDirThrottle);
-        waitForLogDirThrottle(Collections.singleton(0), updatedLogDirThrottle);
+        waitForLogDirThrottle(singleton(0), updatedLogDirThrottle);
 
         waitForVerifyAssignment(cluster.adminClient, reassignment.json, true,
-            new VerifyAssignmentResult(Collections.singletonMap(
+            new VerifyAssignmentResult(singletonMap(
                 topicPartition, new PartitionReassignmentState(asList(0, 1, 2), asList(0, 1, 2), true)
-            ), false, Collections.singletonMap(
+            ), false, singletonMap(
                 new TopicPartitionReplica(topicPartition.topic(), topicPartition.partition(), targetBrokerId),
                 new CompletedMoveState(reassignment.targetDir)
             ), false));
@@ -822,7 +826,7 @@ public class ReassignPartitionsIntegrationTest extends QuorumTestHarness {
             TestUtils.waitUntilBrokerMetadataIsPropagated(seq(servers), DEFAULT_MAX_WAIT_MS);
             brokerList = TestUtils.plaintextBootstrapServers(seq(servers));
 
-            adminClient = Admin.create(Collections.singletonMap(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList));
+            adminClient = Admin.create(singletonMap(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList));
 
             adminClient.createTopics(topics.entrySet().stream().map(e -> {
                 Map<Integer, List<Integer>> partMap = new HashMap<>();
@@ -874,5 +878,53 @@ public class ReassignPartitionsIntegrationTest extends QuorumTestHarness {
     @SuppressWarnings({"deprecation"})
     private static <T> Seq<T> seq(Collection<T> seq) {
         return JavaConverters.asScalaIteratorConverter(seq.iterator()).asScala().toSeq();
+    }
+
+    /**
+     * Remove a set of throttled partitions and reset the overall replication quota.
+     */
+    private void removeReplicationThrottleForPartitions(Admin admin, TopicPartition part) {
+        try {
+            removePartitionReplicaThrottles(admin, new HashSet<>(singleton(part)));
+            throttleAllBrokersReplication(admin, asList(0, 1, 2, 3), Integer.MAX_VALUE);
+        } catch (ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void removePartitionReplicaThrottles(Admin adminClient, Set<TopicPartition> partitions) {
+        Map<ConfigResource, Collection<AlterConfigOp>> throttles = partitions.stream()
+            .map(tp -> {
+                ConfigResource resource = new ConfigResource(TOPIC, tp.topic());
+                return new AbstractMap.SimpleEntry<>(
+                    resource,
+                    asList(
+                        new AlterConfigOp(new ConfigEntry(LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG, ""),
+                                AlterConfigOp.OpType.DELETE),
+                        new AlterConfigOp(new ConfigEntry(FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, ""),
+                                AlterConfigOp.OpType.DELETE)
+                    )
+                );
+            })
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        try {
+            adminClient.incrementalAlterConfigs(throttles).all().get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Set broker replication quotas and enable throttling for a set of partitions. This
+     * will override any previous replication quotas, but will leave the throttling status
+     * of other partitions unaffected.
+     */
+    private void setReplicationThrottleForPartitions(Admin admin, TopicPartition topicPartition) {
+        try {
+            throttleAllBrokersReplication(admin, singletonList(4), 1);
+            assignThrottledPartitionReplicas(admin, singletonMap(topicPartition, singletonList(4)));
+        } catch (ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
Because TestUtils.scala has some unused method, and some methods only use in one class, so I delete unused methods and move methods to individual class which only one class used