### PR TITLE
MINOR: Change the Brokers field documentation .

### DIFF
--- a/clients/src/main/resources/common/message/MetadataResponse.json
+++ b/clients/src/main/resources/common/message/MetadataResponse.json
@@ -48,7 +48,7 @@
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "3+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "Brokers", "type": "[]MetadataResponseBroker", "versions": "0+",
-      "about": "Each broker in the response.", "fields": [
+      "about": "A list of brokers present in the cluster.", "fields": [
       { "name": "NodeId", "type": "int32", "versions": "0+", "mapKey": true, "entityType": "brokerId",
         "about": "The broker ID." },
       { "name": "Host", "type": "string", "versions": "0+",


### PR DESCRIPTION
The change is because it doesn't contain all the brokers in the response: in case a broker is down it will be listed in some partition `Replicas` but not be present in this array.

### Committer Checklist (excluded from commit message)
- [ ] Verify documentation (including upgrade notes)
