### PR TITLE
MINOR: fix timeouts of EosIntegrationTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -123,8 +123,8 @@ public class EosIntegrationTest {
     public Timeout globalTimeout = Timeout.seconds(600);
     private static final Logger LOG = LoggerFactory.getLogger(EosIntegrationTest.class);
     private static final int NUM_BROKERS = 3;
-    private static final int MAX_POLL_INTERVAL_MS = 30_1000;
-    private static final int MAX_WAIT_TIME_MS = 120_1000;
+    private static final int MAX_POLL_INTERVAL_MS = 30_000;
+    private static final int MAX_WAIT_TIME_MS = 120_000;
 
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(
         NUM_BROKERS,


### PR DESCRIPTION
Typo sets timeout way too high... Test still passes as test timeout is 10 minutes and test runs 5 minutes (with this fix, test runtime drops to 30 seconds as intended).