### PR TITLE
Add a retriable JMX tag for ErrorsMeter

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -478,6 +478,14 @@ public enum Errors {
     }
 
     /**
+     * Is error a retriable error
+     * @return true if the error is a retriable error
+     */
+    public boolean isRetriable() {
+        return exception instanceof RetriableException;
+    }
+
+    /**
      * Throw the exception if there is one
      */
     public static Errors forCode(short code) {
@@ -540,7 +548,7 @@ public enum Errors {
             b.append(error.code());
             b.append("</td>");
             b.append("<td>");
-            b.append(error.exception() != null && error.exception() instanceof RetriableException ? "True" : "False");
+            b.append(error.isRetriable() ? "True" : "False");
             b.append("</td>");
             b.append("<td>");
             b.append(error.exception() != null ? error.exception().getMessage() : "");

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -601,8 +601,7 @@ class RequestMetrics(name: String) {
   }
 
   private class ErrorMeter(name: String, error: Errors) {
-    private val tags = Map("request" -> name, "error" -> error.name).asJava
-
+    private val tags = Map("request" -> name, "error" -> error.name, "retriable" -> error.isRetriable.toString).asJava
     @volatile private var meter: Meter = _
 
     def getOrCreateMeter(): Meter = {


### PR DESCRIPTION
This will expose whether or not a specific error is a retriable error or not. Allowing to filter retriable errors when fetching metrics.