### PR TITLE
KAFKA-16589: Consider removing `ClusterInstance#createAdminClient` since callers are not sure whether they need to call close

### DIFF
--- a/core/src/test/java/kafka/test/ClusterInstance.java
+++ b/core/src/test/java/kafka/test/ClusterInstance.java
@@ -20,13 +20,13 @@ package kafka.test;
 import kafka.network.SocketServer;
 import kafka.server.BrokerFeatures;
 import kafka.test.annotation.ClusterTest;
-import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.network.ListenerName;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 
 public interface ClusterInstance {
@@ -131,10 +131,10 @@ public interface ClusterInstance {
         return asClass.cast(getUnderlying());
     }
 
-    Admin createAdminClient(Properties configOverrides);
-
-    default Admin createAdminClient() {
-        return createAdminClient(new Properties());
+    default Map<String, Object> adminConfigs(Map<String, String> configOverrides) {
+        Map<String, Object> adminConfigs = new HashMap<>(configOverrides);
+        adminConfigs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
+        return adminConfigs;
     }
 
     void start();

--- a/core/src/test/java/kafka/test/junit/RaftClusterInvocationContext.java
+++ b/core/src/test/java/kafka/test/junit/RaftClusterInvocationContext.java
@@ -41,7 +41,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
@@ -238,14 +237,6 @@ public class RaftClusterInvocationContext implements TestTemplateInvocationConte
         @Override
         public KafkaClusterTestKit getUnderlying() {
             return clusterReference.get();
-        }
-
-        @Override
-        public Admin createAdminClient(Properties configOverrides) {
-            Admin admin = Admin.create(clusterReference.get().
-                newClientPropertiesBuilder(configOverrides).build());
-            admins.add(admin);
-            return admin;
         }
 
         @Override

--- a/core/src/test/java/kafka/test/junit/ZkClusterInvocationContext.java
+++ b/core/src/test/java/kafka/test/junit/ZkClusterInvocationContext.java
@@ -25,7 +25,6 @@ import kafka.test.ClusterConfig;
 import kafka.test.ClusterInstance;
 import kafka.utils.EmptyTestInfo;
 import kafka.utils.TestUtils;
-import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -287,11 +286,6 @@ public class ZkClusterInvocationContext implements TestTemplateInvocationContext
         @Override
         public IntegrationTestHarness getUnderlying() {
             return clusterReference.get();
-        }
-
-        @Override
-        public Admin createAdminClient(Properties configOverrides) {
-            return clusterReference.get().createAdminClient(clientListener(), configOverrides);
         }
 
         @Override

--- a/core/src/test/scala/integration/kafka/server/MetadataVersionIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/MetadataVersionIntegrationTest.scala
@@ -22,12 +22,14 @@ import kafka.test.annotation.{ClusterTest, ClusterTests, Type}
 import kafka.test.junit.ClusterTestExtensions
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.FeatureUpdate.UpgradeType
-import org.apache.kafka.clients.admin.{FeatureUpdate, UpdateFeaturesOptions}
+import org.apache.kafka.clients.admin.{Admin, FeatureUpdate, UpdateFeaturesOptions}
 import org.apache.kafka.server.common.MetadataVersion
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.extension.ExtendWith
 
+import java.util.Collections
 import scala.jdk.CollectionConverters._
+import scala.util.Using
 
 @ExtendWith(value = Array(classOf[ClusterTestExtensions]))
 class MetadataVersionIntegrationTest {
@@ -40,42 +42,45 @@ class MetadataVersionIntegrationTest {
       new ClusterTest(clusterType = Type.KRAFT, metadataVersion = MetadataVersion.IBP_3_4_IV0)
   ))
   def testBasicMetadataVersionUpgrade(clusterInstance: ClusterInstance): Unit = {
-    val admin = clusterInstance.createAdminClient()
-    val describeResult = admin.describeFeatures()
-    val ff = describeResult.featureMetadata().get().finalizedFeatures().get(MetadataVersion.FEATURE_NAME)
-    assertEquals(ff.minVersionLevel(), clusterInstance.config().metadataVersion().featureLevel())
-    assertEquals(ff.maxVersionLevel(), clusterInstance.config().metadataVersion().featureLevel())
+    Using(Admin.create(clusterInstance.adminConfigs(Collections.emptyMap()))) { admin =>
+      val describeResult = admin.describeFeatures()
+      val ff = describeResult.featureMetadata().get().finalizedFeatures().get(MetadataVersion.FEATURE_NAME)
+      assertEquals(ff.minVersionLevel(), clusterInstance.config().metadataVersion().featureLevel())
+      assertEquals(ff.maxVersionLevel(), clusterInstance.config().metadataVersion().featureLevel())
 
-    // Update to new version
-    val updateVersion = MetadataVersion.IBP_3_5_IV1.featureLevel.shortValue
-    val updateResult = admin.updateFeatures(
-      Map("metadata.version" -> new FeatureUpdate(updateVersion, UpgradeType.UPGRADE)).asJava, new UpdateFeaturesOptions())
-    updateResult.all().get()
+      // Update to new version
+      val updateVersion = MetadataVersion.IBP_3_5_IV1.featureLevel.shortValue
+      val updateResult = admin.updateFeatures(
+        Map("metadata.version" -> new FeatureUpdate(updateVersion, UpgradeType.UPGRADE)).asJava, new UpdateFeaturesOptions())
+      updateResult.all().get()
 
-    // Verify that new version is visible on broker
-    TestUtils.waitUntilTrue(() => {
-      val describeResult2 = admin.describeFeatures()
-      val ff2 = describeResult2.featureMetadata().get().finalizedFeatures().get(MetadataVersion.FEATURE_NAME)
-      ff2.minVersionLevel() == updateVersion && ff2.maxVersionLevel() == updateVersion
-    }, "Never saw metadata.version increase on broker")
+      // Verify that new version is visible on broker
+      TestUtils.waitUntilTrue(() => {
+        val describeResult2 = admin.describeFeatures()
+        val ff2 = describeResult2.featureMetadata().get().finalizedFeatures().get(MetadataVersion.FEATURE_NAME)
+        ff2.minVersionLevel() == updateVersion && ff2.maxVersionLevel() == updateVersion
+      }, "Never saw metadata.version increase on broker")
+    }
   }
 
   @ClusterTest(clusterType = Type.KRAFT, metadataVersion = MetadataVersion.IBP_3_3_IV0)
   def testUpgradeSameVersion(clusterInstance: ClusterInstance): Unit = {
-    val admin = clusterInstance.createAdminClient()
-    val updateVersion = MetadataVersion.IBP_3_3_IV0.featureLevel.shortValue
-    val updateResult = admin.updateFeatures(
-      Map("metadata.version" -> new FeatureUpdate(updateVersion, UpgradeType.UPGRADE)).asJava, new UpdateFeaturesOptions())
-    updateResult.all().get()
+    Using(Admin.create(clusterInstance.adminConfigs(Collections.emptyMap()))) { admin =>
+      val updateVersion = MetadataVersion.IBP_3_3_IV0.featureLevel.shortValue
+      val updateResult = admin.updateFeatures(
+        Map("metadata.version" -> new FeatureUpdate(updateVersion, UpgradeType.UPGRADE)).asJava, new UpdateFeaturesOptions())
+      updateResult.all().get()
+    }
   }
 
   @ClusterTest(clusterType = Type.KRAFT)
   def testDefaultIsLatestVersion(clusterInstance: ClusterInstance): Unit = {
-    val admin = clusterInstance.createAdminClient()
-    val describeResult = admin.describeFeatures()
-    val ff = describeResult.featureMetadata().get().finalizedFeatures().get(MetadataVersion.FEATURE_NAME)
-    assertEquals(ff.minVersionLevel(), MetadataVersion.latestTesting().featureLevel(),
-      "If this test fails, check the default MetadataVersion in the @ClusterTest annotation")
-    assertEquals(ff.maxVersionLevel(), MetadataVersion.latestTesting().featureLevel())
+    Using(Admin.create(clusterInstance.adminConfigs(Collections.emptyMap()))) { admin =>
+      val describeResult = admin.describeFeatures()
+      val ff = describeResult.featureMetadata().get().finalizedFeatures().get(MetadataVersion.FEATURE_NAME)
+      assertEquals(ff.minVersionLevel(), MetadataVersion.latestTesting().featureLevel(),
+        "If this test fails, check the default MetadataVersion in the @ClusterTest annotation")
+      assertEquals(ff.maxVersionLevel(), MetadataVersion.latestTesting().featureLevel())
+    }
   }
 }

--- a/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/zk/ZkMigrationIntegrationTest.scala
@@ -60,6 +60,7 @@ import java.util.concurrent.{CompletableFuture, ExecutionException, TimeUnit}
 import java.util.{Collections, Optional, Properties, UUID}
 import scala.collection.Seq
 import scala.jdk.CollectionConverters._
+import scala.util.Using
 
 object ZkMigrationIntegrationTest {
   def addZkBrokerProps(props: Properties): Unit = {
@@ -122,37 +123,37 @@ class ZkMigrationIntegrationTest {
     )
   )
   def testMigrateAcls(clusterInstance: ClusterInstance): Unit = {
-    val admin = clusterInstance.createAdminClient()
+    Using(Admin.create(clusterInstance.adminConfigs(Collections.emptyMap()))) { admin =>
+      val resource1 = new ResourcePattern(TOPIC, "foo-" + UUID.randomUUID(), LITERAL)
+      val resource2 = new ResourcePattern(TOPIC, "bar-" + UUID.randomUUID(), LITERAL)
+      val prefixedResource = new ResourcePattern(TOPIC, "bar-", PREFIXED)
+      val username = "alice"
+      val principal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, username)
+      val wildcardPrincipal = SecurityUtils.parseKafkaPrincipal(WILDCARD_PRINCIPAL_STRING)
 
-    val resource1 = new ResourcePattern(TOPIC, "foo-" + UUID.randomUUID(), LITERAL)
-    val resource2 = new ResourcePattern(TOPIC, "bar-" + UUID.randomUUID(), LITERAL)
-    val prefixedResource = new ResourcePattern(TOPIC, "bar-", PREFIXED)
-    val username = "alice"
-    val principal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, username)
-    val wildcardPrincipal = SecurityUtils.parseKafkaPrincipal(WILDCARD_PRINCIPAL_STRING)
+      val acl1 = new AclBinding(resource1, new AccessControlEntry(principal.toString, WILDCARD_HOST, READ, ALLOW))
+      val acl2 = new AclBinding(resource1, new AccessControlEntry(principal.toString, "192.168.0.1", WRITE, ALLOW))
+      val acl3 = new AclBinding(resource2, new AccessControlEntry(principal.toString, WILDCARD_HOST, DESCRIBE, ALLOW))
+      val acl4 = new AclBinding(prefixedResource, new AccessControlEntry(wildcardPrincipal.toString, WILDCARD_HOST, READ, ALLOW))
 
-    val acl1 = new AclBinding(resource1, new AccessControlEntry(principal.toString, WILDCARD_HOST, READ, ALLOW))
-    val acl2 = new AclBinding(resource1, new AccessControlEntry(principal.toString, "192.168.0.1", WRITE, ALLOW))
-    val acl3 = new AclBinding(resource2, new AccessControlEntry(principal.toString, WILDCARD_HOST, DESCRIBE, ALLOW))
-    val acl4 = new AclBinding(prefixedResource, new AccessControlEntry(wildcardPrincipal.toString, WILDCARD_HOST, READ, ALLOW))
+      val result = admin.createAcls(List(acl1, acl2, acl3, acl4).asJava)
+      result.all().get
 
-    val result = admin.createAcls(List(acl1, acl2, acl3, acl4).asJava)
-    result.all().get
-
-    val underlying = clusterInstance.asInstanceOf[ZkClusterInstance].getUnderlying()
-    val zkClient = underlying.zkClient
-    val migrationClient = ZkMigrationClient(zkClient, PasswordEncoder.NOOP)
-    val verifier = new MetadataDeltaVerifier()
-    migrationClient.readAllMetadata(batch => verifier.accept(batch), _ => { })
-    verifier.verify { image =>
-      val aclMap = image.acls().acls()
-      assertEquals(4, aclMap.size())
-      assertTrue(aclMap.values().containsAll(Seq(
-        StandardAcl.fromAclBinding(acl1),
-        StandardAcl.fromAclBinding(acl2),
-        StandardAcl.fromAclBinding(acl3),
-        StandardAcl.fromAclBinding(acl4)
-      ).asJava))
+      val underlying = clusterInstance.asInstanceOf[ZkClusterInstance].getUnderlying()
+      val zkClient = underlying.zkClient
+      val migrationClient = ZkMigrationClient(zkClient, PasswordEncoder.NOOP)
+      val verifier = new MetadataDeltaVerifier()
+      migrationClient.readAllMetadata(batch => verifier.accept(batch), _ => {})
+      verifier.verify { image =>
+        val aclMap = image.acls().acls()
+        assertEquals(4, aclMap.size())
+        assertTrue(aclMap.values().containsAll(Seq(
+          StandardAcl.fromAclBinding(acl1),
+          StandardAcl.fromAclBinding(acl2),
+          StandardAcl.fromAclBinding(acl3),
+          StandardAcl.fromAclBinding(acl4)
+        ).asJava))
+      }
     }
   }
 
@@ -218,87 +219,88 @@ class ZkMigrationIntegrationTest {
    */
   @ClusterTest(brokers = 3, clusterType = Type.ZK, metadataVersion = MetadataVersion.IBP_3_4_IV0)
   def testMigrate(clusterInstance: ClusterInstance): Unit = {
-    val admin = clusterInstance.createAdminClient()
-    val newTopics = new util.ArrayList[NewTopic]()
-    newTopics.add(new NewTopic("test-topic-1", 2, 3.toShort)
-      .configs(Map(TopicConfig.SEGMENT_BYTES_CONFIG -> "102400", TopicConfig.SEGMENT_MS_CONFIG -> "300000").asJava))
-    newTopics.add(new NewTopic("test-topic-2", 1, 3.toShort))
-    newTopics.add(new NewTopic("test-topic-3", 10, 3.toShort))
-    val createTopicResult = admin.createTopics(newTopics)
-    createTopicResult.all().get(60, TimeUnit.SECONDS)
+    Using(Admin.create(clusterInstance.adminConfigs(Collections.emptyMap()))) { admin =>
+      val newTopics = new util.ArrayList[NewTopic]()
+      newTopics.add(new NewTopic("test-topic-1", 2, 3.toShort)
+        .configs(Map(TopicConfig.SEGMENT_BYTES_CONFIG -> "102400", TopicConfig.SEGMENT_MS_CONFIG -> "300000").asJava))
+      newTopics.add(new NewTopic("test-topic-2", 1, 3.toShort))
+      newTopics.add(new NewTopic("test-topic-3", 10, 3.toShort))
+      val createTopicResult = admin.createTopics(newTopics)
+      createTopicResult.all().get(60, TimeUnit.SECONDS)
 
-    val quotas = new util.ArrayList[ClientQuotaAlteration]()
-    val defaultUserEntity = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.USER, null))
-    quotas.add(new ClientQuotaAlteration(defaultUserEntity, List(new ClientQuotaAlteration.Op("consumer_byte_rate", 900.0)).asJava))
-    val defaultClientIdEntity = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.CLIENT_ID, null))
-    quotas.add(new ClientQuotaAlteration(defaultClientIdEntity, List(new ClientQuotaAlteration.Op("consumer_byte_rate", 900.0)).asJava))
-    val defaultIpEntity = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.IP, null))
-    quotas.add(new ClientQuotaAlteration(defaultIpEntity, List(new ClientQuotaAlteration.Op("connection_creation_rate", 9.0)).asJava))
-    val userEntity = new ClientQuotaEntity(Map(ClientQuotaEntity.USER -> "user/1@prod").asJava)
-    quotas.add(new ClientQuotaAlteration(userEntity, List(new ClientQuotaAlteration.Op("consumer_byte_rate", 1000.0)).asJava))
-    val userClientEntity = new ClientQuotaEntity(Map(ClientQuotaEntity.USER -> "user/1@prod", ClientQuotaEntity.CLIENT_ID -> "client/1@domain").asJava)
-    quotas.add(new ClientQuotaAlteration(userClientEntity,
-      List(new ClientQuotaAlteration.Op("consumer_byte_rate", 800.0), new ClientQuotaAlteration.Op("producer_byte_rate", 100.0)).asJava))
-    val ipEntity = new ClientQuotaEntity(Map(ClientQuotaEntity.IP -> "8.8.8.8").asJava)
-    quotas.add(new ClientQuotaAlteration(ipEntity, List(new ClientQuotaAlteration.Op("connection_creation_rate", 10.0)).asJava))
-    admin.alterClientQuotas(quotas).all().get(60, TimeUnit.SECONDS)
+      val quotas = new util.ArrayList[ClientQuotaAlteration]()
+      val defaultUserEntity = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.USER, null))
+      quotas.add(new ClientQuotaAlteration(defaultUserEntity, List(new ClientQuotaAlteration.Op("consumer_byte_rate", 900.0)).asJava))
+      val defaultClientIdEntity = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.CLIENT_ID, null))
+      quotas.add(new ClientQuotaAlteration(defaultClientIdEntity, List(new ClientQuotaAlteration.Op("consumer_byte_rate", 900.0)).asJava))
+      val defaultIpEntity = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.IP, null))
+      quotas.add(new ClientQuotaAlteration(defaultIpEntity, List(new ClientQuotaAlteration.Op("connection_creation_rate", 9.0)).asJava))
+      val userEntity = new ClientQuotaEntity(Map(ClientQuotaEntity.USER -> "user/1@prod").asJava)
+      quotas.add(new ClientQuotaAlteration(userEntity, List(new ClientQuotaAlteration.Op("consumer_byte_rate", 1000.0)).asJava))
+      val userClientEntity = new ClientQuotaEntity(Map(ClientQuotaEntity.USER -> "user/1@prod", ClientQuotaEntity.CLIENT_ID -> "client/1@domain").asJava)
+      quotas.add(new ClientQuotaAlteration(userClientEntity,
+        List(new ClientQuotaAlteration.Op("consumer_byte_rate", 800.0), new ClientQuotaAlteration.Op("producer_byte_rate", 100.0)).asJava))
+      val ipEntity = new ClientQuotaEntity(Map(ClientQuotaEntity.IP -> "8.8.8.8").asJava)
+      quotas.add(new ClientQuotaAlteration(ipEntity, List(new ClientQuotaAlteration.Op("connection_creation_rate", 10.0)).asJava))
+      admin.alterClientQuotas(quotas).all().get(60, TimeUnit.SECONDS)
 
-    val zkClient = clusterInstance.asInstanceOf[ZkClusterInstance].getUnderlying().zkClient
-    val kafkaConfig = clusterInstance.asInstanceOf[ZkClusterInstance].getUnderlying.servers.head.config
-    val zkConfigEncoder = kafkaConfig.passwordEncoderSecret match {
-      case Some(secret) =>
-        PasswordEncoder.encrypting(secret,
-          kafkaConfig.passwordEncoderKeyFactoryAlgorithm,
-          kafkaConfig.passwordEncoderCipherAlgorithm,
-          kafkaConfig.passwordEncoderKeyLength,
-          kafkaConfig.passwordEncoderIterations)
-      case None => PasswordEncoder.NOOP
+      val zkClient = clusterInstance.asInstanceOf[ZkClusterInstance].getUnderlying().zkClient
+      val kafkaConfig = clusterInstance.asInstanceOf[ZkClusterInstance].getUnderlying.servers.head.config
+      val zkConfigEncoder = kafkaConfig.passwordEncoderSecret match {
+        case Some(secret) =>
+          PasswordEncoder.encrypting(secret,
+            kafkaConfig.passwordEncoderKeyFactoryAlgorithm,
+            kafkaConfig.passwordEncoderCipherAlgorithm,
+            kafkaConfig.passwordEncoderKeyLength,
+            kafkaConfig.passwordEncoderIterations)
+        case None => PasswordEncoder.NOOP
+      }
+
+      val migrationClient = ZkMigrationClient(zkClient, zkConfigEncoder)
+      var migrationState = migrationClient.getOrCreateMigrationRecoveryState(ZkMigrationLeadershipState.EMPTY)
+      migrationState = migrationState.withNewKRaftController(3000, 42)
+      migrationState = migrationClient.claimControllerLeadership(migrationState)
+
+      val brokers = new java.util.HashSet[Integer]()
+      val verifier = new MetadataDeltaVerifier()
+      migrationClient.readAllMetadata(batch => verifier.accept(batch), brokerId => brokers.add(brokerId))
+      assertEquals(Seq(0, 1, 2), brokers.asScala.toSeq)
+
+      verifier.verify { image =>
+        assertNotNull(image.topics().getTopic("test-topic-1"))
+        assertEquals(2, image.topics().getTopic("test-topic-1").partitions().size())
+
+        assertNotNull(image.topics().getTopic("test-topic-2"))
+        assertEquals(1, image.topics().getTopic("test-topic-2").partitions().size())
+
+        assertNotNull(image.topics().getTopic("test-topic-3"))
+        assertEquals(10, image.topics().getTopic("test-topic-3").partitions().size())
+
+        val clientQuotas = image.clientQuotas().entities()
+        assertEquals(new java.util.HashSet[ClientQuotaEntity](java.util.Arrays.asList(
+          defaultUserEntity,
+          defaultClientIdEntity,
+          defaultIpEntity,
+          userEntity,
+          userClientEntity,
+          ipEntity
+        )), clientQuotas.keySet())
+      }
+      migrationState = migrationClient.releaseControllerLeadership(migrationState)
     }
-
-    val migrationClient = ZkMigrationClient(zkClient, zkConfigEncoder)
-    var migrationState = migrationClient.getOrCreateMigrationRecoveryState(ZkMigrationLeadershipState.EMPTY)
-    migrationState = migrationState.withNewKRaftController(3000, 42)
-    migrationState = migrationClient.claimControllerLeadership(migrationState)
-
-    val brokers = new java.util.HashSet[Integer]()
-    val verifier = new MetadataDeltaVerifier()
-    migrationClient.readAllMetadata(batch => verifier.accept(batch), brokerId => brokers.add(brokerId))
-    assertEquals(Seq(0, 1, 2), brokers.asScala.toSeq)
-
-    verifier.verify { image =>
-      assertNotNull(image.topics().getTopic("test-topic-1"))
-      assertEquals(2, image.topics().getTopic("test-topic-1").partitions().size())
-
-      assertNotNull(image.topics().getTopic("test-topic-2"))
-      assertEquals(1, image.topics().getTopic("test-topic-2").partitions().size())
-
-      assertNotNull(image.topics().getTopic("test-topic-3"))
-      assertEquals(10, image.topics().getTopic("test-topic-3").partitions().size())
-
-      val clientQuotas = image.clientQuotas().entities()
-      assertEquals(new java.util.HashSet[ClientQuotaEntity](java.util.Arrays.asList(
-        defaultUserEntity,
-        defaultClientIdEntity,
-        defaultIpEntity,
-        userEntity,
-        userClientEntity,
-        ipEntity
-      )), clientQuotas.keySet())
-    }
-    migrationState = migrationClient.releaseControllerLeadership(migrationState)
   }
 
   @ClusterTemplate("zkClustersForAllMigrationVersions")
   def testMigrateTopicDeletions(zkCluster: ClusterInstance): Unit = {
     // Create some topics in ZK mode
-    var admin = zkCluster.createAdminClient()
-    val newTopics = new util.ArrayList[NewTopic]()
-    newTopics.add(new NewTopic("test-topic-1", 10, 3.toShort))
-    newTopics.add(new NewTopic("test-topic-2", 10, 3.toShort))
-    newTopics.add(new NewTopic("test-topic-3", 10, 3.toShort))
-    val createTopicResult = admin.createTopics(newTopics)
-    createTopicResult.all().get(300, TimeUnit.SECONDS)
-    admin.close()
+    Using(Admin.create(zkCluster.adminConfigs(Collections.emptyMap()))) { admin =>
+      val newTopics = new util.ArrayList[NewTopic]()
+      newTopics.add(new NewTopic("test-topic-1", 10, 3.toShort))
+      newTopics.add(new NewTopic("test-topic-2", 10, 3.toShort))
+      newTopics.add(new NewTopic("test-topic-3", 10, 3.toShort))
+      val createTopicResult = admin.createTopics(newTopics)
+      createTopicResult.all().get(300, TimeUnit.SECONDS)
+    }
     val zkClient = zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying().zkClient
 
     // Bootstrap the ZK cluster ID into KRaft
@@ -356,66 +358,66 @@ class ZkMigrationIntegrationTest {
         topics.isEmpty
       }
 
-      admin = zkCluster.createAdminClient()
-      log.info("Waiting for topics to be deleted")
-      TestUtils.waitUntilTrue(
-        () => topicsAllDeleted(admin),
-        "Timed out waiting for topics to be deleted",
-        30000,
-        1000)
+      Using(Admin.create(zkCluster.adminConfigs(Collections.emptyMap()))) { admin =>
+        log.info("Waiting for topics to be deleted")
+        TestUtils.waitUntilTrue(
+          () => topicsAllDeleted(admin),
+          "Timed out waiting for topics to be deleted",
+          30000,
+          1000)
 
-      val newTopics = new util.ArrayList[NewTopic]()
-      newTopics.add(new NewTopic("test-topic-1", 2, 3.toShort))
-      newTopics.add(new NewTopic("test-topic-2", 1, 3.toShort))
-      newTopics.add(new NewTopic("test-topic-3", 10, 3.toShort))
-      val createTopicResult = admin.createTopics(newTopics)
-      createTopicResult.all().get(60, TimeUnit.SECONDS)
+        val newTopics = new util.ArrayList[NewTopic]()
+        newTopics.add(new NewTopic("test-topic-1", 2, 3.toShort))
+        newTopics.add(new NewTopic("test-topic-2", 1, 3.toShort))
+        newTopics.add(new NewTopic("test-topic-3", 10, 3.toShort))
+        val createTopicResult = admin.createTopics(newTopics)
+        createTopicResult.all().get(60, TimeUnit.SECONDS)
 
-      def topicsAllRecreated(admin: Admin): Boolean = {
-        val topics = admin.listTopics().names().get(60, TimeUnit.SECONDS)
-        topics.retainAll(util.Arrays.asList(
-          "test-topic-1", "test-topic-2", "test-topic-3"
-        ))
-        topics.size() == 3
-      }
-
-      log.info("Waiting for topics to be re-created")
-      TestUtils.waitUntilTrue(
-        () => topicsAllRecreated(admin),
-        "Timed out waiting for topics to be created",
-        30000,
-        1000)
-
-      TestUtils.retry(300000) {
-        // Need a retry here since topic metadata may be inconsistent between brokers
-        val topicDescriptions = try {
-          admin.describeTopics(util.Arrays.asList(
+        def topicsAllRecreated(admin: Admin): Boolean = {
+          val topics = admin.listTopics().names().get(60, TimeUnit.SECONDS)
+          topics.retainAll(util.Arrays.asList(
             "test-topic-1", "test-topic-2", "test-topic-3"
-          )).topicNameValues().asScala.map { case (name, description) =>
-            name -> description.get(60, TimeUnit.SECONDS)
-          }.toMap
-        } catch {
-          case e: ExecutionException if e.getCause.isInstanceOf[UnknownTopicOrPartitionException] => Map.empty[String, TopicDescription]
-          case t: Throwable => fail("Error describing topics", t.getCause)
+          ))
+          topics.size() == 3
         }
 
-        assertEquals(2, topicDescriptions("test-topic-1").partitions().size())
-        assertEquals(1, topicDescriptions("test-topic-2").partitions().size())
-        assertEquals(10, topicDescriptions("test-topic-3").partitions().size())
-        topicDescriptions.foreach { case (topic, description) =>
-          description.partitions().forEach(partition => {
-            assertEquals(3, partition.replicas().size(), s"Unexpected number of replicas for $topic-${partition.partition()}")
-            assertEquals(3, partition.isr().size(), s"Unexpected ISR for $topic-${partition.partition()}")
-          })
+        log.info("Waiting for topics to be re-created")
+        TestUtils.waitUntilTrue(
+          () => topicsAllRecreated(admin),
+          "Timed out waiting for topics to be created",
+          30000,
+          1000)
+
+        TestUtils.retry(300000) {
+          // Need a retry here since topic metadata may be inconsistent between brokers
+          val topicDescriptions = try {
+            admin.describeTopics(util.Arrays.asList(
+              "test-topic-1", "test-topic-2", "test-topic-3"
+            )).topicNameValues().asScala.map { case (name, description) =>
+              name -> description.get(60, TimeUnit.SECONDS)
+            }.toMap
+          } catch {
+            case e: ExecutionException if e.getCause.isInstanceOf[UnknownTopicOrPartitionException] => Map.empty[String, TopicDescription]
+            case t: Throwable => fail("Error describing topics", t.getCause)
+          }
+
+          assertEquals(2, topicDescriptions("test-topic-1").partitions().size())
+          assertEquals(1, topicDescriptions("test-topic-2").partitions().size())
+          assertEquals(10, topicDescriptions("test-topic-3").partitions().size())
+          topicDescriptions.foreach { case (topic, description) =>
+            description.partitions().forEach(partition => {
+              assertEquals(3, partition.replicas().size(), s"Unexpected number of replicas for $topic-${partition.partition()}")
+              assertEquals(3, partition.isr().size(), s"Unexpected ISR for $topic-${partition.partition()}")
+            })
+          }
+
+          val absentTopics = admin.listTopics().names().get(60, TimeUnit.SECONDS).asScala
+          assertTrue(absentTopics.contains("test-topic-1"))
+          assertTrue(absentTopics.contains("test-topic-2"))
+          assertTrue(absentTopics.contains("test-topic-3"))
         }
 
-        val absentTopics = admin.listTopics().names().get(60, TimeUnit.SECONDS).asScala
-        assertTrue(absentTopics.contains("test-topic-1"))
-        assertTrue(absentTopics.contains("test-topic-2"))
-        assertTrue(absentTopics.contains("test-topic-3"))
       }
-
-      admin.close()
     } finally {
       shutdownInSequence(zkCluster, kraftCluster)
     }
@@ -429,9 +431,9 @@ class ZkMigrationIntegrationTest {
     new ClusterConfigProperty(key = "listener.security.protocol.map", value = "EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT"),
   ))
   def testDualWriteScram(zkCluster: ClusterInstance): Unit = {
-    var admin = zkCluster.createAdminClient()
-    createUserScramCredentials(admin).all().get(60, TimeUnit.SECONDS)
-    admin.close()
+    Using(Admin.create(zkCluster.adminConfigs(Collections.emptyMap()))) { admin =>
+      createUserScramCredentials(admin).all().get(60, TimeUnit.SECONDS)
+    }
 
     val zkClient = zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying().zkClient
 
@@ -470,8 +472,9 @@ class ZkMigrationIntegrationTest {
 
       // Alter the metadata
       log.info("Updating metadata with AdminClient")
-      admin = zkCluster.createAdminClient()
-      alterUserScramCredentials(admin).all().get(60, TimeUnit.SECONDS)
+      Using(Admin.create(zkCluster.adminConfigs(Collections.emptyMap()))) { admin =>
+        alterUserScramCredentials(admin).all().get(60, TimeUnit.SECONDS)
+      }
 
       // Verify the changes made to KRaft are seen in ZK
       log.info("Verifying metadata changes with ZK")
@@ -488,15 +491,12 @@ class ZkMigrationIntegrationTest {
     new ClusterConfigProperty(key = "listener.security.protocol.map", value = "EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT"),
   ))
   def testDeleteLogOnStartup(zkCluster: ClusterInstance): Unit = {
-    var admin = zkCluster.createAdminClient()
-    try {
+    Using(Admin.create(zkCluster.adminConfigs(Collections.emptyMap()))) { admin =>
       val newTopics = new util.ArrayList[NewTopic]()
       newTopics.add(new NewTopic("testDeleteLogOnStartup", 2, 3.toShort)
         .configs(Map(TopicConfig.SEGMENT_BYTES_CONFIG -> "102400", TopicConfig.SEGMENT_MS_CONFIG -> "300000").asJava))
       val createTopicResult = admin.createTopics(newTopics)
       createTopicResult.all().get(60, TimeUnit.SECONDS)
-    } finally {
-      admin.close()
     }
 
     // Bootstrap the ZK cluster ID into KRaft
@@ -545,8 +545,7 @@ class ZkMigrationIntegrationTest {
       zkCluster.rollingBrokerRestart()
       zkCluster.waitForReadyBrokers()
 
-      admin = zkCluster.createAdminClient()
-      try {
+      Using(Admin.create(zkCluster.adminConfigs(Collections.emptyMap()))) { admin =>
         // List topics is served from local MetadataCache on brokers. For ZK brokers this cache is populated by UMR
         // which won't be sent until the broker has been unfenced by the KRaft controller. So, seeing the topic in
         // the brokers cache tells us it has recreated and re-replicated the metadata log
@@ -554,8 +553,6 @@ class ZkMigrationIntegrationTest {
           () => admin.listTopics().names().get(30, TimeUnit.SECONDS).asScala.contains("testDeleteLogOnStartup"),
           "Timed out listing topics",
           30000)
-      } finally {
-        admin.close()
       }
     } finally {
       shutdownInSequence(zkCluster, kraftCluster)
@@ -567,13 +564,13 @@ class ZkMigrationIntegrationTest {
   def testDualWrite(zkCluster: ClusterInstance): Unit = {
     // Create a topic in ZK mode
     val topicName = "test"
-    var admin = zkCluster.createAdminClient()
-    val newTopics = new util.ArrayList[NewTopic]()
-    newTopics.add(new NewTopic(topicName, 2, 3.toShort)
-      .configs(Map(TopicConfig.SEGMENT_BYTES_CONFIG -> "102400", TopicConfig.SEGMENT_MS_CONFIG -> "300000").asJava))
-    val createTopicResult = admin.createTopics(newTopics)
-    createTopicResult.all().get(60, TimeUnit.SECONDS)
-    admin.close()
+    Using(Admin.create(zkCluster.adminConfigs(Collections.emptyMap()))) { admin =>
+      val newTopics = new util.ArrayList[NewTopic]()
+      newTopics.add(new NewTopic(topicName, 2, 3.toShort)
+        .configs(Map(TopicConfig.SEGMENT_BYTES_CONFIG -> "102400", TopicConfig.SEGMENT_MS_CONFIG -> "300000").asJava))
+      val createTopicResult = admin.createTopics(newTopics)
+      createTopicResult.all().get(60, TimeUnit.SECONDS)
+    }
 
     // Verify the configs exist in ZK
     val zkClient = zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying().zkClient
@@ -619,9 +616,10 @@ class ZkMigrationIntegrationTest {
 
       // Alter the metadata
       log.info("Updating metadata with AdminClient")
-      admin = zkCluster.createAdminClient()
-      alterTopicConfig(admin).all().get(60, TimeUnit.SECONDS)
-      alterClientQuotas(admin).all().get(60, TimeUnit.SECONDS)
+      Using(Admin.create(zkCluster.adminConfigs(Collections.emptyMap()))) { admin =>
+        alterTopicConfig(admin).all().get(60, TimeUnit.SECONDS)
+        alterClientQuotas(admin).all().get(60, TimeUnit.SECONDS)
+      }
 
       // Verify the changes made to KRaft are seen in ZK
       log.info("Verifying metadata changes with ZK")
@@ -643,9 +641,9 @@ class ZkMigrationIntegrationTest {
     new ClusterConfigProperty(key = "listener.security.protocol.map", value = "EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT"),
   ))
   def testDualWriteQuotaAndScram(zkCluster: ClusterInstance): Unit = {
-    var admin = zkCluster.createAdminClient()
-    createUserScramCredentials(admin).all().get(60, TimeUnit.SECONDS)
-    admin.close()
+    Using(Admin.create(zkCluster.adminConfigs(Collections.emptyMap()))) { admin =>
+      createUserScramCredentials(admin).all().get(60, TimeUnit.SECONDS)
+    }
 
     val zkClient = zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying().zkClient
 
@@ -684,9 +682,10 @@ class ZkMigrationIntegrationTest {
 
       // Alter the metadata
       log.info("Updating metadata with AdminClient")
-      admin = zkCluster.createAdminClient()
-      alterUserScramCredentials(admin).all().get(60, TimeUnit.SECONDS)
-      alterClientQuotas(admin).all().get(60, TimeUnit.SECONDS)
+      Using(Admin.create(zkCluster.adminConfigs(Collections.emptyMap()))) { admin =>
+        alterUserScramCredentials(admin).all().get(60, TimeUnit.SECONDS)
+        alterClientQuotas(admin).all().get(60, TimeUnit.SECONDS)
+      }
 
       // Verify the changes made to KRaft are seen in ZK
       log.info("Verifying metadata changes with ZK")
@@ -706,7 +705,6 @@ class ZkMigrationIntegrationTest {
   def testNewAndChangedTopicsInDualWrite(zkCluster: ClusterInstance): Unit = {
     val topic1 = "test1"
     val topic2 = "test2"
-    var admin = zkCluster.createAdminClient()
     val zkClient = zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying().zkClient
 
     // Bootstrap the ZK cluster ID into KRaft
@@ -743,30 +741,31 @@ class ZkMigrationIntegrationTest {
         30000)
 
       // Alter the metadata
-      admin = zkCluster.createAdminClient()
-      log.info(s"Create new topic $topic1 with AdminClient with some configs")
-      val topicConfigs = util.Collections.singletonMap("cleanup.policy", "compact")
-      createTopic(topic1, 2, 3.toShort, topicConfigs, admin)
-      verifyTopic(topic1, 2, 3.toShort, topicConfigs, admin, zkClient)
+      Using(Admin.create(zkCluster.adminConfigs(Collections.emptyMap()))) { admin =>
+        log.info(s"Create new topic $topic1 with AdminClient with some configs")
+        val topicConfigs = util.Collections.singletonMap("cleanup.policy", "compact")
+        createTopic(topic1, 2, 3.toShort, topicConfigs, admin)
+        verifyTopic(topic1, 2, 3.toShort, topicConfigs, admin, zkClient)
 
-      log.info(s"Create new topic $topic2 with AdminClient without configs")
-      val emptyTopicConfigs: util.Map[String, String] = util.Collections.emptyMap[String, String]
-      createTopic(topic2, 2, 3.toShort, emptyTopicConfigs, admin)
-      verifyTopic(topic2, 2, 3.toShort, emptyTopicConfigs, admin, zkClient)
+        log.info(s"Create new topic $topic2 with AdminClient without configs")
+        val emptyTopicConfigs: util.Map[String, String] = util.Collections.emptyMap[String, String]
+        createTopic(topic2, 2, 3.toShort, emptyTopicConfigs, admin)
+        verifyTopic(topic2, 2, 3.toShort, emptyTopicConfigs, admin, zkClient)
 
-      val newPartitionCount = 3
-      log.info(s"Create new partitions with AdminClient to $topic1")
-      admin.createPartitions(Map(topic1 -> NewPartitions.increaseTo(newPartitionCount)).asJava).all().get(60, TimeUnit.SECONDS)
-      val (topicDescOpt, _) = TestUtils.computeUntilTrue(topicDesc(topic1, admin))(td => {
-        td.isDefined && td.get.partitions().asScala.size == newPartitionCount
-      })
-      assertTrue(topicDescOpt.isDefined)
-      val partitions = topicDescOpt.get.partitions().asScala
-      assertEquals(newPartitionCount, partitions.size)
+        val newPartitionCount = 3
+        log.info(s"Create new partitions with AdminClient to $topic1")
+        admin.createPartitions(Map(topic1 -> NewPartitions.increaseTo(newPartitionCount)).asJava).all().get(60, TimeUnit.SECONDS)
+        val (topicDescOpt, _) = TestUtils.computeUntilTrue(topicDesc(topic1, admin))(td => {
+          td.isDefined && td.get.partitions().asScala.size == newPartitionCount
+        })
+        assertTrue(topicDescOpt.isDefined)
+        val partitions = topicDescOpt.get.partitions().asScala
+        assertEquals(newPartitionCount, partitions.size)
 
-      // Verify the changes
-      verifyZKTopicPartitionMetadata(topic1, newPartitionCount, 3.toShort, zkClient)
-      verifyKRaftTopicPartitionMetadata(topic1, newPartitionCount, 3.toShort, admin)
+        // Verify the changes
+        verifyZKTopicPartitionMetadata(topic1, newPartitionCount, 3.toShort, zkClient)
+        verifyKRaftTopicPartitionMetadata(topic1, newPartitionCount, 3.toShort, admin)
+      }
     } finally {
       shutdownInSequence(zkCluster, kraftCluster)
     }
@@ -781,7 +780,6 @@ class ZkMigrationIntegrationTest {
   def testPartitionReassignmentInHybridMode(zkCluster: ClusterInstance): Unit = {
     // Create a topic in ZK mode
     val topicName = "test"
-    var admin = zkCluster.createAdminClient()
     val zkClient = zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying().zkClient
 
     // Bootstrap the ZK cluster ID into KRaft
@@ -819,34 +817,37 @@ class ZkMigrationIntegrationTest {
 
       // Create a topic with replicas on brokers 0, 1, 2
       log.info("Create new topic with AdminClient")
-      admin = zkCluster.createAdminClient()
-      val newTopics = new util.ArrayList[NewTopic]()
-      val replicaAssignment = Collections.singletonMap(Integer.valueOf(0), Seq(0, 1, 2).map(int2Integer).asJava)
-      newTopics.add(new NewTopic(topicName, replicaAssignment))
-      val createTopicResult = admin.createTopics(newTopics)
-      createTopicResult.all().get(60, TimeUnit.SECONDS)
+      Using(Admin.create(zkCluster.adminConfigs(Collections.emptyMap()))) { admin =>
+        val newTopics = new util.ArrayList[NewTopic]()
+        val replicaAssignment = Collections.singletonMap(Integer.valueOf(0), Seq(0, 1, 2).map(int2Integer).asJava)
+        newTopics.add(new NewTopic(topicName, replicaAssignment))
+        val createTopicResult = admin.createTopics(newTopics)
+        createTopicResult.all().get(60, TimeUnit.SECONDS)
 
-      val topicPartition = new TopicPartition(topicName, 0)
 
-      // Verify the changes made to KRaft are seen in ZK
-      verifyZKTopicPartitionMetadata(topicName, 1, 3.toShort, zkClient)
+        val topicPartition = new TopicPartition(topicName, 0)
 
-      // Reassign replicas to brokers 1, 2, 3 and wait for reassignment to complete
-      admin.alterPartitionReassignments(Collections.singletonMap(topicPartition,
-        Optional.of(new NewPartitionReassignment(Seq(1, 2, 3).map(int2Integer).asJava)))).all().get()
+        // Verify the changes made to KRaft are seen in ZK
+        verifyZKTopicPartitionMetadata(topicName, 1, 3.toShort, zkClient)
 
-      TestUtils.waitUntilTrue(() => {
-        val listPartitionReassignmentsResult = admin.listPartitionReassignments().reassignments().get()
-        listPartitionReassignmentsResult.isEmpty
-      }, "Timed out waiting for reassignments to complete.")
+        // Reassign replicas to brokers 1, 2, 3 and wait for reassignment to complete
+        admin.alterPartitionReassignments(Collections.singletonMap(topicPartition,
+          Optional.of(new NewPartitionReassignment(Seq(1, 2, 3).map(int2Integer).asJava)))).all().get()
 
-      // Verify that the partition is removed from broker 0
-      TestUtils.waitUntilTrue(() => {
-        val brokers = zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.brokers
-        assertTrue(brokers.size == 4)
-        assertTrue(brokers.head.config.brokerId == 0)
-        brokers.head.replicaManager.onlinePartition(topicPartition).isEmpty
-      }, "Timed out waiting for removed replica reassignment to be marked offline")
+        TestUtils.waitUntilTrue(() => {
+          val listPartitionReassignmentsResult = admin.listPartitionReassignments().reassignments().get()
+          listPartitionReassignmentsResult.isEmpty
+        }, "Timed out waiting for reassignments to complete.")
+
+
+        // Verify that the partition is removed from broker 0
+        TestUtils.waitUntilTrue(() => {
+          val brokers = zkCluster.asInstanceOf[ZkClusterInstance].getUnderlying.brokers
+          assertTrue(brokers.size == 4)
+          assertTrue(brokers.head.config.brokerId == 0)
+          brokers.head.replicaManager.onlinePartition(topicPartition).isEmpty
+        }, "Timed out waiting for removed replica reassignment to be marked offline")
+      }
     } finally {
       shutdownInSequence(zkCluster, kraftCluster)
     }

--- a/tools/src/test/java/org/apache/kafka/tools/DeleteRecordsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/DeleteRecordsCommandTest.java
@@ -60,11 +60,7 @@ public class DeleteRecordsCommandTest {
 
     @ClusterTest
     public void testCommand() throws Exception {
-        Properties adminProps = new Properties();
-
-        adminProps.put(AdminClientConfig.RETRIES_CONFIG, 1);
-
-        try (Admin admin = cluster.createAdminClient(adminProps)) {
+        try (Admin admin = Admin.create(cluster.adminConfigs(Collections.singletonMap(AdminClientConfig.RETRIES_CONFIG, "1")))) {
             assertThrows(
                 AdminCommandFailedException.class,
                 () -> DeleteRecordsCommand.execute(admin, "{\"partitions\":[" +

--- a/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
@@ -72,7 +73,7 @@ public class GetOffsetShellTest {
     }
 
     private void setUp() {
-        try (Admin admin = cluster.createAdminClient()) {
+        try (Admin admin = Admin.create(cluster.adminConfigs(Collections.emptyMap()))) {
             List<NewTopic> topics = new ArrayList<>();
 
             IntStream.range(0, topicCount + 1).forEach(i -> topics.add(new NewTopic(getTopicName(i), i, (short) 1)));


### PR DESCRIPTION
Sometimes we close the admin created by `createAdminClient`, and sometimes we don't. That is not a true problem since the `ClusterInstance` will call `close` when stopping.

However, that cause a lot of inconsistent code, and in fact it does not save much time since creating a Admin is not a hard work. We can get `bootstrapServers` and `bootstrapControllers` from `ClusterInstance` easily.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
