### PR TITLE
MINOR: Fix the flaky testConsumerGroupHeartbeatWithStableClassicGroup by sorting the topic partition list

### DIFF
--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
@@ -258,25 +258,6 @@ public class Assertions {
                 Comparator.comparing(ConsumerGroupTargetAssignmentMemberValue.TopicPartition::topicId)
             );
             assertEquals(expectedValue, actualValue);
-        } else if (actual.message() instanceof ConsumerGroupCurrentMemberAssignmentValue) {
-            ConsumerGroupCurrentMemberAssignmentValue expectedValue =
-                (ConsumerGroupCurrentMemberAssignmentValue) expected.message().duplicate();
-            ConsumerGroupCurrentMemberAssignmentValue actualValue =
-                (ConsumerGroupCurrentMemberAssignmentValue) actual.message().duplicate();
-
-            expectedValue.assignedPartitions().sort(
-                Comparator.comparing(ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions::topicId)
-            );
-            actualValue.assignedPartitions().sort(
-                Comparator.comparing(ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions::topicId)
-            );
-            expectedValue.partitionsPendingRevocation().sort(
-                Comparator.comparing(ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions::topicId)
-            );
-            actualValue.partitionsPendingRevocation().sort(
-                Comparator.comparing(ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions::topicId)
-            );
-            assertEquals(expectedValue, actualValue);
         } else {
             assertEquals(expected.message(), actual.message());
         }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
@@ -212,8 +212,10 @@ public class Assertions {
             GroupMetadataValue expectedValue = (GroupMetadataValue) expected.message().duplicate();
             GroupMetadataValue actualValue = (GroupMetadataValue) actual.message().duplicate();
 
-            expectedValue.members().sort(Comparator.comparing(GroupMetadataValue.MemberMetadata::memberId));
-            actualValue.members().sort(Comparator.comparing(GroupMetadataValue.MemberMetadata::memberId));
+            Comparator<GroupMetadataValue.MemberMetadata> comparator =
+                Comparator.comparing(GroupMetadataValue.MemberMetadata::memberId);
+            expectedValue.members().sort(comparator);
+            actualValue.members().sort(comparator);
             try {
                 Arrays.asList(expectedValue, actualValue).forEach(value ->
                     value.members().forEach(memberMetadata -> {
@@ -251,12 +253,11 @@ public class Assertions {
             ConsumerGroupTargetAssignmentMemberValue actualValue =
                 (ConsumerGroupTargetAssignmentMemberValue) actual.message().duplicate();
 
-            expectedValue.topicPartitions().sort(
-                Comparator.comparing(ConsumerGroupTargetAssignmentMemberValue.TopicPartition::topicId)
-            );
-            actualValue.topicPartitions().sort(
-                Comparator.comparing(ConsumerGroupTargetAssignmentMemberValue.TopicPartition::topicId)
-            );
+            Comparator<ConsumerGroupTargetAssignmentMemberValue.TopicPartition> comparator =
+                Comparator.comparing(ConsumerGroupTargetAssignmentMemberValue.TopicPartition::topicId);
+            expectedValue.topicPartitions().sort(comparator);
+            actualValue.topicPartitions().sort(comparator);
+
             assertEquals(expectedValue, actualValue);
         } else {
             assertEquals(expected.message(), actual.message());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.protocol.types.SchemaException;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupPartitionMetadataValue;
+import org.apache.kafka.coordinator.group.generated.ConsumerGroupTargetAssignmentMemberValue;
 import org.apache.kafka.coordinator.group.generated.GroupMetadataValue;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.opentest4j.AssertionFailedError;
@@ -243,6 +244,38 @@ public class Assertions {
             } catch (SchemaException ex) {
                 fail("Failed deserialization: " + ex.getMessage());
             }
+            assertEquals(expectedValue, actualValue);
+        } else if (actual.message() instanceof ConsumerGroupTargetAssignmentMemberValue) {
+            ConsumerGroupTargetAssignmentMemberValue expectedValue =
+                (ConsumerGroupTargetAssignmentMemberValue) expected.message().duplicate();
+            ConsumerGroupTargetAssignmentMemberValue actualValue =
+                (ConsumerGroupTargetAssignmentMemberValue) actual.message().duplicate();
+
+            expectedValue.topicPartitions().sort(
+                Comparator.comparing(ConsumerGroupTargetAssignmentMemberValue.TopicPartition::topicId)
+            );
+            actualValue.topicPartitions().sort(
+                Comparator.comparing(ConsumerGroupTargetAssignmentMemberValue.TopicPartition::topicId)
+            );
+            assertEquals(expectedValue, actualValue);
+        } else if (actual.message() instanceof ConsumerGroupCurrentMemberAssignmentValue) {
+            ConsumerGroupCurrentMemberAssignmentValue expectedValue =
+                (ConsumerGroupCurrentMemberAssignmentValue) expected.message().duplicate();
+            ConsumerGroupCurrentMemberAssignmentValue actualValue =
+                (ConsumerGroupCurrentMemberAssignmentValue) actual.message().duplicate();
+
+            expectedValue.assignedPartitions().sort(
+                Comparator.comparing(ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions::topicId)
+            );
+            actualValue.assignedPartitions().sort(
+                Comparator.comparing(ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions::topicId)
+            );
+            expectedValue.partitionsPendingRevocation().sort(
+                Comparator.comparing(ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions::topicId)
+            );
+            actualValue.partitionsPendingRevocation().sort(
+                Comparator.comparing(ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions::topicId)
+            );
             assertEquals(expectedValue, actualValue);
         } else {
             assertEquals(expected.message(), actual.message());


### PR DESCRIPTION
We are seeing flaky test in `testConsumerGroupHeartbeatWithStableClassicGroup` where the error is caused by the different ordering in the expected and actual values. The patch sorts the topic partition list in the records to fix the issue.

https://ci-builds.apache.org/blue/organizations/jenkins/Kafka%2Fkafka-pr/detail/PR-15698/11/tests/

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
