### PR TITLE
KAFKA-16511: Fix the leaking tiered segments during segment deletion

### DIFF
--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1232,10 +1232,10 @@ public class RemoteLogManager implements Closeable {
             return false;
         }
         // There can be overlapping remote log segments in the remote storage. (eg)
-        // leader-epoch-file-cache: {(5, 10), (7, 15), (8, 100)}
+        // leader-epoch-file-cache: {(5, 10), (7, 15), (9, 100)}
         // segment1: offset-range = 5-50, Broker = 0, epochs = {(5, 10), (7, 15)}
-        // segment2: offset-range = 14-150, Broker = 1, epochs = {(5, 14), (7, 15), (8, 100)}, after leader-election.
-        // When the segment1 gets deleted, then the leader-epoch-file-cache gets updated to: {(7, 51), (8, 100), (9, 200)}.
+        // segment2: offset-range = 14-150, Broker = 1, epochs = {(5, 14), (7, 15), (9, 100)}, after leader-election.
+        // When the segment1 gets deleted, then the log-start-offset = 51 and leader-epoch-file-cache gets updated to: {(7, 51), (9, 100)}.
         // While validating the segment2, we should ensure the overlapping remote log segments case.
         Integer segmentFirstEpoch = segmentLeaderEpochs.ceilingKey(leaderEpochs.firstKey());
         if (segmentFirstEpoch == null || !leaderEpochs.containsKey(segmentFirstEpoch)) {

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1266,7 +1266,7 @@ public class RemoteLogManager implements Closeable {
             // case-2: When the segment-first-epoch is not equal to the first-epoch in the leader-epoch-lineage, then
             // the offset value should be between (current-epoch-start-offset) to (next-epoch-start-offset - 1).
             if (epoch == segmentFirstEpoch && leaderEpochs.lowerKey(epoch) != null && offset < leaderEpochs.get(epoch)) {
-                LOGGER.debug("Segment {} first-valid epoch {} offset is less than leader epoch offset {}." +
+                LOGGER.debug("Segment {} first-valid epoch {} offset is less than first leader epoch offset {}." +
                                 "Remote segment epochs: {} and partition leader epochs: {}",
                         segmentMetadata.remoteLogSegmentId(), epoch, leaderEpochs.get(epoch),
                         segmentLeaderEpochs, leaderEpochs);

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1247,11 +1247,9 @@ public class RemoteLogManager implements Closeable {
         for (Map.Entry<Integer, Long> entry : segmentLeaderEpochs.entrySet()) {
             int epoch = entry.getKey();
             long offset = entry.getValue();
-
             if (epoch < segmentFirstEpoch) {
                 continue;
             }
-
             // If segment's epoch does not exist in the leader epoch lineage then it is not a valid segment.
             if (!leaderEpochs.containsKey(epoch)) {
                 LOGGER.debug("Segment {} epoch {} is not within the leader epoch lineage. " +
@@ -1259,7 +1257,6 @@ public class RemoteLogManager implements Closeable {
                         segmentMetadata.remoteLogSegmentId(), epoch, segmentLeaderEpochs, leaderEpochs);
                 return false;
             }
-
             // Two cases:
             // case-1: When the segment-first-epoch equals to the first-epoch in the leader-epoch-lineage, then the
             // offset value can lie anywhere between 0 to (next-epoch-start-offset - 1) is valid.
@@ -1272,7 +1269,6 @@ public class RemoteLogManager implements Closeable {
                         segmentLeaderEpochs, leaderEpochs);
                 return false;
             }
-
             // Segment's end offset should be less than or equal to the respective leader epoch's offset.
             if (epoch == segmentLastEpoch) {
                 Map.Entry<Integer, Long> nextEntry = leaderEpochs.higherEntry(epoch);
@@ -1284,7 +1280,6 @@ public class RemoteLogManager implements Closeable {
                     return false;
                 }
             }
-
             // Next segment epoch entry and next leader epoch entry should be same to ensure that the segment's epoch
             // is within the leader epoch lineage.
             if (epoch != segmentLastEpoch && !leaderEpochs.higherEntry(epoch).equals(segmentLeaderEpochs.higherEntry(epoch))) {
@@ -1345,11 +1340,9 @@ public class RemoteLogManager implements Closeable {
             }
             previousEpochAndOffset = currentEpochAndOffset;
         }
-
         if (epochsWithNoMessages.isEmpty()) {
             return leaderEpochs;
         }
-
         TreeMap<Integer, Long> filteredLeaderEpochs = new TreeMap<>(leaderEpochs);
         for (Integer epochWithNoMessage : epochsWithNoMessages) {
             filteredLeaderEpochs.remove(epochWithNoMessage);

--- a/core/src/main/java/kafka/log/remote/RemoteLogManager.java
+++ b/core/src/main/java/kafka/log/remote/RemoteLogManager.java
@@ -1238,7 +1238,7 @@ public class RemoteLogManager implements Closeable {
         // When the segment1 gets deleted, then the log-start-offset = 51 and leader-epoch-file-cache gets updated to: {(7, 51), (9, 100)}.
         // While validating the segment2, we should ensure the overlapping remote log segments case.
         Integer segmentFirstEpoch = segmentLeaderEpochs.ceilingKey(leaderEpochs.firstKey());
-        if (segmentFirstEpoch == null || !leaderEpochs.containsKey(segmentFirstEpoch)) {
+        if (segmentFirstEpoch == null) {
             LOGGER.debug("Segment {} is not within the partition leader epoch lineage. " +
                             "Remote segment epochs: {} and partition leader epochs: {}",
                     segmentMetadata.remoteLogSegmentId(), segmentLeaderEpochs, leaderEpochs);

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -152,6 +152,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import static kafka.log.remote.RemoteLogManager.isRemoteSegmentWithinLeaderEpochs;
+
 public class RemoteLogManagerTest {
     private final Time time = new MockTime();
     private final int brokerId = 0;
@@ -1475,7 +1477,7 @@ public class RemoteLogManagerTest {
         segmentEpochs1.put(2, 20L);
         segmentEpochs1.put(3, 30L);
 
-        assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
+        assertTrue(isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 15,
                 35,
                 segmentEpochs1), logEndOffset, leaderEpochToStartOffset));
@@ -1483,7 +1485,7 @@ public class RemoteLogManagerTest {
         // Test whether a remote segment's epochs/offsets(single) are within the range of leader epochs
         TreeMap<Integer, Long> segmentEpochs2 = new TreeMap<>();
         segmentEpochs2.put(1, 15L);
-        assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
+        assertTrue(isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 15,
                 19,
                 segmentEpochs2), logEndOffset, leaderEpochToStartOffset));
@@ -1491,7 +1493,7 @@ public class RemoteLogManagerTest {
         // Test whether a remote segment's start offset is same as the offset of the respective leader epoch entry.
         TreeMap<Integer, Long> segmentEpochs3 = new TreeMap<>();
         segmentEpochs3.put(0, 0L); // same as leader epoch's start offset
-        assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
+        assertTrue(isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 0,
                 5,
                 segmentEpochs3), logEndOffset, leaderEpochToStartOffset));
@@ -1499,7 +1501,7 @@ public class RemoteLogManagerTest {
         // Test whether a remote segment's start offset is same as the offset of the respective leader epoch entry.
         TreeMap<Integer, Long> segmentEpochs4 = new TreeMap<>();
         segmentEpochs4.put(7, 70L); // same as leader epoch's start offset
-        assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
+        assertTrue(isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 70,
                 75,
                 segmentEpochs4), logEndOffset, leaderEpochToStartOffset));
@@ -1510,7 +1512,7 @@ public class RemoteLogManagerTest {
         segmentEpochs5.put(1, 15L);
         segmentEpochs5.put(2, 20L);
 
-        assertTrue(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
+        assertTrue(isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 15,
                 29, // same as end offset for epoch 2 in leaderEpochToStartOffset
                 segmentEpochs5), logEndOffset, leaderEpochToStartOffset));
@@ -1521,7 +1523,7 @@ public class RemoteLogManagerTest {
         segmentEpochs6.put(6, 60L); // epoch 6 exists here but it is missing in leaderEpochToStartOffset
         segmentEpochs6.put(7, 70L);
 
-        assertFalse(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
+        assertFalse(isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 55,
                 85,
                 segmentEpochs6), logEndOffset, leaderEpochToStartOffset));
@@ -1532,18 +1534,18 @@ public class RemoteLogManagerTest {
         segmentEpochs7.put(2, 20L); // epoch 3 is missing here which exists in leaderEpochToStartOffset
         segmentEpochs7.put(4, 40L);
 
-        assertFalse(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
+        assertFalse(isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 15,
                 45,
                 segmentEpochs7), logEndOffset, leaderEpochToStartOffset));
 
         // Test a remote segment having larger end offset than the log end offset
-        assertFalse(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
+        assertFalse(isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 15,
                 95, // larger than log end offset
                 leaderEpochToStartOffset), logEndOffset, leaderEpochToStartOffset));
 
-        assertFalse(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
+        assertFalse(isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 15,
                 90, // equal to the log end offset
                 leaderEpochToStartOffset), logEndOffset, leaderEpochToStartOffset));
@@ -1553,7 +1555,7 @@ public class RemoteLogManagerTest {
         segmentEpochs9.put(1, 5L);
         segmentEpochs9.put(2, 20L);
 
-        assertFalse(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
+        assertFalse(isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 5, // earlier to epoch 1's start offset
                 25,
                 segmentEpochs9), logEndOffset, leaderEpochToStartOffset));
@@ -1562,10 +1564,39 @@ public class RemoteLogManagerTest {
         TreeMap<Integer, Long> segmentEpochs10 = new TreeMap<>();
         segmentEpochs10.put(1, 15L);
         segmentEpochs10.put(2, 20L);
-        assertFalse(RemoteLogManager.isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
+        assertFalse(isRemoteSegmentWithinLeaderEpochs(createRemoteLogSegmentMetadata(
                 15,
                 35, // more than epoch 2's end offset
                 segmentEpochs10), logEndOffset, leaderEpochToStartOffset));
+    }
+
+    @Test
+    public void testRemoteSegmentWithinLeaderEpochsForOverlappingSegments() {
+        NavigableMap<Integer, Long> leaderEpochCache = new TreeMap<>();
+        leaderEpochCache.put(7, 51L);
+        leaderEpochCache.put(8, 100L);
+
+        TreeMap<Integer, Long> segment1Epochs = new TreeMap<>();
+        segment1Epochs.put(5, 14L);
+        segment1Epochs.put(7, 15L);
+        segment1Epochs.put(8, 100L);
+        RemoteLogSegmentMetadata segment1 = createRemoteLogSegmentMetadata(14, 150, segment1Epochs);
+        assertTrue(isRemoteSegmentWithinLeaderEpochs(segment1, 210, leaderEpochCache));
+
+        // segment2Epochs are not within the leaderEpochCache
+        TreeMap<Integer, Long> segment2Epochs = new TreeMap<>();
+        segment2Epochs.put(2, 5L);
+        segment2Epochs.put(3, 6L);
+        RemoteLogSegmentMetadata segment2 = createRemoteLogSegmentMetadata(2, 7, segment2Epochs);
+        assertFalse(isRemoteSegmentWithinLeaderEpochs(segment2, 210, leaderEpochCache));
+
+        // segment3Epochs are not within the leaderEpochCache
+        TreeMap<Integer, Long> segment3Epochs = new TreeMap<>();
+        segment3Epochs.put(7, 15L);
+        segment3Epochs.put(8, 100L);
+        segment3Epochs.put(9, 200L);
+        RemoteLogSegmentMetadata segment3 = createRemoteLogSegmentMetadata(15, 250, segment3Epochs);
+        assertFalse(isRemoteSegmentWithinLeaderEpochs(segment3, 210, leaderEpochCache));
     }
 
     @Test

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -1574,12 +1574,12 @@ public class RemoteLogManagerTest {
     public void testRemoteSegmentWithinLeaderEpochsForOverlappingSegments() {
         NavigableMap<Integer, Long> leaderEpochCache = new TreeMap<>();
         leaderEpochCache.put(7, 51L);
-        leaderEpochCache.put(8, 100L);
+        leaderEpochCache.put(9, 100L);
 
         TreeMap<Integer, Long> segment1Epochs = new TreeMap<>();
         segment1Epochs.put(5, 14L);
         segment1Epochs.put(7, 15L);
-        segment1Epochs.put(8, 100L);
+        segment1Epochs.put(9, 100L);
         RemoteLogSegmentMetadata segment1 = createRemoteLogSegmentMetadata(14, 150, segment1Epochs);
         assertTrue(isRemoteSegmentWithinLeaderEpochs(segment1, 210, leaderEpochCache));
 
@@ -1593,10 +1593,16 @@ public class RemoteLogManagerTest {
         // segment3Epochs are not within the leaderEpochCache
         TreeMap<Integer, Long> segment3Epochs = new TreeMap<>();
         segment3Epochs.put(7, 15L);
-        segment3Epochs.put(8, 100L);
-        segment3Epochs.put(9, 200L);
+        segment3Epochs.put(9, 100L);
+        segment3Epochs.put(10, 200L);
         RemoteLogSegmentMetadata segment3 = createRemoteLogSegmentMetadata(15, 250, segment3Epochs);
         assertFalse(isRemoteSegmentWithinLeaderEpochs(segment3, 210, leaderEpochCache));
+
+        // segment4Epochs are not within the leaderEpochCache
+        TreeMap<Integer, Long> segment4Epochs = new TreeMap<>();
+        segment4Epochs.put(8, 75L);
+        RemoteLogSegmentMetadata segment4 = createRemoteLogSegmentMetadata(75, 100, segment4Epochs);
+        assertFalse(isRemoteSegmentWithinLeaderEpochs(segment4, 210, leaderEpochCache));
     }
 
     @Test

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -1609,6 +1609,12 @@ public class RemoteLogManagerTest {
         segment5Epochs.put(9, 101L);
         RemoteLogSegmentMetadata segment5 = createRemoteLogSegmentMetadata(15, 150, segment5Epochs);
         assertFalse(isRemoteSegmentWithinLeaderEpochs(segment5, 210, leaderEpochCache));
+
+        // segment6Epochs does not match with the leaderEpochCache
+        TreeMap<Integer, Long> segment6Epochs = new TreeMap<>();
+        segment6Epochs.put(9, 99L);
+        RemoteLogSegmentMetadata segment6 = createRemoteLogSegmentMetadata(99, 150, segment6Epochs);
+        assertFalse(isRemoteSegmentWithinLeaderEpochs(segment6, 210, leaderEpochCache));
     }
 
     @Test

--- a/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
+++ b/core/src/test/java/kafka/log/remote/RemoteLogManagerTest.java
@@ -1506,7 +1506,6 @@ public class RemoteLogManagerTest {
                 75,
                 segmentEpochs4), logEndOffset, leaderEpochToStartOffset));
 
-
         // Test whether a remote segment's end offset is same as the end offset of the respective leader epoch entry.
         TreeMap<Integer, Long> segmentEpochs5 = new TreeMap<>();
         segmentEpochs5.put(1, 15L);
@@ -1603,6 +1602,13 @@ public class RemoteLogManagerTest {
         segment4Epochs.put(8, 75L);
         RemoteLogSegmentMetadata segment4 = createRemoteLogSegmentMetadata(75, 100, segment4Epochs);
         assertFalse(isRemoteSegmentWithinLeaderEpochs(segment4, 210, leaderEpochCache));
+
+        // segment5Epochs does not match with the leaderEpochCache
+        TreeMap<Integer, Long> segment5Epochs = new TreeMap<>();
+        segment5Epochs.put(7, 15L);
+        segment5Epochs.put(9, 101L);
+        RemoteLogSegmentMetadata segment5 = createRemoteLogSegmentMetadata(15, 150, segment5Epochs);
+        assertFalse(isRemoteSegmentWithinLeaderEpochs(segment5, 210, leaderEpochCache));
     }
 
     @Test


### PR DESCRIPTION
When there are overlapping segments in the remote storage, then the deletion may fail to remove the segments due to `isRemoteSegmentWithinLeaderEpochs` check. Once the deletion starts to fail for a partition, then segments won't be eligible for cleanup. The one workaround that we have is to move the log-start-offset using the kafka-delete-records script.



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
