### PR TITLE
MINOR: Add replayRecords to CoordinatorResult

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2301,7 +2301,7 @@ public class GroupMetadataManager {
                     RecordHelpers.newEmptyGroupMetadataRecord(group, metadataImage.features().metadataVersion())
                 );
 
-                return new CoordinatorResult<>(records, appendFuture, appendFuture == null);
+                return new CoordinatorResult<>(records, appendFuture, false);
             }
         }
         return result;
@@ -2719,7 +2719,7 @@ public class GroupMetadataManager {
                 List<Record> records = Collections.singletonList(RecordHelpers.newGroupMetadataRecord(
                     group, Collections.emptyMap(), metadataImage.features().metadataVersion()));
 
-                return new CoordinatorResult<>(records, appendFuture, appendFuture == null);
+                return new CoordinatorResult<>(records, appendFuture, false);
 
             } else {
                 log.info("Stabilized group {} generation {} with {} members.",
@@ -3382,7 +3382,7 @@ public class GroupMetadataManager {
                     RecordHelpers.newGroupMetadataRecord(group, groupAssignment, metadataImage.features().metadataVersion())
                 );
 
-                return new CoordinatorResult<>(records, appendFuture, appendFuture == null);
+                return new CoordinatorResult<>(records, appendFuture, false);
             } else {
                 return maybePrepareRebalanceOrCompleteJoin(
                     group,
@@ -3498,7 +3498,7 @@ public class GroupMetadataManager {
                 List<Record> records = Collections.singletonList(
                     RecordHelpers.newGroupMetadataRecord(group, assignment, metadataImage.features().metadataVersion())
                 );
-                return new CoordinatorResult<>(records, appendFuture, appendFuture == null);
+                return new CoordinatorResult<>(records, appendFuture, false);
             }
         } else if (group.isInState(STABLE)) {
             removePendingSyncMember(group, memberId);
@@ -3774,7 +3774,7 @@ public class GroupMetadataManager {
             new LeaveGroupResponseData()
                 .setMembers(memberResponses),
             coordinatorResult.appendFuture(),
-            coordinatorResult.appendFuture() == null
+            coordinatorResult.replayRecords()
         );
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -810,6 +810,7 @@ public class GroupMetadataManager {
      *
      * @param consumerGroup     The converted ConsumerGroup.
      * @param leavingMemberId   The leaving member that triggers the downgrade validation.
+     * @param response          The response of the returned CoordinatorResult.
      * @return A CoordinatorResult.
      */
     private <T> CoordinatorResult<T, Record> convertToClassicGroup(
@@ -1533,8 +1534,8 @@ public class GroupMetadataManager {
      * instance id decided to leave the group and would be back within session
      * timeout.
      *
-     * @param group         The group.
-     * @param member        The static member in the group for the instance id.
+     * @param group     The group.
+     * @param member    The static member in the group for the instance id.
      *
      * @return A CoordinatorResult with a single record signifying that the static member is leaving.
      */
@@ -1562,6 +1563,7 @@ public class GroupMetadataManager {
      * @param group     The group.
      * @param member    The member.
      * @param response  The response of the CoordinatorResult.
+     *
      * @return The CoordinatorResult to be applied.
      */
     private <T> CoordinatorResult<T, Record> consumerGroupFenceMember(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -367,7 +367,7 @@ public class GroupMetadataManager {
      * Package private for testing.
      */
     static final CoordinatorResult<Void, Record> EMPTY_RESULT =
-        new CoordinatorResult<>(Collections.emptyList(), CompletableFuture.completedFuture(null));
+        new CoordinatorResult<>(Collections.emptyList(), CompletableFuture.completedFuture(null), false);
 
     /**
      * The maximum number of members allowed in a single classic group.
@@ -1524,7 +1524,8 @@ public class GroupMetadataManager {
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId)
                 .setMemberEpoch(memberEpoch),
-            appendFuture
+            appendFuture,
+            appendFuture == null
         );
     }
 
@@ -1638,7 +1639,7 @@ public class GroupMetadataManager {
 
                 List<Record> records = new ArrayList<>();
                 CompletableFuture<Void> appendFuture = consumerGroupFenceMember(group, member, records);
-                return new CoordinatorResult<>(records, appendFuture);
+                return new CoordinatorResult<>(records, appendFuture, appendFuture == null);
             } catch (GroupIdNotFoundException ex) {
                 log.debug("[GroupId {}] Could not fence {} because the group does not exist.",
                     groupId, memberId);
@@ -1691,7 +1692,7 @@ public class GroupMetadataManager {
 
                     List<Record> records = new ArrayList<>();
                     CompletableFuture<Void> appendFuture = consumerGroupFenceMember(group, member, records);
-                    return new CoordinatorResult<>(records, appendFuture);
+                    return new CoordinatorResult<>(records, appendFuture, appendFuture == null);
                 } else {
                     log.debug("[GroupId {}] Ignoring rebalance timeout for {} because the member " +
                         "left the epoch {}.", groupId, memberId, memberEpoch);
@@ -2300,7 +2301,7 @@ public class GroupMetadataManager {
                     RecordHelpers.newEmptyGroupMetadataRecord(group, metadataImage.features().metadataVersion())
                 );
 
-                return new CoordinatorResult<>(records, appendFuture);
+                return new CoordinatorResult<>(records, appendFuture, appendFuture == null);
             }
         }
         return result;
@@ -2718,7 +2719,7 @@ public class GroupMetadataManager {
                 List<Record> records = Collections.singletonList(RecordHelpers.newGroupMetadataRecord(
                     group, Collections.emptyMap(), metadataImage.features().metadataVersion()));
 
-                return new CoordinatorResult<>(records, appendFuture);
+                return new CoordinatorResult<>(records, appendFuture, appendFuture == null);
 
             } else {
                 log.info("Stabilized group {} generation {} with {} members.",
@@ -3381,7 +3382,7 @@ public class GroupMetadataManager {
                     RecordHelpers.newGroupMetadataRecord(group, groupAssignment, metadataImage.features().metadataVersion())
                 );
 
-                return new CoordinatorResult<>(records, appendFuture);
+                return new CoordinatorResult<>(records, appendFuture, appendFuture == null);
             } else {
                 return maybePrepareRebalanceOrCompleteJoin(
                     group,
@@ -3497,7 +3498,7 @@ public class GroupMetadataManager {
                 List<Record> records = Collections.singletonList(
                     RecordHelpers.newGroupMetadataRecord(group, assignment, metadataImage.features().metadataVersion())
                 );
-                return new CoordinatorResult<>(records, appendFuture);
+                return new CoordinatorResult<>(records, appendFuture, appendFuture == null);
             }
         } else if (group.isInState(STABLE)) {
             removePendingSyncMember(group, memberId);
@@ -3772,7 +3773,8 @@ public class GroupMetadataManager {
             coordinatorResult.records(),
             new LeaveGroupResponseData()
                 .setMembers(memberResponses),
-            coordinatorResult.appendFuture()
+            coordinatorResult.appendFuture(),
+            coordinatorResult.appendFuture() == null
         );
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1511,7 +1511,7 @@ public class GroupMetadataManager {
             if (memberEpoch == LEAVE_GROUP_STATIC_MEMBER_EPOCH) {
                 log.info("[GroupId {}] Static Member {} with instance id {} temporarily left the consumer group.",
                     group.groupId(), memberId, instanceId);
-                records = consumerGroupStaticMemberGroupLeave(group, member);
+                return consumerGroupStaticMemberGroupLeave(group, member);
             } else {
                 log.info("[GroupId {}] Static Member {} with instance id {} left the consumer group.",
                     group.groupId(), memberId, instanceId);
@@ -1536,12 +1536,12 @@ public class GroupMetadataManager {
      * instance id decided to leave the group and would be back within session
      * timeout.
      *
-     * @param group      The group.
-     * @param member     The static member in the group for the instance id.
+     * @param group         The group.
+     * @param member        The static member in the group for the instance id.
      *
-     * @return A list with a single record signifying that the static member is leaving.
+     * @return A CoordinatorResult with a single record signifying that the static member is leaving.
      */
-    private List<Record> consumerGroupStaticMemberGroupLeave(
+    private CoordinatorResult<ConsumerGroupHeartbeatResponseData, Record> consumerGroupStaticMemberGroupLeave(
         ConsumerGroup group,
         ConsumerGroupMember member
     ) {
@@ -1550,7 +1550,13 @@ public class GroupMetadataManager {
             .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH)
             .setPartitionsPendingRevocation(Collections.emptyMap())
             .build();
-        return Collections.singletonList(newCurrentAssignmentRecord(group.groupId(), leavingStaticMember));
+
+        return new CoordinatorResult<>(
+            Collections.singletonList(newCurrentAssignmentRecord(group.groupId(), leavingStaticMember)),
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(member.memberId())
+                .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH)
+        );
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorResult.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorResult.java
@@ -44,6 +44,12 @@ public class CoordinatorResult<T, U> {
     private final CompletableFuture<Void> appendFuture;
 
     /**
+     * The boolean indicating whether to replay the records. Without specifying.
+     * The default value is {@code appendFuture == null}.
+     */
+    private final Boolean replayRecords;
+
+    /**
      * Constructs a Result with records and a response.
      *
      * @param records   A non-null list of records.
@@ -53,7 +59,7 @@ public class CoordinatorResult<T, U> {
         List<U> records,
         T response
     ) {
-        this(records, response, null);
+        this(records, response, null, true);
     }
 
     /**
@@ -66,7 +72,7 @@ public class CoordinatorResult<T, U> {
         List<U> records,
         CompletableFuture<Void> appendFuture
     ) {
-        this(records, null, appendFuture);
+        this(records, null, appendFuture, appendFuture == null);
     }
 
     /**
@@ -81,9 +87,27 @@ public class CoordinatorResult<T, U> {
         T response,
         CompletableFuture<Void> appendFuture
     ) {
+        this(records, response, appendFuture, appendFuture == null);
+    }
+
+    /**
+     * Constructs a Result with records, a response, an append-future, and replayRecords.
+     *
+     * @param records
+     * @param response
+     * @param appendFuture
+     * @param replayRecords
+     */
+    public CoordinatorResult(
+        List<U> records,
+        T response,
+        CompletableFuture<Void> appendFuture,
+        boolean replayRecords
+    ) {
         this.records = Objects.requireNonNull(records);
         this.response = response;
         this.appendFuture = appendFuture;
+        this.replayRecords = Objects.requireNonNull(replayRecords);
     }
 
     /**
@@ -94,7 +118,7 @@ public class CoordinatorResult<T, U> {
     public CoordinatorResult(
         List<U> records
     ) {
-        this(records, null, null);
+        this(records, null, null, true);
     }
 
     /**
@@ -119,13 +143,10 @@ public class CoordinatorResult<T, U> {
     }
 
     /**
-     * If the append-future exists, this means
-     * that the in-memory state was already updated.
-     *
      * @return Whether to replay the records.
      */
     public boolean replayRecords() {
-        return appendFuture == null;
+        return replayRecords;
     }
 
     @Override
@@ -137,6 +158,7 @@ public class CoordinatorResult<T, U> {
 
         if (!Objects.equals(records, that.records)) return false;
         if (!Objects.equals(response, that.response)) return false;
+        if (!Objects.equals(replayRecords, that.replayRecords)) return false;
         return Objects.equals(appendFuture, that.appendFuture);
     }
 
@@ -145,6 +167,7 @@ public class CoordinatorResult<T, U> {
         int result = records != null ? records.hashCode() : 0;
         result = 31 * result + (response != null ? response.hashCode() : 0);
         result = 31 * result + (appendFuture != null ? appendFuture.hashCode() : 0);
+        result = 31 * result + replayRecords.hashCode();
         return result;
     }
     @Override
@@ -152,6 +175,7 @@ public class CoordinatorResult<T, U> {
         return "CoordinatorResult(records=" + records +
             ", response=" + response +
             ", appendFuture=" + appendFuture +
+            ", replayRecords=" + replayRecords +
             ")";
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorResult.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorResult.java
@@ -47,7 +47,7 @@ public class CoordinatorResult<T, U> {
      * The boolean indicating whether to replay the records.
      * The default value is {@code true} unless specified otherwise.
      */
-    private final Boolean replayRecords;
+    private final boolean replayRecords;
 
     /**
      * Constructs a Result with records and a response.
@@ -154,7 +154,7 @@ public class CoordinatorResult<T, U> {
         int result = records != null ? records.hashCode() : 0;
         result = 31 * result + (response != null ? response.hashCode() : 0);
         result = 31 * result + (appendFuture != null ? appendFuture.hashCode() : 0);
-        result = 31 * result + replayRecords.hashCode();
+        result = 31 * result + (replayRecords ? 1 : 0);
         return result;
     }
     @Override

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorResult.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/runtime/CoordinatorResult.java
@@ -44,8 +44,8 @@ public class CoordinatorResult<T, U> {
     private final CompletableFuture<Void> appendFuture;
 
     /**
-     * The boolean indicating whether to replay the records. Without specifying.
-     * The default value is {@code appendFuture == null}.
+     * The boolean indicating whether to replay the records.
+     * The default value is {@code true} unless specified otherwise.
      */
     private final Boolean replayRecords;
 
@@ -67,36 +67,23 @@ public class CoordinatorResult<T, U> {
      *
      * @param records       A non-null list of records.
      * @param appendFuture  The future to complete once the records are committed.
+     * @param replayRecords The replayRecords.
      */
     public CoordinatorResult(
         List<U> records,
-        CompletableFuture<Void> appendFuture
+        CompletableFuture<Void> appendFuture,
+        boolean replayRecords
     ) {
-        this(records, null, appendFuture, appendFuture == null);
-    }
-
-    /**
-     * Constructs a Result with records, a response, and an append-future.
-     *
-     * @param records       A non-null list of records.
-     * @param response      A response.
-     * @param appendFuture  The future to complete once the records are committed.
-     */
-    public CoordinatorResult(
-        List<U> records,
-        T response,
-        CompletableFuture<Void> appendFuture
-    ) {
-        this(records, response, appendFuture, appendFuture == null);
+        this(records, null, appendFuture, replayRecords);
     }
 
     /**
      * Constructs a Result with records, a response, an append-future, and replayRecords.
      *
-     * @param records
-     * @param response
-     * @param appendFuture
-     * @param replayRecords
+     * @param records       A non-null list of records.
+     * @param response      A response.
+     * @param appendFuture  The future to complete once the records are committed.
+     * @param replayRecords The replayRecords.
      */
     public CoordinatorResult(
         List<U> records,
@@ -107,7 +94,7 @@ public class CoordinatorResult<T, U> {
         this.records = Objects.requireNonNull(records);
         this.response = response;
         this.appendFuture = appendFuture;
-        this.replayRecords = Objects.requireNonNull(replayRecords);
+        this.replayRecords = replayRecords;
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -528,7 +528,7 @@ public class GroupMetadataManagerTestContext {
             request
         );
 
-        if (result.appendFuture() == null) {
+        if (result.replayRecords()) {
             result.records().forEach(this::replay);
         }
         return result;


### PR DESCRIPTION
The patch adds a boolean attribute `replayRecords` that specifies whether the records should be replayed. The default value is `appendFuture == null` so no change is needed for the existing code.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
