### PR TITLE
KAFKA-16452: Don't throw OOORE when converting the offset to metadata

### DIFF
--- a/core/src/main/scala/kafka/log/LocalLog.scala
+++ b/core/src/main/scala/kafka/log/LocalLog.scala
@@ -374,12 +374,12 @@ class LocalLog(@volatile private var _dir: File,
         emptyFetchDataInfo(maxOffsetMetadata, includeAbortedTxns)
       } else if (startOffset > maxOffsetMetadata.messageOffset ||
         maxOffsetMetadata.messageOffsetOnly() ||
-        maxOffsetMetadata.segmentBaseOffset < segmentOpt.get().baseOffset()) {
+        maxOffsetMetadata.segmentBaseOffset < segmentOpt.get.baseOffset) {
         // We need to be careful before reading the segment as `maxOffsetMetadata` may not be a complete metadata:
         // 1. If maxOffsetMetadata is message-offset-only, then return empty fetchDataInfo since
         // maxOffsetMetadata.offset is not on local log segments.
         // 2. If maxOffsetMetadata.segmentBaseOffset is smaller than segment.baseOffset, then return empty fetchDataInfo.
-        emptyFetchDataInfo(new LogOffsetMetadata(startOffset), includeAbortedTxns)
+        emptyFetchDataInfo(convertToOffsetMetadataOrThrow(startOffset), includeAbortedTxns)
       } else {
         // Do the read on the segment with a base offset less than the target offset
         // but if that segment doesn't contain any messages with an offset greater than that

--- a/core/src/main/scala/kafka/log/LocalLog.scala
+++ b/core/src/main/scala/kafka/log/LocalLog.scala
@@ -370,11 +370,11 @@ class LocalLog(@volatile private var _dir: File,
         throw new OffsetOutOfRangeException(s"Received request for offset $startOffset for partition $topicPartition, " +
           s"but we only have log segments upto $endOffset.")
 
-      if (startOffset == maxOffsetMetadata.messageOffset) {
+      if (startOffset == maxOffsetMetadata.messageOffset)
         emptyFetchDataInfo(maxOffsetMetadata, includeAbortedTxns)
-      } else if (startOffset > maxOffsetMetadata.messageOffset) {
+      else if (startOffset > maxOffsetMetadata.messageOffset)
         emptyFetchDataInfo(convertToOffsetMetadataOrThrow(startOffset), includeAbortedTxns)
-      } else {
+      else {
         // Do the read on the segment with a base offset less than the target offset
         // but if that segment doesn't contain any messages with an offset greater than that
         // continue to read from successive segments until we get some messages or we reach the end of the log

--- a/core/src/main/scala/kafka/log/LocalLog.scala
+++ b/core/src/main/scala/kafka/log/LocalLog.scala
@@ -370,11 +370,12 @@ class LocalLog(@volatile private var _dir: File,
         throw new OffsetOutOfRangeException(s"Received request for offset $startOffset for partition $topicPartition, " +
           s"but we only have log segments upto $endOffset.")
 
-      if (startOffset == maxOffsetMetadata.messageOffset)
+      if (startOffset == maxOffsetMetadata.messageOffset) {
         emptyFetchDataInfo(maxOffsetMetadata, includeAbortedTxns)
-      else if (startOffset > maxOffsetMetadata.messageOffset)
-        emptyFetchDataInfo(convertToOffsetMetadataOrThrow(startOffset), includeAbortedTxns)
-      else {
+      } else if (startOffset > maxOffsetMetadata.messageOffset) {
+        // Instead of converting the `startOffset` to metadata, returning message-only metadata to avoid potential loop
+        emptyFetchDataInfo(new LogOffsetMetadata(startOffset), includeAbortedTxns)
+      } else {
         // Do the read on the segment with a base offset less than the target offset
         // but if that segment doesn't contain any messages with an offset greater than that
         // continue to read from successive segments until we get some messages or we reach the end of the log

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1429,7 +1429,11 @@ class UnifiedLog(@volatile var logStartOffset: Long,
     */
   private def convertToOffsetMetadataOrThrow(offset: Long): LogOffsetMetadata = {
     checkLogStartOffset(offset)
-    localLog.convertToOffsetMetadataOrThrow(offset)
+    if (remoteLogEnabled() && offset < localLogStartOffset()) {
+      new LogOffsetMetadata(offset, LogOffsetMetadata.REMOTE_LOG_UNKNOWN_OFFSET)
+    } else {
+      localLog.convertToOffsetMetadataOrThrow(offset)
+    }
   }
 
   /**

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -361,7 +361,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
     val offsetMetadata = highWatermarkMetadata
     if (offsetMetadata.messageOffsetOnly) {
       lock.synchronized {
-        val fullOffset = convertToOffsetMetadataOrThrow(highWatermark)
+        val fullOffset = convertToOffsetMetadata(highWatermark)
         updateHighWatermarkMetadata(fullOffset)
         fullOffset
       }
@@ -405,7 +405,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
       case Some(offsetMetadata) if offsetMetadata.messageOffset < highWatermarkMetadata.messageOffset =>
         if (offsetMetadata.messageOffsetOnly) {
           lock synchronized {
-            val fullOffset = convertToOffsetMetadataOrThrow(offsetMetadata.messageOffset)
+            val fullOffset = convertToOffsetMetadata(offsetMetadata.messageOffset)
             if (firstUnstableOffsetMetadata.contains(offsetMetadata))
               firstUnstableOffsetMetadata = Some(fullOffset)
             fullOffset
@@ -964,7 +964,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
     val updatedFirstUnstableOffset = producerStateManager.firstUnstableOffset.asScala match {
       case Some(logOffsetMetadata) if logOffsetMetadata.messageOffsetOnly || logOffsetMetadata.messageOffset < logStartOffset =>
         val offset = math.max(logOffsetMetadata.messageOffset, logStartOffset)
-        Some(convertToOffsetMetadataOrThrow(offset))
+        Some(convertToOffsetMetadata(offset))
       case other => other
     }
 
@@ -1425,12 +1425,12 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 
   /**
     * Given a message offset, find its corresponding offset metadata in the log.
-    * 1. If the message offset is lesser than the log-start-offset, then throw an OffsetOutOfRangeException
-    * 2. If the message offset is lesser than the local-log-start-offset, then it returns the message-only metadata
-    * 3. If the message offset is greater than the log-end-offset, then it returns the message-only metadata
+    * 1. If the message offset is less than the log-start-offset (or) local-log-start-offset, then it returns the
+   *     message-only metadata.
+    * 2. If the message offset is beyond the log-end-offset, then it returns the message-only metadata.
+    * 3. For all other cases, it returns the offset metadata from the log.
     */
-  private[log] def convertToOffsetMetadataOrThrow(offset: Long): LogOffsetMetadata = {
-    checkLogStartOffset(offset)
+  private[log] def convertToOffsetMetadata(offset: Long): LogOffsetMetadata = {
     try {
       localLog.convertToOffsetMetadataOrThrow(offset)
     } catch {

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -223,7 +223,7 @@ final class KafkaMetadataLog private (
 
   override def highWatermark: LogOffsetMetadata = {
     val hwm = log.fetchOffsetSnapshot.highWatermark
-    val segmentPosition: Optional[OffsetMetadata] = if (hwm.messageOffsetOnly) {
+    val segmentPosition: Optional[OffsetMetadata] = if (!hwm.messageOffsetOnly) {
       Optional.of(SegmentPosition(hwm.segmentBaseOffset, hwm.relativePositionInSegment))
     } else {
       Optional.empty()

--- a/core/src/main/scala/kafka/server/DelayedFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedFetch.scala
@@ -96,11 +96,10 @@ class DelayedFetch(
               debug(s"Satisfying fetch $this since it is fetching later segments of partition $topicIdPartition.")
               return forceComplete()
             } else if (fetchOffset.messageOffset < endOffset.messageOffset) {
-              if (endOffset.messageOffsetOnly() || fetchOffset.messageOffsetOnly()) {
-                // If we don't know the position of the offset on log segments, just pessimistically assume that we
-                // only gained 1 byte when fetchOffset < endOffset, otherwise do nothing. This can happen when the
+              if (fetchOffset.messageOffsetOnly() || endOffset.messageOffsetOnly()) {
+                // If fetchOffset or endOffset is message only, we return empty records when reading from the log.
+                // So, to be consistent, we want to avoid accumulating new bytes in this case. This can happen when the
                 // high-watermark is stale, but should be rare.
-                accumulatedSize += 1
               } else if (fetchOffset.onOlderSegment(endOffset)) {
                 // Case F, this can happen when the fetch operation is falling behind the current segment
                 // or the partition has just rolled a new segment

--- a/core/src/main/scala/kafka/server/DelayedFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedFetch.scala
@@ -100,6 +100,8 @@ class DelayedFetch(
                 // If fetchOffset or endOffset is message only, we return empty records when reading from the log.
                 // So, to be consistent, we want to avoid accumulating new bytes in this case. This can happen when the
                 // high-watermark is stale, but should be rare.
+                debug(s"Not satisfying fetch $this since the fetchOffset (or) endOffset is message-offset only " +
+                  s"for partition $topicIdPartition.")
               } else if (fetchOffset.onOlderSegment(endOffset)) {
                 // Case F, this can happen when the fetch operation is falling behind the current segment
                 // or the partition has just rolled a new segment

--- a/core/src/main/scala/kafka/server/DelayedFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedFetch.scala
@@ -92,7 +92,10 @@ class DelayedFetch(
             // has just rolled, then the high watermark offset will remain the same but be on the old segment,
             // which would incorrectly be seen as an instance of Case F.
             if (endOffset.messageOffset != fetchOffset.messageOffset) {
-              if (endOffset.onOlderSegment(fetchOffset)) {
+              if (endOffset.messageOffsetOnly() || fetchOffset.messageOffsetOnly()) {
+                // This case is to handle the stale high-watermark on the leader until it gets updated with the correct value
+                accumulatedSize += 1
+              } else if (endOffset.onOlderSegment(fetchOffset)) {
                 // Case F, this can happen when the new fetch operation is on a truncated leader
                 debug(s"Satisfying fetch $this since it is fetching later segments of partition $topicIdPartition.")
                 return forceComplete()

--- a/core/src/main/scala/kafka/server/DelayedFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedFetch.scala
@@ -94,8 +94,11 @@ class DelayedFetch(
             if (endOffset.messageOffset != fetchOffset.messageOffset) {
               if (endOffset.messageOffsetOnly() || fetchOffset.messageOffsetOnly()) {
                 // If we don't know the position of the offset on log segments, just pessimistically assume that we
-                // only gained 1 byte. This can happen when the high watermark is stale, but should be rare.
-                accumulatedSize += 1
+                // only gained 1 byte when fetchOffset < endOffset, otherwise do nothing. This can happen when the
+                // high-watermark is stale, but should be rare.
+                if (fetchOffset.messageOffset < endOffset.messageOffset) {
+                  accumulatedSize += 1
+                }
               } else if (endOffset.onOlderSegment(fetchOffset)) {
                 // Case F, this can happen when the new fetch operation is on a truncated leader
                 debug(s"Satisfying fetch $this since it is fetching later segments of partition $topicIdPartition.")

--- a/core/src/main/scala/kafka/server/DelayedFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedFetch.scala
@@ -93,7 +93,8 @@ class DelayedFetch(
             // which would incorrectly be seen as an instance of Case F.
             if (endOffset.messageOffset != fetchOffset.messageOffset) {
               if (endOffset.messageOffsetOnly() || fetchOffset.messageOffsetOnly()) {
-                // This case is to handle the stale high-watermark on the leader until it gets updated with the correct value
+                // If we don't know the position of the offset on log segments, just pessimistically assume that we
+                // only gained 1 byte. This can happen when the high watermark is stale, but should be rare.
                 accumulatedSize += 1
               } else if (endOffset.onOlderSegment(fetchOffset)) {
                 // Case F, this can happen when the new fetch operation is on a truncated leader

--- a/core/src/main/scala/kafka/server/DelayedFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedFetch.scala
@@ -91,19 +91,19 @@ class DelayedFetch(
             // Go directly to the check for Case G if the message offsets are the same. If the log segment
             // has just rolled, then the high watermark offset will remain the same but be on the old segment,
             // which would incorrectly be seen as an instance of Case F.
-            if (endOffset.messageOffset != fetchOffset.messageOffset) {
-              if (endOffset.onOlderSegment(fetchOffset)) {
-                // Case F, this can happen when the new fetch operation is on a truncated leader
-                debug(s"Satisfying fetch $this since it is fetching later segments of partition $topicIdPartition.")
-                return forceComplete()
-              } else if (fetchOffset.onOlderSegment(endOffset)) {
+            if (fetchOffset.messageOffset > endOffset.messageOffset) {
+              // Case F, this can happen when the new fetch operation is on a truncated leader
+              debug(s"Satisfying fetch $this since it is fetching later segments of partition $topicIdPartition.")
+              return forceComplete()
+            } else if (fetchOffset.messageOffset < endOffset.messageOffset) {
+              if (fetchOffset.onOlderSegment(endOffset)) {
                 // Case F, this can happen when the fetch operation is falling behind the current segment
                 // or the partition has just rolled a new segment
                 debug(s"Satisfying fetch $this immediately since it is fetching older segments.")
                 // We will not force complete the fetch request if a replica should be throttled.
                 if (!params.isFromFollower || !replicaManager.shouldLeaderThrottle(quota, partition, params.replicaId))
                   return forceComplete()
-              } else if (fetchOffset.onSameSegment(endOffset) && fetchOffset.messageOffset < endOffset.messageOffset) {
+              } else if (fetchOffset.onSameSegment(endOffset)) {
                 // we take the partition fetch size as upper bound when accumulating the bytes (skip if a throttled partition)
                 val bytesAvailable = math.min(endOffset.positionDiff(fetchOffset), fetchStatus.fetchInfo.maxBytes)
                 if (!params.isFromFollower || !replicaManager.shouldLeaderThrottle(quota, partition, params.replicaId))

--- a/core/src/test/scala/integration/kafka/server/DelayedFetchTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DelayedFetchTest.scala
@@ -203,7 +203,7 @@ class DelayedFetchTest {
 
     val partition: Partition = mock(classOf[Partition])
     when(replicaManager.getPartitionOrException(topicIdPartition.topicPartition)).thenReturn(partition)
-    // Note that the high-watermark does not contain the complete metadata
+    // Note that the high-watermark does not contain the complete metadata so the delayed-fetch won't be satisfied
     val endOffsetMetadata = new LogOffsetMetadata(endOffset, -1L, -1)
     when(partition.fetchOffsetSnapshot(
       currentLeaderEpoch,
@@ -212,15 +212,9 @@ class DelayedFetchTest {
     when(replicaManager.isAddingReplica(any(), anyInt())).thenReturn(false)
     expectReadFromReplica(fetchParams, topicIdPartition, fetchStatus.fetchInfo, Errors.NONE)
 
-    // 1. When `endOffset` is 0, it refers to the truncation case
-    // 2. When `endOffset` is 500, it refers to the normal case
-    val expected = endOffset == 0
-    assertEquals(expected, delayedFetch.tryComplete())
-    assertEquals(expected, delayedFetch.isCompleted)
-    assertEquals(expected, fetchResultOpt.isDefined)
-    if (fetchResultOpt.isDefined) {
-      assertEquals(Errors.NONE, fetchResultOpt.get.error)
-    }
+    assertFalse(delayedFetch.tryComplete())
+    assertFalse(delayedFetch.isCompleted)
+    assertFalse(fetchResultOpt.isDefined)
   }
 
   private def buildFollowerFetchParams(

--- a/core/src/test/scala/integration/kafka/server/DelayedFetchTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DelayedFetchTest.scala
@@ -212,10 +212,15 @@ class DelayedFetchTest {
     when(replicaManager.isAddingReplica(any(), anyInt())).thenReturn(false)
     expectReadFromReplica(fetchParams, topicIdPartition, fetchStatus.fetchInfo, Errors.NONE)
 
-    assertTrue(delayedFetch.tryComplete())
-    assertTrue(delayedFetch.isCompleted)
-    assertTrue(fetchResultOpt.isDefined)
-    assertEquals(Errors.NONE, fetchResultOpt.get.error)
+    // 1. When `endOffset` is 0, it refers to the truncation case
+    // 2. When `endOffset` is 500, it refers to the normal case
+    val expected = endOffset == 0
+    assertEquals(expected, delayedFetch.tryComplete())
+    assertEquals(expected, delayedFetch.isCompleted)
+    assertEquals(expected, fetchResultOpt.isDefined)
+    if (fetchResultOpt.isDefined) {
+      assertEquals(Errors.NONE, fetchResultOpt.get.error)
+    }
   }
 
   private def buildFollowerFetchParams(

--- a/core/src/test/scala/integration/kafka/server/DelayedFetchTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DelayedFetchTest.scala
@@ -174,9 +174,9 @@ class DelayedFetchTest {
     assertEquals(Errors.NONE, fetchResult.error)
   }
 
-  @ParameterizedTest(name = "testDelayedFetchWithInvalidHighWatermark endOffset={0}")
+  @ParameterizedTest(name = "testDelayedFetchWithMessageOnlyHighWatermark endOffset={0}")
   @ValueSource(longs = Array(0, 500))
-  def testDelayedFetchWithInvalidHighWatermark(endOffset: Long): Unit = {
+  def testDelayedFetchWithMessageOnlyHighWatermark(endOffset: Long): Unit = {
     val topicIdPartition = new TopicIdPartition(Uuid.randomUuid(), 0, "topic")
     val fetchOffset = 450L
     val logStartOffset = 5L
@@ -203,7 +203,7 @@ class DelayedFetchTest {
 
     val partition: Partition = mock(classOf[Partition])
     when(replicaManager.getPartitionOrException(topicIdPartition.topicPartition)).thenReturn(partition)
-    // Note that the high-watermark does not contains the complete metadata
+    // Note that the high-watermark does not contain the complete metadata
     val endOffsetMetadata = new LogOffsetMetadata(endOffset, -1L, -1)
     when(partition.fetchOffsetSnapshot(
       currentLeaderEpoch,
@@ -212,15 +212,10 @@ class DelayedFetchTest {
     when(replicaManager.isAddingReplica(any(), anyInt())).thenReturn(false)
     expectReadFromReplica(fetchParams, topicIdPartition, fetchStatus.fetchInfo, Errors.NONE)
 
-    val expected = endOffset == 500
-    assertEquals(expected, delayedFetch.tryComplete())
-    assertEquals(expected, delayedFetch.isCompleted)
-    assertEquals(expected, fetchResultOpt.isDefined)
-
-    if (fetchResultOpt.isDefined) {
-      val fetchResult = fetchResultOpt.get
-      assertEquals(Errors.NONE, fetchResult.error)
-    }
+    assertTrue(delayedFetch.tryComplete())
+    assertTrue(delayedFetch.isCompleted)
+    assertTrue(fetchResultOpt.isDefined)
+    assertEquals(Errors.NONE, fetchResultOpt.get.error)
   }
 
   private def buildFollowerFetchParams(

--- a/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
@@ -185,6 +185,24 @@ final class KafkaMetadataLogTest {
   }
 
   @Test
+  def testHighWatermarkOffsetMetadata(): Unit = {
+    val numberOfRecords = 10
+    val epoch = 1
+    val log = buildMetadataLog(tempDir, mockTime)
+
+    append(log, numberOfRecords, epoch)
+    log.updateHighWatermark(new LogOffsetMetadata(numberOfRecords))
+
+    val highWatermarkMetadata = log.highWatermark
+    assertEquals(numberOfRecords, highWatermarkMetadata.offset)
+    assertTrue(highWatermarkMetadata.metadata.isPresent)
+
+    val segmentPosition = highWatermarkMetadata.metadata.get().asInstanceOf[SegmentPosition]
+    assertEquals(0, segmentPosition.baseOffset)
+    assertTrue(segmentPosition.relativePosition > 0)
+  }
+
+  @Test
   def testCreateSnapshotBeforeLogStartOffset(): Unit = {
     val numberOfRecords = 10
     val epoch = 1

--- a/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
@@ -395,18 +395,18 @@ class LocalLogTest {
     // case-2: `startOffset` > `maxOffsetMetadata.offset`
     fetchDataInfo = readRecords(startOffset = 5L, maxOffsetMetadata = new LogOffsetMetadata(4L, 4L, 0))
     assertTrue(fetchDataInfo.records.records.asScala.isEmpty)
-    assertEquals(new LogOffsetMetadata(5L, -1L, -1), fetchDataInfo.fetchOffsetMetadata)
+    assertEquals(new LogOffsetMetadata(5L, 4L, 69), fetchDataInfo.fetchOffsetMetadata)
 
     // case-3: `startOffset` < `maxMessageOffset.offset` but `maxMessageOffset.messageOnlyOffset` is true
     fetchDataInfo = readRecords(startOffset = 3L, maxOffsetMetadata = new LogOffsetMetadata(4L, -1L, -1))
     assertTrue(fetchDataInfo.records.records.asScala.isEmpty)
-    assertEquals(new LogOffsetMetadata(3L, -1L, -1), fetchDataInfo.fetchOffsetMetadata)
+    assertEquals(new LogOffsetMetadata(3L, 2L, 69), fetchDataInfo.fetchOffsetMetadata)
 
     // case-4: `startOffset` < `maxMessageOffset.offset`, `maxMessageOffset.messageOnlyOffset` is false, but
     // `maxOffsetMetadata.segmentBaseOffset` < `startOffset.segmentBaseOffset`
     fetchDataInfo = readRecords(startOffset = 3L, maxOffsetMetadata = new LogOffsetMetadata(4L, 0L, 40))
     assertTrue(fetchDataInfo.records.records.asScala.isEmpty)
-    assertEquals(new LogOffsetMetadata(3L, -1L, -1), fetchDataInfo.fetchOffsetMetadata)
+    assertEquals(new LogOffsetMetadata(3L, 2L, 69), fetchDataInfo.fetchOffsetMetadata)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
@@ -388,7 +388,7 @@ class LocalLogTest {
     assertEquals(new LogOffsetMetadata(3, 2L, 69), fetchDataInfo.fetchOffsetMetadata)
 
     // case-1: `startOffset` == `maxOffsetMetadata.offset`
-     fetchDataInfo = readRecords(startOffset = 4L, maxOffsetMetadata = new LogOffsetMetadata(4L, 4L, 0))
+    fetchDataInfo = readRecords(startOffset = 4L, maxOffsetMetadata = new LogOffsetMetadata(4L, 4L, 0))
     assertTrue(fetchDataInfo.records.records.asScala.isEmpty)
     assertEquals(new LogOffsetMetadata(4L, 4L, 0), fetchDataInfo.fetchOffsetMetadata)
 

--- a/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LocalLogTest.scala
@@ -373,6 +373,43 @@ class LocalLogTest {
   }
 
   @Test
+  def testWhenFetchOffsetHigherThanMaxOffset(): Unit = {
+    val record = new SimpleRecord(mockTime.milliseconds, "a".getBytes)
+    for (offset <- 0 to 4) {
+      appendRecords(List(record), initialOffset = offset)
+      if (offset % 2 != 0)
+        log.roll()
+    }
+    assertEquals(3, log.segments.numberOfSegments)
+
+    // case-0: valid case, `startOffset` < `maxOffsetMetadata.offset`
+    var fetchDataInfo = readRecords(startOffset = 3L, maxOffsetMetadata = new LogOffsetMetadata(4L, 4L, 0))
+    assertEquals(1, fetchDataInfo.records.records.asScala.size)
+    assertEquals(new LogOffsetMetadata(3, 2L, 69), fetchDataInfo.fetchOffsetMetadata)
+
+    // case-1: `startOffset` == `maxOffsetMetadata.offset`
+     fetchDataInfo = readRecords(startOffset = 4L, maxOffsetMetadata = new LogOffsetMetadata(4L, 4L, 0))
+    assertTrue(fetchDataInfo.records.records.asScala.isEmpty)
+    assertEquals(new LogOffsetMetadata(4L, 4L, 0), fetchDataInfo.fetchOffsetMetadata)
+
+    // case-2: `startOffset` > `maxOffsetMetadata.offset`
+    fetchDataInfo = readRecords(startOffset = 5L, maxOffsetMetadata = new LogOffsetMetadata(4L, 4L, 0))
+    assertTrue(fetchDataInfo.records.records.asScala.isEmpty)
+    assertEquals(new LogOffsetMetadata(5L, -1L, -1), fetchDataInfo.fetchOffsetMetadata)
+
+    // case-3: `startOffset` < `maxMessageOffset.offset` but `maxMessageOffset.messageOnlyOffset` is true
+    fetchDataInfo = readRecords(startOffset = 3L, maxOffsetMetadata = new LogOffsetMetadata(4L, -1L, -1))
+    assertTrue(fetchDataInfo.records.records.asScala.isEmpty)
+    assertEquals(new LogOffsetMetadata(3L, -1L, -1), fetchDataInfo.fetchOffsetMetadata)
+
+    // case-4: `startOffset` < `maxMessageOffset.offset`, `maxMessageOffset.messageOnlyOffset` is false, but
+    // `maxOffsetMetadata.segmentBaseOffset` < `startOffset.segmentBaseOffset`
+    fetchDataInfo = readRecords(startOffset = 3L, maxOffsetMetadata = new LogOffsetMetadata(4L, 0L, 40))
+    assertTrue(fetchDataInfo.records.records.asScala.isEmpty)
+    assertEquals(new LogOffsetMetadata(3L, -1L, -1), fetchDataInfo.fetchOffsetMetadata)
+  }
+
+  @Test
   def testTruncateTo(): Unit = {
     for (offset <- 0 to 11) {
       val record = new SimpleRecord(mockTime.milliseconds, "a".getBytes)

--- a/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
@@ -358,7 +358,7 @@ class LogLoaderTest {
           val wrapper = Mockito.spy(segment)
           Mockito.doAnswer { in =>
             segmentsWithReads += wrapper
-            segment.read(in.getArgument(0, classOf[java.lang.Long]), in.getArgument(1, classOf[java.lang.Integer]), in.getArgument(2, classOf[java.lang.Long]), in.getArgument(3, classOf[java.lang.Boolean]))
+            segment.read(in.getArgument(0, classOf[java.lang.Long]), in.getArgument(1, classOf[java.lang.Integer]), in.getArgument(2, classOf[java.util.Optional[java.lang.Long]]), in.getArgument(3, classOf[java.lang.Boolean]))
           }.when(wrapper).read(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())
           Mockito.doAnswer { in =>
             recoveredSegments += wrapper

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -146,7 +146,7 @@ class LogSegmentTest {
 
   @Test
   def testReadWhenNoMaxPosition(): Unit = {
-    val maxPosition = -1
+    val maxPosition: Optional[java.lang.Long] = Optional.empty()
     val maxSize = 1
     val seg = createSegment(40)
     val ms = records(50, "hello", "there")
@@ -360,7 +360,7 @@ class LogSegmentTest {
     writeNonsenseToFile(indexFile, 5, indexFile.length.toInt)
     seg.recover(newProducerStateManager(), Optional.empty())
     for (i <- 0 until 100) {
-      val records = seg.read(i, 1, seg.size(), true).records.records
+      val records = seg.read(i, 1, Optional.of(seg.size()), true).records.records
       assertEquals(i, records.iterator.next().offset)
     }
   }

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -156,22 +156,18 @@ class LogSegmentTest {
       var read = seg.read(48, maxSize, maxPosition, minOneMessage)
       assertEquals(new LogOffsetMetadata(48, 40, 0), read.fetchOffsetMetadata)
       assertTrue(read.records.records().iterator().asScala.isEmpty)
-
       // read at first offset
       read = seg.read(50, maxSize, maxPosition, minOneMessage)
       assertEquals(new LogOffsetMetadata(50, 40, 0), read.fetchOffsetMetadata)
       assertTrue(read.records.records().iterator().asScala.isEmpty)
-
-      // read beyond first offset
+      // read at last offset
       read = seg.read(51, maxSize, maxPosition, minOneMessage)
       assertEquals(new LogOffsetMetadata(51, 40, 39), read.fetchOffsetMetadata)
       assertTrue(read.records.records().iterator().asScala.isEmpty)
-
-      // read at last offset
+      // read at log-end-offset
       read = seg.read(52, maxSize, maxPosition, minOneMessage)
       assertNull(read)
-
-      // read beyond last offset
+      // read beyond log-end-offset
       read = seg.read(53, maxSize, maxPosition, minOneMessage)
       assertNull(read)
     }

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -147,31 +147,32 @@ class LogSegmentTest {
   @Test
   def testReadWhenNoMaxPosition(): Unit = {
     val maxPosition = -1
+    val maxSize = 1
     val seg = createSegment(40)
     val ms = records(50, "hello", "there")
     seg.append(51, RecordBatch.NO_TIMESTAMP, -1L, ms)
     for (minOneMessage <- Array(true, false)) {
       // read before first offset
-      var read = seg.read(48, 200, maxPosition, minOneMessage)
+      var read = seg.read(48, maxSize, maxPosition, minOneMessage)
       assertEquals(new LogOffsetMetadata(48, 40, 0), read.fetchOffsetMetadata)
       assertTrue(read.records.records().iterator().asScala.isEmpty)
 
       // read at first offset
-      read = seg.read(50, 200, maxPosition, minOneMessage)
+      read = seg.read(50, maxSize, maxPosition, minOneMessage)
       assertEquals(new LogOffsetMetadata(50, 40, 0), read.fetchOffsetMetadata)
       assertTrue(read.records.records().iterator().asScala.isEmpty)
 
       // read beyond first offset
-      read = seg.read(51, 200, maxPosition, minOneMessage)
+      read = seg.read(51, maxSize, maxPosition, minOneMessage)
       assertEquals(new LogOffsetMetadata(51, 40, 39), read.fetchOffsetMetadata)
       assertTrue(read.records.records().iterator().asScala.isEmpty)
 
       // read at last offset
-      read = seg.read(52, 200, maxPosition, minOneMessage)
+      read = seg.read(52, maxSize, maxPosition, minOneMessage)
       assertNull(read)
 
       // read beyond last offset
-      read = seg.read(53, 200, maxPosition, minOneMessage)
+      read = seg.read(53, maxSize, maxPosition, minOneMessage)
       assertNull(read)
     }
   }

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -3246,7 +3246,7 @@ class UnifiedLogTest {
 
     val readInfo = segment.read(offsetMetadata.messageOffset,
       2048,
-      segment.size,
+      Optional.of(segment.size),
       false)
 
     if (offsetMetadata.relativePositionInSegment < segment.size)

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -342,10 +342,7 @@ class UnifiedLogTest {
     assertValidLogOffsetMetadata(log, readInfo.fetchOffsetMetadata)
   }
 
-  private def assertEmptyFetch(log: UnifiedLog,
-                               offset: Long,
-                               isolation: FetchIsolation,
-                               messageOffsetOnly: Boolean = false): Unit = {
+  private def assertEmptyFetch(log: UnifiedLog, offset: Long, isolation: FetchIsolation): Unit = {
     val readInfo = log.read(startOffset = offset,
       maxLength = Int.MaxValue,
       isolation = isolation,
@@ -353,11 +350,7 @@ class UnifiedLogTest {
     assertFalse(readInfo.firstEntryIncomplete)
     assertEquals(0, readInfo.records.sizeInBytes)
     assertEquals(offset, readInfo.fetchOffsetMetadata.messageOffset)
-    if (messageOffsetOnly) {
-      assertTrue(readInfo.fetchOffsetMetadata.messageOffsetOnly())
-    } else {
-      assertValidLogOffsetMetadata(log, readInfo.fetchOffsetMetadata)
-    }
+    assertValidLogOffsetMetadata(log, readInfo.fetchOffsetMetadata)
   }
 
   @Test
@@ -400,10 +393,8 @@ class UnifiedLogTest {
         assertNonEmptyFetch(log, offset, FetchIsolation.HIGH_WATERMARK)
       }
 
-      assertEmptyFetch(log, log.highWatermark, FetchIsolation.HIGH_WATERMARK)
-
-      (log.highWatermark + 1 to log.logEndOffset).foreach { offset =>
-        assertEmptyFetch(log, offset, FetchIsolation.HIGH_WATERMARK, messageOffsetOnly = true)
+      (log.highWatermark to log.logEndOffset).foreach { offset =>
+        assertEmptyFetch(log, offset, FetchIsolation.HIGH_WATERMARK)
       }
     }
 
@@ -498,10 +489,8 @@ class UnifiedLogTest {
         assertNonEmptyFetch(log, offset, FetchIsolation.TXN_COMMITTED)
       }
 
-      assertEmptyFetch(log, log.lastStableOffset, FetchIsolation.TXN_COMMITTED)
-
-      (log.lastStableOffset + 1 to log.logEndOffset).foreach { offset =>
-        assertEmptyFetch(log, offset, FetchIsolation.TXN_COMMITTED, messageOffsetOnly = true)
+      (log.lastStableOffset to log.logEndOffset).foreach { offset =>
+        assertEmptyFetch(log, offset, FetchIsolation.TXN_COMMITTED)
       }
     }
 

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -4240,13 +4240,13 @@ class UnifiedLogTest {
     // case-1: offset is higher than the local-log-start-offset.
     // log-start-offset < local-log-start-offset < offset-to-be-converted < log-end-offset
     assertEquals(new LogOffsetMetadata(35, 31, 288), log.maybeConvertToOffsetMetadata(35))
-    // case-2: offset is lesser than the local-log-start-offset
+    // case-2: offset is less than the local-log-start-offset
     // log-start-offset < offset-to-be-converted < local-log-start-offset < log-end-offset
     assertEquals(new LogOffsetMetadata(29, -1L, -1), log.maybeConvertToOffsetMetadata(29))
     // case-3: offset is higher than the log-end-offset
     // log-start-offset < local-log-start-offset < log-end-offset < offset-to-be-converted
     assertEquals(new LogOffsetMetadata(log.logEndOffset + 1, -1L, -1), log.maybeConvertToOffsetMetadata(log.logEndOffset + 1))
-    // case-4: offset is lesser than the log-start-offset
+    // case-4: offset is less than the log-start-offset
     // offset-to-be-converted < log-start-offset < local-log-start-offset < log-end-offset
     assertEquals(new LogOffsetMetadata(14, -1L, -1), log.maybeConvertToOffsetMetadata(14))
   }

--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -4250,16 +4250,16 @@ class UnifiedLogTest {
 
     // case-1: offset is higher than the local-log-start-offset.
     // log-start-offset < local-log-start-offset < offset-to-be-converted < log-end-offset
-    assertEquals(new LogOffsetMetadata(35, 31, 288), log.convertToOffsetMetadata(35))
+    assertEquals(new LogOffsetMetadata(35, 31, 288), log.maybeConvertToOffsetMetadata(35))
     // case-2: offset is lesser than the local-log-start-offset
     // log-start-offset < offset-to-be-converted < local-log-start-offset < log-end-offset
-    assertEquals(new LogOffsetMetadata(29, -1L, -1), log.convertToOffsetMetadata(29))
+    assertEquals(new LogOffsetMetadata(29, -1L, -1), log.maybeConvertToOffsetMetadata(29))
     // case-3: offset is higher than the log-end-offset
     // log-start-offset < local-log-start-offset < log-end-offset < offset-to-be-converted
-    assertEquals(new LogOffsetMetadata(log.logEndOffset + 1, -1L, -1), log.convertToOffsetMetadata(log.logEndOffset + 1))
+    assertEquals(new LogOffsetMetadata(log.logEndOffset + 1, -1L, -1), log.maybeConvertToOffsetMetadata(log.logEndOffset + 1))
     // case-4: offset is lesser than the log-start-offset
     // offset-to-be-converted < log-start-offset < local-log-start-offset < log-end-offset
-    assertEquals(new LogOffsetMetadata(14, -1L, -1), log.convertToOffsetMetadata(14))
+    assertEquals(new LogOffsetMetadata(14, -1L, -1), log.maybeConvertToOffsetMetadata(14))
   }
 
   private def appendTransactionalToBuffer(buffer: ByteBuffer,

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetMetadata.java
@@ -28,6 +28,7 @@ public final class LogOffsetMetadata {
 
     //TODO KAFKA-14484 remove once UnifiedLog has been moved to the storage module
     private static final long UNIFIED_LOG_UNKNOWN_OFFSET = -1L;
+    public static final long REMOTE_LOG_UNKNOWN_OFFSET = -2L;
 
     public static final LogOffsetMetadata UNKNOWN_OFFSET_METADATA = new LogOffsetMetadata(-1L, 0L, 0);
 
@@ -42,6 +43,11 @@ public final class LogOffsetMetadata {
     }
 
     public LogOffsetMetadata(long messageOffset,
+                             long segmentBaseOffset) {
+        this(messageOffset, segmentBaseOffset, UNKNOWN_FILE_POSITION);
+    }
+
+    public LogOffsetMetadata(long messageOffset,
                              long segmentBaseOffset,
                              int relativePositionInSegment) {
         this.messageOffset = messageOffset;
@@ -51,6 +57,8 @@ public final class LogOffsetMetadata {
 
     // check if this offset is already on an older segment compared with the given offset
     public boolean onOlderSegment(LogOffsetMetadata that) {
+        if (this.segmentBaseOffset == REMOTE_LOG_UNKNOWN_OFFSET || that.segmentBaseOffset == REMOTE_LOG_UNKNOWN_OFFSET)
+            return false;
         if (messageOffsetOnly())
             throw new KafkaException(this + " cannot compare its segment info with " + that + " since it only has message offset info");
 
@@ -65,6 +73,8 @@ public final class LogOffsetMetadata {
     // compute the number of bytes between this offset to the given offset
     // if they are on the same segment and this offset precedes the given offset
     public int positionDiff(LogOffsetMetadata that) {
+        if (this.segmentBaseOffset == REMOTE_LOG_UNKNOWN_OFFSET || that.segmentBaseOffset == REMOTE_LOG_UNKNOWN_OFFSET)
+            return 1;
         if (messageOffsetOnly())
             throw new KafkaException(this + " cannot compare its segment position with " + that + " since it only has message offset info");
         if (!onSameSegment(that))
@@ -75,7 +85,8 @@ public final class LogOffsetMetadata {
 
     // decide if the offset metadata only contains message offset info
     public boolean messageOffsetOnly() {
-        return segmentBaseOffset == UNIFIED_LOG_UNKNOWN_OFFSET && relativePositionInSegment == UNKNOWN_FILE_POSITION;
+        return (segmentBaseOffset == UNIFIED_LOG_UNKNOWN_OFFSET || segmentBaseOffset == REMOTE_LOG_UNKNOWN_OFFSET)
+                && relativePositionInSegment == UNKNOWN_FILE_POSITION;
     }
 
     @Override

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetMetadata.java
@@ -28,10 +28,9 @@ public final class LogOffsetMetadata {
 
     //TODO KAFKA-14484 remove once UnifiedLog has been moved to the storage module
     private static final long UNIFIED_LOG_UNKNOWN_OFFSET = -1L;
-
-    public static final LogOffsetMetadata UNKNOWN_OFFSET_METADATA = new LogOffsetMetadata(-1L, 0L, 0);
-
     private static final int UNKNOWN_FILE_POSITION = -1;
+
+    public static final LogOffsetMetadata UNKNOWN_OFFSET_METADATA = new LogOffsetMetadata(-1L, UNIFIED_LOG_UNKNOWN_OFFSET, UNKNOWN_FILE_POSITION);
 
     public final long messageOffset;
     public final long segmentBaseOffset;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetMetadata.java
@@ -50,7 +50,7 @@ public final class LogOffsetMetadata {
 
     // check if this offset is already on an older segment compared with the given offset
     public boolean onOlderSegment(LogOffsetMetadata that) {
-        if (messageOffsetOnly())
+        if (messageOffsetOnly() || that.messageOffsetOnly())
             return false;
 
         return this.segmentBaseOffset < that.segmentBaseOffset;
@@ -64,7 +64,7 @@ public final class LogOffsetMetadata {
     // compute the number of bytes between this offset to the given offset
     // if they are on the same segment and this offset precedes the given offset
     public int positionDiff(LogOffsetMetadata that) {
-        if (messageOffsetOnly())
+        if (messageOffsetOnly() || that.messageOffsetOnly())
             throw new KafkaException(this + " cannot compare its segment position with " + that + " since it only has message offset info");
         if (!onSameSegment(that))
             throw new KafkaException(this + " cannot compare its segment position with " + that + " since they are not on the same segment");

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetMetadata.java
@@ -28,7 +28,6 @@ public final class LogOffsetMetadata {
 
     //TODO KAFKA-14484 remove once UnifiedLog has been moved to the storage module
     private static final long UNIFIED_LOG_UNKNOWN_OFFSET = -1L;
-    public static final long REMOTE_LOG_UNKNOWN_OFFSET = -2L;
 
     public static final LogOffsetMetadata UNKNOWN_OFFSET_METADATA = new LogOffsetMetadata(-1L, 0L, 0);
 
@@ -43,11 +42,6 @@ public final class LogOffsetMetadata {
     }
 
     public LogOffsetMetadata(long messageOffset,
-                             long segmentBaseOffset) {
-        this(messageOffset, segmentBaseOffset, UNKNOWN_FILE_POSITION);
-    }
-
-    public LogOffsetMetadata(long messageOffset,
                              long segmentBaseOffset,
                              int relativePositionInSegment) {
         this.messageOffset = messageOffset;
@@ -57,10 +51,8 @@ public final class LogOffsetMetadata {
 
     // check if this offset is already on an older segment compared with the given offset
     public boolean onOlderSegment(LogOffsetMetadata that) {
-        if (this.segmentBaseOffset == REMOTE_LOG_UNKNOWN_OFFSET || that.segmentBaseOffset == REMOTE_LOG_UNKNOWN_OFFSET)
-            return false;
         if (messageOffsetOnly())
-            throw new KafkaException(this + " cannot compare its segment info with " + that + " since it only has message offset info");
+            return false;
 
         return this.segmentBaseOffset < that.segmentBaseOffset;
     }
@@ -73,8 +65,6 @@ public final class LogOffsetMetadata {
     // compute the number of bytes between this offset to the given offset
     // if they are on the same segment and this offset precedes the given offset
     public int positionDiff(LogOffsetMetadata that) {
-        if (this.segmentBaseOffset == REMOTE_LOG_UNKNOWN_OFFSET || that.segmentBaseOffset == REMOTE_LOG_UNKNOWN_OFFSET)
-            return 1;
         if (messageOffsetOnly())
             throw new KafkaException(this + " cannot compare its segment position with " + that + " since it only has message offset info");
         if (!onSameSegment(that))
@@ -85,8 +75,7 @@ public final class LogOffsetMetadata {
 
     // decide if the offset metadata only contains message offset info
     public boolean messageOffsetOnly() {
-        return (segmentBaseOffset == UNIFIED_LOG_UNKNOWN_OFFSET || segmentBaseOffset == REMOTE_LOG_UNKNOWN_OFFSET)
-                && relativePositionInSegment == UNKNOWN_FILE_POSITION;
+        return segmentBaseOffset == UNIFIED_LOG_UNKNOWN_OFFSET && relativePositionInSegment == UNKNOWN_FILE_POSITION;
     }
 
     @Override

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetMetadata.java
@@ -67,7 +67,7 @@ public final class LogOffsetMetadata {
     public int positionDiff(LogOffsetMetadata that) {
         if (messageOffsetOnly() || that.messageOffsetOnly())
             throw new KafkaException(this + " cannot compare its segment position with " + that + " since it only has message offset info");
-        if (this.segmentBaseOffset != that.segmentBaseOffset)
+        if (!onSameSegment(that))
             throw new KafkaException(this + " cannot compare its segment position with " + that + " since they are not on the same segment");
 
         return this.relativePositionInSegment - that.relativePositionInSegment;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetMetadata.java
@@ -57,7 +57,7 @@ public final class LogOffsetMetadata {
     }
 
     // check if this offset is on the same segment with the given offset
-    private boolean onSameSegment(LogOffsetMetadata that) {
+    public boolean onSameSegment(LogOffsetMetadata that) {
         return this.segmentBaseOffset == that.segmentBaseOffset;
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetMetadata.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogOffsetMetadata.java
@@ -52,12 +52,13 @@ public final class LogOffsetMetadata {
     public boolean onOlderSegment(LogOffsetMetadata that) {
         if (messageOffsetOnly() || that.messageOffsetOnly())
             return false;
-
         return this.segmentBaseOffset < that.segmentBaseOffset;
     }
 
     // check if this offset is on the same segment with the given offset
     public boolean onSameSegment(LogOffsetMetadata that) {
+        if (messageOffsetOnly() || that.messageOffsetOnly())
+            return false;
         return this.segmentBaseOffset == that.segmentBaseOffset;
     }
 
@@ -66,7 +67,7 @@ public final class LogOffsetMetadata {
     public int positionDiff(LogOffsetMetadata that) {
         if (messageOffsetOnly() || that.messageOffsetOnly())
             throw new KafkaException(this + " cannot compare its segment position with " + that + " since it only has message offset info");
-        if (!onSameSegment(that))
+        if (this.segmentBaseOffset != that.segmentBaseOffset)
             throw new KafkaException(this + " cannot compare its segment position with " + that + " since they are not on the same segment");
 
         return this.relativePositionInSegment - that.relativePositionInSegment;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
@@ -398,7 +398,7 @@ public class LogSegment implements Closeable {
     /**
      * Equivalent to {@code read(startOffset, maxSize, size())}.
      *
-     * See {@link #read(long, int, long, boolean)} for details.
+     * See {@link #read(long, int, Optional, boolean)} for details.
      */
     public FetchDataInfo read(long startOffset, int maxSize) throws IOException {
         return read(startOffset, maxSize, size());
@@ -407,10 +407,10 @@ public class LogSegment implements Closeable {
     /**
      * Equivalent to {@code read(startOffset, maxSize, maxPosition, false)}.
      *
-     * See {@link #read(long, int, long, boolean)} for details.
+     * See {@link #read(long, int, Optional, boolean)} for details.
      */
     public FetchDataInfo read(long startOffset, int maxSize, long maxPosition) throws IOException {
-        return read(startOffset, maxSize, maxPosition, false);
+        return read(startOffset, maxSize, Optional.of(maxPosition), false);
     }
 
     /**
@@ -421,13 +421,13 @@ public class LogSegment implements Closeable {
      *
      * @param startOffset A lower bound on the first offset to include in the message set we read
      * @param maxSize The maximum number of bytes to include in the message set we read
-     * @param maxPosition The maximum position in the log segment that should be exposed for read
+     * @param maxPositionOpt The maximum position in the log segment that should be exposed for read
      * @param minOneMessage If this is true, the first message will be returned even if it exceeds `maxSize` (if one exists)
      *
      * @return The fetched data and the offset metadata of the first message whose offset is >= startOffset,
      *         or null if the startOffset is larger than the largest offset in this log
      */
-    public FetchDataInfo read(long startOffset, int maxSize, long maxPosition, boolean minOneMessage) throws IOException {
+    public FetchDataInfo read(long startOffset, int maxSize, Optional<Long> maxPositionOpt, boolean minOneMessage) throws IOException {
         if (maxSize < 0)
             throw new IllegalArgumentException("Invalid max size " + maxSize + " for log read from segment " + log);
 
@@ -445,11 +445,11 @@ public class LogSegment implements Closeable {
             adjustedMaxSize = Math.max(maxSize, startOffsetAndSize.size);
 
         // return a log segment but with zero size in the case below
-        if (adjustedMaxSize == 0 || maxPosition == -1)
+        if (adjustedMaxSize == 0 || !maxPositionOpt.isPresent())
             return new FetchDataInfo(offsetMetadata, MemoryRecords.EMPTY);
 
         // calculate the length of the message set to read based on whether or not they gave us a maxOffset
-        int fetchSize = Math.min((int) (maxPosition - startPosition), adjustedMaxSize);
+        int fetchSize = Math.min((int) (maxPositionOpt.get() - startPosition), adjustedMaxSize);
 
         return new FetchDataInfo(offsetMetadata, log.slice(startPosition, fetchSize),
             adjustedMaxSize < startOffsetAndSize.size, Optional.empty());

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
@@ -445,7 +445,7 @@ public class LogSegment implements Closeable {
             adjustedMaxSize = Math.max(maxSize, startOffsetAndSize.size);
 
         // return a log segment but with zero size in the case below
-        if (adjustedMaxSize == 0)
+        if (adjustedMaxSize == 0 || maxPosition == -1)
             return new FetchDataInfo(offsetMetadata, MemoryRecords.EMPTY);
 
         // calculate the length of the message set to read based on whether or not they gave us a maxOffset

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
@@ -444,7 +444,9 @@ public class LogSegment implements Closeable {
         if (minOneMessage)
             adjustedMaxSize = Math.max(maxSize, startOffsetAndSize.size);
 
-        // return a log segment but with zero size in the case below
+        // return empty records in the fetch-data-info when:
+        // 1. adjustedMaxSize is 0 (or)
+        // 2. maxPosition to read is unavailable
         if (adjustedMaxSize == 0 || !maxPositionOpt.isPresent())
             return new FetchDataInfo(offsetMetadata, MemoryRecords.EMPTY);
 

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogOffsetMetadataTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogOffsetMetadataTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.storage.internals.log;
+
+import org.apache.kafka.common.KafkaException;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.kafka.storage.internals.log.LogOffsetMetadata.UNKNOWN_OFFSET_METADATA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LogOffsetMetadataTest {
+
+    @Test
+    void testOnOlderSegment() {
+        LogOffsetMetadata metadata1 = new LogOffsetMetadata(1L, 0L, 1);
+        LogOffsetMetadata metadata2 = new LogOffsetMetadata(5L, 4L, 2);
+        LogOffsetMetadata messageOnlyMetadata = new LogOffsetMetadata(1L);
+        assertFalse(UNKNOWN_OFFSET_METADATA.onOlderSegment(UNKNOWN_OFFSET_METADATA));
+        assertFalse(metadata1.onOlderSegment(messageOnlyMetadata));
+        assertFalse(messageOnlyMetadata.onOlderSegment(metadata1));
+        assertFalse(metadata1.onOlderSegment(metadata1));
+        assertFalse(metadata2.onOlderSegment(metadata1));
+        assertTrue(metadata1.onOlderSegment(metadata2));
+    }
+
+    @Test
+    void testPositionDiff() {
+        LogOffsetMetadata metadata1 = new LogOffsetMetadata(1L);
+        LogOffsetMetadata metadata2 = new LogOffsetMetadata(5L, 0L, 5);
+        KafkaException exception = assertThrows(KafkaException.class, () -> metadata1.positionDiff(metadata2));
+        assertTrue(exception.getMessage().endsWith("since it only has message offset info"));
+
+        exception = assertThrows(KafkaException.class, () -> metadata2.positionDiff(metadata1));
+        assertTrue(exception.getMessage().endsWith("since they are not on the same segment"));
+
+        LogOffsetMetadata metadata3 = new LogOffsetMetadata(15L, 10L, 5);
+        exception = assertThrows(KafkaException.class, () -> metadata3.positionDiff(metadata2));
+        assertTrue(exception.getMessage().endsWith("since they are not on the same segment"));
+
+        LogOffsetMetadata metadata4 = new LogOffsetMetadata(40L, 10L, 100);
+        assertEquals(95, metadata4.positionDiff(metadata3));
+    }
+
+    @Test
+    void testMessageOffsetOnly() {
+        LogOffsetMetadata metadata1 = new LogOffsetMetadata(1L);
+        LogOffsetMetadata metadata2 = new LogOffsetMetadata(1L, 0L, 1);
+        assertFalse(UNKNOWN_OFFSET_METADATA.messageOffsetOnly());
+        assertFalse(metadata2.messageOffsetOnly());
+        assertTrue(metadata1.messageOffsetOnly());
+    }
+}

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogOffsetMetadataTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogOffsetMetadataTest.java
@@ -74,5 +74,9 @@ class LogOffsetMetadataTest {
         LogOffsetMetadata metadata3 = new LogOffsetMetadata(10L, 4L, 200);
         assertFalse(metadata1.onSameSegment(metadata2));
         assertTrue(metadata2.onSameSegment(metadata3));
+
+        LogOffsetMetadata metadata4 = new LogOffsetMetadata(50);
+        LogOffsetMetadata metadata5 = new LogOffsetMetadata(100);
+        assertFalse(metadata4.onSameSegment(metadata5));
     }
 }

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogOffsetMetadataTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogOffsetMetadataTest.java
@@ -48,7 +48,7 @@ class LogOffsetMetadataTest {
         assertTrue(exception.getMessage().endsWith("since it only has message offset info"));
 
         exception = assertThrows(KafkaException.class, () -> metadata2.positionDiff(metadata1));
-        assertTrue(exception.getMessage().endsWith("since they are not on the same segment"));
+        assertTrue(exception.getMessage().endsWith("since it only has message offset info"));
 
         LogOffsetMetadata metadata3 = new LogOffsetMetadata(15L, 10L, 5);
         exception = assertThrows(KafkaException.class, () -> metadata3.positionDiff(metadata2));

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogOffsetMetadataTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogOffsetMetadataTest.java
@@ -62,7 +62,7 @@ class LogOffsetMetadataTest {
     void testMessageOffsetOnly() {
         LogOffsetMetadata metadata1 = new LogOffsetMetadata(1L);
         LogOffsetMetadata metadata2 = new LogOffsetMetadata(1L, 0L, 1);
-        assertFalse(UNKNOWN_OFFSET_METADATA.messageOffsetOnly());
+        assertTrue(UNKNOWN_OFFSET_METADATA.messageOffsetOnly());
         assertFalse(metadata2.messageOffsetOnly());
         assertTrue(metadata1.messageOffsetOnly());
     }

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogOffsetMetadataTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogOffsetMetadataTest.java
@@ -66,4 +66,13 @@ class LogOffsetMetadataTest {
         assertFalse(metadata2.messageOffsetOnly());
         assertTrue(metadata1.messageOffsetOnly());
     }
+
+    @Test
+    void testOnSameSegment() {
+        LogOffsetMetadata metadata1 = new LogOffsetMetadata(1L, 0L, 1);
+        LogOffsetMetadata metadata2 = new LogOffsetMetadata(5L, 4L, 2);
+        LogOffsetMetadata metadata3 = new LogOffsetMetadata(10L, 4L, 200);
+        assertFalse(metadata1.onSameSegment(metadata2));
+        assertTrue(metadata2.onSameSegment(metadata3));
+    }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestBuilder.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestBuilder.java
@@ -55,6 +55,7 @@ import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.server.log.remote.storage.LocalTieredStorageEvent;
 import org.apache.kafka.storage.internals.log.EpochEntry;
 
+import java.io.FilenameFilter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -290,8 +291,10 @@ public final class TieredStorageTestBuilder {
         return this;
     }
 
-    public TieredStorageTestBuilder eraseBrokerStorage(Integer brokerId, List<String> files, boolean isStopped) {
-        actions.add(new EraseBrokerStorageAction(brokerId, files, isStopped));
+    public TieredStorageTestBuilder eraseBrokerStorage(Integer brokerId,
+                                                       FilenameFilter filenameFilter,
+                                                       boolean isStopped) {
+        actions.add(new EraseBrokerStorageAction(brokerId, filenameFilter, isStopped));
         return this;
     }
 

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestBuilder.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestBuilder.java
@@ -290,6 +290,11 @@ public final class TieredStorageTestBuilder {
         return this;
     }
 
+    public TieredStorageTestBuilder eraseBrokerStorage(Integer brokerId, List<String> files, boolean isStopped) {
+        actions.add(new EraseBrokerStorageAction(brokerId, files, isStopped));
+        return this;
+    }
+
     public TieredStorageTestBuilder expectEmptyRemoteStorage(String topic,
                                                              Integer partition) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestContext.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/TieredStorageTestContext.java
@@ -49,6 +49,7 @@ import org.apache.kafka.server.log.remote.storage.LocalTieredStorageSnapshot;
 import scala.Function0;
 import scala.Function1;
 
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -259,8 +260,20 @@ public final class TieredStorageTestContext implements AutoCloseable {
         initContext();
     }
 
-    public void eraseBrokerStorage(int brokerId) throws IOException {
-        localStorages.get(brokerId).eraseStorage();
+    public void eraseBrokerStorage(int brokerId,
+                                   FilenameFilter filter,
+                                   boolean isStopped) throws IOException {
+        BrokerLocalStorage brokerLocalStorage;
+        if (isStopped) {
+            brokerLocalStorage = TieredStorageTestHarness.localStorages(harness.brokers())
+                    .stream()
+                    .filter(bls -> bls.getBrokerId() == brokerId)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("No local storage found for broker " + brokerId));
+        } else {
+            brokerLocalStorage = localStorages.get(brokerId);
+        }
+        brokerLocalStorage.eraseStorage(filter);
     }
 
     public TopicSpec topicSpec(String topicName) {

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/actions/EraseBrokerStorageAction.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/actions/EraseBrokerStorageAction.java
@@ -22,33 +22,32 @@ import org.apache.kafka.tiered.storage.TieredStorageTestContext;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.Collections;
-import java.util.List;
 
 public final class EraseBrokerStorageAction implements TieredStorageTestAction {
 
     private final int brokerId;
-    private final List<String> files;
+    private final FilenameFilter filenameFilter;
     private final boolean isStopped;
 
     public EraseBrokerStorageAction(int brokerId) {
-        this(brokerId, Collections.emptyList(), false);
+        this(brokerId, (dir, name) -> true, false);
     }
 
-    public EraseBrokerStorageAction(int brokerId, List<String> files, boolean isStopped) {
+    public EraseBrokerStorageAction(int brokerId,
+                                    FilenameFilter filenameFilter,
+                                    boolean isStopped) {
         this.brokerId = brokerId;
-        this.files = files;
+        this.filenameFilter = filenameFilter;
         this.isStopped = isStopped;
     }
 
     @Override
     public void doExecute(TieredStorageTestContext context) throws IOException {
-        FilenameFilter filter = (dir, name) -> files.isEmpty() || files.contains(name);
-        context.eraseBrokerStorage(brokerId, filter, isStopped);
+        context.eraseBrokerStorage(brokerId, filenameFilter, isStopped);
     }
 
     @Override
     public void describe(PrintStream output) {
-        output.println("erase-broker-storage: " + brokerId + ", files: " + files + ", isStopped: " + isStopped);
+        output.println("erase-broker-storage: " + brokerId + ", isStopped: " + isStopped);
     }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/actions/EraseBrokerStorageAction.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/actions/EraseBrokerStorageAction.java
@@ -48,6 +48,7 @@ public final class EraseBrokerStorageAction implements TieredStorageTestAction {
 
     @Override
     public void describe(PrintStream output) {
-        output.println("erase-broker-storage: " + brokerId + ", isStopped: " + isStopped);
+        output.println("erase-broker-storage: " + brokerId + ", isStopped: " + isStopped +
+                ", filenameFilter: " + filenameFilter);
     }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/actions/EraseBrokerStorageAction.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/actions/EraseBrokerStorageAction.java
@@ -19,24 +19,36 @@ package org.apache.kafka.tiered.storage.actions;
 import org.apache.kafka.tiered.storage.TieredStorageTestAction;
 import org.apache.kafka.tiered.storage.TieredStorageTestContext;
 
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Collections;
+import java.util.List;
 
 public final class EraseBrokerStorageAction implements TieredStorageTestAction {
 
     private final int brokerId;
+    private final List<String> files;
+    private final boolean isStopped;
 
     public EraseBrokerStorageAction(int brokerId) {
+        this(brokerId, Collections.emptyList(), false);
+    }
+
+    public EraseBrokerStorageAction(int brokerId, List<String> files, boolean isStopped) {
         this.brokerId = brokerId;
+        this.files = files;
+        this.isStopped = isStopped;
     }
 
     @Override
     public void doExecute(TieredStorageTestContext context) throws IOException {
-        context.eraseBrokerStorage(brokerId);
+        FilenameFilter filter = (dir, name) -> files.isEmpty() || files.contains(name);
+        context.eraseBrokerStorage(brokerId, filter, isStopped);
     }
 
     @Override
     public void describe(PrintStream output) {
-        output.println("erase-broker-storage: " + brokerId);
+        output.println("erase-broker-storage: " + brokerId + ", files: " + files + ", isStopped: " + isStopped);
     }
 }

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/FetchFromLeaderWithCorruptedCheckpointTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/FetchFromLeaderWithCorruptedCheckpointTest.java
@@ -53,8 +53,7 @@ public class FetchFromLeaderWithCorruptedCheckpointTest extends TieredStorageTes
                 LogManager.RecoveryPointCheckpointFile(),
                 CleanShutdownFileHandler.CLEAN_SHUTDOWN_FILE_NAME);
 
-        builder
-                .createTopic(topicA, partitionCount, replicationFactor, maxBatchCountPerSegment, assignment,
+        builder.createTopic(topicA, partitionCount, replicationFactor, maxBatchCountPerSegment, assignment,
                         enableRemoteLogStorage)
                 // send records to partition 0
                 .expectSegmentToBeOffloaded(broker0, topicA, p0, 0, new KeyValueSpec("k0", "v0"))

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/FetchFromLeaderWithCorruptedCheckpointTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/FetchFromLeaderWithCorruptedCheckpointTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tiered.storage.integration;
+
+import kafka.log.LogManager;
+import kafka.server.ReplicaManager;
+import org.apache.kafka.storage.internals.checkpoint.CleanShutdownFileHandler;
+import org.apache.kafka.tiered.storage.TieredStorageTestBuilder;
+import org.apache.kafka.tiered.storage.TieredStorageTestHarness;
+import org.apache.kafka.tiered.storage.specs.KeyValueSpec;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+
+public class FetchFromLeaderWithCorruptedCheckpointTest extends TieredStorageTestHarness {
+
+    @Override
+    public int brokerCount() {
+        return 2;
+    }
+
+    @Override
+    protected void writeTestSpecifications(TieredStorageTestBuilder builder) {
+        final Integer broker0 = 0;
+        final Integer broker1 = 1;
+        final String topicA = "topicA";
+        final Integer p0 = 0;
+        final Integer partitionCount = 1;
+        final Integer replicationFactor = 2;
+        final Integer maxBatchCountPerSegment = 1;
+        final boolean enableRemoteLogStorage = true;
+        final Map<Integer, List<Integer>> assignment = mkMap(mkEntry(p0, Arrays.asList(broker0, broker1)));
+        final List<String> checkpointFiles = Arrays.asList(
+                ReplicaManager.HighWatermarkFilename(),
+                LogManager.RecoveryPointCheckpointFile(),
+                CleanShutdownFileHandler.CLEAN_SHUTDOWN_FILE_NAME);
+
+        builder
+                .createTopic(topicA, partitionCount, replicationFactor, maxBatchCountPerSegment, assignment,
+                        enableRemoteLogStorage)
+                // send records to partition 0
+                .expectSegmentToBeOffloaded(broker0, topicA, p0, 0, new KeyValueSpec("k0", "v0"))
+                .expectSegmentToBeOffloaded(broker0, topicA, p0, 1, new KeyValueSpec("k1", "v1"))
+                .expectEarliestLocalOffsetInLogDirectory(topicA, p0, 2L)
+                .produce(topicA, p0, new KeyValueSpec("k0", "v0"), new KeyValueSpec("k1", "v1"),
+                        new KeyValueSpec("k2", "v2"))
+                .expectFetchFromTieredStorage(broker0, topicA, p0, 2)
+                .consume(topicA, p0, 0L, 3, 2)
+                // shutdown the brokers
+                .stop(broker1)
+                .stop(broker0)
+                // delete the checkpoint files
+                .eraseBrokerStorage(broker0, checkpointFiles, true)
+                // start the broker first whose checkpoint files were deleted.
+                .start(broker0)
+                .start(broker1)
+                // send some records to partition 0
+                // Note that the segment 2 gets offloaded for p0, but we cannot expect those events deterministically
+                // because the rlm-task-thread runs in background and this framework doesn't support it.
+                .expectSegmentToBeOffloaded(broker0, topicA, p0, 3, new KeyValueSpec("k3", "v3"))
+                .expectEarliestLocalOffsetInLogDirectory(topicA, p0, 4L)
+                .produce(topicA, p0, new KeyValueSpec("k3", "v3"), new KeyValueSpec("k4", "v4"))
+                .expectFetchFromTieredStorage(broker0, topicA, p0, 4)
+                .consume(topicA, p0, 0L, 5, 4);
+
+    }
+}

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/FetchFromLeaderWithCorruptedCheckpointTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/FetchFromLeaderWithCorruptedCheckpointTest.java
@@ -68,7 +68,7 @@ public class FetchFromLeaderWithCorruptedCheckpointTest extends TieredStorageTes
                 .stop(broker1)
                 .stop(broker0)
                 // delete the checkpoint files
-                .eraseBrokerStorage(broker0, checkpointFiles, true)
+                .eraseBrokerStorage(broker0, (dir, name) -> checkpointFiles.contains(name), true)
                 // start the broker first whose checkpoint files were deleted.
                 .start(broker0)
                 .start(broker1)

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/utils/BrokerLocalStorage.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/utils/BrokerLocalStorage.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.storage.internals.log.LogFileUtils;
 
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -156,8 +157,8 @@ public final class BrokerLocalStorage {
         return false;
     }
 
-    public void eraseStorage() throws IOException {
-        for (File file : Objects.requireNonNull(brokerStorageDirectory.listFiles())) {
+    public void eraseStorage(FilenameFilter filter) throws IOException {
+        for (File file : Objects.requireNonNull(brokerStorageDirectory.listFiles(filter))) {
             Utils.delete(file);
         }
     }


### PR DESCRIPTION
### Test Plan

Steps to reproduce the issue:

1. Create a topic with 1 partition and 2 RF
2. Send some messages to the topic, wait for the segments to roll over, and upload them to remote storage.
3. Ensure that the log-start-offset < local-log-start-offset
4. Stop all the nodes where the replica is placed.
5. Delete the replication-offset-checkpoint, recovery-point-offset-checkpoint, and kafka_cleanshutdown files on one node that is about to be started first.
6. Start the remaining nodes
7. The high-watermark will be set to log-start-offset and the leader will throw OFFSET_OUT_OF_RANGE errors for the follower fetch-requests and cannot accept the produce requests.

Commands:

```
 sh kafka-topics.sh --create --topic tieredTopic --partitions 1 --replication-factor 2 --bootstrap-server localhost:9092 \
    --config remote.storage.enable=true --config local.retention.ms=60000 --config retention.ms=7200000 \
    --config segment.bytes=104857600 --config file.delete.delay.ms=1000

sh kafka-producer-perf-test.sh --topic tieredTopic --num-records 120000 --record-size 1024 --throughput -1 --producer-props bootstrap.servers=localhost:9092
```


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
