### PR TITLE
KAFKA-15897: fix ControllerRegistrationManagerTest

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ControllerRegistrationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerRegistrationManagerTest.scala
@@ -218,7 +218,6 @@ class ControllerRegistrationManagerTest {
         r => Some(r.setIncarnationId(new Uuid(456, r.controllerId()))))
       manager.start(context.mockChannelManager)
       TestUtils.retryOnExceptionWithTimeout(30000, () => {
-        context.mockChannelManager.poll()
         assertEquals((true, 0, 0), rpcStats(manager))
       })
 


### PR DESCRIPTION
## Context
ControllerRegistrationManagerTest is flaky due to the poll in L221. The potential root cause is a race condition between the first poll (L221) and the second poll (L229). Before the second poll, we mock a response (L226), which should be processed by the second poll. However, if the first poll take this away, the second poll would get nothing, and this could lead to an error. 
Jira: https://issues.apache.org/jira/browse/KAFKA-15897

## Solution
Remove the first poll since it is not necessary. We can check the manager status with `rpcStats` without polling.

## Test
test with `./gradlew clean core:test --tests ControllerRegistrationManagerTest` and passed

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
