### PR TITLE
[KAFKA-16646] Don't run cve scan job on forks

### DIFF
--- a/.github/workflows/docker_scan.yml
+++ b/.github/workflows/docker_scan.yml
@@ -21,6 +21,7 @@ on:
   workflow_dispatch:
 jobs:
   scan_jvm:
+    if: github.repository == 'apache/kafka'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Minor fix PR to ensure scan job runs only on apache/kafka