### PR TITLE
KAFKA-16307: fix coordinator thread idle ratio

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/CoordinatorRuntimeMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/CoordinatorRuntimeMetrics.java
@@ -54,10 +54,10 @@ public interface CoordinatorRuntimeMetrics extends AutoCloseable {
     void recordEventQueueProcessingTime(long durationMs);
 
     /**
-     * Record the thread idle ratio.
-     * @param ratio The idle ratio.
+     * Record the thread idle time.
+     * @param idleTimeMs The idle time in milliseconds.
      */
-    void recordThreadIdleRatio(double ratio);
+    void recordThreadIdleTime(long idleTimeMs);
 
     /**
      * Register the event queue size gauge.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Meter;
+import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.coordinator.group.runtime.CoordinatorRuntime.CoordinatorState;
 
 import java.util.Arrays;
@@ -96,7 +97,7 @@ public class GroupCoordinatorRuntimeMetrics implements CoordinatorRuntimeMetrics
         );
 
         this.numPartitionsFailed = kafkaMetricName(
-            NUM_PARTITIONS_METRIC_NAME,
+        NUM_PARTITIONS_METRIC_NAME,
             "The number of partitions in Failed state.",
             "state", "failed"
         );
@@ -122,13 +123,12 @@ public class GroupCoordinatorRuntimeMetrics implements CoordinatorRuntimeMetrics
             ), new Avg());
 
         this.threadIdleSensor = metrics.sensor("ThreadIdleRatio");
-        this.threadIdleSensor.add(new Meter(TimeUnit.MILLISECONDS,
-            metrics.metricName("thread-idle-ratio",
-                METRICS_GROUP,
-                "The fraction of time the threads spent waiting for an event."),
-            metrics.metricName("thread-idle-time-ms-total",
-                METRICS_GROUP,
-                "The thread idle total time in milliseconds")));
+        this.threadIdleSensor.add(metrics.metricName(
+            "thread-idle-ratio-avg",
+            METRICS_GROUP,
+            "The fraction of time the threads spent waiting for an event. This is an average across " +
+                "all coordinator event processor threads."),
+            new Rate(TimeUnit.MILLISECONDS));
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetrics.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
-import org.apache.kafka.common.metrics.stats.Meter;
 import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.coordinator.group.runtime.CoordinatorRuntime.CoordinatorState;
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorRuntimeMetricsTest.java
@@ -47,8 +47,7 @@ public class GroupCoordinatorRuntimeMetricsTest {
             metrics.metricName("event-queue-size", METRICS_GROUP),
             metrics.metricName("partition-load-time-max", METRICS_GROUP),
             metrics.metricName("partition-load-time-avg", METRICS_GROUP),
-            metrics.metricName("thread-idle-ratio", METRICS_GROUP),
-            metrics.metricName("thread-idle-time-ms-total", METRICS_GROUP)
+            metrics.metricName("thread-idle-ratio-avg", METRICS_GROUP)
         ));
 
         try (GroupCoordinatorRuntimeMetrics runtimeMetrics = new GroupCoordinatorRuntimeMetrics(metrics)) {
@@ -111,14 +110,8 @@ public class GroupCoordinatorRuntimeMetricsTest {
         IntStream.range(0, 3).forEach(i -> runtimeMetrics.recordThreadIdleTime((i + 1) * 1000L));
 
         org.apache.kafka.common.MetricName metricName = metrics.metricName(
-            "thread-idle-time-ms-total", METRICS_GROUP);
+            "thread-idle-ratio-avg", METRICS_GROUP);
         KafkaMetric metric = metrics.metrics().get(metricName);
-        assertEquals(6.0 * 1000, metric.metricValue());
-
-        metricName = metrics.metricName(
-            "thread-idle-ratio", METRICS_GROUP);
-
-        metric = metrics.metrics().get(metricName);
         assertEquals(6 / 30.0, metric.metricValue()); // 'total_ms / window_ms'
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/runtime/MultiThreadedEventProcessorTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -73,7 +73,7 @@ public class MultiThreadedEventProcessorTest {
         private final boolean block;
         private final CountDownLatch latch;
         private final CountDownLatch executed;
-        private long createdTimeMs;
+        private final long createdTimeMs;
 
         FutureEvent(
             TopicPartition key,
@@ -442,8 +442,6 @@ public class MultiThreadedEventProcessorTest {
             // e2 poll time = 500
             // e2 processing time = 5000
 
-            // e1 poll time / e1 poll time
-            verify(mockRuntimeMetrics, times(1)).recordThreadIdleRatio(1.0);
             // e1 poll time
             verify(mockRuntimeMetrics, times(1)).recordEventQueueTime(500L);
             // e1 processing time + e2 enqueue time
@@ -451,8 +449,8 @@ public class MultiThreadedEventProcessorTest {
 
             // Second event (e2)
 
-            // idle ratio = e2 poll time / (e1 poll time + e1 processing time + e2 enqueue time + e2 poll time)
-            verify(mockRuntimeMetrics, times(1)).recordThreadIdleRatio(500.0 / (500.0 + 7000.0 + 500.0));
+            // e1, e2 poll time
+            verify(mockRuntimeMetrics, times(2)).recordThreadIdleTime(500L);
             // event queue time = e2 enqueue time + e2 poll time
             verify(mockRuntimeMetrics, times(1)).recordEventQueueTime(3500L);
         }
@@ -461,26 +459,30 @@ public class MultiThreadedEventProcessorTest {
     @Test
     public void testRecordThreadIdleRatioTwoThreads() throws Exception {
         GroupCoordinatorRuntimeMetrics mockRuntimeMetrics = mock(GroupCoordinatorRuntimeMetrics.class);
+        Time time = Time.SYSTEM;
 
         try (CoordinatorEventProcessor eventProcessor = new MultiThreadedEventProcessor(
             new LogContext(),
             "event-processor-",
             2,
-            Time.SYSTEM,
+            time,
             mockRuntimeMetrics,
-            new DelayEventAccumulator(Time.SYSTEM, 100L)
+            new DelayEventAccumulator(time, 100L)
         )) {
-            List<Double> recordedRatios = new ArrayList<>();
+            List<Long> recordedIdleTimesMs = new ArrayList<>();
             AtomicInteger numEventsExecuted = new AtomicInteger(0);
-            ArgumentCaptor<Double> ratioCaptured = ArgumentCaptor.forClass(Double.class);
+            ArgumentCaptor<Long> idleTimeCaptured = ArgumentCaptor.forClass(Long.class);
             doAnswer(invocation -> {
-                double threadIdleRatio = ratioCaptured.getValue();
-                assertTrue(threadIdleRatio > 0.0);
-                synchronized (recordedRatios) {
-                    recordedRatios.add(threadIdleRatio);
+                long threadIdleTime = idleTimeCaptured.getValue();
+
+                // As each thread sleeps for 100ms before returning from take(),
+                // we know that each recorded idle time must be at least 50 (100/2)ms.
+                assertTrue(threadIdleTime >= 50);
+                synchronized (recordedIdleTimesMs) {
+                    recordedIdleTimesMs.add(threadIdleTime);
                 }
                 return null;
-            }).when(mockRuntimeMetrics).recordThreadIdleRatio(ratioCaptured.capture());
+            }).when(mockRuntimeMetrics).recordThreadIdleTime(idleTimeCaptured.capture());
 
             List<FutureEvent<Integer>> events = Arrays.asList(
                 new FutureEvent<>(new TopicPartition("foo", 0), numEventsExecuted::incrementAndGet),
@@ -489,9 +491,11 @@ public class MultiThreadedEventProcessorTest {
                 new FutureEvent<>(new TopicPartition("foo", 0), numEventsExecuted::incrementAndGet),
                 new FutureEvent<>(new TopicPartition("foo", 1), numEventsExecuted::incrementAndGet),
                 new FutureEvent<>(new TopicPartition("foo", 2), numEventsExecuted::incrementAndGet),
+                new FutureEvent<>(new TopicPartition("foo", 2), numEventsExecuted::incrementAndGet),
                 new FutureEvent<>(new TopicPartition("foo", 2), numEventsExecuted::incrementAndGet)
             );
 
+            long startMs = time.milliseconds();
             events.forEach(eventProcessor::enqueueLast);
 
             CompletableFuture.allOf(events
@@ -499,18 +503,20 @@ public class MultiThreadedEventProcessorTest {
                 .map(FutureEvent::future)
                 .toArray(CompletableFuture[]::new)
             ).get(10, TimeUnit.SECONDS);
-
             events.forEach(event -> {
                 assertTrue(event.future.isDone());
                 assertFalse(event.future.isCompletedExceptionally());
             });
 
-            assertEquals(events.size(), numEventsExecuted.get());
-            verify(mockRuntimeMetrics, times(7)).recordThreadIdleRatio(anyDouble());
+            long diff = time.milliseconds() - startMs;
 
-            assertEquals(7, recordedRatios.size());
-            double average = recordedRatios.stream().mapToDouble(Double::doubleValue).sum() / 7;
-            assertTrue(average > 0.0 && average < 1.0);
+            assertEquals(events.size(), numEventsExecuted.get());
+            verify(mockRuntimeMetrics, times(8)).recordThreadIdleTime(anyLong());
+            assertEquals(8, recordedIdleTimesMs.size());
+
+            long sum = recordedIdleTimesMs.stream().mapToLong(Long::longValue).sum();
+            double idleRatio = (double) sum / diff;
+            assertTrue(idleRatio >= 0.5 && idleRatio <= 1.0);
         }
     }
 }


### PR DESCRIPTION
This PR fixes the thread idle ratio. We take a similar approach to the kafka request handler idle ratio: https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/KafkaRequestHandler.scala#L108-L117

Instead of calculating the actual ratio per thread, we record the time each thread stays idle while waiting for a new event, divided by the number of threads as an approximation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
