### PR TITLE
KAFKA-9401: Reduce contention for Fetch requests

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -389,9 +389,17 @@ class BrokerServer(
       authorizer = config.createNewAuthorizer()
       authorizer.foreach(_.configure(config.originals))
 
-      val fetchManager = new FetchManager(Time.SYSTEM,
-        new FetchSessionCache(config.maxIncrementalFetchSessionCacheSlots,
-          KafkaServer.MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS))
+      // The FetchSessionCache is divided into config.numIoThreads shards, each responsible
+      // for sessionIds falling in [Max(1, shardNum * sessionIdRange), (shardNum + 1) * sessionIdRange)
+      val sessionIdRange = Int.MaxValue / config.numIoThreads
+      val fetchSessionCaches = Range(0, config.numIoThreads)
+        .map(shardNum => new FetchSessionCache(
+          config.maxIncrementalFetchSessionCacheSlots / config.numIoThreads,
+          KafkaServer.MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS,
+          sessionIdRange,
+          shardNum
+        ))
+      val fetchManager = new FetchManager(Time.SYSTEM, fetchSessionCaches)
 
       // Create the request processor objects.
       val raftSupport = RaftSupport(forwardingManager, metadataCache)

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -391,10 +391,10 @@ class BrokerServer(
 
       // The FetchSessionCache is divided into config.numIoThreads shards, each responsible
       // for sessionIds falling in [Max(1, shardNum * sessionIdRange), (shardNum + 1) * sessionIdRange)
-      val sessionIdRange = Int.MaxValue / config.numIoThreads
-      val fetchSessionCaches = Range(0, config.numIoThreads)
+      val sessionIdRange = Int.MaxValue / NumFetchSessionCacheShards
+      val fetchSessionCaches = (0 until NumFetchSessionCacheShards)
         .map(shardNum => new FetchSessionCache(
-          config.maxIncrementalFetchSessionCacheSlots / config.numIoThreads,
+          config.maxIncrementalFetchSessionCacheSlots / NumFetchSessionCacheShards,
           KafkaServer.MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS,
           sessionIdRange,
           shardNum

--- a/core/src/main/scala/kafka/server/KafkaBroker.scala
+++ b/core/src/main/scala/kafka/server/KafkaBroker.scala
@@ -73,6 +73,9 @@ object KafkaBroker {
 }
 
 trait KafkaBroker extends Logging {
+  // Number of shards to split FetchSessionCache into. This is to reduce contention when trying to
+  // acquire lock while handling Fetch requests.
+  val NumFetchSessionCacheShards: Int = 8
 
   def authorizer: Option[Authorizer]
   def brokerState: BrokerState

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -179,7 +179,7 @@ object KafkaConfig {
   val ControlledShutdownEnableDoc = "Enable controlled shutdown of the server."
 
   /** ********* Fetch Configuration **************/
-  val MaxIncrementalFetchSessionCacheSlotsDoc = "The maximum number of incremental fetch sessions that we will maintain."
+  val MaxIncrementalFetchSessionCacheSlotsDoc = "The maximum number of total incremental fetch sessions that we will maintain. FetchSessionCache is sharded into 8 shards and the limit is equally divided among all shards. Sessions are allocated to each shard in round-robin. Only entries within a shard are considered eligible for eviction."
   val FetchMaxBytesDoc = "The maximum number of bytes we will return for a fetch request. Must be at least 1024."
 
   /** ********* Request Limit Configuration **************/

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -543,10 +543,10 @@ class KafkaServer(
 
         // The FetchSessionCache is divided into config.numIoThreads shards, each responsible
         // for sessionIds falling in [Max(1, shardNum * sessionIdRange), (shardNum + 1) * sessionIdRange)
-        val sessionIdRange = Int.MaxValue / config.numIoThreads
-        val fetchSessionCaches = Range(0, config.numIoThreads)
+        val sessionIdRange = Int.MaxValue / NumFetchSessionCacheShards
+        val fetchSessionCaches = (0 until NumFetchSessionCacheShards)
           .map(shardNum => new FetchSessionCache(
-            config.maxIncrementalFetchSessionCacheSlots / config.numIoThreads,
+            config.maxIncrementalFetchSessionCacheSlots / NumFetchSessionCacheShards,
             KafkaServer.MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS,
             sessionIdRange,
             shardNum

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -4166,7 +4166,7 @@ class KafkaApisTest extends Logging {
     val fetchDataBuilder = Map(tp -> new FetchRequest.PartitionData(Uuid.ZERO_UUID, 0, 0, 1000,
       Optional.empty())).asJava
     val fetchMetadata = new JFetchMetadata(0, 0)
-    val fetchContext = new FullFetchContext(time, new FetchSessionCache(1000, 100),
+    val fetchContext = new FullFetchContext(time, new FetchSessionCacheShard(1000, 100),
       fetchMetadata, fetchData, false, false)
     when(fetchManager.newContext(
       any[Short],
@@ -4218,7 +4218,7 @@ class KafkaApisTest extends Logging {
     val fetchDataBuilder = Map(foo.topicPartition -> new FetchRequest.PartitionData(foo.topicId, 0, 0, 1000,
       Optional.empty())).asJava
     val fetchMetadata = new JFetchMetadata(0, 0)
-    val fetchContext = new FullFetchContext(time, new FetchSessionCache(1000, 100),
+    val fetchContext = new FullFetchContext(time, new FetchSessionCacheShard(1000, 100),
       fetchMetadata, fetchData, true, replicaId >= 0)
     // We expect to have the resolved partition, but we will simulate an unknown one with the fetchContext we return.
     when(fetchManager.newContext(
@@ -4289,7 +4289,7 @@ class KafkaApisTest extends Logging {
     val fetchDataBuilder = Map(tp -> new FetchRequest.PartitionData(topicId, 0, 0, 1000,
       Optional.empty())).asJava
     val fetchMetadata = new JFetchMetadata(0, 0)
-    val fetchContext = new FullFetchContext(time, new FetchSessionCache(1000, 100),
+    val fetchContext = new FullFetchContext(time, new FetchSessionCacheShard(1000, 100),
       fetchMetadata, fetchData, true, false)
     when(fetchManager.newContext(
       any[Short],
@@ -5532,7 +5532,7 @@ class KafkaApisTest extends Logging {
     })
 
     val fetchMetadata = new JFetchMetadata(0, 0)
-    val fetchContext = new FullFetchContext(time, new FetchSessionCache(1000, 100),
+    val fetchContext = new FullFetchContext(time, new FetchSessionCacheShard(1000, 100),
       fetchMetadata, fetchData, true, true)
     when(fetchManager.newContext(
       any[Short],


### PR DESCRIPTION
KIP-227 introduced in-memory caching of FetchSessions. Brokers with a large number of Fetch requests suffer from contention on trying to acquire a lock on FetchSessionCache.

This change aims to reduce lock contention for FetchSessionCache by sharding the cache into multiple segments, each responsible for an equal range of sessionIds. Assuming Fetch requests have a uniform distribution of sessionIds, the probability of contention on a segment is reduced by a factor of the number of segments.

We ensure backwards compatibility by ensuring total number of cache entries remain the same as configured and sessionIds are randomly allocated.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
