### PR TITLE
KAFKA-16427: KafkaConsumer#position() does not respect timeout when group protocol is CONSUMER

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -906,6 +906,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
                     return position.offset;
 
                 updateFetchPositions(timer);
+                timer.update();
             } while (timer.notExpired());
 
             throw new TimeoutException("Timeout of " + timeout.toMillis() + "ms expired before the position " +

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerCommitTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerCommitTest.scala
@@ -17,7 +17,6 @@ import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.test.MockConsumerInterceptor
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Timeout
@@ -270,19 +269,6 @@ class PlaintextConsumerCommitTest extends AbstractConsumerTest {
     consumer.seek(tp, 0)
 
     consumer.commitSync()
-  }
-
-  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
-  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
-  @Timeout(15)
-  def testPositionRespectsTimeout(quorum: String, groupProtocol: String): Unit = {
-    val topicPartition = new TopicPartition(topic, 15)
-    val consumer = createConsumer()
-    consumer.assign(List(topicPartition).asJava)
-
-    // When position() is called for a topic/partition that doesn't exist, the consumer will repeatedly update the
-    // local metadata. However, it should give up after the user-supplied timeout has past.
-    assertThrows(classOf[TimeoutException], () => consumer.position(topicPartition, Duration.ofSeconds(3)))
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)


### PR DESCRIPTION
The AsyncKafkaConsumer implementation of `position(TopicPartition, Duration)` was not updating its internal `Timer`, causing it to execute the loop forever. Adding a call to update the `Timer` at the bottom of the loop fixes the issue.

An integration test was added to catch this case; it fails without the newly added call to `Timer.update(long)`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
