### PR TITLE
MINOR: ConsumerGroup#getOrMaybeCreateMember should not add the member to the group

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -328,7 +328,8 @@ public class ConsumerGroup implements Group {
     }
 
     /**
-     * Gets or creates a member.
+     * Gets or creates a new member but without adding it to the group. Adding a member
+     * is done via the {@link ConsumerGroup#updateMember(ConsumerGroupMember)} method.
      *
      * @param memberId          The member id.
      * @param createIfNotExists Booleans indicating whether the member must be
@@ -347,9 +348,7 @@ public class ConsumerGroup implements Group {
                     memberId, groupId));
             }
             member = new ConsumerGroupMember.Builder(memberId).build();
-            members.put(memberId, member);
         }
-
         return member;
     }
 
@@ -366,7 +365,7 @@ public class ConsumerGroup implements Group {
     }
 
     /**
-     * Updates the member.
+     * Add or updates the member.
      *
      * @param newMember The new member state.
      */

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/ConsumerGroup.java
@@ -342,14 +342,15 @@ public class ConsumerGroup implements Group {
         boolean createIfNotExists
     ) {
         ConsumerGroupMember member = members.get(memberId);
-        if (member == null) {
-            if (!createIfNotExists) {
-                throw new UnknownMemberIdException(String.format("Member %s is not a member of group %s.",
-                    memberId, groupId));
-            }
-            member = new ConsumerGroupMember.Builder(memberId).build();
+        if (member != null) return member;
+
+        if (!createIfNotExists) {
+            throw new UnknownMemberIdException(
+                String.format("Member %s is not a member of group %s.", memberId, groupId)
+            );
         }
-        return member;
+
+        return new ConsumerGroupMember.Builder(memberId).build();
     }
 
     /**
@@ -365,7 +366,7 @@ public class ConsumerGroup implements Group {
     }
 
     /**
-     * Add or updates the member.
+     * Adds or updates the member.
      *
      * @param newMember The new member state.
      */

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilder.java
@@ -252,14 +252,16 @@ public class TargetAssignmentBuilder {
             if (updatedMemberOrNull == null) {
                 memberSpecs.remove(memberId);
             } else {
-                ConsumerGroupMember member = members.get(memberId);
-                Assignment assignment;
+                Assignment assignment = targetAssignment.getOrDefault(memberId, Assignment.EMPTY);
+
                 // A new static member joins and needs to replace an existing departed one.
-                if (member == null && staticMembers.containsKey(updatedMemberOrNull.instanceId())) {
-                    assignment = targetAssignment.getOrDefault(staticMembers.get(updatedMemberOrNull.instanceId()), Assignment.EMPTY);
-                } else {
-                    assignment = targetAssignment.getOrDefault(memberId, Assignment.EMPTY);
+                if (updatedMemberOrNull.instanceId() != null) {
+                    String previousMemberId = staticMembers.get(updatedMemberOrNull.instanceId());
+                    if (previousMemberId != null) {
+                        assignment = targetAssignment.getOrDefault(updatedMemberOrNull.instanceId(), Assignment.EMPTY);
+                    }
                 }
+
                 memberSpecs.put(memberId, createAssignmentMemberSpec(
                     updatedMemberOrNull,
                     assignment,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilder.java
@@ -257,8 +257,8 @@ public class TargetAssignmentBuilder {
                 // A new static member joins and needs to replace an existing departed one.
                 if (updatedMemberOrNull.instanceId() != null) {
                     String previousMemberId = staticMembers.get(updatedMemberOrNull.instanceId());
-                    if (previousMemberId != null) {
-                        assignment = targetAssignment.getOrDefault(updatedMemberOrNull.instanceId(), Assignment.EMPTY);
+                    if (previousMemberId != null && !previousMemberId.equals(memberId)) {
+                        assignment = targetAssignment.getOrDefault(previousMemberId, Assignment.EMPTY);
                     }
                 }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetMetadataManagerTest.java
@@ -2125,7 +2125,6 @@ public class OffsetMetadataManagerTest {
         // the transaction is committed.
         context.commitOffset(10L, "group", "bar", 1, 211L, 1, context.time.milliseconds());
 
-
         // Fetching offsets with "require stable" (Long.MAX_VALUE) should return the committed offset for
         // foo-0 and the UNSTABLE_OFFSET_COMMIT error for foo-1 and bar-0.
         assertEquals(Arrays.asList(
@@ -2184,7 +2183,7 @@ public class OffsetMetadataManagerTest {
         // Create consumer group.
         ConsumerGroup group = context.groupMetadataManager.getOrMaybeCreatePersistedConsumerGroup("group", true);
         // Create member.
-        group.getOrMaybeCreateMember("member", true);
+        group.updateMember(new ConsumerGroupMember.Builder("member").build());
         // Commit offset.
         context.commitOffset("group", "foo", 0, 100L, 1);
 
@@ -2277,7 +2276,7 @@ public class OffsetMetadataManagerTest {
     public void testConsumerGroupOffsetFetchWithStaleMemberEpoch() {
         OffsetMetadataManagerTestContext context = new OffsetMetadataManagerTestContext.Builder().build();
         ConsumerGroup group = context.groupMetadataManager.getOrMaybeCreatePersistedConsumerGroup("group", true);
-        group.getOrMaybeCreateMember("member", true);
+        group.updateMember(new ConsumerGroupMember.Builder("member").build());
 
         // Fetch offsets case.
         List<OffsetFetchRequestData.OffsetFetchRequestTopics> topics = Collections.singletonList(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/consumer/TargetAssignmentBuilderTest.java
@@ -143,17 +143,7 @@ public class TargetAssignmentBuilderTest {
         public void removeMemberSubscription(
             String memberId
         ) {
-            removeMemberSubscription(memberId, null);
-        }
-
-        public void removeMemberSubscription(
-            String memberId,
-            String instanceId
-        ) {
             this.updatedMembers.put(memberId, null);
-            if (instanceId != null) {
-                this.staticMembers.remove(instanceId);
-            }
         }
 
         public void prepareMemberAssignment(
@@ -182,14 +172,16 @@ public class TargetAssignmentBuilderTest {
                 if (updatedMemberOrNull == null) {
                     memberSpecs.remove(memberId);
                 } else {
-                    ConsumerGroupMember member = members.get(memberId);
-                    Assignment assignment;
+                    Assignment assignment = targetAssignment.getOrDefault(memberId, Assignment.EMPTY);
+
                     // A new static member joins and needs to replace an existing departed one.
-                    if (member == null && staticMembers.containsKey(updatedMemberOrNull.instanceId())) {
-                        assignment = targetAssignment.getOrDefault(staticMembers.get(updatedMemberOrNull.instanceId()), Assignment.EMPTY);
-                    } else {
-                        assignment = targetAssignment.getOrDefault(memberId, Assignment.EMPTY);
+                    if (updatedMemberOrNull.instanceId() != null) {
+                        String previousMemberId = staticMembers.get(updatedMemberOrNull.instanceId());
+                        if (previousMemberId != null && !previousMemberId.equals(memberId)) {
+                            assignment = targetAssignment.getOrDefault(previousMemberId, Assignment.EMPTY);
+                        }
                     }
+
                     memberSpecs.put(memberId, createAssignmentMemberSpec(
                         updatedMemberOrNull,
                         assignment,
@@ -213,7 +205,6 @@ public class TargetAssignmentBuilderTest {
             // to ensure that the input was correct.
             when(assignor.assign(any(), any()))
                 .thenReturn(new GroupAssignment(memberAssignments));
-
 
             // Create and populate the assignment builder.
             TargetAssignmentBuilder builder = new TargetAssignmentBuilder(groupId, groupEpoch, assignor)
@@ -722,7 +713,7 @@ public class TargetAssignmentBuilderTest {
     }
 
     @Test
-    public void testStaticMemberReplace() {
+    public void testReplaceStaticMember() {
         TargetAssignmentBuilderTestContext context = new TargetAssignmentBuilderTestContext(
             "my-group",
             20
@@ -731,26 +722,26 @@ public class TargetAssignmentBuilderTest {
         Uuid fooTopicId = context.addTopicMetadata("foo", 6, Collections.emptyMap());
         Uuid barTopicId = context.addTopicMetadata("bar", 6, Collections.emptyMap());
 
-        context.addGroupMember("member-1", "member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+        context.addGroupMember("member-1", "instance-member-1", Arrays.asList("foo", "bar", "zar"), mkAssignment(
             mkTopicAssignment(fooTopicId, 1, 2),
             mkTopicAssignment(barTopicId, 1, 2)
         ));
 
-        context.addGroupMember("member-2", "member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+        context.addGroupMember("member-2", "instance-member-2", Arrays.asList("foo", "bar", "zar"), mkAssignment(
             mkTopicAssignment(fooTopicId, 3, 4),
             mkTopicAssignment(barTopicId, 3, 4)
         ));
 
-        context.addGroupMember("member-3", "member-3", Arrays.asList("foo", "bar", "zar"), mkAssignment(
+        context.addGroupMember("member-3", "instance-member-3", Arrays.asList("foo", "bar", "zar"), mkAssignment(
             mkTopicAssignment(fooTopicId, 5, 6),
             mkTopicAssignment(barTopicId, 5, 6)
         ));
 
         // Static member 3 leaves
-        context.removeMemberSubscription("member-3", "member-3");
+        context.removeMemberSubscription("member-3");
 
         // Another static member joins with the same instance id as the departed one
-        context.updateMemberSubscription("member-3-a", Arrays.asList("foo", "bar", "zar"), Optional.of("member-3"), Optional.empty());
+        context.updateMemberSubscription("member-3-a", Arrays.asList("foo", "bar", "zar"), Optional.of("instance-member-3"), Optional.empty());
 
         context.prepareMemberAssignment("member-1", mkAssignment(
             mkTopicAssignment(fooTopicId, 1, 2),


### PR DESCRIPTION
While reviewing https://github.com/apache/kafka/pull/15785, I noticed that the member is added to the group directly in `ConsumerGroup#getOrMaybeCreateMember`. This does not hurt but confuses people because the state must not be mutated at this point. It should only be mutated when records are replayed. I think that it is better to remove it in order to make it clear.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
