### PR TITLE
KAFKA-10199: Accept only one task per exception in queue for failed tasks

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
@@ -21,24 +21,23 @@ import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.streams.processor.TaskId;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
 public interface StateUpdater {
 
-    class ExceptionAndTasks {
-        private final Set<Task> tasks;
+    class ExceptionAndTask {
+        private final Task task;
         private final RuntimeException exception;
 
-        public ExceptionAndTasks(final Set<Task> tasks, final RuntimeException exception) {
-            this.tasks = Objects.requireNonNull(tasks);
+        public ExceptionAndTask(final RuntimeException exception, final Task task) {
             this.exception = Objects.requireNonNull(exception);
+            this.task = Objects.requireNonNull(task);
         }
 
-        public Set<Task> getTasks() {
-            return Collections.unmodifiableSet(tasks);
+        public Task task() {
+            return task;
         }
 
         public RuntimeException exception() {
@@ -48,14 +47,22 @@ public interface StateUpdater {
         @Override
         public boolean equals(final Object o) {
             if (this == o) return true;
-            if (!(o instanceof ExceptionAndTasks)) return false;
-            final ExceptionAndTasks that = (ExceptionAndTasks) o;
-            return tasks.equals(that.tasks) && exception.equals(that.exception);
+            if (!(o instanceof ExceptionAndTask)) return false;
+            final ExceptionAndTask that = (ExceptionAndTask) o;
+            return task.id().equals(that.task.id()) && exception.equals(that.exception);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(tasks, exception);
+            return Objects.hash(task, exception);
+        }
+
+        @Override
+        public String toString() {
+            return "ExceptionAndTask{" +
+                "task=" + task.id() +
+                ", exception=" + exception +
+                '}';
         }
     }
 
@@ -142,7 +149,7 @@ public interface StateUpdater {
      *
      * @return list of failed tasks and the corresponding exceptions
      */
-    List<ExceptionAndTasks> drainExceptionsAndFailedTasks();
+    List<ExceptionAndTask> drainExceptionsAndFailedTasks();
 
     /**
      * Checks if the state updater has any failed tasks that should be returned to the StreamThread

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -26,7 +26,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
 import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.processor.internals.StateUpdater.ExceptionAndTasks;
+import org.apache.kafka.streams.processor.internals.StateUpdater.ExceptionAndTask;
 import org.apache.kafka.streams.processor.internals.Task.State;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
@@ -458,7 +458,7 @@ class DefaultStateUpdaterTest {
         stateUpdater.add(task);
         verifyRestoredActiveTasks();
         verifyUpdatingTasks();
-        verifyExceptionsAndFailedTasks(new ExceptionAndTasks(mkSet(task), taskCorruptedException));
+        verifyExceptionsAndFailedTasks(new ExceptionAndTask(taskCorruptedException, task));
         verifyRemovedTasks();
         verifyPausedTasks();
 
@@ -666,9 +666,9 @@ class DefaultStateUpdaterTest {
         stateUpdater.add(activeTask2);
         stateUpdater.add(standbyTask);
 
-        final ExceptionAndTasks expectedExceptionAndTasks =
-            new ExceptionAndTasks(mkSet(activeTask1, activeTask2), taskCorruptedException);
-        verifyExceptionsAndFailedTasks(expectedExceptionAndTasks);
+        final ExceptionAndTask expectedExceptionAndTask1 = new ExceptionAndTask(taskCorruptedException, activeTask1);
+        final ExceptionAndTask expectedExceptionAndTask2 = new ExceptionAndTask(taskCorruptedException, activeTask2);
+        verifyExceptionsAndFailedTasks(expectedExceptionAndTask1, expectedExceptionAndTask2);
         final InOrder orderVerifier = inOrder(changelogReader);
         orderVerifier.verify(changelogReader, atLeast(1)).enforceRestoreActive();
         orderVerifier.verify(changelogReader).transitToUpdateStandby();
@@ -683,7 +683,7 @@ class DefaultStateUpdaterTest {
                 mkEntry(task2.id(), task2)
         );
         final TaskCorruptedException taskCorruptedException = new TaskCorruptedException(mkSet(task1.id()));
-        final ExceptionAndTasks expectedExceptionAndTasks = new ExceptionAndTasks(mkSet(task1), taskCorruptedException);
+        final ExceptionAndTask expectedExceptionAndTasks = new ExceptionAndTask(taskCorruptedException, task1);
         when(changelogReader.allChangelogsCompleted()).thenReturn(false);
         doThrow(taskCorruptedException).doReturn(0L).when(changelogReader).restore(updatingTasks);
 
@@ -849,7 +849,7 @@ class DefaultStateUpdaterTest {
 
         stateUpdater.add(task);
         stateUpdater.add(controlTask);
-        final ExceptionAndTasks expectedExceptionAndTasks = new ExceptionAndTasks(mkSet(task), streamsException);
+        final ExceptionAndTask expectedExceptionAndTasks = new ExceptionAndTask(streamsException, task);
         verifyExceptionsAndFailedTasks(expectedExceptionAndTasks);
 
         stateUpdater.remove(task.id());
@@ -991,7 +991,7 @@ class DefaultStateUpdaterTest {
 
         stateUpdater.add(task);
         stateUpdater.add(controlTask);
-        final ExceptionAndTasks expectedExceptionAndTasks = new ExceptionAndTasks(mkSet(task), streamsException);
+        final ExceptionAndTask expectedExceptionAndTasks = new ExceptionAndTask(streamsException, task);
         verifyExceptionsAndFailedTasks(expectedExceptionAndTasks);
         verifyUpdatingTasks(controlTask);
 
@@ -1172,7 +1172,7 @@ class DefaultStateUpdaterTest {
 
         stateUpdater.add(task);
         stateUpdater.add(controlTask);
-        final ExceptionAndTasks expectedExceptionAndTasks = new ExceptionAndTasks(mkSet(task), streamsException);
+        final ExceptionAndTask expectedExceptionAndTasks = new ExceptionAndTask(streamsException, task);
         verifyExceptionsAndFailedTasks(expectedExceptionAndTasks);
         verifyUpdatingTasks(controlTask);
 
@@ -1223,8 +1223,9 @@ class DefaultStateUpdaterTest {
         stateUpdater.add(task1);
         stateUpdater.add(task2);
 
-        final ExceptionAndTasks expectedExceptionAndTasks = new ExceptionAndTasks(mkSet(task1, task2), streamsException);
-        verifyExceptionsAndFailedTasks(expectedExceptionAndTasks);
+        final ExceptionAndTask expectedExceptionAndTask1 = new ExceptionAndTask(streamsException, task1);
+        final ExceptionAndTask expectedExceptionAndTask2 = new ExceptionAndTask(streamsException, task2);
+        verifyExceptionsAndFailedTasks(expectedExceptionAndTask1, expectedExceptionAndTask2);
         verifyRemovedTasks();
         verifyPausedTasks();
         verifyUpdatingTasks();
@@ -1260,8 +1261,8 @@ class DefaultStateUpdaterTest {
         stateUpdater.add(task2);
         stateUpdater.add(task3);
 
-        final ExceptionAndTasks expectedExceptionAndTasks1 = new ExceptionAndTasks(mkSet(task1), streamsException1);
-        final ExceptionAndTasks expectedExceptionAndTasks2 = new ExceptionAndTasks(mkSet(task3), streamsException2);
+        final ExceptionAndTask expectedExceptionAndTasks1 = new ExceptionAndTask(streamsException1, task1);
+        final ExceptionAndTask expectedExceptionAndTasks2 = new ExceptionAndTask(streamsException2, task3);
         verifyExceptionsAndFailedTasks(expectedExceptionAndTasks1, expectedExceptionAndTasks2);
         verifyUpdatingTasks(task2);
         verifyRestoredActiveTasks();
@@ -1288,8 +1289,9 @@ class DefaultStateUpdaterTest {
         stateUpdater.add(task2);
         stateUpdater.add(task3);
 
-        final ExceptionAndTasks expectedExceptionAndTasks = new ExceptionAndTasks(mkSet(task1, task2), taskCorruptedException);
-        verifyExceptionsAndFailedTasks(expectedExceptionAndTasks);
+        final ExceptionAndTask expectedExceptionAndTask1 = new ExceptionAndTask(taskCorruptedException, task1);
+        final ExceptionAndTask expectedExceptionAndTask2 = new ExceptionAndTask(taskCorruptedException, task2);
+        verifyExceptionsAndFailedTasks(expectedExceptionAndTask1, expectedExceptionAndTask2);
         verifyUpdatingTasks(task3);
         verifyRestoredActiveTasks();
         verifyRemovedTasks();
@@ -1313,8 +1315,9 @@ class DefaultStateUpdaterTest {
         stateUpdater.add(task1);
         stateUpdater.add(task2);
 
-        final ExceptionAndTasks expectedExceptionAndTasks = new ExceptionAndTasks(mkSet(task1, task2), illegalStateException);
-        verifyExceptionsAndFailedTasks(expectedExceptionAndTasks);
+        final ExceptionAndTask expectedExceptionAndTask1 = new ExceptionAndTask(illegalStateException, task1);
+        final ExceptionAndTask expectedExceptionAndTask2 = new ExceptionAndTask(illegalStateException, task2);
+        verifyExceptionsAndFailedTasks(expectedExceptionAndTask1, expectedExceptionAndTask2);
         verifyUpdatingTasks();
         verifyRestoredActiveTasks();
         verifyRemovedTasks();
@@ -1359,16 +1362,16 @@ class DefaultStateUpdaterTest {
 
         stateUpdater.add(task1);
 
-        final ExceptionAndTasks expectedExceptionAndTasks1 = new ExceptionAndTasks(mkSet(task1), streamsException1);
+        final ExceptionAndTask expectedExceptionAndTasks1 = new ExceptionAndTask(streamsException1, task1);
         verifyDrainingExceptionsAndFailedTasks(expectedExceptionAndTasks1);
 
         stateUpdater.add(task2);
         stateUpdater.add(task3);
         stateUpdater.add(task4);
 
-        final ExceptionAndTasks expectedExceptionAndTasks2 = new ExceptionAndTasks(mkSet(task2), streamsException2);
-        final ExceptionAndTasks expectedExceptionAndTasks3 = new ExceptionAndTasks(mkSet(task3), streamsException3);
-        final ExceptionAndTasks expectedExceptionAndTasks4 = new ExceptionAndTasks(mkSet(task4), streamsException4);
+        final ExceptionAndTask expectedExceptionAndTasks2 = new ExceptionAndTask(streamsException2, task2);
+        final ExceptionAndTask expectedExceptionAndTasks3 = new ExceptionAndTask(streamsException3, task3);
+        final ExceptionAndTask expectedExceptionAndTasks4 = new ExceptionAndTask(streamsException4, task4);
         verifyDrainingExceptionsAndFailedTasks(expectedExceptionAndTasks2, expectedExceptionAndTasks3, expectedExceptionAndTasks4);
     }
 
@@ -1511,10 +1514,10 @@ class DefaultStateUpdaterTest {
         stateUpdater.add(standbyTask1);
         stateUpdater.add(activeTask1);
         stateUpdater.add(standbyTask2);
-        final ExceptionAndTasks expectedExceptionAndTasks1 =
-            new ExceptionAndTasks(mkSet(standbyTask1, standbyTask2), taskCorruptedException);
-        final ExceptionAndTasks expectedExceptionAndTasks2 = new ExceptionAndTasks(mkSet(activeTask1), streamsException);
-        verifyExceptionsAndFailedTasks(expectedExceptionAndTasks1, expectedExceptionAndTasks2);
+        final ExceptionAndTask expectedExceptionAndTasks1 = new ExceptionAndTask(taskCorruptedException, standbyTask1);
+        final ExceptionAndTask expectedExceptionAndTasks2 = new ExceptionAndTask(taskCorruptedException, standbyTask2);
+        final ExceptionAndTask expectedExceptionAndTasks3 = new ExceptionAndTask(streamsException, activeTask1);
+        verifyExceptionsAndFailedTasks(expectedExceptionAndTasks1, expectedExceptionAndTasks2, expectedExceptionAndTasks3);
 
         verifyGetTasks(mkSet(activeTask1), mkSet(standbyTask1, standbyTask2));
 
@@ -1838,9 +1841,9 @@ class DefaultStateUpdaterTest {
         assertTrue(stateUpdater.drainRemovedTasks().isEmpty());
     }
 
-    private void verifyExceptionsAndFailedTasks(final ExceptionAndTasks... exceptionsAndTasks) throws Exception {
-        final List<ExceptionAndTasks> expectedExceptionAndTasks = Arrays.asList(exceptionsAndTasks);
-        final Set<ExceptionAndTasks> failedTasks = new HashSet<>();
+    private void verifyExceptionsAndFailedTasks(final ExceptionAndTask... exceptionsAndTasks) throws Exception {
+        final List<ExceptionAndTask> expectedExceptionAndTasks = Arrays.asList(exceptionsAndTasks);
+        final Set<ExceptionAndTask> failedTasks = new HashSet<>();
         waitForCondition(
             () -> {
                 failedTasks.addAll(stateUpdater.getExceptionsAndFailedTasks());
@@ -1856,27 +1859,27 @@ class DefaultStateUpdaterTest {
         final List<Task> expectedFailedTasks = Arrays.asList(tasks);
         final Set<Task> failedTasks = new HashSet<>();
         waitForCondition(
-                () -> {
-                    for (final ExceptionAndTasks exceptionsAndTasks : stateUpdater.getExceptionsAndFailedTasks()) {
-                        if (clazz.isInstance(exceptionsAndTasks.exception())) {
-                            failedTasks.addAll(exceptionsAndTasks.getTasks());
-                        }
+            () -> {
+                for (final ExceptionAndTask exceptionAndTask : stateUpdater.getExceptionsAndFailedTasks()) {
+                    if (clazz.isInstance(exceptionAndTask.exception())) {
+                        failedTasks.add(exceptionAndTask.task());
                     }
-                    return failedTasks.containsAll(expectedFailedTasks)
-                            && failedTasks.size() == expectedFailedTasks.size();
-                },
-                VERIFICATION_TIMEOUT,
-                "Did not get all exceptions and failed tasks within the given timeout!"
+                }
+                return failedTasks.containsAll(expectedFailedTasks)
+                    && failedTasks.size() == expectedFailedTasks.size();
+            },
+            VERIFICATION_TIMEOUT,
+            "Did not get all exceptions and failed tasks within the given timeout!"
         );
     }
 
-    private void verifyDrainingExceptionsAndFailedTasks(final ExceptionAndTasks... exceptionsAndTasks) throws Exception {
-        final List<ExceptionAndTasks> expectedExceptionAndTasks = Arrays.asList(exceptionsAndTasks);
-        final List<ExceptionAndTasks> failedTasks = new ArrayList<>();
+    private void verifyDrainingExceptionsAndFailedTasks(final ExceptionAndTask... exceptionsAndTasks) throws Exception {
+        final List<ExceptionAndTask> expectedExceptionAndTasks = Arrays.asList(exceptionsAndTasks);
+        final List<ExceptionAndTask> failedTasks = new ArrayList<>();
         waitForCondition(
             () -> {
                 if (stateUpdater.hasExceptionsAndFailedTasks()) {
-                    final List<ExceptionAndTasks> exceptionAndTasks = stateUpdater.drainExceptionsAndFailedTasks();
+                    final List<ExceptionAndTask> exceptionAndTasks = stateUpdater.drainExceptionsAndFailedTasks();
                     assertFalse(exceptionAndTasks.isEmpty());
                     failedTasks.addAll(exceptionAndTasks);
                 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -47,7 +47,7 @@ import org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.StateDirectory.TaskDirectory;
-import org.apache.kafka.streams.processor.internals.StateUpdater.ExceptionAndTasks;
+import org.apache.kafka.streams.processor.internals.StateUpdater.ExceptionAndTask;
 import org.apache.kafka.streams.processor.internals.Task.State;
 import org.apache.kafka.streams.processor.internals.tasks.DefaultTaskManager;
 import org.apache.kafka.streams.processor.internals.testutil.DummyStreamsConfig;
@@ -1790,10 +1790,7 @@ public class TaskManagerTest {
             .inState(State.RESTORING)
             .withInputPartitions(taskId00Partitions).build();
         final StreamsException exception = new StreamsException("boom!");
-        final StateUpdater.ExceptionAndTasks exceptionAndTasks = new StateUpdater.ExceptionAndTasks(
-            Collections.singleton(statefulTask),
-            exception
-        );
+        final ExceptionAndTask exceptionAndTasks = new ExceptionAndTask(exception, statefulTask);
         when(stateUpdater.hasExceptionsAndFailedTasks()).thenReturn(true);
         when(stateUpdater.drainExceptionsAndFailedTasks()).thenReturn(Collections.singletonList(exceptionAndTasks));
 
@@ -1815,10 +1812,7 @@ public class TaskManagerTest {
             .inState(State.RESTORING)
             .withInputPartitions(taskId00Partitions).build();
         final RuntimeException exception = new RuntimeException("boom!");
-        final StateUpdater.ExceptionAndTasks exceptionAndTasks = new StateUpdater.ExceptionAndTasks(
-            Collections.singleton(statefulTask),
-            exception
-        );
+        final ExceptionAndTask exceptionAndTasks = new ExceptionAndTask(exception, statefulTask);
         when(stateUpdater.hasExceptionsAndFailedTasks()).thenReturn(true);
         when(stateUpdater.drainExceptionsAndFailedTasks()).thenReturn(Collections.singletonList(exceptionAndTasks));
 
@@ -1843,13 +1837,13 @@ public class TaskManagerTest {
         final StreamTask statefulTask1 = statefulTask(taskId01, taskId01ChangelogPartitions)
             .inState(State.RESTORING)
             .withInputPartitions(taskId01Partitions).build();
-        final StateUpdater.ExceptionAndTasks exceptionAndTasks0 = new StateUpdater.ExceptionAndTasks(
-            Collections.singleton(statefulTask0),
-            new TaskCorruptedException(Collections.singleton(taskId00))
+        final ExceptionAndTask exceptionAndTasks0 = new ExceptionAndTask(
+            new TaskCorruptedException(Collections.singleton(taskId00)),
+            statefulTask0
         );
-        final StateUpdater.ExceptionAndTasks exceptionAndTasks1 = new StateUpdater.ExceptionAndTasks(
-            Collections.singleton(statefulTask1),
-            new TaskCorruptedException(Collections.singleton(taskId01))
+        final ExceptionAndTask exceptionAndTasks1 = new ExceptionAndTask(
+            new TaskCorruptedException(Collections.singleton(taskId01)),
+            statefulTask1
         );
         when(stateUpdater.hasExceptionsAndFailedTasks()).thenReturn(true);
         when(stateUpdater.drainExceptionsAndFailedTasks()).thenReturn(Arrays.asList(exceptionAndTasks0, exceptionAndTasks1));
@@ -3749,8 +3743,8 @@ public class TaskManagerTest {
             .inState(State.RUNNING).build();
         when(stateUpdater.drainExceptionsAndFailedTasks())
             .thenReturn(Arrays.asList(
-                new ExceptionAndTasks(mkSet(failedStatefulTask), new RuntimeException()),
-                new ExceptionAndTasks(mkSet(failedStandbyTask), new RuntimeException()))
+                new ExceptionAndTask(new RuntimeException(), failedStatefulTask),
+                new ExceptionAndTask(new RuntimeException(), failedStandbyTask))
             );
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, true);
 


### PR DESCRIPTION
Currently, the state updater writes multiple tasks per exception in the output queue for failed tasks. To add the functionality to remove tasks synchronously from the state updater, it is simpler that each element of the output queue for failed tasks holds one single task.

This commit refactors the class that holds exceptions and failed tasks in the state updater -- i.e., ExceptionAndTasks -- to just hold one single task.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
