### PR TITLE
MINOR: log newly created processId

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -183,7 +183,9 @@ public class StateDirectory implements AutoCloseable {
 
     public UUID initializeProcessId() {
         if (!hasPersistentStores) {
-            return UUID.randomUUID();
+            final UUID processId = UUID.randomUUID();
+            log.info("Created new processId: {}", processId);
+            return processId;
         }
 
         if (!lockStateDirectory()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -184,7 +184,7 @@ public class StateDirectory implements AutoCloseable {
     public UUID initializeProcessId() {
         if (!hasPersistentStores) {
             final UUID processId = UUID.randomUUID();
-            log.info("Created new processId: {}", processId);
+            log.info("Created new process id: {}", processId);
             return processId;
         }
 


### PR DESCRIPTION
We should always log the processId -- not just for the case of existing persistent storage.