### PR TITLE
MINOR: Remove `ConsumerGroupPartitionMetadataValue.Epoch` field

### DIFF
--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupPartitionMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupPartitionMetadataValue.json
@@ -20,8 +20,6 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "Epoch", "versions": "0+", "type": "int32",
-      "about": "The group epoch." },
     { "name": "Topics", "versions": "0+", "type": "[]TopicMetadata",
       "about": "The list of topic metadata.", "fields": [
       { "name": "TopicId", "versions": "0+", "type": "uuid",


### PR DESCRIPTION
`ConsumerGroupPartitionMetadataValue.Epoch` is not used anywhere so we can remove it. Note that we already have non-backward compatible changes lined up for 3.8 so it is fine to do it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
