### PR TITLE
KAFKA-16574: The metrics of LogCleaner disappear after reconfiguration

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -131,7 +131,7 @@ class LogCleaner(initialConfig: CleanerConfig,
   /**
    * Activate metrics
    */
-  private def activateMetrics():Unit = {
+  private def activateMetrics(): Unit = {
     /* a metric to track the maximum utilization of any thread's buffer in the last cleaning */
     metricsGroup.newGauge(MaxBufferUtilizationPercentMetricName,
       () => maxOverCleanerThreads(_.lastStats.bufferUtilization) * 100)
@@ -164,7 +164,7 @@ class LogCleaner(initialConfig: CleanerConfig,
       cleaners += cleaner
       cleaner.start()
     }
-    activateMetrics();
+    activateMetrics()
   }
 
   /**

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -170,13 +170,21 @@ class LogCleaner(initialConfig: CleanerConfig,
   /**
    * Stop the background cleaner threads
    */
-  def shutdown(): Unit = {
+  private[this] def shutdownCleaners(): Unit = {
     info("Shutting down the log cleaner.")
+    cleaners.foreach(_.shutdown())
+    cleaners.clear()
+  }
+
+  /**
+   * Stop the background cleaner threads
+   */
+  def shutdown(): Unit = {
     try {
-      cleaners.foreach(_.shutdown())
-      cleaners.clear()
+      shutdownCleaners()
     } finally {
       removeMetrics()
+      info("Shutting down the log cleaner.")
     }
   }
 
@@ -230,7 +238,7 @@ class LogCleaner(initialConfig: CleanerConfig,
       throttler.updateDesiredRatePerSec(maxIoBytesPerSecond)
     }
 
-    shutdown()
+    shutdownCleaners()
     startup()
   }
 

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -178,7 +178,6 @@ class LogCleaner(initialConfig: CleanerConfig,
       shutdownCleaners()
     } finally {
       removeMetrics()
-      info("Shutting down the log cleaner.")
     }
   }
 
@@ -231,7 +230,7 @@ class LogCleaner(initialConfig: CleanerConfig,
       info(s"Updating logCleanerIoMaxBytesPerSecond: $maxIoBytesPerSecond")
       throttler.updateDesiredRatePerSec(maxIoBytesPerSecond)
     }
-
+    /* call shutdownCleaners() instead of shutdown to avoid unnecessary deletion of metrics */
     shutdownCleaners()
     startup()
   }

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -101,7 +101,6 @@ class LogCleaner(initialConfig: CleanerConfig,
                  time: Time = Time.SYSTEM) extends Logging with BrokerReconfigurable {
   // Visible for test.
   private[log] val metricsGroup = new KafkaMetricsGroup(this.getClass)
-  activateMetrics()
 
   /* Log cleaner configuration which may be dynamically updated */
   @volatile private var config = initialConfig

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -126,33 +126,28 @@ class LogCleaner(initialConfig: CleanerConfig,
   private def maxOverCleanerThreads(f: CleanerThread => Double): Int =
     cleaners.foldLeft(0.0d)((max: Double, thread: CleanerThread) => math.max(max, f(thread))).toInt
 
+  /* a metric to track the maximum utilization of any thread's buffer in the last cleaning */
+  metricsGroup.newGauge(MaxBufferUtilizationPercentMetricName,
+    () => maxOverCleanerThreads(_.lastStats.bufferUtilization) * 100)
+
+  /* a metric to track the recopy rate of each thread's last cleaning */
+  metricsGroup.newGauge(CleanerRecopyPercentMetricName, () => {
+    val stats = cleaners.map(_.lastStats)
+    val recopyRate = stats.iterator.map(_.bytesWritten).sum.toDouble / math.max(stats.iterator.map(_.bytesRead).sum, 1)
+    (100 * recopyRate).toInt
+  })
+
+  /* a metric to track the maximum cleaning time for the last cleaning from each thread */
+  metricsGroup.newGauge(MaxCleanTimeMetricName, () => maxOverCleanerThreads(_.lastStats.elapsedSecs))
+
+  // a metric to track delay between the time when a log is required to be compacted
+  // as determined by max compaction lag and the time of last cleaner run.
+  metricsGroup.newGauge(MaxCompactionDelayMetricsName,
+    () => maxOverCleanerThreads(_.lastPreCleanStats.maxCompactionDelayMs.toDouble) / 1000)
+
+  metricsGroup.newGauge(DeadThreadCountMetricName, () => deadThreadCount)
+
   private[log] def deadThreadCount: Int = cleaners.count(_.isThreadFailed)
-
-  /**
-   * Activate metrics
-   */
-  private def activateMetrics(): Unit = {
-    /* a metric to track the maximum utilization of any thread's buffer in the last cleaning */
-    metricsGroup.newGauge(MaxBufferUtilizationPercentMetricName,
-      () => maxOverCleanerThreads(_.lastStats.bufferUtilization) * 100)
-
-    /* a metric to track the recopy rate of each thread's last cleaning */
-    metricsGroup.newGauge(CleanerRecopyPercentMetricName, () => {
-      val stats = cleaners.map(_.lastStats)
-      val recopyRate = stats.iterator.map(_.bytesWritten).sum.toDouble / math.max(stats.iterator.map(_.bytesRead).sum, 1)
-      (100 * recopyRate).toInt
-    })
-
-    /* a metric to track the maximum cleaning time for the last cleaning from each thread */
-    metricsGroup.newGauge(MaxCleanTimeMetricName, () => maxOverCleanerThreads(_.lastStats.elapsedSecs))
-
-    // a metric to track delay between the time when a log is required to be compacted
-    // as determined by max compaction lag and the time of last cleaner run.
-    metricsGroup.newGauge(MaxCompactionDelayMetricsName,
-      () => maxOverCleanerThreads(_.lastPreCleanStats.maxCompactionDelayMs.toDouble) / 1000)
-
-    metricsGroup.newGauge(DeadThreadCountMetricName, () => deadThreadCount)
-  }
 
   /**
    * Start the background cleaner threads
@@ -164,7 +159,6 @@ class LogCleaner(initialConfig: CleanerConfig,
       cleaners += cleaner
       cleaner.start()
     }
-    activateMetrics()
   }
 
   /**

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -230,7 +230,7 @@ class LogCleaner(initialConfig: CleanerConfig,
       info(s"Updating logCleanerIoMaxBytesPerSecond: $maxIoBytesPerSecond")
       throttler.updateDesiredRatePerSec(maxIoBytesPerSecond)
     }
-    /* call shutdownCleaners() instead of shutdown to avoid unnecessary deletion of metrics */
+//    call shutdownCleaners() instead of shutdown to avoid unnecessary deletion of metrics
     shutdownCleaners()
     startup()
   }

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -230,7 +230,7 @@ class LogCleaner(initialConfig: CleanerConfig,
       info(s"Updating logCleanerIoMaxBytesPerSecond: $maxIoBytesPerSecond")
       throttler.updateDesiredRatePerSec(maxIoBytesPerSecond)
     }
-//    call shutdownCleaners() instead of shutdown to avoid unnecessary deletion of metrics
+    // call shutdownCleaners() instead of shutdown to avoid unnecessary deletion of metrics
     shutdownCleaners()
     startup()
   }

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -127,11 +127,15 @@ class LogCleanerTest extends Logging {
       time = time)
 
     try {
+      logCleaner.startup()
+      var nonexistent = LogCleaner.MetricNames.diff(KafkaYammerMetrics.defaultRegistry.allMetrics().keySet().asScala.map(_.getName))
+      assertEquals(0, nonexistent.size, s"$nonexistent should be existent")
+
       logCleaner.reconfigure(new KafkaConfig(TestUtils.createBrokerConfig(1, "localhost:2181")),
         new KafkaConfig(TestUtils.createBrokerConfig(1, "localhost:2181")))
 
-      LogCleaner.MetricNames.foreach(name => assertNotNull(KafkaYammerMetrics.defaultRegistry.allMetrics().get(logCleaner.metricsGroup
-              .metricName(name, java.util.Collections.emptyMap())), s"$name is gone?"))
+      nonexistent = LogCleaner.MetricNames.diff(KafkaYammerMetrics.defaultRegistry.allMetrics().keySet().asScala.map(_.getName))
+      assertEquals(0, nonexistent.size, s"$nonexistent should be existent")
     } finally logCleaner.shutdown()
   }
 

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -78,7 +78,6 @@ class LogCleanerTest extends Logging {
         logs = new Pool[TopicPartition, UnifiedLog](),
         logDirFailureChannel = new LogDirFailureChannel(1),
         time = time)
-      logCleaner.startup()
       val metricsToVerify = new java.util.HashMap[String, java.util.List[java.util.Map[String, String]]]()
       logCleaner.cleanerManager.gaugeMetricNameWithTag.asScala.foreach { metricNameAndTags =>
         val tags = new java.util.ArrayList[java.util.Map[String, String]]()
@@ -1963,7 +1962,6 @@ class LogCleanerTest extends Logging {
       logs = new Pool[TopicPartition, UnifiedLog](),
       logDirFailureChannel = new LogDirFailureChannel(1),
       time = time)
-    logCleaner.startup()
 
     def checkGauge(name: String): Unit = {
       val gauge = logCleaner.metricsGroup.newGauge(name, () => 999)

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -78,7 +78,7 @@ class LogCleanerTest extends Logging {
         logs = new Pool[TopicPartition, UnifiedLog](),
         logDirFailureChannel = new LogDirFailureChannel(1),
         time = time)
-
+      logCleaner.startup()
       val metricsToVerify = new java.util.HashMap[String, java.util.List[java.util.Map[String, String]]]()
       logCleaner.cleanerManager.gaugeMetricNameWithTag.asScala.foreach { metricNameAndTags =>
         val tags = new java.util.ArrayList[java.util.Map[String, String]]()
@@ -1963,6 +1963,7 @@ class LogCleanerTest extends Logging {
       logs = new Pool[TopicPartition, UnifiedLog](),
       logDirFailureChannel = new LogDirFailureChannel(1),
       time = time)
+    logCleaner.startup()
 
     def checkGauge(name: String): Unit = {
       val gauge = logCleaner.metricsGroup.newGauge(name, () => 999)


### PR DESCRIPTION
The metrics of LogCleaner is missing when we reconfigure the clean. This patch would fix the issue.