### PR TITLE
Wall-Clock based Windowing / Suppression

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/FinalResultsSuppressionBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/FinalResultsSuppressionBuilder.java
@@ -33,7 +33,12 @@ public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppr
         this(name, bufferConfig, PunctuationType.STREAM_TIME, Duration.ZERO);
     }
 
-    public FinalResultsSuppressionBuilder(final String name, final Suppressed.StrictBufferConfig bufferConfig, PunctuationType punctuationType, Duration wallClockPunctuationInterval) {
+    public FinalResultsSuppressionBuilder(
+            final String name,
+            final Suppressed.StrictBufferConfig bufferConfig,
+            final PunctuationType punctuationType,
+            final Duration wallClockPunctuationInterval
+    ) {
         this.name = name;
         this.bufferConfig = bufferConfig;
         this.punctuationType = punctuationType;
@@ -42,11 +47,11 @@ public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppr
 
     public SuppressedInternal<K> buildFinalResultsSuppression(final Duration gracePeriod) {
         return new SuppressedInternal<>(
-            name,
-            gracePeriod,
-            bufferConfig,
-            TimeDefinitions.WindowEndTimeDefinition.instance(),
-            true,
+                name,
+                gracePeriod,
+                bufferConfig,
+                TimeDefinitions.WindowEndTimeDefinition.instance(),
+                true,
                 punctuationType,
                 wallClockPunctuationInterval
         );
@@ -67,7 +72,7 @@ public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppr
         }
         final FinalResultsSuppressionBuilder<?> that = (FinalResultsSuppressionBuilder<?>) o;
         return Objects.equals(name, that.name) &&
-            Objects.equals(bufferConfig, that.bufferConfig);
+                Objects.equals(bufferConfig, that.bufferConfig);
     }
 
     @Override
@@ -83,8 +88,8 @@ public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppr
     @Override
     public String toString() {
         return "FinalResultsSuppressionBuilder{" +
-            "name='" + name + '\'' +
-            ", bufferConfig=" + bufferConfig +
-            '}';
+                "name='" + name + '\'' +
+                ", bufferConfig=" + bufferConfig +
+                '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/FinalResultsSuppressionBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/FinalResultsSuppressionBuilder.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.kstream.internals.suppress;
 
 import org.apache.kafka.streams.kstream.Suppressed;
 import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.processor.PunctuationType;
 
 import java.time.Duration;
 import java.util.Objects;
@@ -25,10 +26,18 @@ import java.util.Objects;
 public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppressed<K>, NamedSuppressed<K> {
     private final String name;
     private final StrictBufferConfig bufferConfig;
+    private final PunctuationType punctuationType;
+    private final Duration wallClockPunctuationInterval;
 
     public FinalResultsSuppressionBuilder(final String name, final Suppressed.StrictBufferConfig bufferConfig) {
+        this(name, bufferConfig, PunctuationType.STREAM_TIME, Duration.ZERO);
+    }
+
+    public FinalResultsSuppressionBuilder(final String name, final Suppressed.StrictBufferConfig bufferConfig, PunctuationType punctuationType, Duration wallClockPunctuationInterval) {
         this.name = name;
         this.bufferConfig = bufferConfig;
+        this.punctuationType = punctuationType;
+        this.wallClockPunctuationInterval = wallClockPunctuationInterval;
     }
 
     public SuppressedInternal<K> buildFinalResultsSuppression(final Duration gracePeriod) {
@@ -37,13 +46,15 @@ public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppr
             gracePeriod,
             bufferConfig,
             TimeDefinitions.WindowEndTimeDefinition.instance(),
-            true
+            true,
+                punctuationType,
+                wallClockPunctuationInterval
         );
     }
 
     @Override
     public Suppressed<K> withName(final String name) {
-        return new FinalResultsSuppressionBuilder<>(name, bufferConfig);
+        return new FinalResultsSuppressionBuilder<>(name, bufferConfig, punctuationType, wallClockPunctuationInterval);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorSupplier.java
@@ -37,8 +37,6 @@ import org.apache.kafka.streams.processor.internals.metrics.ProcessorNodeMetrics
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.internals.Maybe;
 import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Objects;
@@ -177,7 +175,7 @@ public class KTableSuppressProcessorSupplier<K, V> implements
                     throw new StreamsException("PunctuationType.WALL_CLOCK_TIME needs a nonnull and > 0 " +
                             "wallClockPunctuationInterval parameter");
                 }
-                context.schedule(wallClockPunctuationInterval, PunctuationType.WALL_CLOCK_TIME, (wallClockTs) -> {
+                context.schedule(wallClockPunctuationInterval, PunctuationType.WALL_CLOCK_TIME, wallClockTs -> {
                     final long expiryTime = wallClockTs - suppressDurationMillis;
                     buffer.evictWhile(() -> wallClockTs <= expiryTime, this::emit);
                 });

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressScenarioTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressScenarioTest.java
@@ -63,10 +63,12 @@ import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.apache.kafka.streams.kstream.Suppressed.*;
 import static org.apache.kafka.streams.kstream.Suppressed.BufferConfig.maxBytes;
 import static org.apache.kafka.streams.kstream.Suppressed.BufferConfig.maxRecords;
 import static org.apache.kafka.streams.kstream.Suppressed.BufferConfig.unbounded;
+import static org.apache.kafka.streams.kstream.Suppressed.untilTimeLimit;
+import static org.apache.kafka.streams.kstream.Suppressed.untilWindowCloses;
+import static org.apache.kafka.streams.kstream.Suppressed.untilWindowClosesAfterWallClock;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 


### PR DESCRIPTION
The change adds the possibility to suppress events during windowing based on WALL_CLOCK_TIME instead of STREAM_CLOCK_TIME. 

**Problem Statement**:
In our use case we needed this functionality, as the amount of events varies very much. Sometimes we get so few events, that the event won't be emitted at all unless a new event comes in to advance STREAM_CLOCK_TIME.

**Solution**:
We implemented a new possibility to use WALL_CLOCK_TIME instead of STREAM_CLOCK_TIME for suppression during windowing. It is based on a scheduled operation and punctuates the clock on each interval.


**Testing**:
For testing we extended the `streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressScenarioTest.java` with a new scenario where the suppression is based on wall clock time.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
