### PR TITLE
MINOR: Update upgrade documentation for 3.7.1

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -19,10 +19,10 @@
 
 <script id="upgrade-template" type="text/x-handlebars-template">
 
-<h4><a id="upgrade_3_7_0" href="#upgrade_3_7_0">Upgrading to 3.7.0 from any version 0.8.x through 3.6.x</a></h4>
+<h4><a id="upgrade_3_7_1" href="#upgrade_3_7_1">Upgrading to 3.7.1 from any version 0.8.x through 3.6.x</a></h4>
 
 
-    <h5><a id="upgrade_370_zk" href="#upgrade_370_zk">Upgrading ZooKeeper-based clusters</a></h5>
+    <h5><a id="upgrade_371_zk" href="#upgrade_371_zk">Upgrading ZooKeeper-based clusters</a></h5>
     <p><b>If you are upgrading from a version prior to 2.1.x, please see the note in step 5 below about the change to the schema used to store consumer offsets.
         Once you have changed the inter.broker.protocol.version to the latest version, it will not be possible to downgrade to a version prior to 2.1.</b></p>
 
@@ -63,7 +63,7 @@
         </li>
     </ol>
 
-    <h5><a id="upgrade_370_kraft" href="#upgrade_370_kraft">Upgrading KRaft-based clusters</a></h5>
+    <h5><a id="upgrade_371_kraft" href="#upgrade_371_kraft">Upgrading KRaft-based clusters</a></h5>
     <p><b>If you are upgrading from a version prior to 3.3.0, please see the note in step 3 below. Once you have changed the metadata.version to the latest version, it will not be possible to downgrade to a version prior to 3.3-IV0.</b></p>
 
     <p><b>For a rolling upgrade:</b></p>


### PR DESCRIPTION
Following the release process:

> For a bugfix release, make sure to at least bump the version number in the ["Upgrading to ..."](https://github.com/apache/kafka/blob/2.8/docs/upgrade.html#L42) header in docs/upgrade.html

 https://cwiki.apache.org/confluence/display/KAFKA/Release+Process