### PR TITLE
KAFKA-10199: Remove lost tasks in state updater with new remove

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -51,6 +52,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -191,14 +193,20 @@ public class DefaultStateUpdater implements StateUpdater {
             tasksAndActionsLock.lock();
             try {
                 for (final TaskAndAction taskAndAction : getTasksAndActions()) {
-                    final Action action = taskAndAction.getAction();
+                    final Action action = taskAndAction.action();
                     switch (action) {
                         case ADD:
-                            addTask(taskAndAction.getTask());
+                            addTask(taskAndAction.task());
                             break;
                         case REMOVE:
-                            removeTask(taskAndAction.getTaskId());
+                            if (taskAndAction.futureForRemove() == null) {
+                                removeTask(taskAndAction.taskId());
+                            } else {
+                                removeTask(taskAndAction.taskId(), taskAndAction.futureForRemove());
+                            }
                             break;
+                        default:
+                            throw new IllegalStateException("Unknown action type " + action);
                     }
                 }
             } finally {
@@ -496,6 +504,103 @@ public class DefaultStateUpdater implements StateUpdater {
             }
         }
 
+        private void removeTask(final TaskId taskId, final CompletableFuture<RemovedTaskResult> future) {
+            try {
+                if (updatingTasks.containsKey(taskId)) {
+                    removeUpdatingTask(taskId, future);
+                } else if (pausedTasks.containsKey(taskId)) {
+                    removePausedTask(taskId, future);
+                } else {
+                    if (!removeRestoredTask(taskId, future)) {
+                        if (!removeFailedTask(taskId, future)) {
+                            future.complete(null);
+                            log.warn("Task " + taskId + " could not be removed from the state updater because "
+                                + "the state updater does not own this task.");
+                        }
+                    }
+                }
+            } catch (final StreamsException streamsException) {
+                handleStreamsException(streamsException);
+                future.completeExceptionally(streamsException);
+            } catch (final RuntimeException runtimeException) {
+                handleRuntimeException(runtimeException);
+                future.completeExceptionally(runtimeException);
+            }
+        }
+
+        private void removeUpdatingTask(final TaskId taskId, final CompletableFuture<RemovedTaskResult> future) {
+            final Task task = updatingTasks.get(taskId);
+            prepareUpdatingTaskForRemoval(task);
+            updatingTasks.remove(taskId);
+            if (task.isActive()) {
+                transitToUpdateStandbysIfOnlyStandbysLeft();
+            }
+            log.info((task.isActive() ? "Active" : "Standby")
+                + " task " + task.id() + " was removed from the updating tasks.");
+            future.complete(new RemovedTaskResult(task));
+        }
+
+        private void prepareUpdatingTaskForRemoval(final Task task) {
+            measureCheckpointLatency(() -> task.maybeCheckpoint(true));
+            final Collection<TopicPartition> changelogPartitions = task.changelogPartitions();
+            changelogReader.unregister(changelogPartitions);
+        }
+
+        private void removePausedTask(final TaskId taskId, final CompletableFuture<RemovedTaskResult> future) {
+            final Task task = pausedTasks.get(taskId);
+            preparePausedTaskForRemoval(task);
+            pausedTasks.remove(taskId);
+            log.info((task.isActive() ? "Active" : "Standby")
+                + " task " + task.id() + " was removed from the paused tasks.");
+            future.complete(new RemovedTaskResult(task));
+        }
+
+        private void preparePausedTaskForRemoval(final Task task) {
+            final Collection<TopicPartition> changelogPartitions = task.changelogPartitions();
+            changelogReader.unregister(changelogPartitions);
+        }
+
+        private boolean removeRestoredTask(final TaskId taskId, final CompletableFuture<RemovedTaskResult> future) {
+            restoredActiveTasksLock.lock();
+            try {
+                final Iterator<StreamTask> iterator = restoredActiveTasks.iterator();
+                while (iterator.hasNext()) {
+                    final StreamTask restoredTask = iterator.next();
+                    if (restoredTask.id().equals(taskId)) {
+                        iterator.remove();
+                        log.info((restoredTask.isActive() ? "Active" : "Standby")
+                            + " task " + restoredTask.id() + " was removed from the restored tasks.");
+                        future.complete(new RemovedTaskResult(restoredTask));
+                        return true;
+                    }
+                }
+                return false;
+            } finally {
+                restoredActiveTasksLock.unlock();
+            }
+        }
+
+        private boolean removeFailedTask(final TaskId taskId, final CompletableFuture<RemovedTaskResult> future) {
+            exceptionsAndFailedTasksLock.lock();
+            try {
+                final Iterator<ExceptionAndTask> iterator = exceptionsAndFailedTasks.iterator();
+                while (iterator.hasNext()) {
+                    final ExceptionAndTask exceptionAndTask = iterator.next();
+                    final Task failedTask = exceptionAndTask.task();
+                    if (failedTask.id().equals(taskId)) {
+                        iterator.remove();
+                        log.info((failedTask.isActive() ? "Active" : "Standby")
+                            + " task " + failedTask.id() + " was removed from the failed tasks.");
+                        future.complete(new RemovedTaskResult(failedTask, exceptionAndTask.exception()));
+                        return true;
+                    }
+                }
+                return false;
+            } finally {
+                exceptionsAndFailedTasksLock.unlock();
+            }
+        }
+
         private void removeTask(final TaskId taskId) {
             final Task task;
             if (updatingTasks.containsKey(taskId)) {
@@ -722,8 +827,8 @@ public class DefaultStateUpdater implements StateUpdater {
         try {
             TaskAndAction taskAndAction;
             while ((taskAndAction = tasksAndActions.peek()) != null) {
-                if (taskAndAction.getAction() == Action.ADD) {
-                    removedTasks.add(taskAndAction.getTask());
+                if (taskAndAction.action() == Action.ADD) {
+                    removedTasks.add(taskAndAction.task());
                 }
                 tasksAndActions.poll();
             }
@@ -752,6 +857,19 @@ public class DefaultStateUpdater implements StateUpdater {
         if (!task.isActive() && task.state() != State.RUNNING) {
             throw new IllegalStateException("Standby task " + task.id() + " is not in state RUNNING. " + BUG_ERROR_MESSAGE);
         }
+    }
+
+    @Override
+    public CompletableFuture<RemovedTaskResult> removeWithFuture(final TaskId taskId) {
+        final CompletableFuture<RemovedTaskResult> future = new CompletableFuture<>();
+        tasksAndActionsLock.lock();
+        try {
+            tasksAndActions.add(TaskAndAction.createRemoveTask(taskId, future));
+            tasksAndActionsCondition.signalAll();
+        } finally {
+            tasksAndActionsLock.unlock();
+        }
+        return future;
     }
 
     @Override
@@ -909,6 +1027,10 @@ public class DefaultStateUpdater implements StateUpdater {
         return stateUpdaterThread.restoreConsumerInstanceId(timeout);
     }
 
+    public boolean isRunning() {
+        return stateUpdaterThread != null && stateUpdaterThread.isRunning.get();
+    }
+
     // used for testing
     boolean isIdle() {
         if (stateUpdaterThread != null) {
@@ -942,8 +1064,8 @@ public class DefaultStateUpdater implements StateUpdater {
         return
             Stream.concat(
                 tasksAndActions.stream()
-                    .filter(taskAndAction -> taskAndAction.getAction() == Action.ADD)
-                    .map(TaskAndAction::getTask),
+                    .filter(taskAndAction -> taskAndAction.action() == Action.ADD)
+                    .map(TaskAndAction::task),
                 Stream.concat(
                     getUpdatingTasks().stream(),
                     Stream.concat(

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DeleteRecordsResult;
@@ -71,6 +73,10 @@ import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMo
 import static org.apache.kafka.streams.processor.internals.StateManagerUtil.parseTaskDirectoryName;
 
 public class TaskManager {
+
+    private final static String BUG_ERROR_MESSAGE = "This indicates a bug. " +
+        "Please report at https://issues.apache.org/jira/projects/KAFKA/issues or to the dev-mailing list (https://kafka.apache.org/contact).";
+
     // initialize the task list
     // activeTasks needs to be concurrent as it can be accessed
     // by QueryableState
@@ -600,6 +606,47 @@ public class TaskManager {
     private void removeUnusedTaskFromStateUpdater(final TaskId taskId) {
         stateUpdater.remove(taskId);
         tasks.addPendingTaskToCloseClean(taskId);
+    }
+
+    private void addToTasksToClose(final Map<TaskId, CompletableFuture<StateUpdater.RemovedTaskResult>> futures,
+                                   final Set<Task> tasksToCloseCleanFromStateUpdater,
+                                   final Set<Task> tasksToCloseDirtyFromStateUpdater) {
+        iterateAndActOnFuture(futures, removedTaskResult -> {
+            final Task task = removedTaskResult.task();
+            final Optional<RuntimeException> exception = removedTaskResult.exception();
+            if (exception.isPresent()) {
+                tasksToCloseDirtyFromStateUpdater.add(task);
+            } else {
+                tasksToCloseCleanFromStateUpdater.add(task);
+            }
+        });
+    }
+
+    private void iterateAndActOnFuture(final Map<TaskId, CompletableFuture<StateUpdater.RemovedTaskResult>> futures,
+                                       final java.util.function.Consumer<StateUpdater.RemovedTaskResult> action) {
+        for (final Map.Entry<TaskId, CompletableFuture<StateUpdater.RemovedTaskResult>> entry : futures.entrySet()) {
+            final TaskId taskId = entry.getKey();
+            final CompletableFuture<StateUpdater.RemovedTaskResult> future = entry.getValue();
+            try {
+                final StateUpdater.RemovedTaskResult removedTaskResult = waitForFuture(taskId, future);
+                action.accept(removedTaskResult);
+            } catch (final ExecutionException executionException) {
+                log.warn("An exception happened when removing task {} from the state updater. The exception will be handled later: ",
+                    taskId, executionException);
+            } catch (final InterruptedException ignored) { }
+        }
+    }
+
+    private StateUpdater.RemovedTaskResult waitForFuture(final TaskId taskId,
+                                                         final CompletableFuture<StateUpdater.RemovedTaskResult> future)
+        throws ExecutionException, InterruptedException {
+
+        final StateUpdater.RemovedTaskResult removedTaskResult = future.get();
+        if (removedTaskResult == null) {
+            throw new IllegalStateException("Task " + taskId + " was not found in the state updater. "
+                + BUG_ERROR_MESSAGE);
+        }
+        return removedTaskResult;
     }
 
     private Map<TaskId, Set<TopicPartition>> pendingTasksToCreate(final Map<TaskId, Set<TopicPartition>> tasksToCreate) {
@@ -1186,11 +1233,22 @@ public class TaskManager {
 
     private void removeLostActiveTasksFromStateUpdater() {
         if (stateUpdater != null) {
+            final Map<TaskId, CompletableFuture<StateUpdater.RemovedTaskResult>> futures = new LinkedHashMap<>();
+            final Map<TaskId, RuntimeException> failedTasksDuringCleanClose = new HashMap<>();
+            final Set<Task> tasksToCloseClean = new HashSet<>();
+            final Set<Task> tasksToCloseDirty = new HashSet<>();
             for (final Task restoringTask : stateUpdater.getTasks()) {
                 if (restoringTask.isActive()) {
-                    tasks.addPendingTaskToCloseClean(restoringTask.id());
-                    stateUpdater.remove(restoringTask.id());
+                    futures.put(restoringTask.id(), stateUpdater.removeWithFuture(restoringTask.id()));
                 }
+            }
+
+            addToTasksToClose(futures, tasksToCloseClean, tasksToCloseDirty);
+            for (final Task task : tasksToCloseClean) {
+                closeTaskClean(task, tasksToCloseDirty, failedTasksDuringCleanClose);
+            }
+            for (final Task task : tasksToCloseDirty) {
+                closeTaskDirty(task, false);
             }
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskAndActionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskAndActionTest.java
@@ -19,6 +19,8 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.streams.processor.TaskId;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CompletableFuture;
+
 import static org.apache.kafka.streams.processor.internals.TaskAndAction.Action.ADD;
 import static org.apache.kafka.streams.processor.internals.TaskAndAction.Action.REMOVE;
 import static org.apache.kafka.streams.processor.internals.TaskAndAction.createAddTask;
@@ -36,22 +38,26 @@ class TaskAndActionTest {
 
         final TaskAndAction addTask = createAddTask(task);
 
-        assertEquals(ADD, addTask.getAction());
-        assertEquals(task, addTask.getTask());
-        final Exception exception = assertThrows(IllegalStateException.class, addTask::getTaskId);
-        assertEquals("Action type ADD cannot have a task ID!", exception.getMessage());
+        assertEquals(ADD, addTask.action());
+        assertEquals(task, addTask.task());
+        final Exception exceptionForTaskId = assertThrows(IllegalStateException.class, addTask::taskId);
+        assertEquals("Action type ADD cannot have a task ID!", exceptionForTaskId.getMessage());
+        final Exception exceptionForFutureForRemove = assertThrows(IllegalStateException.class, addTask::futureForRemove);
+        assertEquals("Action type ADD cannot have a future with a single result!", exceptionForFutureForRemove.getMessage());
     }
 
     @Test
     public void shouldCreateRemoveTaskAction() {
         final TaskId taskId = new TaskId(0, 0);
+        final CompletableFuture<StateUpdater.RemovedTaskResult> future = new CompletableFuture<>();
 
-        final TaskAndAction removeTask = createRemoveTask(taskId);
+        final TaskAndAction removeTask = createRemoveTask(taskId, future);
 
-        assertEquals(REMOVE, removeTask.getAction());
-        assertEquals(taskId, removeTask.getTaskId());
-        final Exception exception = assertThrows(IllegalStateException.class, removeTask::getTask);
-        assertEquals("Action type REMOVE cannot have a task!", exception.getMessage());
+        assertEquals(REMOVE, removeTask.action());
+        assertEquals(taskId, removeTask.taskId());
+        assertEquals(future, removeTask.futureForRemove());
+        final Exception exceptionForTask = assertThrows(IllegalStateException.class, removeTask::task);
+        assertEquals("Action type REMOVE cannot have a task!", exceptionForTask.getMessage());
     }
 
     @Test
@@ -62,7 +68,19 @@ class TaskAndActionTest {
 
     @Test
     public void shouldThrowIfRemoveTaskActionIsCreatedWithNullTaskId() {
-        final Exception exception = assertThrows(NullPointerException.class, () -> createRemoveTask(null));
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> createRemoveTask(null, new CompletableFuture<>())
+        );
         assertTrue(exception.getMessage().contains("Task ID of task to remove is null!"));
+    }
+
+    @Test
+    public void shouldThrowIfRemoveTaskActionIsCreatedWithNullFuture() {
+        final Exception exception = assertThrows(
+            NullPointerException.class,
+            () -> createRemoveTask(new TaskId(0, 0), null)
+        );
+        assertTrue(exception.getMessage().contains("Future for task to remove is null!"));
     }
 }


### PR DESCRIPTION
Uses the new remove operation of the state updater that returns a future to remove lost tasks from the state udpater. 

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
