### PR TITLE
MINOR: Remove dev_version parameter from streams tests

### DIFF
--- a/tests/kafkatest/tests/streams/streams_application_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_application_upgrade_test.py
@@ -29,7 +29,6 @@ smoke_test_versions = [str(LATEST_2_2), str(LATEST_2_3), str(LATEST_2_4),
                        str(LATEST_2_8), str(LATEST_3_0), str(LATEST_3_1),
                        str(LATEST_3_2), str(LATEST_3_3), str(LATEST_3_4),
                        str(LATEST_3_5), str(LATEST_3_6), str(LATEST_3_7)]
-dev_version = [str(DEV_VERSION)]
 
 class StreamsUpgradeTest(Test):
     """
@@ -57,11 +56,13 @@ class StreamsUpgradeTest(Test):
             self.kafka.start_node(node)
 
     @cluster(num_nodes=6)
-    @matrix(from_version=smoke_test_versions, to_version=dev_version, bounce_type=["full"])
-    def test_app_upgrade(self, from_version, to_version, bounce_type):
+    @matrix(from_version=smoke_test_versions, bounce_type=["full"])
+    def test_app_upgrade(self, from_version, bounce_type):
         """
         Starts 3 KafkaStreams instances with <old_version>, and upgrades one-by-one to <new_version>
         """
+
+        to_version = str(DEV_VERSION)
 
         if from_version == to_version:
             return

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -203,16 +203,17 @@ class StreamsUpgradeTest(Test):
         processor.node.account.ssh_capture("grep SMOKE-TEST-CLIENT-CLOSED %s" % processor.STDOUT_FILE, allow_fail=False)
 
     @cluster(num_nodes=6)
-    @matrix(from_version=metadata_1_versions, to_version=[str(DEV_VERSION)])
-    @matrix(from_version=metadata_2_versions, to_version=[str(DEV_VERSION)])
-    @matrix(from_version=fk_join_versions, to_version=[str(DEV_VERSION)])
-    def test_rolling_upgrade_with_2_bounces(self, from_version, to_version):
+    @matrix(from_version=metadata_1_versions)
+    @matrix(from_version=metadata_2_versions)
+    @matrix(from_version=fk_join_versions)
+    def test_rolling_upgrade_with_2_bounces(self, from_version):
         """
         This test verifies that the cluster successfully upgrades despite changes in the metadata and FK
         join protocols.
         
         Starts 3 KafkaStreams instances with version <from_version> and upgrades one-by-one to <to_version>
         """
+        to_version = str(DEV_VERSION)
 
         if KafkaVersion(from_version).supports_fk_joins() and KafkaVersion(to_version).supports_fk_joins():
             extra_properties = {'test.run_fk_join': 'true'}
@@ -271,8 +272,8 @@ class StreamsUpgradeTest(Test):
         self.stop_and_await()
 
     @cluster(num_nodes=6)
-    @matrix(from_version=[str(LATEST_3_2), str(DEV_VERSION)], to_version=[str(DEV_VERSION)], upgrade=[True, False])
-    def test_upgrade_downgrade_state_updater(self, from_version, to_version, upgrade):
+    @matrix(from_version=[str(LATEST_3_2), str(DEV_VERSION)],  upgrade=[True, False])
+    def test_upgrade_downgrade_state_updater(self, from_version, upgrade):
         """
         Starts 3 KafkaStreams instances, and enables / disables state restoration
         for the instances in a rolling bounce.
@@ -280,6 +281,8 @@ class StreamsUpgradeTest(Test):
         Once same-thread state restoration is removed from the code, this test
         should use different versions of the code.
         """
+        to_version=str(DEV_VERSION)
+
         if upgrade:
             extra_properties_first = { '__state.updater.enabled__': 'false' }
             first_version = from_version


### PR DESCRIPTION
In two streams tests, we are using the current snapshot version as a test parameter `to_version`, but as the only option. We can hardcode it. This simplifies testing downstream, since the test parameters do not change with every version. In particular, some tests downstream are blacklisted because they do not work with ARM. These lists need to be updated every time `DEV_VERSION` is bumped.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
