### PR TITLE
KAFKA-16678: Remove variable "unimplementedquorum"

### DIFF
--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -143,7 +143,6 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
   this.consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "group")
   this.consumerConfig.setProperty(ConsumerConfig.METADATA_MAX_AGE_CONFIG, "1500")
 
-  val unimplementedquorum = ""
 
   /**
     * Starts MiniKDC and only then sets up the parent trait.
@@ -189,15 +188,11 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
   @ParameterizedTest
   @ValueSource(strings = Array("kraft", "zk"))
   def testProduceConsumeViaAssign(quorum: String): Unit = {
-    if (quorum == unimplementedquorum) {
-        Console.err.println("QuorumName : " + quorum + " is not supported.")
-    } else {
-      setAclsAndProduce(tp)
-      val consumer = createConsumer()
-      consumer.assign(List(tp).asJava)
-      consumeRecords(consumer, numRecords)
-      confirmReauthenticationMetrics()
-    }
+    setAclsAndProduce(tp)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumeRecords(consumer, numRecords)
+    confirmReauthenticationMetrics()
   }
 
   protected def confirmReauthenticationMetrics(): Unit = {
@@ -222,23 +217,16 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
   @ParameterizedTest
   @ValueSource(strings = Array("kraft", "zk"))
   def testProduceConsumeViaSubscribe(quorum: String): Unit = {
-    if (quorum == unimplementedquorum) {
-        Console.err.println("QuorumName : " + quorum + " is not supported.")
-    } else {
     setAclsAndProduce(tp)
     val consumer = createConsumer()
     consumer.subscribe(List(topic).asJava)
     consumeRecords(consumer, numRecords)
     confirmReauthenticationMetrics()
-    }
   }
 
   @ParameterizedTest
   @ValueSource(strings = Array("kraft", "zk"))
   def testProduceConsumeWithWildcardAcls(quorum: String): Unit = {
-    if (quorum == unimplementedquorum) {
-        Console.err.println("QuorumName : " + quorum + " is not supported.")
-    } else {
     setWildcardResourceAcls()
     val producer = createProducer()
     sendRecords(producer, numRecords, tp)
@@ -246,15 +234,11 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     consumer.subscribe(List(topic).asJava)
     consumeRecords(consumer, numRecords)
     confirmReauthenticationMetrics()
-    }
   }
 
   @ParameterizedTest
   @ValueSource(strings = Array("kraft", "zk"))
   def testProduceConsumeWithPrefixedAcls(quorum: String): Unit = {
-    if (quorum == unimplementedquorum) {
-        Console.err.println("QuorumName : " + quorum + " is not supported.")
-    } else {
     setPrefixedResourceAcls()
     val producer = createProducer()
     sendRecords(producer, numRecords, tp)
@@ -262,15 +246,11 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     consumer.subscribe(List(topic).asJava)
     consumeRecords(consumer, numRecords)
     confirmReauthenticationMetrics()
-    }
   }
 
   @ParameterizedTest
   @ValueSource(strings = Array("kraft", "zk"))
   def testProduceConsumeTopicAutoCreateTopicCreateAcl(quorum: String): Unit = {
-    if (quorum == unimplementedquorum) {
-        Console.err.println("QuorumName : " + quorum + " is not supported.")
-    } else {
     // topic2 is not created on setup()
     val tp2 = new TopicPartition("topic2", 0)
     setAclsAndProduce(tp2)
@@ -278,7 +258,6 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     consumer.assign(List(tp2).asJava)
     consumeRecords(consumer, numRecords, topic = tp2.topic)
     confirmReauthenticationMetrics()
-    }
   }
 
   private def setWildcardResourceAcls(): Unit = {
@@ -345,14 +324,10 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     "zk, false"
   ))
   def testNoDescribeProduceOrConsumeWithoutTopicDescribeAcl(quorum:String, isIdempotenceEnabled:Boolean): Unit = {
-    if (quorum == unimplementedquorum) {
-        Console.err.println("QuorumName : " + quorum + " is not supported.")
-    } else {
     // Set consumer group acls since we are testing topic authorization
     setConsumerGroupAcls()
 
     // Verify produce/consume/describe throw TopicAuthorizationException
-
     val prop = new Properties()
     prop.setProperty(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, isIdempotenceEnabled.toString)
     val producer = createProducer(configOverrides = prop)
@@ -410,7 +385,6 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     val describeResults2 = adminClient.describeTopics(Set(topic, topic2).asJava).topicNameValues
     assertEquals(1, describeResults2.get(topic).get().partitions().size())
     assertEquals(1, describeResults2.get(topic2).get().partitions().size())
-    }
   }
 
   @ParameterizedTest
@@ -421,9 +395,6 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     "zk, false"
   ))
   def testNoProduceWithDescribeAcl(quorum:String, isIdempotenceEnabled:Boolean): Unit = {
-    if (quorum == unimplementedquorum) {
-        Console.err.println("QuorumName : " + quorum + " is not supported.")
-    } else {
     val superuserAdminClient = createSuperuserAdminClient()
     superuserAdminClient.createAcls(List(AclTopicDescribe()).asJava).values
 
@@ -443,7 +414,6 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
       assertEquals(Set(topic).asJava, e.unauthorizedTopics())
     }
     confirmReauthenticationMetrics()
-    }
   }
 
    /**
@@ -453,24 +423,17 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
   @ParameterizedTest
   @ValueSource(strings = Array("kraft", "zk"))
   def testNoConsumeWithoutDescribeAclViaAssign(quorum: String): Unit = {
-    if (quorum == unimplementedquorum) {
-        Console.err.println("QuorumName : " + quorum + " is not supported.")
-    } else {
     noConsumeWithoutDescribeAclSetup()
     val consumer = createConsumer()
     consumer.assign(List(tp).asJava)
     // the exception is expected when the consumer attempts to lookup offsets
     assertThrows(classOf[KafkaException], () => consumeRecords(consumer))
     confirmReauthenticationMetrics()
-    }
   }
 
   @ParameterizedTest
   @ValueSource(strings = Array("kraft", "zk"))
   def testNoConsumeWithoutDescribeAclViaSubscribe(quorum: String): Unit = {
-    if (quorum == unimplementedquorum) {
-        Console.err.println("QuorumName : " + quorum + " is not supported.")
-    } else {
     noConsumeWithoutDescribeAclSetup()
     val consumer = createConsumer()
     consumer.subscribe(List(topic).asJava)
@@ -485,7 +448,6 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     // Verify that records are consumed if all topics are authorized
     consumer.subscribe(List(topic).asJava)
     consumeRecordsIgnoreOneAuthorizationException(consumer)
-    }
   }
 
   private def noConsumeWithoutDescribeAclSetup(): Unit = {
@@ -513,9 +475,6 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
   @ParameterizedTest
   @ValueSource(strings = Array("kraft", "zk"))
   def testNoConsumeWithDescribeAclViaAssign(quorum: String): Unit = {
-    if (quorum == unimplementedquorum) {
-        Console.err.println("QuorumName : " + quorum + " is not supported.")
-    } else {
     noConsumeWithDescribeAclSetup()
     val consumer = createConsumer()
     consumer.assign(List(tp).asJava)
@@ -523,15 +482,11 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     val e = assertThrows(classOf[TopicAuthorizationException], () => consumeRecords(consumer))
     assertEquals(Set(topic).asJava, e.unauthorizedTopics())
     confirmReauthenticationMetrics()
-    }
   }
 
   @ParameterizedTest
   @ValueSource(strings = Array("kraft", "zk"))
   def testNoConsumeWithDescribeAclViaSubscribe(quorum: String): Unit = {
-    if (quorum == unimplementedquorum) {
-        Console.err.println("QuorumName : " + quorum + " is not supported.")
-    } else {
     noConsumeWithDescribeAclSetup()
     val consumer = createConsumer()
     consumer.subscribe(List(topic).asJava)
@@ -539,7 +494,6 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     val e = assertThrows(classOf[TopicAuthorizationException], () => consumeRecords(consumer))
     assertEquals(Set(topic).asJava, e.unauthorizedTopics())
     confirmReauthenticationMetrics()
-    }
   }
 
   private def noConsumeWithDescribeAclSetup(): Unit = {
@@ -562,9 +516,6 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
   @ParameterizedTest
   @ValueSource(strings = Array("kraft", "zk"))
   def testNoGroupAcl(quorum: String): Unit = {
-    if (quorum == unimplementedquorum) {
-        Console.err.println("QuorumName : " + quorum + " is not supported.")
-    } else {
     val superuserAdminClient = createSuperuserAdminClient()
     superuserAdminClient.createAcls(List(AclTopicWrite(), AclTopicCreate(), AclTopicDescribe()).asJava).values
     brokers.foreach { s =>
@@ -578,7 +529,6 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     val e = assertThrows(classOf[GroupAuthorizationException], () => consumeRecords(consumer))
     assertEquals(group, e.groupId())
     confirmReauthenticationMetrics()
-    }
   }
 
   protected final def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]],


### PR DESCRIPTION
Remove variable "unimplementedquorum" from EndToEndAuthorizationTest.scala and SaslEndToEndAuthorizationTest.scala

- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
