### PR TITLE
KAFKA-16640: Replace TestUtils#resource by scala.util.Using

### DIFF
--- a/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationWithOwnerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DelegationTokenEndToEndAuthorizationWithOwnerTest.scala
@@ -105,8 +105,8 @@ class DelegationTokenEndToEndAuthorizationWithOwnerTest extends DelegationTokenE
   @ParameterizedTest
   @ValueSource(strings = Array("kraft", "zk"))
   def testDescribeTokenForOtherUserFails(quorum: String): Unit = {
-    TestUtils.resource(createScramAdminClient(kafkaClientSaslMechanism, describeTokenFailPrincipal.getName, describeTokenFailPassword)) { describeTokenFailAdminClient =>
-      TestUtils.resource(createScramAdminClient(kafkaClientSaslMechanism, otherClientPrincipal.getName, otherClientPassword)) { otherClientAdminClient =>
+    Using(createScramAdminClient(kafkaClientSaslMechanism, describeTokenFailPrincipal.getName, describeTokenFailPassword)) { describeTokenFailAdminClient =>
+      Using(createScramAdminClient(kafkaClientSaslMechanism, otherClientPrincipal.getName, otherClientPassword)) { otherClientAdminClient =>
         otherClientAdminClient.createDelegationToken().delegationToken().get()
         val tokens = describeTokenFailAdminClient.describeDelegationToken(
           new DescribeDelegationTokenOptions().owners(Collections.singletonList(otherClientPrincipal))

--- a/core/src/test/scala/integration/kafka/api/SaslSetup.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSetup.scala
@@ -38,6 +38,8 @@ import org.apache.kafka.common.utils.Time
 import org.apache.kafka.server.config.{ConfigType, KafkaSecurityConfigs}
 import org.apache.zookeeper.client.ZKClientConfig
 
+import scala.util.Using
+
 /*
  * Implements an enumeration for the modes enabled here:
  * zk only, kafka only, both, custom KafkaServer.
@@ -199,7 +201,7 @@ trait SaslSetup {
 
   def createScramCredentials(zkConnect: String, userName: String, password: String): Unit = {
     val zkClientConfig = new ZKClientConfig()
-    TestUtils.resource(KafkaZkClient(
+    Using(KafkaZkClient(
       zkConnect, JaasUtils.isZkSaslEnabled || KafkaConfig.zkTlsClientAuthEnabled(zkClientConfig), 30000, 30000,
       Int.MaxValue, Time.SYSTEM, name = "SaslSetup", zkClientConfig = zkClientConfig, enableEntityConfigControllerCheck = false)) { zkClient =>
       val adminZkClient = new AdminZkClient(zkClient)

--- a/core/src/test/scala/integration/kafka/server/RaftClusterSnapshotTest.scala
+++ b/core/src/test/scala/integration/kafka/server/RaftClusterSnapshotTest.scala
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 
 import scala.jdk.CollectionConverters._
+import scala.util.Using
 
 @Timeout(120)
 class RaftClusterSnapshotTest {
@@ -40,7 +41,7 @@ class RaftClusterSnapshotTest {
     val numberOfBrokers = 3
     val numberOfControllers = 3
 
-    TestUtils.resource(
+    Using(
       new KafkaClusterTestKit
         .Builder(
           new TestKitNodes.Builder()
@@ -73,7 +74,7 @@ class RaftClusterSnapshotTest {
 
       // For every controller and broker perform some sanity checks against the latest snapshot
       for ((_, raftManager) <- cluster.raftManagers().asScala) {
-        TestUtils.resource(
+        Using(
           RecordsSnapshotReader.of(
             raftManager.replicatedLog.latestSnapshot.get(),
             new MetadataRecordSerde(),

--- a/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
@@ -41,6 +41,7 @@ import java.nio.file.{Files, Path}
 import java.util
 import java.util.{Collections, Optional, Properties}
 import scala.jdk.CollectionConverters._
+import scala.util.Using
 
 final class KafkaMetadataLogTest {
   import KafkaMetadataLogTest._
@@ -123,7 +124,7 @@ final class KafkaMetadataLogTest {
     append(log, numberOfRecords, epoch)
     log.updateHighWatermark(new LogOffsetMetadata(numberOfRecords))
 
-    TestUtils.resource(log.createNewSnapshot(snapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshot(snapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
 
@@ -191,7 +192,7 @@ final class KafkaMetadataLogTest {
 
     append(log, numberOfRecords, epoch)
     log.updateHighWatermark(new LogOffsetMetadata(numberOfRecords))
-    TestUtils.resource(log.createNewSnapshot(snapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshot(snapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
 
@@ -227,7 +228,7 @@ final class KafkaMetadataLogTest {
     append(log, numberOfRecords, epoch)
     log.updateHighWatermark(new LogOffsetMetadata(numberOfRecords))
 
-    TestUtils.resource(log.createNewSnapshot(snapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshot(snapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
 
@@ -276,7 +277,7 @@ final class KafkaMetadataLogTest {
     append(log, numberOfRecords, epoch)
     log.updateHighWatermark(new LogOffsetMetadata(numberOfRecords))
 
-    TestUtils.resource(log.createNewSnapshot(snapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshot(snapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
 
@@ -323,7 +324,7 @@ final class KafkaMetadataLogTest {
 
     append(log, numberOfRecords, epoch)
 
-    TestUtils.resource(log.createNewSnapshotUnchecked(sameEpochSnapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(sameEpochSnapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
 
@@ -337,7 +338,7 @@ final class KafkaMetadataLogTest {
 
     append(log, numberOfRecords, epoch)
 
-    TestUtils.resource(log.createNewSnapshotUnchecked(greaterEpochSnapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(greaterEpochSnapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
 
@@ -356,25 +357,25 @@ final class KafkaMetadataLogTest {
 
     append(log, 1, epoch - 1)
     val oldSnapshotId1 = new OffsetAndEpoch(1, epoch - 1)
-    TestUtils.resource(log.createNewSnapshotUnchecked(oldSnapshotId1).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(oldSnapshotId1).get()) { snapshot =>
       snapshot.freeze()
     }
 
     append(log, 1, epoch)
     val oldSnapshotId2 = new OffsetAndEpoch(2, epoch)
-    TestUtils.resource(log.createNewSnapshotUnchecked(oldSnapshotId2).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(oldSnapshotId2).get()) { snapshot =>
       snapshot.freeze()
     }
 
     append(log, numberOfRecords - 2, epoch)
     val oldSnapshotId3 = new OffsetAndEpoch(numberOfRecords, epoch)
-    TestUtils.resource(log.createNewSnapshotUnchecked(oldSnapshotId3).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(oldSnapshotId3).get()) { snapshot =>
       snapshot.freeze()
     }
 
     val greaterSnapshotId = new OffsetAndEpoch(3 * numberOfRecords, epoch)
     append(log, numberOfRecords, epoch)
-    TestUtils.resource(log.createNewSnapshotUnchecked(greaterSnapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(greaterSnapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
 
@@ -467,7 +468,7 @@ final class KafkaMetadataLogTest {
     metadataDir: File,
     snapshotId: OffsetAndEpoch
   ): Unit = {
-    TestUtils.resource(FileRawSnapshotWriter.create(metadataDir.toPath, snapshotId))(_.freeze())
+    Using(FileRawSnapshotWriter.create(metadataDir.toPath, snapshotId))(_.freeze())
   }
 
   @Test
@@ -479,7 +480,7 @@ final class KafkaMetadataLogTest {
     append(log, numberOfRecords, epoch)
 
     val olderEpochSnapshotId = new OffsetAndEpoch(numberOfRecords, epoch - 1)
-    TestUtils.resource(log.createNewSnapshotUnchecked(olderEpochSnapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(olderEpochSnapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
 
@@ -488,7 +489,7 @@ final class KafkaMetadataLogTest {
     append(log, numberOfRecords, epoch)
 
     val olderOffsetSnapshotId = new OffsetAndEpoch(numberOfRecords, epoch)
-    TestUtils.resource(log.createNewSnapshotUnchecked(olderOffsetSnapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(olderOffsetSnapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
 
@@ -503,7 +504,7 @@ final class KafkaMetadataLogTest {
     val snapshotId = new OffsetAndEpoch(1, epoch)
 
     append(log, numberOfRecords, epoch)
-    TestUtils.resource(log.createNewSnapshotUnchecked(snapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(snapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
 
@@ -540,25 +541,25 @@ final class KafkaMetadataLogTest {
 
     append(log, 1, epoch - 1)
     val oldSnapshotId1 = new OffsetAndEpoch(1, epoch - 1)
-    TestUtils.resource(log.createNewSnapshotUnchecked(oldSnapshotId1).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(oldSnapshotId1).get()) { snapshot =>
       snapshot.freeze()
     }
 
     append(log, 1, epoch)
     val oldSnapshotId2 = new OffsetAndEpoch(2, epoch)
-    TestUtils.resource(log.createNewSnapshotUnchecked(oldSnapshotId2).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(oldSnapshotId2).get()) { snapshot =>
       snapshot.freeze()
     }
 
     append(log, numberOfRecords - 2, epoch)
     val oldSnapshotId3 = new OffsetAndEpoch(numberOfRecords, epoch)
-    TestUtils.resource(log.createNewSnapshotUnchecked(oldSnapshotId3).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(oldSnapshotId3).get()) { snapshot =>
       snapshot.freeze()
     }
 
     val greaterSnapshotId = new OffsetAndEpoch(3 * numberOfRecords, epoch)
     append(log, numberOfRecords, epoch)
-    TestUtils.resource(log.createNewSnapshotUnchecked(greaterSnapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(greaterSnapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
 
@@ -589,7 +590,7 @@ final class KafkaMetadataLogTest {
     val snapshotId = new OffsetAndEpoch(numberOfRecords + 1, epoch + 1)
 
     append(log, numberOfRecords, epoch)
-    TestUtils.resource(log.createNewSnapshotUnchecked(snapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(snapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
 
@@ -688,7 +689,7 @@ final class KafkaMetadataLogTest {
     log.updateHighWatermark(new LogOffsetMetadata(numberOfRecords))
 
     val snapshotId = new OffsetAndEpoch(numberOfRecords, epoch)
-    TestUtils.resource(log.createNewSnapshot(snapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshot(snapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
 
@@ -708,7 +709,7 @@ final class KafkaMetadataLogTest {
     log.updateHighWatermark(new LogOffsetMetadata(offset))
 
     val snapshotId = new OffsetAndEpoch(offset, epoch)
-    TestUtils.resource(log.createNewSnapshot(snapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshot(snapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
     // Simulate log cleaning advancing the LSO
@@ -730,7 +731,7 @@ final class KafkaMetadataLogTest {
     log.updateHighWatermark(new LogOffsetMetadata(offset))
 
     val snapshotId = new OffsetAndEpoch(offset, epoch)
-    TestUtils.resource(log.createNewSnapshot(snapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshot(snapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
 
@@ -747,7 +748,7 @@ final class KafkaMetadataLogTest {
     val log = buildMetadataLog(tempDir, mockTime)
     log.updateHighWatermark(new LogOffsetMetadata(offset))
     val snapshotId = new OffsetAndEpoch(offset, 1)
-    TestUtils.resource(log.createNewSnapshotUnchecked(snapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(snapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
     log.truncateToLatestSnapshot()
@@ -771,7 +772,7 @@ final class KafkaMetadataLogTest {
     val log = buildMetadataLog(tempDir, mockTime)
     log.updateHighWatermark(new LogOffsetMetadata(offset))
     val snapshotId = new OffsetAndEpoch(offset, 1)
-    TestUtils.resource(log.createNewSnapshotUnchecked(snapshotId).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(snapshotId).get()) { snapshot =>
       snapshot.freeze()
     }
     log.truncateToLatestSnapshot()
@@ -853,13 +854,13 @@ final class KafkaMetadataLogTest {
     assertFalse(log.maybeClean(), "Should not clean since no snapshots exist")
 
     val snapshotId1 = new OffsetAndEpoch(1000, 1)
-    TestUtils.resource(log.createNewSnapshotUnchecked(snapshotId1).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(snapshotId1).get()) { snapshot =>
       append(snapshot, 100)
       snapshot.freeze()
     }
 
     val snapshotId2 = new OffsetAndEpoch(2000, 1)
-    TestUtils.resource(log.createNewSnapshotUnchecked(snapshotId2).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(snapshotId2).get()) { snapshot =>
       append(snapshot, 100)
       snapshot.freeze()
     }
@@ -891,7 +892,7 @@ final class KafkaMetadataLogTest {
 
     for (offset <- Seq(100, 200, 300, 400, 500, 600)) {
       val snapshotId = new OffsetAndEpoch(offset, 1)
-      TestUtils.resource(log.createNewSnapshotUnchecked(snapshotId).get()) { snapshot =>
+      Using(log.createNewSnapshotUnchecked(snapshotId).get()) { snapshot =>
         append(snapshot, 10)
         snapshot.freeze()
       }
@@ -926,14 +927,14 @@ final class KafkaMetadataLogTest {
 
     // Then generate two snapshots
     val snapshotId1 = new OffsetAndEpoch(1000, 1)
-    TestUtils.resource(log.createNewSnapshotUnchecked(snapshotId1).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(snapshotId1).get()) { snapshot =>
       append(snapshot, 500)
       snapshot.freeze()
     }
 
     // Then generate a snapshot
     val snapshotId2 = new OffsetAndEpoch(2000, 1)
-    TestUtils.resource(log.createNewSnapshotUnchecked(snapshotId2).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(snapshotId2).get()) { snapshot =>
       append(snapshot, 500)
       snapshot.freeze()
     }
@@ -973,7 +974,7 @@ final class KafkaMetadataLogTest {
       log.log.logSegments.asScala.drop(1).head.baseOffset,
       1
     )
-    TestUtils.resource(log.createNewSnapshotUnchecked(snapshotId1).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(snapshotId1).get()) { snapshot =>
       snapshot.freeze()
     }
     // Generate second snapshots that includes the second segment by using the base offset of the third segment
@@ -981,7 +982,7 @@ final class KafkaMetadataLogTest {
       log.log.logSegments.asScala.drop(2).head.baseOffset,
       1
     )
-    TestUtils.resource(log.createNewSnapshotUnchecked(snapshotId2).get()) { snapshot =>
+    Using(log.createNewSnapshotUnchecked(snapshotId2).get()) { snapshot =>
       snapshot.freeze()
     }
 

--- a/core/src/test/scala/kafka/server/metadata/BrokerServerMetricsTest.scala
+++ b/core/src/test/scala/kafka/server/metadata/BrokerServerMetricsTest.scala
@@ -18,7 +18,6 @@
 package kafka.server.metadata
 
 import java.util.Collections
-import kafka.utils.TestUtils
 import org.apache.kafka.common.MetricName
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.utils.MockTime
@@ -28,6 +27,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
+import scala.util.Using
 
 final class BrokerServerMetricsTest {
   @Test
@@ -44,7 +44,7 @@ final class BrokerServerMetricsTest {
       new MetricName("metadata-apply-error-count", expectedGroup, "", Collections.emptyMap())
     )
      
-    TestUtils.resource(BrokerServerMetrics(metrics)) { brokerMetrics =>
+    Using(BrokerServerMetrics(metrics)) { brokerMetrics =>
       val metricsMap = metrics.metrics().asScala.filter{ case (name, _) => name.group == expectedGroup }
       assertEquals(expectedMetrics.size, metricsMap.size)
       metricsMap.foreach { case (name, metric) =>
@@ -59,7 +59,7 @@ final class BrokerServerMetricsTest {
   @Test
   def testLastAppliedRecordOffset(): Unit = {
     val metrics = new Metrics()
-    TestUtils.resource(BrokerServerMetrics(metrics)) { brokerMetrics =>
+    Using(BrokerServerMetrics(metrics)) { brokerMetrics =>
       val offsetMetric = metrics.metrics().get(brokerMetrics.lastAppliedRecordOffsetName)
       assertEquals(-1L, offsetMetric.metricValue.asInstanceOf[Long])
 
@@ -77,7 +77,7 @@ final class BrokerServerMetricsTest {
   def testLastAppliedRecordTimestamp(): Unit = {
     val time = new MockTime()
     val metrics = new Metrics(time)
-    TestUtils.resource(BrokerServerMetrics(metrics)) { brokerMetrics =>
+    Using(BrokerServerMetrics(metrics)) { brokerMetrics =>
       time.sleep(1000)
       val timestampMetric = metrics.metrics().get(brokerMetrics.lastAppliedRecordTimestampName)
       val lagMetric = metrics.metrics().get(brokerMetrics.lastAppliedRecordLagMsName)
@@ -101,7 +101,7 @@ final class BrokerServerMetricsTest {
   def testMetadataLoadErrorCount(): Unit = {
     val time = new MockTime()
     val metrics = new Metrics(time)
-    TestUtils.resource(BrokerServerMetrics(metrics)) { brokerMetrics =>
+    Using(BrokerServerMetrics(metrics)) { brokerMetrics =>
       val metadataLoadErrorCountMetric = metrics.metrics().get(brokerMetrics.metadataLoadErrorCountName)
 
       assertEquals(0L, metadataLoadErrorCountMetric.metricValue.asInstanceOf[Long])
@@ -117,7 +117,7 @@ final class BrokerServerMetricsTest {
   def testMetadataApplyErrorCount(): Unit = {
     val time = new MockTime()
     val metrics = new Metrics(time)
-    TestUtils.resource(BrokerServerMetrics(metrics)) { brokerMetrics =>
+    Using(BrokerServerMetrics(metrics)) { brokerMetrics =>
       val metadataApplyErrorCountMetric = metrics.metrics().get(brokerMetrics.metadataApplyErrorCountName)
 
       assertEquals(0L, metadataApplyErrorCountMetric.metricValue.asInstanceOf[Long])

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutionException
 import java.util.{Collections, Optional, Properties}
 import scala.collection.{Map, Seq}
 import scala.jdk.CollectionConverters._
+import scala.util.Using
 
 class DeleteTopicTest extends QuorumTestHarness {
 
@@ -219,7 +220,7 @@ class DeleteTopicTest extends QuorumTestHarness {
       // increase the partition count for topic
       val props = new Properties()
       props.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, TestUtils.plaintextBootstrapServers(partitionHostingBrokers))
-      TestUtils.resource(Admin.create(props)) { adminClient =>
+      Using(Admin.create(props)) { adminClient =>
         try {
           adminClient.createPartitions(Map(topic -> NewPartitions.increaseTo(2)).asJava).all().get()
         } catch {
@@ -254,7 +255,7 @@ class DeleteTopicTest extends QuorumTestHarness {
       // increase the partition count for topic
       val props = new Properties()
       props.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, TestUtils.plaintextBootstrapServers(partitionHostingServers))
-      TestUtils.resource(Admin.create(props)) { adminClient =>
+      Using(Admin.create(props)) { adminClient =>
         try {
           adminClient.createPartitions(Map(topic -> NewPartitions.increaseTo(2)).asJava).all().get()
         } catch {

--- a/core/src/test/scala/unit/kafka/coordinator/group/CoordinatorLoaderImplTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/CoordinatorLoaderImplTest.scala
@@ -18,7 +18,6 @@ package kafka.coordinator.group
 
 import kafka.log.UnifiedLog
 import kafka.server.ReplicaManager
-import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException
 import org.apache.kafka.common.record.{CompressionType, ControlRecordType, EndTransactionMarker, FileRecords, MemoryRecords, RecordBatch, SimpleRecord}
@@ -38,6 +37,7 @@ import org.mockito.invocation.InvocationOnMock
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import java.util.concurrent.{CountDownLatch, TimeUnit}
+import scala.util.Using
 
 class StringKeyValueDeserializer extends CoordinatorLoader.Deserializer[(String, String)] {
   override def deserialize(key: ByteBuffer, value: ByteBuffer): (String, String) = {
@@ -57,7 +57,7 @@ class CoordinatorLoaderImplTest {
     val serde = mock(classOf[CoordinatorLoader.Deserializer[(String, String)]])
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
-    TestUtils.resource(new CoordinatorLoaderImpl[(String, String)](
+    Using(new CoordinatorLoaderImpl[(String, String)](
       time = Time.SYSTEM,
       replicaManager = replicaManager,
       deserializer = serde,
@@ -77,7 +77,7 @@ class CoordinatorLoaderImplTest {
     val serde = mock(classOf[CoordinatorLoader.Deserializer[(String, String)]])
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
-    TestUtils.resource(new CoordinatorLoaderImpl[(String, String)](
+    Using(new CoordinatorLoaderImpl[(String, String)](
       time = Time.SYSTEM,
       replicaManager = replicaManager,
       deserializer = serde,
@@ -98,7 +98,7 @@ class CoordinatorLoaderImplTest {
     val log = mock(classOf[UnifiedLog])
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
-    TestUtils.resource(new CoordinatorLoaderImpl[(String, String)](
+    Using(new CoordinatorLoaderImpl[(String, String)](
       time = Time.SYSTEM,
       replicaManager = replicaManager,
       deserializer = serde,
@@ -201,7 +201,7 @@ class CoordinatorLoaderImplTest {
     val log = mock(classOf[UnifiedLog])
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
-    TestUtils.resource(new CoordinatorLoaderImpl[(String, String)](
+    Using(new CoordinatorLoaderImpl[(String, String)](
       time = Time.SYSTEM,
       replicaManager = replicaManager,
       deserializer = serde,
@@ -244,7 +244,7 @@ class CoordinatorLoaderImplTest {
     val log = mock(classOf[UnifiedLog])
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
-    TestUtils.resource(new CoordinatorLoaderImpl[(String, String)](
+    Using(new CoordinatorLoaderImpl[(String, String)](
       time = Time.SYSTEM,
       replicaManager = replicaManager,
       deserializer = serde,
@@ -284,7 +284,7 @@ class CoordinatorLoaderImplTest {
     val log = mock(classOf[UnifiedLog])
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
-    TestUtils.resource(new CoordinatorLoaderImpl[(String, String)](
+    Using(new CoordinatorLoaderImpl[(String, String)](
       time = Time.SYSTEM,
       replicaManager = replicaManager,
       deserializer = serde,
@@ -325,7 +325,7 @@ class CoordinatorLoaderImplTest {
     val log = mock(classOf[UnifiedLog])
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
-    TestUtils.resource(new CoordinatorLoaderImpl[(String, String)](
+    Using(new CoordinatorLoaderImpl[(String, String)](
       time = Time.SYSTEM,
       replicaManager = replicaManager,
       deserializer = serde,
@@ -357,7 +357,7 @@ class CoordinatorLoaderImplTest {
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
     val time = new MockTime()
 
-    TestUtils.resource(new CoordinatorLoaderImpl[(String, String)](
+    Using(new CoordinatorLoaderImpl[(String, String)](
       time,
       replicaManager = replicaManager,
       deserializer = serde,
@@ -412,7 +412,7 @@ class CoordinatorLoaderImplTest {
     val log = mock(classOf[UnifiedLog])
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
-    TestUtils.resource(new CoordinatorLoaderImpl[(String, String)](
+    Using(new CoordinatorLoaderImpl[(String, String)](
       time = Time.SYSTEM,
       replicaManager = replicaManager,
       deserializer = serde,
@@ -487,7 +487,7 @@ class CoordinatorLoaderImplTest {
     val log = mock(classOf[UnifiedLog])
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
-    TestUtils.resource(new CoordinatorLoaderImpl[(String, String)](
+    Using(new CoordinatorLoaderImpl[(String, String)](
       time = Time.SYSTEM,
       replicaManager = replicaManager,
       deserializer = serde,
@@ -513,7 +513,7 @@ class CoordinatorLoaderImplTest {
     val log = mock(classOf[UnifiedLog])
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
-    TestUtils.resource(new CoordinatorLoaderImpl[(String, String)](
+    Using(new CoordinatorLoaderImpl[(String, String)](
       time = Time.SYSTEM,
       replicaManager = replicaManager,
       deserializer = serde,
@@ -589,7 +589,7 @@ class CoordinatorLoaderImplTest {
     val log = mock(classOf[UnifiedLog])
     val coordinator = mock(classOf[CoordinatorPlayback[(String, String)]])
 
-    TestUtils.resource(new CoordinatorLoaderImpl[(String, String)](
+    Using(new CoordinatorLoaderImpl[(String, String)](
       time = Time.SYSTEM,
       replicaManager = replicaManager,
       deserializer = serde,

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -40,6 +40,7 @@ import java.util
 import java.util.{Collections, Properties}
 import scala.collection.{Seq, mutable}
 import scala.jdk.CollectionConverters._
+import scala.util.Using
 
 /**
  * A test harness that brings up some number of broker nodes
@@ -154,7 +155,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
     adminClientConfig: Properties = new Properties
   ): Unit = {
     if (isKRaftTest()) {
-      resource(createAdminClient(brokers, listenerName, adminClientConfig)) { admin =>
+      Using(createAdminClient(brokers, listenerName, adminClientConfig)) { admin =>
         TestUtils.createOffsetsTopicWithAdmin(admin, brokers, controllerServers)
       }
     } else {
@@ -176,7 +177,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
     adminClientConfig: Properties = new Properties
   ): scala.collection.immutable.Map[Int, Int] = {
     if (isKRaftTest()) {
-      resource(createAdminClient(brokers, listenerName, adminClientConfig)) { admin =>
+      Using.resource(createAdminClient(brokers, listenerName, adminClientConfig)) { admin =>
         TestUtils.createTopicWithAdmin(
           admin = admin,
           topic = topic,
@@ -210,7 +211,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
     listenerName: ListenerName = listenerName
   ): scala.collection.immutable.Map[Int, Int] =
     if (isKRaftTest()) {
-      resource(createAdminClient(brokers, listenerName)) { admin =>
+      Using.resource(createAdminClient(brokers, listenerName)) { admin =>
         TestUtils.createTopicWithAdmin(
           admin = admin,
           topic = topic,
@@ -233,7 +234,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
     listenerName: ListenerName = listenerName
   ): Unit = {
     if (isKRaftTest()) {
-      resource(createAdminClient(brokers, listenerName)) { admin =>
+      Using(createAdminClient(brokers, listenerName)) { admin =>
         TestUtils.deleteTopicWithAdmin(
           admin = admin,
           topic = topic,
@@ -427,7 +428,7 @@ abstract class KafkaServerTestHarness extends QuorumTestHarness {
 
   def changeClientIdConfig(sanitizedClientId: String, configs: Properties): Unit = {
     if (isKRaftTest()) {
-      resource(createAdminClient(brokers, listenerName)) {
+      Using(createAdminClient(brokers, listenerName)) {
         admin => {
           admin.alterClientQuotas(Collections.singleton(
             new ClientQuotaAlteration(

--- a/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.raft.QuorumConfig
-import org.apache.kafka.server.config.{KRaftConfigs,ReplicationConfigs, ServerLogConfigs, ZkConfigs}
+import org.apache.kafka.server.config.{KRaftConfigs, ReplicationConfigs, ServerLogConfigs, ZkConfigs}
 import org.apache.kafka.server.ProcessRole
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
@@ -39,6 +39,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.apache.kafka.server.fault.FaultHandler
 import org.mockito.Mockito._
+
+import scala.util.Using
 
 
 class RaftManagerTest {
@@ -304,7 +306,7 @@ class RaftManagerTest {
   }
 
   private def fileLocked(path: Path): Boolean = {
-    TestUtils.resource(FileChannel.open(path, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) { channel =>
+    Using.resource(FileChannel.open(path, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) { channel =>
       try {
         Option(channel.tryLock()).foreach(_.close())
         false

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -24,7 +24,6 @@ import kafka.server.KafkaConfig.fromProps
 import kafka.server.QuotaType._
 import kafka.utils.TestUtils._
 import kafka.utils.CoreUtils._
-import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET
 import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry, NewTopic}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
@@ -44,6 +43,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 import scala.jdk.CollectionConverters._
+import scala.util.Using
 
 /**
   * This is the main test which ensure Replication Quotas work correctly.
@@ -112,7 +112,7 @@ class ReplicationQuotasTest extends QuorumTestHarness {
     //replicate for each of the two follower brokers.
     if (!leaderThrottle) throttle = throttle * 3
 
-    TestUtils.resource(createAdminClient(brokers, listenerName)) { admin =>
+    Using(createAdminClient(brokers, listenerName)) { admin =>
       if (isKRaftTest()) {
         (106 to 107).foreach(registerBroker)
       }
@@ -228,7 +228,7 @@ class ReplicationQuotasTest extends QuorumTestHarness {
     val expectedDuration = 4
     val throttle: Long = msg.length * msgCount / expectedDuration
 
-    TestUtils.resource(createAdminClient(brokers, listenerName)) { admin =>
+    Using(createAdminClient(brokers, listenerName)) { admin =>
       if (isKRaftTest()) {
         registerBroker(101)
       }

--- a/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochIntegrationTest.scala
@@ -44,6 +44,7 @@ import org.junit.jupiter.params.provider.ValueSource
 import scala.collection.mutable.ListBuffer
 import scala.collection.{Map, Seq}
 import scala.jdk.CollectionConverters._
+import scala.util.Using
 
 class LeaderEpochIntegrationTest extends QuorumTestHarness with Logging {
   var brokers: ListBuffer[KafkaBroker] = ListBuffer()
@@ -287,7 +288,7 @@ class LeaderEpochIntegrationTest extends QuorumTestHarness with Logging {
   }
 
   private def createTopic(topic: String, partitionReplicaAssignment: collection.Map[Int, Seq[Int]]): Unit = {
-    resource(createAdminClient(brokers, ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT))) { admin =>
+    Using(createAdminClient(brokers, ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT))) { admin =>
       TestUtils.createTopicWithAdmin(
         admin = admin,
         topic = topic,

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -55,6 +55,7 @@ import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.util.Using
 import scala.util.matching.Regex
 
 case class BatchInfo(records: Seq[SimpleRecord], hasKeys: Boolean, hasValues: Boolean)
@@ -331,7 +332,7 @@ class DumpLogSegmentsTest {
 
     val lastContainedLogTimestamp = 10000
 
-    TestUtils.resource(
+    Using(
       new RecordsSnapshotWriter.Builder()
         .setTime(new MockTime)
         .setLastContainedLogTimestamp(lastContainedLogTimestamp)

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1786,14 +1786,6 @@ object TestUtils extends Logging {
       KafkaYammerMetrics.defaultRegistry.removeMetric(metricName)
   }
 
-  def resource[R <: AutoCloseable, A](resource: R)(func: R => A): A = {
-    try {
-      func(resource)
-    } finally {
-      resource.close()
-    }
-  }
-
   def waitForAllReassignmentsToComplete(adminClient: Admin, pause: Long = 100L): Unit = {
     waitUntilTrue(() => adminClient.listPartitionReassignments().reassignments().get().isEmpty,
       s"There still are ongoing reassignments", pause = pause)


### PR DESCRIPTION
Check all uses of `TestUtils#resource` and replace with `scala.util.Using`

- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
