### PR TITLE
MINOR: Rewrite OptimizedUniformAssignmentBuilder#assignStickyPartitions to improve performance

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AbstractUniformAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AbstractUniformAssignmentBuilder.java
@@ -211,6 +211,7 @@ public abstract class AbstractUniformAssignmentBuilder {
          * @return {@code true} for a mismatch; {@code false} if member and partition racks exist and align.
          */
         protected boolean racksMismatch(String memberId, TopicIdPartition tp) {
+            if (!useRackStrategy) return false;
             String memberRack = memberRacks.get(memberId);
             Set<String> replicaRacks = partitionRacks.get(tp);
             return memberRack == null || (replicaRacks == null || !replicaRacks.contains(memberRack));


### PR DESCRIPTION
This PR is still WIP. I am still playing with an alternative approach.

Trunk:
```
Benchmark                                       (assignmentType)  (assignorType)  (isRackAware)  (memberCount)  (partitionsToMemberRatio)  (subscriptionModel)  (topicCount)  Mode  Cnt   Score   Error  Units
ServerSideAssignorBenchmark.doAssignment             INCREMENTAL         UNIFORM          false          10000                         10          HOMOGENEOUS           100  avgt    5   27.636 ±  0.131  ms/op
```

Patch:
```
Benchmark                                       (assignmentType)  (assignorType)  (isRackAware)  (memberCount)  (partitionsToMemberRatio)  (subscriptionModel)  (topicCount)  Mode  Cnt   Score   Error  Units
ServerSideAssignorBenchmark.doAssignment             INCREMENTAL         UNIFORM          false          10000                         10          HOMOGENEOUS           100  avgt    5  20.868 ± 0.320  ms/op
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
