### PR TITLE
KAFKA-16688: Use helper method to shutdown ExecutorService

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/util/timer/SystemTimer.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/timer/SystemTimer.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.server.util.timer;
 
 import org.apache.kafka.common.utils.KafkaThread;
+import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.common.utils.Time;
 
 import java.util.concurrent.DelayQueue;
@@ -110,7 +111,7 @@ public class SystemTimer implements Timer {
 
     @Override
     public void close() {
-        taskExecutor.shutdown();
+        ThreadUtils.shutdownExecutorServiceQuietly(taskExecutor, 5, TimeUnit.SECONDS);
     }
 
     // visible for testing


### PR DESCRIPTION
We observe some thread leaks in CI which point to the executor service thread. This change tries to shutdown the executor service using the helper method in `ThreadUtils`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
