### PR TITLE
[MINOR] Renaming created to unassigned in IncrementalCooperativeAssignor#performTaskAssignment

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -255,10 +255,11 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         ConnectorsAndTasks lostAssignments = diff(previousAssignment, activeAssignments, deleted);
         log.debug("Lost assignments: {}", lostAssignments);
 
-        // Derived set: The set of new connectors-and-tasks is a derived set from the set
-        // difference of configured - previous - active
-        ConnectorsAndTasks created = diff(configured, previousAssignment, activeAssignments);
-        log.debug("Created: {}", created);
+        // Derived set: The set of unassigned connectors-and-tasks is a derived set from the set
+        // difference of configured - previous - active. This contains both newly created connectors
+        // and tasks and connectors and tasks revoked in the previous round.
+        ConnectorsAndTasks unassigned = diff(configured, previousAssignment, activeAssignments);
+        log.debug("Unassigned: {}", unassigned);
 
         // A collection of the current assignment excluding the connectors-and-tasks to be deleted
         List<WorkerLoad> currentWorkerAssignment = workerAssignment(memberAssignments, deleted);
@@ -338,7 +339,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
 
         // The complete set of connectors and tasks that should be newly-assigned during this round
         ConnectorsAndTasks toAssign = new ConnectorsAndTasks.Builder()
-                .addAll(created)
+                .addAll(unassigned)
                 .addAll(lostAssignmentsToReassign)
                 .build();
 


### PR DESCRIPTION
In IncrementalCooperativeAssignor in Connect, during `performTaskAssignment`, there is a step where it finds the newly created connectors and tasks [here](https://github.com/apache/kafka/blob/2a5efe4a334611fc7c15f76b322482bad0942db0/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java#L258-L260). However, the name of the variable is incorrect because any connectors and tasks revoked in the previous round would also be reflecting here. This is easy to validate with the test `IncrementalCooperativeAssignorTest$testTaskAssignmentWhenWorkerJoins` and setting a debugger on the above line after the rebalance that happens [here](https://github.com/apache/kafka/blob/2a5efe4a334611fc7c15f76b322482bad0942db0/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java#L115). We can see that the set would be non empty as it contains the revoked connectors and tasks from the previous round after a second worker joined.

I have updated the variable's name to `unassigned` as it reflects all the unassigned connectors and tasks in this round (newly created and revoked in previous rounds). 