### PR TITLE
Improve code example for using a transactional KafkaProducer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -192,21 +192,40 @@ import java.util.concurrent.atomic.AtomicReference;
  * props.put("bootstrap.servers", "localhost:9092");
  * props.put("transactional.id", "my-transactional-id");
  * Producer<String, String> producer = new KafkaProducer<>(props, new StringSerializer(), new StringSerializer());
- *
  * producer.initTransactions();
- *
+ * 
  * try {
- *     producer.beginTransaction();
- *     for (int i = 0; i < 100; i++)
- *         producer.send(new ProducerRecord<>("my-topic", Integer.toString(i), Integer.toString(i)));
- *     producer.commitTransaction();
- * } catch (ProducerFencedException | OutOfOrderSequenceException | AuthorizationException e) {
- *     // We can't recover from these exceptions, so our only option is to close the producer and exit.
+ *   producer.beginTransaction();
+ *   try {
+ *     for(int i = 0; i < 100; i++) {
+ *       producer.send(new ProducerRecord<>("my-topic", Integer.toString(i), Integer.toString(i)));
+ *     }
+ *   } catch(KafkaException e) {
+ *     try {
+ *       producer.abortTransaction();
+ *     } catch(KafkaException e2) {
+ *       e.addSuppressed(e2);
+ *     }
+ *     throw e;
+ *   }
+ *   producer.commitTransaction();
+ * } catch(TimeoutException e) {
+ *   try {
+ *     // closing with timeout after timeout starts endless loop
+ *     producer.close(Duration.ZERO);
+ *   } catch(KafkaException e2) {
+ *     e.addSuppressed(e2);
+ *   }
+ *   throw e;
+ * } catch(KafkaException e) {
+ *   try {
  *     producer.close();
- * } catch (KafkaException e) {
- *     // For all other exceptions, just abort the transaction and try again.
- *     producer.abortTransaction();
+ *   } catch(KafkaException e2) {
+ *     e.addSuppressed(e2);
+ *   }
+ *   throw e;
  * }
+ * 
  * producer.close();
  * } </pre>
  * </p>


### PR DESCRIPTION
After a short discussion with Sophie Blee-Goldman (see https://lists.apache.org/thread/x4szs4szq0gq1twrpdv0fppzr92rr623), I dived into a few days of debugging and testing with a network connection that can deliberately switched to drop all packages. As I also work with Spring sometimes, I finally looked up how Spring Kafka does the exception handling and came up with quite a simple solution that at least works very well with my test scenarios: I used all the default timeouts for the configuration of the producer and tested with network outages (packages are dropped) of 20 seconds, 45 seconds and 75 seconds.

While transforming my production code back into a code sample, I changed it from catching general Exceptions to catching KafkaExceptions, because Sophie mentioned she doesn't like general Exceptions to be caught.

Please consider this PR as a request for comments, as I am rather new to Kafka and I didn't quite understand all the details of the original code sample.