### PR TITLE
KAFKA-16694: Remove Rack Awareness Code from the Server Side Assignors

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AbstractUniformAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/assignor/AbstractUniformAssignmentBuilder.java
@@ -19,47 +19,18 @@ package org.apache.kafka.coordinator.group.assignor;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.server.common.TopicIdPartition;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
  * The assignment builder is used to construct the target assignment based on the members' subscriptions.
- *
- * This class contains common utility methods and a class for obtaining and storing rack information.
  */
 public abstract class AbstractUniformAssignmentBuilder {
     protected abstract GroupAssignment buildAssignment();
-
-    /**
-     * Determines if rack-aware assignment is appropriate based on the provided rack information.
-     *
-     * @param memberRacks               Racks where members are located.
-     * @param allPartitionRacks         Racks where partitions are located.
-     * @param racksPerPartition         Map of partitions to their associated racks.
-     *
-     * @return {@code true} if rack-aware assignment should be applied; {@code false} otherwise.
-     */
-    protected static boolean useRackAwareAssignment(
-        Set<String> memberRacks,
-        Set<String> allPartitionRacks,
-        Map<TopicIdPartition, Set<String>> racksPerPartition
-    ) {
-        if (memberRacks.isEmpty() || Collections.disjoint(memberRacks, allPartitionRacks))
-            return false;
-        else {
-            return !racksPerPartition.values().stream().allMatch(allPartitionRacks::equals);
-        }
-    }
 
     /**
      * Adds the topic's partition to the member's target assignment.
@@ -93,175 +64,5 @@ public abstract class AbstractUniformAssignmentBuilder {
                 .range(0, subscribedTopicDescriber.numPartitions(topic))
                 .mapToObj(i -> new TopicIdPartition(topic, i))
             ).collect(Collectors.toSet());
-    }
-
-    /**
-     * Processes partitions for the given topic Ids using the provided function.
-     *
-     * @param topicIds                   Collection of topic Ids.
-     * @param subscribedTopicDescriber   Describer to fetch partition counts for topics.
-     * @param func                       Function to apply on each {@code TopicIdPartition}.
-     */
-    protected static void processTopicIdPartitions(
-        Collection<Uuid> topicIds,
-        SubscribedTopicDescriber subscribedTopicDescriber,
-        Consumer<TopicIdPartition> func
-    ) {
-        topicIds.stream()
-            .flatMap(topic -> IntStream
-                .range(0, subscribedTopicDescriber.numPartitions(topic))
-                .mapToObj(i -> new TopicIdPartition(topic, i))
-            ).forEach(func);
-    }
-
-    /**
-     * Represents the rack information of members and partitions along with utility methods
-     * to facilitate rack-aware assignment strategies for a given consumer group.
-     */
-    protected static class RackInfo {
-        /**
-         * Map of every member to its rack.
-         */
-        protected final Map<String, String> memberRacks;
-
-        /**
-         * Map of every partition to a list of its racks.
-         */
-        protected final Map<TopicIdPartition, Set<String>> partitionRacks;
-
-        /**
-         * List of members with the same rack as the partition.
-         */
-        protected final Map<TopicIdPartition, List<String>> membersWithSameRackAsPartition;
-
-        /**
-         * Indicates if a rack aware assignment can be done.
-         * True if racks are defined for both members and partitions and there is an intersection between the sets.
-         */
-        protected final boolean useRackStrategy;
-
-        /**
-         * Constructs rack information based on the assignment specification and subscribed topics.
-         *
-         * @param assignmentSpec                The current assignment specification.
-         * @param subscribedTopicDescriber      Topic and partition metadata of the subscribed topics.
-         * @param topicIds                      List of topic Ids.
-         */
-        public RackInfo(
-            AssignmentSpec assignmentSpec,
-            SubscribedTopicDescriber subscribedTopicDescriber,
-            Set<Uuid> topicIds
-        ) {
-            Map<String, List<String>> membersByRack = new HashMap<>();
-            assignmentSpec.members().forEach((memberId, assignmentMemberSpec) ->
-                assignmentMemberSpec.rackId().filter(r -> !r.isEmpty()).ifPresent(
-                    rackId -> membersByRack.computeIfAbsent(rackId, __ -> new ArrayList<>()).add(memberId)
-                )
-            );
-
-            Set<String> allPartitionRacks;
-            Map<TopicIdPartition, Set<String>> racksPerPartition;
-
-            if (membersByRack.isEmpty()) {
-                allPartitionRacks = Collections.emptySet();
-                racksPerPartition = Collections.emptyMap();
-            } else {
-                racksPerPartition = new HashMap<>();
-                allPartitionRacks = new HashSet<>();
-                processTopicIdPartitions(topicIds, subscribedTopicDescriber, tp -> {
-                    Set<String> racks = subscribedTopicDescriber.racksForPartition(tp.topicId(), tp.partitionId());
-                    racksPerPartition.put(tp, racks);
-                    if (!racks.isEmpty()) allPartitionRacks.addAll(racks);
-                });
-            }
-
-            if (useRackAwareAssignment(membersByRack.keySet(), allPartitionRacks, racksPerPartition)) {
-                this.memberRacks = new HashMap<>(assignmentSpec.members().size());
-                membersByRack.forEach((rack, rackMembers) -> rackMembers.forEach(c -> memberRacks.put(c, rack)));
-                this.partitionRacks = racksPerPartition;
-                useRackStrategy = true;
-            } else {
-                this.memberRacks = Collections.emptyMap();
-                this.partitionRacks = Collections.emptyMap();
-                useRackStrategy = false;
-            }
-
-            this.membersWithSameRackAsPartition = racksPerPartition.entrySet().stream()
-                .collect(Collectors.toMap(
-                    Map.Entry::getKey,
-                    entry -> entry.getValue().stream()
-                        .flatMap(rack -> membersByRack.getOrDefault(rack, Collections.emptyList()).stream())
-                        .distinct() // Ensure that there are no duplicate members
-                        .collect(Collectors.toList())
-                ));
-        }
-
-        /**
-         * Determines if there's a mismatch between the member's rack and the partition's replica racks.
-         *
-         * <p> Racks are considered mismatched under the following conditions: (returns {@code true}):
-         * <ul>
-         *     <li> Member lacks an associated rack. </li>
-         *     <li> Partition lacks associated replica racks. </li>
-         *     <li> Member's rack isn't among the partition's replica racks. </li>
-         * </ul>
-         *
-         * @param memberId      The member Id.
-         * @param tp            The topic partition.
-         * @return {@code true} for a mismatch; {@code false} if member and partition racks exist and align.
-         */
-        protected boolean racksMismatch(String memberId, TopicIdPartition tp) {
-            String memberRack = memberRacks.get(memberId);
-            Set<String> replicaRacks = partitionRacks.get(tp);
-            return memberRack == null || (replicaRacks == null || !replicaRacks.contains(memberRack));
-        }
-
-        /**
-         * Sort partitions in ascending order by number of members with matching racks.
-         *
-         * @param topicIdPartitions    The partitions to be sorted.
-         * @return A sorted list of partitions with potential members in the same rack.
-         */
-        protected List<TopicIdPartition> sortPartitionsByRackMembers(Collection<TopicIdPartition> topicIdPartitions) {
-            return topicIdPartitions.stream()
-                .filter(tp -> membersWithSameRackAsPartition.containsKey(tp) && !membersWithSameRackAsPartition.get(tp).isEmpty())
-                .sorted(Comparator.comparing(
-                        (TopicIdPartition tp) -> membersWithSameRackAsPartition.getOrDefault(tp, Collections.emptyList()).size())
-                    .thenComparing(TopicIdPartition::topicId)
-                    .thenComparing(TopicIdPartition::partitionId))
-                .collect(Collectors.toList());
-        }
-
-        /**
-         * @return List of members with the same rack as any of the provided partition's replicas.
-         *         Members are sorted in ascending order of number of partitions in the assignment.
-         */
-        protected List<String> getSortedMembersWithMatchingRack(
-            TopicIdPartition topicIdPartition,
-            Map<String, MemberAssignment> assignment
-        ) {
-            List<String> membersList = membersWithSameRackAsPartition.getOrDefault(
-                topicIdPartition,
-                Collections.emptyList()
-            );
-
-            // Sort the list based on the size of each member's assignment.
-            membersList.sort((member1, member2) -> {
-                int sum1 = assignment.get(member1).targetPartitions().values().stream().mapToInt(Set::size).sum();
-                int sum2 = assignment.get(member2).targetPartitions().values().stream().mapToInt(Set::size).sum();
-
-                return Integer.compare(sum1, sum2);
-            });
-
-            return membersList;
-        }
-
-        @Override
-        public String toString() {
-            return "RackInfo(" +
-                "memberRacks=" + memberRacks +
-                ", partitionRacks=" + partitionRacks +
-                ")";
-        }
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/GeneralUniformAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/GeneralUniformAssignmentBuilderTest.java
@@ -33,6 +33,7 @@ import static org.apache.kafka.coordinator.group.AssignmentTestUtil.assertAssign
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
 import static org.apache.kafka.coordinator.group.RecordHelpersTest.mkMapOfPartitionRacks;
+import static org.apache.kafka.coordinator.group.assignor.SubscriptionType.HETEROGENEOUS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -78,7 +79,7 @@ public class GeneralUniformAssignmentBuilderTest {
             Collections.emptyMap()
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
         GroupAssignment groupAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
 
         assertEquals(Collections.emptyMap(), groupAssignment.members());
@@ -112,7 +113,7 @@ public class GeneralUniformAssignmentBuilderTest {
             Collections.emptyMap()
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
 
         assertThrows(PartitionAssignorException.class,
             () -> assignor.assign(assignmentSpec, subscribedTopicMetadata));
@@ -148,7 +149,7 @@ public class GeneralUniformAssignmentBuilderTest {
             Collections.emptyMap()
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -201,7 +202,7 @@ public class GeneralUniformAssignmentBuilderTest {
             Collections.emptyMap()
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -284,7 +285,7 @@ public class GeneralUniformAssignmentBuilderTest {
             currentAssignmentForC
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -361,7 +362,7 @@ public class GeneralUniformAssignmentBuilderTest {
             currentAssignmentForB
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -428,7 +429,7 @@ public class GeneralUniformAssignmentBuilderTest {
             Collections.emptyMap()
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -495,7 +496,7 @@ public class GeneralUniformAssignmentBuilderTest {
 
         // Member C was removed
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -553,7 +554,7 @@ public class GeneralUniformAssignmentBuilderTest {
             currentAssignmentForB
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/GeneralUniformAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/GeneralUniformAssignmentBuilderTest.java
@@ -33,7 +33,6 @@ import static org.apache.kafka.coordinator.group.AssignmentTestUtil.assertAssign
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
 import static org.apache.kafka.coordinator.group.RecordHelpersTest.mkMapOfPartitionRacks;
-import static org.apache.kafka.coordinator.group.assignor.SubscriptionType.HETEROGENEOUS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -79,7 +78,7 @@ public class GeneralUniformAssignmentBuilderTest {
             Collections.emptyMap()
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
         GroupAssignment groupAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
 
         assertEquals(Collections.emptyMap(), groupAssignment.members());
@@ -113,14 +112,14 @@ public class GeneralUniformAssignmentBuilderTest {
             Collections.emptyMap()
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
 
         assertThrows(PartitionAssignorException.class,
             () -> assignor.assign(assignmentSpec, subscribedTopicMetadata));
     }
 
     @Test
-    public void testFirstAssignmentTwoMembersTwoTopicsNoMemberRacks() {
+    public void testFirstAssignmentTwoMembersTwoTopics() {
         Map<Uuid, TopicMetadata> topicMetadata = new HashMap<>();
         topicMetadata.put(topic1Uuid, new TopicMetadata(
             topic1Uuid,
@@ -149,7 +148,7 @@ public class GeneralUniformAssignmentBuilderTest {
             Collections.emptyMap()
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -161,193 +160,6 @@ public class GeneralUniformAssignmentBuilderTest {
         ));
         expectedAssignment.put(memberB, mkAssignment(
             mkTopicAssignment(topic3Uuid, 0, 1, 2, 4)
-        ));
-
-        assertAssignment(expectedAssignment, computedAssignment);
-    }
-
-    @Test
-    public void testFirstAssignmentThreeMembersThreeTopicsNoPartitionRacks() {
-        Map<Uuid, TopicMetadata> topicMetadata = new HashMap<>();
-        topicMetadata.put(topic1Uuid, new TopicMetadata(
-            topic1Uuid,
-            topic1Name,
-            6,
-            Collections.emptyMap()
-        ));
-        topicMetadata.put(topic2Uuid, new TopicMetadata(
-            topic2Uuid,
-            topic2Name,
-            8,
-            Collections.emptyMap()
-        ));
-        topicMetadata.put(topic3Uuid, new TopicMetadata(
-            topic3Uuid,
-            topic3Name,
-            2,
-            Collections.emptyMap()
-        ));
-
-        Map<String, AssignmentMemberSpec> members = new TreeMap<>();
-        members.put(memberA, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack1"),
-            Arrays.asList(topic1Uuid, topic2Uuid),
-            Collections.emptyMap()
-        ));
-        members.put(memberB, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack2"),
-            Collections.singletonList(topic2Uuid),
-            Collections.emptyMap()
-        ));
-        members.put(memberC, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack3"),
-            Arrays.asList(topic1Uuid, topic3Uuid),
-            Collections.emptyMap()
-        ));
-
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
-        SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
-
-        GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
-
-        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
-        expectedAssignment.put(memberA, mkAssignment(
-            mkTopicAssignment(topic2Uuid, 2, 4, 6),
-            mkTopicAssignment(topic1Uuid, 0, 4)
-        ));
-        expectedAssignment.put(memberB, mkAssignment(
-            mkTopicAssignment(topic2Uuid, 0, 1, 3, 5, 7)
-        ));
-        expectedAssignment.put(memberC, mkAssignment(
-            mkTopicAssignment(topic1Uuid, 1, 2, 3, 5),
-            mkTopicAssignment(topic3Uuid, 0, 1)
-        ));
-
-        assertAssignment(expectedAssignment, computedAssignment);
-    }
-
-    //checked alreaddy
-    @Test
-    public void testFirstAssignmentThreeMembersThreeTopicsWithMemberAndPartitionRacks() {
-        Map<Uuid, TopicMetadata> topicMetadata = new HashMap<>();
-        topicMetadata.put(topic1Uuid, new TopicMetadata(
-            topic1Uuid,
-            topic1Name,
-            3,
-            mkMapOfPartitionRacks(3)
-        ));
-        topicMetadata.put(topic2Uuid, new TopicMetadata(
-            topic2Uuid,
-            topic2Name,
-            3,
-            mkMapOfPartitionRacks(3)
-        ));
-        topicMetadata.put(topic3Uuid, new TopicMetadata(
-            topic3Uuid,
-            topic3Name,
-            2,
-            mkMapOfPartitionRacks(2)
-        ));
-
-        Map<String, AssignmentMemberSpec> members = new TreeMap<>();
-        members.put(memberA, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack1"),
-            Collections.singletonList(topic1Uuid),
-            Collections.emptyMap()
-        ));
-        members.put(memberB, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack2"),
-            Arrays.asList(topic1Uuid, topic2Uuid),
-            Collections.emptyMap()
-        ));
-        members.put(memberC, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack3"),
-            Collections.singletonList(topic3Uuid),
-            Collections.emptyMap()
-        ));
-
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
-        SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
-
-        GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
-
-        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
-        expectedAssignment.put(memberA, mkAssignment(
-            mkTopicAssignment(topic1Uuid, 0, 1, 2)
-        ));
-        expectedAssignment.put(memberB, mkAssignment(
-            mkTopicAssignment(topic2Uuid, 0, 1, 2)
-        ));
-        expectedAssignment.put(memberC, mkAssignment(
-            mkTopicAssignment(topic3Uuid, 0, 1)
-        ));
-
-        assertAssignment(expectedAssignment, computedAssignment);
-    }
-
-    @Test
-    public void testFirstAssignmentThreeMembersThreeTopicsWithSomeMemberAndPartitionRacks() {
-        Map<Uuid, TopicMetadata> topicMetadata = new HashMap<>();
-        topicMetadata.put(topic1Uuid, new TopicMetadata(
-            topic1Uuid,
-            topic1Name,
-            3,
-            mkMapOfPartitionRacks(3)
-        ));
-        topicMetadata.put(topic2Uuid, new TopicMetadata(
-            topic2Uuid,
-            topic2Name,
-            3,
-            mkMapOfPartitionRacks(3)
-        ));
-        topicMetadata.put(topic3Uuid, new TopicMetadata(
-            topic3Uuid,
-            topic3Name,
-            2,
-            Collections.emptyMap()
-        ));
-
-        Map<String, AssignmentMemberSpec> members = new TreeMap<>();
-        members.put(memberA, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.empty(),
-            Arrays.asList(topic2Uuid, topic3Uuid),
-            Collections.emptyMap()
-        ));
-        members.put(memberB, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack2"),
-            Collections.singletonList(topic2Uuid),
-            Collections.emptyMap()
-        ));
-        members.put(memberC, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.empty(),
-            Collections.singletonList(topic1Uuid),
-            Collections.emptyMap()
-        ));
-
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
-        SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
-
-        GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
-
-        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
-        expectedAssignment.put(memberA, mkAssignment(
-            mkTopicAssignment(topic2Uuid, 0),
-            mkTopicAssignment(topic3Uuid, 0, 1)
-        ));
-        expectedAssignment.put(memberB, mkAssignment(
-            mkTopicAssignment(topic2Uuid, 1, 2)
-        ));
-        expectedAssignment.put(memberC, mkAssignment(
-            mkTopicAssignment(topic1Uuid, 0, 1, 2)
         ));
 
         assertAssignment(expectedAssignment, computedAssignment);
@@ -389,7 +201,7 @@ public class GeneralUniformAssignmentBuilderTest {
             Collections.emptyMap()
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -472,7 +284,7 @@ public class GeneralUniformAssignmentBuilderTest {
             currentAssignmentForC
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -493,151 +305,7 @@ public class GeneralUniformAssignmentBuilderTest {
     }
 
     @Test
-    public void testReassignmentOnRackChangesWithMemberAndPartitionRacks() {
-        Map<Uuid, TopicMetadata> topicMetadata = new HashMap<>();
-        topicMetadata.put(topic1Uuid, new TopicMetadata(
-            topic1Uuid,
-            topic1Name,
-            3,
-            mkMapOfPartitionRacks(3)
-        ));
-        topicMetadata.put(topic2Uuid, new TopicMetadata(
-            topic2Uuid,
-            topic2Name,
-            3,
-            mkMapOfPartitionRacks(3)
-        ));
-        topicMetadata.put(topic3Uuid, new TopicMetadata(
-            topic3Uuid,
-            topic3Name,
-            3,
-            mkMapOfPartitionRacks(3)
-        ));
-
-        // Initially A was in rack 1 and B was in rack 2, now let's switch them.
-        Map<String, AssignmentMemberSpec> members = new TreeMap<>();
-
-        Map<Uuid, Set<Integer>> currentAssignmentForA = new TreeMap<>(
-            mkAssignment(
-                mkTopicAssignment(topic1Uuid, 0, 1),
-                mkTopicAssignment(topic3Uuid, 0, 1, 2)
-            )
-        );
-        members.put(memberA, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack2"),
-            Arrays.asList(topic1Uuid, topic3Uuid),
-            currentAssignmentForA
-        ));
-
-        Map<Uuid, Set<Integer>> currentAssignmentForB = new TreeMap<>(
-            mkAssignment(
-                mkTopicAssignment(topic1Uuid, 2),
-                mkTopicAssignment(topic2Uuid, 0, 1, 2)
-            )
-        );
-        members.put(memberB, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack1"),
-            Arrays.asList(topic1Uuid, topic2Uuid),
-            currentAssignmentForB
-        ));
-
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
-        SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
-
-        GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
-
-        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
-        expectedAssignment.put(memberA, mkAssignment(
-            mkTopicAssignment(topic1Uuid, 1, 2),
-            mkTopicAssignment(topic3Uuid, 0, 1, 2)
-        ));
-        expectedAssignment.put(memberB, mkAssignment(
-            mkTopicAssignment(topic1Uuid, 0),
-            mkTopicAssignment(topic2Uuid, 0, 1, 2)
-        ));
-
-        assertAssignment(expectedAssignment, computedAssignment);
-    }
-
-    @Test
-    public void testReassignmentOnAddingPartitionsWithMemberAndPartitionRacks() {
-        // Initially they had 3 partitions each.
-        Map<Uuid, TopicMetadata> topicMetadata = new HashMap<>();
-        topicMetadata.put(topic1Uuid, new TopicMetadata(
-            topic1Uuid,
-            topic1Name,
-            5,
-            mkMapOfPartitionRacks(5)
-        ));
-        topicMetadata.put(topic2Uuid, new TopicMetadata(
-            topic2Uuid,
-            topic2Name,
-            5,
-            mkMapOfPartitionRacks(5)
-        ));
-        topicMetadata.put(topic3Uuid, new TopicMetadata(
-            topic3Uuid,
-            topic3Name,
-            4,
-            mkMapOfPartitionRacks(4)
-        ));
-        topicMetadata.put(topic4Uuid, new TopicMetadata(
-            topic4Uuid,
-            topic4Name,
-            4,
-            mkMapOfPartitionRacks(4)
-        ));
-
-        Map<String, AssignmentMemberSpec> members = new TreeMap<>();
-
-        Map<Uuid, Set<Integer>> currentAssignmentForA = new TreeMap<>(
-            mkAssignment(
-                mkTopicAssignment(topic1Uuid, 0, 1, 2),
-                mkTopicAssignment(topic4Uuid, 0, 1, 2)
-            )
-        );
-        members.put(memberA, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack0"),
-            Arrays.asList(topic1Uuid, topic4Uuid),
-            currentAssignmentForA
-        ));
-
-        Map<Uuid, Set<Integer>> currentAssignmentForB = new TreeMap<>(
-            mkAssignment(
-                mkTopicAssignment(topic2Uuid, 0, 1, 2),
-                mkTopicAssignment(topic3Uuid, 0, 1, 2)
-            )
-        );
-        members.put(memberB, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack1"),
-            Arrays.asList(topic3Uuid, topic2Uuid),
-            currentAssignmentForB
-        ));
-
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
-        SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
-
-        GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
-
-        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
-        expectedAssignment.put(memberA, mkAssignment(
-            mkTopicAssignment(topic1Uuid, 0, 1, 2, 3, 4),
-            mkTopicAssignment(topic4Uuid, 0, 1, 2, 3)
-        ));
-        expectedAssignment.put(memberB, mkAssignment(
-            mkTopicAssignment(topic2Uuid, 0, 1, 2, 3, 4),
-            mkTopicAssignment(topic3Uuid, 0, 1, 2, 3)
-        ));
-
-        assertAssignment(expectedAssignment, computedAssignment);
-    }
-
-    @Test
-    public void testReassignmentWhenPartitionsAreAddedForTwoMembersNoMemberRack() {
+    public void testReassignmentWhenPartitionsAreAddedForTwoMembers() {
         // Simulating adding partitions to T1, T2, T3 - originally T1 -> 4, T2 -> 3, T3 -> 2, T4 -> 3
         Map<Uuid, TopicMetadata> topicMetadata = new HashMap<>();
         topicMetadata.put(topic1Uuid, new TopicMetadata(
@@ -693,7 +361,7 @@ public class GeneralUniformAssignmentBuilderTest {
             currentAssignmentForB
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -760,7 +428,7 @@ public class GeneralUniformAssignmentBuilderTest {
             Collections.emptyMap()
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -775,76 +443,6 @@ public class GeneralUniformAssignmentBuilderTest {
         ));
         expectedAssignment.put(memberC, mkAssignment(
             mkTopicAssignment(topic2Uuid, 0, 3, 4, 6)
-        ));
-
-        assertAssignment(expectedAssignment, computedAssignment);
-    }
-
-    @Test
-    public void testReassignmentOnAddingMemberWithRackAndPartitionRacks() {
-        Map<Uuid, TopicMetadata> topicMetadata = new HashMap<>();
-        topicMetadata.put(topic1Uuid, new TopicMetadata(
-            topic1Uuid,
-            topic1Name,
-            6,
-            mkMapOfPartitionRacks(6)
-        ));
-        topicMetadata.put(topic2Uuid, new TopicMetadata(
-            topic2Uuid,
-            topic2Name,
-            5,
-            mkMapOfPartitionRacks(5)
-        ));
-
-        Map<String, AssignmentMemberSpec> members = new TreeMap<>();
-
-        Map<Uuid, Set<Integer>> currentAssignmentForA = new TreeMap<>(
-            mkAssignment(
-                mkTopicAssignment(topic1Uuid, 0, 1, 2, 3, 4, 5)
-            )
-        );
-        members.put(memberA, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack0"),
-            Collections.singletonList(topic1Uuid),
-            currentAssignmentForA
-        ));
-
-        Map<Uuid, Set<Integer>> currentAssignmentForB = new TreeMap<>(
-            mkAssignment(
-                mkTopicAssignment(topic2Uuid, 0, 1, 2, 3, 4)
-            )
-        );
-        members.put(memberB, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack1"),
-            Collections.singletonList(topic2Uuid),
-            currentAssignmentForB
-        ));
-
-        // New member added.
-        members.put(memberC, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack2"),
-            Arrays.asList(topic1Uuid, topic2Uuid),
-            Collections.emptyMap()
-        ));
-
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
-        SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
-
-        GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
-
-        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
-        expectedAssignment.put(memberA, mkAssignment(
-            mkTopicAssignment(topic1Uuid, 0, 3, 4)
-        ));
-        expectedAssignment.put(memberB, mkAssignment(
-            mkTopicAssignment(topic2Uuid, 0, 1, 3, 4)
-        ));
-        expectedAssignment.put(memberC, mkAssignment(
-            mkTopicAssignment(topic1Uuid, 1, 2, 5),
-            mkTopicAssignment(topic2Uuid, 2)
         ));
 
         assertAssignment(expectedAssignment, computedAssignment);
@@ -897,7 +495,7 @@ public class GeneralUniformAssignmentBuilderTest {
 
         // Member C was removed
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -955,7 +553,7 @@ public class GeneralUniformAssignmentBuilderTest {
             currentAssignmentForB
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -966,67 +564,6 @@ public class GeneralUniformAssignmentBuilderTest {
         ));
         expectedAssignment.put(memberB, mkAssignment(
             mkTopicAssignment(topic2Uuid, 0, 1, 2, 3, 4)
-        ));
-
-        assertAssignment(expectedAssignment, computedAssignment);
-    }
-
-    @Test
-    public void testReassignmentWhenOneSubscriptionRemovedWithMemberAndPartitionRacks() {
-        Map<Uuid, TopicMetadata> topicMetadata = new HashMap<>();
-        topicMetadata.put(topic1Uuid, new TopicMetadata(
-            topic1Uuid,
-            topic1Name,
-            5,
-            mkMapOfPartitionRacks(5)
-        ));
-        topicMetadata.put(topic2Uuid, new TopicMetadata(
-            topic2Uuid,
-            topic2Name,
-            2,
-            mkMapOfPartitionRacks(2)
-        ));
-
-        // Initial subscriptions were [T1, T2].
-        Map<String, AssignmentMemberSpec> members = new TreeMap<>();
-
-        Map<Uuid, Set<Integer>> currentAssignmentForA = new TreeMap<>(
-            mkAssignment(
-                mkTopicAssignment(topic1Uuid, 0, 2, 4),
-                mkTopicAssignment(topic2Uuid, 0)
-            )
-        );
-        members.put(memberA, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack0"),
-            Arrays.asList(topic1Uuid, topic2Uuid),
-            currentAssignmentForA
-        ));
-
-        Map<Uuid, Set<Integer>> currentAssignmentForB = new TreeMap<>(
-            mkAssignment(
-                mkTopicAssignment(topic1Uuid, 1, 3),
-                mkTopicAssignment(topic2Uuid, 1)
-            )
-        );
-        members.put(memberB, new AssignmentMemberSpec(
-            Optional.empty(),
-            Optional.of("rack1"),
-            Collections.singletonList(topic2Uuid),
-            currentAssignmentForB
-        ));
-
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HETEROGENEOUS);
-        SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
-
-        GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
-
-        Map<String, Map<Uuid, Set<Integer>>> expectedAssignment = new HashMap<>();
-        expectedAssignment.put(memberA, mkAssignment(
-            mkTopicAssignment(topic1Uuid, 0, 1, 2, 3, 4)
-        ));
-        expectedAssignment.put(memberB, mkAssignment(
-            mkTopicAssignment(topic2Uuid, 0, 1)
         ));
 
         assertAssignment(expectedAssignment, computedAssignment);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/OptimizedUniformAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/assignor/OptimizedUniformAssignmentBuilderTest.java
@@ -36,6 +36,7 @@ import static org.apache.kafka.coordinator.group.AssignmentTestUtil.assertAssign
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
 import static org.apache.kafka.coordinator.group.RecordHelpersTest.mkMapOfPartitionRacks;
+import static org.apache.kafka.coordinator.group.assignor.SubscriptionType.HOMOGENEOUS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -76,7 +77,7 @@ public class OptimizedUniformAssignmentBuilderTest {
             )
         );
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HOMOGENEOUS);
         GroupAssignment groupAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
 
         assertEquals(Collections.emptyMap(), groupAssignment.members());
@@ -106,7 +107,7 @@ public class OptimizedUniformAssignmentBuilderTest {
             )
         );
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HOMOGENEOUS);
 
         assertThrows(PartitionAssignorException.class,
             () -> assignor.assign(assignmentSpec, subscribedTopicMetadata));
@@ -142,7 +143,7 @@ public class OptimizedUniformAssignmentBuilderTest {
             Collections.emptyMap()
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HOMOGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -191,7 +192,7 @@ public class OptimizedUniformAssignmentBuilderTest {
             Collections.emptyMap()
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HOMOGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -237,7 +238,7 @@ public class OptimizedUniformAssignmentBuilderTest {
             ));
         }
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HOMOGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -289,7 +290,7 @@ public class OptimizedUniformAssignmentBuilderTest {
             currentAssignmentForB
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HOMOGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -353,7 +354,7 @@ public class OptimizedUniformAssignmentBuilderTest {
             currentAssignmentForB
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HOMOGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -420,7 +421,7 @@ public class OptimizedUniformAssignmentBuilderTest {
             Collections.emptyMap()
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HOMOGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -483,7 +484,7 @@ public class OptimizedUniformAssignmentBuilderTest {
 
         // Member C was removed
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HOMOGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);
@@ -543,7 +544,7 @@ public class OptimizedUniformAssignmentBuilderTest {
             currentAssignmentForB
         ));
 
-        AssignmentSpec assignmentSpec = new AssignmentSpec(members);
+        AssignmentSpec assignmentSpec = new AssignmentSpec(members, HOMOGENEOUS);
         SubscribedTopicMetadata subscribedTopicMetadata = new SubscribedTopicMetadata(topicMetadata);
 
         GroupAssignment computedAssignment = assignor.assign(assignmentSpec, subscribedTopicMetadata);


### PR DESCRIPTION
During performance testing we realized the the rack aware portion of the code is not performing as expected. We are going to temporarily remove it for 3.8 and re-analyze and add it after more thorough testing