### PR TITLE
KAFKA-16672 fix flaky DedicatedMirrorIntegrationTest

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
@@ -260,8 +260,8 @@ public class DedicatedMirrorIntegrationTest {
             // wait for heartbeat connector to start running
             awaitConnectorTasksStart(mirrorMakers.get("node 0"), MirrorHeartbeatConnector.class, sourceAndTarget);
 
-            // Create one topic per Kafka cluster per MirrorMaker node
             final int messagesPerTopic = 10;
+            // Create one topic per Kafka cluster per MirrorMaker node
             for (int i = 0; i < numNodes; i++) {
                 String topic = testTopicPrefix + i;
 
@@ -354,6 +354,9 @@ public class DedicatedMirrorIntegrationTest {
                         .allMatch(predicate);
             } catch (Exception ex) {
                 if (ex instanceof RebalanceNeededException) {
+                    // RebalanceNeededException should be retry-able.
+                    // This happens when a worker has read a new config from the config topic, but hasn't completed the
+                    // subsequent rebalance yet
                     throw ex;
                 }
                 log.error("Something unexpected occurred. Unable to get configuration of connector {} for mirror maker with source->target={}", connName, sourceAndTarget, ex);


### PR DESCRIPTION
## Context
from DistributedHerder, the comment

> Similar to handling HTTP requests, config changes which are observed asynchronously by polling the config log are 
> batched for handling in the work thread.


Thus, when there is a rebalance, the herder would throw an error `RebalanceNeededException` (in DistributedHerder, L2309). I think this should be an retryable exception since it's possible and we should wait for a while and try again.
Jira: https://issues.apache.org/jira/browse/KAFKA-16672

## Test
run `./gradlew clean connect:test --tests DedicatedMirrorIntegrationTest` and passed 
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
