### PR TITLE
KAFKA-16695: Improve expired poll logging

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -257,7 +257,7 @@ public class HeartbeatRequestManager implements RequestManager {
     public void resetPollTimer(final long pollMs) {
         pollTimer.update(pollMs);
         if (pollTimer.isExpired()) {
-            logger.warn("Time between subsequent calls to poll() was longer than the configured" +
+            logger.warn("Time between subsequent calls to poll() was longer than the configured " +
                 "max.poll.interval.ms, exceeded approximately by {} ms.", pollTimer.isExpiredBy());
             membershipManager.maybeRejoinStaleMember();
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -214,11 +214,6 @@ public class HeartbeatRequestManager implements RequestManager {
         return new NetworkClientDelegate.PollResult(heartbeatRequestState.heartbeatIntervalMs, Collections.singletonList(request));
     }
 
-    // Visible for testing
-    long pollTimerExceededTime() {
-        return pollTimer.elapsedMs() - pollTimer.timeoutMs();
-    }
-
     /**
      * Returns the {@link MembershipManager} that this request manager is using to track the state of the group.
      * This is provided so that the {@link ApplicationEventProcessor} can access the state for querying or updating.
@@ -263,7 +258,7 @@ public class HeartbeatRequestManager implements RequestManager {
                 "max.poll.interval.ms, exceeded by {} ms. This typically implies that the " +
                 "poll loop is spending too much time processing messages. You can address this " +
                 "either by increasing max.poll.interval.ms or by reducing the maximum size of " +
-                "batches returned in poll() with max.poll.records.", pollTimerExceededTime());
+                "batches returned in poll() with max.poll.records.", pollTimer.isExpiredBy());
             membershipManager.maybeRejoinStaleMember();
         }
         pollTimer.reset(maxPollIntervalMs);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManager.java
@@ -260,7 +260,7 @@ public class HeartbeatRequestManager implements RequestManager {
         pollTimer.update(pollMs);
         if (pollTimer.isExpired()) {
             logger.warn("Time between subsequent calls to poll() was longer than the configured" +
-                "max.poll.interval.ms, exceeded by %s ms. This typically implies that the " +
+                "max.poll.interval.ms, exceeded by {} ms. This typically implies that the " +
                 "poll loop is spending too much time processing messages. You can address this " +
                 "either by increasing max.poll.interval.ms or by reducing the maximum size of " +
                 "batches returned in poll() with max.poll.records.", pollTimerExceededTime());

--- a/clients/src/main/java/org/apache/kafka/common/utils/Timer.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Timer.java
@@ -72,6 +72,15 @@ public class Timer {
     }
 
     /**
+     * Get the time in milliseconds that the timer has been expired. Like {@link #remainingMs()},
+     * this depends on the current cached time in milliseconds, which is only updated through one
+     * of the {@link #update()} methods or with {@link #sleep(long)}.
+     */
+    public long isExpiredBy() {
+        return Math.max(0, currentTimeMs - deadlineMs);
+    }
+
+    /**
      * Check whether the timer has not yet expired.
      * @return true if there is still time remaining before expiration
      */

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
@@ -656,7 +656,11 @@ public class HeartbeatRequestManagerTest {
     }
 
     @Test
-    public void testPollTimerExceededTimeUsedForLogging() {
+    public void testisExpiredByUsedForLogging() {
+        Timer pollTimer = spy(time.timer(DEFAULT_MAX_POLL_INTERVAL_MS));
+        heartbeatRequestManager = new HeartbeatRequestManager(new LogContext(), pollTimer, config(),
+            coordinatorRequestManager, membershipManager, heartbeatState, heartbeatRequestState,
+            backgroundEventHandler, metrics);
         when(membershipManager.shouldSkipHeartbeat()).thenReturn(false);
 
         int exceededTimeMs = 5;
@@ -665,12 +669,12 @@ public class HeartbeatRequestManagerTest {
         NetworkClientDelegate.PollResult pollResult = heartbeatRequestManager.poll(time.milliseconds());
         assertEquals(1, pollResult.unsentRequests.size());
         verify(membershipManager).transitionToSendingLeaveGroup(true);
-        verify(heartbeatRequestManager, never()).pollTimerExceededTime();
-        assertEquals(exceededTimeMs, heartbeatRequestManager.pollTimerExceededTime());
+        verify(pollTimer, never()).isExpiredBy();
+        assertEquals(exceededTimeMs, pollTimer.isExpiredBy());
 
-        clearInvocations(heartbeatRequestManager);
+        clearInvocations(pollTimer);
         heartbeatRequestManager.resetPollTimer(time.milliseconds());
-        verify(heartbeatRequestManager).pollTimerExceededTime();
+        verify(pollTimer).isExpiredBy();
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
@@ -655,6 +655,20 @@ public class HeartbeatRequestManagerTest {
     }
 
     @Test
+    public void testPollTimerExceededTimeUsedForLogging() {
+        when(membershipManager.shouldSkipHeartbeat()).thenReturn(false);
+
+        int exceededTimeMs = 5;
+        time.sleep(DEFAULT_MAX_POLL_INTERVAL_MS + exceededTimeMs);
+
+        NetworkClientDelegate.PollResult pollResult = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(1, pollResult.unsentRequests.size());
+        verify(membershipManager).transitionToSendingLeaveGroup(true);
+
+        assertEquals(exceededTimeMs, heartbeatRequestManager.pollTimerExceededTime());
+    }
+
+    @Test
     public void testHeartbeatMetrics() {
         // setup
         coordinatorRequestManager = mock(CoordinatorRequestManager.class);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestManagerTest.java
@@ -80,6 +80,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -664,8 +665,12 @@ public class HeartbeatRequestManagerTest {
         NetworkClientDelegate.PollResult pollResult = heartbeatRequestManager.poll(time.milliseconds());
         assertEquals(1, pollResult.unsentRequests.size());
         verify(membershipManager).transitionToSendingLeaveGroup(true);
-
+        verify(heartbeatRequestManager, never()).pollTimerExceededTime();
         assertEquals(exceededTimeMs, heartbeatRequestManager.pollTimerExceededTime());
+
+        clearInvocations(heartbeatRequestManager);
+        heartbeatRequestManager.resetPollTimer(time.milliseconds());
+        verify(heartbeatRequestManager).pollTimerExceededTime();
     }
 
     @Test


### PR DESCRIPTION
Improve consumer log for expired poll timer, by showing how much time was the max.poll.interval.ms exceeded. This should be helpful in guiding the user to tune that config on the common case of long-running processing causing the consumer to leave the group. Inspired by other clients that log such information on the same situation. 
