### PR TITLE
KAFKA-15045: (KIP-924 pt. 2) Implement ApplicationState and KafkaStreamsState

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/ApplicationState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/ApplicationState.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.processor.assignment;
 import java.util.Map;
 import java.util.Set;
 import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration.AssignmentConfigs;
 import org.apache.kafka.streams.errors.TaskAssignmentException;
 
 /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
@@ -142,4 +142,18 @@ public class AssignmentConfigs {
         }
         return value;
     }
+
+    @Override
+    public String toString() {
+        return "AssignmentConfigs{" +
+               "\n  acceptableRecoveryLag=" + acceptableRecoveryLag +
+               "\n  maxWarmupReplicas=" + maxWarmupReplicas +
+               "\n  numStandbyReplicas=" + numStandbyReplicas +
+               "\n  probingRebalanceIntervalMs=" + probingRebalanceIntervalMs +
+               "\n  rackAwareAssignmentTags=" + rackAwareAssignmentTags +
+               "\n  rackAwareTrafficCost=" + rackAwareTrafficCost +
+               "\n  rackAwareNonOverlapCost=" + rackAwareNonOverlapCost +
+               "\n  rackAwareAssignmentStrategy=" + rackAwareAssignmentStrategy +
+               "\n}";
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/ProcessId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/ProcessId.java
@@ -34,4 +34,9 @@ public class ProcessId {
     public UUID id() {
         return id;
     }
+
+    @Override
+    public String toString() {
+        return "ProcessId{id=" + id + "}";
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/ProcessId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/ProcessId.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.streams.processor.assignment;
 
-import org.apache.kafka.common.protocol.types.Field.UUID;
+import java.util.UUID;
 
 /** A simple wrapper around UUID that abstracts a Process ID */
 public class ProcessId {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ApplicationStateImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ApplicationStateImpl.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals.assignment;
+
+import static java.util.Collections.unmodifiableMap;
+import static java.util.Collections.unmodifiableSet;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.ApplicationState;
+import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
+import org.apache.kafka.streams.processor.assignment.KafkaStreamsState;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
+
+public class ApplicationStateImpl implements ApplicationState {
+
+    private final AssignmentConfigs assignmentConfigs;
+    private final Set<TaskId> statelessTasks;
+    private final Set<TaskId> statefulTasks;
+    private final Map<ProcessId, KafkaStreamsState> kafkaStreamsStates;
+
+    public ApplicationStateImpl(
+        final AssignmentConfigs assignmentConfigs,
+        final Map<ProcessId, KafkaStreamsState> kafkaStreamsStates,
+        final Set<TaskId> statefulTasks,
+        final Set<TaskId> statelessTasks
+    ) {
+        this.assignmentConfigs = assignmentConfigs;
+        this.kafkaStreamsStates = unmodifiableMap(kafkaStreamsStates);
+        this.statefulTasks = unmodifiableSet(statefulTasks);
+        this.statelessTasks = unmodifiableSet(statelessTasks);
+    }
+
+    @Override
+    public Map<ProcessId, KafkaStreamsState> kafkaStreamsStates(final boolean computeTaskLags) {
+        return kafkaStreamsStates;
+    }
+
+    @Override
+    public AssignmentConfigs assignmentConfigs() {
+        return assignmentConfigs;
+    }
+
+    @Override
+    public Set<TaskId> allTasks() {
+        final Set<TaskId> union = new HashSet<>(statefulTasks);
+        union.addAll(statelessTasks);
+        return union;
+    }
+
+    @Override
+    public Set<TaskId> statefulTasks() {
+        return statefulTasks;
+    }
+
+    @Override
+    public Set<TaskId> statelessTasks() {
+        return statelessTasks;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ApplicationStateImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ApplicationStateImpl.java
@@ -33,18 +33,18 @@ public class ApplicationStateImpl implements ApplicationState {
     private final AssignmentConfigs assignmentConfigs;
     private final Set<TaskId> statelessTasks;
     private final Set<TaskId> statefulTasks;
+    private final Set<TaskId> allTasks;
     private final Map<ProcessId, KafkaStreamsState> kafkaStreamsStates;
 
-    public ApplicationStateImpl(
-        final AssignmentConfigs assignmentConfigs,
-        final Map<ProcessId, KafkaStreamsState> kafkaStreamsStates,
-        final Set<TaskId> statefulTasks,
-        final Set<TaskId> statelessTasks
-    ) {
+    public ApplicationStateImpl(final AssignmentConfigs assignmentConfigs,
+                                final Map<ProcessId, KafkaStreamsState> kafkaStreamsStates,
+                                final Set<TaskId> statefulTasks,
+                                final Set<TaskId> statelessTasks) {
         this.assignmentConfigs = assignmentConfigs;
         this.kafkaStreamsStates = unmodifiableMap(kafkaStreamsStates);
         this.statefulTasks = unmodifiableSet(statefulTasks);
         this.statelessTasks = unmodifiableSet(statelessTasks);
+        this.allTasks = unmodifiableSet(computeAllTasks(statelessTasks, statefulTasks));
     }
 
     @Override
@@ -59,9 +59,7 @@ public class ApplicationStateImpl implements ApplicationState {
 
     @Override
     public Set<TaskId> allTasks() {
-        final Set<TaskId> union = new HashSet<>(statefulTasks);
-        union.addAll(statelessTasks);
-        return union;
+        return allTasks;
     }
 
     @Override
@@ -72,5 +70,11 @@ public class ApplicationStateImpl implements ApplicationState {
     @Override
     public Set<TaskId> statelessTasks() {
         return statelessTasks;
+    }
+
+    private static Set<TaskId> computeAllTasks(Set<TaskId> statelessTasks, Set<TaskId> statefulTasks) {
+        final Set<TaskId> union = new HashSet<>(statefulTasks);
+        union.addAll(statelessTasks);
+        return union;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -340,5 +340,18 @@ public final class AssignorConfiguration {
                 "\n  rackAwareAssignmentTags=" + rackAwareAssignmentTags +
                 "\n}";
         }
+
+        public org.apache.kafka.streams.processor.assignment.AssignmentConfigs toPublicAssignmentConfigs() {
+            return new org.apache.kafka.streams.processor.assignment.AssignmentConfigs(
+                acceptableRecoveryLag,
+                maxWarmupReplicas,
+                numStandbyReplicas,
+                probingRebalanceIntervalMs,
+                rackAwareAssignmentTags,
+                rackAwareAssignmentTrafficCost,
+                rackAwareAssignmentNonOverlapCost,
+                rackAwareAssignmentStrategy
+            );
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
+import java.util.SortedMap;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task;
@@ -454,6 +455,22 @@ public class ClientState {
 
     public String consumers() {
         return consumerToPreviousStatefulTaskIds.keySet().toString();
+    }
+
+    public Map<TaskId, Long> taskLagTotals() {
+        return taskLagTotals;
+    }
+
+    public SortedSet<TaskId> previousActiveTasks() {
+        return new TreeSet<>(previousActiveTasks.taskIds());
+    }
+
+    public SortedSet<TaskId> previousStandbyTasks() {
+        return new TreeSet<>(previousStandbyTasks.taskIds());
+    }
+
+    public SortedMap<String, Set<TaskId>> taskIdsByConsumer() {
+        return new TreeMap<>(consumerToPreviousStatefulTaskIds);
     }
 
     public String currentAssignment() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -469,7 +469,7 @@ public class ClientState {
         return new TreeSet<>(previousStandbyTasks.taskIds());
     }
 
-    public SortedMap<String, Set<TaskId>> taskIdsByConsumer() {
+    public SortedMap<String, Set<TaskId>> taskIdsByPreviousConsumer() {
         return new TreeMap<>(consumerToPreviousStatefulTaskIds);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/KafkaStreamsStateImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/KafkaStreamsStateImpl.java
@@ -21,6 +21,7 @@ import static java.util.Collections.unmodifiableSortedMap;
 import static java.util.Collections.unmodifiableSortedSet;
 import static java.util.Comparator.comparingLong;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -48,16 +49,14 @@ public class KafkaStreamsStateImpl implements KafkaStreamsState {
     private final SortedMap<String, Set<TaskId>> taskIdsByConsumer;
     private final Optional<HostInfo> hostInfo;
 
-    public KafkaStreamsStateImpl(
-        final ProcessId processId,
-        final int numProcessingThreads,
-        final Map<String, String> clientTags,
-        final Map<TaskId, Long> taskLagTotals,
-        final SortedSet<TaskId> previousActiveTasks,
-        final SortedSet<TaskId> previousStandbyTasks,
-        final SortedMap<String, Set<TaskId>> taskIdsByConsumer,
-        final Optional<HostInfo> hostInfo
-    ) {
+    public KafkaStreamsStateImpl(final ProcessId processId,
+                                 final int numProcessingThreads,
+                                 final Map<String, String> clientTags,
+                                 final Map<TaskId, Long> taskLagTotals,
+                                 final SortedSet<TaskId> previousActiveTasks,
+                                 final SortedSet<TaskId> previousStandbyTasks,
+                                 final SortedMap<String, Set<TaskId>> taskIdsByConsumer,
+                                 final Optional<HostInfo> hostInfo) {
         this.processId = processId;
         this.numProcessingThreads = numProcessingThreads;
         this.clientTags = unmodifiableMap(clientTags);
@@ -97,6 +96,8 @@ public class KafkaStreamsStateImpl implements KafkaStreamsState {
     public long lagFor(final TaskId task) {
         final Long totalLag = taskLagTotals.get(task);
         if (totalLag == null) {
+            LOG.error("Task lag lookup failed: {} not in {}", task,
+                Arrays.toString(taskLagTotals.keySet().toArray()));
             throw new IllegalStateException("Tried to lookup lag for unknown task " + task);
         }
         return totalLag;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/KafkaStreamsStateImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/KafkaStreamsStateImpl.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals.assignment;
+
+import static java.util.Collections.unmodifiableMap;
+import static java.util.Collections.unmodifiableSortedMap;
+import static java.util.Collections.unmodifiableSortedSet;
+import static java.util.Comparator.comparingLong;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.assignment.KafkaStreamsState;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
+import org.apache.kafka.streams.state.HostInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KafkaStreamsStateImpl implements KafkaStreamsState {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaStreamsStateImpl.class);
+
+    private final ProcessId processId;
+    private final int numProcessingThreads;
+    private final Map<String, String> clientTags;
+    private final Map<TaskId, Long> taskLagTotals; // contains lag for all stateful tasks in the app topology
+    private final SortedSet<TaskId> previousActiveTasks;
+    private final SortedSet<TaskId> previousStandbyTasks;
+    private final SortedMap<String, Set<TaskId>> taskIdsByConsumer;
+    private final Optional<HostInfo> hostInfo;
+
+    public KafkaStreamsStateImpl(
+        final ProcessId processId,
+        final int numProcessingThreads,
+        final Map<String, String> clientTags,
+        final Map<TaskId, Long> taskLagTotals,
+        final SortedSet<TaskId> previousActiveTasks,
+        final SortedSet<TaskId> previousStandbyTasks,
+        final SortedMap<String, Set<TaskId>> taskIdsByConsumer,
+        final Optional<HostInfo> hostInfo
+    ) {
+        this.processId = processId;
+        this.numProcessingThreads = numProcessingThreads;
+        this.clientTags = unmodifiableMap(clientTags);
+        this.taskLagTotals = unmodifiableMap(taskLagTotals);
+        this.previousActiveTasks = unmodifiableSortedSet(previousActiveTasks);
+        this.previousStandbyTasks = unmodifiableSortedSet(previousStandbyTasks);
+        this.taskIdsByConsumer = unmodifiableSortedMap(taskIdsByConsumer);
+        this.hostInfo = hostInfo;
+    }
+
+    @Override
+    public ProcessId processId() {
+        return processId;
+    }
+
+    @Override
+    public int numProcessingThreads() {
+        return numProcessingThreads;
+    }
+
+    @Override
+    public SortedSet<String> consumerClientIds() {
+        return new TreeSet<>(taskIdsByConsumer.keySet());
+    }
+
+    @Override
+    public SortedSet<TaskId> previousActiveTasks() {
+        return previousActiveTasks;
+    }
+
+    @Override
+    public SortedSet<TaskId> previousStandbyTasks() {
+        return previousStandbyTasks;
+    }
+
+    @Override
+    public long lagFor(final TaskId task) {
+        final Long totalLag = taskLagTotals.get(task);
+        if (totalLag == null) {
+            throw new IllegalStateException("Tried to lookup lag for unknown task " + task);
+        }
+        return totalLag;
+    }
+
+    @Override
+    public SortedSet<TaskId> prevTasksByLag(final String consumerClientId) {
+        final SortedSet<TaskId> prevTasksByLag =
+            new TreeSet<>(comparingLong(this::lagFor).thenComparing(TaskId::compareTo));
+        final Set<TaskId> prevOwnedStatefulTasks = taskIdsByConsumer.containsKey(consumerClientId)
+            ? taskIdsByConsumer.get(consumerClientId) : new HashSet<>();
+        for (final TaskId task : prevOwnedStatefulTasks) {
+            if (taskLagTotals.containsKey(task)) {
+                prevTasksByLag.add(task);
+            } else {
+                LOG.debug(
+                    "Skipping previous task {} since it's not part of the current assignment",
+                    task
+                );
+            }
+        }
+        return prevTasksByLag;
+    }
+
+    @Override
+    public Map<TaskId, Long> statefulTasksToLagSums() {
+        return taskLagTotals.keySet()
+            .stream()
+            .collect(Collectors.toMap(taskId -> taskId, this::lagFor));
+    }
+
+    @Override
+    public Optional<HostInfo> hostInfo() {
+        return hostInfo;
+    }
+
+    @Override
+    public Map<String, String> clientTags() {
+        return clientTags;
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/KafkaStreamsStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/KafkaStreamsStateTest.java
@@ -43,16 +43,18 @@ public class KafkaStreamsStateTest {
             new ProcessId(UUID.randomUUID()),
             10,
             mkMap(),
-            mkMap(
-                mkEntry(NAMED_TASK_T0_0_0, 2000L),
-                mkEntry(NAMED_TASK_T0_0_1, 1000L)
-            ),
             mkSortedSet(NAMED_TASK_T0_0_0, NAMED_TASK_T0_0_1),
             mkSortedSet(),
             new TreeMap<>(mkMap(
                 mkEntry("c1", mkSet(NAMED_TASK_T0_0_0, NAMED_TASK_T0_0_1))
             )),
-            Optional.empty()
+            Optional.empty(),
+            Optional.of(
+                mkMap(
+                    mkEntry(NAMED_TASK_T0_0_0, 2000L),
+                    mkEntry(NAMED_TASK_T0_0_1, 1000L)
+                )
+            )
         );
 
         assertThrows(IllegalStateException.class, () -> state.lagFor(NAMED_TASK_T0_1_0));
@@ -63,5 +65,25 @@ public class KafkaStreamsStateTest {
         assertThat(state.prevTasksByLag("c1"), equalTo(new TreeSet<>(
             Arrays.asList(NAMED_TASK_T0_0_1, NAMED_TASK_T0_0_0)
         )));
+    }
+
+    @Test
+    public void shouldThrowExceptionOnLagOperationsIfLagsWereNotComputed() {
+        final KafkaStreamsState state = new KafkaStreamsStateImpl(
+            new ProcessId(UUID.randomUUID()),
+            10,
+            mkMap(),
+            mkSortedSet(NAMED_TASK_T0_0_0, NAMED_TASK_T0_0_1),
+            mkSortedSet(),
+            new TreeMap<>(mkMap(
+                mkEntry("c1", mkSet(NAMED_TASK_T0_0_0, NAMED_TASK_T0_0_1))
+            )),
+            Optional.empty(),
+            Optional.empty()
+        );
+
+        assertThrows(UnsupportedOperationException.class, () -> state.lagFor(NAMED_TASK_T0_0_0));
+        assertThrows(UnsupportedOperationException.class, () -> state.prevTasksByLag("c1"));
+        assertThrows(UnsupportedOperationException.class, state::statefulTasksToLagSums);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/KafkaStreamsStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/KafkaStreamsStateTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals.assignment;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.common.utils.Utils.mkSortedSet;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NAMED_TASK_T0_0_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NAMED_TASK_T0_0_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NAMED_TASK_T0_1_0;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.UUID;
+import org.apache.kafka.streams.processor.assignment.KafkaStreamsState;
+import org.apache.kafka.streams.processor.assignment.ProcessId;
+import org.junit.Test;
+
+public class KafkaStreamsStateTest {
+    @Test
+    public void shouldCorrectlyReturnTasksByLag() {
+        final KafkaStreamsState state = new KafkaStreamsStateImpl(
+            new ProcessId(UUID.randomUUID()),
+            10,
+            mkMap(),
+            mkMap(
+                mkEntry(NAMED_TASK_T0_0_0, 2000L),
+                mkEntry(NAMED_TASK_T0_0_1, 1000L)
+            ),
+            mkSortedSet(NAMED_TASK_T0_0_0, NAMED_TASK_T0_0_1),
+            mkSortedSet(),
+            new TreeMap<>(mkMap(
+                mkEntry("c1", mkSet(NAMED_TASK_T0_0_0, NAMED_TASK_T0_0_1))
+            )),
+            Optional.empty()
+        );
+
+        assertThrows(IllegalStateException.class, () -> state.lagFor(NAMED_TASK_T0_1_0));
+        assertThat(state.lagFor(NAMED_TASK_T0_0_0), equalTo(2000L));
+        assertThat(state.lagFor(NAMED_TASK_T0_0_1), equalTo(1000L));
+
+        assertThat(state.prevTasksByLag("c0"), equalTo(new TreeSet<>()));
+        assertThat(state.prevTasksByLag("c1"), equalTo(new TreeSet<>(
+            Arrays.asList(NAMED_TASK_T0_0_1, NAMED_TASK_T0_0_0)
+        )));
+    }
+}


### PR DESCRIPTION
This PR implements read-only container classes for ApplicationState and KafkaStreamsState, and initializes those within
StreamsPartitionAssignor#assign.

New internal methods were also added to the ClientState to easily pass this data through to the KafkaStreamsState.

One test was added to check the lag sorting within the implementation of KafkaStreamsState, which is the counterpart to the test that existed for the ClientState class. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
